### PR TITLE
Mousedown handling improvements

### DIFF
--- a/osu.Framework/Graphics/Containers/BoundsBypassContainer.cs
+++ b/osu.Framework/Graphics/Containers/BoundsBypassContainer.cs
@@ -1,0 +1,15 @@
+﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+//Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// A container that always considers input to be inside it.
+    /// </summary>
+    class BoundsBypassContainer : Container
+    {
+        internal override bool Contains(Vector2 screenSpacePos) => true;
+    }
+}

--- a/osu.Framework/Graphics/Containers/ProcessingContainer.cs
+++ b/osu.Framework/Graphics/Containers/ProcessingContainer.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Graphics.Containers
 {
     public class ProcessingContainer : Container
     {
-        private Container processingContainer = new Container() { SizeMode = InheritMode.XY };
+        private Container processingContainer = new BoundsBypassContainer() { SizeMode = InheritMode.XY };
 
         public override void Load()
         {

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Drawables;
 using osu.Framework.Input;
 using OpenTK;
+using osu.Framework.Graphics.Primitives;
 
 namespace osu.Framework.Graphics.Cursor
 {
@@ -16,6 +17,8 @@ namespace osu.Framework.Graphics.Cursor
         {
             Add(cursor = new Cursor());
         }
+
+        internal override bool Contains(Vector2 screenSpacePos) => true;
 
         protected override bool OnMouseMove(InputState state)
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics
         internal event Action OnInvalidate;
 
         private LifetimeList<Drawable> children;
-        internal ReadOnlyList<Drawable> Children
+        internal LifetimeList<Drawable> Children
         {
             get
             {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -3,10 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
-using System.Windows.Forms;
 using OpenTK.Input;
-using Rectangle = System.Drawing.Rectangle;
 using System.Linq;
 using OpenTK;
 using osu.Framework.Graphics;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -366,6 +366,8 @@ namespace osu.Framework.Input
             }
         }
 
+        Drawable mouseDownDrawable;
+
         private void updateMouseEvents(InputState state)
         {
             MouseState mouse = state.Mouse;
@@ -382,7 +384,7 @@ namespace osu.Framework.Input
                 if (b.State != mouse.LastState?.ButtonStates.Find(c => c.Button == b.Button).State)
                 {
                     if (b.State)
-                        handleMouseDown(state, b.Button);
+                        mouseDownDrawable = handleMouseDown(state, b.Button);
                     else
                         handleMouseUp(state, b.Button);
                 }
@@ -429,6 +431,7 @@ namespace osu.Framework.Input
                 if (isValidClick)
                     handleMouseClick(state);
 
+                mouseDownDrawable = null;
                 mouse.PositionMouseDown = null;
 
                 if (isDragging)
@@ -439,14 +442,14 @@ namespace osu.Framework.Input
             }
         }
 
-        private bool handleMouseDown(InputState state, MouseButton button)
+        private Drawable handleMouseDown(InputState state, MouseButton button)
         {
             MouseDownEventArgs args = new MouseDownEventArgs()
             {
                 Button = button
             };
 
-            return mouseInputQueue.Any(target => target.TriggerMouseDown(state, args));
+            return mouseInputQueue.Find(target => target.TriggerMouseDown(state, args));
         }
 
         private bool handleMouseUp(InputState state, MouseButton button)
@@ -466,6 +469,9 @@ namespace osu.Framework.Input
 
         private bool handleMouseClick(InputState state)
         {
+            if (mouseDownDrawable != null)
+                return mouseDownDrawable.TriggerClick(state) | mouseDownDrawable.TriggerFocus(state, true);
+
             if (mouseInputQueue.Any(target => target.TriggerClick(state) | target.TriggerFocus(state, true)))
                 return true;
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -1,6 +1,7 @@
 ﻿//Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
 //Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using OpenTK;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.Handlers.Keyboard;
 using osu.Framework.Input.Handlers.Mouse;
@@ -9,6 +10,8 @@ namespace osu.Framework.Input
 {
     public class UserInputManager : InputManager
     {
+        internal override bool Contains(Vector2 screenSpacePos) => true;
+
         public override void Load()
         {
             base.Load();

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -84,6 +84,7 @@
     <Compile Include="DebugUtils\ThreadSafety.cs" />
     <Compile Include="Extensions\GeneralExtensions.cs" />
     <Compile Include="Graphics\BlendingInfo.cs" />
+    <Compile Include="Graphics\Containers\BoundsBypassContainer.cs" />
     <Compile Include="Graphics\Containers\BufferedContainerDrawNode.cs" />
     <Compile Include="Graphics\Containers\ClickableContainer.cs" />
     <Compile Include="Graphics\Containers\ScrollContainer.cs" />


### PR DESCRIPTION
- Input should be fed in to the draw tree even when "outside" the `BasicGameHost` (else the cursor stops at the edge.
- If a drawable handles `OnMouseDown`, it should be the only drawable allowed to handle `OnClick`.
- `OnMouseUp` events should be sent to the same input queue that `OnMouseDown` was sent to, regardless of if the mouse moved.