### PR TITLE
Fixes nullreference preventing ppy:osu from compiling

### DIFF
--- a/osu.Framework/Graphics/Transformations/Transform.cs
+++ b/osu.Framework/Graphics/Transformations/Transform.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.Transformations
 
         protected IClock Clock;
 
-        protected double Time => Clock.CurrentTime;
+        protected double Time => Clock != null ? Clock.CurrentTime : 0;
 
         public bool IsAlive => Clock == null || (StartTime <= Clock.CurrentTime && EndTime >= Clock.CurrentTime);
 


### PR DESCRIPTION
Attempting to read Clock before it was assigned to anything, that operation will now just return a time of 0. 
ppy:osu currently looks like this, but i assume it's just because it's an older sample game
(pippipidoooooon is a more up to date test):
![StateOfTheGame](http://i.imgur.com/6S241NT.png)

used the webeditor because it's a one-liner, let me know if that's not acceptable for the future :) it's a habit I've picked up from other projects.