### PR TITLE
fixed different text box behavior with selections.

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -447,6 +447,7 @@ namespace osu.Framework.Graphics.UserInterface
                     return true;
                 }    
                 case Key.Enter:
+                    selectionStart = selectionEnd = 0;
                     TriggerFocusLost(state);
                     return true;
                 case Key.Delete:

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -85,22 +85,12 @@ namespace osu.Framework.Graphics.UserInterface
 
             textContainer.Add(cursor);
             textContainer.Add(textFlow);
-
         }
 
         private void resetSelection()
         {
             selectionStart = selectionEnd;
             cursorAndLayout.Invalidate();
-        }
-
-        private void resetSelection(bool reset)
-        {
-            if (reset)
-            {
-                selectionStart = selectionEnd;
-                cursorAndLayout.Invalidate();
-            }
         }
 
         protected override void Dispose(bool disposing)
@@ -397,8 +387,9 @@ namespace osu.Framework.Graphics.UserInterface
 
                     if (selectionEnd == 0)
                     {
-                        //we only clear if you aren't holding shift
-                        resetSelection(!state.Keyboard.ShiftPressed);
+                            //we only clear if you aren't holding shift
+                        if (!state.Keyboard.ShiftPressed)
+                            resetSelection();
                         return true;
                     }
 
@@ -410,7 +401,8 @@ namespace osu.Framework.Graphics.UserInterface
                         {
                             //if you have something selected and shift is not held down
                             //A selection reset is required to select a word inside the current selection
-                            resetSelection(!state.Keyboard.ShiftPressed);
+                            if(!state.Keyboard.ShiftPressed)
+                                resetSelection();
                             amount = (selectionEnd - lastSpace - 1);
                         }
                          else
@@ -426,7 +418,8 @@ namespace osu.Framework.Graphics.UserInterface
 
                     if (selectionEnd == text.Length)
                     {
-                        resetSelection(!state.Keyboard.ShiftPressed);
+                        if (!state.Keyboard.ShiftPressed)
+                            resetSelection();
                         return true;
                     }
 
@@ -436,7 +429,8 @@ namespace osu.Framework.Graphics.UserInterface
                         int nextSpace = text.IndexOf(' ', selectionEnd + 1);
                         if (nextSpace >= 0)
                         {
-                            resetSelection(!state.Keyboard.ShiftPressed);
+                            if (!state.Keyboard.ShiftPressed)
+                                resetSelection();
                             amount = nextSpace - selectionEnd;
                         }
                         else
@@ -552,7 +546,7 @@ namespace osu.Framework.Graphics.UserInterface
                 }
                 else if (getCharacterClosestTo(state.Mouse.Position) < doubleClickWord[0]) 
                 {
-                    selectionEnd = text.LastIndexOf(' ', getCharacterClosestTo(state.Mouse.Position))+1;
+                    selectionEnd = text.LastIndexOf(' ', getCharacterClosestTo(state.Mouse.Position)) + 1;
                     selectionStart = doubleClickWord[1];
                 }
                 else
@@ -583,7 +577,7 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         protected override bool OnDoubleClick(InputState state)
-        {   
+        {
             if (textInput?.ImeActive == true) return true;
 
             if (text.Length == 0) return true;
@@ -638,8 +632,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
         {
-            if (doubleClickWord != null)
-                doubleClickWord = null;
+            doubleClickWord = null;
             return true;
         }
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -380,58 +380,58 @@ namespace osu.Framework.Graphics.UserInterface
                     moveSelection(-text.Length, state.Keyboard.ShiftPressed);
                     return true;
                 case Key.Left:
+                {
+                    if (!HandleLeftRightArrows) return false;
+
+                    if (selectionEnd == 0)
                     {
-                        if (!HandleLeftRightArrows) return false;
-
-                        if (selectionEnd == 0)
-                        {
-                            if (!state.Keyboard.ShiftPressed) resetSelection();
-                            return true;
-                        }
-
-                        int amount = 1;
-                        if (state.Keyboard.ControlPressed)
-                        {
-                            int lastSpace = text.LastIndexOf(' ', Math.Max(0, selectionEnd - 2));
-                            if (lastSpace >= 0)
-                            {
-                                if (!state.Keyboard.ShiftPressed)
-                                    resetSelection();
-                                amount = (selectionEnd - lastSpace - 1);
-                            } else
-                                amount = selectionEnd;
-                        }
-                        moveSelection(-amount, state.Keyboard.ShiftPressed);
+                        if (!state.Keyboard.ShiftPressed) resetSelection();
+                        return true;
                     }
-                    return true;
+
+                    int amount = 1;
+                    if (state.Keyboard.ControlPressed)
+                    {
+                        int lastSpace = text.LastIndexOf(' ', Math.Max(0, selectionEnd - 2));
+                        if (lastSpace >= 0)
+                        {
+                            if (!state.Keyboard.ShiftPressed)
+                                resetSelection();
+                            amount = (selectionEnd - lastSpace - 1);
+                        } else
+                            amount = selectionEnd;
+                    }
+                    moveSelection(-amount, state.Keyboard.ShiftPressed);
+                }
+                return true;
                 case Key.Right:
+                {
+                    if (!HandleLeftRightArrows) return false;
+
+                    if (selectionEnd == text.Length)
                     {
-                        if (!HandleLeftRightArrows) return false;
-
-                        if (selectionEnd == text.Length)
-                        {
-                            if (!state.Keyboard.ShiftPressed) resetSelection();
-                            return true;
-                        }
-
-                        int amount = 1;
-                        if (state.Keyboard.ControlPressed)
-                        {
-                            int nextSpace = text.IndexOf(' ', selectionEnd + 1);
-                            if (nextSpace >= 0)
-                            {
-                                if (!state.Keyboard.ShiftPressed)
-                                    resetSelection();
-                                amount = nextSpace - selectionEnd;
-                            }
-                            else
-                                amount = text.Length - selectionEnd;
-                        }
-
-                        moveSelection(amount, state.Keyboard.ShiftPressed);
+                        if (!state.Keyboard.ShiftPressed) resetSelection();
+                        return true;
                     }
 
-                    return true;
+                    int amount = 1;
+                    if (state.Keyboard.ControlPressed)
+                    {
+                        int nextSpace = text.IndexOf(' ', selectionEnd + 1);
+                        if (nextSpace >= 0)
+                        {
+                            if (!state.Keyboard.ShiftPressed)
+                                resetSelection();
+                            amount = nextSpace - selectionEnd;
+                        }
+                        else
+                            amount = text.Length - selectionEnd;
+                    }
+
+                    moveSelection(amount, state.Keyboard.ShiftPressed);
+                }
+
+                return true;
                 case Key.Enter:
                     TriggerFocusLost(state);
                     return true;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -387,7 +387,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                     if (selectionEnd == 0)
                     {
-                            //we only clear if you aren't holding shift
+                        //we only clear if you aren't holding shift
                         if (!state.Keyboard.ShiftPressed)
                             resetSelection();
                         return true;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -82,11 +82,12 @@ namespace osu.Framework.Graphics.UserInterface
 
             textContainer.Add(cursor);
             textContainer.Add(textFlow);
+
         }
 
         private void resetSelection()
         {
-            selectionStart = selectionEnd = text.Length;
+            selectionStart = selectionEnd;
             cursorAndLayout.Invalidate();
         }
 
@@ -379,42 +380,56 @@ namespace osu.Framework.Graphics.UserInterface
                     moveSelection(-text.Length, state.Keyboard.ShiftPressed);
                     return true;
                 case Key.Left:
-                {
-                    if (!HandleLeftRightArrows) return false;
-
-                    if (selectionEnd == 0) return true;
-
-                    int amount = 1;
-                    if (state.Keyboard.ControlPressed)
                     {
-                        int lastSpace = text.LastIndexOf(' ', Math.Max(0, selectionEnd - 2));
-                        if (lastSpace >= 0)
-                            amount = selectionEnd - lastSpace - 1;
-                        else
-                            amount = selectionEnd;
-                    }
+                        if (!HandleLeftRightArrows) return false;
 
-                    moveSelection(-amount, state.Keyboard.ShiftPressed);
-                }
+                        if (selectionEnd == 0)
+                        {
+                            if (!state.Keyboard.ShiftPressed) resetSelection();
+                            return true;
+                        }
+
+                        int amount = 1;
+                        if (state.Keyboard.ControlPressed)
+                        {
+                            int lastSpace = text.LastIndexOf(' ', Math.Max(0, selectionEnd - 2));
+                            if (lastSpace >= 0)
+                            {
+                                if (!state.Keyboard.ShiftPressed)
+                                    resetSelection();
+                                amount = (selectionEnd - lastSpace - 1);
+                            } else
+                                amount = selectionEnd;
+                        }
+                        moveSelection(-amount, state.Keyboard.ShiftPressed);
+                    }
                     return true;
                 case Key.Right:
-                {
-                    if (!HandleLeftRightArrows) return false;
-
-                    if (selectionEnd == text.Length) return true;
-
-                    int amount = 1;
-                    if (state.Keyboard.ControlPressed)
                     {
-                        int nextSpace = text.IndexOf(' ', selectionEnd + 1);
-                        if (nextSpace >= 0)
-                            amount = nextSpace - selectionEnd;
-                        else
-                            amount = text.Length - selectionEnd;
-                    }
+                        if (!HandleLeftRightArrows) return false;
 
-                    moveSelection(amount, state.Keyboard.ShiftPressed);
-                }
+                        if (selectionEnd == text.Length)
+                        {
+                            if (!state.Keyboard.ShiftPressed) resetSelection();
+                            return true;
+                        }
+
+                        int amount = 1;
+                        if (state.Keyboard.ControlPressed)
+                        {
+                            int nextSpace = text.IndexOf(' ', selectionEnd + 1);
+                            if (nextSpace >= 0)
+                            {
+                                if (!state.Keyboard.ShiftPressed)
+                                    resetSelection();
+                                amount = nextSpace - selectionEnd;
+                            }
+                            else
+                                amount = text.Length - selectionEnd;
+                        }
+
+                        moveSelection(amount, state.Keyboard.ShiftPressed);
+                    }
 
                     return true;
                 case Key.Enter:

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -29,9 +29,9 @@ namespace osu.Framework.Graphics.UserInterface
         public int? LengthLimit;
 
         public bool AllowClipboardExport => true;
-        
-        private bool doubleClickDragging = false;
-        private Vector2 doubleClickWord;
+
+        //represents the left/right selection coordinates of the word double clicked on when dragging
+        private int[] doubleClickWord = null;
 
         /// <summary>
         /// Should this TextBox accept arrow keys for navigation?
@@ -540,26 +540,26 @@ namespace osu.Framework.Graphics.UserInterface
         {
             //if (textInput?.ImeActive == true) return true;
 
-            if (doubleClickDragging)
+            if (doubleClickWord != null)
             {
                 //select words at a time
-                if (getCharacterClosestTo(state.Mouse.Position) > doubleClickWord.Y) 
+                if (getCharacterClosestTo(state.Mouse.Position) > doubleClickWord[1]) 
                 {
                     selectionEnd = text.IndexOf(' ', getCharacterClosestTo(state.Mouse.Position));
                     if (selectionEnd < selectionStart)
                         selectionEnd = text.Length;
-                    selectionStart = (int)doubleClickWord.X;
+                    selectionStart = doubleClickWord[0];
                 }
-                else if (getCharacterClosestTo(state.Mouse.Position) < doubleClickWord.X) 
+                else if (getCharacterClosestTo(state.Mouse.Position) < doubleClickWord[0]) 
                 {
                     selectionEnd = text.LastIndexOf(' ', getCharacterClosestTo(state.Mouse.Position))+1;
-                    selectionStart = (int)doubleClickWord.Y;
+                    selectionStart = doubleClickWord[1];
                 }
                 else
                 {
                     //in the middle
-                    selectionStart = (int)doubleClickWord.X;
-                    selectionEnd = (int)doubleClickWord.Y;
+                    selectionStart = doubleClickWord[0];
+                    selectionEnd = doubleClickWord[1];
                 }
                 cursorAndLayout.Invalidate();
             }
@@ -589,8 +589,6 @@ namespace osu.Framework.Graphics.UserInterface
             if (text.Length == 0) return true;
 
             int hover = Math.Min(text.Length - 1, getCharacterClosestTo(state.Mouse.Position));
-            
-            doubleClickDragging = true;
 
             int lastSeparator = findSeparatorIndex(text, hover, -1);
             int nextSeparator = findSeparatorIndex(text, hover, 1);
@@ -599,7 +597,7 @@ namespace osu.Framework.Graphics.UserInterface
             selectionEnd = nextSeparator >= 0 ? nextSeparator : text.Length;
 
             //in order to keep the home word selected
-            doubleClickWord = new Vector2(selectionStart,selectionEnd);
+            doubleClickWord = new int[] { selectionStart, selectionEnd };
 
             cursorAndLayout.Invalidate();
             return true;
@@ -640,8 +638,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
         {
-            if (doubleClickDragging)
-                doubleClickDragging = false;
+            if (doubleClickWord != null)
+                doubleClickWord = null;
             return true;
         }
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -91,6 +91,15 @@ namespace osu.Framework.Graphics.UserInterface
             cursorAndLayout.Invalidate();
         }
 
+        private void resetSelection(bool reset)
+        {
+            if (reset)
+            {
+                selectionStart = selectionEnd;
+                cursorAndLayout.Invalidate();
+            }
+        }
+
         protected override void Dispose(bool disposing)
         {
             OnChange = null;
@@ -385,7 +394,8 @@ namespace osu.Framework.Graphics.UserInterface
 
                     if (selectionEnd == 0)
                     {
-                        if (!state.Keyboard.ShiftPressed) resetSelection();
+                        //we only clear if you aren't holding shift
+                        resetSelection(!state.Keyboard.ShiftPressed);
                         return true;
                     }
 
@@ -395,22 +405,25 @@ namespace osu.Framework.Graphics.UserInterface
                         int lastSpace = text.LastIndexOf(' ', Math.Max(0, selectionEnd - 2));
                         if (lastSpace >= 0)
                         {
-                            if (!state.Keyboard.ShiftPressed)
-                                resetSelection();
+                            //if you have something selected and shift is not held down
+                            //A selection reset is required to select a word inside the current selection
+                            resetSelection(!state.Keyboard.ShiftPressed);
                             amount = (selectionEnd - lastSpace - 1);
-                        } else
+                        }
+                         else
                             amount = selectionEnd;
                     }
+
                     moveSelection(-amount, state.Keyboard.ShiftPressed);
+                    return true;
                 }
-                return true;
                 case Key.Right:
                 {
                     if (!HandleLeftRightArrows) return false;
 
                     if (selectionEnd == text.Length)
                     {
-                        if (!state.Keyboard.ShiftPressed) resetSelection();
+                        resetSelection(!state.Keyboard.ShiftPressed);
                         return true;
                     }
 
@@ -420,8 +433,7 @@ namespace osu.Framework.Graphics.UserInterface
                         int nextSpace = text.IndexOf(' ', selectionEnd + 1);
                         if (nextSpace >= 0)
                         {
-                            if (!state.Keyboard.ShiftPressed)
-                                resetSelection();
+                            resetSelection(!state.Keyboard.ShiftPressed);
                             amount = nextSpace - selectionEnd;
                         }
                         else
@@ -429,9 +441,8 @@ namespace osu.Framework.Graphics.UserInterface
                     }
 
                     moveSelection(amount, state.Keyboard.ShiftPressed);
-                }
-
-                return true;
+                    return true;
+                }    
                 case Key.Enter:
                     TriggerFocusLost(state);
                     return true;


### PR DESCRIPTION
pressing right when you selection ends at the end of the text clears the selection now
same with pressing left at the beginning of the text

ctrl+selection fixes:
ctrl+move selected text without holding shift doesn't move in weird ways anymore