### PR TITLE
Fix ArgumentException in GLControl.Initialize (RDP).

### DIFF
--- a/osu.Framework/OS/GLControl.cs
+++ b/osu.Framework/OS/GLControl.cs
@@ -68,8 +68,7 @@ namespace osu.Framework.OS
 
         private string GetVersionNumberSubstring(string version)
         {
-            var stringParts = version.Split(' ');
-            var result = stringParts.FirstOrDefault(s => char.IsDigit(s, 0));
+            string result = version.Split(' ').FirstOrDefault(s => char.IsDigit(s, 0));
             if (result != null) return result;
             throw new ArgumentException(nameof(version));
         }

--- a/osu.Framework/OS/GLControl.cs
+++ b/osu.Framework/OS/GLControl.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
 using osu.Framework.Logging;
 using OpenTK.Graphics;
@@ -32,13 +33,14 @@ namespace osu.Framework.OS
             MakeCurrent();
 
             string version = GL.GetString(StringName.Version);
-            GLVersion = new Version(version.Split(' ')[0]);
+            var versionNumberSubstring = GetVersionNumberSubstring(version);
+            GLVersion = new Version(versionNumberSubstring);
             version = GL.GetString(StringName.ShadingLanguageVersion);
             if (!string.IsNullOrEmpty(version))
             {
                 try
                 {
-                    GLSLVersion = new Version(version.Split(' ')[0]);
+                    GLSLVersion = new Version(versionNumberSubstring);
                 }
                 catch (Exception e)
                 {
@@ -62,6 +64,14 @@ namespace osu.Framework.OS
                         GL Vendor:                  {GL.GetString(StringName.Vendor)}
                         GL Extensions:              {GL.GetString(StringName.Extensions)}
                         GL Context:                 {GraphicsMode}", LoggingTarget.Runtime, LogLevel.Important);
+        }
+
+        private string GetVersionNumberSubstring(string version)
+        {
+            var stringParts = version.Split(' ');
+            var result = stringParts.FirstOrDefault(s => char.IsDigit(s, 0));
+            if (result != null) return result;
+            throw new ArgumentException(nameof(version));
         }
 
         protected override void OnMouseEnter(EventArgs e)

--- a/osu.Framework/OS/GLControl.cs
+++ b/osu.Framework/OS/GLControl.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.OS
             MakeCurrent();
 
             string version = GL.GetString(StringName.Version);
-            var versionNumberSubstring = GetVersionNumberSubstring(version);
+            string versionNumberSubstring = GetVersionNumberSubstring(version);
             GLVersion = new Version(versionNumberSubstring);
             version = GL.GetString(StringName.ShadingLanguageVersion);
             if (!string.IsNullOrEmpty(version))


### PR DESCRIPTION
version.Split(' ')[0] throws ArgumentException if you are connected via RDP.

Here are my GL.GetString(StringName.Version) results for different cases:
MSI GX680 via RDP: OpenGL ES 3.0 (ANGLE 2.1.0.0d79a9db3d42)
MSI GX680 without RDP: 4.5.0 NVIDIA 365.10
Surface Pro 2 without RDP: 4.3.0 - Build 20.19.15.4501

I did not try it on Linux, but on Windows it looks ok :)
![screenshot 59](https://cloud.githubusercontent.com/assets/22450664/19044219/feda3958-899b-11e6-9441-5a81e0d4d085.png)
