### PR TITLE
Fixed unused variable warning in release mode

### DIFF
--- a/osu.Framework/Graphics/Shaders/ShaderPart.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderPart.cs
@@ -102,14 +102,9 @@ namespace osu.Framework.Graphics.Shaders
             int compileResult;
             GL.GetShader(this, ShaderParameter.CompileStatus, out compileResult);
             Compiled = compileResult == 1;
+
 #if DEBUG
             string compileLog = GL.GetShaderInfoLog(this);
-#endif
-
-            if (!Compiled)
-                Dispose(true);
-
-#if DEBUG
             Log.AppendLine(string.Format('\t' + BOUNDARY, Name));
             Log.AppendLine(string.Format("\tCompiled: {0}", Compiled));
             if (!Compiled)
@@ -118,6 +113,9 @@ namespace osu.Framework.Graphics.Shaders
                 Log.AppendLine('\t' + compileLog);
             }
 #endif
+
+            if (!Compiled)
+                Dispose(true);
 
             return Compiled;
         }

--- a/osu.Framework/Graphics/Shaders/ShaderPart.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderPart.cs
@@ -102,7 +102,9 @@ namespace osu.Framework.Graphics.Shaders
             int compileResult;
             GL.GetShader(this, ShaderParameter.CompileStatus, out compileResult);
             Compiled = compileResult == 1;
+#if DEBUG
             string compileLog = GL.GetShaderInfoLog(this);
+#endif
 
             if (!Compiled)
                 Dispose(true);


### PR DESCRIPTION
compileLog isn't used in release mode

This also removes a `GetShaderInfoLog` call for every shader unit in release mode, which should save a tiny bit of memory/reduce allocations + one less GPU call