### PR TITLE
Adds CheckBoxes and a TestCase

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
@@ -1,0 +1,115 @@
+﻿// Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.GameModes.Testing;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Drawables;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+
+namespace osu.Framework.VisualTests.Tests
+{
+    class TestCaseCheckBox : TestCase
+    {
+        public override string Name => @"Checkboxes";
+
+        public override string Description => @"CheckBoxes with clickable labels";
+
+        public CheckBox BasicCheckBox;
+        public CheckBox ResizingWidthCheckBox;
+        public CheckBox ResizingHeightCheckBox;
+        public CheckBox ActionsCheckBox;
+
+        public override void Reset()
+        {
+            base.Reset();
+
+            Children = new Drawable[]
+            {
+                new FlowContainer
+                {
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                    Spacing = new Vector2(0,10),
+                    Padding = new MarginPadding(10),
+                    Direction = FlowDirection.VerticalOnly,
+                    Children = new Drawable[]
+                    {
+                        BasicCheckBox = new CheckBox
+                        {
+                            Labels = new Drawable[]
+                            {
+                                new SpriteText
+                                {
+                                    Padding = new MarginPadding
+                                    {
+                                        Left = 20
+                                    },
+                                    Text = @"Basic Test"
+                                }
+                            }
+                        },
+                        ResizingWidthCheckBox = new CheckBox
+                        {
+                            CheckedDrawable = new Box
+                            {
+                                Size = new Vector2(50, 20),
+                                Colour = Color4.Cyan
+                            },
+                            Labels = new Drawable[]
+                            {
+                                new SpriteText
+                                {
+                                    Padding = new MarginPadding
+                                    {
+                                        Left = 20
+                                    },
+                                    Text = @"Resizing Width Test"
+                                },
+                            }
+                        },
+                        ResizingHeightCheckBox = new CheckBox
+                        {
+                            CheckedDrawable = new Box
+                            {
+                                Size = new Vector2(20, 50),
+                                Colour = Color4.Cyan
+                            },
+                            Labels = new Drawable[]
+                            {
+                                new SpriteText
+                                {
+                                    Padding = new MarginPadding
+                                    {
+                                        Left = 20
+                                    },
+                                    Text = @"Resizing Height Test"
+                                }
+                            }
+                        },
+                        ActionsCheckBox = new CheckBox
+                        {
+                            CheckedAction = () => ActionsCheckBox.RotateTo(45, 100),
+                            UncheckedAction = () => ActionsCheckBox.RotateTo(0, 100),
+                            Labels = new Drawable[]
+                            {
+                                new SpriteText
+                                {
+                                    Padding = new MarginPadding
+                                    {
+                                        Left = 20
+                                    },
+                                    Text = @"Enabled/Disabled Actions Test"
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
@@ -83,11 +83,13 @@ namespace osu.Framework.VisualTests.Tests
     {
         protected override void OnChecked()
         {
+            base.OnChecked();
             RotateTo(45, 100);
         }
 
         protected override void OnUnchecked()
         {
+            base.OnUnchecked();
             RotateTo(0, 100);
         }
     }

--- a/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
@@ -39,77 +39,56 @@ namespace osu.Framework.VisualTests.Tests
                     Direction = FlowDirection.VerticalOnly,
                     Children = new Drawable[]
                     {
-                        BasicCheckBox = new CheckBox
+                        BasicCheckBox = new BasicCheckBox
                         {
-                            Labels = new Drawable[]
-                            {
-                                new SpriteText
-                                {
-                                    Padding = new MarginPadding
-                                    {
-                                        Left = 20
-                                    },
-                                    Text = @"Basic Test"
-                                }
-                            }
+                            LabelText = @"Basic Test",
                         },
-                        ResizingWidthCheckBox = new CheckBox
+                        ResizingWidthCheckBox = new WidthTestCheckBox
                         {
-                            CheckedDrawable = new Box
-                            {
-                                Size = new Vector2(50, 20),
-                                Colour = Color4.Cyan
-                            },
-                            Labels = new Drawable[]
-                            {
-                                new SpriteText
-                                {
-                                    Padding = new MarginPadding
-                                    {
-                                        Left = 20
-                                    },
-                                    Text = @"Resizing Width Test"
-                                },
-                            }
+                            LabelText = @"Resizing Width Test",
                         },
-                        ResizingHeightCheckBox = new CheckBox
+                        ResizingHeightCheckBox = new HeightTestCheckBox
                         {
-                            CheckedDrawable = new Box
-                            {
-                                Size = new Vector2(20, 50),
-                                Colour = Color4.Cyan
-                            },
-                            Labels = new Drawable[]
-                            {
-                                new SpriteText
-                                {
-                                    Padding = new MarginPadding
-                                    {
-                                        Left = 20
-                                    },
-                                    Text = @"Resizing Height Test"
-                                }
-                            }
+                            LabelText = @"Resizing Height Test",
                         },
-                        ActionsCheckBox = new CheckBox
+                        ActionsCheckBox = new ActionsTestCheckBox
                         {
-                            CheckedAction = () => ActionsCheckBox.RotateTo(45, 100),
-                            UncheckedAction = () => ActionsCheckBox.RotateTo(0, 100),
-                            Labels = new Drawable[]
-                            {
-                                new SpriteText
-                                {
-                                    Padding = new MarginPadding
-                                    {
-                                        Left = 20
-                                    },
-                                    Text = @"Enabled/Disabled Actions Test"
-                                }
-                            }
-                        }
+                            LabelText = @"Enabled/Disabled Actions Test",
+                        },
                     }
                 }
             };
+        }
+    }
+
+    public class WidthTestCheckBox : BasicCheckBox
+    {
+        protected override Drawable CheckedDrawable => new Box
+        {
+            Size = new Vector2(20, 50),
+            Colour = Color4.Cyan
+        };
+    }
+
+    public class HeightTestCheckBox : BasicCheckBox
+    {
+        protected override Drawable CheckedDrawable => new Box
+        {
+            Size = new Vector2(50, 20),
+            Colour = Color4.Cyan
+        };
+    }
+
+    public class ActionsTestCheckBox : BasicCheckBox
+    {
+        protected override void OnChecked()
+        {
+            RotateTo(45, 100);
+        }
+
+        protected override void OnUnchecked()
+        {
+            RotateTo(0, 100);
         }
     }
 }

--- a/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.VisualTests.Tests
 
     public class WidthTestCheckBox : BasicCheckBox
     {
-        protected override Drawable CheckedDrawable => new Box
+        protected override Drawable CreateCheckedDrawable() => new Box
         {
             Size = new Vector2(20, 50),
             Colour = Color4.Cyan
@@ -72,7 +72,7 @@ namespace osu.Framework.VisualTests.Tests
 
     public class HeightTestCheckBox : BasicCheckBox
     {
-        protected override Drawable CheckedDrawable => new Box
+        protected override Drawable CreateCheckedDrawable() => new Box
         {
             Size = new Vector2(50, 20),
             Colour = Color4.Cyan

--- a/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
+++ b/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
@@ -62,6 +62,7 @@
       <Link>osu-framework.licenseheader</Link>
     </None>
     <None Include="packages.config" />
+    <Compile Include="Tests\TestCaseCheckBoxes.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Framework.Desktop\osu.Framework.Desktop.csproj">

--- a/osu.Framework/Graphics/UserInterface/BasicCheckBox.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicCheckBox.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Graphics.Drawables;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Graphics.UserInterface
+{
+
+    public class BasicCheckBox : CheckBox
+    {
+        protected virtual Drawable CreateCheckedDrawable() => new Box { Size = new Vector2(20, 20), Colour = Color4.Cyan, Depth = float.MinValue };
+        protected virtual Drawable CreateUncheckedDrawable() => new Box { Size = new Vector2(20, 20), Depth = float.MinValue };
+        private Drawable checkedDrawable;
+        private Drawable uncheckedDrawable;
+        private SpriteText labelSpriteText;
+        private string labelText = string.Empty;
+        public string LabelText
+        {
+            get { return labelText; }
+            set
+            {
+                labelText = value;
+                if (labelSpriteText != null)
+                    labelSpriteText.Text = labelText;
+            }
+        }
+        private MarginPadding labelPadding;
+        public MarginPadding LabelPadding
+        {
+            get { return labelPadding; }
+            set
+            {
+                labelPadding = value;
+                if (labelSpriteText != null)
+                    labelSpriteText.Padding = labelPadding;
+            }
+        }
+
+        public BasicCheckBox()
+        {
+            LabelPadding = new MarginPadding
+            {
+                Left = 20
+            };
+        }
+
+        public override void Load(BaseGame game)
+        {
+            base.Load(game);
+            checkedDrawable = CreateCheckedDrawable();
+            uncheckedDrawable = CreateUncheckedDrawable();
+
+            Children = new Drawable[]
+            {
+                uncheckedDrawable,
+                labelSpriteText = new SpriteText
+                {
+                    Padding = LabelPadding,
+                    Text = labelText
+                }
+            };
+        }
+
+        protected override void OnUnchecked()
+        {
+            Remove(checkedDrawable);
+            Add(uncheckedDrawable);
+        }
+
+        protected override void OnChecked()
+        {
+            Remove(uncheckedDrawable);
+            Add(checkedDrawable);
+        }
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/BasicCheckBox.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicCheckBox.cs
@@ -12,8 +12,8 @@ namespace osu.Framework.Graphics.UserInterface
 
     public class BasicCheckBox : CheckBox
     {
-        protected virtual Drawable CreateCheckedDrawable() => new Box { Size = new Vector2(20, 20), Colour = Color4.Cyan, Depth = float.MinValue };
-        protected virtual Drawable CreateUncheckedDrawable() => new Box { Size = new Vector2(20, 20), Depth = float.MinValue };
+        protected virtual Drawable CreateCheckedDrawable() => new Box { Size = new Vector2(20, 20), Colour = Color4.Cyan };
+        protected virtual Drawable CreateUncheckedDrawable() => new Box { Size = new Vector2(20, 20) };
         private Drawable checkedDrawable;
         private Drawable uncheckedDrawable;
         private SpriteText labelSpriteText;
@@ -46,6 +46,15 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 Left = 20
             };
+            Children = new Drawable[]
+            {
+                labelSpriteText = new SpriteText
+                {
+                    Padding = LabelPadding,
+                    Text = labelText,
+                    Depth = float.MaxValue
+                }
+            };
         }
 
         public override void Load(BaseGame game)
@@ -53,16 +62,7 @@ namespace osu.Framework.Graphics.UserInterface
             base.Load(game);
             checkedDrawable = CreateCheckedDrawable();
             uncheckedDrawable = CreateUncheckedDrawable();
-
-            Children = new Drawable[]
-            {
-                uncheckedDrawable,
-                labelSpriteText = new SpriteText
-                {
-                    Padding = LabelPadding,
-                    Text = labelText
-                }
-            };
+            Add(uncheckedDrawable);
         }
 
         protected override void OnUnchecked()

--- a/osu.Framework/Graphics/UserInterface/CheckBox.cs
+++ b/osu.Framework/Graphics/UserInterface/CheckBox.cs
@@ -5,37 +5,18 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Drawables;
 using osu.Framework.Input;
 using OpenTK.Graphics;
-using System;
 using OpenTK;
-using System.Collections.Generic;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Primitives;
 
 namespace osu.Framework.Graphics.UserInterface
 {
     public class CheckBox : FlowContainer, IStateful<CheckBoxState>
     {
 
-        public Drawable CheckedDrawable = new Box { Size = new Vector2(20, 20), Colour = Color4.Cyan };
-        public Drawable UncheckedDrawable = new Box { Size = new Vector2(20, 20) };
-        private AutoSizeContainer visualsCont;
-
-        private List<Drawable> labels = new List<Drawable>();
-        public IEnumerable<Drawable> Labels
-        {
-            get { return labels; }
-            set
-            {
-                if (IsLoaded)
-                {
-                    foreach (Drawable d in value)
-                        AddLabel(d);
-                }
-                else
-                {
-                    foreach (Drawable d in value)
-                        labels.Add(d);
-                }
-            }
-        }
+        protected virtual Drawable CheckedDrawable => new Box { Size = new Vector2(20, 20), Colour = Color4.Cyan };
+        protected virtual Drawable UncheckedDrawable => new Box { Size = new Vector2(20, 20) };
+        private AutoSizeContainer content;
 
         private CheckBoxState state = CheckBoxState.Unchecked;
         public CheckBoxState State
@@ -50,37 +31,32 @@ namespace osu.Framework.Graphics.UserInterface
                 switch (state)
                 {
                     case CheckBoxState.Checked:
-                        CheckedAction?.Invoke();
-                        visualsCont.Remove(UncheckedDrawable);
-                        visualsCont.Add(CheckedDrawable);
+                        OnChecked();
+                        content.Clear();
+                        content.Add(CheckedDrawable);
                         break;
                     case CheckBoxState.Unchecked:
-                        UncheckedAction?.Invoke();
-                        visualsCont.Remove(CheckedDrawable);
-                        visualsCont.Add(UncheckedDrawable);
+                        OnUnchecked();
+                        content.Clear();
+                        content.Add(UncheckedDrawable);
                         break;
                 }
             }
         }
-
-        public Action CheckedAction;
-        public Action UncheckedAction;
 
         public CheckBox()
         {
             Direction = FlowDirection.HorizontalOnly;
             Children = new Drawable[]
             {
-                visualsCont = new AutoSizeContainer()
+                content = new AutoSizeContainer()
             };
         }
 
         public override void Load(BaseGame game)
         {
             base.Load(game);
-            visualsCont.Add(UncheckedDrawable);
-            foreach (Drawable d in labels)
-                Add(d);
+            content.Add(UncheckedDrawable);
         }
 
         protected override bool OnClick(InputState state)
@@ -97,16 +73,12 @@ namespace osu.Framework.Graphics.UserInterface
             return true;
         }
 
-        public void AddLabel(Drawable d)
+        protected virtual void OnChecked()
         {
-            Add(d);
-            labels.Add(d);
         }
 
-        public void RemoveLabel(Drawable d)
+        protected virtual void OnUnchecked()
         {
-            Remove(d);
-            labels.Remove(d);
         }
     }
 
@@ -116,4 +88,46 @@ namespace osu.Framework.Graphics.UserInterface
         Unchecked
     }
 
+    public class BasicCheckBox : CheckBox
+    {
+        private SpriteText labelSpriteText;
+        private string labelText = string.Empty;
+        public string LabelText
+        {
+            get { return labelText; }
+            set
+            {
+                labelText = value;
+                if (labelSpriteText != null)
+                    labelSpriteText.Text = labelText;
+            }
+        }
+        private MarginPadding labelPadding;
+        public MarginPadding LabelPadding
+        {
+            get { return labelPadding; }
+            set
+            {
+                labelPadding = value;
+            }
+        }
+
+        public BasicCheckBox()
+        {
+            LabelPadding = new MarginPadding
+            {
+                Left = 20
+            };
+        }
+
+        public override void Load(BaseGame game)
+        {
+            base.Load(game);
+            Add(labelSpriteText = new SpriteText
+            {
+                Padding = LabelPadding,
+                Text = labelText
+            });
+        }
+    }
 }

--- a/osu.Framework/Graphics/UserInterface/CheckBox.cs
+++ b/osu.Framework/Graphics/UserInterface/CheckBox.cs
@@ -1,0 +1,119 @@
+﻿// Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Drawables;
+using osu.Framework.Input;
+using OpenTK.Graphics;
+using System;
+using OpenTK;
+using System.Collections.Generic;
+
+namespace osu.Framework.Graphics.UserInterface
+{
+    public class CheckBox : FlowContainer, IStateful<CheckBoxState>
+    {
+
+        public Drawable CheckedDrawable = new Box { Size = new Vector2(20, 20), Colour = Color4.Cyan };
+        public Drawable UncheckedDrawable = new Box { Size = new Vector2(20, 20) };
+        private AutoSizeContainer visualsCont;
+
+        private List<Drawable> labels = new List<Drawable>();
+        public IEnumerable<Drawable> Labels
+        {
+            get { return labels; }
+            set
+            {
+                if (IsLoaded)
+                {
+                    foreach (Drawable d in value)
+                        AddLabel(d);
+                }
+                else
+                {
+                    foreach (Drawable d in value)
+                        labels.Add(d);
+                }
+            }
+        }
+
+        private CheckBoxState state = CheckBoxState.Unchecked;
+        public CheckBoxState State
+        {
+            get { return state; }
+            set
+            {
+                if (state == value)
+                    return;
+
+                state = value;
+                switch (state)
+                {
+                    case CheckBoxState.Checked:
+                        CheckedAction?.Invoke();
+                        visualsCont.Remove(UncheckedDrawable);
+                        visualsCont.Add(CheckedDrawable);
+                        break;
+                    case CheckBoxState.Unchecked:
+                        UncheckedAction?.Invoke();
+                        visualsCont.Remove(CheckedDrawable);
+                        visualsCont.Add(UncheckedDrawable);
+                        break;
+                }
+            }
+        }
+
+        public Action CheckedAction;
+        public Action UncheckedAction;
+
+        public CheckBox()
+        {
+            Direction = FlowDirection.HorizontalOnly;
+            Children = new Drawable[]
+            {
+                visualsCont = new AutoSizeContainer()
+            };
+        }
+
+        public override void Load(BaseGame game)
+        {
+            base.Load(game);
+            visualsCont.Add(UncheckedDrawable);
+            foreach (Drawable d in labels)
+                Add(d);
+        }
+
+        protected override bool OnClick(InputState state)
+        {
+            if (State == CheckBoxState.Checked)
+            {
+                State = CheckBoxState.Unchecked;
+            }
+            else
+            {
+                State = CheckBoxState.Checked;
+            }
+            base.OnClick(state);
+            return true;
+        }
+
+        public void AddLabel(Drawable d)
+        {
+            Add(d);
+            labels.Add(d);
+        }
+
+        public void RemoveLabel(Drawable d)
+        {
+            Remove(d);
+            labels.Remove(d);
+        }
+    }
+
+    public enum CheckBoxState
+    {
+        Checked,
+        Unchecked
+    }
+
+}

--- a/osu.Framework/Graphics/UserInterface/CheckBox.cs
+++ b/osu.Framework/Graphics/UserInterface/CheckBox.cs
@@ -2,12 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Drawables;
 using osu.Framework.Input;
-using OpenTK.Graphics;
-using OpenTK;
-using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Primitives;
 
 namespace osu.Framework.Graphics.UserInterface
 {
@@ -42,93 +37,19 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnClick(InputState state)
         {
-            if (State == CheckBoxState.Checked)
-            {
-                State = CheckBoxState.Unchecked;
-            }
-            else
-            {
-                State = CheckBoxState.Checked;
-            }
+            State = State == CheckBoxState.Checked ? CheckBoxState.Unchecked : CheckBoxState.Checked;
             base.OnClick(state);
             return true;
         }
 
-        protected virtual void OnChecked()
-        {
-        }
+        protected abstract void OnChecked();
 
-        protected virtual void OnUnchecked()
-        {
-        }
+        protected abstract void OnUnchecked();
     }
 
     public enum CheckBoxState
     {
         Checked,
         Unchecked
-    }
-
-    public class BasicCheckBox : CheckBox
-    {
-        protected virtual Drawable CheckedDrawable => new Box { Size = new Vector2(20, 20), Colour = Color4.Cyan };
-        protected virtual Drawable UncheckedDrawable => new Box { Size = new Vector2(20, 20) };
-        private AutoSizeContainer content;
-        private SpriteText labelSpriteText;
-        private string labelText = string.Empty;
-        public string LabelText
-        {
-            get { return labelText; }
-            set
-            {
-                labelText = value;
-                if (labelSpriteText != null)
-                    labelSpriteText.Text = labelText;
-            }
-        }
-        private MarginPadding labelPadding;
-        public MarginPadding LabelPadding
-        {
-            get { return labelPadding; }
-            set
-            {
-                labelPadding = value;
-            }
-        }
-
-        public BasicCheckBox()
-        {
-            LabelPadding = new MarginPadding
-            {
-                Left = 20
-            };
-            Children = new Drawable[]
-            {
-                content = new AutoSizeContainer()
-            };
-        }
-
-        public override void Load(BaseGame game)
-        {
-            base.Load(game);
-            content.Add(UncheckedDrawable);
-            Add(labelSpriteText = new SpriteText
-            {
-                Padding = LabelPadding,
-                Text = labelText
-            });
-        }
-
-        protected override void OnUnchecked()
-        {
-            content.Clear();
-            content.Add(UncheckedDrawable);
-        }
-
-        protected override void OnChecked()
-        {
-            content.Clear();
-            content.Add(CheckedDrawable);
-        }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/CheckBox.cs
+++ b/osu.Framework/Graphics/UserInterface/CheckBox.cs
@@ -11,13 +11,8 @@ using osu.Framework.Graphics.Primitives;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    public class CheckBox : FlowContainer, IStateful<CheckBoxState>
+    public abstract class CheckBox : FlowContainer, IStateful<CheckBoxState>
     {
-
-        protected virtual Drawable CheckedDrawable => new Box { Size = new Vector2(20, 20), Colour = Color4.Cyan };
-        protected virtual Drawable UncheckedDrawable => new Box { Size = new Vector2(20, 20) };
-        private AutoSizeContainer content;
-
         private CheckBoxState state = CheckBoxState.Unchecked;
         public CheckBoxState State
         {
@@ -32,13 +27,9 @@ namespace osu.Framework.Graphics.UserInterface
                 {
                     case CheckBoxState.Checked:
                         OnChecked();
-                        content.Clear();
-                        content.Add(CheckedDrawable);
                         break;
                     case CheckBoxState.Unchecked:
                         OnUnchecked();
-                        content.Clear();
-                        content.Add(UncheckedDrawable);
                         break;
                 }
             }
@@ -47,16 +38,6 @@ namespace osu.Framework.Graphics.UserInterface
         public CheckBox()
         {
             Direction = FlowDirection.HorizontalOnly;
-            Children = new Drawable[]
-            {
-                content = new AutoSizeContainer()
-            };
-        }
-
-        public override void Load(BaseGame game)
-        {
-            base.Load(game);
-            content.Add(UncheckedDrawable);
         }
 
         protected override bool OnClick(InputState state)
@@ -90,6 +71,9 @@ namespace osu.Framework.Graphics.UserInterface
 
     public class BasicCheckBox : CheckBox
     {
+        protected virtual Drawable CheckedDrawable => new Box { Size = new Vector2(20, 20), Colour = Color4.Cyan };
+        protected virtual Drawable UncheckedDrawable => new Box { Size = new Vector2(20, 20) };
+        private AutoSizeContainer content;
         private SpriteText labelSpriteText;
         private string labelText = string.Empty;
         public string LabelText
@@ -118,16 +102,33 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 Left = 20
             };
+            Children = new Drawable[]
+            {
+                content = new AutoSizeContainer()
+            };
         }
 
         public override void Load(BaseGame game)
         {
             base.Load(game);
+            content.Add(UncheckedDrawable);
             Add(labelSpriteText = new SpriteText
             {
                 Padding = LabelPadding,
                 Text = labelText
             });
+        }
+
+        protected override void OnUnchecked()
+        {
+            content.Clear();
+            content.Add(UncheckedDrawable);
+        }
+
+        protected override void OnChecked()
+        {
+            content.Clear();
+            content.Add(CheckedDrawable);
         }
     }
 }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -263,6 +263,7 @@
     <Compile Include="Platform\IpcChannel.cs" />
     <Compile Include="Platform\IpcMessage.cs" />
     <Compile Include="Graphics\UserInterface\CheckBox.cs" />
+    <Compile Include="Graphics\UserInterface\BasicCheckBox.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\osu-framework.licenseheader">

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -262,6 +262,7 @@
     <Compile Include="Platform\BasicStorage.cs" />
     <Compile Include="Platform\IpcChannel.cs" />
     <Compile Include="Platform\IpcMessage.cs" />
+    <Compile Include="Graphics\UserInterface\CheckBox.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\osu-framework.licenseheader">


### PR DESCRIPTION
![CheckBoxes](http://i.imgur.com/seweJpB.gif)

The feature that kickstarted the movement of ```Padding``` to ```Container``` and helped Peppy and me discover ```FlowContainer```s were applying their ```Spacing``` to the edges when they shouldn't.

A Simple abstract container with two ```CheckBoxState```s, ```CheckBoxState.Unchecked``` and ```CheckBoxState.Checked```, has two overridable methods ```OnChecked()``` and ```OnUnchecked()```

Provides one Subclass: ```BasicCheckBox```, this brings a basic UI featuring a White/Cyan Box based on state, and one clickable label with properties to alter that label's text and padding