### PR TITLE
Fix unapplied transforms with no delay and duration = 0

### DIFF
--- a/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
+++ b/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
@@ -199,7 +199,7 @@ namespace osu.Framework.Graphics
             transform.EndValue = newValue;
             transform.Easing = easing;
 
-            if (duration == 0)
+            if (duration == 0 && transformationDelay == 0)
                 transform.Apply(this);
             else
                 Transforms.Add(transform);
@@ -258,7 +258,7 @@ namespace osu.Framework.Graphics
             transform.EndValue = newValue;
             transform.Easing = easing;
 
-            if (duration == 0)
+            if (duration == 0 && transformationDelay == 0)
                 transform.Apply(this);
             else
                 Transforms.Add(transform);


### PR DESCRIPTION
Before this, inmediate transformations with delay (e.g. `drawable.Delay(duration); drawable.FadeOut();`) wouldn't be applied.