### PR TITLE
Add border feature to masking containers.

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
@@ -24,8 +24,6 @@ namespace osu.Framework.VisualTests.Tests
         {
             base.Reset();
 
-            AddToggle(@"debug autosize", reloadCallback);
-
             Add(testContainer = new Container()
             {
                 RelativeSizeAxes = Axes.Both,
@@ -72,22 +70,13 @@ namespace osu.Framework.VisualTests.Tests
             });
         }
 
-        private void reloadCallback()
-        {
-            loadTest(currentTest);
-        }
-
-        private int currentTest;
-
         private void loadTest(int testType)
         {
-            currentTest = testType;
-
             testContainer.Clear();
 
             Container box;
 
-            switch (currentTest)
+            switch (testType)
             {
                 case 1:
                     testContainer.Add(box = new InfofulBoxAutoSize

--- a/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
@@ -33,6 +33,7 @@ namespace osu.Framework.VisualTests.Tests
             {
                 @"Round corner masking",
                 @"Edge/border blurriness",
+                @"Nested masking",
             };
 
             for (int i = 0; i < testNames.Length; i++)
@@ -206,6 +207,39 @@ namespace osu.Framework.VisualTests.Tests
                             }
                         });
 
+                        break;
+                    }
+
+                case 2:
+                    {
+                        testContainer.Add(new Container
+                        {
+                            Masking = true,
+                            Size = new Vector2(0.5f),
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new[]
+                            {
+                                new Container
+                                {
+                                    Masking = true,
+                                    CornerRadius = 100f,
+                                    BorderThickness = 50f,
+                                    BorderColour = Color4.Red,
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(1.5f),
+                                    Anchor = Anchor.BottomRight,
+                                    Origin = Anchor.Centre,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = Color4.White,
+                                        },
+                                    }
+                                }
+                            }
+                        });
                         break;
                     }
             }

--- a/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
@@ -1,0 +1,259 @@
+﻿// Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Transformations;
+using osu.Framework.Input;
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.GameModes.Testing;
+
+namespace osu.Framework.VisualTests.Tests
+{
+    class TestCaseMasking : TestCase
+    {
+        public override string Name => @"Masking";
+        public override string Description => @"Various scenarios which potentially challenge masking calculations.";
+
+        private Container testContainer;
+
+        public override void Reset()
+        {
+            base.Reset();
+
+            Add(testContainer = new Container()
+            {
+                RelativeSizeAxes = Axes.Both,
+            });
+
+            string[] testNames = new[]
+            {
+                @"Round corner masking",
+                @"Edge/border blurriness",
+            };
+
+            for (int i = 0; i < testNames.Length; i++)
+            {
+                int test = i;
+                AddButton(testNames[i], delegate { loadTest(test); });
+            }
+
+            loadTest(0);
+        }
+
+        private void loadTest(int testType)
+        {
+            testContainer.Clear();
+
+            switch (testType)
+            {
+                default:
+                case 0:
+                    {
+                        Container box;
+                        testContainer.Add(box = new InfofulBoxAutoSize
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Masking = true,
+                            CornerRadius = 100,
+                        });
+
+                        addCornerMarkers(box);
+
+                        box.Add(new InfofulBox(RectangleF.Empty, 0, Color4.Blue)
+                        {
+                            Position = new Vector2(0, 0),
+                            Size = new Vector2(25, 25),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre
+                        });
+
+                        box.Add(box = new InfofulBox(RectangleF.Empty, 0, Color4.DarkSeaGreen)
+                        {
+                            Size = new Vector2(250, 250),
+                            Alpha = 0.5f,
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre
+                        });
+
+                        box.OnUpdate += delegate { box.Rotation += 0.05f; };
+                        break;
+                    }
+
+                case 1:
+                    {
+                        testContainer.Add(new FlowContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new[]
+                            {
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.5f),
+                                    Masking = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new Container
+                                        {
+                                            Masking = true,
+                                            CornerRadius = 0.25f,
+                                            BorderThickness = 0.125f,
+                                            BorderColour = Color4.Red,
+                                            Size = new Vector2(2),
+                                            Scale = new Vector2(100),
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new Drawable[]
+                                            {
+                                                new Box
+                                                {
+                                                    RelativeSizeAxes = Axes.Both,
+                                                    Colour = Color4.White,
+                                                },
+                                            }
+                                        }
+                                    }
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.5f),
+                                    Masking = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new Container
+                                        {
+                                            Masking = true,
+                                            CornerRadius = 2.5f,
+                                            BorderThickness = 1.25f,
+                                            BorderColour = Color4.Red,
+                                            Size = new Vector2(20),
+                                            Scale = new Vector2(10),
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new Drawable[]
+                                            {
+                                                new Box
+                                                {
+                                                    RelativeSizeAxes = Axes.Both,
+                                                    Colour = Color4.White,
+                                                },
+                                            }
+                                        }
+                                    }
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.5f),
+                                    Masking = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new Container
+                                        {
+                                            Masking = true,
+                                            CornerRadius = 25,
+                                            BorderThickness = 12.5f,
+                                            BorderColour = Color4.Red,
+                                            Size = new Vector2(200),
+                                            Scale = new Vector2(1),
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new Drawable[]
+                                            {
+                                                new Box
+                                                {
+                                                    RelativeSizeAxes = Axes.Both,
+                                                    Colour = Color4.White,
+                                                },
+                                            }
+                                        }
+                                    }
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.5f),
+                                    Masking = true,
+                                    Children = new Drawable[]
+                                    {
+                                        new Container
+                                        {
+                                            Masking = true,
+                                            CornerRadius = 250,
+                                            BorderThickness = 125,
+                                            BorderColour = Color4.Red,
+                                            Size = new Vector2(2000),
+                                            Scale = new Vector2(0.1f),
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new Drawable[]
+                                            {
+                                                new Box
+                                                {
+                                                    RelativeSizeAxes = Axes.Both,
+                                                    Colour = Color4.White,
+                                                },
+                                            }
+                                        }
+                                    }
+                                },
+                            }
+                        });
+
+                        break;
+                    }
+            }
+
+#if DEBUG
+            //if (toggleDebugAutosize.State)
+            //    testContainer.Children.FindAll(c => c.HasAutosizeChildren).ForEach(c => c.AutoSizeDebug = true);
+#endif
+        }
+
+        private void addCornerMarkers(Container box, int size = 50, Color4? colour = null)
+        {
+            box.Add(new InfofulBox(RectangleF.Empty, 2, colour ?? Color4.Red)
+            {
+                //chameleon = true,
+                Size = new Vector2(size, size),
+                Origin = Anchor.TopLeft,
+                Anchor = Anchor.TopLeft,
+                AllowDrag = false
+            });
+
+            box.Add(new InfofulBox(RectangleF.Empty, 2, colour ?? Color4.Red)
+            {
+                //chameleon = true,
+                Size = new Vector2(size, size),
+                Origin = Anchor.TopRight,
+                Anchor = Anchor.TopRight,
+                AllowDrag = false
+            });
+
+            box.Add(new InfofulBox(RectangleF.Empty, 2, colour ?? Color4.Red)
+            {
+                //chameleon = true,
+                Size = new Vector2(size, size),
+                Origin = Anchor.BottomLeft,
+                Anchor = Anchor.BottomLeft,
+                AllowDrag = false
+            });
+
+            box.Add(new InfofulBox(RectangleF.Empty, 2, colour ?? Color4.Red)
+            {
+                //chameleon = true,
+                Size = new Vector2(size, size),
+                Origin = Anchor.BottomRight,
+                Anchor = Anchor.BottomRight,
+                AllowDrag = false
+            });
+        }
+    }
+
+}

--- a/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
@@ -10,6 +10,7 @@ using osu.Framework.Input;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.GameModes.Testing;
+using System;
 
 namespace osu.Framework.VisualTests.Tests
 {
@@ -87,6 +88,40 @@ namespace osu.Framework.VisualTests.Tests
 
                 case 1:
                     {
+                        Func<float, Drawable> createMaskingBox = delegate(float scale)
+                        {
+                            float size = 200 / scale;
+                            return new Container
+                            {
+                                Masking = true,
+                                CornerRadius = 25 / scale,
+                                BorderThickness = 12.5f / scale,
+                                BorderColour = Color4.Red,
+                                Size = new Vector2(size),
+                                Scale = new Vector2(scale),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Children = new Drawable[]
+                                {
+                                    new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = Color4.White,
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                    },
+                                    new SpriteText
+                                    {
+                                        Text = @"Size: " + size + ", Scale: " + scale,
+                                        TextSize = 20 / scale,
+                                        Colour = Color4.Blue,
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                    },
+                                }
+                            };
+                        };
+
                         testContainer.Add(new FlowContainer
                         {
                             RelativeSizeAxes = Axes.Both,
@@ -97,112 +132,28 @@ namespace osu.Framework.VisualTests.Tests
                                     RelativeSizeAxes = Axes.Both,
                                     Size = new Vector2(0.5f),
                                     Masking = true,
-                                    Children = new Drawable[]
-                                    {
-                                        new Container
-                                        {
-                                            Masking = true,
-                                            CornerRadius = 0.25f,
-                                            BorderThickness = 0.125f,
-                                            BorderColour = Color4.Red,
-                                            Size = new Vector2(2),
-                                            Scale = new Vector2(100),
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Children = new Drawable[]
-                                            {
-                                                new Box
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = Color4.White,
-                                                },
-                                            }
-                                        }
-                                    }
+                                    Children = new Drawable[] { createMaskingBox(100) }
                                 },
                                 new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                     Size = new Vector2(0.5f),
                                     Masking = true,
-                                    Children = new Drawable[]
-                                    {
-                                        new Container
-                                        {
-                                            Masking = true,
-                                            CornerRadius = 2.5f,
-                                            BorderThickness = 1.25f,
-                                            BorderColour = Color4.Red,
-                                            Size = new Vector2(20),
-                                            Scale = new Vector2(10),
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Children = new Drawable[]
-                                            {
-                                                new Box
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = Color4.White,
-                                                },
-                                            }
-                                        }
-                                    }
+                                    Children = new Drawable[] { createMaskingBox(10) }
                                 },
                                 new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                     Size = new Vector2(0.5f),
                                     Masking = true,
-                                    Children = new Drawable[]
-                                    {
-                                        new Container
-                                        {
-                                            Masking = true,
-                                            CornerRadius = 25,
-                                            BorderThickness = 12.5f,
-                                            BorderColour = Color4.Red,
-                                            Size = new Vector2(200),
-                                            Scale = new Vector2(1),
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Children = new Drawable[]
-                                            {
-                                                new Box
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = Color4.White,
-                                                },
-                                            }
-                                        }
-                                    }
+                                    Children = new Drawable[] { createMaskingBox(1) }
                                 },
                                 new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                     Size = new Vector2(0.5f),
                                     Masking = true,
-                                    Children = new Drawable[]
-                                    {
-                                        new Container
-                                        {
-                                            Masking = true,
-                                            CornerRadius = 250,
-                                            BorderThickness = 125,
-                                            BorderColour = Color4.Red,
-                                            Size = new Vector2(2000),
-                                            Scale = new Vector2(0.1f),
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Children = new Drawable[]
-                                            {
-                                                new Box
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = Color4.White,
-                                                },
-                                            }
-                                        }
-                                    }
+                                    Children = new Drawable[] { createMaskingBox(0.1f) }
                                 },
                             }
                         });

--- a/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
+++ b/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tests\TestCaseAutosize.cs" />
     <Compile Include="Tests\TestCaseGameMode.cs" />
+    <Compile Include="Tests\TestCaseMasking.cs" />
     <Compile Include="Tests\TestCaseOnlineTextures.cs" />
     <Compile Include="Tests\TestCasePadding.cs" />
     <Compile Include="Tests\TestCaseSpriteText.cs" />

--- a/osu.Framework/GameModes/Testing/TestCase.cs
+++ b/osu.Framework/GameModes/Testing/TestCase.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.GameModes.Testing
             buttonsContainer.Add(b = new Button
             {
                 Colour = Color4.LightBlue,
-                Size = new Vector2(100, 50),
+                Size = new Vector2(150, 50),
                 Text = text
             });
 

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using OpenTK;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.OpenGL;
+using OpenTK.Graphics;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -26,6 +27,22 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public virtual float CornerRadius { get { return cornerRadius; } set { cornerRadius = value; } }
 
+        private float borderThickness = 0.0f;
+
+        /// <summary>
+        /// Only has an effect when Masking == true.
+        /// Determines how thick of a border to draw around masked children.
+        /// </summary>
+        public virtual float BorderThickness { get { return borderThickness; } set { borderThickness = value; } }
+
+        private Color4 borderColour = Color4.Black;
+
+        /// <summary>
+        /// Only has an effect when Masking == true.
+        /// Determines the color of the drawn border.
+        /// </summary>
+        public virtual Color4 BorderColour { get { return borderColour; } set { borderColour = value; } }
+
         protected override DrawNode CreateDrawNode() => new ContainerDrawNode();
 
         protected override void ApplyDrawNode(DrawNode node)
@@ -38,6 +55,8 @@ namespace osu.Framework.Graphics.Containers
                 MaskingRect = DrawRectangle,
                 ToMaskingSpace = DrawInfo.MatrixInverse,
                 CornerRadius = this.CornerRadius,
+                BorderThickness = this.BorderThickness,
+                BorderColour = this.BorderColour,
             };
 
             base.ApplyDrawNode(node);

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void onScrollbarMovement(float value)
         {
-            offset(value / scrollbar.Scale.Y, true, false);
+            offset(value / scrollbar.InternalSize.Y, true, false);
         }
 
         private void offset(float value, bool clamp = true, bool animated = true)
@@ -141,14 +141,14 @@ namespace osu.Framework.Graphics.Containers
 
         private void updateSize()
         {
-            scrollbar?.ScaleTo(new Vector2(1, Math.Min(1, displayableContent / availableContent)), 200, EasingTypes.OutExpo);
+            scrollbar?.ResizeTo(new Vector2(10, Math.Min(1, displayableContent / availableContent)), 200, EasingTypes.OutExpo);
         }
 
         private void updateScroll(bool animated = true)
         {
             float adjusted = (current + currentClamped) / 2;
 
-            scrollbar?.MoveToY(adjusted * scrollbar.Scale.Y, animated ? 800 : 0, EasingTypes.OutExpo);
+            scrollbar?.MoveToY(adjusted * scrollbar.InternalSize.Y, animated ? 800 : 0, EasingTypes.OutExpo);
             content.MoveToY(-adjusted, animated ? 800 : 0, EasingTypes.OutExpo);
         }
 
@@ -175,6 +175,8 @@ namespace osu.Framework.Graphics.Containers
                 RelativeSizeAxes = Axes.Y;
                 Size = new Vector2(10, 1);
                 Colour = defaultColour;
+                CornerRadius = 5;
+                Masking = true;
             }
 
             protected override bool OnHover(InputState state)

--- a/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
+++ b/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
@@ -273,14 +273,15 @@ namespace osu.Framework.Graphics
 
         public Drawable ScaleTo(float newScale, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            updateTransformsOfType(typeof(TransformScaleVector));
-            return transformVectorTo(Scale, new Vector2(newScale), duration, easing, new TransformScaleVector(Clock));
+            updateTransformsOfType(typeof(TransformScale));
+            return transformVectorTo(Scale, new Vector2(newScale), duration, easing, new TransformScale(Clock));
         }
 
         public Drawable ScaleTo(Vector2 newScale, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            updateTransformsOfType(typeof(TransformScaleVector));
-            return transformVectorTo(Scale, newScale, duration, easing, new TransformScaleVector(Clock));
+            updateTransformsOfType(typeof(TransformScale));
+            return transformVectorTo(Scale, newScale, duration, easing, new TransformScale(Clock));
+        }
         }
 
         public Drawable MoveTo(Vector2 newPosition, double duration = 0, EasingTypes easing = EasingTypes.None)

--- a/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
+++ b/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
@@ -282,6 +282,17 @@ namespace osu.Framework.Graphics
             updateTransformsOfType(typeof(TransformScale));
             return transformVectorTo(Scale, newScale, duration, easing, new TransformScale(Clock));
         }
+
+        public Drawable ResizeTo(float newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            updateTransformsOfType(typeof(TransformSize));
+            return transformVectorTo(InternalSize, new Vector2(newSize), duration, easing, new TransformSize(Clock));
+        }
+
+        public Drawable ResizeTo(Vector2 newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            updateTransformsOfType(typeof(TransformSize));
+            return transformVectorTo(InternalSize, newSize, duration, easing, new TransformSize(Clock));
         }
 
         public Drawable MoveTo(Vector2 newPosition, double duration = 0, EasingTypes easing = EasingTypes.None)

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -286,6 +286,13 @@ namespace osu.Framework.Graphics.OpenGL
             Shader.SetGlobalProperty(@"g_ToMaskingSpace", maskingInfo.ToMaskingSpace);
             Shader.SetGlobalProperty(@"g_CornerRadius", maskingInfo.CornerRadius);
 
+            Shader.SetGlobalProperty(@"g_BorderThickness", maskingInfo.BorderThickness);
+            Shader.SetGlobalProperty(@"g_BorderColour", new Vector4(
+                maskingInfo.BorderColour.R,
+                maskingInfo.BorderColour.G,
+                maskingInfo.BorderColour.B,
+                maskingInfo.BorderColour.A));
+
             Rectangle actualRect = maskingInfo.ScreenSpaceAABB;
             actualRect.X += Viewport.X;
             actualRect.Y += Viewport.Y;
@@ -432,13 +439,18 @@ namespace osu.Framework.Graphics.OpenGL
         public Matrix3 ToMaskingSpace;
         public float CornerRadius;
 
+        public float BorderThickness;
+        public Color4 BorderColour;
+
         public bool Equals(MaskingInfo other)
         {
             return
                 ScreenSpaceAABB.Equals(other.ScreenSpaceAABB) &&
                 MaskingRect.Equals(other.MaskingRect) &&
                 ToMaskingSpace.Equals(other.ToMaskingSpace) &&
-                CornerRadius == other.CornerRadius;
+                CornerRadius == other.CornerRadius &&
+                BorderThickness == other.BorderThickness &&
+                BorderColour.Equals(other.BorderColour);
         }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -273,9 +273,9 @@ namespace osu.Framework.Graphics.OpenGL
         }
 
         private static Stack<MaskingInfo> maskingStack = new Stack<MaskingInfo>();
+        private static Rectangle currentScissorRect;
 
-
-        private static void setMaskingInfo(MaskingInfo maskingInfo)
+        private static void setMaskingQuad(MaskingInfo maskingInfo, bool overwritePreviousScissor)
         {
             Shader.SetGlobalProperty(@"g_MaskingRect", new Vector4(
                 maskingInfo.MaskingRect.Left,
@@ -313,7 +313,11 @@ namespace osu.Framework.Graphics.OpenGL
                 actualRect.Height = -actualRect.Height;
             }
 
-            GL.Scissor(actualRect.X, Viewport.Height - actualRect.Bottom, actualRect.Width, actualRect.Height);
+            if (overwritePreviousScissor)
+                currentScissorRect = actualRect;
+            else
+                currentScissorRect.Intersect(actualRect);
+            GL.Scissor(currentScissorRect.X, Viewport.Height - currentScissorRect.Bottom, currentScissorRect.Width, currentScissorRect.Height);
         }
 
         /// <summary>
@@ -327,7 +331,7 @@ namespace osu.Framework.Graphics.OpenGL
                 return;
 
             CurrentMaskingInfo = maskingInfo;
-            setMaskingInfo(CurrentMaskingInfo);
+            setMaskingQuad(CurrentMaskingInfo, false);
         }
 
         /// <summary>
@@ -344,7 +348,7 @@ namespace osu.Framework.Graphics.OpenGL
                 return;
 
             CurrentMaskingInfo = maskingInfo;
-            setMaskingInfo(CurrentMaskingInfo);
+            setMaskingQuad(CurrentMaskingInfo, true);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -293,6 +293,9 @@ namespace osu.Framework.Graphics.OpenGL
                 maskingInfo.BorderColour.B,
                 maskingInfo.BorderColour.A));
 
+            Vector3 scale = maskingInfo.ToMaskingSpace.ExtractScale();
+            Shader.SetGlobalProperty(@"g_PixelScale", (scale.X + scale.Y) / 2);
+
             Rectangle actualRect = maskingInfo.ScreenSpaceAABB;
             actualRect.X += Viewport.X;
             actualRect.Y += Viewport.Y;

--- a/osu.Framework/Graphics/Transformations/TransformScale.cs
+++ b/osu.Framework/Graphics/Transformations/TransformScale.cs
@@ -5,7 +5,7 @@ using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.Transformations
 {
-    public class TransformScaleVector : TransformVector
+    public class TransformScale : TransformVector
     {
         public override void Apply(Drawable d)
         {
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.Transformations
             d.Scale = CurrentValue;
         }
 
-        public TransformScaleVector(IClock clock)
+        public TransformScale(IClock clock)
             : base(clock)
         {
         }

--- a/osu.Framework/Graphics/Transformations/TransformSize.cs
+++ b/osu.Framework/Graphics/Transformations/TransformSize.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Timing;
+
+namespace osu.Framework.Graphics.Transformations
+{
+    public class TransformSize : TransformVector
+    {
+        public override void Apply(Drawable d)
+        {
+            base.Apply(d);
+            d.Size = CurrentValue;
+        }
+
+        public TransformSize(IClock clock)
+            : base(clock)
+        {
+        }
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/Button.cs
+++ b/osu.Framework/Graphics/UserInterface/Button.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 Text = text,
                 Origin = Anchor.Centre,
-                Anchor = Anchor.Centre
+                Anchor = Anchor.Centre,
             });
         }
 

--- a/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
@@ -39,7 +39,7 @@ void main(void)
     float dist = distanceFromRoundedRect();
 
     // This correction is needed to avoid fading of the alpha value for radii below 1px.
-    float radiusCorrection = max(0.0, g_PixelScale - g_CornerRadius);
+    float radiusCorrection = g_CornerRadius <= 0.0 ? 1.0 : max(0.0, g_PixelScale - g_CornerRadius);
     float fadeStart = g_CornerRadius + radiusCorrection;
     float alphaFactor = min((fadeStart - dist) / g_PixelScale, 1.0);
     if (alphaFactor <= 0.0)

--- a/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
@@ -15,42 +15,42 @@ uniform vec4 g_BorderColour;
 
 float distanceFromRoundedRect()
 {
-	// Compute offset distance from masking rect in masking space.
+    // Compute offset distance from masking rect in masking space.
     vec2 topLeftOffset = g_MaskingRect.xy - v_MaskingPosition;
     vec2 bottomRightOffset = v_MaskingPosition - g_MaskingRect.zw;
 
     vec2 distanceFromShrunkRect = max(bottomRightOffset + vec2(g_CornerRadius), topLeftOffset + vec2(g_CornerRadius));
-	float maxDist = max(distanceFromShrunkRect.x, distanceFromShrunkRect.y);
+    float maxDist = max(distanceFromShrunkRect.x, distanceFromShrunkRect.y);
 
-	if (maxDist <= 0.0)
-		return maxDist;
-	else
-		return length(max(vec2(0.0), distanceFromShrunkRect));
+    if (maxDist <= 0.0)
+        return maxDist;
+    else
+        return length(max(vec2(0.0), distanceFromShrunkRect));
 }
 
 void main(void)
 {
     float dist = distanceFromRoundedRect();
 
-	// This correction is needed to avoid fading of the alpha value for radii below 1px.
+    // This correction is needed to avoid fading of the alpha value for radii below 1px.
     float radiusCorrection = max(0.0, 1.0 - g_CornerRadius);
-	float fadeStart = g_CornerRadius + radiusCorrection;
-	float alphaFactor = min(fadeStart - dist, 1.0);
-	if (alphaFactor <= 0.0)
-	{
-		gl_FragColor = vec4(0.0);
-		return;
-	}
+    float fadeStart = g_CornerRadius + radiusCorrection;
+    float alphaFactor = min(fadeStart - dist, 1.0);
+    if (alphaFactor <= 0.0)
+    {
+        gl_FragColor = vec4(0.0);
+        return;
+    }
 
-	float borderStart = fadeStart - g_BorderThickness + 1.0;
-	float colourWeight = min(borderStart - dist, 1.0);
-	if (colourWeight <= 0.0)
-	{
-		gl_FragColor = vec4(g_BorderColour.r, g_BorderColour.g, g_BorderColour.b, g_BorderColour.a * alphaFactor);
-		return;
-	}
+    float borderStart = fadeStart - g_BorderThickness + 1.0;
+    float colourWeight = min(borderStart - dist, 1.0);
+    if (colourWeight <= 0.0)
+    {
+        gl_FragColor = vec4(g_BorderColour.r, g_BorderColour.g, g_BorderColour.b, g_BorderColour.a * alphaFactor);
+        return;
+    }
 
     gl_FragColor =
-		colourWeight * vec4(v_Colour.r, v_Colour.g, v_Colour.b, v_Colour.a * alphaFactor) * texture2D(m_Sampler, v_TexCoord, -0.9) +
-		(1.0 - colourWeight) * g_BorderColour;
+        colourWeight * vec4(v_Colour.r, v_Colour.g, v_Colour.b, v_Colour.a * alphaFactor) * texture2D(m_Sampler, v_TexCoord, -0.9) +
+        (1.0 - colourWeight) * g_BorderColour;
 }

--- a/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
@@ -12,6 +12,7 @@ uniform vec4 g_MaskingRect;
 uniform float g_BorderThickness;
 uniform vec4 g_BorderColour;
 
+uniform float g_PixelScale;
 
 float distanceFromRoundedRect()
 {
@@ -19,11 +20,16 @@ float distanceFromRoundedRect()
     vec2 topLeftOffset = g_MaskingRect.xy - v_MaskingPosition;
     vec2 bottomRightOffset = v_MaskingPosition - g_MaskingRect.zw;
 
-    vec2 distanceFromShrunkRect = max(bottomRightOffset + vec2(g_CornerRadius), topLeftOffset + vec2(g_CornerRadius));
+    vec2 distanceFromShrunkRect = max(
+        bottomRightOffset + vec2(g_CornerRadius),
+        topLeftOffset + vec2(g_CornerRadius));
+
     float maxDist = max(distanceFromShrunkRect.x, distanceFromShrunkRect.y);
 
+    // Inside the shrunk rectangle
     if (maxDist <= 0.0)
         return maxDist;
+    // Outside of the shrunk rectangle
     else
         return length(max(vec2(0.0), distanceFromShrunkRect));
 }
@@ -33,24 +39,24 @@ void main(void)
     float dist = distanceFromRoundedRect();
 
     // This correction is needed to avoid fading of the alpha value for radii below 1px.
-    float radiusCorrection = max(0.0, 1.0 - g_CornerRadius);
+    float radiusCorrection = max(0.0, g_PixelScale - g_CornerRadius);
     float fadeStart = g_CornerRadius + radiusCorrection;
-    float alphaFactor = min(fadeStart - dist, 1.0);
+    float alphaFactor = min((fadeStart - dist) / g_PixelScale, 1.0);
     if (alphaFactor <= 0.0)
     {
         gl_FragColor = vec4(0.0);
         return;
     }
 
-    float borderStart = fadeStart - g_BorderThickness + 1.0;
-    float colourWeight = min(borderStart - dist, 1.0);
+    float borderStart = fadeStart - g_BorderThickness + g_PixelScale;
+    float colourWeight = min((borderStart - dist) / g_PixelScale, 1.0);
     if (colourWeight <= 0.0)
     {
-        gl_FragColor = vec4(g_BorderColour.r, g_BorderColour.g, g_BorderColour.b, g_BorderColour.a * alphaFactor);
+        gl_FragColor = vec4(g_BorderColour.rgb, g_BorderColour.a * alphaFactor);
         return;
     }
 
     gl_FragColor =
-        colourWeight * vec4(v_Colour.r, v_Colour.g, v_Colour.b, v_Colour.a * alphaFactor) * texture2D(m_Sampler, v_TexCoord, -0.9) +
+        colourWeight * vec4(v_Colour.rgb, v_Colour.a * alphaFactor) * texture2D(m_Sampler, v_TexCoord, -0.9) +
         (1.0 - colourWeight) * g_BorderColour;
 }

--- a/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
@@ -7,32 +7,50 @@ varying vec4 v_Colour;
 varying vec2 v_TexCoord;
 
 uniform sampler2D m_Sampler;
-
 uniform float g_CornerRadius;
-
 uniform vec4 g_MaskingRect;
+uniform float g_BorderThickness;
+uniform vec4 g_BorderColour;
 
-vec2 max3(vec2 a, vec2 b, vec2 c)
-{
-    return max(max(a, b), c);
-}
 
 float distanceFromRoundedRect()
 {
 	// Compute offset distance from masking rect in masking space.
     vec2 topLeftOffset = g_MaskingRect.xy - v_MaskingPosition;
     vec2 bottomRightOffset = v_MaskingPosition - g_MaskingRect.zw;
-    vec2 distanceFromShrunkRect = max3(vec2(0.0), bottomRightOffset + vec2(g_CornerRadius), topLeftOffset + vec2(g_CornerRadius));
-    return length(distanceFromShrunkRect);
+
+    vec2 distanceFromShrunkRect = max(bottomRightOffset + vec2(g_CornerRadius), topLeftOffset + vec2(g_CornerRadius));
+	float maxDist = max(distanceFromShrunkRect.x, distanceFromShrunkRect.y);
+
+	if (maxDist <= 0.0)
+		return maxDist;
+	else
+		return length(max(vec2(0.0), distanceFromShrunkRect));
 }
 
 void main(void)
 {
-    float dist = g_CornerRadius == 0.0 ? 0.0 : distanceFromRoundedRect();
-    gl_FragColor = v_Colour * texture2D(m_Sampler, v_TexCoord, -0.9);
+    float dist = distanceFromRoundedRect();
 
-    // This correction is needed to avoid fading of the alpha value for radii below 1px.
+	// This correction is needed to avoid fading of the alpha value for radii below 1px.
     float radiusCorrection = max(0.0, 1.0 - g_CornerRadius);
-    if (dist > g_CornerRadius - 1.0 + radiusCorrection)
-        gl_FragColor.a *= max(0.0, g_CornerRadius - dist + radiusCorrection);
+	float fadeStart = g_CornerRadius + radiusCorrection;
+	float alphaFactor = min(fadeStart - dist, 1.0);
+	if (alphaFactor <= 0.0)
+	{
+		gl_FragColor = vec4(0.0);
+		return;
+	}
+
+	float borderStart = fadeStart - g_BorderThickness + 1.0;
+	float colourWeight = min(borderStart - dist, 1.0);
+	if (colourWeight <= 0.0)
+	{
+		gl_FragColor = vec4(g_BorderColour.r, g_BorderColour.g, g_BorderColour.b, g_BorderColour.a * alphaFactor);
+		return;
+	}
+
+    gl_FragColor =
+		colourWeight * vec4(v_Colour.r, v_Colour.g, v_Colour.b, v_Colour.a * alphaFactor) * texture2D(m_Sampler, v_TexCoord, -0.9) +
+		(1.0 - colourWeight) * g_BorderColour;
 }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Graphics\Containers\ContainerDrawNode.cs" />
     <Compile Include="Graphics\Cursor\CursorContainer.cs" />
     <Compile Include="Graphics\Sprites\Box.cs" />
+    <Compile Include="Graphics\Transformations\TransformSize.cs" />
     <Compile Include="Graphics\Visualisation\DrawVisualiser.cs" />
     <Compile Include="Graphics\DrawNode.cs" />
     <Compile Include="Allocation\BufferStack.cs" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -130,7 +130,7 @@
     <Compile Include="Graphics\Transformations\TransformPositionY.cs" />
     <Compile Include="Graphics\Transformations\TransformRotation.cs" />
     <Compile Include="Graphics\Transformations\TransformVector.cs" />
-    <Compile Include="Graphics\Transformations\TransformScaleVector.cs" />
+    <Compile Include="Graphics\Transformations\TransformScale.cs" />
     <Compile Include="Graphics\UserInterface\Button.cs" />
     <Compile Include="Graphics\UserInterface\TextBox.cs" />
     <Compile Include="Graphics\Visualisation\FlashyBox.cs" />


### PR DESCRIPTION
Not sure if this is faster or slower compared to just drawing additional quads with increased size underneath. In my (rudimentary) performance testing this didn't seem to affect FPS at all, but I suspect I was not fill-rate limited.