### PR TITLE
Fix IPC test case failing at random

### DIFF
--- a/osu.Framework.Desktop.Tests/Benchmark/BenchmarkTests.cs
+++ b/osu.Framework.Desktop.Tests/Benchmark/BenchmarkTests.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Desktop.Tests.Benchmark
         [Test]
         public void TestBenchmark()
         {
-            using (var host = new HeadlessGameHost())
+            using (var host = new HeadlessGameHost() { ListenForIpc = false })
             {
                 host.Add(new VisualTests.Benchmark());
                 host.Run();

--- a/osu.Framework.Desktop.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Desktop.Tests/Platform/HeadlessGameHostTest.cs
@@ -28,8 +28,8 @@ namespace osu.Framework.Desktop.Tests.Platform
                 server.Load(null);
                 client.Load(null);
 
-                Assert.IsTrue(server.IsPrimaryInstance);
-                Assert.IsFalse(client.IsPrimaryInstance);
+                Assert.IsTrue(server.IsPrimaryInstance, @"Server wasn't able to bind");
+                Assert.IsFalse(client.IsPrimaryInstance, @"Client was able to bind when it shouldn't have been able to");
 
                 var serverChannel = new IpcChannel<Foobar>(server);
                 var clientChannel = new IpcChannel<Foobar>(client);

--- a/osu.Framework.Desktop/Platform/DesktopGameHost.cs
+++ b/osu.Framework.Desktop/Platform/DesktopGameHost.cs
@@ -23,17 +23,23 @@ namespace osu.Framework.Desktop.Platform
 
         private TextInputSource textInputBox;
         public override TextInputSource TextInput => textInputBox ?? (textInputBox = ((DesktopGameWindow)Window).CreateTextInput());
+
+        public bool ListenForIpc = true;
+
         private TcpIpcProvider IpcProvider;
         private Task IpcTask;
         
         public override void Load(BaseGame game)
         {
-            IpcProvider = new TcpIpcProvider();
-            IsPrimaryInstance = IpcProvider.Bind();
-            if (IsPrimaryInstance)
+            if (ListenForIpc)
             {
-                IpcProvider.MessageReceived += msg => OnMessageReceived(msg);
-                IpcTask = IpcProvider.Start();
+                IpcProvider = new TcpIpcProvider();
+                IsPrimaryInstance = IpcProvider.Bind();
+                if (IsPrimaryInstance)
+                {
+                    IpcProvider.MessageReceived += msg => OnMessageReceived(msg);
+                    IpcTask = IpcProvider.Start();
+                }
             }
             base.Load(game);
         }
@@ -46,7 +52,7 @@ namespace osu.Framework.Desktop.Platform
         
         protected override void Dispose(bool isDisposing)
         {
-            IpcProvider.Dispose();
+            IpcProvider?.Dispose();
             IpcTask?.Wait(50);
             base.Dispose(isDisposing);
         }


### PR DESCRIPTION
Looks to have been running in parallel with the BenchmarkTest in some cases, which caused a port bind conflict.