### PR TITLE
Adds missing AutoSize invalidation definition, Fixes FlowContainer layout regression

### DIFF
--- a/osu.Framework/Graphics/Containers/AutoSizeContainer.cs
+++ b/osu.Framework/Graphics/Containers/AutoSizeContainer.cs
@@ -118,6 +118,14 @@ namespace osu.Framework.Graphics.Containers
             return result;
         }
 
+        public override bool Invalidate(Invalidation invalidation, Drawable source = null, bool shallPropagate = true)
+        {
+            if ((invalidation & (Invalidation.Visibility | Invalidation.Geometry)) > 0)
+                autoSize.Invalidate();
+
+            return base.Invalidate(invalidation, source, shallPropagate);
+        }
+
         internal override void InvalidateFromChild(Invalidation invalidation, Drawable source)
         {
             if ((invalidation & (Invalidation.Visibility | Invalidation.Geometry)) > 0)


### PR DESCRIPTION
Needed to invalidate cached ```autoSize``` vector
Fixes #174 

This bug is most prominent in ```FlowContainers```, but actually appears to stem from ```AutoSizeContainer``` (their parent)'s ```autoSize``` vector not being invalidated correctly/at all from non-child Invalidate calls.