### PR TITLE
Store Drawable.size internally as 2 floating point numbers such that …

### DIFF
--- a/osu.Framework/Graphics/Containers/AutoSizeContainer.cs
+++ b/osu.Framework/Graphics/Containers/AutoSizeContainer.cs
@@ -15,13 +15,29 @@ namespace osu.Framework.Graphics.Containers
 
         private Cached<Vector2> autoSize = new Cached<Vector2>();
 
+        public override float Width
+        {
+            set
+            {
+                Debug.Assert((RelativeSizeAxes & Axes.X) > 0, @"The width of an AutoSizeContainer should only be manually set if it is relative to its parent.");
+                base.Width = value;
+            }
+        }
+
+        public override float Height
+        {
+            set
+            {
+                Debug.Assert((RelativeSizeAxes & Axes.Y) > 0, @"The height of an AutoSizeContainer should only be manually set if it is relative to its parent.");
+                base.Height = value;
+            }
+        }
+
         public override Vector2 Size
         {
             set
             {
-                Debug.Assert((RelativeSizeAxes & Axes.X) > 0 || value.X == -1, @"The Size of an AutoSizeContainer should never be manually set.");
-                Debug.Assert((RelativeSizeAxes & Axes.Y) > 0 || value.Y == -1, @"The Size of an AutoSizeContainer should never be manually set.");
-
+                Debug.Assert((RelativeSizeAxes & Axes.Both) > 0, @"The Size of an AutoSizeContainer should only be manually set if it is relative to its parent.");
                 base.Size = value;
             }
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -268,7 +268,49 @@ namespace osu.Framework.Graphics
             }
         }
 
-        private Vector2 size;
+        private float width;
+        private float height;
+
+        public virtual float Width
+        {
+            get { return width; }
+            set
+            {
+                if (width == value) return;
+                width = value;
+
+                Invalidate(Invalidation.Geometry);
+            }
+        }
+
+        public float DrawWidth
+        {
+            get { return DrawSize.X; }
+        }
+
+        public virtual float Height
+        {
+            get { return height; }
+            set
+            {
+                if (height == value) return;
+                height = value;
+
+                Invalidate(Invalidation.Geometry);
+            }
+        }
+
+        public float DrawHeight
+        {
+            get { return DrawSize.Y; }
+        }
+
+        private Vector2 size
+        {
+            get { return new Vector2(width, height); }
+            set { width = value.X; height = value.Y; }
+        }
+
         public virtual Vector2 Size
         {
             get
@@ -373,28 +415,6 @@ namespace osu.Framework.Graphics
         }
 
         public float Depth;
-
-        public float Width
-        {
-            get { return Size.X; }
-            set { Size = new Vector2(value, Size.Y); }
-        }
-
-        public float DrawWidth
-        {
-            get { return DrawSize.X; }
-        }
-
-        public float Height
-        {
-            get { return Size.Y; }
-            set { Size = new Vector2(Size.X, value); }
-        }
-
-        public float DrawHeight
-        {
-            get { return DrawSize.Y; }
-        }
 
         protected virtual IFrameBasedClock Clock => Parent?.Clock;
 


### PR DESCRIPTION
…its components can be changed individually.

Not sure if this is the correct way to go. @SirCmpwn disagreed with these changes in discord (see log), whereas I am very much against the "-1" placeholders within the old `AutoSizeContainer.Size` setter that this PR avoids. Are there any other opinions?