### PR TITLE
Don't check for input on masked-away drawables.

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -502,9 +502,12 @@ namespace osu.Framework.Graphics.Containers
                 {
                     // The masking check is overly expensive (requires creation of ScreenSpaceDrawQuad)
                     // when only few children exist.
-                    if (container.children.AliveItems.Count < AMOUNT_CHILDREN_REQUIRED_FOR_MASKING_CHECK ||
-                        maskingBounds.IntersectsWith(drawable.ScreenSpaceDrawQuad.AABBf))
+                    container.IsMaskedAway = container.children.AliveItems.Count >= AMOUNT_CHILDREN_REQUIRED_FOR_MASKING_CHECK &&
+                        !maskingBounds.IntersectsWith(drawable.ScreenSpaceDrawQuad.AABBf);
+
+                    if (!container.IsMaskedAway)
                         addFromContainer(treeIndex, ref j, container, target, maskingBounds);
+
                     continue;
                 }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -431,6 +431,7 @@ namespace osu.Framework.Graphics
 
         private Cached<bool> isVisibleBacking = new Cached<bool>();
         public virtual bool IsVisible => isVisibleBacking.EnsureValid() ? isVisibleBacking.Value : isVisibleBacking.Refresh(() => Alpha > visibility_cutoff && Parent?.IsVisible == true);
+        public bool IsMaskedAway = false;
 
         private bool? additive;
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -152,7 +152,7 @@ namespace osu.Framework.Input
 
         private void buildKeyboardInputQueue(Drawable current)
         {
-            if (!current.HandleInput || !current.IsVisible)
+            if (!current.HandleInput || !current.IsVisible || current.IsMaskedAway)
                 return;
 
             if (current != this)
@@ -197,7 +197,7 @@ namespace osu.Framework.Input
 
         private bool checkIsHoverable(Drawable d, InputState state)
         {
-            if (!d.HandleInput || !d.IsVisible)
+            if (!d.HandleInput || !d.IsVisible || d.IsMaskedAway)
                 return false;
 
             if (!d.Contains(state.Mouse.Position))


### PR DESCRIPTION
Gives minor (~5-10%) speedup in our tests, but has big potential cost savings in the future e.g. on the options scrollbar.
