### PR TITLE
Better scrolling

### DIFF
--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
@@ -64,8 +64,7 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
 
         public bool? Forward => state.XButton2 == ButtonState.Pressed && host.IsActive;
 
-        public bool? WheelUp => wheelDiff > 0 && host.IsActive;
-        public bool? WheelDown => wheelDiff < 0 && host.IsActive;
+        public int? WheelDiff => host.IsActive ? wheelDiff : 0;
 
         public List<Vector2> IntermediatePositions => new List<Vector2>();
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -171,14 +171,7 @@ namespace osu.Framework.Graphics.Containers
             return base.OnDragEnd(state);
         }
 
-        protected override bool OnWheelDown(InputState state)
-        {
-            distanceDecay = distanceDecayWheel;
-            offset(80);
-            return true;
-        }
-
-        protected override bool OnWheelUp(InputState state)
+        protected override bool OnWheel(InputState state)
         {
             distanceDecay = distanceDecayWheel;
             offset(-80);

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -45,12 +45,12 @@ namespace osu.Framework.Graphics.Containers
         /// Effectively, larger values result in bouncier behavior as the scroll boundaries are approached
         /// with high velocity.
         /// </summary>
-        private const float CLAMP_EXTENSION = 50;
+        private const float CLAMP_EXTENSION = 500;
 
         /// <summary>
         /// This corresponds to the clamping force. A larger value means more aggressive clamping.
         /// </summary>
-        private const double DISTANCE_DECAY_CLAMPING = 0.01;
+        private const double DISTANCE_DECAY_CLAMPING = 0.012;
 
         /// <summary>
         /// Controls the rate with which the target position is approached after ending a drag.

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -231,7 +231,8 @@ namespace osu.Framework.Graphics.Containers
 
                 // Secondly, we would like to quickly approach the target while we are out of bounds.
                 // This is simulating a "strong" clamping force towards the target.
-                localDistanceDecay = DISTANCE_DECAY_CLAMPING * 2;
+                if ((current < target && target < 0) || (current > target && target > scrollableExtent))
+                    localDistanceDecay = DISTANCE_DECAY_CLAMPING * 2;
 
                 // Lastly, we gradually nudge the target towards valid bounds.
                 target = (float)Interpolation.Lerp(clamp(target), target, Math.Exp(-DISTANCE_DECAY_CLAMPING * Clock.ElapsedFrameTime));

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -76,8 +76,8 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         private float target;
 
-        private float contentHeight => availableContent - displayableContent;
-        private float clamp(float position, float extension = 0) => MathHelper.Clamp(position, -extension, contentHeight + extension);
+        private float scrollableExtent => (float)Math.Max(availableContent - displayableContent, 0);
+        private float clamp(float position, float extension = 0) => MathHelper.Clamp(position, -extension, scrollableExtent + extension);
 
         protected override Container Content => content;
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -121,7 +121,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void onScrollbarMovement(float value)
         {
-            offset(value / scrollbar.Size.Y, true, false);
+            scrollTo(value / scrollbar.Size.Y, true, false);
         }
 
         private void offset(float value, bool clamp = true, bool animated = true)
@@ -174,6 +174,8 @@ namespace osu.Framework.Graphics.Containers
             private Color4 highlightColour = Color4.GreenYellow;
             private Box box;
 
+            private float dragOffset;
+
             public ScrollBar()
             {
                 Children = new Drawable[]
@@ -205,7 +207,11 @@ namespace osu.Framework.Graphics.Containers
                 FadeColour(defaultColour, 100);
             }
 
-            protected override bool OnDragStart(InputState state) => true;
+            protected override bool OnDragStart(InputState state)
+            {
+                dragOffset = state.Mouse.Position.Y - Position.Y;
+                return true;
+            }
 
             protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
             {
@@ -223,7 +229,7 @@ namespace osu.Framework.Graphics.Containers
 
             protected override bool OnDrag(InputState state)
             {
-                Dragged?.Invoke(state.Mouse.Delta.Y);
+                Dragged?.Invoke(state.Mouse.Position.Y - dragOffset);
                 return true;
             }
         }

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -187,7 +187,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void onScrollbarMovement(float value)
         {
-            scrollTo(value / scrollbar.Size.Y, false);
+            scrollTo(clamp(value / scrollbar.Size.Y), false);
         }
 
         private void offset(float value, bool animated = true)
@@ -238,6 +238,10 @@ namespace osu.Framework.Graphics.Containers
 
                 // Lastly, we gradually nudge the target towards valid bounds.
                 target = (float)Interpolation.Lerp(clamp(target), target, Math.Exp(-DISTANCE_DECAY_CLAMPING * Clock.ElapsedFrameTime));
+
+                float clampedTarget = clamp(target);
+                if (Precision.AlmostEquals(clampedTarget, target))
+                    target = clampedTarget;
             }
 
             // Exponential interpolation between the target and our current scroll position.

--- a/osu.Framework/Graphics/Drawable_Interaction.cs
+++ b/osu.Framework/Graphics/Drawable_Interaction.cs
@@ -87,16 +87,9 @@ namespace osu.Framework.Graphics
             return false;
         }
 
-        public bool TriggerWheelUp(InputState state) => OnWheelUp(getLocalState(state));
+        public bool TriggerWheel(InputState state) => OnWheel(getLocalState(state));
 
-        protected virtual bool OnWheelUp(InputState state)
-        {
-            return false;
-        }
-
-        public bool TriggerWheelDown(InputState state) => OnWheelDown(getLocalState(state));
-
-        protected virtual bool OnWheelDown(InputState state)
+        protected virtual bool OnWheel(InputState state)
         {
             return false;
         }
@@ -225,6 +218,10 @@ namespace osu.Framework.Graphics
             public bool LeftButton => NativeState.LeftButton;
             public bool MiddleButton => NativeState.MiddleButton;
             public bool RightButton => NativeState.RightButton;
+
+            public bool WheelUp => NativeState.WheelUp;
+            public bool WheelDown => NativeState.WheelDown;
+            public int WheelDiff => NativeState.WheelDiff;
         }
     }
 

--- a/osu.Framework/Input/Handlers/ICursorInputHandler.cs
+++ b/osu.Framework/Input/Handlers/ICursorInputHandler.cs
@@ -47,8 +47,7 @@ namespace osu.Framework.Input.Handlers
         /// </summary>
         bool? Forward { get; }
 
-        bool? WheelUp { get; }
-        bool? WheelDown { get; }
+        int? WheelDiff { get; }
 
 
         /// <summary>

--- a/osu.Framework/Input/IMouseState.cs
+++ b/osu.Framework/Input/IMouseState.cs
@@ -24,5 +24,9 @@ namespace osu.Framework.Input
         bool LeftButton { get; }
         bool MiddleButton { get; }
         bool RightButton { get; }
+
+        bool WheelUp { get; }
+        bool WheelDown { get; }
+        int WheelDiff { get; }
     }
 }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -330,8 +330,9 @@ namespace osu.Framework.Input
                     }
                 }
 
-                mouse.WheelUp |= ch.WheelUp ?? false;
-                mouse.WheelDown |= ch.WheelDown ?? false;
+                mouse.WheelUp |= ch.WheelDiff.HasValue && ch.WheelDiff.Value > 0;
+                mouse.WheelDown |= ch.WheelDiff.HasValue && ch.WheelDiff.Value < 0;
+                mouse.WheelDiff += ch.WheelDiff ?? 0;
             }
 
             if (currentCursorHandler != null)
@@ -428,11 +429,8 @@ namespace osu.Framework.Input
                 }
             }
 
-            if (mouse.WheelUp)
-                handleWheelUp(state);
-
-            if (mouse.WheelDown)
-                handleWheelDown(state);
+            if (mouse.WheelUp || mouse.WheelDown)
+                handleWheel(state);
 
             if (mouse.HasMainButtonPressed)
             {
@@ -547,14 +545,9 @@ namespace osu.Framework.Input
             return result;
         }
 
-        private bool handleWheelUp(InputState state)
+        private bool handleWheel(InputState state)
         {
-            return mouseInputQueue.Any(target => target.TriggerWheelUp(state));
-        }
-
-        private bool handleWheelDown(InputState state)
-        {
-            return mouseInputQueue.Any(target => target.TriggerWheelDown(state));
+            return mouseInputQueue.Any(target => target.TriggerWheel(state));
         }
 
         private bool handleKeyDown(InputState state, Key key, bool repeat)

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -30,8 +30,10 @@ namespace osu.Framework.Input
 
         public IMouseState NativeState => this;
 
-        public bool WheelUp;
-        public bool WheelDown;
+        public bool WheelUp { get; set; }
+        public bool WheelDown { get; set; }
+
+        public int WheelDiff { get; set; }
 
         public bool HasMainButtonPressed => LeftButton || RightButton;
 


### PR DESCRIPTION
This code may become a bit nicer if we expose the input clock within drawables. More specifically, the member variables https://github.com/ppy/osu-framework/commit/cd565e125ec0095a83d54bb7eb892c4209359606#diff-35bbcf584966891fe1dcd0f8f38d5f80R138 will then not be needed.