### PR TITLE
Covariance/contravariance for Containers [proposal]

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Graphics.Containers
     /// <summary>
     /// A drawable which can have children added externally.
     /// </summary>
-    public partial class Container<T> : Drawable, IContainer<T>
+    public partial class Container<T> : Drawable, IContainerEnumerable<T>, IContainerCollection<T>
         where T : Drawable
     {
         private bool masking = false;

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -16,15 +16,21 @@ namespace osu.Framework.Graphics.Containers
         void InvalidateFromChild(Invalidation invalidation, IDrawable source);
     }
 
-    public interface IContainer<T> : IContainer
+    public interface IContainerEnumerable<out T> : IContainer
     {
-        IEnumerable<T> Children { get; set; }
+        IEnumerable<T> Children { get; }
         IEnumerable<T> AliveChildren { get; }
+        
+        int RemoveAll(Predicate<T> match, bool dispose = false);
+    }
+
+    public interface IContainerCollection<in T> : IContainer
+    {
+        IEnumerable<T> Children { set; }
 
         void Add(IEnumerable<T> collection);
         void Add(T drawable);
         void Remove(IEnumerable<T> range, bool dispose = false);
         bool Remove(T drawable, bool dispose = false);
-        int RemoveAll(Predicate<T> match, bool dispose = false);
     }
 }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -186,7 +186,7 @@ namespace osu.Framework.Input
                 mouseInputQueue.Add(current);
             }
 
-            IContainer<Drawable> currentContainer = current as IContainer<Drawable>;
+            IContainerEnumerable<Drawable> currentContainer = current as IContainerEnumerable<Drawable>;
 
             if (currentContainer != null)
             {


### PR DESCRIPTION
Currently, `Container<T>` cannot cast to anything but `IContainer<T>`.

    FlowContainer<Box> container = new FlowContainer<Box>();
    IContainer<Box> iBox = container as IContainer<Box>; // iBox ok
    IContainer<Drawable> iDrawable = container as IContainer<Drawable>; // iDrawable = null

As a consecuence, many scenarios are not possible. For instance:

    void DoStuff(Drawable drawable)
    {
        IContainer<Drawable> container = drawable as IContainer<Drawable>;
        if (container != null)
            foreach (Drawable child in container.Children)
                DoChildStuff(child);
    }
    
    DoStuff(new FlowContainer<Drawable>()); // will iterate over children
    DoStuff(new FlowContainer<Box>()); // will NOT iterate over children

This is important, as this is actually what happens when queuing mouse events; for `Container<T>` where `T` is not exactly a `Drawable`, mouse events will not be queued.

What I propose is to separate `IContainer<T>` into two interfaces `IContainerEnumerable<T>` and `IContainerCollection<T>` that are covariant and contravariant, respectively, allowing the aforementioned scenario to be possible.

    void DoStuff(Drawable drawable)
    {
        IContainerEnumerable<Drawable> container = drawable as IContainerEnumerable<Drawable>;
        if (container != null)
            foreach (Drawable child in container.Children)
                DoChildStuff(child);
    }
    
    DoStuff(new FlowContainer<Drawable>()); // will iterate over children
    DoStuff(new FlowContainer<Box>()); // will also iterate over children :)
