### PR TITLE
Encapsulate away linear and sRGB conversions from Drawable and Container.

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
@@ -7,7 +7,8 @@ using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.GameModes.Testing;
-using osu.Framework.Extensions.ColourExtensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.VisualTests.Tests
 {
@@ -54,9 +55,9 @@ namespace osu.Framework.VisualTests.Tests
                                         ColourInfo = new ColourInfo()
                                         {
                                             TopLeft = Color4.White,
-                                            BottomLeft = Color4.Blue.ToLinear(),
-                                            TopRight = Color4.Red.ToLinear(),
-                                            BottomRight = Color4.Green.ToLinear(),
+                                            BottomLeft = Color4.Blue,
+                                            TopRight = Color4.Red,
+                                            BottomRight = Color4.Green,
                                         },
                                     }
                                 }

--- a/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
+++ b/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
@@ -4,9 +4,9 @@
 using OpenTK.Graphics;
 using System;
 
-namespace osu.Framework.Extensions.ColourExtensions
+namespace osu.Framework.Extensions.Color4Extensions
 {
-    public static class ColourExtensions
+    public static class Color4Extensions
     {
         public const double GAMMA = 2.4;
 

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -5,9 +5,9 @@ using System;
 using osu.Framework.Extensions.MatrixExtensions;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Extensions.ColourExtensions;
+using osu.Framework.Extensions.Color4Extensions;
 
-namespace osu.Framework.Graphics
+namespace osu.Framework.Graphics.Colour
 {
     /// <summary>
     /// ColourInfo contains information about the colours of all 4 vertices of a quad.
@@ -15,10 +15,10 @@ namespace osu.Framework.Graphics
     /// </summary>
     public struct ColourInfo : IEquatable<ColourInfo>
     {
-        public Color4 TopLeft;
-        public Color4 BottomLeft;
-        public Color4 TopRight;
-        public Color4 BottomRight;
+        public SRGBColour TopLeft;
+        public SRGBColour BottomLeft;
+        public SRGBColour TopRight;
+        public SRGBColour BottomRight;
         public bool HasSingleColour;
 
         public ColourInfo(ref DrawInfo parent, ColourInfo colour)
@@ -26,23 +26,23 @@ namespace osu.Framework.Graphics
             if (colour.HasSingleColour && parent.Colour.HasSingleColour)
             {
                 HasSingleColour = true;
-                TopLeft = BottomLeft = TopRight = BottomRight = ColourExtensions.Multiply(colour.TopLeft, parent.Colour.TopLeft);
+                TopLeft = BottomLeft = TopRight = BottomRight = colour.TopLeft * parent.Colour.TopLeft;
             }
             else if (!colour.HasSingleColour && parent.Colour.HasSingleColour)
             {
                 HasSingleColour = false;
-                TopLeft = ColourExtensions.Multiply(colour.TopLeft, parent.Colour.TopLeft);
-                BottomLeft = ColourExtensions.Multiply(colour.BottomLeft, parent.Colour.TopLeft);
-                TopRight = ColourExtensions.Multiply(colour.TopRight, parent.Colour.TopLeft);
-                BottomRight = ColourExtensions.Multiply(colour.BottomRight, parent.Colour.TopLeft);
+                TopLeft = colour.TopLeft * parent.Colour.TopLeft;
+                BottomLeft = colour.BottomLeft * parent.Colour.TopLeft;
+                TopRight = colour.TopRight * parent.Colour.TopLeft;
+                BottomRight = colour.BottomRight * parent.Colour.TopLeft;
             }
             else
             {
                 HasSingleColour = false;
-                TopLeft = ColourExtensions.Multiply(colour.TopLeft, parent.Colour.TopLeft);
-                BottomLeft = ColourExtensions.Multiply(colour.BottomLeft, parent.Colour.BottomLeft);
-                TopRight = ColourExtensions.Multiply(colour.TopRight, parent.Colour.TopRight);
-                BottomRight = ColourExtensions.Multiply(colour.BottomRight, parent.Colour.BottomRight);
+                TopLeft = colour.TopLeft * parent.Colour.TopLeft;
+                BottomLeft = colour.BottomLeft * parent.Colour.BottomLeft;
+                TopRight = colour.TopRight * parent.Colour.TopRight;
+                BottomRight = colour.BottomRight * parent.Colour.BottomRight;
             }
         }
 
@@ -50,7 +50,7 @@ namespace osu.Framework.Graphics
         /// Creates a ColourInfo with a single linear colour assigned to all vertices.
         /// </summary>
         /// <param name="colour">The single linear colour to be assigned to all vertices.</param>
-        public ColourInfo(Color4 colour)
+        public ColourInfo(SRGBColour colour)
         {
             TopLeft = BottomLeft = TopRight = BottomRight = colour;
             HasSingleColour = true;
@@ -68,13 +68,13 @@ namespace osu.Framework.Graphics
                 return this;
 
             ColourInfo result = this;
-            result.TopLeft.A *= alpha;
+            result.TopLeft.MultiplyAlpha(alpha);
 
             if (!HasSingleColour)
             {
-                result.BottomLeft.A *= alpha;
-                result.TopRight.A *= alpha;
-                result.BottomRight.A *= alpha;
+                result.BottomLeft.MultiplyAlpha(alpha);
+                result.TopRight.MultiplyAlpha(alpha);
+                result.BottomRight.MultiplyAlpha(alpha);
             }
 
             return result;
@@ -97,7 +97,7 @@ namespace osu.Framework.Graphics
             return other.HasSingleColour && TopLeft.Equals(other.TopLeft);
         }
 
-        public bool Equals(Color4 other)
+        public bool Equals(SRGBColour other)
         {
             return HasSingleColour && TopLeft.Equals(other);
         }

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Graphics.Colour
+{
+    /// <summary>
+    /// A wrapper struct around Color4 that takes care of converting between sRGB and linear colour spaces.
+    /// Internally this struct stores the colour in linear space, which is exposed by the Linear member.
+    /// This struct implicitly converts to sRGB space Color4 values (i.e. it can be assigned and implicitly cast)
+    /// to sRGB Color4.
+    /// </summary>
+    public struct SRGBColour : IEquatable<SRGBColour>
+    {
+        public Color4 Linear;
+
+        public static implicit operator SRGBColour(Color4 value) => new SRGBColour { Linear = value.ToLinear() };
+        public static implicit operator Color4(SRGBColour value) => value.Linear.ToSRGB();
+
+        /// <summary>
+        /// Multiplies 2 colours in linear colour space.
+        /// </summary>
+        /// <param name="first">First factor.</param>
+        /// <param name="second">Second factor.</param>
+        /// <returns>Product of first and second.</returns>
+        public static SRGBColour operator *(SRGBColour first, SRGBColour second)
+        {
+            return new SRGBColour { Linear = Color4Extensions.Multiply(first.Linear, second.Linear) };
+        }
+
+        /// <summary>
+        /// Multiplies the alpha value of this colour by the given alpha factor.
+        /// </summary>
+        /// <param name="alpha">The alpha factor to multiply with.</param>
+        public void MultiplyAlpha(float alpha) => Linear.A *= alpha;
+
+        public bool Equals(SRGBColour other) => Linear.Equals(other.Linear);
+    }
+}

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -11,6 +11,7 @@ using OpenTK.Graphics;
 using osu.Framework.Graphics.Shaders;
 using System;
 using OpenTK;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.Containers
 {

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shaders;
 using System;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.Containers
 {

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.OpenGL;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -75,13 +76,13 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Color4 borderColour = Color4.Black;
+        private SRGBColour borderColour = Color4.Black;
 
         /// <summary>
         /// Only has an effect when Masking == true.
         /// Determines the color of the drawn border.
         /// </summary>
-        public virtual Color4 BorderColour
+        public virtual SRGBColour BorderColour
         {
             get { return borderColour; }
             set

--- a/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
@@ -12,7 +12,8 @@ using osu.Framework.Extensions.MatrixExtensions;
 using OpenTK;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Extensions.ColourExtensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -25,7 +26,7 @@ namespace osu.Framework.Graphics.Containers
 
     public struct EdgeEffect
     {
-        public Color4 Colour;
+        public SRGBColour Colour;
         public Vector2 Offset;
         public EdgeEffectType Type;
         public float Roundness;
@@ -52,7 +53,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void drawEdgeEffect()
         {
-            if (MaskingInfo == null || EdgeEffect.Type == EdgeEffectType.None || EdgeEffect.Radius <= 0.0f || EdgeEffect.Colour.A <= 0.0f)
+            if (MaskingInfo == null || EdgeEffect.Type == EdgeEffectType.None || EdgeEffect.Radius <= 0.0f || EdgeEffect.Colour.Linear.A <= 0.0f)
                 return;
 
             RectangleF effectRect = MaskingInfo.Value.MaskingRect.Inflate(EdgeEffect.Radius).Offset(EdgeEffect.Offset);
@@ -72,11 +73,11 @@ namespace osu.Framework.Graphics.Containers
 
             Shader.Bind();
 
-            ColourInfo colour = new ColourInfo(EdgeEffect.Colour.ToLinear());
-            colour.TopLeft.A *= DrawInfo.Colour.TopLeft.A;
-            colour.BottomLeft.A *= DrawInfo.Colour.BottomLeft.A;
-            colour.TopRight.A *= DrawInfo.Colour.TopRight.A;
-            colour.BottomRight.A *= DrawInfo.Colour.BottomRight.A;
+            ColourInfo colour = new ColourInfo(EdgeEffect.Colour);
+            colour.TopLeft.MultiplyAlpha(DrawInfo.Colour.TopLeft.Linear.A);
+            colour.BottomLeft.MultiplyAlpha(DrawInfo.Colour.BottomLeft.Linear.A);
+            colour.TopRight.MultiplyAlpha(DrawInfo.Colour.TopRight.Linear.A);
+            colour.BottomRight.MultiplyAlpha(DrawInfo.Colour.BottomRight.Linear.A);
 
             Texture.WhitePixel.Draw(ScreenSpaceMaskingQuad.Value, colour);
 

--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -5,7 +5,8 @@ using System;
 using osu.Framework.Extensions.MatrixExtensions;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Extensions.ColourExtensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics
 {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -22,7 +22,8 @@ using osu.Framework.Graphics.Shaders;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
-using osu.Framework.Extensions.ColourExtensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics
 {
@@ -217,7 +218,7 @@ namespace osu.Framework.Graphics
             }
         }
 
-        public Color4 ColourLinear
+        public SRGBColour Colour
         {
             get
             {
@@ -227,19 +228,13 @@ namespace osu.Framework.Graphics
 
             set
             {
-                if (colourInfo.HasSingleColour && colourInfo.TopLeft == value) return;
+                if (colourInfo.HasSingleColour && colourInfo.TopLeft.Equals(value)) return;
 
                 colourInfo.TopLeft = value;
                 colourInfo.HasSingleColour = true;
 
                 Invalidate(Invalidation.Colour);
             }
-        }
-
-        public Color4 Colour
-        {
-            get { return ColourLinear.ToSRGB(); }
-            set { ColourLinear = value.ToLinear(); }
         }
 
         private Anchor anchor = Anchor.TopLeft;

--- a/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
+++ b/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
@@ -8,7 +8,8 @@ using osu.Framework.Graphics.Transformations;
 using osu.Framework.Threading;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Extensions.ColourExtensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics
 {
@@ -307,11 +308,10 @@ namespace osu.Framework.Graphics
 
         #region Color4-based helpers
 
-        public void FadeColour(Color4 newColour, int duration, EasingTypes easing = EasingTypes.None)
+        public void FadeColour(SRGBColour newColour, int duration, EasingTypes easing = EasingTypes.None)
         {
             updateTransformsOfType(typeof(TransformColour));
-            Color4 startValue = (Transforms.FindLast(t => t is TransformColour) as TransformColour)?.EndValue ?? ColourLinear;
-            newColour = newColour.ToLinear();
+            Color4 startValue = (Transforms.FindLast(t => t is TransformColour) as TransformColour)?.EndValue ?? Colour.Linear;
 
             if (transformationDelay == 0)
             {
@@ -322,30 +322,32 @@ namespace osu.Framework.Graphics
 
             double startTime = Time.Current + transformationDelay;
 
+            // We need to pass colours in linear space, since colour transformations work in linear colour space.
             Transforms.Add(new TransformColour
             {
                 StartTime = startTime,
                 EndTime = startTime + duration,
                 StartValue = startValue,
-                EndValue = newColour,
+                EndValue = newColour.Linear,
                 Easing = easing,
             });
         }
 
-        public void FlashColour(Color4 flashColour, int duration)
+        public void FlashColour(SRGBColour flashColour, int duration)
         {
             Debug.Assert(transformationDelay == 0, @"FlashColour doesn't support Delay() currently");
 
-            Color4 startValue = (Transforms.FindLast(t => t is TransformColour) as TransformColour)?.EndValue ?? ColourLinear;
+            Color4 startValue = (Transforms.FindLast(t => t is TransformColour) as TransformColour)?.EndValue ?? Colour.Linear;
             Transforms.RemoveAll(t => t is TransformColour);
 
             double startTime = Time.Current + transformationDelay;
 
+            // We need to pass colours in linear space, since colour transformations work in linear colour space.
             Transforms.Add(new TransformColour
             {
                 StartTime = startTime,
                 EndTime = startTime + duration,
-                StartValue = flashColour.ToLinear(),
+                StartValue = flashColour.Linear,
                 EndValue = startValue,
             });
 

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -17,7 +17,8 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Statistics;
 using osu.Framework.MathUtils;
 using osu.Framework.Graphics.Primitives;
-using osu.Framework.Extensions.ColourExtensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.OpenGL
 {
@@ -377,13 +378,11 @@ namespace osu.Framework.Graphics.OpenGL
             Shader.SetGlobalProperty(@"g_CornerRadius", maskingInfo.CornerRadius);
 
             Shader.SetGlobalProperty(@"g_BorderThickness", maskingInfo.BorderThickness / maskingInfo.BlendRange);
-
-            Color4 linearBorderColour = maskingInfo.BorderColour.ToLinear();
             Shader.SetGlobalProperty(@"g_BorderColour", new Vector4(
-                linearBorderColour.R,
-                linearBorderColour.G,
-                linearBorderColour.B,
-                linearBorderColour.A));
+                maskingInfo.BorderColour.Linear.R,
+                maskingInfo.BorderColour.Linear.G,
+                maskingInfo.BorderColour.Linear.B,
+                maskingInfo.BorderColour.Linear.A));
 
             Shader.SetGlobalProperty(@"g_MaskingBlendRange", maskingInfo.BlendRange);
 
@@ -604,7 +603,7 @@ namespace osu.Framework.Graphics.OpenGL
         public float CornerRadius;
 
         public float BorderThickness;
-        public Color4 BorderColour;
+        public SRGBColour BorderColour;
 
         public float BlendRange;
 

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Primitives;
 using OpenTK.Graphics;
 using OpenTK.Graphics.ES30;
 using OpenTK;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.OpenGL.Textures
 {

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -14,7 +14,8 @@ using OpenTK.Graphics;
 using OpenTK.Graphics.ES30;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 using osu.Framework.Statistics;
-using osu.Framework.Extensions.ColourExtensions;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.OpenGL.Textures
 {
@@ -164,25 +165,25 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             {
                 Position = vertexQuad.BottomLeft,
                 TexturePosition = new Vector2(texRect.Left, texRect.Bottom),
-                Colour = drawColour.BottomLeft,
+                Colour = drawColour.BottomLeft.Linear,
             });
             spriteBatch.Add(new TexturedVertex2D
             {
                 Position = vertexQuad.BottomRight,
                 TexturePosition = new Vector2(texRect.Right, texRect.Bottom),
-                Colour = drawColour.BottomRight,
+                Colour = drawColour.BottomRight.Linear,
             });
             spriteBatch.Add(new TexturedVertex2D
             {
                 Position = vertexQuad.TopRight,
                 TexturePosition = new Vector2(texRect.Right, texRect.Top),
-                Colour = drawColour.TopRight,
+                Colour = drawColour.TopRight.Linear,
             });
             spriteBatch.Add(new TexturedVertex2D
             {
                 Position = vertexQuad.TopLeft,
                 TexturePosition = new Vector2(texRect.Left, texRect.Top),
-                Colour = drawColour.TopLeft,
+                Colour = drawColour.TopLeft.Linear,
             });
 
             FrameStatistics.Increment(StatisticsCounterType.KiloPixels, (long)vertexQuad.ConservativeArea);

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Primitives;
 using OpenTK.Graphics;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 using OpenTK;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.OpenGL.Textures
 {

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -14,6 +14,7 @@ using OpenTK.Graphics;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 using OpenTK;
 using OpenTK.Graphics.ES30;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.Textures
 {

--- a/osu.Framework/Graphics/Transformations/TransformColour.cs
+++ b/osu.Framework/Graphics/Transformations/TransformColour.cs
@@ -4,11 +4,18 @@
 using osu.Framework.MathUtils;
 using osu.Framework.Timing;
 using OpenTK.Graphics;
+using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.Transformations
 {
+    /// <summary>
+    /// Transforms colour value in linear colour space.
+    /// </summary>
     public class TransformColour : Transform<Color4>
     {
+        /// <summary>
+        /// Current value of the transformed colour in linear colour space.
+        /// </summary>
         protected override Color4 CurrentValue
         {
             get
@@ -24,7 +31,7 @@ namespace osu.Framework.Graphics.Transformations
         public override void Apply(Drawable d)
         {
             base.Apply(d);
-            d.ColourLinear = CurrentValue;
+            d.Colour = new SRGBColour { Linear = CurrentValue };
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Button.cs
+++ b/osu.Framework/Graphics/UserInterface/Button.cs
@@ -23,11 +23,7 @@ namespace osu.Framework.Graphics.UserInterface
         public new Color4 Colour
         {
             get { return box.Colour; }
-            set
-            {
-                if (box != null)
-                    box.Colour = value;
-            }
+            set { box.Colour = value; }
         }
 
         private Box box;

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -158,7 +158,7 @@ namespace osu.Framework.Graphics.Visualisation
         private void updateSpecifics()
         {
             previewBox.Alpha = Math.Max(0.2f, Target.Alpha);
-            previewBox.ColourLinear = Target.ColourLinear;
+            previewBox.Colour = Target.Colour;
 
             int childCount = (Target as Container)?.Children.Count() ?? 0;
 

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -7,7 +7,7 @@ using osu.Framework.Graphics.Transformations;
 using OpenTK;
 using OpenTK.Graphics;
 using System.Diagnostics;
-using osu.Framework.Extensions.ColourExtensions;
+using osu.Framework.Extensions.Color4Extensions;
 
 namespace osu.Framework.MathUtils
 {

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -85,7 +85,7 @@
   <ItemGroup>
     <Compile Include="Caching\Cached.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\MatrixExtensions\MatrixExtensions.cs" />
-    <Compile Include="Extensions\ColourExtensions\ColourExtensions.cs" />
+    <Compile Include="Extensions\Color4Extensions\Color4Extensions.cs" />
     <Compile Include="Extensions\PolygonExtensions\ConvexPolygonExtensions.cs" />
     <Compile Include="Extensions\PolygonExtensions\PolygonExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\RectangleExtensions\RectangleExtensions.cs" />
@@ -104,7 +104,8 @@
     <Compile Include="GameModes\Testing\TestBrowser.cs" />
     <Compile Include="GameModes\Testing\TestCase.cs" />
     <Compile Include="Graphics\BlendingInfo.cs" />
-    <Compile Include="Graphics\ColourInfo.cs" />
+    <Compile Include="Graphics\Colour\ColourInfo.cs" />
+    <Compile Include="Graphics\Colour\SRGBColour.cs" />
     <Compile Include="Graphics\Containers\BufferedContainerDrawNode.cs" />
     <Compile Include="Graphics\Containers\CircularContainer.cs" />
     <Compile Include="Graphics\Containers\ClickableContainer.cs" />


### PR DESCRIPTION
Not 100% sure if this makes things simpler or more complicated for the end user.