### PR TITLE
Make Margin a property of Drawable instead of Container.

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
@@ -41,6 +41,8 @@ namespace osu.Framework.VisualTests.Tests
                 @"RelativeSize",
                 @"Padding",
                 @"Margin",
+                @"Inner Margin",
+                @"Drawable Margin",
             };
 
             for (int i = 0; i < testNames.Length; i++)
@@ -580,6 +582,262 @@ namespace osu.Framework.VisualTests.Tests
 
                         break;
                     }
+
+                case 9:
+                    {
+                        Container box1;
+                        Container box2;
+                        Container box3;
+
+                        testContainer.Add(new FlowContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                            {
+                                // This first guy is used for spacing.
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.125f, 1),
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.25f, 1),
+                                    Children = new[]
+                                    {
+                                        new InfofulBoxAutoSize
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new[]
+                                            {
+                                                new Container
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Depth = 1,
+                                                    Children = new Drawable[]
+                                                    {
+                                                        box1 = new InfofulBox
+                                                        {
+                                                            Margin = new MarginPadding(50),
+                                                            Anchor = Anchor.TopLeft,
+                                                            Origin = Anchor.TopLeft,
+                                                            Size = new Vector2(50),
+                                                            Colour = Color4.Blue,
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    }
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.25f, 1),
+                                    Children = new[]
+                                    {
+                                        new InfofulBoxAutoSize
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new[]
+                                            {
+                                                new Container
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Depth = 1,
+                                                    Children = new Drawable[]
+                                                    {
+                                                        box2 = new InfofulBox
+                                                        {
+                                                            Margin = new MarginPadding(50),
+                                                            Anchor = Anchor.Centre,
+                                                            Origin = Anchor.Centre,
+                                                            Size = new Vector2(50),
+                                                            Colour = Color4.Blue,
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    }
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.25f, 1),
+                                    Children = new[]
+                                    {
+                                        new InfofulBoxAutoSize
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new[]
+                                            {
+                                                new Container
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Depth = 1,
+                                                    Children = new Drawable[]
+                                                    {
+                                                        box3 = new InfofulBox
+                                                        {
+                                                            Margin = new MarginPadding(50),
+                                                            Anchor = Anchor.BottomRight,
+                                                            Origin = Anchor.BottomRight,
+                                                            Size = new Vector2(50),
+                                                            Colour = Color4.Blue,
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    }
+                                },
+                            }
+                        });
+
+                        foreach (Container b in new[] { box1, box2, box3 })
+                        {
+                            b.ScaleTo(new Vector2(2, 2), 1000);
+                            b.Delay(1000);
+                            b.ScaleTo(new Vector2(1, 1), 1000);
+                            b.Delay(1000);
+                            b.Loop();
+                        }
+
+                        break;
+                    }
+
+                case 10:
+                    {
+                        Drawable box1;
+                        Drawable box2;
+                        Drawable box3;
+
+                        testContainer.Add(new FlowContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                            {
+                                // This first guy is used for spacing.
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.125f, 1),
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.25f, 1),
+                                    Children = new[]
+                                    {
+                                        new InfofulBoxAutoSize
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new[]
+                                            {
+                                                new Container
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Depth = 1,
+                                                    Children = new Drawable[]
+                                                    {
+                                                        box1 = new Box
+                                                        {
+                                                            Margin = new MarginPadding(50),
+                                                            Anchor = Anchor.TopLeft,
+                                                            Origin = Anchor.TopLeft,
+                                                            Size = new Vector2(50),
+                                                            Colour = Color4.Blue,
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    }
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.25f, 1),
+                                    Children = new[]
+                                    {
+                                        new InfofulBoxAutoSize
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new[]
+                                            {
+                                                new Container
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Depth = 1,
+                                                    Children = new Drawable[]
+                                                    {
+                                                        box2 = new Box
+                                                        {
+                                                            Margin = new MarginPadding(50),
+                                                            Anchor = Anchor.Centre,
+                                                            Origin = Anchor.Centre,
+                                                            Size = new Vector2(50),
+                                                            Colour = Color4.Blue,
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    }
+                                },
+                                new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.25f, 1),
+                                    Children = new[]
+                                    {
+                                        new InfofulBoxAutoSize
+                                        {
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Children = new[]
+                                            {
+                                                new Container
+                                                {
+                                                    AutoSizeAxes = Axes.Both,
+                                                    Depth = 1,
+                                                    Children = new Drawable[]
+                                                    {
+                                                        box3 = new Box
+                                                        {
+                                                            Margin = new MarginPadding(50),
+                                                            Anchor = Anchor.BottomRight,
+                                                            Origin = Anchor.BottomRight,
+                                                            Size = new Vector2(50),
+                                                            Colour = Color4.Blue,
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    }
+                                },
+                            }
+                        });
+
+                        foreach (Drawable b in new[] { box1, box2, box3 })
+                        {
+                            b.ScaleTo(new Vector2(2, 2), 1000);
+                            b.Delay(1000);
+                            b.ScaleTo(new Vector2(1, 1), 1000);
+                            b.Delay(1000);
+                            b.Loop();
+                        }
+
+                        break;
+                    }
             }
 
 #if DEBUG
@@ -692,8 +950,7 @@ namespace osu.Framework.VisualTests.Tests
 
         protected override bool OnDragStart(InputState state) => AllowDrag;
 
-        [BackgroundDependencyLoader]
-        private void load()
+        public InfofulBox()
         {
             Add(new Box
             {

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -134,7 +134,7 @@ namespace osu.Framework.Graphics.Containers
             n.MaskingInfo = !Masking ? (MaskingInfo?)null : new MaskingInfo
             {
                 ScreenSpaceAABB = ScreenSpaceDrawQuad.AABB,
-                MaskingRect = DrawRectangle.Shrink(Margin),
+                MaskingRect = DrawRectangle,
                 ToMaskingSpace = DrawInfo.MatrixInverse,
                 CornerRadius = CornerRadius,
                 BorderThickness = BorderThickness,
@@ -207,22 +207,6 @@ namespace osu.Framework.Graphics.Containers
                     c.Invalidate(Invalidation.Geometry);
             }
         }
-
-        private MarginPadding margin;
-        public MarginPadding Margin
-        {
-            get { return margin; }
-            set
-            {
-                if (margin.Equals(value)) return;
-
-                margin = value;
-
-                Invalidate(Invalidation.Geometry);
-            }
-        }
-
-        public override Vector2 DrawSize => base.DrawSize + new Vector2(Margin.TotalHorizontal, Margin.TotalVertical);
 
         /// <summary>
         /// The Size (coordinate space) revealed to Children.
@@ -580,14 +564,12 @@ namespace osu.Framework.Graphics.Containers
         public override bool Contains(Vector2 screenSpacePos)
         {
             float cornerRadius = CornerRadius;
-            Vector2 localPos = GetLocalPosition(screenSpacePos);
-            RectangleF inputRect = DrawRectangle.Shrink(Margin);
 
             // Select a cheaper contains method when we don't need rounded edges.
             if (!Masking || cornerRadius == 0.0f)
-                return inputRect.Contains(localPos);
+                return base.Contains(screenSpacePos);
             else
-                return inputRect.Shrink(cornerRadius).DistanceSquared(localPos) <= cornerRadius * cornerRadius;
+                return DrawRectangle.Shrink(cornerRadius).DistanceSquared(GetLocalPosition(screenSpacePos)) <= cornerRadius * cornerRadius;
         }
 
         protected override RectangleF BoundingBox
@@ -598,7 +580,7 @@ namespace osu.Framework.Graphics.Containers
                 if (!Masking || cornerRadius == 0.0f)
                     return base.BoundingBox;
 
-                RectangleF drawRect = DrawRectangle.Shrink(cornerRadius);
+                RectangleF drawRect = DrawRectangle.Shrink(cornerRadius).Inflate(Margin);
 
                 // Inflate bounding box in parent space by the half-size of the bounding box of the
                 // ellipse obtained by transforming the unit circle into parent space.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -142,6 +142,20 @@ namespace osu.Framework.Graphics
             }
         }
 
+        private MarginPadding margin;
+        public MarginPadding Margin
+        {
+            get { return margin; }
+            set
+            {
+                if (margin.Equals(value)) return;
+
+                margin = value;
+
+                Invalidate(Invalidation.Geometry);
+            }
+        }
+
         private Vector2 customOrigin;
 
         public virtual Vector2 OriginPosition
@@ -154,7 +168,7 @@ namespace osu.Framework.Graphics
                 if (Origin == Anchor.TopLeft)
                     return Vector2.Zero;
 
-                return computeAnchorPosition(DrawSize, Origin);
+                return computeAnchorPosition(DrawSize + new Vector2(margin.TotalHorizontal, margin.TotalVertical), Origin);
             }
 
             set
@@ -528,7 +542,7 @@ namespace osu.Framework.Graphics
             get
             {
                 Vector2 s = DrawSize;
-                return new RectangleF(0, 0, s.X, s.Y);
+                return new RectangleF(margin.Left, margin.Top, s.X, s.Y);
             }
         }
 
@@ -580,7 +594,7 @@ namespace osu.Framework.Graphics
             return false;
         }
 
-        protected virtual RectangleF BoundingBox => ToParentSpace(DrawRectangle).AABBf;
+        protected virtual RectangleF BoundingBox => ToParentSpace(DrawRectangle.Inflate(margin)).AABBf;
 
         private Cached<Vector2> boundingSizeBacking = new Cached<Vector2>();
 


### PR DESCRIPTION
This moves the Margin property over to Drawables. Conceptually, this simplifies the following: The DrawRectangle (and the ScreenSpaceDrawingQuad) of containers now corresponds to only their visible region and not the entire region including the margin.

Also, this PR adds additional tests for nested margins with scale applied, and for margins applied directly to drawables.