### PR TITLE
Move debug tools to background loading.

### DIFF
--- a/osu.Framework/BaseGame.cs
+++ b/osu.Framework/BaseGame.cs
@@ -73,15 +73,15 @@ namespace osu.Framework
 
         private void addDebugTools()
         {
-            AddInternal(DrawVisualiser = new DrawVisualiser()
+            (DrawVisualiser = new DrawVisualiser()
             {
                 Depth = float.MaxValue / 2,
-            });
+            }).Preload(this, AddInternal);
 
-            AddInternal(LogOverlay = new LogOverlay()
+            (LogOverlay = new LogOverlay()
             {
                 Depth = float.MaxValue / 2,
-            });
+            }).Preload(this, AddInternal);
         }
 
         /// <summary>


### PR DESCRIPTION
Reasoning: They currently trigger font atlas loads (framework) which could delay game loading.

in the future we may want to avoid loading these elements until they are first used or similar.