### PR TITLE
Game freezes after finishing theme song

### DIFF
--- a/osu.Framework/Audio/Track/AudioTrackBass.cs
+++ b/osu.Framework/Audio/Track/AudioTrackBass.cs
@@ -137,6 +137,7 @@ namespace osu.Framework.Audio.Track
         {
             get
             {
+                if (Bass.ChannelIsActive(activeStream) == PlaybackState.Stopped) return 0;
                 double value = Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetPosition(activeStream)) * 1000;
                 if (value == Length && !isPlayed) return 0;
                 else return value;


### PR DESCRIPTION
Fix for [Game freezes after finishing theme song](https://github.com/ppy/osu/issues/162) issue.