### PR TITLE
Exposes SpriteText's shadow colour as a property.

### DIFF
--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -57,6 +57,19 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
+
+        private Color4 shadowColour = new Color4(0f, 0f, 0f, 0.5f);
+        public Color4 ShadowColour
+        {
+            get { return shadowColour; }
+            set
+            {
+                shadowColour = value;
+                if(shadow)
+                    internalSize.Invalidate();
+            }
+        }
+
         private Cached<Vector2> internalSize = new Cached<Vector2>();
 
         private float spaceWidth;
@@ -196,7 +209,7 @@ namespace osu.Framework.Graphics.Sprites
                         {
                             Sprite shadowSprite = getSprite(c);
                             shadowSprite.Position = new Vector2(-0.02f, 0.02f);
-                            shadowSprite.Colour = new Color4(0f, 0f, 0f, 0.5f);
+                            shadowSprite.Colour = shadowColour;
                             shadowSprite.Depth = float.MinValue;
                             ctn.Add(shadowSprite);
                         }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -65,7 +65,7 @@ namespace osu.Framework.Graphics.Sprites
             set
             {
                 shadowColour = value;
-                if(shadow)
+                if (shadow)
                     internalSize.Invalidate();
             }
         }


### PR DESCRIPTION
For https://github.com/ppy/osu/pull/202 , it's just so the Shadows can be darker to match the designs, I chose to expose it rather than simply make all shadows darker because customisation is king, but feel free to ask for that. or to close this (in which case I'll adjust my other PR to use current shadows)