### PR TITLE
When initially popping out, recursively flush all transformations of …

### DIFF
--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Containers
             if (state == Visibility.Hidden)
             {
                 PopOut();
-                Flush();
+                Flush(true);
             }
 
             base.LoadComplete();


### PR DESCRIPTION
…overlay containers instead of just their own transformations.