### PR TITLE
Always use a multiple of 3 vertices when creating triangle batches to…

### DIFF
--- a/osu.Framework/Graphics/Line/PathDrawNode.cs
+++ b/osu.Framework/Graphics/Line/PathDrawNode.cs
@@ -8,15 +8,16 @@ using OpenTK.Graphics.ES30;
 using osu.Framework.Graphics.OpenGL;
 using OpenTK;
 using System;
-using osu.Framework.Graphics.OpenGL.Buffers;
 using System.Collections.Generic;
 using osu.Framework.Graphics.Batches;
-using OpenTK.Graphics;
 
 namespace osu.Framework.Graphics.Sprites
 {
     public class PathDrawNodeSharedData
     {
+        // We multiply the size param by 3 such that the amount of vertices is a multiple of the amount of vertices
+        // per primitive (triangles in this case). Otherwise overflowing the batch will result in wrong
+        // grouping of vertices into primitives.
         public LinearBatch<TexturedVertex3D> HalfCircleBatch = new LinearBatch<TexturedVertex3D>(PathDrawNode.MAXRES * 100 * 3, 10, PrimitiveType.Triangles);
         public QuadBatch<TexturedVertex3D> QuadBatch = new QuadBatch<TexturedVertex3D>(200, 10);
     }

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -156,7 +156,10 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             if (vertexAction == null)
             {
                 if (triangleBatch == null)
-                    triangleBatch = new LinearBatch<TexturedVertex2D>(512, 128, PrimitiveType.Triangles);
+                    // We multiply the size param by 3 such that the amount of vertices is a multiple of the amount of vertices
+                    // per primitive (triangles in this case). Otherwise overflowing the batch will result in wrong
+                    // grouping of vertices into primitives.
+                    triangleBatch = new LinearBatch<TexturedVertex2D>(512 * 3, 128, PrimitiveType.Triangles);
                 vertexAction = triangleBatch.Add;
             }
 


### PR DESCRIPTION
… avoid incorrect grouping of vertices into primitives after buffer overflows.