### PR TITLE
Make Container.Children calling Add instead of AddInternal.

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -171,19 +171,15 @@ namespace osu.Framework.Graphics.Containers
 
         public virtual IEnumerable<T> Children
         {
-            get {
+            get
+            {
                 return Content != this ? Content.Children : children;
             }
 
             set
             {
-                if (Content != this)
-                    Content.Children = value;
-                else
-                {
-                    Clear();
-                    Add(value);
-                }
+                Clear();
+                Add(value);
             }
         }
 
@@ -632,7 +628,7 @@ namespace osu.Framework.Graphics.Containers
                 return ToParentSpace(drawRect).AABBf.Inflate(inflation);
             }
         }
-        
+
         protected override void Dispose(bool isDisposing)
         {
             //this could cause issues if a child is referenced in more than one containers (or referenced for future use elsewhere).

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -180,7 +180,10 @@ namespace osu.Framework.Graphics.Containers
                 if (Content != this)
                     Content.Children = value;
                 else
-                    InternalChildren = value;
+                {
+                    Clear();
+                    Add(value);
+                }
             }
         }
 


### PR DESCRIPTION
This is for scenario that `Add` is doing something to the item. Example: `KeyCounterCollection`.
Reason for modifying `Children` is that it's already virtual, so acceptable for calling virtual method.