### PR TITLE
Eliminate busy wait loops for game thread synchronization

### DIFF
--- a/osu.Framework.Desktop/Platform/HeadlessGameHost.cs
+++ b/osu.Framework.Desktop/Platform/HeadlessGameHost.cs
@@ -35,7 +35,5 @@ namespace osu.Framework.Desktop.Platform
         }
 
         public override IEnumerable<InputHandler> GetInputHandlers() => new InputHandler[] { };
-
-        protected override bool ReadyToLoad => true;
     }
 }

--- a/osu.Framework.Desktop/Platform/HeadlessGameHost.cs
+++ b/osu.Framework.Desktop/Platform/HeadlessGameHost.cs
@@ -35,5 +35,9 @@ namespace osu.Framework.Desktop.Platform
         }
 
         public override IEnumerable<InputHandler> GetInputHandlers() => new InputHandler[] { };
+
+        protected override void WaitTillReadyToLoad()
+        {
+        }
     }
 }

--- a/osu.Framework.Desktop/Platform/HeadlessGameHost.cs
+++ b/osu.Framework.Desktop/Platform/HeadlessGameHost.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Desktop.Platform
 
         public override IEnumerable<InputHandler> GetInputHandlers() => new InputHandler[] { };
 
-        protected override void WaitTillReadyToLoad()
+        protected override void WaitUntilReadyToLoad()
         {
         }
     }

--- a/osu.Framework/Platform/BasicGameHost.cs
+++ b/osu.Framework/Platform/BasicGameHost.cs
@@ -392,7 +392,7 @@ namespace osu.Framework.Platform
             LoadGame(game);
         }
 
-        protected virtual void WaitTillReadyToLoad()
+        protected virtual void WaitUntilReadyToLoad()
         {
             updateThread.WaitUntilInitialized();
             drawThread.WaitUntilInitialized();
@@ -403,7 +403,7 @@ namespace osu.Framework.Platform
             Task.Run(delegate
             {
                 // Make sure we are not loading anything game-related before our threads have been initialized.
-                WaitTillReadyToLoad();
+                WaitUntilReadyToLoad();
 
                 game.PerformLoad(game);
             }).ContinueWith(obj => Schedule(() => base.Add(game)));

--- a/osu.Framework/Platform/BasicGameHost.cs
+++ b/osu.Framework/Platform/BasicGameHost.cs
@@ -271,7 +271,7 @@ namespace osu.Framework.Platform
                 ExitRequested = true;
 
                 threads.ForEach(t => t.Exit());
-                threads.Where(t => t.Thread.IsAlive).ForEach(t => t.Thread.Join());
+                threads.Where(t => t.Running).ForEach(t => t.Thread.Join());
                 Window?.Close();
             }, false);
         }

--- a/osu.Framework/Platform/BasicGameHost.cs
+++ b/osu.Framework/Platform/BasicGameHost.cs
@@ -220,7 +220,7 @@ namespace osu.Framework.Platform
         protected virtual void UpdateInitialize()
         {
             //this was added due to the dependency on GLWrapper.MaxTextureSize begin initialised.
-            drawThread.WaitTillInitialized();
+            drawThread.WaitUntilInitialized();
         }
 
         protected void UpdateFrame()
@@ -263,8 +263,6 @@ namespace osu.Framework.Platform
         }
 
         protected volatile bool ExitRequested;
-
-        private bool threadsRunning => updateThread.Running || drawThread.Running;
 
         public void Exit()
         {
@@ -394,15 +392,13 @@ namespace osu.Framework.Platform
             LoadGame(game);
         }
 
-        protected virtual bool ReadyToLoad => updateThread.IsInitialized && drawThread.IsInitialized;
-
         protected virtual void LoadGame(BaseGame game)
         {
             Task.Run(delegate
             {
                 // Make sure we are not loading anything game-related before our threads have been initialized.
-                updateThread.WaitTillInitialized();
-                drawThread.WaitTillInitialized();
+                updateThread.WaitUntilInitialized();
+                drawThread.WaitUntilInitialized();
 
                 game.PerformLoad(game);
             }).ContinueWith(obj => Schedule(() => base.Add(game)));

--- a/osu.Framework/Platform/BasicGameHost.cs
+++ b/osu.Framework/Platform/BasicGameHost.cs
@@ -392,13 +392,18 @@ namespace osu.Framework.Platform
             LoadGame(game);
         }
 
+        protected virtual void WaitTillReadyToLoad()
+        {
+            updateThread.WaitUntilInitialized();
+            drawThread.WaitUntilInitialized();
+        }
+
         protected virtual void LoadGame(BaseGame game)
         {
             Task.Run(delegate
             {
                 // Make sure we are not loading anything game-related before our threads have been initialized.
-                updateThread.WaitUntilInitialized();
-                drawThread.WaitUntilInitialized();
+                WaitTillReadyToLoad();
 
                 game.PerformLoad(game);
             }).ContinueWith(obj => Schedule(() => base.Add(game)));

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -69,9 +69,6 @@ namespace osu.Framework.Threading
 
         private volatile bool exitRequested;
 
-        private volatile bool isInitialized;
-        public bool IsInitialized => isInitialized;
-
         private readonly ManualResetEvent initializedEvent = new ManualResetEvent(false);
 
         public Action OnThreadStart;
@@ -90,7 +87,7 @@ namespace osu.Framework.Threading
             Scheduler = new Scheduler(null);
         }
 
-        public void WaitTillInitialized()
+        public void WaitUntilInitialized()
         {
             initializedEvent.WaitOne();
         }
@@ -101,7 +98,6 @@ namespace osu.Framework.Threading
 
             OnThreadStart?.Invoke();
 
-            isInitialized = true;
             initializedEvent.Set();
 
             while (!exitRequested)

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -72,6 +72,8 @@ namespace osu.Framework.Threading
         private volatile bool isInitialized;
         public bool IsInitialized => isInitialized;
 
+        private readonly ManualResetEvent initializedEvent = new ManualResetEvent(false);
+
         public Action OnThreadStart;
 
         public GameThread(Action onNewFrame, string threadName)
@@ -88,6 +90,11 @@ namespace osu.Framework.Threading
             Scheduler = new Scheduler(null);
         }
 
+        public void WaitTillInitialized()
+        {
+            initializedEvent.WaitOne();
+        }
+
         private void runWork()
         {
             Scheduler.SetCurrentThread();
@@ -95,6 +102,7 @@ namespace osu.Framework.Threading
             OnThreadStart?.Invoke();
 
             isInitialized = true;
+            initializedEvent.Set();
 
             while (!exitRequested)
                 ProcessFrame();


### PR DESCRIPTION
Uses an EventWaitHandle to block threads waiting for other threads to finish initializing.  On game shutdown uses Thread.Join() to wait for threads in the process of terminating.