### PR TITLE
Position Transforms now correctly handle RelativePositionAxes, always use Position instead of DrawPosition

### DIFF
--- a/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
+++ b/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
@@ -228,13 +228,23 @@ namespace osu.Framework.Graphics
         public void MoveToX(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPositionX));
-            TransformFloatTo(DrawPosition.X, destination, duration, easing, new TransformPositionX());
+
+            float start = DrawPosition.X;
+            Vector2 parentSize = Parent?.ChildSize ?? Vector2.One;
+            if ((RelativePositionAxes & Axes.X) > 0)
+                start /= parentSize.X;
+            TransformFloatTo(start, destination, duration, easing, new TransformPositionX());
         }
 
         public void MoveToY(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPositionY));
-            TransformFloatTo(DrawPosition.Y, destination, duration, easing, new TransformPositionY());
+
+            float start = DrawPosition.Y;
+            Vector2 parentSize = Parent?.ChildSize ?? Vector2.One;
+            if ((RelativePositionAxes & Axes.Y) > 0)
+                start /= parentSize.Y;
+            TransformFloatTo(start, destination, duration, easing, new TransformPositionY());
         }
 
         #endregion
@@ -305,7 +315,18 @@ namespace osu.Framework.Graphics
         public void MoveTo(Vector2 newPosition, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPosition));
-            TransformVectorTo(DrawPosition, newPosition, duration, easing, new TransformPosition());
+
+            Vector2 startPosition = DrawPosition;
+            if (RelativePositionAxes != Axes.None)
+            {
+                Vector2 parentSize = Parent?.ChildSize ?? Vector2.One;
+                if ((RelativePositionAxes & Axes.X) > 0)
+                    startPosition.X /= parentSize.X;
+                if ((RelativePositionAxes & Axes.Y) > 0)
+                    startPosition.Y /= parentSize.Y;
+            }
+
+            TransformVectorTo(startPosition/*DrawPosition*/, newPosition, duration, easing, new TransformPosition());
         }
 
         public void MoveToRelative(Vector2 offset, int duration = 0, EasingTypes easing = EasingTypes.None)

--- a/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
+++ b/osu.Framework/Graphics/Drawable_TransformationHelpers.cs
@@ -228,23 +228,13 @@ namespace osu.Framework.Graphics
         public void MoveToX(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPositionX));
-
-            float start = DrawPosition.X;
-            Vector2 parentSize = Parent?.ChildSize ?? Vector2.One;
-            if ((RelativePositionAxes & Axes.X) > 0)
-                start /= parentSize.X;
-            TransformFloatTo(start, destination, duration, easing, new TransformPositionX());
+            TransformFloatTo(Position.X, destination, duration, easing, new TransformPositionX());
         }
 
         public void MoveToY(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPositionY));
-
-            float start = DrawPosition.Y;
-            Vector2 parentSize = Parent?.ChildSize ?? Vector2.One;
-            if ((RelativePositionAxes & Axes.Y) > 0)
-                start /= parentSize.Y;
-            TransformFloatTo(start, destination, duration, easing, new TransformPositionY());
+            TransformFloatTo(Position.Y, destination, duration, easing, new TransformPositionY());
         }
 
         #endregion
@@ -315,24 +305,13 @@ namespace osu.Framework.Graphics
         public void MoveTo(Vector2 newPosition, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPosition));
-
-            Vector2 startPosition = DrawPosition;
-            if (RelativePositionAxes != Axes.None)
-            {
-                Vector2 parentSize = Parent?.ChildSize ?? Vector2.One;
-                if ((RelativePositionAxes & Axes.X) > 0)
-                    startPosition.X /= parentSize.X;
-                if ((RelativePositionAxes & Axes.Y) > 0)
-                    startPosition.Y /= parentSize.Y;
-            }
-
-            TransformVectorTo(startPosition/*DrawPosition*/, newPosition, duration, easing, new TransformPosition());
+            TransformVectorTo(Position, newPosition, duration, easing, new TransformPosition());
         }
 
-        public void MoveToRelative(Vector2 offset, int duration = 0, EasingTypes easing = EasingTypes.None)
+        public void MoveToOffset(Vector2 offset, int duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPosition));
-            MoveTo((Transforms.FindLast(t => t is TransformPosition) as TransformPosition)?.EndValue ?? DrawPosition + offset, duration, easing);
+            MoveTo((Transforms.FindLast(t => t is TransformPosition) as TransformPosition)?.EndValue ?? Position + offset, duration, easing);
         }
 
         #endregion


### PR DESCRIPTION
Discovered this while cleaning/fixing up https://github.com/ppy/osu/pull/202

For example:
A Parent Container of dimensions 1000x1000
A Child Drawable of Relative Position 0.5fx0.5f
So Child's position is 500x500
If you the tell Child to MoveToX(0.9f), the expected outcome is for it to be at 900x500, the actual outcome is different, the Transforms all work with a "start value", for the relative transitions to work, the start value here should be 0.5f, but is instead 500 (0.5f *Parent.ChildSize.X), this has the effect of applying the Parent.ChildSize.X at every step of the transformation (because it's pre-multiplied), which essentially leads to the drawable disappearing at the beginning of the transform and reappearing at the end.

This has now changed how Drawables react to position transforms.
<B>Before:</B>
Non-Relative: Expect Non-Relative Coords
Relative: Expect Non-Relative Coords
<B>After:</B>
Non-Relative: Expect Non-Relative Coords
Relative: Expect Relative Coords

This does mean you can no longer supply non-relative coords to a relative drawable, for transformations, but that feels like it should be intentional, if a drawable is Relative then it should be 100% relative in terms of that Axis.

The alternative is to pre-divide all coordinates by Parent.ChildSize.[your_axes] so they become relative every time you do a transform like this, which just seems wrong.

## Changes:
* ```Position``` is always used in Position Transformations, as opposed to ```DrawPosition```
* ```MoveToRelative()``` has been renamed to ```MoveToOffset()``` to avoid confusion with Relative Space.