### PR TITLE
fix mouse button handling

### DIFF
--- a/osu.Framework/Graphics/Drawable_Interaction.cs
+++ b/osu.Framework/Graphics/Drawable_Interaction.cs
@@ -39,16 +39,37 @@ namespace osu.Framework.Graphics
         {
         }
 
-        public bool TriggerMouseDown(InputState state = null, MouseDownEventArgs args = null) => OnMouseDown(getLocalState(state), args);
-
+        public bool TriggerMouseDown(InputState state = null, MouseDownEventArgs args = null)
+        {
+            if (state == null || state.Mouse.HasMainButtonPressed)
+                return OnMouseDown(getLocalState(state), args);
+            else
+                return OnAuxMouseDown(getLocalState(state), args);
+        }
         protected virtual bool OnMouseDown(InputState state, MouseDownEventArgs args)
         {
             return false;
         }
 
-        public bool TriggerMouseUp(InputState state = null, MouseUpEventArgs args = null) => OnMouseUp(getLocalState(state), args);
+        protected virtual bool OnAuxMouseDown(InputState state, MouseDownEventArgs args)
+        {
+            return false;
+        }
+
+        public bool TriggerMouseUp(InputState state = null, MouseUpEventArgs args = null)
+        {
+            if (state == null || state.Last.Mouse.HasMainButtonPressed)
+                return OnMouseUp(getLocalState(state), args);
+            else
+                return OnAuxMouseUp(getLocalState(state), args);
+        }
 
         protected virtual bool OnMouseUp(InputState state, MouseUpEventArgs args)
+        {
+            return false;
+        }
+
+        protected virtual bool OnAuxMouseUp(InputState state, MouseUpEventArgs args)
         {
             return false;
         }
@@ -205,6 +226,7 @@ namespace osu.Framework.Graphics
 
             public Vector2? PositionMouseDown => NativeState.PositionMouseDown == null ? (Vector2?)null : us.Parent?.ToLocalSpace(NativeState.PositionMouseDown.Value) ?? NativeState.PositionMouseDown;
             public bool HasMainButtonPressed => NativeState.HasMainButtonPressed;
+            public bool HasButtonPressed => NativeState.HasButtonPressed;
             public bool LeftButton => NativeState.LeftButton;
             public bool MiddleButton => NativeState.MiddleButton;
             public bool RightButton => NativeState.RightButton;

--- a/osu.Framework/Graphics/Drawable_Interaction.cs
+++ b/osu.Framework/Graphics/Drawable_Interaction.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Graphics
 
         public bool TriggerMouseDown(InputState state = null, MouseDownEventArgs args = null)
         {
-            if (state == null || state.Mouse.HasMainButtonPressed)
+            if (args == null || args.Button == MouseButton.Left || args.Button == MouseButton.Right)
                 return OnMouseDown(getLocalState(state), args);
             else
                 return OnAuxMouseDown(getLocalState(state), args);
@@ -58,7 +58,7 @@ namespace osu.Framework.Graphics
 
         public bool TriggerMouseUp(InputState state = null, MouseUpEventArgs args = null)
         {
-            if (state == null || state.Last.Mouse.HasMainButtonPressed)
+            if (args == null || args.Button == MouseButton.Left || args.Button == MouseButton.Right)
                 return OnMouseUp(getLocalState(state), args);
             else
                 return OnAuxMouseUp(getLocalState(state), args);

--- a/osu.Framework/Input/IMouseState.cs
+++ b/osu.Framework/Input/IMouseState.cs
@@ -20,6 +20,7 @@ namespace osu.Framework.Input
         Vector2? PositionMouseDown { get; }
 
         bool HasMainButtonPressed { get; }
+        bool HasButtonPressed { get; }
 
         bool LeftButton { get; }
         bool MiddleButton { get; }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -383,7 +383,8 @@ namespace osu.Framework.Input
                 if (isValidClick)
                     handleMouseClick(state);
 
-                mouseDownInputQueue = null;
+                if(mouse.LastState?.HasButtonPressed != true)
+                    mouseDownInputQueue = null;
                 mouse.PositionMouseDown = null;
 
                 if (isDragging)

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using osu.Framework.Lists;
 using OpenTK;
 using OpenTK.Input;
+using System.Linq;
 
 namespace osu.Framework.Input
 {
@@ -35,6 +36,7 @@ namespace osu.Framework.Input
         public int Wheel { get; set; }
 
         public bool HasMainButtonPressed => LeftButton || RightButton;
+        public bool HasButtonPressed => ButtonStates.Any(b => b.State);
 
         public Vector2 Delta => Position - (LastState?.Position ?? Vector2.Zero);
 


### PR DESCRIPTION
fixes crash caused by releasing a main mouse button while having a now main button pressed.
Clicks and double clicks are now handled for all the buttons and not only for the main ones.
Double click will be fired for any combination of 2 fast mouse button clicks.
 