### PR TITLE
Add sanity check to dissalow invalid file paths

### DIFF
--- a/osu.Framework/IO/File/FileSafety.cs
+++ b/osu.Framework/IO/File/FileSafety.cs
@@ -17,14 +17,14 @@ namespace osu.Framework.IO.File
 
         public const string CLEANUP_DIRECTORY = @"_cleanup";
 
-        public static string WindowsFilenameStrip(string entry)
+        public static string FilenameStrip(string entry)
         {
             foreach (char c in Path.GetInvalidFileNameChars())
                 entry = entry.Replace(c.ToString(), string.Empty);
             return entry;
         }
 
-        public static string WindowsPathStrip(string entry)
+        public static string PathStrip(string entry)
         {
             foreach (char c in Path.GetInvalidFileNameChars())
                 entry = entry.Replace(c.ToString(), string.Empty);

--- a/osu.Framework/Platform/BasicStorage.cs
+++ b/osu.Framework/Platform/BasicStorage.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Platform
     
         protected BasicStorage(string baseName)
         {
-            BaseName = FileSafety.WindowsFilenameStrip(baseName);
+            BaseName = FileSafety.FilenameStrip(baseName);
         }
 
         public abstract bool Exists(string path);

--- a/osu.Framework/Platform/BasicStorage.cs
+++ b/osu.Framework/Platform/BasicStorage.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
 using System.IO;
+using osu.Framework.IO.File;
 using SQLite.Net;
 
 namespace osu.Framework.Platform
@@ -13,7 +13,7 @@ namespace osu.Framework.Platform
     
         protected BasicStorage(string baseName)
         {
-            BaseName = baseName;
+            BaseName = FileSafety.WindowsFilenameStrip(baseName);
         }
 
         public abstract bool Exists(string path);


### PR DESCRIPTION
If the gameName given contains invalid path or file name characters, the Logger will have issues later.
This should strip out invalid characters before that happens.

For example, ":theori" crashes the Logger.