### PR TITLE
Remove DisplayAsRoot (handled automatically now).

### DIFF
--- a/osu.Framework/GameModes/GameMode.cs
+++ b/osu.Framework/GameModes/GameMode.cs
@@ -113,12 +113,6 @@ namespace osu.Framework.GameModes
             return base.OnKeyDown(state, args);
         }
 
-        public void DisplayAsRoot()
-        {
-            Debug.Assert(ParentGameMode == null);
-            OnEntering(null);
-        }
-
         /// <summary>
         /// Changes to a new GameMode.
         /// </summary>

--- a/osu.Framework/GameModes/GameMode.cs
+++ b/osu.Framework/GameModes/GameMode.cs
@@ -92,6 +92,15 @@ namespace osu.Framework.GameModes
             base.PerformLoad(game);
         }
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            //for the case where we are at the top of the mode stack, we still want to run our OnEntering method.
+            if (ParentGameMode == null)
+                OnEntering(null);
+        }
+
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {
             switch (args.Key)


### PR DESCRIPTION
Was pretty ugly having to call DisplayAsRoot everr time (and a testcase missed out on it soooo).