### PR TITLE
Exception handling (and a bit of log tidying)

### DIFF
--- a/osu.Framework.Desktop/Platform/DesktopStorage.cs
+++ b/osu.Framework.Desktop/Platform/DesktopStorage.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Desktop.Platform
         public override bool Exists(string path) => File.Exists(Path.Combine(BasePath, path));
 
         public override void Delete(string path) => File.Delete(Path.Combine(BasePath, path));
-        
+
         public override void OpenInNativeExplorer()
         {
             Process.Start(BasePath);
@@ -57,5 +57,7 @@ namespace osu.Framework.Desktop.Platform
                 platform = new SQLitePlatformGeneric();
             return new SQLiteConnection(platform, Path.Combine(BasePath, $@"{name}.db"));
         }
+
+        public override void DeleteDatabase(string name) => Delete($@"{name}.db");
     }
 }

--- a/osu.Framework/Extensions/GeneralExtensions.cs
+++ b/osu.Framework/Extensions/GeneralExtensions.cs
@@ -8,9 +8,11 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
+using System.Threading.Tasks;
 
 // this is an abusive thing to do, but it increases the visibility of Extension Methods to virtually every file.
 
@@ -146,5 +148,11 @@ namespace osu.Framework.Extensions
         public static string GetDescription(this Enum value)
             => value.GetType().GetField(value.ToString())
             .GetCustomAttribute<DescriptionAttribute>()?.Description ?? value.ToString();
+
+        public static void ThrowIfFaulted(this Task task)
+        {
+            if (task.IsFaulted)
+                ExceptionDispatchInfo.Capture(task.Exception.InnerException).Throw();
+        }
     }
 }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1187,7 +1187,7 @@ namespace osu.Framework.Graphics
         public Task Preload(BaseGame game, Action<Drawable> onLoaded = null)
         {
             if (LoadState == LoadState.NotLoaded)
-                return Task.Run(() => PerformLoad(game)).ContinueWith(task => Schedule(() =>
+                return Task.Run(() => PerformLoad(game)).ContinueWith(task => game.Schedule(() =>
                 {
                     task.ThrowIfFaulted();
                     onLoaded?.Invoke(this);

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1214,7 +1214,7 @@ namespace osu.Framework.Graphics
             double t1 = perf.CurrentTime;
             game.Dependencies.Initialize(this);
             double elapsed = perf.CurrentTime - t1;
-            if (elapsed > 50 && ThreadSafety.IsUpdateThread)
+            if (perf.CurrentTime > 1000 && elapsed > 50 && ThreadSafety.IsUpdateThread)
                 Logger.Log($@"Drawable [{ToString()}] took {elapsed:0.00}ms to load and was not async!", LoggingTarget.Performance);
             LoadState = LoadState.Loaded;
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1186,7 +1186,12 @@ namespace osu.Framework.Graphics
         public Task Preload(BaseGame game, Action<Drawable> onLoaded = null)
         {
             if (LoadState == LoadState.NotLoaded)
-                return Task.Run(() => PerformLoad(game)).ContinueWith(obj => game.Schedule(() => onLoaded?.Invoke(this)));
+                return Task.Run(() => PerformLoad(game)).ContinueWith(task => Schedule(() =>
+                {
+                    if (task.IsFaulted)
+                        throw task.Exception;
+                    onLoaded?.Invoke(this);
+                }));
 
             Debug.Assert(LoadState >= LoadState.Loaded, "Preload got called twice on the same Drawable.");
             onLoaded?.Invoke(this);

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -17,6 +17,7 @@ using osu.Framework.Threading;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Caching;
+using osu.Framework.Extensions;
 using osu.Framework.Logging;
 using osu.Framework.Statistics;
 using osu.Framework.Graphics.Colour;
@@ -1188,8 +1189,7 @@ namespace osu.Framework.Graphics
             if (LoadState == LoadState.NotLoaded)
                 return Task.Run(() => PerformLoad(game)).ContinueWith(task => Schedule(() =>
                 {
-                    if (task.IsFaulted)
-                        throw task.Exception;
+                    task.ThrowIfFaulted();
                     onLoaded?.Invoke(this);
                 }));
 

--- a/osu.Framework/Platform/BasicGameHost.cs
+++ b/osu.Framework/Platform/BasicGameHost.cs
@@ -22,6 +22,7 @@ using osu.Framework.Timing;
 using OpenTK;
 using System.Threading.Tasks;
 using osu.Framework.Caching;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Sprites;
 using OpenTK.Input;
@@ -415,8 +416,7 @@ namespace osu.Framework.Platform
                 game.PerformLoad(game);
             }).ContinueWith(task => Schedule(() =>
             {
-                if (task.IsFaulted)
-                    throw task.Exception;
+                task.ThrowIfFaulted();
                 base.Add(game);
             }));
         }

--- a/osu.Framework/Platform/BasicGameHost.cs
+++ b/osu.Framework/Platform/BasicGameHost.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -192,7 +193,10 @@ namespace osu.Framework.Platform
             if (ExceptionThrown != null)
                 ExceptionThrown.Invoke(exception);
             else
+            {
+                AppDomain.CurrentDomain.UnhandledException -= exceptionHandler;
                 throw exception;
+            }
         }
 
         protected virtual void OnActivated() => Schedule(() => setActive(true));

--- a/osu.Framework/Platform/BasicGameHost.cs
+++ b/osu.Framework/Platform/BasicGameHost.cs
@@ -54,6 +54,8 @@ namespace osu.Framework.Platform
         public event Func<bool> Exiting;
         public event Action Exited;
 
+        public event Action<Exception> ExceptionThrown;
+
         public event Action<IpcMessage> MessageReceived;
 
         protected void OnMessageReceived(IpcMessage message) => MessageReceived?.Invoke(message);
@@ -144,6 +146,8 @@ namespace osu.Framework.Platform
         {
             Instance = this;
 
+            AppDomain.CurrentDomain.UnhandledException += exceptionHandler;
+
             Dependencies.Cache(this);
             name = gameName;
 
@@ -178,6 +182,16 @@ namespace osu.Framework.Platform
             AddInternal(inputManager = new UserInputManager(this));
 
             Dependencies.Cache(inputManager);
+        }
+
+        private void exceptionHandler(object sender, UnhandledExceptionEventArgs e)
+        {
+            var exception = e.ExceptionObject as Exception;
+
+            if (ExceptionThrown != null)
+                ExceptionThrown.Invoke(exception);
+            else
+                throw exception;
         }
 
         protected virtual void OnActivated() => Schedule(() => setActive(true));

--- a/osu.Framework/Platform/BasicGameHost.cs
+++ b/osu.Framework/Platform/BasicGameHost.cs
@@ -413,11 +413,16 @@ namespace osu.Framework.Platform
                 WaitUntilReadyToLoad();
 
                 game.PerformLoad(game);
-            }).ContinueWith(obj => Schedule(() => base.Add(game)));
+            }).ContinueWith(task => Schedule(() =>
+            {
+                if (task.IsFaulted)
+                    throw task.Exception;
+                base.Add(game);
+            }));
         }
 
-        public abstract IEnumerable<InputHandler> GetInputHandlers();
+    public abstract IEnumerable<InputHandler> GetInputHandlers();
 
-        public abstract TextInputSource GetTextInput();
-    }
+    public abstract TextInputSource GetTextInput();
+}
 }

--- a/osu.Framework/Platform/BasicStorage.cs
+++ b/osu.Framework/Platform/BasicStorage.cs
@@ -24,6 +24,8 @@ namespace osu.Framework.Platform
 
         public abstract SQLiteConnection GetDatabase(string name);
 
+        public abstract void DeleteDatabase(string name);
+
         public abstract void OpenInNativeExplorer();
     }
 }


### PR DESCRIPTION
Until now, exceptions have been thrown out and ignored when inside Task.Run blocks, which can regularly leave the framework in an unrecoverable state (to the point you can't close the window).

This resolves that by throwing the exceptions. Note this doesn't yet gracefully handle exceptions, it just ensures the application crashes.