### PR TITLE
Set parent before adding drawables to containers

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -267,11 +267,9 @@ namespace osu.Framework.Graphics.Containers
             else
             {
                 if (drawable.IsLoaded)
-                {
                     Debug.Assert(drawable.Parent == null, "May not add a drawable to multiple containers.");
-                    drawable.ChangeParent(this);
-                }
 
+                drawable.ChangeParent(this);
                 children.Add(drawable);
             }
 

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -266,10 +266,9 @@ namespace osu.Framework.Graphics.Containers
                 pendingChildren.Add(drawable);
             else
             {
-                if (drawable.IsLoaded)
-                    Debug.Assert(drawable.Parent == null, "May not add a drawable to multiple containers.");
-
+                Debug.Assert(drawable.Parent == null, "May not add a drawable to multiple containers.");
                 drawable.ChangeParent(this);
+
                 children.Add(drawable);
             }
 


### PR DESCRIPTION
PRing this for feedback.

I came across a case where the IsAlive check in children.Add (just after this change) would nullref due to having no clock present. This fixes that case, but I'm not 100% sure it's correct logic.

Basically if you happen to set LifetimeStart or LifetimeEnd of a drawable before adding it to a container, it will fail without this change:

![image](https://cloud.githubusercontent.com/assets/191335/22241772/32e0e032-e264-11e6-9cb2-70fe4c4c56d7.png)

![image](https://cloud.githubusercontent.com/assets/191335/22241776/38bc24da-e264-11e6-869c-0898342e4193.png)

![image](https://cloud.githubusercontent.com/assets/191335/22241784/48efaeb2-e264-11e6-9713-9576316d45e3.png)
