### PR TITLE
Implement Drag&Drop for Windows

### DIFF
--- a/osu.Framework.Desktop/Platform/DesktopGameWindow.cs
+++ b/osu.Framework.Desktop/Platform/DesktopGameWindow.cs
@@ -3,13 +3,20 @@
 
 using osu.Framework.Platform;
 using OpenTK;
+using System;
+using System.Windows.Forms;
 
 namespace osu.Framework.Desktop.Platform
 {
-    public class DesktopGameWindow : BasicGameWindow
+    public class DesktopGameWindow : BasicGameWindow, IDropTarget
     {
         private const int default_width = 1366;
         private const int default_height = 768;
+
+        public event Action<DragEventArgs> DragEnter;
+        public event Action<EventArgs> DragLeave;
+        public event Action<DragEventArgs> DragDrop;
+        public event Action<DragEventArgs> DragOver;
 
         public DesktopGameWindow() : base(default_width, default_height)
         {
@@ -23,5 +30,13 @@ namespace osu.Framework.Desktop.Platform
                 (DisplayDevice.Default.Height - Size.Height) / 2
             );
         }
+
+        public void OnDragEnter(DragEventArgs e) => DragEnter?.Invoke(e);
+
+        public void OnDragLeave(EventArgs e) => DragLeave?.Invoke(e);
+
+        public void OnDragDrop(DragEventArgs e) => DragDrop?.Invoke(e);
+
+        public void OnDragOver(DragEventArgs e) => DragOver?.Invoke(e);
     }
 }

--- a/osu.Framework.Desktop/Platform/Windows/WindowsGameWindow.cs
+++ b/osu.Framework.Desktop/Platform/Windows/WindowsGameWindow.cs
@@ -27,9 +27,9 @@ namespace osu.Framework.Desktop.Platform.Windows
                 // us the trouble of creating and using our own custom-built COM-Wrapper for drag&drop
                 // and generally makes our lives much easier (trust me, you don't want to implement drag&drop with win32).
 
-                var windowsFormsTypes = typeof(System.Windows.Forms.Form).Assembly.GetTypes();
+                var windowsFormsTypes = typeof(Form).Assembly.GetTypes();
                 // Internal DropTarget. This is a COM-object that we can use for RegisterDragDrop which does the bulk of win32 API interaction for us.
-                var dropTarget = Activator.CreateInstance(windowsFormsTypes.Single(x => x.Name == "DropTarget"), (IDropTarget)this);
+                var dropTarget = Activator.CreateInstance(windowsFormsTypes.Single(x => x.Name == "DropTarget"), this);
                 var unsafeNativeMethods = windowsFormsTypes.Single(x => x.Name == "UnsafeNativeMethods");
                 var oleInitializeMethod = unsafeNativeMethods.GetMethod("OleInitialize", BindingFlags.Static | BindingFlags.Public);
                 var registerDragDropMethod = unsafeNativeMethods.GetMethod("RegisterDragDrop", BindingFlags.Static | BindingFlags.Public);

--- a/osu.Framework.Desktop/Platform/Windows/WindowsGameWindow.cs
+++ b/osu.Framework.Desktop/Platform/Windows/WindowsGameWindow.cs
@@ -1,12 +1,51 @@
 ﻿// Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
+using System.Linq;
 using OpenTK.Input;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using System.Reflection;
 
 namespace osu.Framework.Desktop.Platform.Windows
 {
     class WindowsGameWindow : DesktopGameWindow
     {
+        protected override void OnLoad(EventArgs e)
+        {
+            try
+            {
+                // This code is kind of... bad. But it saves us a lot of trouble in the end.
+                // Basically, what this does is, it grabs various System.Windows.Forms internals
+                // by using reflection and orchestrates them so that we can register this window
+                // for drag&drop with windows without needing a Form object.
+                // We cannot retrieve a Form object using the typical Control.FromHandle method because
+                // the window we are operating on has not been originally created by WinForms and thus
+                // this will only give us null back.
+                // Utilizing the .NET Framework internals directly instead of using the Win32 API saves
+                // us the trouble of creating and using our own custom-built COM-Wrapper for drag&drop
+                // and generally makes our lives much easier (trust me, you don't want to implement drag&drop with win32).
+
+                var windowsFormsTypes = typeof(System.Windows.Forms.Form).Assembly.GetTypes();
+                // Internal DropTarget. This is a COM-object that we can use for RegisterDragDrop which does the bulk of win32 API interaction for us.
+                var dropTarget = Activator.CreateInstance(windowsFormsTypes.Single(x => x.Name == "DropTarget"), (IDropTarget)this);
+                var unsafeNativeMethods = windowsFormsTypes.Single(x => x.Name == "UnsafeNativeMethods");
+                var oleInitializeMethod = unsafeNativeMethods.GetMethod("OleInitialize", BindingFlags.Static | BindingFlags.Public);
+                var registerDragDropMethod = unsafeNativeMethods.GetMethod("RegisterDragDrop", BindingFlags.Static | BindingFlags.Public);
+
+                // We need to call the OleInitialize()-Method because otherwise we will get an E_OUTOFMEMORY-Error from the RegisterDragDrop-Method we are about to call.
+                oleInitializeMethod.Invoke(null, null);
+                var errorCode = registerDragDropMethod.Invoke(null, new object[] { new HandleRef(this, WindowInfo.Handle), dropTarget });
+            }
+            catch
+            {
+                // Ignore whatever exceptions may occur in the above code.
+                // If something goes wrong, we just won't have Drag&Drop functionality.
+            }
+            base.OnLoad(e);
+        }
+
         protected override void OnKeyDown(KeyboardKeyEventArgs e)
         {
             if (e.Key == Key.F4 && e.Alt)

--- a/osu.Framework.Desktop/osu.Framework.Desktop.csproj
+++ b/osu.Framework.Desktop/osu.Framework.Desktop.csproj
@@ -58,6 +58,7 @@
     <Reference Include="SQLiteNetExtensions">
       <HintPath>$(SolutionDir)\packages\SQLiteNetExtensions.1.3.0\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\SQLiteNetExtensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Host.cs" />

--- a/osu.Framework/BaseGame.cs
+++ b/osu.Framework/BaseGame.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Windows.Forms;
+using System.Linq;
 using osu.Framework.Audio;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -171,28 +171,6 @@ namespace osu.Framework
             addDebugTools();
         }
 
-        private void dragDrop(object sender, DragEventArgs e)
-        {
-            Array fileDrop = e.Data.GetData(DataFormats.FileDrop) as Array;
-            string textDrop = e.Data.GetData(DataFormats.Text) as string;
-
-            if (fileDrop != null)
-            {
-                for (int i = 0; i < fileDrop.Length; i++)
-                    OnDroppedFile(fileDrop.GetValue(i).ToString());
-            }
-
-            if (!string.IsNullOrEmpty(textDrop))
-                OnDroppedText(textDrop);
-        }
-
-        private void dragEnter(object sender, DragEventArgs e)
-        {
-            bool isFile = e.Data.GetDataPresent(DataFormats.FileDrop);
-            bool isUrl = e.Data.GetDataPresent(DataFormats.Text);
-            e.Effect = isFile || isUrl ? DragDropEffects.Copy : DragDropEffects.None;
-        }
-
         /// <summary>
         /// Whether the Game environment is active (in the foreground).
         /// </summary>
@@ -248,22 +226,6 @@ namespace osu.Framework
         public void Exit()
         {
             host.Exit();
-        }
-
-        protected virtual void OnDroppedText(string text)
-        {
-        }
-
-        protected virtual void OnDroppedFile(string file)
-        {
-        }
-
-        protected virtual void OnFormClosing(object sender, FormClosingEventArgs args)
-        {
-        }
-
-        protected virtual void OnDragEnter(object sender, EventArgs args)
-        {
         }
 
         protected virtual void OnActivated()

--- a/osu.Framework/Platform/BasicGameWindow.cs
+++ b/osu.Framework/Platform/BasicGameWindow.cs
@@ -88,16 +88,10 @@ namespace osu.Framework.Platform
         public event Func<bool> ExitRequested;
 
         public event Action Exited;
-        
-        protected void OnExited()
-        {
-            Exited?.Invoke();
-        }
 
-        protected bool OnExitRequested()
-        {
-            return ExitRequested?.Invoke() ?? false;
-        }
+        protected void OnExited() => Exited?.Invoke();
+
+        protected bool OnExitRequested() => ExitRequested?.Invoke() ?? false;
 
         public virtual void CentreToScreen()
         {

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -77,7 +77,6 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="SQLiteNetExtensions">
       <HintPath>$(SolutionDir)\packages\SQLiteNetExtensions.1.3.0\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\SQLiteNetExtensions.dll</HintPath>
     </Reference>


### PR DESCRIPTION
Uses .NET Framework internals to implement Drag&Drop events
for the WindowsGameWindow. The events themselves are defined on
BasicGameWindow so that other platforms can use the same event
infrastructure later on by manually creating the necessary EventArgs.
Further, OnDroppedFile has been changed to OnDroppedFiles and receives
a string[] instead of a single string. This is to keep symmetry between
OnDroppedFiles and OnDragEnterFiles.

Should be noted that the changes for WindowsGameWindow.cs are worth reviewing. The usage of .NET Framework internals there may cause breakage when those internals change (which, unlike the public .NET Framework API, is something that can happen).
Arguably, it's very unlikely that it will ever break, and if it does, all that happens is that drag&drop on windows gets broken.

Fulfills https://github.com/ppy/osu-framework/issues/431