### PR TITLE
Allow bypassing auto sized parents in select axes without resorting t…

### DIFF
--- a/osu.Framework/Graphics/Containers/Container_AutoSize.cs
+++ b/osu.Framework/Graphics/Containers/Container_AutoSize.cs
@@ -126,10 +126,10 @@ namespace osu.Framework.Graphics.Containers
 
                     Vector2 cBound = c.BoundingSize;
 
-                    if ((c.RelativeSizeAxes & Axes.X) == 0 && (c.RelativePositionAxes & Axes.X) == 0)
+                    if ((c.BypassAutoSizeAxes & Axes.X) == 0)
                         maxBoundSize.X = Math.Max(maxBoundSize.X, cBound.X);
 
-                    if ((c.RelativeSizeAxes & Axes.Y) == 0 && (c.RelativePositionAxes & Axes.Y) == 0)
+                    if ((c.BypassAutoSizeAxes & Axes.Y) == 0)
                         maxBoundSize.Y = Math.Max(maxBoundSize.Y, cBound.Y);
                 }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -472,6 +472,25 @@ namespace osu.Framework.Graphics
             return v;
         }
 
+        private Axes bypassAutoSizeAxes;
+
+        /// <summary>
+        /// Controls which <see cref="Axes"/> are ignored by parent <see cref="Parent"/>'s auto size containers.
+        /// </summary>
+        public Axes BypassAutoSizeAxes
+        {
+            get { return bypassAutoSizeAxes | relativeSizeAxes | relativePositionAxes; }
+
+            set
+            {
+                if (value == bypassAutoSizeAxes)
+                    return;
+
+                bypassAutoSizeAxes = value;
+                Parent?.InvalidateFromChild(Invalidation.Geometry, this);
+            }
+        }
+
         #endregion
 
         #region Scale / Shear / Rotation


### PR DESCRIPTION
…o RelativeSizeAxes.

Previously auto sized containers would ignore children with either RelativePositionAxes or
RelativePositionAxes. Now we also allow bypassing without such a restriction, which can
avoid hacky additional nesting levels.