### PR TITLE
Focus improvements

### DIFF
--- a/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) 2007-2016 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Linq;
+using osu.Framework.Input;
+using OpenTK.Input;
+using System;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// An overlay container that eagerly holds keyboard focus.
+    /// </summary>
+    public abstract class FocusedOverlayContainer : OverlayContainer
+    {
+        public override bool RequestingFocus => IsPresent && State == Visibility.Visible;
+
+        public override bool IsPresent => base.IsPresent || State == Visibility.Visible;
+
+        protected override bool OnFocus(InputState state) => true;
+
+        protected override void OnFocusLost(InputState state)
+        {
+            if (state.Keyboard.Keys.Contains(Key.Escape))
+                Hide();
+            base.OnFocusLost(state);
+        }
+
+        protected override void PopIn()
+        {
+            TriggerFocusContention();
+        }
+
+        protected override bool OnHover(InputState state) => true;
+
+        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => true;
+
+        protected override bool OnClick(InputState state) => true;
+
+        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
+        {
+            switch (args.Key)
+            {
+                case Key.Escape:
+                    if (State == Visibility.Hidden) return false;
+                    Hide();
+                    return true;
+            }
+            return base.OnKeyDown(state, args);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override void Show() => State = Visibility.Visible;
 
-        public void ToggleVisibility() => State = (State == Visibility.Visible ? Visibility.Hidden : Visibility.Visible);
+        public void ToggleVisibility() => State = State == Visibility.Visible ? Visibility.Hidden : Visibility.Visible;
     }
 
     public enum Visibility

--- a/osu.Framework/Graphics/Drawable_Interaction.cs
+++ b/osu.Framework/Graphics/Drawable_Interaction.cs
@@ -61,17 +61,6 @@ namespace osu.Framework.Graphics
         protected virtual bool OnWheel(InputState state) => false;
 
         /// <summary>
-        /// Request focus, but only receive if nothing else already has focus.
-        /// </summary>
-        /// <returns>Whether we received focus.</returns>
-        protected bool RequestFocus()
-        {
-            if (ourInputManager.FocusedDrawable != null) return false;
-
-            return TriggerFocus();
-        }
-
-        /// <summary>
         /// Focuses this drawable.
         /// </summary>
         /// <param name="screenSpaceState">The input state.</param>
@@ -90,6 +79,16 @@ namespace osu.Framework.Graphics
             ourInputManager?.ChangeFocus(this);
 
             return true;
+        }
+
+        /// <summary>
+        /// If we are not the current focus, this will force our parent InputManager to reconsider what to focus.
+        /// Useful in combination with <see cref="RequestingFocus"/>
+        /// </summary>
+        protected void TriggerFocusContention()
+        {
+            if (ourInputManager.FocusedDrawable != this)
+                ourInputManager.ChangeFocus(null);
         }
 
         protected virtual bool OnFocus(InputState state) => false;
@@ -132,7 +131,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public virtual bool HandleInput => false;
 
-        public virtual bool HasFocus => ourInputManager?.FocusedDrawable == this;
+        public bool HasFocus => ourInputManager?.FocusedDrawable == this;
+
+        /// <summary>
+        /// If true, we are eagerly requesting focus. If nothing else above us has (or is requesting focus) we will get it.
+        /// </summary>
+        public virtual bool RequestingFocus => false;
 
         internal bool Hovering;
 

--- a/osu.Framework/Graphics/Drawable_Interaction.cs
+++ b/osu.Framework/Graphics/Drawable_Interaction.cs
@@ -131,6 +131,9 @@ namespace osu.Framework.Graphics
         /// </summary>
         public virtual bool HandleInput => false;
 
+        /// <summary>
+        /// Check whether we have active focus. Walks up the drawable tree; use sparingly.
+        /// </summary>
         public bool HasFocus => ourInputManager?.FocusedDrawable == this;
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -651,7 +651,6 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnDragStart(InputState state)
         {
-
             if (HasFocus) return true;
 
             Vector2 posDiff = state.Mouse.PositionMouseDown.Value - state.Mouse.Position;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -118,7 +118,8 @@ namespace osu.Framework.Input
             //may have lost focus due to visibility changes in hierarchy.
             checkFocusedDrawable(CurrentState);
 
-            checkFocusRequests(CurrentState);
+            if (FocusedDrawable == null)
+                focusTopMostRequestingDrawable(CurrentState);
 
             if (!PassThrough)
             {
@@ -541,12 +542,7 @@ namespace osu.Framework.Input
             return false;
         }
 
-        private void checkFocusRequests(InputState state)
-        {
-            if (FocusedDrawable != null) return;
-
-            keyboardInputQueue.FirstOrDefault(target => target.RequestingFocus)?.TriggerFocus(state, true);
-        }
+        private void focusTopMostRequestingDrawable(InputState state) => keyboardInputQueue.FirstOrDefault(target => target.RequestingFocus)?.TriggerFocus(state, true);
 
         public InputHandler GetHandler(Type handlerType)
         {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -115,8 +115,7 @@ namespace osu.Framework.Input
                     pendingStates.AddRange(h.GetPendingStates());
             }
 
-            //may have lost focus due to visibility changes in hierarchy.
-            checkFocusedDrawable(CurrentState);
+            unfocusIsNoLongerValid(CurrentState);
 
             if (FocusedDrawable == null)
                 focusTopMostRequestingDrawable(CurrentState);
@@ -483,7 +482,7 @@ namespace osu.Framework.Input
                 Repeat = repeat
             };
 
-            if (checkFocusedDrawable(state))
+            if (!unfocusIsNoLongerValid(state))
             {
                 if (args.Key == Key.Escape)
                 {
@@ -504,18 +503,19 @@ namespace osu.Framework.Input
                 Key = key
             };
 
-            if (checkFocusedDrawable(state) && (FocusedDrawable?.TriggerKeyUp(state, args) ?? false))
+            if (!unfocusIsNoLongerValid(state) && (FocusedDrawable?.TriggerKeyUp(state, args) ?? false))
                 return true;
 
             return keyboardInputQueue.Any(target => target.TriggerKeyUp(state, args));
         }
 
         /// <summary>
-        /// Ensure the focused drawable is still in a valid state.
+        /// Unfocus the current focused drawable if it is no longer in a valid state.
         /// </summary>
-        private bool checkFocusedDrawable(InputState state)
+        /// <returns>true if there is no longer a focus.</returns>
+        private bool unfocusIsNoLongerValid(InputState state)
         {
-            if (FocusedDrawable == null) return false;
+            if (FocusedDrawable == null) return true;
 
             bool stillValid = FocusedDrawable.IsPresent && FocusedDrawable.Parent != null;
 
@@ -535,11 +535,11 @@ namespace osu.Framework.Input
             }
 
             if (stillValid)
-                return true;
+                return false;
 
             FocusedDrawable.TriggerFocusLost(state);
             FocusedDrawable = null;
-            return false;
+            return true;
         }
 
         private void focusTopMostRequestingDrawable(InputState state) => keyboardInputQueue.FirstOrDefault(target => target.RequestingFocus)?.TriggerFocus(state, true);

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -92,12 +92,18 @@ namespace osu.Framework.Input
             RelativeSizeAxes = Axes.Both;
         }
 
+        /// <summary>
+        /// Handles the internal passing on focus. Note that this doesn't perform a check on the new focus drawable.
+        /// Usually you'd want to call TriggerFocus on the drawable directly instead.
+        /// </summary>
+        /// <param name="focus">The drawable to become focused.</param>
         internal void ChangeFocus(Drawable focus)
         {
             if (focus == FocusedDrawable) return;
 
             FocusedDrawable?.TriggerFocusLost(null, true);
             FocusedDrawable = focus;
+            FocusedDrawable?.TriggerFocus(CurrentState, true);
         }
 
         protected override void Update()
@@ -111,6 +117,8 @@ namespace osu.Framework.Input
 
             //may have lost focus due to visibility changes in hierarchy.
             checkFocusedDrawable(CurrentState);
+
+            checkFocusRequests(CurrentState);
 
             if (!PassThrough)
             {
@@ -531,6 +539,13 @@ namespace osu.Framework.Input
             FocusedDrawable.TriggerFocusLost(state);
             FocusedDrawable = null;
             return false;
+        }
+
+        private void checkFocusRequests(InputState state)
+        {
+            if (FocusedDrawable != null) return;
+
+            keyboardInputQueue.FirstOrDefault(target => target.RequestingFocus)?.TriggerFocus(state, true);
         }
 
         public InputHandler GetHandler(Type handlerType)

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Graphics\Containers\CircularContainer.cs" />
     <Compile Include="Graphics\Containers\ClickableContainer.cs" />
     <Compile Include="Graphics\Containers\Container_AutoSize.cs" />
+    <Compile Include="Graphics\Containers\FocusedOverlayContainer.cs" />
     <Compile Include="Graphics\Containers\IContainer.cs" />
     <Compile Include="Graphics\Containers\OverlayContainer.cs" />
     <Compile Include="Graphics\Containers\ScrollContainer.cs" />


### PR DESCRIPTION
- Makes focus requesting a non-explicit call.
- Makes it possible for focus requests to be made by multiple drawables; the highest in keyboard priority is chosen.
- Adds the ability to trigger a recalculation of what should have focus (by forcefully unfocusing oneself and letting nature take its course).