### PR TITLE
Make EdgeSmoothness work on non-bottom sides of triangles.

### DIFF
--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -33,6 +33,12 @@ namespace osu.Framework.Graphics.Colour
         /// <returns>Product of first and second.</returns>
         public static SRGBColour operator *(SRGBColour first, SRGBColour second) => FromVector(first.ToVector() * second.ToVector());
 
+        public static SRGBColour operator *(SRGBColour first, float second) => FromVector(first.ToVector() * second);
+
+        public static SRGBColour operator /(SRGBColour first, float second) => FromVector(first.ToVector() / second);
+
+        public static SRGBColour operator +(SRGBColour first, SRGBColour second) => FromVector(first.ToVector() + second.ToVector());
+
         public Vector4 ToVector() => new Vector4(Linear.R, Linear.G, Linear.B, Linear.A);
         public static SRGBColour FromVector(Vector4 v) => new SRGBColour { Linear = new Color4(v.X, v.Y, v.Z, v.W) };
 

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -162,13 +162,21 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 vertexAction = triangleBatch.Add;
             }
 
+            // We split the triangle into two, such that we can obtain smooth edges with our
+            // texture coordinate trick. We might want to revert this so drawing a single
+            // triangle in case we ever need proper texturing, or if the additional vertices
+            // end up becoming an overhead (unlikely).
+            SRGBColour topColour = (drawColour.TopLeft + drawColour.TopRight) / 2;
+            SRGBColour bottomColour = (drawColour.BottomLeft + drawColour.BottomRight) / 2;
+
+            // Left triangle half
             vertexAction(new TexturedVertex2D
             {
                 Position = vertexTriangle.P0,
-                TexturePosition = new Vector2((inflatedTexRect.Left + inflatedTexRect.Right) / 2, inflatedTexRect.Top),
+                TexturePosition = new Vector2(inflatedTexRect.Left, inflatedTexRect.Top),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
-                Colour = drawColour.TopLeft.Linear,
+                Colour = topColour.Linear,
             });
             vertexAction(new TexturedVertex2D
             {
@@ -177,6 +185,32 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 BlendRange = inflationAmount,
                 Colour = drawColour.BottomLeft.Linear,
+            });
+            vertexAction(new TexturedVertex2D
+            {
+                Position = (vertexTriangle.P1 + vertexTriangle.P2) / 2,
+                TexturePosition = new Vector2((inflatedTexRect.Left + inflatedTexRect.Right) / 2, inflatedTexRect.Bottom),
+                TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
+                BlendRange = inflationAmount,
+                Colour = bottomColour.Linear,
+            });
+
+            // Right triangle half
+            vertexAction(new TexturedVertex2D
+            {
+                Position = vertexTriangle.P0,
+                TexturePosition = new Vector2(inflatedTexRect.Right, inflatedTexRect.Top),
+                TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
+                BlendRange = inflationAmount,
+                Colour = topColour.Linear,
+            });
+            vertexAction(new TexturedVertex2D
+            {
+                Position = (vertexTriangle.P1 + vertexTriangle.P2) / 2,
+                TexturePosition = new Vector2((inflatedTexRect.Left + inflatedTexRect.Right) / 2, inflatedTexRect.Bottom),
+                TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
+                BlendRange = inflationAmount,
+                Colour = bottomColour.Linear,
             });
             vertexAction(new TexturedVertex2D
             {

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -163,7 +163,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
 
             // We split the triangle into two, such that we can obtain smooth edges with our
-            // texture coordinate trick. We might want to revert this so drawing a single
+            // texture coordinate trick. We might want to revert this to drawing a single
             // triangle in case we ever need proper texturing, or if the additional vertices
             // end up becoming an overhead (unlikely).
             SRGBColour topColour = (drawColour.TopLeft + drawColour.TopRight) / 2;


### PR DESCRIPTION
Drawing one triangle by drawing two smaller triangles! 💯 

Still better than back when we draw triangles by drawing a quad (which was also two triangles) with a triangle-shaped texture.