### PR TITLE
Only consider enabled audio devices

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -276,7 +276,7 @@ namespace osu.Framework.Audio
 
         private void updateAvailableAudioDevices()
         {
-            var currentDeviceList = new List<DeviceInfo>(getAllDevices());
+            var currentDeviceList = getAllDevices().Where(d => d.IsEnabled).ToList();
             var currentDeviceNames = getDeviceNames(currentDeviceList).ToList();
 
             var newDevices = currentDeviceNames.Except(audioDeviceNames).ToList();


### PR DESCRIPTION
Previously we considered disabled audio devices as available (although
playback was blocked). This commit treats them as if they don't exist.