### PR TITLE
Make drawvis great again

### DIFF
--- a/osu.Framework/GameModes/GameMode.cs
+++ b/osu.Framework/GameModes/GameMode.cs
@@ -37,7 +37,6 @@ namespace osu.Framework.GameModes
 
         public GameMode()
         {
-            DisposeOnRemove = true;
             RelativeSizeAxes = Axes.Both;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;
@@ -57,6 +56,8 @@ namespace osu.Framework.GameModes
                 },
             });
         }
+
+        public override bool DisposeOnDeathRemoval => true;
 
         public override bool HandleInput => !hasExited;
 

--- a/osu.Framework/GameModes/GameMode.cs
+++ b/osu.Framework/GameModes/GameMode.cs
@@ -30,8 +30,6 @@ namespace osu.Framework.GameModes
 
         private bool hasExited;
 
-        protected internal override bool DisposeOnRemove => true;
-
         /// <summary>
         /// Make this GameMode directly exited when resuming from a child.
         /// </summary>
@@ -39,6 +37,7 @@ namespace osu.Framework.GameModes
 
         public GameMode()
         {
+            DisposeOnRemove = true;
             RelativeSizeAxes = Axes.Both;
             Anchor = Anchor.Centre;
             Origin = Anchor.Centre;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -310,23 +310,20 @@ namespace osu.Framework.Graphics.Containers
                 AddInternal(d);
         }
 
-        public virtual bool Remove(T drawable, bool dispose = false)
+        public virtual bool Remove(T drawable)
         {
             if (drawable == null)
                 return false;
 
             if (Content != this)
-                return Content.Remove(drawable, dispose);
+                return Content.Remove(drawable);
 
             bool result = children.Remove(drawable);
             drawable.Parent = null;
 
             if (!result) return false;
 
-            if (dispose)
-                drawable.Dispose();
-            else
-                drawable.Invalidate();
+            drawable.Invalidate();
 
             if (AutoSizeAxes != Axes.None)
                 InvalidateFromChild(Invalidation.Geometry, drawable);
@@ -334,22 +331,22 @@ namespace osu.Framework.Graphics.Containers
             return true;
         }
 
-        public int RemoveAll(Predicate<T> match, bool dispose = false)
+        public int RemoveAll(Predicate<T> match)
         {
             List<T> toRemove = children.FindAll(match);
             for (int i = 0; i < toRemove.Count; i++)
-                Remove(toRemove[i], dispose);
+                Remove(toRemove[i]);
 
             return toRemove.Count;
         }
 
-        public void Remove(IEnumerable<T> range, bool dispose = false)
+        public void Remove(IEnumerable<T> range)
         {
             if (range == null)
                 return;
 
             foreach (T p in range)
-                Remove(p, dispose);
+                Remove(p);
         }
 
         public virtual void Clear(bool dispose = true)

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -223,7 +223,6 @@ namespace osu.Framework.Graphics.Containers
             {
                 if (obj.DisposeOnRemove) obj.Dispose();
             };
-
         }
 
         private MarginPadding padding;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -221,7 +221,7 @@ namespace osu.Framework.Graphics.Containers
             children = lifetimeList ?? new LifetimeList<T>(DepthComparer);
             children.Removed += obj =>
             {
-                if (obj.DisposeOnRemove) obj.Dispose();
+                if (obj.DisposeOnDeathRemoval) obj.Dispose();
             };
         }
 

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Graphics.Containers
         IEnumerable<T> Children { get; }
         IEnumerable<T> AliveChildren { get; }
         
-        int RemoveAll(Predicate<T> match, bool dispose = false);
+        int RemoveAll(Predicate<T> match);
     }
 
     public interface IContainerCollection<in T> : IContainer
@@ -35,7 +35,7 @@ namespace osu.Framework.Graphics.Containers
 
         void Add(IEnumerable<T> collection);
         void Add(T drawable);
-        void Remove(IEnumerable<T> range, bool dispose = false);
-        bool Remove(T drawable, bool dispose = false);
+        void Remove(IEnumerable<T> range);
+        bool Remove(T drawable);
     }
 }

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Graphics.Containers
         protected virtual bool HideOnEscape => true;
 
         /// <summary>
-        /// Whether we shoul block any mouse input from interacting with things behind us.
+        /// Whether we should block any mouse input from interacting with things behind us.
         /// </summary>
         protected virtual bool BlockPassThroughInput => true;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -74,7 +74,11 @@ namespace osu.Framework.Graphics
 
         private bool isDisposed;
 
-        public bool DisposeOnRemove;
+        /// <summary>
+        /// Whether this Drawable should be disposed when it is automatically removed from
+        /// its <see cref="Parent"/> due to <see cref="IsAlive"/> being false.
+        /// </summary>
+        public virtual bool DisposeOnDeathRemoval => false;
 
         protected virtual void Dispose(bool isDisposing)
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -74,7 +74,7 @@ namespace osu.Framework.Graphics
 
         private bool isDisposed;
 
-        protected internal virtual bool DisposeOnRemove => false;
+        public bool DisposeOnRemove;
 
         protected virtual void Dispose(bool isDisposing)
         {

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -37,6 +37,8 @@ namespace osu.Framework.Graphics.Visualisation
             };
         }
 
+        protected override bool BlockPassThroughInput => false;
+
         protected override void PopIn()
         {
             task = Scheduler.AddDelayed(runUpdate, 200, true);

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Threading;
 using System.Collections.Generic;
+using osu.Framework.Platform;
 
 namespace osu.Framework.Graphics.Visualisation
 {
@@ -31,7 +32,12 @@ namespace osu.Framework.Graphics.Visualisation
                 {
                     Depth = float.MinValue,
                     ChooseTarget = chooseTarget,
-                    GoUpOneParent = delegate { Target = Target?.Parent ?? Target; }
+                    GoUpOneParent = delegate
+                    {
+                        var parent = Target?.Parent;
+                        if (parent != null && !(parent is BasicGameHost))
+                            Target = Target?.Parent;
+                    }
                 },
                 new CursorContainer()
             };

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -117,7 +117,8 @@ namespace osu.Framework.Graphics.Visualisation
         {
             if (targetDrawable != null)
             {
-                treeContainer.Remove(targetDrawable, true);
+                treeContainer.Remove(targetDrawable);
+                targetDrawable.Dispose();
                 targetDrawable = null;
             }
         }

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -136,10 +136,8 @@ namespace osu.Framework.Graphics.Visualisation
 
             var drawables = vis.Flow.Children.Cast<VisualisedDrawable>();
             foreach (var dd in drawables)
-            {
                 if (!dd.CheckExpiry())
                     visualise(dd.Target, dd);
-            }
 
             var dContainer = d as IContainerEnumerable<Drawable>;
 

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -154,7 +154,7 @@ namespace osu.Framework.Graphics.Visualisation
         protected override bool OnHover(InputState state)
         {
             State = TreeContainerStatus.Onscreen;
-            return base.OnHover(state);
+            return true;
         }
 
         protected override void OnHoverLost(InputState state)
@@ -170,6 +170,10 @@ namespace osu.Framework.Graphics.Visualisation
             Position += state.Mouse.Delta;
             return base.OnDrag(state);
         }
+
+        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => true;
+
+        protected override bool OnClick(InputState state) => true;
 
         protected override void LoadComplete()
         {

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         private Box titleBar;
 
-        const float width = 300;
+        const float width = 400;
         const float height = 600;
 
         private TreeContainerStatus state;

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -40,7 +40,6 @@ namespace osu.Framework.Graphics.Visualisation
             Target = d;
 
             attachEvents();
-            DisposeOnRemove = true;
 
             var sprite = Target as Sprite;
 
@@ -113,6 +112,8 @@ namespace osu.Framework.Graphics.Visualisation
             var df = Target as FlowContainer<Drawable>;
             if (df != null) df.OnLayout -= onLayout;
         }
+
+        public override bool DisposeOnDeathRemoval => true;
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.Visualisation
 {
     internal class VisualisedDrawable : Container
     {
-        public Drawable Target;
+        public Drawable Target { get; private set; }
 
         private SpriteText text;
         private Drawable previewBox;
@@ -180,7 +180,7 @@ namespace osu.Framework.Graphics.Visualisation
         {
             if (!IsAlive) return false;
 
-            if (!Target.IsAlive || Target.Parent == null || Target.Alpha == 0)
+            if (!Target.IsAlive || Target.Parent == null || !Target.IsPresent)
             {
                 Expire();
                 return false;

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -35,13 +35,9 @@ namespace osu.Framework.Graphics.Visualisation
         public VisualisedDrawable(Drawable d)
         {
             Target = d;
-            Target.OnInvalidate += onInvalidate;
 
-            var da = Target as Container<Drawable>;
-            if (da != null) da.OnAutoSize += onAutoSize;
-
-            var df = Target as FlowContainer<Drawable>;
-            if (df != null) df.OnLayout += onLayout;
+            attachEvents();
+            DisposeOnRemove = true;
 
             var sprite = Target as Sprite;
 
@@ -93,6 +89,33 @@ namespace osu.Framework.Graphics.Visualisation
             updateSpecifics();
         }
 
+        private void attachEvents()
+        {
+            Target.OnInvalidate += onInvalidate;
+
+            var da = Target as Container<Drawable>;
+            if (da != null) da.OnAutoSize += onAutoSize;
+
+            var df = Target as FlowContainer<Drawable>;
+            if (df != null) df.OnLayout += onLayout;
+        }
+
+        private void detachEvents()
+        {
+            Target.OnInvalidate -= onInvalidate;
+
+            var da = Target as Container<Drawable>;
+            if (da != null) da.OnAutoSize -= onAutoSize;
+
+            var df = Target as FlowContainer<Drawable>;
+            if (df != null) df.OnLayout -= onLayout;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            detachEvents();
+        }
 
         protected override bool OnHover(InputState state)
         {

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -32,8 +32,11 @@ namespace osu.Framework.Graphics.Visualisation
 
         public FlowContainer Flow;
 
-        public VisualisedDrawable(Drawable d)
+        private TreeContainer tree;
+
+        public VisualisedDrawable(Drawable d, TreeContainer tree)
         {
+            this.tree = tree;
             Target = d;
 
             attachEvents();
@@ -145,23 +148,27 @@ namespace osu.Framework.Graphics.Visualisation
         private void onAutoSize()
         {
             Scheduler.Add(() => activityAutosize.FadeOutFromOne(1));
-            updateSpecifics();
         }
 
         private void onLayout()
         {
             Scheduler.Add(() => activityLayout.FadeOutFromOne(1));
-            updateSpecifics();
         }
 
         private void onInvalidate()
         {
             Scheduler.Add(() => activityInvalidate.FadeOutFromOne(1));
-            updateSpecifics();
         }
 
         private void updateSpecifics()
         {
+            Vector2 posInTree = ToSpaceOfOtherDrawable(Vector2.Zero, tree);
+            if (posInTree.Y < -previewBox.DrawHeight || posInTree.Y > tree.Height)
+            {
+                text.Text = string.Empty;
+                return;
+            }
+
             previewBox.Alpha = Math.Max(0.2f, Target.Alpha);
             previewBox.ColourInfo = Target.ColourInfo;
 
@@ -172,6 +179,8 @@ namespace osu.Framework.Graphics.Visualisation
 
         protected override void Update()
         {
+            updateSpecifics();
+
             text.Colour = !Flow.IsPresent ? Color4.LightBlue : Color4.White;
             base.Update();
         }


### PR DESCRIPTION
A series of changes which bring the performance of draw vis from "grinding to a halt in the main menu when visualizing a bunch of triangles" to "can zoom out fully inside song select with 120 fps".

Also makes behavior slightly nicer by fixing input regressions related to overlay container changes, and making the root visualised drawable interactive.