### PR TITLE
Add better fallback window title support.

### DIFF
--- a/osu.Framework/BaseGame.cs
+++ b/osu.Framework/BaseGame.cs
@@ -41,6 +41,8 @@ namespace osu.Framework
 
         public BasicGameHost Host => host;
 
+        public override string Name => GetType().ToString();
+
         private bool isActive;
 
         public AudioManager Audio;
@@ -113,6 +115,9 @@ namespace osu.Framework
             this.host = host;
             host.Size = new Vector2(Config.Get<int>(FrameworkConfig.Width), Config.Get<int>(FrameworkConfig.Height));
             host.Exiting += OnExiting;
+
+            if (Window != null)
+                Window.Title = $@"osu.Framework (running ""{Name}"")";
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Framework/Platform/BasicGameHost.cs
+++ b/osu.Framework/Platform/BasicGameHost.cs
@@ -313,8 +313,6 @@ namespace osu.Framework.Platform
                 Window.Resize += window_ClientSizeChanged;
                 Window.ExitRequested += OnExitRequested;
                 Window.Exited += OnExited;
-                if (string.IsNullOrEmpty(Window.Title))
-                    Window.Title = $@"osu.Framework (running ""{Name}"")";
                 Window.FocusedChanged += delegate { setActive(Window.Focused); };
                 window_ClientSizeChanged(null, null);
 


### PR DESCRIPTION
I broke default window titles by assuming the title was empty when not specified (was actually "OpenTK Game Window").