### PR TITLE
Improve performance of masked away containers

### DIFF
--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -69,8 +69,8 @@ namespace osu.Framework.Graphics
             //========================================================================================
             //== Uncomment the following 2 lines to use a ground-truth matrix inverse for debugging ==
             //========================================================================================
-            //target.MatrixInverse = target.Matrix;
-            //MatrixExtensions.FastInvert(ref target.MatrixInverse);
+            //MatrixInverse = Matrix;
+            //MatrixExtensions.FastInvert(ref MatrixInverse);
         }
 
         public bool Equals(DrawInfo other)


### PR DESCRIPTION
This commit adds masked-away checks for non-flattened containers
and prevents updates to children of containers masked-away in the
previous frame.