### PR TITLE
Extend doc of AutoSizeAxes and BypassAutoSizeAxes

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -834,6 +834,9 @@ namespace osu.Framework.Graphics.Containers
 
         /// <summary>
         /// Controls which <see cref="Axes"/> are automatically sized w.r.t. <see cref="InternalChildren"/>.
+        /// Children's <see cref="Drawable.BypassAutoSizeAxes"/> are ignored for automatic sizing.
+        /// Most notably, <see cref="RelativePositionAxes"/> and <see cref="RelativeSizeAxes"/> of children
+        /// do not affect automatic sizing to avoid circular size dependencies.
         /// It is not allowed to manually set <see cref="Size"/> (or <see cref="Width"/> / <see cref="Height"/>)
         /// on any <see cref="Axes"/> which are automatically sized.
         /// </summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -425,6 +425,8 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Controls which <see cref="Axes"/> of <see cref="Position"/> are relative w.r.t.
         /// <see cref="Parent"/>'s size (from 0 to 1) rather than absolute.
+        /// The <see cref="Axes"/> set in this property are ignored by automatically sizing
+        /// parents.
         /// </summary>
         /// <remarks>
         /// When setting this property, the <see cref="Position"/> is converted such that
@@ -526,6 +528,8 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Controls which <see cref="Axes"/> are relative sizes w.r.t. <see cref="Parent"/>'s size
         /// (from 0 to 1) in the <see cref="Parent"/>'s coordinate system, rather than absolute sizes.
+        /// The <see cref="Axes"/> set in this property are ignored by automatically sizing
+        /// parents.
         /// </summary>
         /// <remarks>
         /// If an axis becomes relatively sized and its component of <see cref="Size"/> was previously 0,
@@ -658,7 +662,9 @@ namespace osu.Framework.Graphics
         private Axes bypassAutoSizeAxes;
 
         /// <summary>
-        /// Controls which <see cref="Axes"/> are ignored by parent <see cref="Parent"/>'s auto size containers.
+        /// Controls which <see cref="Axes"/> are ignored by parent <see cref="Parent"/> automatic sizing.
+        /// Most notably, <see cref="RelativePositionAxes"/> and <see cref="RelativeSizeAxes"/> do not affect
+        /// automatic sizing to avoid circular size dependencies.
         /// </summary>
         public Axes BypassAutoSizeAxes
         {


### PR DESCRIPTION
Adds remarks about relative size axes and relative position axes
not affecting auto sizing.