### PR TITLE
Explicitly set refresh rate when going into fullscreen

### DIFF
--- a/osu.Framework.Desktop/Platform/DesktopGameWindow.cs
+++ b/osu.Framework.Desktop/Platform/DesktopGameWindow.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Desktop.Platform
             switch (mode.Value)
             {
                 case WindowMode.Fullscreen:
-                    DisplayResolution newResolution = DisplayDevice.Default.SelectResolution(widthFullscreen, heightFullscreen, 0, 0);
+                    DisplayResolution newResolution = DisplayDevice.Default.SelectResolution(widthFullscreen, heightFullscreen, 0, DisplayDevice.Default.RefreshRate);
                     DisplayDevice.Default.ChangeResolution(newResolution);
 
                     WindowState = WindowState.Fullscreen;


### PR DESCRIPTION
If the argument is left at 0 it will use the specified resolution using the first refresh rate OpenTK sees. Even though windows reports a refresh rate as available it might not necessarily work (in my case 25Hz does not work). By using the currently set refresh rate we (almost) know for sure that the refresh rate will work.