### PR TITLE
Improve access modifiers

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -323,7 +323,7 @@ namespace osu.Framework.Graphics.Containers
             return changed;
         }
 
-        internal override void UpdateClock(IFrameBasedClock clock)
+        internal sealed override void UpdateClock(IFrameBasedClock clock)
         {
             if (Clock == clock)
                 return;
@@ -340,7 +340,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected virtual bool RequiresChildrenUpdate => !IsMaskedAway || !autoSize.IsValid;
 
-        protected internal override bool UpdateSubTree()
+        internal sealed override bool UpdateSubTree()
         {
             if (!base.UpdateSubTree()) return false;
 
@@ -522,7 +522,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        protected internal override DrawNode GenerateDrawNodeSubtree(int treeIndex, RectangleF bounds)
+        internal sealed override DrawNode GenerateDrawNodeSubtree(int treeIndex, RectangleF bounds)
         {
             // No need for a draw node at all if there are no children and we are not glowing.
             if (internalChildren.AliveItems.Count == 0 && CanBeFlattened)
@@ -620,7 +620,7 @@ namespace osu.Framework.Graphics.Containers
             return DrawRectangle.Shrink(cornerRadius).DistanceSquared(ToLocalSpace(screenSpacePos)) <= cornerRadius * cornerRadius;
         }
 
-        internal override bool BuildKeyboardInputQueue(List<Drawable> queue)
+        internal sealed override bool BuildKeyboardInputQueue(List<Drawable> queue)
         {
             if (!base.BuildKeyboardInputQueue(queue))
                 return false;
@@ -632,7 +632,7 @@ namespace osu.Framework.Graphics.Containers
             return true;
         }
 
-        internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
+        internal sealed override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
         {
             if (!base.BuildMouseInputQueue(screenSpaceMousePos, queue))
                 return false;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -620,7 +620,7 @@ namespace osu.Framework.Graphics.Containers
             return DrawRectangle.Shrink(cornerRadius).DistanceSquared(ToLocalSpace(screenSpacePos)) <= cornerRadius * cornerRadius;
         }
 
-        internal sealed override bool BuildKeyboardInputQueue(List<Drawable> queue)
+        internal override bool BuildKeyboardInputQueue(List<Drawable> queue)
         {
             if (!base.BuildKeyboardInputQueue(queue))
                 return false;
@@ -632,7 +632,7 @@ namespace osu.Framework.Graphics.Containers
             return true;
         }
 
-        internal sealed override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
+        internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
         {
             if (!base.BuildMouseInputQueue(screenSpaceMousePos, queue))
                 return false;

--- a/osu.Framework/Graphics/ProxyDrawable.cs
+++ b/osu.Framework/Graphics/ProxyDrawable.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics
 
         private Drawable original;
 
-        internal override Drawable Original => original;
+        internal sealed override Drawable Original => original;
 
         // We do not want to receive updates. That is the business
         // of the original drawable.

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -132,9 +132,8 @@ namespace osu.Framework.Platform
             }
         }
 
-        protected internal PerformanceMonitor InputMonitor => InputThread.Monitor;
-        protected internal PerformanceMonitor UpdateMonitor => UpdateThread.Monitor;
-        protected internal PerformanceMonitor DrawMonitor => DrawThread.Monitor;
+        private PerformanceMonitor inputMonitor => InputThread.Monitor;
+        private PerformanceMonitor drawMonitor => DrawThread.Monitor;
 
         private Cached<string> fullPathBacking = new Cached<string>();
         public string FullPath => fullPathBacking.EnsureValid() ? fullPathBacking.Value : fullPathBacking.Refresh(() =>
@@ -260,7 +259,7 @@ namespace osu.Framework.Platform
             if (Root == null)
                 return;
 
-            using (DrawMonitor.BeginCollecting(PerformanceCollectionType.GLReset))
+            using (drawMonitor.BeginCollecting(PerformanceCollectionType.GLReset))
             {
                 GLWrapper.Reset(Root.DrawSize);
                 GLWrapper.ClearColour(Color4.Black);
@@ -283,7 +282,7 @@ namespace osu.Framework.Platform
 
             GLWrapper.FlushCurrentBatch();
 
-            using (DrawMonitor.BeginCollecting(PerformanceCollectionType.SwapBuffer))
+            using (drawMonitor.BeginCollecting(PerformanceCollectionType.SwapBuffer))
                 Window.SwapBuffers();
         }
 
@@ -334,7 +333,7 @@ namespace osu.Framework.Platform
                     {
                         inputPerformanceCollectionPeriod?.Dispose();
                         InputThread.RunUpdate();
-                        inputPerformanceCollectionPeriod = InputMonitor.BeginCollecting(PerformanceCollectionType.WndProc);
+                        inputPerformanceCollectionPeriod = inputMonitor.BeginCollecting(PerformanceCollectionType.WndProc);
                     };
                     Window.Closed += delegate
                     {


### PR DESCRIPTION
Mostly makes access more restricted. internal Drawable<->Container
composability overrides have been made sealed. Drawable.Hovering
has gotten a public getter and documentation.