### PR TITLE
Fix auto size not updating when children change visibility

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -384,7 +384,7 @@ namespace osu.Framework.Graphics.Containers
         {
             if (AutoSizeAxes == Axes.None) return;
 
-            if ((invalidation & Invalidation.Geometry) > 0)
+            if ((invalidation & (Invalidation.Geometry | Invalidation.Colour)) > 0)
                 autoSize.Invalidate();
         }
 


### PR DESCRIPTION
This was a case of not invalidating correctly. There is future
potential for optimization by separating Colour invalidations
frorm visibility invalidations, but there is no measurable difference
to be found for now.