### PR TITLE
"Security" enhancements for PasswordTextBox

### DIFF
--- a/osu.Framework/Graphics/UserInterface/PasswordTextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/PasswordTextBox.cs
@@ -7,6 +7,8 @@ namespace osu.Framework.Graphics.UserInterface
     {
         protected virtual char MaskCharacter => '*';
 
+        public override bool AllowClipboardExport => false;
+
         protected override Drawable AddCharacterToFlow(char c) => base.AddCharacterToFlow(MaskCharacter);
     }
 }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public int? LengthLimit;
 
-        public bool AllowClipboardExport => true;
+        public virtual bool AllowClipboardExport => true;
 
         //represents the left/right selection coordinates of the word double clicked on when dragging
         private int[] doubleClickWord;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -669,12 +669,20 @@ namespace osu.Framework.Graphics.UserInterface
             if (text.Length == 0) return true;
 
             int hover = Math.Min(text.Length - 1, getCharacterClosestTo(state.Mouse.Position));
+            
+            if (AllowClipboardExport)
+            {
+                int lastSeparator = findSeparatorIndex(text, hover, -1);
+                int nextSeparator = findSeparatorIndex(text, hover, 1);
 
-            int lastSeparator = findSeparatorIndex(text, hover, -1);
-            int nextSeparator = findSeparatorIndex(text, hover, 1);
-
-            selectionStart = lastSeparator >= 0 ? lastSeparator + 1 : 0;
-            selectionEnd = nextSeparator >= 0 ? nextSeparator : text.Length;
+                selectionStart = lastSeparator >= 0 ? lastSeparator + 1 : 0;
+                selectionEnd = nextSeparator >= 0 ? nextSeparator : text.Length;
+            }
+            else
+            {
+                selectionStart = 0;
+                selectionEnd = text.Length;
+            }
 
             //in order to keep the home word selected
             doubleClickWord = new[] { selectionStart, selectionEnd };

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -668,10 +668,10 @@ namespace osu.Framework.Graphics.UserInterface
 
             if (text.Length == 0) return true;
 
-            int hover = Math.Min(text.Length - 1, getCharacterClosestTo(state.Mouse.Position));
-            
             if (AllowClipboardExport)
             {
+                int hover = Math.Min(text.Length - 1, getCharacterClosestTo(state.Mouse.Position));
+            
                 int lastSeparator = findSeparatorIndex(text, hover, -1);
                 int nextSeparator = findSeparatorIndex(text, hover, 1);
 


### PR DESCRIPTION
Prohibit copying or separating by actual content.
Using `AllowClipboardExport` for the flag. Create a new flag for separating if needed.