### PR TITLE
Make fill direction be determined partially by child Anchors

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
@@ -335,7 +335,7 @@ namespace osu.Framework.VisualTests.Tests
                             boxes = new FillFlowContainer {
                                 RelativeSizeAxes = Axes.X,
                                 AutoSizeAxes = Axes.Y,
-                                Direction = FillDirection.Down,
+                                Direction = FillDirection.Vertical,
                                 Spacing = new Vector2(0, 10),
                             }
                         }

--- a/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.VisualTests.Tests
                 {
                     Anchor = Anchor.TopLeft,
                     Origin = Anchor.TopLeft,
-                    Direction = FillDirection.Down,
+                    Direction = FillDirection.Vertical,
                     Spacing = new Vector2(0, 10),
                     Padding = new MarginPadding(10),
                     AutoSizeAxes = Axes.Both,

--- a/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
@@ -24,8 +24,16 @@ namespace osu.Framework.VisualTests.Tests
         public override string Description => "Test lots of different settings for Flow Containers";
 
         FlowTestCase current;
-        TestCaseDropdown selectionDropdown;
+        FillDirectionDropdown selectionDropdown;
         Container testContainer;
+
+        Anchor childAnchor = Anchor.TopLeft;
+        AnchorDropDown anchorDropdown;
+
+        Anchor childOrigin = Anchor.TopLeft;
+        AnchorDropDown originDropdown;
+
+        FillFlowContainer fc;
 
         protected override Container<Drawable> Content => testContainer;
 
@@ -37,15 +45,28 @@ namespace osu.Framework.VisualTests.Tests
             {
                 RelativeSizeAxes = Axes.Both,
             });
-            ButtonsContainer.Add(selectionDropdown = new TestCaseDropdown
+            ButtonsContainer.Add(selectionDropdown = new FillDirectionDropdown
             {
                 Width = 150,
-                Position = new Vector2(10, 10),
-                Description = @"Drop-down menu",
+                Description = @"Fill mode",
                 Items = null,
                 SelectedIndex = 0,
             });
-            changeTest(FlowTestCase.RightDown);
+            ButtonsContainer.Add(anchorDropdown = new AnchorDropDown
+            {
+                Width = 150,
+                Description = @"Child anchor",
+                Items = null,
+                SelectedIndex = 0,
+            });
+            ButtonsContainer.Add(originDropdown = new AnchorDropDown
+            {
+                Width = 150,
+                Description = @"Child origin",
+                Items = null,
+                SelectedIndex = 0,
+            });
+            changeTest(FlowTestCase.Full);
         }
 
         protected override void Update()
@@ -54,6 +75,20 @@ namespace osu.Framework.VisualTests.Tests
 
             if (current != selectionDropdown.SelectedValue)
                 changeTest(selectionDropdown.SelectedValue);
+
+            if (childAnchor != anchorDropdown.SelectedValue)
+            {
+                childAnchor = anchorDropdown.SelectedValue;
+                foreach (var child in fc.Children)
+                    child.Anchor = childAnchor;
+            }
+
+            if (childOrigin != originDropdown.SelectedValue)
+            {
+                childOrigin = originDropdown.SelectedValue;
+                foreach (var child in fc.Children)
+                    child.Origin = childOrigin;
+            }
         }
 
         private void changeTest(FlowTestCase testCase)
@@ -68,9 +103,8 @@ namespace osu.Framework.VisualTests.Tests
 
         private FillFlowContainer buildTest(FillDirection dir, Vector2 spacing)
         {
-            ButtonsContainer.RemoveAll(btn => btn != selectionDropdown);
+            ButtonsContainer.RemoveAll(btn => (btn != selectionDropdown && btn != anchorDropdown && btn != originDropdown));
 
-            FillFlowContainer fc;
             var cnt = new Container()
             {
                 Padding = new MarginPadding(25f) { Top = 100f },
@@ -88,23 +122,23 @@ namespace osu.Framework.VisualTests.Tests
             };
             Add(cnt);
 
-            var rotateBtn = AddButton("Rotate Container", () =>
+            var rotateBtn = AddToggle("Rotate Container", (state) =>
             {
-                if (fc.Rotation > 0)
+                if (!state)
                     fc.RotateTo(0f, 1000);
                 else
                     fc.RotateTo(45f, 1000);
             });
-            AddButton("Scale Container", () =>
+            AddToggle("Scale Container", (state) =>
             {
-                if (fc.Scale.X == 1f)
+                if (state)
                     fc.ScaleTo(1.2f, 1000);
                 else
                     fc.ScaleTo(1f, 1000);
             });
-            AddButton("Shear Container", () =>
+            AddToggle("Shear Container", (state) =>
             {
-                if (fc.Shear.X == 0)
+                if (state)
                     fc.Shear = new Vector2(0.5f, 0f);
                 else
                     fc.Shear = new Vector2(0f, 0f);
@@ -136,19 +170,6 @@ namespace osu.Framework.VisualTests.Tests
                     fc.RelativeSizeAxes = Axes.Both;
                     fc.Width = 1;
                     fc.Height = 1;
-                }
-            });
-            AddToggle("Anchor TopCenter children", (state) =>
-            {
-                if (state)
-                {
-                    foreach (var child in fc.Children)
-                        child.Anchor = Anchor.TopCentre;
-                }
-                else
-                {
-                    foreach (var child in fc.Children)
-                        child.Anchor = Anchor.TopLeft;
                 }
             });
             AddToggle("Rotate children", (state) =>
@@ -190,19 +211,6 @@ namespace osu.Framework.VisualTests.Tests
                         child.ScaleTo(1f, 1000);
                 }
             });
-            AddToggle("Change children origin", (state) =>
-            {
-                if (state)
-                {
-                    foreach (var child in fc.Children)
-                        child.Origin = Anchor.Centre;
-                }
-                else
-                {
-                    foreach (var child in fc.Children)
-                        child.Origin = Anchor.TopLeft;
-                }
-            });
             var addChildrenBtn = AddToggle("Stop adding children", (state) => { });
             cnt.Position = new Vector2(rotateBtn.Width, 0f);
             cnt.Padding = new MarginPadding(25f) { Top = cnt.Padding.Top, Right = 25f + cnt.Position.X };
@@ -227,6 +235,8 @@ namespace osu.Framework.VisualTests.Tests
                     {
                         fc.Add(new Container
                         {
+                            Anchor = childAnchor,
+                            Origin = childOrigin,
                             AutoSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
@@ -255,81 +265,28 @@ namespace osu.Framework.VisualTests.Tests
             return fc;
         }
 
-        [FlowTestCase(FlowTestCase.RightDown)]
+        [FlowTestCase(FlowTestCase.Full)]
         private void test1()
         {
             // Expected behaviour: Boxes appear left-to-right, top-to-bottom
             // and wrap into the next line
-            buildTest(FillDirection.RightDown, new Vector2(5, 5));
+            buildTest(FillDirection.Full, new Vector2(5, 5));
         }
 
-        [FlowTestCase(FlowTestCase.Right)]
+        [FlowTestCase(FlowTestCase.Horizontal)]
         private void test2()
         {
             // Expected behaviour: Boxes appear left-to-right
             // and start going off-screen
-            buildTest(FillDirection.Right, new Vector2(5, 5));
+            buildTest(FillDirection.Horizontal, new Vector2(5, 5));
         }
 
-        [FlowTestCase(FlowTestCase.Down)]
+        [FlowTestCase(FlowTestCase.Vertical)]
         private void test3()
         {
             // Expected behaviour: Boxes appear top-to-bottom
             // and start going off-screen
-            buildTest(FillDirection.Down, new Vector2(5, 5));
-        }
-
-        [FlowTestCase(FlowTestCase.Left)]
-        private void test4()
-        {
-            // Expected behaviour: Boxes appear right-to-left
-            // and start going off-screen
-            buildTest(FillDirection.Left, new Vector2(5, 5));
-        }
-
-        [FlowTestCase(FlowTestCase.Up)]
-        private void test5()
-        {
-            // Expected behaviour: Boxes appear bottom-to-top
-            // and start going off-screen
-            buildTest(FillDirection.Up, new Vector2(5, 5));
-        }
-
-        [FlowTestCase(FlowTestCase.LeftUp)]
-        private void test6()
-        {
-            // Expected behaviour: Boxes appear right-to-left, bottom-to-top
-            // and wrap into the next line
-            buildTest(FillDirection.LeftUp, new Vector2(5, 5));
-        }
-
-        [FlowTestCase(FlowTestCase.LeftDown)]
-        private void test7()
-        {
-            // Expected behaviour: Boxes appear right-to-left, top-to-bottom
-            // and wrap into the next line
-            buildTest(FillDirection.LeftDown, new Vector2(5, 5));
-        }
-
-        [FlowTestCase(FlowTestCase.RightUp)]
-        private void test8()
-        {
-            // Expected behaviour: Boxes appear left-to-right, top-to-bottom
-            // and wrap into the next line
-            buildTest(FillDirection.RightUp, new Vector2(5, 5));
-        }
-
-        private class TestCaseDropdown : DropDownMenu<FlowTestCase>
-        {
-            protected override DropDownHeader CreateHeader()
-            {
-                return new TestCaseDropDownHeader();
-            }
-
-            protected override IEnumerable<DropDownMenuItem<FlowTestCase>> GetDropDownItems(IEnumerable<KeyValuePair<string, FlowTestCase>> values)
-            {
-                return Enum.GetValues(typeof(FlowTestCase)).Cast<FlowTestCase>().Select(ftc => new TestCaseDropDownMenuItem(ftc));
-            }
+            buildTest(FillDirection.Vertical, new Vector2(5, 5));
         }
 
         private class TestCaseDropDownHeader : DropDownHeader
@@ -353,9 +310,62 @@ namespace osu.Framework.VisualTests.Tests
             }
         }
 
-        private class TestCaseDropDownMenuItem : DropDownMenuItem<FlowTestCase>
+        private class AnchorDropDown : DropDownMenu<Anchor>
         {
-            public TestCaseDropDownMenuItem(FlowTestCase testCase) : base(testCase.ToString(), testCase)
+            protected override DropDownHeader CreateHeader()
+            {
+                return new TestCaseDropDownHeader();
+            }
+
+            protected override IEnumerable<DropDownMenuItem<Anchor>> GetDropDownItems(IEnumerable<KeyValuePair<string, Anchor>> values)
+            {
+                return new[]
+                {
+                    Anchor.TopLeft,
+                    Anchor.TopCentre,
+                    Anchor.TopRight,
+
+                    Anchor.CentreLeft,
+                    Anchor.Centre,
+                    Anchor.CentreRight,
+
+                    Anchor.BottomLeft,
+                    Anchor.BottomCentre,
+                    Anchor.BottomRight,
+                }.Select(ftc => new AnchorDropdownMenuItem(ftc));
+            }
+        }
+
+        private class AnchorDropdownMenuItem : DropDownMenuItem<Anchor>
+        {
+            public AnchorDropdownMenuItem(Anchor anchor) : base(anchor.ToString(), anchor)
+            {
+                AutoSizeAxes = Axes.Y;
+                Foreground.Padding = new MarginPadding(2);
+
+                Children = new[]
+                {
+                    new SpriteText { Text = anchor.ToString() },
+                };
+            }
+        }
+
+        private class FillDirectionDropdown : DropDownMenu<FlowTestCase>
+        {
+            protected override DropDownHeader CreateHeader()
+            {
+                return new TestCaseDropDownHeader();
+            }
+
+            protected override IEnumerable<DropDownMenuItem<FlowTestCase>> GetDropDownItems(IEnumerable<KeyValuePair<string, FlowTestCase>> values)
+            {
+                return Enum.GetValues(typeof(FlowTestCase)).Cast<FlowTestCase>().Select(ftc => new FillDirectionDropdownMenuItem(ftc));
+            }
+        }
+
+        private class FillDirectionDropdownMenuItem : DropDownMenuItem<FlowTestCase>
+        {
+            public FillDirectionDropdownMenuItem(FlowTestCase testCase) : base(testCase.ToString(), testCase)
             {
                 AutoSizeAxes = Axes.Y;
                 Foreground.Padding = new MarginPadding(2);
@@ -379,14 +389,9 @@ namespace osu.Framework.VisualTests.Tests
         }
         enum FlowTestCase
         {
-            RightDown,
-            RightUp,
-            Right,
-            LeftDown,
-            LeftUp,
-            Left,
-            Down,
-            Up,
+            Full,
+            Horizontal,
+            Vertical,
         }
     }
 }

--- a/osu.Framework.VisualTests/Tests/TestCaseSpriteText.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSpriteText.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.VisualTests.Tests
                         {
                             Anchor = Anchor.TopLeft,
                             AutoSizeAxes = Axes.Both,
-                            Direction = FillDirection.Down,
+                            Direction = FillDirection.Vertical,
                         }
                     }
                 }

--- a/osu.Framework.VisualTests/Tests/TestCaseTextBox.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTextBox.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.VisualTests.Tests
 
             FillFlowContainer textBoxes = new FillFlowContainer
             {
-                Direction = FillDirection.Down,
+                Direction = FillDirection.Vertical,
                 Spacing = new Vector2(0, 50),
                 Padding = new MarginPadding
                 {
@@ -74,7 +74,7 @@ namespace osu.Framework.VisualTests.Tests
 
             FillFlowContainer otherTextBoxes = new FillFlowContainer
             {
-                Direction = FillDirection.Down,
+                Direction = FillDirection.Vertical,
                 Spacing = new Vector2(0, 50),
                 Padding = new MarginPadding
                 {
@@ -104,7 +104,7 @@ namespace osu.Framework.VisualTests.Tests
 
             FillFlowContainer nestedTextBoxes = new FillFlowContainer
             {
-                Direction = FillDirection.Down,
+                Direction = FillDirection.Vertical,
                 Spacing = new Vector2(0, 50),
                 Anchor = Anchor.TopCentre,
                 Origin = Anchor.TopCentre,

--- a/osu.Framework.VisualTests/Tests/TestCaseTextBox.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTextBox.cs
@@ -106,8 +106,7 @@ namespace osu.Framework.VisualTests.Tests
             {
                 Direction = FillDirection.Vertical,
                 Spacing = new Vector2(0, 50),
-                Anchor = Anchor.TopCentre,
-                Origin = Anchor.TopCentre,
+                Margin = new MarginPadding { Left = 50 },
                 RelativeSizeAxes = Axes.Both,
                 Size = new Vector2(0.8f, 1)
             };

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -149,7 +149,7 @@ namespace osu.Framework
             (performanceContainer = new PerformanceOverlay
             {
                 Margin = new MarginPadding(5),
-                Direction = FillDirection.Down,
+                Direction = FillDirection.Vertical,
                 Spacing = new Vector2(10, 10),
                 AutoSizeAxes = Axes.Both,
                 Alpha = 0,

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -11,17 +11,41 @@ using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Containers
 {
-    using static FillDirection;
-
+    /// <summary>
+    /// A <see cref="FlowContainer{Drawable}"/> that fills space by arranging its children
+    /// next to each other.
+    /// <see cref="Children"/> can be arranged horizontally, vertically, and in a
+    /// combined fashion, which is controlled by <see cref="Direction"/>.
+    /// <see cref="Children"/> are arranged from left-to-right if their
+    /// <see cref="Drawable.Anchor"/> is to the left or centered horizontally.
+    /// They are arranged from right-to-left otherwise.
+    /// <see cref="Children"/> are arranged from top-to-bottom if their
+    /// <see cref="Drawable.Anchor"/> is to the top or centered vertically.
+    /// They are arranged from bottom-to-top otherwise.
+    /// If non-<see cref="Drawable"/> <see cref="Children"/> are desired, use
+    /// <see cref="FillFlowContainer{T}"/>. 
+    /// </summary>
     public class FillFlowContainer : FillFlowContainer<Drawable>
     { }
 
+    /// <summary>
+    /// A <see cref="FlowContainer{T}"/> that fills space by arranging its children
+    /// next to each other.
+    /// <see cref="Children"/> can be arranged horizontally, vertically, and in a
+    /// combined fashion, which is controlled by <see cref="Direction"/>.
+    /// <see cref="Children"/> are arranged from left-to-right if their
+    /// <see cref="Drawable.Anchor"/> is to the left or centered horizontally.
+    /// They are arranged from right-to-left otherwise.
+    /// <see cref="Children"/> are arranged from top-to-bottom if their
+    /// <see cref="Drawable.Anchor"/> is to the top or centered vertically.
+    /// They are arranged from bottom-to-top otherwise.
+    /// </summary>
     public class FillFlowContainer<T> : FlowContainer<T> where T : Drawable
     {
-        private FillDirection direction = RightDown;
+        private FillDirection direction = FillDirection.Full;
 
         /// <summary>
-        /// The direction of the fill. Default is <see cref="RightDown"/>.
+        /// The direction of the fill. Default is <see cref="Full"/>.
         /// </summary>
         public FillDirection Direction
         {
@@ -35,11 +59,6 @@ namespace osu.Framework.Graphics.Containers
                 InvalidateLayout();
             }
         }
-
-        private bool flowsRightToLeft => direction == LeftDown || direction == LeftUp || direction == Left;
-        private bool flowsBottomToTop => direction == RightUp || direction == LeftUp || direction == Up;
-        private bool flowsVertical => direction != Right && direction != Left;
-        private bool flowsHorizontal => direction != Up && direction != Down;
 
         private Vector2 spacing;
         /// <summary>
@@ -75,10 +94,6 @@ namespace osu.Framework.Graphics.Containers
 
         protected override IEnumerable<Vector2> ComputeLayoutPositions()
         {
-            var elementSizes = FlowingChildren.Select(d => d.BoundingBox.Size).ToArray();
-
-            var current = Vector2.Zero;
-
             var max = MaximumSize;
             if (max == Vector2.Zero)
             {
@@ -89,14 +104,30 @@ namespace osu.Framework.Graphics.Containers
                 max.X = (AutoSizeAxes & Axes.X) > 0 ? float.MaxValue : s.X;
                 max.Y = (AutoSizeAxes & Axes.Y) > 0 ? float.MaxValue : s.Y;
             }
-            float rowMaxHeight = 0;
-            KeyValuePair<Vector2, Vector2>[] result = new KeyValuePair<Vector2, Vector2>[elementSizes.Length];
+            
+            var children = FlowingChildren.ToArray();
+            if (children.Length == 0)
+                return new List<Vector2>();
 
-            var i = -1;
-            foreach (var size in elementSizes)
+            // The positions for each child we will return later on.
+            Vector2[] result = new Vector2[children.Length];
+
+            // We need to keep track of row widths such that we can compute correct
+            // positions for horizontal centre anchor children.
+            // We also store for each child to which row it belongs.
+            int[] rowIndices = new int[children.Length];
+            List<float> rowWidths = new List<float>();
+
+            // Variables keeping track of the current state while iterating over children
+            // and computing initial flow positions.
+            float rowMaxHeight = 0;
+            var current = Vector2.Zero;
+
+            // First pass, computing initial flow positions
+            for (int i = 0; i < children.Length; ++i)
             {
-                ++i;
-                
+                Vector2 size = children[i].BoundingBox.Size;
+
                 Vector2 spacing = size;
                 if (spacing.X > 0)
                     spacing.X = Math.Max(0, spacing.X + Spacing.X);
@@ -104,36 +135,46 @@ namespace osu.Framework.Graphics.Containers
                     spacing.Y = Math.Max(0, spacing.Y + Spacing.Y);
 
                 //We've exceeded our allowed width, move to a new row
-                if (flowsVertical && (Precision.DefinitelyBigger(current.X + size.X, max.X) || !flowsHorizontal))
+                if (direction != FillDirection.Horizontal && (Precision.DefinitelyBigger(current.X + size.X, max.X) || direction == FillDirection.Vertical))
                 {
                     current.X = 0;
                     current.Y += rowMaxHeight;
 
-                    result[i] = new KeyValuePair<Vector2, Vector2>(size, current);
-
+                    result[i] = current;
+                    rowWidths.Add(i == 0 ? 0 : result[i - 1].X);
                     rowMaxHeight = 0;
                 }
                 else
-                    result[i] = new KeyValuePair<Vector2, Vector2>(size, current);
+                    result[i] = current;
+
+                rowIndices[i] = rowWidths.Count;
 
                 if (spacing.Y > rowMaxHeight)
                     rowMaxHeight = spacing.Y;
                 current.X += spacing.X;
             }
 
-            IEnumerable<KeyValuePair<Vector2, Vector2>> resultEnum = result;
-            if (flowsRightToLeft)
+            rowWidths.Add(result.Last().X);
+            float height = result.Last().Y;
+
+            // Second pass, adjusting the positions for anchors of children.
+            // Uses rowWidths and height for centre-anchors.
+            for (int i = 0; i < children.Length; ++i)
             {
-                var maxX = (AutoSizeAxes & Axes.X) > 0 ? result.Max(kvp => kvp.Value.X) : max.X;
-                resultEnum = resultEnum.Select(kvp => new KeyValuePair<Vector2, Vector2>(kvp.Key, new Vector2(maxX - kvp.Value.X - kvp.Key.X, kvp.Value.Y)));
-            }
-            if (flowsBottomToTop)
-            {
-                var maxY = (AutoSizeAxes & Axes.Y) > 0 ? result.Max(kvp => kvp.Value.Y) : max.Y;
-                resultEnum = resultEnum.Select(kvp => new KeyValuePair<Vector2, Vector2>(kvp.Key, new Vector2(kvp.Value.X, maxY - kvp.Value.Y - kvp.Key.Y)));
+                var c = children[i];
+
+                if ((c.Anchor & Anchor.x1) > 0)
+                    result[i].X -= rowWidths[rowIndices[i]] / 2;
+                else if ((c.Anchor & Anchor.x2) > 0)
+                    result[i].X = -result[i].X;
+
+                if ((c.Anchor & Anchor.y1) > 0)
+                    result[i].Y -= height / 2;
+                else if ((c.Anchor & Anchor.y2) > 0)
+                    result[i].Y = -result[i].Y;
             }
 
-            return resultEnum.Select(kvp => kvp.Value);
+            return result;
         }
     }
 
@@ -143,36 +184,16 @@ namespace osu.Framework.Graphics.Containers
     public enum FillDirection
     {
         /// <summary>
-        /// Flow left to right, then top to bottom.
+        /// Fill horizontally first, then fill vertically via multiple rows.
         /// </summary>
-        RightDown,
+        Full,
         /// <summary>
-        /// Flow left to right, then bottom to top.
+        /// Fill only horizontally.
         /// </summary>
-        RightUp,
+        Horizontal,
         /// <summary>
-        /// Flow left to right.
+        /// Fill only vertically.
         /// </summary>
-        Right,
-        /// <summary>
-        /// Flow right to left, then top to bottom.
-        /// </summary>
-        LeftDown,
-        /// <summary>
-        /// Flow right to left, then bottom to top.
-        /// </summary>
-        LeftUp,
-        /// <summary>
-        /// Flow right to left.
-        /// </summary>
-        Left,
-        /// <summary>
-        /// Flow top to bottom.
-        /// </summary>
-        Down,
-        /// <summary>
-        /// Flow bottom to top.
-        /// </summary>
-        Up,
+        Vertical,
     }
 }

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -157,11 +157,18 @@ namespace osu.Framework.Graphics.Containers
             rowWidths.Add(result.Last().X);
             float height = result.Last().Y;
 
+            Anchor ourAnchor = children[0].Anchor;
+
             // Second pass, adjusting the positions for anchors of children.
             // Uses rowWidths and height for centre-anchors.
             for (int i = 0; i < children.Length; ++i)
             {
                 var c = children[i];
+
+                if (c.Anchor != ourAnchor)
+                    throw new InvalidOperationException(
+                        $@"All drawables in a {nameof(FillFlowContainer)} must use the same {nameof(Anchor)} ({ourAnchor} != {c.Anchor}). " +
+                        $@"Consider using multiple instances of {nameof(FillFlowContainer)} if this is intentional.");
 
                 if ((c.Anchor & Anchor.x1) > 0)
                     // Begin flow at centre of row

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -164,13 +164,17 @@ namespace osu.Framework.Graphics.Containers
                 var c = children[i];
 
                 if ((c.Anchor & Anchor.x1) > 0)
+                    // Begin flow at centre of row
                     result[i].X -= rowWidths[rowIndices[i]] / 2;
                 else if ((c.Anchor & Anchor.x2) > 0)
+                    // Flow right-to-left
                     result[i].X = -result[i].X;
 
                 if ((c.Anchor & Anchor.y1) > 0)
+                    // Begin flow at centre of total height
                     result[i].Y -= height / 2;
                 else if ((c.Anchor & Anchor.y2) > 0)
+                    // Flow bottom-to-top
                     result[i].Y = -result[i].Y;
             }
 

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -152,7 +152,7 @@ namespace osu.Framework.Graphics.Performance
                                         },
                                         new FillFlowContainer
                                         {
-                                            Direction = FillDirection.Right,
+                                            Direction = FillDirection.Horizontal,
                                             AutoSizeAxes = Axes.X,
                                             RelativeSizeAxes = Axes.Y,
                                             Children = from StatisticsCounterType t in Enum.GetValues(typeof(StatisticsCounterType))

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Graphics.Performance
 
         public PerformanceOverlay()
         {
-            Direction = FillDirection.Down;
+            Direction = FillDirection.Vertical;
             atlas = new TextureAtlas(GLWrapper.MaxTextureSize, GLWrapper.MaxTextureSize, true, All.Nearest);
         }
     }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -34,13 +34,13 @@ namespace osu.Framework.Graphics.Sprites
 
         public bool AllowMultiline
         {
-            get { return Direction == FillDirection.RightDown; }
+            get { return Direction == FillDirection.Full; }
             set
             {
                 if (value)
-                    Direction = FillDirection.RightDown;
+                    Direction = FillDirection.Full;
                 else
-                    Direction = FillDirection.Right;
+                    Direction = FillDirection.Horizontal;
             }
         }
 

--- a/osu.Framework/Graphics/UserInterface/BasicCheckBox.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicCheckBox.cs
@@ -46,7 +46,7 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 new FillFlowContainer
                 {
-                    Direction = FillDirection.Right,
+                    Direction = FillDirection.Horizontal,
                     AutoSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {

--- a/osu.Framework/Graphics/UserInterface/DropDownMenu.cs
+++ b/osu.Framework/Graphics/UserInterface/DropDownMenu.cs
@@ -170,7 +170,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected DropDownMenu()
         {
             AutoSizeAxes = Axes.Y;
-            Direction = FillDirection.Down;
+            Direction = FillDirection.Vertical;
 
             Children = new Drawable[]
             {
@@ -196,7 +196,7 @@ namespace osu.Framework.Graphics.UserInterface
                                 {
                                     RelativeSizeAxes = Axes.X,
                                     AutoSizeAxes = Axes.Y,
-                                    Direction = FillDirection.Down,
+                                    Direction = FillDirection.Vertical,
                                 },
                             },
                         },

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -95,7 +95,7 @@ namespace osu.Framework.Graphics.UserInterface
                         },
                         TextFlow = new FillFlowContainer
                         {
-                            Direction = FillDirection.Right,
+                            Direction = FillDirection.Horizontal,
                             AutoSizeAxes = Axes.X,
                             RelativeSizeAxes = Axes.Y,
                         },

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -79,7 +79,7 @@ namespace osu.Framework.Graphics.Visualisation
                 {
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
-                    Direction = FillDirection.Down,
+                    Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
                         titleBar = new Box //title decoration

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Graphics.Visualisation
                 },
                 Flow = new FillFlowContainer
                 {
-                    Direction = FillDirection.Down,
+                    Direction = FillDirection.Vertical,
                     AutoSizeAxes = Axes.Both,
                     Position = new Vector2(10, 14)
                 },

--- a/osu.Framework/Screens/Testing/TestBrowser.cs
+++ b/osu.Framework/Screens/Testing/TestBrowser.cs
@@ -85,7 +85,7 @@ namespace osu.Framework.Screens.Testing
             leftScrollContainer.Add(leftFlowContainer = new FillFlowContainer
             {
                 Padding = new MarginPadding(3),
-                Direction = FillDirection.Down,
+                Direction = FillDirection.Vertical,
                 Spacing = new Vector2(0, 5),
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,

--- a/osu.Framework/Screens/Testing/TestCase.cs
+++ b/osu.Framework/Screens/Testing/TestCase.cs
@@ -50,7 +50,7 @@ namespace osu.Framework.Screens.Testing
                     },
                     ButtonsContainer = new FillFlowContainer
                     {
-                        Direction = FillDirection.Down,
+                        Direction = FillDirection.Vertical,
                         Spacing = new Vector2(15, 5),
                         AutoSizeAxes = Axes.Both,
                     },

--- a/osu.Framework/Screens/Testing/TestCase.cs
+++ b/osu.Framework/Screens/Testing/TestCase.cs
@@ -52,7 +52,8 @@ namespace osu.Framework.Screens.Testing
                     {
                         Direction = FillDirection.Vertical,
                         Spacing = new Vector2(15, 5),
-                        AutoSizeAxes = Axes.Both,
+                        Width = 150,
+                        AutoSizeAxes = Axes.Y,
                     },
                 };
             }


### PR DESCRIPTION
FillDirection now only controls horizontal, vertical and full,
whereas left-to-right and bottom-to-top are controlled by the
Anchors of children. Centre anchors will now correctly fill starting
from the centre of the flow.