### PR TITLE
Draw vis fixes, some refactoring, better usage of Drawable.Name

### DIFF
--- a/osu.Framework.Desktop/Platform/DesktopGameHost.cs
+++ b/osu.Framework.Desktop/Platform/DesktopGameHost.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Platform;
-using OpenTK;
 using osu.Framework.Desktop.Input;
 using osu.Framework.Input;
 

--- a/osu.Framework.Desktop/Platform/HeadlessGameHost.cs
+++ b/osu.Framework.Desktop/Platform/HeadlessGameHost.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using osu.Framework.Input.Handlers;
-using OpenTK;
 
 namespace osu.Framework.Desktop.Platform
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
@@ -16,7 +16,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseSizing : TestCase
     {
-        public override string Name => @"Size calculations";
         public override string Description => @"Various scenarios which potentially challenge size calculations.";
 
         private Container testContainer;

--- a/osu.Framework.VisualTests/Tests/TestCaseBufferedContainer.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseBufferedContainer.cs
@@ -10,7 +10,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseBufferedContainer : TestCaseMasking
     {
-        public override string Name => @"BufferedContainer";
         public override string Description => @"Buffered containers containing almost all visual effects.";
 
         public override void Reset()

--- a/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
@@ -12,8 +12,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseCheckBox : TestCase
     {
-        public override string Name => @"Checkboxes";
-
         public override string Description => @"CheckBoxes with clickable labels";
 
         public override void Reset()

--- a/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
@@ -13,7 +13,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseColourGradient : TestCase
     {
-        public override string Name => @"Colour Gradient";
         public override string Description => @"Various cases of colour gradients.";
 
         private Box[] boxes = new Box[4];

--- a/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
@@ -17,7 +17,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseDrawablePath : TestCase
     {
-        public override string Name => @"Drawable Paths";
         public override string Description => @"Various cases of drawable paths.";
 
         public override void Reset()

--- a/osu.Framework.VisualTests/Tests/TestCaseDropDownBox.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseDropDownBox.cs
@@ -15,8 +15,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseDropDownBox : TestCase
     {
-        public override string Name => @"Drop-down boxes";
-
         public override string Description => @"Drop-down boxes";
 
         private StyledDropDownMenu styledDropDownMenu;

--- a/osu.Framework.VisualTests/Tests/TestCaseFillModes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFillModes.cs
@@ -15,8 +15,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseFillModes : TestCase
     {
-        public override string Name => @"Sprites - FillModes";
-
         public override string Description => @"Test sprite display and fill modes";
 
         Texture sampleTexture;

--- a/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
@@ -20,7 +20,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseFlow : TestCase
     {
-        public override string Name => "Flow";
         public override string Description => "Test lots of different settings for Flow Containers";
 
         FlowTestCase current;

--- a/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
@@ -13,7 +13,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseMasking : TestCase
     {
-        public override string Name => @"Masking";
         public override string Description => @"Various scenarios which potentially challenge masking calculations.";
 
         protected Container TestContainer;

--- a/osu.Framework.VisualTests/Tests/TestCaseNestedHover.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseNestedHover.cs
@@ -13,7 +13,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseNestedHover : TestCase
     {
-        public override string Name => @"Nested Hover";
         public override string Description => @"Hovering multiple nested elements";
 
         public override void Reset()

--- a/osu.Framework.VisualTests/Tests/TestCaseOnlineTextures.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseOnlineTextures.cs
@@ -13,8 +13,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseOnlineTextures : TestCase
     {
-        public override string Name => @"Online Textures";
-
         private FillFlowContainer flow;
 
         int loadId = 55;

--- a/osu.Framework.VisualTests/Tests/TestCasePadding.cs
+++ b/osu.Framework.VisualTests/Tests/TestCasePadding.cs
@@ -14,8 +14,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCasePadding : TestCase
     {
-        public override string Name => @"Padding";
-
         public override string Description => @"Add fixed padding via a PaddingContainer";
 
         public override void Reset()

--- a/osu.Framework.VisualTests/Tests/TestCaseScreen.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseScreen.cs
@@ -17,8 +17,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseScreen : TestCase
     {
-        public override string Name => @"Screen";
-
         public override string Description => @"Test stackable game screens";
 
         public override void Reset()

--- a/osu.Framework.VisualTests/Tests/TestCaseScrollableFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseScrollableFlow.cs
@@ -18,7 +18,6 @@ namespace osu.Framework.VisualTests.Tests
     {
         private ScheduledDelegate boxCreator;
 
-        public override string Name => @"Scrollable Flow";
         public override string Description => @"A flow container in a scroll container";
         
         ScrollContainer scroll;

--- a/osu.Framework.VisualTests/Tests/TestCaseSliderbar.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSliderbar.cs
@@ -13,7 +13,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     public class TestCaseSliderbar : TestCase
     {
-        public override string Name => @"Sliderbar";
         public override string Description => @"Sliderbar tests.";
         private SliderBar<double> sliderBar;
         private BindableDouble sliderBarValue;

--- a/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
@@ -12,7 +12,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseSmoothedEdges : TestCase
     {
-        public override string Name => @"Smoothed Edges";
         public override string Description => @"Boxes with automatically smoothed edges (no anti-aliasing).";
 
         private Box[] boxes = new Box[4];

--- a/osu.Framework.VisualTests/Tests/TestCaseSpriteText.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSpriteText.cs
@@ -10,8 +10,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseSpriteText : TestCase
     {
-        public override string Name => @"SpriteText";
-
         public override string Description => @"Test all sizes of text rendering";
 
         public override void Reset()

--- a/osu.Framework.VisualTests/Tests/TestCaseTextBox.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTextBox.cs
@@ -12,8 +12,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseTextBox : TestCase
     {
-        public override string Name => @"TextBox";
-
         public override string Description => @"Text entry evolved";
 
         public override void Reset()

--- a/osu.Framework.VisualTests/Tests/TestCaseTriangles.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTriangles.cs
@@ -14,7 +14,6 @@ namespace osu.Framework.VisualTests.Tests
 {
     class TestCaseTriangles : TestCase
     {
-        public override string Name => @"Triangles";
         public override string Description => @"Various scenarios which potentially challenge triangles.";
 
         private Container testContainer;

--- a/osu.Framework/Configuration/FrameworkDebugConfig.cs
+++ b/osu.Framework/Configuration/FrameworkDebugConfig.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Runtime;
-using osu.Framework.Platform;
 
 namespace osu.Framework.Configuration
 {

--- a/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
+++ b/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
@@ -20,6 +20,10 @@ namespace osu.Framework.Extensions.Color4Extensions
             return color < 0.0031308 ? 12.92 * color : 1.055 * Math.Pow(color, 1.0 / GAMMA) - 0.055;
         }
 
+        public static Color4 Opacity(this Color4 color, float a) => new Color4(color.R, color.G, color.B, a);
+
+        public static Color4 Opacity(this Color4 color, byte a) => new Color4(color.R, color.G, color.B, a / 255f);
+
         public static Color4 ToLinear(this Color4 colour)
         {
             return new Color4(

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Extensions.TypeExtensions
+{
+    public static class TypeExtensions
+    {
+        public static string ReadableName(this Type t)
+        {
+            string result = t.Name;
+
+            // Trim away amount of type arguments
+            int amountTypeArgumentsPos = result.IndexOf("`");
+            if (amountTypeArgumentsPos >= 0)
+                result = result.Substring(0, amountTypeArgumentsPos);
+
+            // We were declared inside another class. Preprend the name of that class.
+            if (t.DeclaringType != null)
+                result = t.DeclaringType.ReadableName() + "+" + result;
+
+            if (t.IsGenericType)
+            {
+                result += "<";
+                var typeArgs = t.GetGenericArguments();
+                for (int i = 0; i < typeArgs.Length; ++i)
+                {
+                    if (i > 0)
+                        result += ", ";
+                    result += typeArgs[i].ReadableName();
+                }
+                result += ">";
+            }
+
+            return result;
+        }
+    }
+}

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -41,8 +41,6 @@ namespace osu.Framework
 
         public GameHost Host => host;
 
-        public override string Name => GetType().ToString();
-
         private bool isActive;
 
         public AudioManager Audio;
@@ -63,6 +61,8 @@ namespace osu.Framework
 
         public Game()
         {
+            Name = GetType().ToString();
+
             RelativeSizeAxes = Axes.Both;
 
             AddInternal(new Drawable[]

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using OpenTK;
 using System.Linq;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.MathUtils;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -21,7 +21,6 @@ using osu.Framework.Logging;
 using osu.Framework.Statistics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Input;
-using System.Linq;
 using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Graphics

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2042,7 +2042,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// A name used to identify this Drawable internally.
         /// </summary>
-        public virtual string Name => string.Empty;
+        public string Name = string.Empty;
 
         public override string ToString()
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -21,6 +21,8 @@ using osu.Framework.Logging;
 using osu.Framework.Statistics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Input;
+using System.Linq;
+using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Graphics
 {
@@ -2044,13 +2046,12 @@ namespace osu.Framework.Graphics
 
         public override string ToString()
         {
-            string shortClass = base.ToString();
-            shortClass = shortClass.Substring(shortClass.LastIndexOf('.') + 1);
+            string shortClass = GetType().ReadableName();
 
             if (!string.IsNullOrEmpty(Name))
                 shortClass = $@"{Name} ({shortClass})";
 
-            return $@"{shortClass} ({DrawPosition.X:#,0},{DrawPosition.Y:#,0}) @ {DrawSize.X:#,0}x{DrawSize.Y:#,0}";
+            return $@"{shortClass} ({DrawPosition.X:#,0},{DrawPosition.Y:#,0}) {DrawSize.X:#,0}x{DrawSize.Y:#,0}";
         }
     }
 

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -59,8 +59,6 @@ namespace osu.Framework.Graphics.Performance
 
         private FpsDisplay fpsDisplay;
 
-        public override string Name { get; }
-
         private FrameStatisticsMode state;
         public FrameStatisticsMode State
         {

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics.Containers;
-using System.Linq;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.Textures;
 using OpenTK.Graphics.ES30;

--- a/osu.Framework/Graphics/Sprites/Sprite.cs
+++ b/osu.Framework/Graphics/Sprites/Sprite.cs
@@ -111,7 +111,10 @@ namespace osu.Framework.Graphics.Sprites
 
         public override string ToString()
         {
-            return base.ToString() + $" tex: {texture?.AssetName}";
+            string result = base.ToString();
+            if (!string.IsNullOrEmpty(texture?.AssetName))
+                result += $" tex: {texture?.AssetName}";
+            return result;
         }
 
         public FillMode FillMode { get; set; }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -11,7 +11,6 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.IO.Stores;
-using osu.Framework.Graphics.Transforms;
 
 namespace osu.Framework.Graphics.Sprites
 {

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -7,8 +7,6 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Threading;
-using System.Collections.Generic;
-using osu.Framework.Platform;
 using osu.Framework.Lists;
 
 namespace osu.Framework.Graphics.Visualisation

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -10,7 +10,6 @@ using osu.Framework.Threading;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Graphics.Primitives;
 using System.Collections.Generic;
 
 namespace osu.Framework.Graphics.Visualisation

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -29,6 +29,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         public Drawable Target { get; }
 
+        private Box textBg;
         private SpriteText text;
         private Drawable previewBox;
         private Drawable activityInvalidate;
@@ -88,10 +89,26 @@ namespace osu.Framework.Graphics.Visualisation
                     Texture = sprite.Texture,
                     Scale = new Vector2(sprite.Texture.DisplayWidth / sprite.Texture.DisplayHeight, 1),
                 },
-                text = new SpriteText
+                new Container
                 {
+                    AutoSizeAxes = Axes.Both,
                     Position = new Vector2(24, -3),
-                    Scale = new Vector2(0.9f),
+
+                    Children = new Drawable[]
+                    {
+                        textBg = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Size = new Vector2(1, 0.8f),
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
+                            Colour = Color4.Transparent,
+                        },
+                        text = new SpriteText
+                        {
+                            Scale = new Vector2(0.9f),
+                        },
+                    }
                 },
                 Flow = new FillFlowContainer
                 {
@@ -140,12 +157,14 @@ namespace osu.Framework.Graphics.Visualisation
         protected override bool OnHover(InputState state)
         {
             HoverGained?.Invoke();
+            textBg.Colour = Color4.PaleVioletRed.Opacity(0.7f);
             return base.OnHover(state);
         }
 
         protected override void OnHoverLost(InputState state)
         {
             HoverLost?.Invoke();
+            textBg.Colour = Color4.Transparent;
             base.OnHoverLost(state);
         }
 

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -9,11 +9,24 @@ using osu.Framework.Input;
 using osu.Framework.Threading;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics.Primitives;
+using System.Collections.Generic;
 
 namespace osu.Framework.Graphics.Visualisation
 {
     internal class VisualisedDrawable : Container
     {
+        public class NestingDepthComparer : IComparer<VisualisedDrawable>
+        {
+            public int Compare(VisualisedDrawable x, VisualisedDrawable y)
+            {
+                return x.nestingDepth.CompareTo(y.nestingDepth);
+            }
+        }
+
+        public static IComparer<VisualisedDrawable> Comparer => new NestingDepthComparer();
+
         public Drawable Target { get; }
 
         private SpriteText text;
@@ -33,9 +46,13 @@ namespace osu.Framework.Graphics.Visualisation
 
         private TreeContainer tree;
 
-        public VisualisedDrawable(Drawable d, TreeContainer tree)
+        private int nestingDepth;
+
+        public VisualisedDrawable(VisualisedDrawable parent, Drawable d, TreeContainer tree)
         {
             this.tree = tree;
+
+            this.nestingDepth = (parent?.nestingDepth ?? 0) + 1;
             Target = d;
 
             attachEvents();

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Reflection;
 using System.Runtime;
@@ -20,7 +19,6 @@ using OpenTK;
 using System.Threading.Tasks;
 using osu.Framework.Caching;
 using osu.Framework.Configuration;
-using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using OpenTK.Input;
 using OpenTK.Graphics;

--- a/osu.Framework/Screens/Testing/TestCase.cs
+++ b/osu.Framework/Screens/Testing/TestCase.cs
@@ -8,12 +8,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Screens.Testing
 {
     public abstract class TestCase : Container
     {
-        public override string Name => @"Test Case";
         public virtual string Description => @"The base class for a test case";
 
         protected FillFlowContainer ButtonsContainer;
@@ -28,6 +28,8 @@ namespace osu.Framework.Screens.Testing
 
         protected TestCase()
         {
+            Name = GetType().ReadableName().Substring(8); // Skip the "TestCase prefix
+
             RelativeSizeAxes = Axes.Both;
             Masking = true;
         }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -109,6 +109,7 @@
     <Compile Include="DebugUtils\ThreadSafety.cs" />
     <Compile Include="Extensions\GeneralExtensions.cs" />
     <Compile Include="Extensions\IEnumerableExtensions\EnumerableExtensions.cs" />
+    <Compile Include="Extensions\TypeExtensions\TypeExtensions.cs" />
     <Compile Include="Graphics\Containers\FillFlowContainer.cs" />
     <Compile Include="Graphics\Containers\TabbableContainer.cs" />
     <Compile Include="Input\EventArgs.cs" />


### PR DESCRIPTION
- Fixes various problems with Draw Visualiser
- Improves Drawable.ToString to yield a better readable type name
- Refactors Opacity into Color4Extensions, removes unnecessary usings, don't display texture asset if string is empty
- Repurposes Drawable.Name to give per-object information rather than per-type