### PR TITLE
Generalize autosize to arbitrary anchors

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -5,8 +5,8 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeModifiers/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AssignNullToNotNullAttribute/@EntryIndexedValue">HINT</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002EGlobal/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002ELocal/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002EGlobal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=AutoPropertyCanBeMadeGetOnly_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CanBeReplacedWithTryCastAndCheckForNull/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckForReferenceEqualityInstead_002E1/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CheckForReferenceEqualityInstead_002E2/@EntryIndexedValue">WARNING</s:String>

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -997,7 +997,7 @@ namespace osu.Framework.Graphics.Containers
                     if (!c.IsPresent)
                         continue;
 
-                    Vector2 cBound = c.BoundingSizeWithOrigin;
+                    Vector2 cBound = c.RequiredParentSizeToFit;
 
                     if ((c.BypassAutoSizeAxes & Axes.X) == 0)
                         maxBoundSize.X = Math.Max(maxBoundSize.X, cBound.X);

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -46,11 +46,11 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The direction of the fill. Default is <see cref="FillDirection.Full"/>.
         /// If <see cref="FillDirection.Full"/> or <see cref="FillDirection.Horizontal"/>,
-        /// <see cref="Children"/> are arranged from left-to-right if their
+        /// <see cref="Container{T}.Children"/> are arranged from left-to-right if their
         /// <see cref="Drawable.Anchor"/> is to the left or centered horizontally.
         /// They are arranged from right-to-left otherwise.
         /// If <see cref="FillDirection.Full"/> or <see cref="FillDirection.Vertical"/>,
-        /// <see cref="Children"/> are arranged from top-to-bottom if their
+        /// <see cref="Container{T}.Children"/> are arranged from top-to-bottom if their
         /// <see cref="Drawable.Anchor"/> is to the top or centered vertically.
         /// They are arranged from bottom-to-top otherwise.
         /// </summary>

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -44,7 +44,15 @@ namespace osu.Framework.Graphics.Containers
         private FillDirection direction = FillDirection.Full;
 
         /// <summary>
-        /// The direction of the fill. Default is <see cref="Full"/>.
+        /// The direction of the fill. Default is <see cref="FillDirection.Full"/>.
+        /// If <see cref="FillDirection.Full"/> or <see cref="FillDirection.Horizontal"/>,
+        /// <see cref="Children"/> are arranged from left-to-right if their
+        /// <see cref="Drawable.Anchor"/> is to the left or centered horizontally.
+        /// They are arranged from right-to-left otherwise.
+        /// If <see cref="FillDirection.Full"/> or <see cref="FillDirection.Vertical"/>,
+        /// <see cref="Children"/> are arranged from top-to-bottom if their
+        /// <see cref="Drawable.Anchor"/> is to the top or centered vertically.
+        /// They are arranged from bottom-to-top otherwise.
         /// </summary>
         public FillDirection Direction
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1245,12 +1245,12 @@ namespace osu.Framework.Graphics
                 Vector2 rap = RelativeAnchorPosition;
 
                 Vector2 ratio1 = new Vector2(
-                    rap.X <= 0 ? 0 : (1 / rap.X),
-                    rap.Y <= 0 ? 0 : (1 / rap.Y));
+                    rap.X <= 0 ? 0 : 1 / rap.X,
+                    rap.Y <= 0 ? 0 : 1 / rap.Y);
 
                 Vector2 ratio2 = new Vector2(
-                    rap.X >= 1 ? 0 : (1 / (1 - rap.X)),
-                    rap.Y >= 1 ? 0 : (1 / (1 - rap.Y)));
+                    rap.X >= 1 ? 0 : 1 / (1 - rap.X),
+                    rap.Y >= 1 ? 0 : 1 / (1 - rap.Y));
 
                 RectangleF bbox = BoundingBox;
 


### PR DESCRIPTION
This commit makes autosize behave correctly when using custom
anchor positions. Custom anchor positions now have to be supplied
in relative coordinates for the sake of auto sizing logic being
possible in the first place.

This commit also does a little bit of refactoring and doc cleanup.