### PR TITLE
Get correct String representation for Enum

### DIFF
--- a/osu.Framework/Graphics/UserInterface/Tab/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/Tab/TabControl.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 
@@ -103,7 +104,7 @@ namespace osu.Framework.Graphics.UserInterface.Tab
             tab.SelectAction += selectTab;
 
             tabMap[value] = tab;
-            DropDown.AddDropDownItem(value.ToString(), value);
+            DropDown.AddDropDownItem((value as Enum)?.GetDescription() ?? value.ToString(), value);
             TabContainer.Add(tab);
         }
 


### PR DESCRIPTION
Alternatively, TabControl can be made to only accept Enum Types.