### PR TITLE
Fix TextureStore blocking globally when loading textures

### DIFF
--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -54,7 +54,9 @@ namespace osu.Framework.Graphics.Textures
         /// <returns>The texture.</returns>
         public new virtual Texture Get(string name)
         {
-            var cachedTex = getCachedTexture(name);
+            var cachedTex = textureCache.GetOrAdd(name, n =>
+                //Laziness ensure we are only ever creating the texture once (and blocking on other access until it is done).
+                new Lazy<TextureGL>(() => getTexture(name)?.TextureGL, LazyThreadSafetyMode.ExecutionAndPublication)).Value;
 
             if (cachedTex == null) return null;
 
@@ -66,10 +68,5 @@ namespace osu.Framework.Graphics.Textures
 
             return tex;
         }
-
-        private TextureGL getCachedTexture(string name) =>
-            textureCache.GetOrAdd(name, n =>
-                //Laziness ensure we are only ever creating the texture once (and blocking on other access until it is done).
-                new Lazy<TextureGL>(() => getTexture(name)?.TextureGL, LazyThreadSafetyMode.ExecutionAndPublication)).Value;
     }
 }

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -32,11 +32,6 @@ namespace osu.Framework.Graphics.Textures
                 atlas = new TextureAtlas(GLWrapper.MaxTextureSize, GLWrapper.MaxTextureSize);
         }
 
-        /// <summary>
-        /// A dictionary of name to lockable objects used to restrict loading of new textures to only happen once.
-        /// </summary>
-        private ConcurrentDictionary<string, object> loadCache = new ConcurrentDictionary<string, object>();
-
         private Texture getTexture(string name)
         {
             RawTexture raw = base.Get($@"{name}");

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
 using System.Collections.Concurrent;
 using System.Drawing;
-using System.Threading;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.IO.Stores;
@@ -33,7 +31,10 @@ namespace osu.Framework.Graphics.Textures
                 atlas = new TextureAtlas(GLWrapper.MaxTextureSize, GLWrapper.MaxTextureSize);
         }
 
-        Dictionary<string, object> loadCache = new Dictionary<string, object>();
+        /// <summary>
+        /// A dictionary of name to lockable objects used to restrict loading of new textures to only happen once.
+        /// </summary>
+        private Dictionary<string, object> loadCache = new Dictionary<string, object>();
 
         private Texture getTexture(string name)
         {
@@ -84,7 +85,7 @@ namespace osu.Framework.Graphics.Textures
             lock (loadCache)
             {
                 if (!loadCache.TryGetValue(name, out mutex))
-                    loadCache[name] = (mutex = new object());
+                    loadCache[name] = mutex = new object();
             }
 
             lock (mutex)


### PR DESCRIPTION
Locking now only occurs when two sources request the same texture.