### PR TITLE
Fix performance degredation with many non-autosized masked drawables.

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -343,7 +343,7 @@ namespace osu.Framework.Graphics.Containers
         /// If the return value is false, then children are not updated and
         /// <see cref="UpdateAfterChildren"/> is not called.
         /// </summary>
-        protected virtual bool RequiresChildrenUpdate => !IsMaskedAway || !autoSize.IsValid;
+        protected virtual bool RequiresChildrenUpdate => !IsMaskedAway || AutoSizeAxes != Axes.None && !autoSize.IsValid;
 
         internal sealed override bool UpdateSubTree()
         {


### PR DESCRIPTION
AutoSizeAxes was not being checked before ensuring autoSize is valid.
It's never in a valid state on non-autosize drawables.