### PR TITLE
Delayed load container

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseOnlineTextures.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseOnlineTextures.cs
@@ -1,22 +1,19 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using OpenTK;
-using osu.Framework.Allocation;
 using osu.Framework.Screens.Testing;
+using OpenTK;
 
 namespace osu.Framework.VisualTests.Tests
 {
     internal class TestCaseOnlineTextures : TestCase
     {
         private FillFlowContainer flow;
-
-        private int loadId = 55;
-        private Game game;
 
         public override void Reset()
         {
@@ -29,7 +26,7 @@ namespace osu.Framework.VisualTests.Tests
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
-                        flow = new FillFlowContainer()
+                        flow = new FillFlowContainer
                         {
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
@@ -38,21 +35,23 @@ namespace osu.Framework.VisualTests.Tests
                 }
             };
 
-            getNextAvatar();
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(Game game)
-        {
-            this.game = game;
-        }
-
-        private void getNextAvatar()
-        {
-            new Avatar(loadId).LoadAsync(game, flow.Add);
-
-            loadId++;
-            Scheduler.AddDelayed(getNextAvatar, 400);
+            for (int i = 55; i < 2048; i++)
+                flow.Add(new Container
+                {
+                    Size = new Vector2(128),
+                    Children = new Drawable[]
+                    {
+                        new DelayedLoadContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                            {
+                                new Avatar(i) { RelativeSizeAxes = Axes.Both }
+                            }
+                        },
+                        new SpriteText { Text = i.ToString() },
+                    }
+                });
         }
     }
 
@@ -69,22 +68,6 @@ namespace osu.Framework.VisualTests.Tests
         private void load(TextureStore textures)
         {
             Texture = textures.Get($@"https://a.ppy.sh/{userId}");
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            if (Texture == null)
-            {
-                Expire();
-                return;
-            }
-
-            //override texture size
-            Size = new Vector2(128);
-
-            FadeInFromZero(500);
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
+++ b/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Called when async loading of children has completed.
         /// </summary>
-        public Action FinishedLoading;
+        public Action<AsyncLoadContainer> FinishedLoading;
 
         protected override Container<Drawable> Content => content;
 
@@ -49,7 +49,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 AddInternal(d);
                 d.FadeInFromZero(150);
-                FinishedLoading?.Invoke();
+                FinishedLoading?.Invoke(this);
             });
         }
 

--- a/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
+++ b/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
@@ -52,6 +52,10 @@ namespace osu.Framework.Graphics.Containers
             });
         }
 
+        /// <summary>
+        /// True if the load task for our content has been started.
+        /// Will remain true even after load is completed.
+        /// </summary>
         protected bool LoadTriggered => loadTask != null;
     }
 }

--- a/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
+++ b/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
@@ -1,0 +1,48 @@
+using System.Threading.Tasks;
+using osu.Framework.Allocation;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// A container which asynchronously loads its children.
+    /// </summary>
+    public class AsyncLoadContainer : Container
+    {
+        protected override Container<Drawable> Content => content;
+
+        private readonly Container content = new Container { RelativeSizeAxes = Axes.Both };
+
+        private Game game;
+
+        protected virtual bool ShouldLoadContent => true;
+
+        [BackgroundDependencyLoader]
+        private void load(Game game)
+        {
+            this.game = game;
+            if (ShouldLoadContent)
+                loadContentAsync();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!LoadTriggered && ShouldLoadContent)
+                loadContentAsync();
+        }
+
+        private Task loadTask;
+
+        private void loadContentAsync()
+        {
+            loadTask = content.LoadAsync(game, d =>
+            {
+                AddInternal(d);
+                d.FadeInFromZero(150);
+            });
+        }
+
+        protected bool LoadTriggered => loadTask != null;
+    }
+}

--- a/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
+++ b/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
@@ -48,7 +48,6 @@ namespace osu.Framework.Graphics.Containers
             loadTask = content.LoadAsync(game, d =>
             {
                 AddInternal(d);
-                d.FadeInFromZero(150);
                 FinishedLoading?.Invoke(this);
             });
         }

--- a/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
+++ b/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 
@@ -11,6 +12,11 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public class AsyncLoadContainer : Container
     {
+        /// <summary>
+        /// Called when async loading of children has completed.
+        /// </summary>
+        public Action FinishedLoading;
+
         protected override Container<Drawable> Content => content;
 
         private readonly Container content = new Container { RelativeSizeAxes = Axes.Both };
@@ -43,6 +49,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 AddInternal(d);
                 d.FadeInFromZero(150);
+                FinishedLoading?.Invoke();
             });
         }
 

--- a/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
+++ b/osu.Framework/Graphics/Containers/AsyncLoadContainer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadContainer.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadContainer.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
 using osu.Framework.Caching;
 using osu.Framework.Graphics.Primitives;
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadContainer.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadContainer.cs
@@ -23,10 +23,14 @@ namespace osu.Framework.Graphics.Containers
 
         protected override void Update()
         {
-            if (LoadTriggered || !isIntersecting)
-                timeVisible = 0;
-            else
-                timeVisible += Time.Elapsed;
+            //this code can be expensive, so only run if we haven't yet loaded.
+            if (!LoadTriggered)
+            {
+                if (!isIntersecting)
+                    timeVisible = 0;
+                else
+                    timeVisible += Time.Elapsed;
+            }
 
             base.Update();
         }

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -13,7 +13,7 @@ using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Graphics.Containers
 {
-    public class ScrollContainer : Container
+    public class ScrollContainer : Container, DelayedLoadContainer.IOnScreenOptimisingContainer
     {
         /// <summary>
         /// Determines whether the scroll dragger appears on the left side. If not, then it always appears on the right side.

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Extensions\IEnumerableExtensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\TypeExtensions\TypeExtensions.cs" />
     <Compile Include="Graphics\Containers\AsyncLoadContainer.cs" />
+    <Compile Include="Graphics\Containers\DelayedLoadContainer.cs" />
     <Compile Include="Graphics\Containers\FillFlowContainer.cs" />
     <Compile Include="Graphics\Containers\TabbableContainer.cs" />
     <Compile Include="Graphics\UserInterface\MenuItem.cs" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Extensions\GeneralExtensions.cs" />
     <Compile Include="Extensions\IEnumerableExtensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\TypeExtensions\TypeExtensions.cs" />
+    <Compile Include="Graphics\Containers\AsyncLoadContainer.cs" />
     <Compile Include="Graphics\Containers\FillFlowContainer.cs" />
     <Compile Include="Graphics\Containers\TabbableContainer.cs" />
     <Compile Include="Graphics\UserInterface\MenuItem.cs" />


### PR DESCRIPTION
New container types to help with common async scenarios.

- `AsyncLoadContainer` can be used in place of manual `LoadAsync` calls to write more elegant code.
- `DelayedLoadContainer` can be used to add a delay to content to avoid prematurely loading children when they haven't been on screen for long enough (ie. online resources or otherwise expensive texture fetches).