### PR TITLE
Don't queue new input states when nothing changed

### DIFF
--- a/osu.Framework.Desktop/Input/Handlers/Keyboard/OpenTKKeyboardHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Keyboard/OpenTKKeyboardHandler.cs
@@ -22,14 +22,20 @@ namespace osu.Framework.Desktop.Input.Handlers.Keyboard
 
         public override int Priority => 0;
 
+        private OpenTK.Input.KeyboardState lastState;
+
         public override bool Initialize(GameHost host)
         {
             host.InputThread.Scheduler.Add(scheduled = new ScheduledDelegate(delegate
             {
-                PendingStates.Enqueue(new InputState
-                {
-                    Keyboard = new TkKeyboardState(host.IsActive ? OpenTK.Input.Keyboard.GetState() : new OpenTK.Input.KeyboardState())
-                });
+                var state = host.IsActive ? OpenTK.Input.Keyboard.GetState() : new OpenTK.Input.KeyboardState();
+
+                if (state.Equals(lastState))
+                    return;
+
+                lastState = state;
+
+                PendingStates.Enqueue(new InputState { Keyboard = new TkKeyboardState(state) });
 
                 FrameStatistics.Increment(StatisticsCounterType.KeyEvents);
             }, 0, 0));

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
@@ -17,21 +17,24 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
     {
         private ScheduledDelegate scheduled;
 
+        private OpenTK.Input.MouseState lastState;
+
         public override bool Initialize(GameHost host)
         {
             host.InputThread.Scheduler.Add(scheduled = new ScheduledDelegate(delegate
             {
-                OpenTK.Input.MouseState state = OpenTK.Input.Mouse.GetCursorState();
-                Point point = host.Window.PointToClient(new Point(state.X, state.Y));
+                var state = OpenTK.Input.Mouse.GetCursorState();
 
-                //todo: reimplement if necessary
-                //Vector2 pos = Vector2.Multiply(point, Vector2.Divide(host.DrawSize, this.Size));
+                if (state.Equals(lastState))
+                    return;
+
+                lastState = state;
+
+                Point point = host.Window.PointToClient(new Point(state.X, state.Y));
 
                 Vector2 pos = new Vector2(point.X, point.Y);
 
-                var tkState = new TkMouseState(state, pos, host.IsActive);
-
-                PendingStates.Enqueue(new InputState { Mouse = tkState });
+                PendingStates.Enqueue(new InputState { Mouse = new TkMouseState(state, pos, host.IsActive) });
 
                 FrameStatistics.Increment(StatisticsCounterType.MouseEvents);
             }, 0, 0));

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -114,6 +114,10 @@ namespace osu.Framework.Input
 
             unfocusIfNoLongerValid(CurrentState);
 
+            //we need to make sure the code in the foreach below is run at least once even if we have no new pending states.
+            if (pendingStates.Count == 0)
+                pendingStates.Add(CurrentState);
+
             foreach (InputState s in pendingStates)
             {
                 bool hasKeyboard = s.Keyboard != null;
@@ -147,10 +151,6 @@ namespace osu.Framework.Input
                 if (hasKeyboard)
                     updateKeyboardEvents(CurrentState);
             }
-
-            //we still want to make sure to update the input queues! they may be used for focus changes.
-            if (pendingStates.Count == 0)
-                updateInputQueues(CurrentState);
 
             if (CurrentState.Mouse != null)
             {


### PR DESCRIPTION
Until now we've been pushing 1,000 states per second even when nothing has changed in those states. This adds equality checks and thus reduces the overhead of input queue building quite substantially.