### PR TITLE
Dynamically recompile VisualTests

### DIFF
--- a/osu-framework.sln
+++ b/osu-framework.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework", "osu.Framework\osu.Framework.csproj", "{C76BF5B3-985E-4D39-95FE-97C9C879B83A}"
 EndProject
@@ -14,6 +14,14 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.VisualTests", "osu.Framework.VisualTests\osu.Framework.VisualTests.csproj", "{1F02F11C-2C66-4D25-BBB5-5C752AAD3E62}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.Desktop.Tests", "osu.Framework.Desktop.Tests\osu.Framework.Desktop.Tests.csproj", "{46C1D3D0-EA66-4488-A186-621A36B9F0D5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.Testing", "osu.Framework.Testing\osu.Framework.Testing.csproj", "{007B2356-AB6F-4BD9-96D5-116FC2DCE69A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{46CA05F7-5AC2-4A96-B065-FB6CB4E4D204}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Framework", "Framework", "{02639B6E-A6E6-41BA-AF02-475E5C2DCB0A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{7E37215E-3CD2-4157-8DBD-51306E8D768E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -45,8 +53,21 @@ Global
 		{46C1D3D0-EA66-4488-A186-621A36B9F0D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{46C1D3D0-EA66-4488-A186-621A36B9F0D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{46C1D3D0-EA66-4488-A186-621A36B9F0D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{007B2356-AB6F-4BD9-96D5-116FC2DCE69A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{007B2356-AB6F-4BD9-96D5-116FC2DCE69A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{007B2356-AB6F-4BD9-96D5-116FC2DCE69A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{007B2356-AB6F-4BD9-96D5-116FC2DCE69A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{C76BF5B3-985E-4D39-95FE-97C9C879B83A} = {02639B6E-A6E6-41BA-AF02-475E5C2DCB0A}
+		{65DC628F-A640-4111-AB35-3A5652BC1E17} = {02639B6E-A6E6-41BA-AF02-475E5C2DCB0A}
+		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D} = {7E37215E-3CD2-4157-8DBD-51306E8D768E}
+		{79803407-6F50-484F-93F5-641911EABD8A} = {46CA05F7-5AC2-4A96-B065-FB6CB4E4D204}
+		{1F02F11C-2C66-4D25-BBB5-5C752AAD3E62} = {46CA05F7-5AC2-4A96-B065-FB6CB4E4D204}
+		{46C1D3D0-EA66-4488-A186-621A36B9F0D5} = {46CA05F7-5AC2-4A96-B065-FB6CB4E4D204}
+		{007B2356-AB6F-4BD9-96D5-116FC2DCE69A} = {02639B6E-A6E6-41BA-AF02-475E5C2DCB0A}
 	EndGlobalSection
 EndGlobal

--- a/osu.Framework.Testing/OpenTK.dll.config
+++ b/osu.Framework.Testing/OpenTK.dll.config
@@ -1,0 +1,25 @@
+<configuration>
+  <dllmap os="linux" dll="opengl32.dll" target="libGL.so.1"/>
+  <dllmap os="linux" dll="glu32.dll" target="libGLU.so.1"/>
+  <dllmap os="linux" dll="openal32.dll" target="libopenal.so.1"/>
+  <dllmap os="linux" dll="alut.dll" target="libalut.so.0"/>
+  <dllmap os="linux" dll="opencl.dll" target="libOpenCL.so"/>
+  <dllmap os="linux" dll="libX11" target="libX11.so.6"/>
+  <dllmap os="linux" dll="libXi" target="libXi.so.6"/>
+  <dllmap os="linux" dll="SDL2.dll" target="libSDL2-2.0.so.0"/>
+  <dllmap os="osx" dll="opengl32.dll" target="/System/Library/Frameworks/OpenGL.framework/OpenGL"/>
+  <dllmap os="osx" dll="openal32.dll" target="/System/Library/Frameworks/OpenAL.framework/OpenAL" />
+  <dllmap os="osx" dll="alut.dll" target="/System/Library/Frameworks/OpenAL.framework/OpenAL" />
+  <dllmap os="osx" dll="libGLES.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="libGLESv1_CM.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="libGLESv2.dll" target="/System/Library/Frameworks/OpenGLES.framework/OpenGLES" />
+  <dllmap os="osx" dll="opencl.dll" target="/System/Library/Frameworks/OpenCL.framework/OpenCL"/>
+  <dllmap os="osx" dll="SDL2.dll" target="libSDL2.dylib"/>
+  <!-- XQuartz compatibility (X11 on Mac) -->
+  <dllmap os="osx" dll="libGL.so.1" target="/usr/X11/lib/libGL.dylib"/>
+  <dllmap os="osx" dll="libX11" target="/usr/X11/lib/libX11.dylib"/>
+  <dllmap os="osx" dll="libXcursor.so.1" target="/usr/X11/lib/libXcursor.dylib"/>
+  <dllmap os="osx" dll="libXi" target="/usr/X11/lib/libXi.dylib"/>
+  <dllmap os="osx" dll="libXinerama" target="/usr/X11/lib/libXinerama.dylib"/>
+  <dllmap os="osx" dll="libXrandr.so.2" target="/usr/X11/lib/libXrandr.dylib"/>
+</configuration>

--- a/osu.Framework.Testing/Properties/AssemblyInfo.cs
+++ b/osu.Framework.Testing/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/osu.Framework.Testing/Properties/AssemblyInfo.cs
+++ b/osu.Framework.Testing/Properties/AssemblyInfo.cs
@@ -1,0 +1,35 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("osu.Framework.Testing")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("osu.Framework.Testing")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("007b2356-ab6f-4bd9-96d5-116fc2dce69a")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/osu.Framework.Testing/TestBrowser.cs
+++ b/osu.Framework.Testing/TestBrowser.cs
@@ -199,8 +199,10 @@ namespace osu.Framework.Testing
         private static string findSolutionPath()
         {
             var di = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
-            while (!Directory.GetFiles(di.FullName, "*.sln").Any())
+
+            while (!Directory.GetFiles(di.FullName, "*.sln").Any() && di.Parent != null)
                 di = di.Parent;
+
             return di.FullName;
         }
 

--- a/osu.Framework.Testing/TestBrowser.cs
+++ b/osu.Framework.Testing/TestBrowser.cs
@@ -112,6 +112,7 @@ namespace osu.Framework.Testing
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
                 Masking = true,
+                Depth = float.MinValue,
                 CornerRadius = 5,
                 AutoSizeAxes = Axes.Both,
                 Children = new Drawable[]

--- a/osu.Framework.Testing/TestBrowser.cs
+++ b/osu.Framework.Testing/TestBrowser.cs
@@ -131,7 +131,14 @@ namespace osu.Framework.Testing
             foreach (var testCase in tests)
                 addTest(testCase);
 
-            startBackgroundCompiling();
+            try
+            {
+                startBackgroundCompiling();
+            }
+            catch
+            {
+                //it's okay for this to fail for now.
+            }
         }
 
         protected override void LoadComplete()

--- a/osu.Framework.Testing/TestBrowser.cs
+++ b/osu.Framework.Testing/TestBrowser.cs
@@ -208,7 +208,7 @@ namespace osu.Framework.Testing
         {
             var csc = new CSharpCodeProvider();
 
-            var newPath = Path.Combine(findSolutionPath(), "packages", "Microsoft.Net.Compilers.1.3.2", "tools", "csc.exe");
+            var newPath = Path.Combine(findSolutionPath(), "packages", "Microsoft.Net.Compilers.2.0.1", "tools", "csc.exe");
 
             //Black magic to fix incorrect packaged path (http://stackoverflow.com/a/40311406)
             var settings = csc.GetType().GetField("_compilerSettings", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(csc);

--- a/osu.Framework.Testing/TestBrowser.cs
+++ b/osu.Framework.Testing/TestBrowser.cs
@@ -2,9 +2,13 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using System.CodeDom.Compiler;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
+using Microsoft.CodeDom.Providers.DotNetCompilerPlatform;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions;
@@ -13,11 +17,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
+using osu.Framework.Screens;
 using OpenTK;
 using OpenTK.Graphics;
 
-namespace osu.Framework.Screens.Testing
+namespace osu.Framework.Testing
 {
     public class TestBrowser : Screen
     {
@@ -60,9 +66,11 @@ namespace osu.Framework.Screens.Testing
         }
 
         [BackgroundDependencyLoader]
-        private void load(Storage storage)
+        private void load(Storage storage, FrameworkConfigManager frameworkConfig)
         {
             config = new TestBrowserConfig(storage);
+
+            frameworkConfig.Set(FrameworkConfig.ShowLogOverlay, true);
 
             Add(leftContainer = new Container
             {
@@ -100,6 +108,8 @@ namespace osu.Framework.Screens.Testing
 
             foreach (var testCase in tests)
                 addTest(testCase);
+
+            startBackgroundCompiling();
         }
 
         protected override void LoadComplete()
@@ -149,6 +159,91 @@ namespace osu.Framework.Screens.Testing
                 testContainer.Add(loadedTest = testCase);
                 testCase.Reset();
             }
+        }
+
+        private FileSystemWatcher fsw;
+
+        /// <summary>
+        /// Black magic to fix incorrect packaged path (http://stackoverflow.com/a/40311406)
+        /// </summary>
+        private static readonly Lazy<CSharpCodeProvider> code_provider = new Lazy<CSharpCodeProvider>(() => {
+            var csc = new CSharpCodeProvider();
+
+            var settings = csc.GetType().GetField("_compilerSettings", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(csc);
+            var path = settings?.GetType().GetField("_compilerFullPath", BindingFlags.Instance | BindingFlags.NonPublic);
+            path?.SetValue(settings, ((string)path.GetValue(settings)).Replace(@"bin\roslyn\", @"roslyn\"));
+
+            return csc;
+        });
+
+        private void startBackgroundCompiling()
+        {
+            var di = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+
+            var basePath = Path.Combine(di.Parent?.Parent?.FullName, @"Tests");
+
+            fsw = new FileSystemWatcher(basePath, @"*.cs")
+            {
+                EnableRaisingEvents = true,
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.CreationTime,
+            };
+
+            fsw.Changed += (sender, e) =>
+            {
+                CompilerParameters cp = new CompilerParameters
+                {
+                    GenerateInMemory = true,
+                    TreatWarningsAsErrors = false,
+                    GenerateExecutable = false,
+                };
+
+                var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic).Select(a => a.Location);
+                cp.ReferencedAssemblies.AddRange(assemblies.ToArray());
+
+                string source;
+                while (true)
+                {
+                    try
+                    {
+                        source = File.ReadAllText(e.FullPath);
+                        break;
+                    }
+                    catch
+                    {
+                        Thread.Sleep(100);
+                    }
+                }
+
+                Logger.Log($@"Recompiling {e.Name}...", LoggingTarget.Runtime, LogLevel.Important);
+
+                CompilerResults compile = code_provider.Value.CompileAssemblyFromSource(cp, source);
+
+                Logger.Log(@"Complete!", LoggingTarget.Runtime, LogLevel.Important);
+
+                if (compile.Errors.HasErrors)
+                {
+                    string text = "Compile error: ";
+                    foreach (CompilerError ce in compile.Errors)
+                        text += "\r\n" + ce;
+
+                    Logger.Log(text, LoggingTarget.Runtime, LogLevel.Error);
+                    return;
+                }
+
+                Module module = compile.CompiledAssembly.GetModules()[0];
+
+                if (module == null) return;
+
+                Type type = module.GetTypes()[0];
+                var newVersion = (TestCase)Activator.CreateInstance(type);
+
+                Schedule(() =>
+                {
+                    int i = testCases.FindIndex(t => t.GetType().Name == type.Name);
+                    testCases[i] = newVersion;
+                    LoadTest(i);
+                });
+            };
         }
 
         private class TestCaseButton : ClickableContainer

--- a/osu.Framework.Testing/TestCase.cs
+++ b/osu.Framework.Testing/TestCase.cs
@@ -3,14 +3,14 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Extensions.TypeExtensions;
 
-namespace osu.Framework.Screens.Testing
+namespace osu.Framework.Testing
 {
     public abstract class TestCase : Container
     {

--- a/osu.Framework.Testing/osu.Framework.Testing.csproj
+++ b/osu.Framework.Testing/osu.Framework.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
-  <Import Project="$(SolutionDir)\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="$(SolutionDir)\packages\Microsoft.Net.Compilers.2.0.1\build\Microsoft.Net.Compilers.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Net.Compilers.2.0.1\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\ppy.OpenTK.2.0.50727.1340\lib\net45\OpenTK.dll</HintPath>
@@ -67,7 +67,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Net.Compilers.2.0.1\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Net.Compilers.2.0.1\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.1\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
   </Target>
 </Project>

--- a/osu.Framework.Testing/osu.Framework.Testing.csproj
+++ b/osu.Framework.Testing/osu.Framework.Testing.csproj
@@ -11,10 +11,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>osu.Framework.Testing</RootNamespace>
     <AssemblyName>osu.Framework.Testing</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/osu.Framework.Testing/osu.Framework.Testing.csproj
+++ b/osu.Framework.Testing/osu.Framework.Testing.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.1\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="OpenTK, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\ppy.OpenTK.2.0.50727.1340\lib\net45\OpenTK.dll</HintPath>

--- a/osu.Framework.Testing/osu.Framework.Testing.csproj
+++ b/osu.Framework.Testing/osu.Framework.Testing.csproj
@@ -1,0 +1,69 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
+  <Import Project="$(SolutionDir)\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{007B2356-AB6F-4BD9-96D5-116FC2DCE69A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>osu.Framework.Testing</RootNamespace>
+    <AssemblyName>osu.Framework.Testing</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+    </Reference>
+    <Reference Include="OpenTK, Version=2.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\ppy.OpenTK.2.0.50727.1340\lib\net45\OpenTK.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestBrowser.cs" />
+    <Compile Include="TestCase.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\osu.Framework\osu.Framework.csproj">
+      <Project>{C76BF5B3-985E-4D39-95FE-97C9C879B83A}</Project>
+      <Name>osu.Framework</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="OpenTK.dll.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Net.Compilers.1.3.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.3\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
+  </Target>
+</Project>

--- a/osu.Framework.Testing/osu.Framework.Testing.csproj
+++ b/osu.Framework.Testing/osu.Framework.Testing.csproj
@@ -55,6 +55,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\osu-framework.licenseheader">
+      <Link>osu-framework.licenseheader</Link>
+    </None>
     <None Include="OpenTK.dll.config" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/osu.Framework.Testing/packages.config
+++ b/osu.Framework.Testing/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall" version="1.0.3.1" targetFramework="net452" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall" version="1.0.3.1" targetFramework="net45" />
   <package id="Microsoft.Net.Compilers" version="2.0.1" targetFramework="net40" developmentDependency="true" />
   <package id="ppy.OpenTK" version="2.0.50727.1340" targetFramework="net452" requireReinstallation="true" />
 </packages>

--- a/osu.Framework.Testing/packages.config
+++ b/osu.Framework.Testing/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net452" />
+  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net452" developmentDependency="true" />
+  <package id="ppy.OpenTK" version="2.0.50727.1340" targetFramework="net452" />
+</packages>

--- a/osu.Framework.Testing/packages.config
+++ b/osu.Framework.Testing/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="1.0.3" targetFramework="net452" />
-  <package id="Microsoft.Net.Compilers" version="1.3.2" targetFramework="net452" developmentDependency="true" />
-  <package id="ppy.OpenTK" version="2.0.50727.1340" targetFramework="net452" />
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall" version="1.0.3.1" targetFramework="net452" />
+  <package id="Microsoft.Net.Compilers" version="2.0.1" targetFramework="net40" developmentDependency="true" />
+  <package id="ppy.OpenTK" version="2.0.50727.1340" targetFramework="net452" requireReinstallation="true" />
 </packages>

--- a/osu.Framework.VisualTests/Benchmark.cs
+++ b/osu.Framework.VisualTests/Benchmark.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseAutosize.cs
@@ -7,9 +7,9 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Input;
+using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Screens.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCheckBoxes.cs
@@ -5,7 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 using OpenTK;
 
 namespace osu.Framework.VisualTests.Tests

--- a/osu.Framework.VisualTests/Tests/TestCaseCircularContainer.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCircularContainer.cs
@@ -6,8 +6,8 @@ using OpenTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Screens.Testing;
 using osu.Framework.Input;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
@@ -7,7 +7,7 @@ using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Colour;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
@@ -11,7 +11,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Input;
 using System.Collections.Generic;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseDropdownBox.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseDropdownBox.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseFillModes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFillModes.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
@@ -10,7 +10,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 using osu.Framework.Threading;
 using OpenTK;
 using OpenTK.Graphics;
@@ -267,7 +267,7 @@ namespace osu.Framework.VisualTests.Tests
                                 {
                                     Width = 50,
                                     Height = 50,
-                                    Colour = new Color4(255, 255, 255, 255)
+                                    Colour = Color4.White
                                 },
                                 new SpriteText
                                 {

--- a/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
@@ -7,7 +7,7 @@ using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;
 using System;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseNestedHover.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseNestedHover.cs
@@ -7,7 +7,7 @@ using osu.Framework.Input;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseOnlineTextures.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseOnlineTextures.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 using OpenTK;
+using OpenTK.Graphics;
 
 namespace osu.Framework.VisualTests.Tests
 {
@@ -44,6 +46,17 @@ namespace osu.Framework.VisualTests.Tests
                         new DelayedLoadContainer
                         {
                             RelativeSizeAxes = Axes.Both,
+                            FinishedLoading = d => {
+                                if ((d.Children.First() as Sprite)?.Texture == null)
+                                {
+                                    d.Add(new SpriteText {
+                                        Colour = Color4.Gray,
+                                        Text = @"nope",
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                    });
+                                }
+                            },
                             Children = new Drawable[]
                             {
                                 new Avatar(i) { RelativeSizeAxes = Axes.Both }

--- a/osu.Framework.VisualTests/Tests/TestCasePadding.cs
+++ b/osu.Framework.VisualTests/Tests/TestCasePadding.cs
@@ -8,7 +8,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseScreen.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseScreen.cs
@@ -11,7 +11,7 @@ using osu.Framework.MathUtils;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Allocation;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseScrollableFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseScrollableFlow.cs
@@ -10,7 +10,7 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseSliderbar.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSliderbar.cs
@@ -5,7 +5,7 @@ using System;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
 

--- a/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
@@ -4,7 +4,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
 

--- a/osu.Framework.VisualTests/Tests/TestCaseSpriteText.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSpriteText.cs
@@ -4,7 +4,7 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseTabControl.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTabControl.cs
@@ -12,7 +12,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseTextBox.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTextBox.cs
@@ -6,7 +6,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using OpenTK;
 using osu.Framework.Graphics.Primitives;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseTriangles.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTriangles.cs
@@ -5,7 +5,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
 

--- a/osu.Framework.VisualTests/VisualTestGame.cs
+++ b/osu.Framework.VisualTests/VisualTestGame.cs
@@ -5,7 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Platform;
-using osu.Framework.Screens.Testing;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests
 {

--- a/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
+++ b/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
@@ -82,6 +82,10 @@
       <Project>{65dc628f-a640-4111-ab35-3a5652bc1e17}</Project>
       <Name>osu.Framework.Desktop</Name>
     </ProjectReference>
+    <ProjectReference Include="..\osu.Framework.Testing\osu.Framework.Testing.csproj">
+      <Project>{007B2356-AB6F-4BD9-96D5-116FC2DCE69A}</Project>
+      <Name>osu.Framework.Testing</Name>
+    </ProjectReference>
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj">
       <Project>{C76BF5B3-985E-4D39-95FE-97C9C879B83A}</Project>
       <Name>osu.Framework</Name>

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -37,8 +37,6 @@ namespace osu.Framework.Graphics.Visualisation
             {
                 flow = new FillFlowContainer
                 {
-                    LayoutDuration = 150,
-                    LayoutEasing = EasingTypes.OutQuart,
                     RelativeSizeAxes = Axes.X,
                     AutoSizeAxes = Axes.Y,
                 }
@@ -50,6 +48,9 @@ namespace osu.Framework.Graphics.Visualisation
 
         private void logger_NewEntry(LogEntry entry)
         {
+            if (entry.Level <= LogLevel.Verbose)
+                return;
+
             Schedule(() =>
             {
                 var drawEntry = new DrawableLogEntry(entry);

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -123,8 +123,6 @@
     <Compile Include="Allocation\TimedExpiryCache.cs" />
     <Compile Include="Input\IRequireHighFrequencyMousePosition.cs" />
     <Compile Include="Input\PassThroughInputManager.cs" />
-    <Compile Include="Screens\Testing\TestBrowser.cs" />
-    <Compile Include="Screens\Testing\TestCase.cs" />
     <Compile Include="Graphics\BlendingInfo.cs" />
     <Compile Include="Graphics\Colour\ColourInfo.cs" />
     <Compile Include="Graphics\Colour\SRGBColour.cs" />

--- a/osu.Framework/packages.config
+++ b/osu.Framework/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
 <!--
 Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE


### PR DESCRIPTION
`TestCase`s will now be [automatically recompiled](https://streamable.com/klb4q) and reloaded without a restart of the `VisualTests program.

- This will only work on platforms with support `FileSystemWatcher` for now.
- Moved `TestBrowser` etc. to its own project so roslyn doesn't need to be referenced in the base framework. The post-compile steps add an overhead which I'd rather avoid.