### PR TITLE
Improve startup time and fix occasional black-screen failures

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -315,13 +315,14 @@ namespace osu.Framework.Platform
             if (Window != null)
             {
                 Window.SetupWindow(config);
-                Window.Title = $@"osu.Framework (running ""{Name}"")";
+                Window.Title = $@"osu!framework (running ""{Name}"")";
             }
-
-            Task.Run(() => bootstrapSceneGraph(game));
 
             DrawThread.Start();
             UpdateThread.Start();
+
+            DrawThread.WaitUntilInitialized();
+            bootstrapSceneGraph(game);
 
             try
             {


### PR DESCRIPTION
Black screens were caused by bootstrapSceneGraph causing a TextureAtlas texture load before the GL initialisation was complete, meaning we could not determine the MaxTextureSize.

Removing the asynchronous load unexpectedly improves startup time quite considerably.