### PR TITLE
Better transform helpers

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -239,7 +239,6 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public void BlurTo(Vector2 newBlurSigma, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformBlurSigma));
             TransformTo(BlurSigma, newBlurSigma, duration, easing, new TransformBlurSigma());
         }
 

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -240,7 +240,7 @@ namespace osu.Framework.Graphics.Containers
         public void BlurTo(Vector2 newBlurSigma, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformBlurSigma));
-            TransformVectorTo(BlurSigma, newBlurSigma, duration, easing, new TransformBlurSigma());
+            TransformTo(BlurSigma, newBlurSigma, duration, easing, new TransformBlurSigma());
         }
 
         protected class TransformBlurSigma : TransformVector

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -604,7 +604,6 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public void FadeEdgeEffectTo(float newAlpha, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformEdgeEffectAlpha));
             TransformTo(EdgeEffect.Colour.Linear.A, newAlpha, duration, easing, new TransformEdgeEffectAlpha());
         }
 

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -605,7 +605,7 @@ namespace osu.Framework.Graphics.Containers
         public void FadeEdgeEffectTo(float newAlpha, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformEdgeEffectAlpha));
-            TransformFloatTo(EdgeEffect.Colour.Linear.A, newAlpha, duration, easing, new TransformEdgeEffectAlpha());
+            TransformTo(EdgeEffect.Colour.Linear.A, newAlpha, duration, easing, new TransformEdgeEffectAlpha());
         }
 
         #endregion

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -86,7 +86,7 @@ namespace osu.Framework.Graphics.Containers
         public void TransformSpacingTo(Vector2 newSpacing, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformSpacing));
-            TransformVectorTo(Spacing, newSpacing, duration, easing, new TransformSpacing());
+            TransformTo(Spacing, newSpacing, duration, easing, new TransformSpacing());
         }
 
         public class TransformSpacing : TransformVector

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -85,7 +85,6 @@ namespace osu.Framework.Graphics.Containers
 
         public void TransformSpacingTo(Vector2 newSpacing, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformSpacing));
             TransformTo(Spacing, newSpacing, duration, easing, new TransformSpacing());
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1779,101 +1779,7 @@ namespace osu.Framework.Graphics
             FadeIn();
         }
 
-        public void FadeIn(double duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            FadeTo(1, duration, easing);
-        }
-
-        public void FadeInFromZero(double duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            if (transformDelay == 0)
-            {
-                Alpha = 0;
-                Transforms.RemoveAll(t => t is TransformAlpha);
-            }
-
-            double startTime = TransformStartTime;
-
-            Transforms.Add(new TransformAlpha
-            {
-                StartTime = startTime,
-                EndTime = startTime + duration,
-                StartValue = 0,
-                EndValue = 1,
-                Easing = easing,
-            });
-        }
-
-        public void FadeOut(double duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            FadeTo(0, duration, easing);
-        }
-
-        public void FadeOutFromOne(double duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            if (transformDelay == 0)
-            {
-                Alpha = 1;
-                Transforms.RemoveAll(t => t is TransformAlpha);
-            }
-
-            double startTime = TransformStartTime;
-
-            TransformAlpha tr = new TransformAlpha
-            {
-                StartTime = startTime,
-                EndTime = startTime + duration,
-                StartValue = 1,
-                EndValue = 0,
-                Easing = easing,
-            };
-
-            Transforms.Add(tr);
-        }
-
-        #region Float-based helpers
-
-        public void FadeTo(float newAlpha, double duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            UpdateTransformsOfType(typeof(TransformAlpha));
-            TransformTo(Alpha, newAlpha, duration, easing, new TransformAlpha());
-        }
-
-        public void RotateTo(float newRotation, double duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            UpdateTransformsOfType(typeof(TransformRotation));
-            TransformTo(Rotation, newRotation, duration, easing, new TransformRotation());
-        }
-
-        public void MoveTo(Direction direction, float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            switch (direction)
-            {
-                case Direction.Horizontal:
-                    MoveToX(destination, duration, easing);
-                    break;
-                case Direction.Vertical:
-                    MoveToY(destination, duration, easing);
-                    break;
-            }
-        }
-
-        public void MoveToX(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            UpdateTransformsOfType(typeof(TransformPositionX));
-            TransformTo(Position.X, destination, duration, easing, new TransformPositionX());
-        }
-
-        public void MoveToY(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            UpdateTransformsOfType(typeof(TransformPositionY));
-            TransformTo(Position.Y, destination, duration, easing, new TransformPositionY());
-        }
-
-        #endregion
-
-        #region Vector2-based helpers
-
+        
         protected void TransformTo<T>(T startValue, T newValue, double duration, EasingTypes easing, Transform<T> transform) where T : IEquatable<T>
         {
             Type type = transform.GetType();
@@ -1911,39 +1817,94 @@ namespace osu.Framework.Graphics
             addTransform(transform);
         }
 
+        public void FadeIn(double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            FadeTo(1, duration, easing);
+        }
+
+        public void FadeInFromZero(double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            FadeTo(0);
+            FadeIn(duration, easing);
+        }
+
+        public void FadeOut(double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            FadeTo(0, duration, easing);
+        }
+
+        public void FadeOutFromOne(double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            FadeTo(1);
+            FadeOut(duration, easing);
+        }
+
+        #region Float-based helpers
+
+        public void FadeTo(float newAlpha, double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            TransformTo(Alpha, newAlpha, duration, easing, new TransformAlpha());
+        }
+
+        public void RotateTo(float newRotation, double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            TransformTo(Rotation, newRotation, duration, easing, new TransformRotation());
+        }
+
+        public void MoveTo(Direction direction, float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            switch (direction)
+            {
+                case Direction.Horizontal:
+                    MoveToX(destination, duration, easing);
+                    break;
+                case Direction.Vertical:
+                    MoveToY(destination, duration, easing);
+                    break;
+            }
+        }
+
+        public void MoveToX(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            TransformTo(Position.X, destination, duration, easing, new TransformPositionX());
+        }
+
+        public void MoveToY(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            TransformTo(Position.Y, destination, duration, easing, new TransformPositionY());
+        }
+
+        #endregion
+
+        #region Vector2-based helpers
+
         public void ScaleTo(float newScale, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformScale));
             TransformTo(Scale, new Vector2(newScale), duration, easing, new TransformScale());
         }
 
         public void ScaleTo(Vector2 newScale, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformScale));
             TransformTo(Scale, newScale, duration, easing, new TransformScale());
         }
 
         public void ResizeTo(float newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformSize));
             TransformTo(Size, new Vector2(newSize), duration, easing, new TransformSize());
         }
 
         public void ResizeTo(Vector2 newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformSize));
             TransformTo(Size, newSize, duration, easing, new TransformSize());
         }
 
         public void MoveTo(Vector2 newPosition, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformPosition));
             TransformTo(Position, newPosition, duration, easing, new TransformPosition());
         }
 
         public void MoveToOffset(Vector2 offset, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformPosition));
             MoveTo((Transforms.FindLast(t => t is TransformPosition) as TransformPosition)?.EndValue ?? Position + offset, duration, easing);
         }
 
@@ -1958,49 +1919,17 @@ namespace osu.Framework.Graphics
 
         public void FadeColour(SRGBColour newColour, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            UpdateTransformsOfType(typeof(TransformColour));
-
-            Color4 startValue = Colour.Linear;
-            if (transformDelay == 0)
-            {
-                Transforms.RemoveAll(t => t is TransformColour);
-
-                if (startValue == newColour)
-                    return;
-            }
-            else
-                startValue = (Transforms.FindLast(t => t is TransformColour) as TransformColour)?.EndValue ?? startValue;
-
-            double startTime = TransformStartTime;
-
-            addTransform(new TransformColour
-            {
-                StartTime = startTime,
-                EndTime = startTime + duration,
-                StartValue = startValue,
-                EndValue = newColour.Linear,
-                Easing = easing
-            });
+            TransformTo(Colour, newColour, duration, easing, new TransformColour());
         }
 
         public void FlashColour(SRGBColour flashColour, double duration, EasingTypes easing = EasingTypes.None)
         {
-            if (transformDelay != 0)
-                throw new NotImplementedException("FlashColour doesn't support Delay() currently");
+            Color4 endValue = (Transforms.FindLast(t => t is TransformColour) as TransformColour)?.EndValue ?? Colour.Linear;
 
-            Color4 startValue = (Transforms.FindLast(t => t is TransformColour) as TransformColour)?.EndValue ?? Colour.Linear;
-            Transforms.RemoveAll(t => t is TransformColour);
+            Flush(false, typeof(TransformColour));
 
-            double startTime = TransformStartTime;
-
-            addTransform(new TransformColour
-            {
-                StartTime = startTime,
-                EndTime = startTime + duration,
-                StartValue = flashColour.Linear,
-                EndValue = startValue,
-                Easing = easing
-            });
+            FadeColour(flashColour);
+            FadeColour(endValue, duration, easing);
         }
 
         private void addTransform(ITransform transform)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -292,17 +292,6 @@ namespace osu.Framework.Graphics
             }
         }
 
-        protected void UpdateTransformsOfType(Type specificType)
-        {
-            //For simplicity let's just update *all* transforms.
-            //The commented (more optimised code) below doesn't consider past "removed" transforms, which can cause discrepancies.
-            updateTransforms();
-
-            //foreach (ITransform t in Transforms.AliveItems)
-            //    if (t.GetType() == specificType)
-            //        t.Apply(this);
-        }
-
         /// <summary>
         /// Process updates to this drawable based on loaded transforms.
         /// </summary>
@@ -1844,39 +1833,16 @@ namespace osu.Framework.Graphics
 
         #region Float-based helpers
 
-        protected void TransformFloatTo(float startValue, float newValue, double duration, EasingTypes easing, TransformFloat transform)
-        {
-            Type type = transform.GetType();
-            if (transformDelay == 0)
-            {
-                Transforms.RemoveAll(t => t.GetType() == type);
-                if (startValue == newValue)
-                    return;
-            }
-            else
-                startValue = (Transforms.FindLast(t => t.GetType() == type) as TransformFloat)?.EndValue ?? startValue;
-
-            double startTime = TransformStartTime;
-
-            transform.StartTime = startTime;
-            transform.EndTime = startTime + duration;
-            transform.StartValue = startValue;
-            transform.EndValue = newValue;
-            transform.Easing = easing;
-
-            addTransform(transform);
-        }
-
         public void FadeTo(float newAlpha, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformAlpha));
-            TransformFloatTo(Alpha, newAlpha, duration, easing, new TransformAlpha());
+            TransformTo(Alpha, newAlpha, duration, easing, new TransformAlpha());
         }
 
         public void RotateTo(float newRotation, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformRotation));
-            TransformFloatTo(Rotation, newRotation, duration, easing, new TransformRotation());
+            TransformTo(Rotation, newRotation, duration, easing, new TransformRotation());
         }
 
         public void MoveTo(Direction direction, float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
@@ -1895,31 +1861,44 @@ namespace osu.Framework.Graphics
         public void MoveToX(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPositionX));
-            TransformFloatTo(Position.X, destination, duration, easing, new TransformPositionX());
+            TransformTo(Position.X, destination, duration, easing, new TransformPositionX());
         }
 
         public void MoveToY(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPositionY));
-            TransformFloatTo(Position.Y, destination, duration, easing, new TransformPositionY());
+            TransformTo(Position.Y, destination, duration, easing, new TransformPositionY());
         }
 
         #endregion
 
         #region Vector2-based helpers
 
-        protected void TransformVectorTo(Vector2 startValue, Vector2 newValue, double duration, EasingTypes easing, TransformVector transform)
+        protected void TransformTo<T>(T startValue, T newValue, double duration, EasingTypes easing, Transform<T> transform) where T : IEquatable<T>
         {
             Type type = transform.GetType();
+
+            //For simplicity let's just update *all* transforms.
+            //The commented (more optimised code) below doesn't consider past "removed" transforms, which can cause discrepancies.
+            updateTransforms();
+
+            //foreach (ITransform t in Transforms.AliveItems)
+            //    if (t.GetType() == type)
+            //        t.Apply(this);
+
             if (transformDelay == 0)
             {
                 Transforms.RemoveAll(t => t.GetType() == type);
 
-                if (startValue == newValue)
+                if (startValue.Equals(newValue))
                     return;
             }
             else
-                startValue = (Transforms.FindLast(t => t.GetType() == type) as TransformVector)?.EndValue ?? startValue;
+            {
+                Transform<T> last = Transforms.FindLast(t => t.GetType() == type) as Transform<T>;
+                if (last != null)
+                    startValue = last.EndValue;
+            }
 
             double startTime = TransformStartTime;
 
@@ -1935,31 +1914,31 @@ namespace osu.Framework.Graphics
         public void ScaleTo(float newScale, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformScale));
-            TransformVectorTo(Scale, new Vector2(newScale), duration, easing, new TransformScale());
+            TransformTo(Scale, new Vector2(newScale), duration, easing, new TransformScale());
         }
 
         public void ScaleTo(Vector2 newScale, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformScale));
-            TransformVectorTo(Scale, newScale, duration, easing, new TransformScale());
+            TransformTo(Scale, newScale, duration, easing, new TransformScale());
         }
 
         public void ResizeTo(float newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformSize));
-            TransformVectorTo(Size, new Vector2(newSize), duration, easing, new TransformSize());
+            TransformTo(Size, new Vector2(newSize), duration, easing, new TransformSize());
         }
 
         public void ResizeTo(Vector2 newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformSize));
-            TransformVectorTo(Size, newSize, duration, easing, new TransformSize());
+            TransformTo(Size, newSize, duration, easing, new TransformSize());
         }
 
         public void MoveTo(Vector2 newPosition, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             UpdateTransformsOfType(typeof(TransformPosition));
-            TransformVectorTo(Position, newPosition, duration, easing, new TransformPosition());
+            TransformTo(Position, newPosition, duration, easing, new TransformPosition());
         }
 
         public void MoveToOffset(Vector2 offset, double duration = 0, EasingTypes easing = EasingTypes.None)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1932,14 +1932,14 @@ namespace osu.Framework.Graphics
             MoveTo((Transforms.FindLast(t => t is TransformPosition) as TransformPosition)?.EndValue ?? Position + offset, duration, easing);
         }
 
-        public void FadeColour(SRGBColour newColour, double duration = 0, EasingTypes easing = EasingTypes.None)
+        public void FadeColour(Color4 newColour, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
             TransformTo(Colour, newColour, duration, easing, new TransformColour());
         }
 
-        public void FlashColour(SRGBColour flashColour, double duration, EasingTypes easing = EasingTypes.None)
+        public void FlashColour(Color4 flashColour, double duration, EasingTypes easing = EasingTypes.None)
         {
-            Color4 endValue = (Transforms.FindLast(t => t is TransformColour) as TransformColour)?.EndValue ?? Colour.Linear;
+            Color4 endValue = (Transforms.FindLast(t => t is TransformColour) as TransformColour)?.EndValue ?? Colour;
 
             Flush(false, typeof(TransformColour));
 

--- a/osu.Framework/Graphics/Transforms/TransformColour.cs
+++ b/osu.Framework/Graphics/Transforms/TransformColour.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.MathUtils;
 using OpenTK.Graphics;
-using osu.Framework.Graphics.Colour;
 
 namespace osu.Framework.Graphics.Transforms
 {

--- a/osu.Framework/Graphics/Transforms/TransformColour.cs
+++ b/osu.Framework/Graphics/Transforms/TransformColour.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Graphics.Transforms
         public override void Apply(Drawable d)
         {
             base.Apply(d);
-            d.Colour = new SRGBColour { Linear = CurrentValue };
+            d.Colour = CurrentValue;
         }
     }
 }


### PR DESCRIPTION
This was spurred by two main issues;

1) `UpdateTransformsOfType()` had to be explicitly called whenever a new transform helper was created in derived classes. E.g. `BufferedContainer.BlurTo`.
2) Transforms lacked the ability to transform colours, through something like `TransformColourTo`.

Both of these are resolved in 2 steps:

1) Adding a generic `TransformTo()` method that replaces the `Transform*To()` methods.
2) Making UpdateTransformsOfType() implicit with the new `TransformTo()`.

Furthermore, this fixes a few transform helpers that were previously not using the `Transform*To()` methods and were not fully implementing it (or were implemented very hackishly).

The ideal end result is that the Transforms list really shouldn't be changed from the outside - it could lead to potentially dangerous scenarios. This isn't done just yet - there are some cases where this is done to loop very specific transformations, but I will touch up on this again and sort that out later.