### PR TITLE
Make TransformTo public and constrain T by struct.

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1784,7 +1784,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         protected double TransformStartTime => Clock != null ? Time.Current + transformDelay : 0;
 
-        protected void TransformTo<T>(T startValue, T newValue, double duration, EasingTypes easing, Transform<T> transform) where T : IEquatable<T>
+        public void TransformTo<T>(T startValue, T newValue, double duration, EasingTypes easing, Transform<T> transform) where T : struct, IEquatable<T>
         {
             Type type = transform.GetType();
 


### PR DESCRIPTION
Consider the case where we want to have an interface that provides a property and a transformation for that property. This interface could be attached onto any object and doesn't need to be a part of the base classes (Drawable/Container).

An example of such an interface implementation is:
```
    public interface IAccented : IDrawable
    {
        Color4 AccentColour { get; set; }
    }

    public static class AccentedExtensions
    {
        public static void FadeAccent<TDrawable>(this TDrawable drawable, Color4 newColour, double duration = 0, EasingTypes easing = EasingTypes.None)
            where TDrawable : Drawable, IAccented
        {
            drawable.TransformTo(drawable.AccentColour, newColour, duration, easing, new TransformAccent());
        }
    }
```

I would've liked to implement a TransformObjectTo() method or something like that, which would accept a boxed object and would allow tweening arbitrary variables/properties, but it seems like that's jumping down a rabbit hole which I can't imagine the depth of.