### PR TITLE
Ignore all mouse events when main window is minimized

### DIFF
--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
@@ -25,6 +25,7 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
             {
                 if (host.Window.WindowState == WindowState.Minimized)
                     return;
+
                 var state = OpenTK.Input.Mouse.GetCursorState();
 
                 if (state.Equals(lastState))

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
@@ -23,6 +23,8 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
         {
             host.InputThread.Scheduler.Add(scheduled = new ScheduledDelegate(delegate
             {
+                if (host.Window.WindowState == WindowState.Minimized)
+                    return;
                 var state = OpenTK.Input.Mouse.GetCursorState();
 
                 if (state.Equals(lastState))


### PR DESCRIPTION
Ignoring these will prevent getting mouse movement events with unexpected results.
For example, https://imgur.com/XEQvcvf (see Delta)

I can't compile it with latest osu, as it gives errors, but on osu's version this check has fixed ppy/osu#429.