### PR TITLE
Fix transforms not being applied correct when drawable is not present.

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -241,7 +241,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public void BlurTo(Vector2 newBlurSigma, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(BlurSigma, newBlurSigma, duration, easing, new TransformBlurSigma());
+            TransformTo(() => BlurSigma, newBlurSigma, duration, easing, new TransformBlurSigma());
         }
 
         protected class TransformBlurSigma : TransformVector

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -602,7 +602,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public void FadeEdgeEffectTo(float newAlpha, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(EdgeEffect.Colour.Linear.A, newAlpha, duration, easing, new TransformEdgeEffectAlpha());
+            TransformTo(() => EdgeEffect.Colour.Linear.A, newAlpha, duration, easing, new TransformEdgeEffectAlpha());
         }
 
         #endregion
@@ -1030,7 +1030,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void autoSizeResizeTo(Vector2 newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Size, newSize, duration, easing, new TransformAutoSize());
+            TransformTo(() => Size, newSize, duration, easing, new TransformAutoSize());
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -87,7 +87,7 @@ namespace osu.Framework.Graphics.Containers
 
         public void TransformSpacingTo(Vector2 newSpacing, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Spacing, newSpacing, duration, easing, new TransformSpacing());
+            TransformTo(() => Spacing, newSpacing, duration, easing, new TransformSpacing());
         }
 
         public class TransformSpacing : TransformVector

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1868,7 +1868,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         protected double TransformStartTime => Clock != null ? Time.Current + transformDelay : 0;
 
-        public void TransformTo<TValue>(TValue startValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue> transform) where TValue : struct, IEquatable<TValue>
+        public void TransformTo<TValue>(Func<TValue> currentValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue> transform) where TValue : struct, IEquatable<TValue>
         {
             Type type = transform.GetType();
 
@@ -1882,13 +1882,7 @@ namespace osu.Framework.Graphics
 
             double startTime = TransformStartTime;
 
-            var last = Transforms.FindLast(t => t.GetType() == type) as Transform<TValue>;
-            if (last != null)
-            {
-                //we may be in the middle of an existing transform, so let's update it to the start time of our new transform.
-                last.UpdateTime(new FrameTimeInfo { Current = startTime });
-                startValue = last.CurrentValue;
-            }
+            TValue startValue = currentValue();
 
             if (transformDelay == 0)
             {
@@ -1957,12 +1951,12 @@ namespace osu.Framework.Graphics
 
         public void FadeTo(float newAlpha, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Alpha, newAlpha, duration, easing, new TransformAlpha());
+            TransformTo(() => Alpha, newAlpha, duration, easing, new TransformAlpha());
         }
 
         public void RotateTo(float newRotation, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Rotation, newRotation, duration, easing, new TransformRotation());
+            TransformTo(() => Rotation, newRotation, duration, easing, new TransformRotation());
         }
 
         public void MoveTo(Direction direction, float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
@@ -1980,37 +1974,37 @@ namespace osu.Framework.Graphics
 
         public void MoveToX(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Position.X, destination, duration, easing, new TransformPositionX());
+            TransformTo(() => Position.X, destination, duration, easing, new TransformPositionX());
         }
 
         public void MoveToY(float destination, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Position.Y, destination, duration, easing, new TransformPositionY());
+            TransformTo(() => Position.Y, destination, duration, easing, new TransformPositionY());
         }
 
         public void ScaleTo(float newScale, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Scale, new Vector2(newScale), duration, easing, new TransformScale());
+            TransformTo(() => Scale, new Vector2(newScale), duration, easing, new TransformScale());
         }
 
         public void ScaleTo(Vector2 newScale, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Scale, newScale, duration, easing, new TransformScale());
+            TransformTo(() => Scale, newScale, duration, easing, new TransformScale());
         }
 
         public void ResizeTo(float newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Size, new Vector2(newSize), duration, easing, new TransformSize());
+            TransformTo(() => Size, new Vector2(newSize), duration, easing, new TransformSize());
         }
 
         public void ResizeTo(Vector2 newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Size, newSize, duration, easing, new TransformSize());
+            TransformTo(() => Size, newSize, duration, easing, new TransformSize());
         }
 
         public void MoveTo(Vector2 newPosition, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Position, newPosition, duration, easing, new TransformPosition());
+            TransformTo(() => Position, newPosition, duration, easing, new TransformPosition());
         }
 
         public void MoveToOffset(Vector2 offset, double duration = 0, EasingTypes easing = EasingTypes.None)
@@ -2020,7 +2014,7 @@ namespace osu.Framework.Graphics
 
         public void FadeColour(Color4 newColour, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(Colour, newColour, duration, easing, new TransformColour());
+            TransformTo(() => Colour, newColour, duration, easing, new TransformColour());
         }
 
         public void FlashColour(Color4 flashColour, double duration, EasingTypes easing = EasingTypes.None)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1872,6 +1872,8 @@ namespace osu.Framework.Graphics
         {
             Type type = transform.GetType();
 
+            double startTime = TransformStartTime;
+
             //For simplicity let's just update *all* transforms.
             //The commented (more optimised code) below doesn't consider past "removed" transforms, which can cause discrepancies.
             updateTransforms();
@@ -1879,8 +1881,6 @@ namespace osu.Framework.Graphics
             //foreach (ITransform t in Transforms.AliveItems)
             //    if (t.GetType() == type)
             //        t.Apply(this);
-
-            double startTime = TransformStartTime;
 
             TValue startValue = currentValue();
 
@@ -1890,6 +1890,16 @@ namespace osu.Framework.Graphics
 
                 if (startValue.Equals(newValue))
                     return;
+            }
+            else
+            {
+                var last = Transforms.FindLast(t => t.GetType() == type) as Transform<TValue>;
+                if (last != null)
+                {
+                    //we may be in the middle of an existing transform, so let's update it to the start time of our new transform.
+                    last.UpdateTime(new FrameTimeInfo { Current = startTime });
+                    startValue = last.CurrentValue;
+                }
             }
 
             transform.StartTime = startTime;

--- a/osu.Framework/Graphics/IDrawable.cs
+++ b/osu.Framework/Graphics/IDrawable.cs
@@ -65,11 +65,11 @@ namespace osu.Framework.Graphics
         /// Applies a transform to this drawable object.
         /// </summary>
         /// <typeparam name="TValue">The value type upon which the transform acts.</typeparam>
-        /// <param name="startValue">The value to transform from.</param>
+        /// <param name="currentValue">A function to get the current value to transform from.</param>
         /// <param name="newValue">The value to transform to.</param>
         /// <param name="duration">The transform duration.</param>
         /// <param name="easing">The transform easing.</param>
         /// <param name="transform">The transform to use.</param>
-        void TransformTo<TValue>(TValue startValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue> transform) where TValue : struct, IEquatable<TValue>;
+        void TransformTo<TValue>(Func<TValue> currentValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue> transform) where TValue : struct, IEquatable<TValue>;
     }
 }


### PR DESCRIPTION
We now pass in a delegate to retrieve the current value, as we want to do a complete update of transforms before querying it. This has the added advantage of simplifying the startValue code, as we no longer need to factor in changes from other transforms.