### PR TITLE
Add Linux clipboard support

### DIFF
--- a/osu.Framework.Desktop/Platform/Linux/LinuxClipboard.cs
+++ b/osu.Framework.Desktop/Platform/Linux/LinuxClipboard.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Windows.Forms;
+
+namespace osu.Framework.Desktop.Platform.Linux
+{
+    public class LinuxClipboard : osu.Framework.Platform.Clipboard
+    {
+        public override string GetText()
+        {
+            return Clipboard.GetText(TextDataFormat.UnicodeText);
+        }
+
+        public override void SetText(string selectedText)
+        {
+            //Clipboard.SetText(selectedText);
+
+            //This works within osu but will hang any application you try to paste to afterwards until osu is closed.
+            //Likely requires the use of X libraries directly to fix
+        }
+    }
+}

--- a/osu.Framework.Desktop/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework.Desktop/Platform/Linux/LinuxGameHost.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using osu.Framework.Desktop.Input.Handlers.Keyboard;
 using osu.Framework.Desktop.Input.Handlers.Mouse;
 using osu.Framework.Input.Handlers;
+using osu.Framework.Platform;
 
 namespace osu.Framework.Desktop.Platform.Linux
 {
@@ -29,6 +30,11 @@ namespace osu.Framework.Desktop.Platform.Linux
         public override IEnumerable<InputHandler> GetInputHandlers()
         {
             return new InputHandler[] { new OpenTKMouseHandler(), keyboardHandler };
+        }
+
+        public override Clipboard GetClipboard()
+        {
+            return new LinuxClipboard();
         }
     }
 }

--- a/osu.Framework.Desktop/osu.Framework.Desktop.csproj
+++ b/osu.Framework.Desktop/osu.Framework.Desktop.csproj
@@ -82,6 +82,7 @@
     <Compile Include="Platform\Linux\LinuxStorage.cs" />
     <Compile Include="Platform\HeadlessGameHost.cs" />
     <Compile Include="Platform\TcpIpcProvider.cs" />
+    <Compile Include="Platform\Linux\LinuxClipboard.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj">


### PR DESCRIPTION
At least half of it.

This allows reading from clipboard, which I really missed when I tried logging in. (I use a password manager)

You still can't copy anything, though. The obvious code is there as a comment, but it causes issues.
If you enable that line and copy something, then try to paste in a different app, that other app will freeze until osu is closed.
I believe this is due to the weird way the clipboard is handled in X.

It will probably require using X libraries directly to be able to write to the clipboard, as well, but for the time being, at least you can paste.