### PR TITLE
Clr vscode debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch VisualTests",
+            "windows": {
+                "type": "clr"
+            },
+            "type": "mono",
+            "request": "launch",
+            "program": "${workspaceRoot}/osu.Framework.VisualTests/bin/Debug/osu.Framework.VisualTests.exe",
+            "cwd": "${workspaceRoot}",
+            "preLaunchTask": "build"
+        },
+        {
+            "name": "Attach",
+            "windows": {
+                "type": "clr",
+                "request": "attach",
+                "processName": "osu.Framework.VisualTests"
+            },
+            "type": "mono",
+            "request": "attach",
+            "address": "localhost",
+            "port": 55555
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -11,7 +11,23 @@
             "command": "msbuild",
             "args": [
                 // Ask msbuild to generate full paths for file names.
-                "/property:GenerateFullPaths=true"
+                "/property:GenerateFullPaths=true",
+                "/property:DebugType=portable"
+            ],
+            // Use the standard MS compiler pattern to detect errors, warnings and infos
+            "problemMatcher": "$msCompile",
+            "isBuildCommand": true
+        },
+        {
+            "taskName": "rebuild",
+            "isShellCommand": true,
+            "showOutput": "silent",
+            "command": "msbuild",
+            "args": [
+                // Ask msbuild to generate full paths for file names.
+                "/property:GenerateFullPaths=true",
+                "/property:DebugType=portable",
+                "/target:Clean,Build"
             ],
             // Use the standard MS compiler pattern to detect errors, warnings and infos
             "problemMatcher": "$msCompile",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "taskSelector": "/t:",
+    "tasks": [
+        {
+            "taskName": "build",
+            "isShellCommand": true,
+            "showOutput": "silent",
+            "command": "msbuild",
+            "args": [
+                // Ask msbuild to generate full paths for file names.
+                "/property:GenerateFullPaths=true"
+            ],
+            // Use the standard MS compiler pattern to detect errors, warnings and infos
+            "problemMatcher": "$msCompile",
+            "isBuildCommand": true
+        }
+    ]
+}


### PR DESCRIPTION
Because MSBuild doesn't check PDBs at compile time, a rebuild is necessary to recompile to portable versions of them.