### PR TITLE
Add rudimentary support for rigid body simulation

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseRigidBody.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseRigidBody.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using OpenTK;
+using OpenTK.Graphics;
+using System;
+using osu.Framework.Physics;
+
+namespace osu.Framework.VisualTests.Tests
+{
+    internal class TestCaseRigidBody : TestCase
+    {
+        public override string Description => @"Various scenarios which potentially challenge size calculations.";
+
+        private Container testContainer;
+        private RigidBodySimulation sim;
+
+        public override void Reset()
+        {
+            base.Reset();
+
+            Add(testContainer = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+            });
+
+            string[] testNames =
+            {
+                @"Random Children",
+            };
+
+            for (int i = 0; i < testNames.Length; i++)
+            {
+                int test = i;
+                AddStep(testNames[i], delegate { loadTest(test); });
+            }
+
+            loadTest(0);
+        }
+
+        private bool overlapsAny(Drawable d)
+        {
+            foreach (Drawable other in testContainer.InternalChildren)
+                if (other.ScreenSpaceDrawQuad.AABB.IntersectsWith(d.ScreenSpaceDrawQuad.AABB))
+                    return true;
+
+            return false;
+        }
+
+        private void generateN(int N, Func<Drawable> generate)
+        {
+            for (int i = 0; i < N; i++)
+            {
+                Drawable d = generate();
+
+                if (overlapsAny(d))
+                {
+                    --i;
+                    continue;
+                }
+
+                testContainer.Add(d);
+            }
+        }
+
+        private void loadTest(int testType)
+        {
+            testContainer.Clear();
+
+            Container box;
+
+            switch (testType)
+            {
+                case 0:
+                    Random random = new Random(1337);
+
+                    // Boxes
+                    generateN(10, delegate
+                    {
+                        return new InfofulBox
+                        {
+                            Position = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 1000,
+                            Size = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 200,
+                            Rotation = (float)random.NextDouble() * 360,
+                            Colour = new Color4(253, 253, 253, 255),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.TopLeft,
+                        };
+                    });
+
+                    // Circles
+                    generateN(10, delegate
+                    {
+                        Vector2 size = new Vector2((float)random.NextDouble()) * 200;
+                        return new InfofulBox
+                        {
+                            Position = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 1000,
+                            Size = size,
+                            Rotation = (float)random.NextDouble() * 360,
+                            CornerRadius = size.X / 2,
+                            Colour = new Color4(253, 253, 253, 255),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.TopLeft,
+                            Masking = true,
+                        };
+                    });
+
+                    // Totally random stuff
+                    generateN(10, delegate
+                    {
+                        Vector2 size = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 200;
+                        return new InfofulBox
+                        {
+                            Position = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 1000,
+                            Size = size,
+                            Rotation = (float)random.NextDouble() * 360,
+                            Shear = new Vector2((float)random.NextDouble(), (float)random.NextDouble()),
+                            CornerRadius = (float)random.NextDouble() * Math.Min(size.X, size.Y) / 2,
+                            Colour = new Color4(253, 253, 253, 255),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.TopLeft,
+                            Masking = true,
+                        };
+                    });
+
+                    break;
+            }
+
+            sim = new RigidBodySimulation(testContainer);
+        }
+
+        protected override void UpdateAfterChildren()
+        {
+            sim.Update((float)Time.Elapsed / 100);
+            base.UpdateAfterChildren();
+        }
+    }
+}

--- a/osu.Framework.VisualTests/Tests/TestCaseRigidBody.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseRigidBody.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.VisualTests.Tests
 {
     internal class TestCaseRigidBody : TestCase
     {
-        public override string Description => @"Various scenarios which potentially challenge size calculations.";
+        public override string Description => @"Rigid body simulation scenarios.";
 
         private Container testContainer;
         private RigidBodySimulation sim;
@@ -117,7 +117,7 @@ namespace osu.Framework.VisualTests.Tests
                             Position = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 1000,
                             Size = size,
                             Rotation = (float)random.NextDouble() * 360,
-                            Shear = new Vector2((float)random.NextDouble(), (float)random.NextDouble()),
+                            Shear = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 2 - new Vector2(1),
                             CornerRadius = (float)random.NextDouble() * Math.Min(size.X, size.Y) / 2,
                             Colour = new Color4(253, 253, 253, 255),
                             Origin = Anchor.Centre,

--- a/osu.Framework.VisualTests/Tests/TestCaseRigidBody.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseRigidBody.cs
@@ -50,9 +50,9 @@ namespace osu.Framework.VisualTests.Tests
             return false;
         }
 
-        private void generateN(int N, Func<Drawable> generate)
+        private void generateN(int n, Func<Drawable> generate)
         {
-            for (int i = 0; i < N; i++)
+            for (int i = 0; i < n; i++)
             {
                 Drawable d = generate();
 
@@ -70,25 +70,20 @@ namespace osu.Framework.VisualTests.Tests
         {
             testContainer.Clear();
 
-            Container box;
-
             switch (testType)
             {
                 case 0:
                     Random random = new Random(1337);
 
                     // Boxes
-                    generateN(10, delegate
+                    generateN(10, () => new InfofulBox
                     {
-                        return new InfofulBox
-                        {
-                            Position = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 1000,
-                            Size = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 200,
-                            Rotation = (float)random.NextDouble() * 360,
-                            Colour = new Color4(253, 253, 253, 255),
-                            Origin = Anchor.Centre,
-                            Anchor = Anchor.TopLeft,
-                        };
+                        Position = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 1000,
+                        Size = new Vector2((float)random.NextDouble(), (float)random.NextDouble()) * 200,
+                        Rotation = (float)random.NextDouble() * 360,
+                        Colour = new Color4(253, 253, 253, 255),
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.TopLeft,
                     });
 
                     // Circles

--- a/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
+++ b/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Tests\TestCaseDrawablePath.cs" />
     <Compile Include="Tests\TestCaseFillModes.cs" />
     <Compile Include="Tests\TestCaseFlow.cs" />
+    <Compile Include="Tests\TestCaseRigidBody.cs" />
     <Compile Include="Tests\TestCaseSizing.cs" />
     <Compile Include="Tests\TestCaseSmoothedEdges.cs" />
     <Compile Include="Tests\TestCaseDropdownBox.cs" />

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -12,6 +12,8 @@ namespace osu.Framework.Graphics.Containers
         Vector2 ChildSize { get; }
         Vector2 ChildOffset { get; }
 
+        float CornerRadius { get; }
+
         void InvalidateFromChild(Invalidation invalidation);
 
         void Clear(bool dispose = true);

--- a/osu.Framework/Graphics/Primitives/RectangleF.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleF.cs
@@ -122,6 +122,9 @@ namespace osu.Framework.Graphics.Primitives
         [Browsable(false)]
         public Vector2 BottomRight => new Vector2(Right, Bottom);
 
+        [Browsable(false)]
+        public Vector2 Centre => new Vector2(X + Width / 2, Y + Height / 2);
+
         /// <summary>Tests whether the <see cref="P:System.Drawing.RectangleF.Width"></see> or <see cref="P:System.Drawing.RectangleF.Height"></see> property of this <see cref="T:System.Drawing.RectangleF"></see> has a value of zero.</summary>
         /// <returns>This property returns true if the <see cref="P:System.Drawing.RectangleF.Width"></see> or <see cref="P:System.Drawing.RectangleF.Height"></see> property of this <see cref="T:System.Drawing.RectangleF"></see> has a value of zero; otherwise, false.</returns>
         /// <filterpriority>1</filterpriority>

--- a/osu.Framework/Physics/RigidBodies/ContainerBody.cs
+++ b/osu.Framework/Physics/RigidBodies/ContainerBody.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics;
+using OpenTK;
+
+namespace osu.Framework.Physics.RigidBodies
+{
+    /// <summary>
+    /// Links a <see cref="RigidBody"/> with a <see cref="Container"/> such that their state
+    /// is interconnected.
+    /// </summary>
+    class ContainerBody : DrawableBody
+    {
+        public ContainerBody(Drawable d, RigidBodySimulation sim) : base(d, sim)
+        {
+            m = float.MaxValue;
+        }
+
+        protected override void UpdateVertices()
+        {
+            base.UpdateVertices();
+
+            // We want to behave like a hollow box, so all normals need to point inward.
+            for (int i = 0; i < Normals.Count; ++i)
+                Normals[i] = -Normals[i];
+        }
+
+        // For hollow-box behavior we want to be contained whenever we are _not_ inside
+        public override bool Contains(Vector2 screenSpacePos) => !base.Contains(screenSpacePos);
+
+        public override void ApplyImpulse(Vector2 impulse, Vector2 pos)
+        {
+            // Do nothing. We want to be immovable.
+        }
+
+        public override void ApplyState()
+        {
+            base.ApplyState();
+
+            p = Vector2.Zero;
+            L = 0;
+        }
+    }
+}

--- a/osu.Framework/Physics/RigidBodies/ContainerBody.cs
+++ b/osu.Framework/Physics/RigidBodies/ContainerBody.cs
@@ -7,14 +7,14 @@ using OpenTK;
 namespace osu.Framework.Physics.RigidBodies
 {
     /// <summary>
-    /// Links a <see cref="RigidBody"/> with a <see cref="Container"/> such that their state
+    /// Links a <see cref="RigidBody"/> with a container such that their state
     /// is interconnected.
     /// </summary>
-    class ContainerBody : DrawableBody
+    public class ContainerBody : DrawableBody
     {
         public ContainerBody(Drawable d, RigidBodySimulation sim) : base(d, sim)
         {
-            m = float.MaxValue;
+            Mass = float.MaxValue;
         }
 
         protected override void UpdateVertices()
@@ -38,8 +38,8 @@ namespace osu.Framework.Physics.RigidBodies
         {
             base.ApplyState();
 
-            p = Vector2.Zero;
-            L = 0;
+            Momentum = Vector2.Zero;
+            AngularMomentum = 0;
         }
     }
 }

--- a/osu.Framework/Physics/RigidBodies/DrawableBody.cs
+++ b/osu.Framework/Physics/RigidBodies/DrawableBody.cs
@@ -1,0 +1,136 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using System;
+using System.Drawing;
+using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
+
+namespace osu.Framework.Physics.RigidBodies
+{
+    /// <summary>
+    /// Links a <see cref="RigidBody"/> with a <see cref="Drawable"/> such that their state
+    /// is interconnected.
+    /// </summary>
+    class DrawableBody : RigidBody
+    {
+        /// <summary>
+        /// The <see cref="Drawable"/> this rigid body is associated with.
+        /// </summary>
+        public Drawable Drawable;
+
+        public DrawableBody(Drawable d, RigidBodySimulation sim) : base(sim)
+        {
+            Drawable = d;
+        }
+
+        protected override float ComputeI()
+        {
+            Matrix3 A = Drawable.DrawInfo.Matrix * Drawable.Parent.DrawInfo.MatrixInverse;
+            Vector2 size = Drawable.DrawSize;
+
+            // Inertial moment for a linearly transformed rectangle with a given size around its center.
+            return (
+                ((A.M11 * A.M11) + (A.M12 * A.M12)) * size.X * size.X +
+                ((A.M21 * A.M21) + (A.M22 * A.M22)) * size.Y * size.Y
+            ) * m / 12;
+        }
+
+        protected override void UpdateVertices()
+        {
+            Vertices.Clear();
+            Normals.Clear();
+
+            float cornerRadius = (Drawable as IContainer)?.CornerRadius ?? 0;
+            
+            // Sides
+            RectangleF rect = Drawable.DrawRectangle;
+            Vector2[] corners = new[] { rect.TopLeft, rect.TopRight, rect.BottomRight, rect.BottomLeft };
+            const int AMOUNT_SIDE_STEPS = 2;
+
+            for (int i = 0; i < 4; ++i)
+            {
+                Vector2 a = corners[i];
+                Vector2 b = corners[(i + 1) % 4];
+                float length = (b - a).Length;
+                float usableLength = Math.Max((b - a).Length - 2 * cornerRadius, 0);
+
+                Vector2 diff = (b - a);
+                Vector2 normal = (b - a).PerpendicularRight.Normalized();
+
+                for (int j = 0; j < AMOUNT_SIDE_STEPS; ++j)
+                {
+                    Vertices.Add(a + ((b - a) / length) * (cornerRadius + j * usableLength / (AMOUNT_SIDE_STEPS - 1)));
+                    Normals.Add(normal);
+                }
+            }
+
+            const int AMOUNT_CORNER_STEPS = 10;
+            if (cornerRadius > 0)
+            {
+                // Rounded corners
+                Vector2[] offsets = new[] {
+                    new Vector2(cornerRadius, cornerRadius),
+                    new Vector2(-cornerRadius, cornerRadius),
+                    new Vector2(-cornerRadius, -cornerRadius),
+                    new Vector2(cornerRadius, -cornerRadius),
+                };
+
+                for (int i = 0; i < 4; ++i)
+                {
+                    Vector2 a = corners[i];
+
+                    float startTheta = (i - 1) * (float)Math.PI / 2;
+
+                    for (int j = 0; j < AMOUNT_CORNER_STEPS; ++j)
+                    {
+                        float theta = startTheta + ((float)j / (AMOUNT_CORNER_STEPS - 1)) * (float)Math.PI / 2;
+
+                        Vector2 normal = new Vector2((float)Math.Sin(theta), (float)Math.Cos(theta));
+                        Vertices.Add(a + offsets[i] + normal * cornerRadius);
+                        Normals.Add(normal);
+                    }
+                }
+            }
+
+            // To simulation space
+            Matrix3 mat = Drawable.DrawInfo.Matrix * ScreenToSimulationSpace;
+            Matrix3 normMat = mat.Inverted();
+            normMat.Transpose();
+
+            // Remove translation
+            normMat.M31 = normMat.M32 = normMat.M13 = normMat.M23 = 0;
+            Vector2 translation = Vector2.Zero * normMat;
+
+            for (int i = 0; i < Vertices.Count; ++i)
+            {
+                Vertices[i] *= mat;
+                Normals[i] = (Normals[i] * normMat - translation).Normalized();
+            }
+        }
+
+        public override void ReadState()
+        {
+            Matrix3 mat = Drawable.Parent.DrawInfo.Matrix * ScreenToSimulationSpace;
+            c = Drawable.BoundingBox.Centre * mat;
+            r = MathHelper.DegreesToRadians(Drawable.Rotation); // TODO: Fix rotations
+
+            base.ReadState();
+        }
+
+        public override void ApplyState()
+        {
+            base.ApplyState();
+
+            Matrix3 mat = SimulationToScreenSpace * Drawable.Parent.DrawInfo.MatrixInverse;
+            Drawable.Position = c * mat + (Drawable.Position - Drawable.BoundingBox.Centre);
+            Drawable.Rotation = MathHelper.RadiansToDegrees(r); // TODO: Fix rotations
+        }
+
+        public override Rectangle ScreenSpaceAABB => Drawable.ScreenSpaceDrawQuad.AABB;
+
+        public override bool Contains(Vector2 screenSpacePos) => Drawable.Contains(screenSpacePos);
+    }
+}

--- a/osu.Framework/Physics/RigidBodies/DrawableBody.cs
+++ b/osu.Framework/Physics/RigidBodies/DrawableBody.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Physics.RigidBodies
     /// Links a <see cref="RigidBody"/> with a <see cref="Drawable"/> such that their state
     /// is interconnected.
     /// </summary>
-    class DrawableBody : RigidBody
+    public class DrawableBody : RigidBody
     {
         /// <summary>
         /// The <see cref="Drawable"/> this rigid body is associated with.
@@ -28,14 +28,14 @@ namespace osu.Framework.Physics.RigidBodies
 
         protected override float ComputeI()
         {
-            Matrix3 A = Drawable.DrawInfo.Matrix * Drawable.Parent.DrawInfo.MatrixInverse;
+            Matrix3 mat = Drawable.DrawInfo.Matrix * Drawable.Parent.DrawInfo.MatrixInverse;
             Vector2 size = Drawable.DrawSize;
 
             // Inertial moment for a linearly transformed rectangle with a given size around its center.
             return (
-                ((A.M11 * A.M11) + (A.M12 * A.M12)) * size.X * size.X +
-                ((A.M21 * A.M21) + (A.M22 * A.M22)) * size.Y * size.Y
-            ) * m / 12;
+                (mat.M11 * mat.M11 + mat.M12 * mat.M12) * size.X * size.X +
+                (mat.M21 * mat.M21 + mat.M22 * mat.M22) * size.Y * size.Y
+            ) * Mass / 12;
         }
 
         protected override void UpdateVertices()
@@ -44,34 +44,35 @@ namespace osu.Framework.Physics.RigidBodies
             Normals.Clear();
 
             float cornerRadius = (Drawable as IContainer)?.CornerRadius ?? 0;
-            
+
             // Sides
             RectangleF rect = Drawable.DrawRectangle;
-            Vector2[] corners = new[] { rect.TopLeft, rect.TopRight, rect.BottomRight, rect.BottomLeft };
-            const int AMOUNT_SIDE_STEPS = 2;
+            Vector2[] corners = { rect.TopLeft, rect.TopRight, rect.BottomRight, rect.BottomLeft };
+            const int amount_side_steps = 2;
 
             for (int i = 0; i < 4; ++i)
             {
                 Vector2 a = corners[i];
                 Vector2 b = corners[(i + 1) % 4];
-                float length = (b - a).Length;
-                float usableLength = Math.Max((b - a).Length - 2 * cornerRadius, 0);
+                Vector2 diff = b - a;
+                float length = diff.Length;
+                Vector2 dir = diff / length;
 
-                Vector2 diff = (b - a);
+                float usableLength = Math.Max(length - 2 * cornerRadius, 0);
+
                 Vector2 normal = (b - a).PerpendicularRight.Normalized();
-
-                for (int j = 0; j < AMOUNT_SIDE_STEPS; ++j)
+                for (int j = 0; j < amount_side_steps; ++j)
                 {
-                    Vertices.Add(a + ((b - a) / length) * (cornerRadius + j * usableLength / (AMOUNT_SIDE_STEPS - 1)));
+                    Vertices.Add(a + dir * (cornerRadius + j * usableLength / (amount_side_steps - 1)));
                     Normals.Add(normal);
                 }
             }
 
-            const int AMOUNT_CORNER_STEPS = 10;
+            const int amount_corner_steps = 10;
             if (cornerRadius > 0)
             {
                 // Rounded corners
-                Vector2[] offsets = new[] {
+                Vector2[] offsets = {
                     new Vector2(cornerRadius, cornerRadius),
                     new Vector2(-cornerRadius, cornerRadius),
                     new Vector2(-cornerRadius, -cornerRadius),
@@ -84,9 +85,9 @@ namespace osu.Framework.Physics.RigidBodies
 
                     float startTheta = (i - 1) * (float)Math.PI / 2;
 
-                    for (int j = 0; j < AMOUNT_CORNER_STEPS; ++j)
+                    for (int j = 0; j < amount_corner_steps; ++j)
                     {
-                        float theta = startTheta + ((float)j / (AMOUNT_CORNER_STEPS - 1)) * (float)Math.PI / 2;
+                        float theta = startTheta + j * (float)Math.PI / (2 * (amount_corner_steps - 1));
 
                         Vector2 normal = new Vector2((float)Math.Sin(theta), (float)Math.Cos(theta));
                         Vertices.Add(a + offsets[i] + normal * cornerRadius);
@@ -114,8 +115,8 @@ namespace osu.Framework.Physics.RigidBodies
         public override void ReadState()
         {
             Matrix3 mat = Drawable.Parent.DrawInfo.Matrix * ScreenToSimulationSpace;
-            c = Drawable.BoundingBox.Centre * mat;
-            r = MathHelper.DegreesToRadians(Drawable.Rotation); // TODO: Fix rotations
+            Centre = Drawable.BoundingBox.Centre * mat;
+            Rotation = MathHelper.DegreesToRadians(Drawable.Rotation); // TODO: Fix rotations
 
             base.ReadState();
         }
@@ -125,8 +126,8 @@ namespace osu.Framework.Physics.RigidBodies
             base.ApplyState();
 
             Matrix3 mat = SimulationToScreenSpace * Drawable.Parent.DrawInfo.MatrixInverse;
-            Drawable.Position = c * mat + (Drawable.Position - Drawable.BoundingBox.Centre);
-            Drawable.Rotation = MathHelper.RadiansToDegrees(r); // TODO: Fix rotations
+            Drawable.Position = Centre * mat + (Drawable.Position - Drawable.BoundingBox.Centre);
+            Drawable.Rotation = MathHelper.RadiansToDegrees(Rotation); // TODO: Fix rotations
         }
 
         public override Rectangle ScreenSpaceAABB => Drawable.ScreenSpaceDrawQuad.AABB;

--- a/osu.Framework/Physics/RigidBodies/DrawableBody.cs
+++ b/osu.Framework/Physics/RigidBodies/DrawableBody.cs
@@ -19,17 +19,17 @@ namespace osu.Framework.Physics.RigidBodies
         /// <summary>
         /// The <see cref="Drawable"/> this rigid body is associated with.
         /// </summary>
-        public Drawable Drawable;
+        private readonly Drawable drawable;
 
         public DrawableBody(Drawable d, RigidBodySimulation sim) : base(sim)
         {
-            Drawable = d;
+            drawable = d;
         }
 
         protected override float ComputeI()
         {
-            Matrix3 mat = Drawable.DrawInfo.Matrix * Drawable.Parent.DrawInfo.MatrixInverse;
-            Vector2 size = Drawable.DrawSize;
+            Matrix3 mat = drawable.DrawInfo.Matrix * drawable.Parent.DrawInfo.MatrixInverse;
+            Vector2 size = drawable.DrawSize;
 
             // Inertial moment for a linearly transformed rectangle with a given size around its center.
             return (
@@ -43,10 +43,10 @@ namespace osu.Framework.Physics.RigidBodies
             Vertices.Clear();
             Normals.Clear();
 
-            float cornerRadius = (Drawable as IContainer)?.CornerRadius ?? 0;
+            float cornerRadius = (drawable as IContainer)?.CornerRadius ?? 0;
 
             // Sides
-            RectangleF rect = Drawable.DrawRectangle;
+            RectangleF rect = drawable.DrawRectangle;
             Vector2[] corners = { rect.TopLeft, rect.TopRight, rect.BottomRight, rect.BottomLeft };
             const int amount_side_steps = 2;
 
@@ -97,7 +97,7 @@ namespace osu.Framework.Physics.RigidBodies
             }
 
             // To simulation space
-            Matrix3 mat = Drawable.DrawInfo.Matrix * ScreenToSimulationSpace;
+            Matrix3 mat = drawable.DrawInfo.Matrix * ScreenToSimulationSpace;
             Matrix3 normMat = mat.Inverted();
             normMat.Transpose();
 
@@ -114,9 +114,9 @@ namespace osu.Framework.Physics.RigidBodies
 
         public override void ReadState()
         {
-            Matrix3 mat = Drawable.Parent.DrawInfo.Matrix * ScreenToSimulationSpace;
-            Centre = Drawable.BoundingBox.Centre * mat;
-            Rotation = MathHelper.DegreesToRadians(Drawable.Rotation); // TODO: Fix rotations
+            Matrix3 mat = drawable.Parent.DrawInfo.Matrix * ScreenToSimulationSpace;
+            Centre = drawable.BoundingBox.Centre * mat;
+            Rotation = MathHelper.DegreesToRadians(drawable.Rotation); // TODO: Fix rotations
 
             base.ReadState();
         }
@@ -125,13 +125,13 @@ namespace osu.Framework.Physics.RigidBodies
         {
             base.ApplyState();
 
-            Matrix3 mat = SimulationToScreenSpace * Drawable.Parent.DrawInfo.MatrixInverse;
-            Drawable.Position = Centre * mat + (Drawable.Position - Drawable.BoundingBox.Centre);
-            Drawable.Rotation = MathHelper.RadiansToDegrees(Rotation); // TODO: Fix rotations
+            Matrix3 mat = SimulationToScreenSpace * drawable.Parent.DrawInfo.MatrixInverse;
+            drawable.Position = Centre * mat + (drawable.Position - drawable.BoundingBox.Centre);
+            drawable.Rotation = MathHelper.RadiansToDegrees(Rotation); // TODO: Fix rotations
         }
 
-        public override Rectangle ScreenSpaceAABB => Drawable.ScreenSpaceDrawQuad.AABB;
+        public override Rectangle ScreenSpaceAABB => drawable.ScreenSpaceDrawQuad.AABB;
 
-        public override bool Contains(Vector2 screenSpacePos) => Drawable.Contains(screenSpacePos);
+        public override bool Contains(Vector2 screenSpacePos) => drawable.Contains(screenSpacePos);
     }
 }

--- a/osu.Framework/Physics/RigidBody.cs
+++ b/osu.Framework/Physics/RigidBody.cs
@@ -1,0 +1,331 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
+using System;
+
+namespace osu.Framework.Physics
+{
+    /// <summary>
+    /// Encapsulates a <see cref="Drawable"/> with additional physical state and methods
+    /// necessary for rigid body simulation.
+    /// </summary>
+    class RigidBody
+    {
+        /// <summary>
+        /// The <see cref="Drawable"/> this rigid body is associated with.
+        /// </summary>
+        public Drawable Drawable;
+
+        /// <summary>
+        /// Controls how elastic the material is. A value of 1 means perfect elasticity
+        /// (kinetic energy is fully preserved). A value of 0 means all energy is absorbed
+        /// on collision, i.e. no rebound occurs at all.
+        /// </summary>
+        public float Restitution = 0.25f;
+
+        /// <summary>
+        /// How much friction happens between objects.
+        /// </summary>
+        public float FrictionCoefficient = 1;
+
+        /// <summary>
+        /// Centre of mass.
+        /// </summary>
+        public Vector2 c;
+
+        /// <summary>
+        /// Rotation.
+        /// </summary>
+        public float r;
+
+        /// <summary>
+        /// Mass.
+        /// </summary>
+        public float m;
+
+        /// <summary>
+        /// Velocity.
+        /// </summary>
+        public Vector2 v
+        {
+            get { return p / m; }
+            set { p = value * m; }
+        }
+
+        /// <summary>
+        /// Momentum.
+        /// </summary>
+        public Vector2 p;
+
+        /// <summary>
+        /// Angular velocity.
+        /// </summary>
+        public float w
+        {
+            get { return L / I; }
+            set { L = value * I; }
+        }
+
+        /// <summary>
+        /// Angular momentum.
+        /// </summary>
+        public float L;
+
+        /// <summary>
+        /// Moment of inertia.
+        /// </summary>
+        public float I { get; private set; }
+
+        /// <summary>
+        /// Total velocity at a given location. Includes angular velocity.
+        /// </summary>
+        public Vector2 VelocityAt(Vector2 pos)
+        {
+            Vector2 diff = pos - c;
+
+            // Add orthogonal direction to rotation, scaled by distance from centre
+            // to the velocity of our centre of mass.
+            return v + diff.PerpendicularLeft * w;
+        }
+
+        /// <summary>
+        /// Contains discrete positions on the surface of this shape used for collision detection.
+        /// In the future this can be potentially replaced by closed-form solutions.
+        /// </summary>
+        private Vector2[] vertices = new Vector2[80];
+
+        /// <summary>
+        /// Normals corresponding to the positions inside <see cref="vertices"/>.
+        /// </summary>
+        private Vector2[] normals = new Vector2[80];
+
+        public RigidBody(Drawable d)
+        {
+            if (d.Origin != Anchor.Centre)
+                throw new InvalidOperationException($@"Non-centre origin drawables (was {d.Origin}) can currently not be rigid bodies.");
+
+            Drawable = d;
+            m = 1f; // Arbitrarily 1 kg for now
+
+            // Initially no momenta
+            p = Vector2.Zero;
+            L = 0;
+        }
+
+        private void computeI()
+        {
+            Matrix3 A = Drawable.DrawInfo.Matrix * Drawable.Parent.DrawInfo.MatrixInverse;
+            Vector2 size = Drawable.DrawSize;
+
+            // Inertial moment for a linearly transformed rectangle with a given size around its center.
+            I = (
+                ((A.M11 * A.M11) + (A.M12 * A.M12)) * size.X * size.X +
+                ((A.M21 * A.M21) + (A.M22 * A.M22)) * size.Y * size.Y
+            ) * m / 12;
+        }
+
+        /// <summary>
+        /// Populates <see cref="vertices"/> and <see cref="normals"/>.
+        /// </summary>
+        private void updateVertices()
+        {
+            float cornerRadius = (Drawable as IContainer)?.CornerRadius ?? 0;
+
+            // Sides
+            RectangleF rect = Drawable.DrawRectangle;
+            Vector2[] corners = new[] { rect.TopLeft, rect.TopRight, rect.BottomRight, rect.BottomLeft };
+
+            for (int i = 0; i < 4; ++i)
+            {
+                Vector2 a = corners[i];
+                Vector2 b = corners[(i + 1) % 4];
+                float length = (b - a).Length;
+                float usableLength = Math.Max((b - a).Length - 2 * cornerRadius, 0);
+
+                Vector2 diff = (b - a);
+                Vector2 normal = (b - a).PerpendicularRight.Normalized();
+
+                for (int j = 0; j < 10; ++j)
+                {
+                    int idx = i * 10 + j;
+                    vertices[idx] = a + ((b - a) / length) * (cornerRadius + j * usableLength / 9);
+                    normals[idx] = normal;
+                }
+            }
+
+            // Rounded corners
+            Vector2[] offsets = new[] {
+                new Vector2(cornerRadius, cornerRadius),
+                new Vector2(-cornerRadius, cornerRadius),
+                new Vector2(-cornerRadius, -cornerRadius),
+                new Vector2(cornerRadius, -cornerRadius),
+            };
+
+            for (int i = 0; i < 4; ++i)
+            {
+                Vector2 a = corners[i];
+
+                float startTheta = (i-1) * (float)Math.PI / 2;
+
+                for (int j = 0; j < 10; ++j)
+                {
+                    float theta = startTheta + ((float)j / 9) * (float)Math.PI / 2;
+                    int idx = 40 + i * 10 + j;
+
+                    normals[idx] = new Vector2((float)Math.Sin(theta), (float)Math.Cos(theta));
+                    vertices[idx] = a + offsets[i] + normals[idx] * cornerRadius;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies a given impulse attacking at a given position.
+        /// </summary>
+        public void ApplyImpulse(Vector2 impulse, Vector2 pos)
+        {
+            // Offset to our centre of mass. Required to obtain torque
+            Vector2 diff = pos - c;
+
+            p += impulse;
+
+            // Cross product between impulse and offset to centre.
+            // If they are orthogonal, then the effect on angular momentum is maximized.
+            // Intuitively, think of hitting something head-on vs hitting it on the far edge.
+            // The first case will not introduce any rotational movement, whereas the latter
+            // will.
+            L += diff.X * impulse.Y - diff.Y * impulse.X;
+        }
+
+        /// <summary>
+        /// Helper function for code brevity in <see cref="handleCollision(RigidBody, Vector2, Vector2)"/>.
+        /// Can be moved into the function as a nested method once C# 7 is out.
+        /// </summary>
+        private float impulseDenominator(Vector2 pos, Vector2 normal)
+        {
+            Vector2 diff = pos - c;
+            float perpDot = Vector2.Dot(normal, diff.PerpendicularRight);
+            return 1.0f / m + perpDot * perpDot / I;
+        }
+
+        /// <summary>
+        /// Handles a collision of 2 rigid bodies, given the other body, the impact position,
+        /// and the surface normal of this body at the impact position.
+        /// This method applies the resulting impulse both to this body and to the other body.
+        /// </summary>
+        private void handleCollision(RigidBody other, Vector2 pos, Vector2 normal)
+        {
+            const float EPSILON = 0.001f;
+
+            Vector2 vrel = VelocityAt(pos) - other.VelocityAt(pos);
+            float vrelOrtho = -Vector2.Dot(vrel, normal);
+
+            // We don't want to consider collisions where objects move away from each other.
+            // (Or with negligible velocity. Let repulsive forces handle these.)
+            if (vrelOrtho > -EPSILON)
+                return;
+
+            float impulseMagnitude = -(1.0f + Restitution) * vrelOrtho;
+            impulseMagnitude /= impulseDenominator(pos, normal) + other.impulseDenominator(pos, normal);
+
+            impulseMagnitude = Math.Max(impulseMagnitude - 0.01f, 0.0f);
+
+            Vector2 impulse = -normal * impulseMagnitude;
+
+            // Add "friction" to the impulse. We arbitrarily reduce the planar velocity relative to the impulse magnitude.
+            Vector2 vrelPlanar = vrel + vrelOrtho * normal;
+            float vrelPlanarLength = vrelPlanar.Length;
+            if (vrelPlanarLength > 0)
+                impulse -= vrelPlanar * Math.Min(impulseMagnitude * 0.05f * FrictionCoefficient * other.FrictionCoefficient / vrelPlanarLength, 1);
+
+            ApplyImpulse(impulse, pos);
+            other.ApplyImpulse(-impulse, pos);
+        }
+
+        /// <summary>
+        /// Checks for and records all collisions with another body. If collisions were found,
+        /// their aggregate is handled.
+        /// </summary>
+        public bool CheckAndHandleCollisionWith(RigidBody other)
+        {
+            if (!other.Drawable.ScreenSpaceDrawQuad.AABB.IntersectsWith(Drawable.ScreenSpaceDrawQuad.AABB))
+                return false;
+
+            int amountCollisions = 0;
+            Vector2 pos = Vector2.Zero;
+            Vector2 normal = Vector2.Zero;
+
+            for (int i = 0; i < vertices.Length; ++i)
+            {
+                if (other.Drawable.Contains(Drawable.ToScreenSpace(vertices[i])))
+                {
+                    Matrix3 mat = Drawable.DrawInfo.Matrix * Drawable.Parent.DrawInfo.MatrixInverse;
+
+                    pos += vertices[i] * mat;
+                    mat = mat.Inverted();
+                    mat.Transpose();
+                    mat.M31 = mat.M32 = mat.M13 = mat.M23 = 0;
+
+                    normal += (normals[i] * mat - Vector2.Zero * mat).Normalized();
+                    ++amountCollisions;
+                }
+            }
+
+            if (amountCollisions > 0)
+            {
+                pos /= amountCollisions;
+                normal.Normalize();
+
+                handleCollision(other, pos, normal);
+                other.handleCollision(this, pos, -normal);
+
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Performs an integration step over time. More precisely, updates the
+        /// physical state as dependent on time according to the forces and torques
+        /// acting on this body.
+        /// </summary>
+        public void Integrate(Vector2 force, float torque, float dt)
+        {
+            Vector2 vPrev = v;
+            float wPrev = w;
+            
+            // Update momenta
+            p += dt * force;
+            L += dt * torque;
+
+            // Update position and rotation given _previous_ velocities. This is a symplectic integration technique, which conserves energy.
+            c += dt * vPrev;
+            r += dt * wPrev;
+        }
+
+        /// <summary>
+        /// Reads the positional and rotational state of this rigid body from its <see cref="Drawable"/>.
+        /// </summary>
+        public void ReadState()
+        {
+            c = Drawable.Position;
+            r = MathHelper.DegreesToRadians(Drawable.Rotation);
+
+            computeI();
+            updateVertices();
+        }
+
+        /// <summary>
+        /// Applies the positional and rotational state of this rigid body to its <see cref="Drawable"/>.
+        /// </summary>
+        public void ApplyState()
+        {
+            Drawable.Position = c;
+            Drawable.Rotation = MathHelper.RadiansToDegrees(r);
+        }
+    }
+}

--- a/osu.Framework/Physics/RigidBody.cs
+++ b/osu.Framework/Physics/RigidBody.cs
@@ -2,35 +2,30 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using OpenTK;
-using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using System;
+using System.Collections.Generic;
+using System.Drawing;
 
 namespace osu.Framework.Physics
 {
     /// <summary>
-    /// Encapsulates a <see cref="Drawable"/> with additional physical state and methods
-    /// necessary for rigid body simulation.
+    /// Contains physical state and methods necessary for rigid body simulation.
     /// </summary>
-    class RigidBody
+    abstract class RigidBody
     {
-        /// <summary>
-        /// The <see cref="Drawable"/> this rigid body is associated with.
-        /// </summary>
-        public Drawable Drawable;
+        private RigidBodySimulation simulation;
 
         /// <summary>
         /// Controls how elastic the material is. A value of 1 means perfect elasticity
         /// (kinetic energy is fully preserved). A value of 0 means all energy is absorbed
         /// on collision, i.e. no rebound occurs at all.
         /// </summary>
-        public float Restitution = 0.25f;
+        public float Restitution = 1.0f;
 
         /// <summary>
         /// How much friction happens between objects.
         /// </summary>
-        public float FrictionCoefficient = 1;
+        public float FrictionCoefficient = 0f;
 
         /// <summary>
         /// Centre of mass.
@@ -96,96 +91,46 @@ namespace osu.Framework.Physics
         /// Contains discrete positions on the surface of this shape used for collision detection.
         /// In the future this can be potentially replaced by closed-form solutions.
         /// </summary>
-        private Vector2[] vertices = new Vector2[80];
+        protected List<Vector2> Vertices = new List<Vector2>();
 
         /// <summary>
-        /// Normals corresponding to the positions inside <see cref="vertices"/>.
+        /// Normals corresponding to the positions inside <see cref="Vertices"/>.
         /// </summary>
-        private Vector2[] normals = new Vector2[80];
+        protected List<Vector2> Normals = new List<Vector2>();
 
-        public RigidBody(Drawable d)
+        public RigidBody(RigidBodySimulation sim)
         {
-            if (d.Origin != Anchor.Centre)
-                throw new InvalidOperationException($@"Non-centre origin drawables (was {d.Origin}) can currently not be rigid bodies.");
-
-            Drawable = d;
+            simulation = sim;
             m = 1f; // Arbitrarily 1 kg for now
 
-            // Initially no momenta
+            // Initially no moments
             p = Vector2.Zero;
             L = 0;
         }
 
-        private void computeI()
-        {
-            Matrix3 A = Drawable.DrawInfo.Matrix * Drawable.Parent.DrawInfo.MatrixInverse;
-            Vector2 size = Drawable.DrawSize;
+        protected Matrix3 ScreenToSimulationSpace => simulation.ScreenToSimulationSpace;
 
-            // Inertial moment for a linearly transformed rectangle with a given size around its center.
-            I = (
-                ((A.M11 * A.M11) + (A.M12 * A.M12)) * size.X * size.X +
-                ((A.M21 * A.M21) + (A.M22 * A.M22)) * size.Y * size.Y
-            ) * m / 12;
+        protected Matrix3 SimulationToScreenSpace => simulation.SimulationToScreenSpace;
+
+        /// <summary>
+        /// Computes the moment of inertia.
+        /// </summary>
+        protected virtual float ComputeI()
+        {
+            return 1;
         }
 
         /// <summary>
-        /// Populates <see cref="vertices"/> and <see cref="normals"/>.
+        /// Populates <see cref="Vertices"/> and <see cref="Normals"/>.
         /// </summary>
-        private void updateVertices()
+        protected virtual void UpdateVertices()
         {
-            float cornerRadius = (Drawable as IContainer)?.CornerRadius ?? 0;
-
-            // Sides
-            RectangleF rect = Drawable.DrawRectangle;
-            Vector2[] corners = new[] { rect.TopLeft, rect.TopRight, rect.BottomRight, rect.BottomLeft };
-
-            for (int i = 0; i < 4; ++i)
-            {
-                Vector2 a = corners[i];
-                Vector2 b = corners[(i + 1) % 4];
-                float length = (b - a).Length;
-                float usableLength = Math.Max((b - a).Length - 2 * cornerRadius, 0);
-
-                Vector2 diff = (b - a);
-                Vector2 normal = (b - a).PerpendicularRight.Normalized();
-
-                for (int j = 0; j < 10; ++j)
-                {
-                    int idx = i * 10 + j;
-                    vertices[idx] = a + ((b - a) / length) * (cornerRadius + j * usableLength / 9);
-                    normals[idx] = normal;
-                }
-            }
-
-            // Rounded corners
-            Vector2[] offsets = new[] {
-                new Vector2(cornerRadius, cornerRadius),
-                new Vector2(-cornerRadius, cornerRadius),
-                new Vector2(-cornerRadius, -cornerRadius),
-                new Vector2(cornerRadius, -cornerRadius),
-            };
-
-            for (int i = 0; i < 4; ++i)
-            {
-                Vector2 a = corners[i];
-
-                float startTheta = (i-1) * (float)Math.PI / 2;
-
-                for (int j = 0; j < 10; ++j)
-                {
-                    float theta = startTheta + ((float)j / 9) * (float)Math.PI / 2;
-                    int idx = 40 + i * 10 + j;
-
-                    normals[idx] = new Vector2((float)Math.Sin(theta), (float)Math.Cos(theta));
-                    vertices[idx] = a + offsets[i] + normals[idx] * cornerRadius;
-                }
-            }
         }
 
         /// <summary>
         /// Applies a given impulse attacking at a given position.
         /// </summary>
-        public void ApplyImpulse(Vector2 impulse, Vector2 pos)
+        public virtual void ApplyImpulse(Vector2 impulse, Vector2 pos)
         {
             // Offset to our centre of mass. Required to obtain torque
             Vector2 diff = pos - c;
@@ -201,7 +146,7 @@ namespace osu.Framework.Physics
         }
 
         /// <summary>
-        /// Helper function for code brevity in <see cref="handleCollision(RigidBody, Vector2, Vector2)"/>.
+        /// Helper function for code brevity in <see cref="computeImpulse(RigidBody, Vector2, Vector2)"/>.
         /// Can be moved into the function as a nested method once C# 7 is out.
         /// </summary>
         private float impulseDenominator(Vector2 pos, Vector2 normal)
@@ -212,11 +157,10 @@ namespace osu.Framework.Physics
         }
 
         /// <summary>
-        /// Handles a collision of 2 rigid bodies, given the other body, the impact position,
+        /// Computes the impulse of a collision of 2 rigid bodies, given the other body, the impact position,
         /// and the surface normal of this body at the impact position.
-        /// This method applies the resulting impulse both to this body and to the other body.
         /// </summary>
-        private void handleCollision(RigidBody other, Vector2 pos, Vector2 normal)
+        private Vector2 computeImpulse(RigidBody other, Vector2 pos, Vector2 normal)
         {
             const float EPSILON = 0.001f;
 
@@ -226,12 +170,12 @@ namespace osu.Framework.Physics
             // We don't want to consider collisions where objects move away from each other.
             // (Or with negligible velocity. Let repulsive forces handle these.)
             if (vrelOrtho > -EPSILON)
-                return;
+                return Vector2.Zero;
 
             float impulseMagnitude = -(1.0f + Restitution) * vrelOrtho;
             impulseMagnitude /= impulseDenominator(pos, normal) + other.impulseDenominator(pos, normal);
 
-            impulseMagnitude = Math.Max(impulseMagnitude - 0.01f, 0.0f);
+            //impulseMagnitude = Math.Max(impulseMagnitude - 0.01f, 0.0f);
 
             Vector2 impulse = -normal * impulseMagnitude;
 
@@ -239,10 +183,9 @@ namespace osu.Framework.Physics
             Vector2 vrelPlanar = vrel + vrelOrtho * normal;
             float vrelPlanarLength = vrelPlanar.Length;
             if (vrelPlanarLength > 0)
-                impulse -= vrelPlanar * Math.Min(impulseMagnitude * 0.05f * FrictionCoefficient * other.FrictionCoefficient / vrelPlanarLength, 1);
+                impulse -= vrelPlanar * Math.Min(impulseMagnitude * 0.05f * FrictionCoefficient * other.FrictionCoefficient / vrelPlanarLength, m);
 
-            ApplyImpulse(impulse, pos);
-            other.ApplyImpulse(-impulse, pos);
+            return impulse;
         }
 
         /// <summary>
@@ -251,41 +194,27 @@ namespace osu.Framework.Physics
         /// </summary>
         public bool CheckAndHandleCollisionWith(RigidBody other)
         {
-            if (!other.Drawable.ScreenSpaceDrawQuad.AABB.IntersectsWith(Drawable.ScreenSpaceDrawQuad.AABB))
+            if (!other.ScreenSpaceAABB.IntersectsWith(ScreenSpaceAABB))
                 return false;
 
-            int amountCollisions = 0;
-            Vector2 pos = Vector2.Zero;
-            Vector2 normal = Vector2.Zero;
-
-            for (int i = 0; i < vertices.Length; ++i)
+            bool didCollide = false;
+            for (int i = 0; i < Vertices.Count; ++i)
             {
-                if (other.Drawable.Contains(Drawable.ToScreenSpace(vertices[i])))
+                if (other.Contains(Vertices[i] * SimulationToScreenSpace))
                 {
-                    Matrix3 mat = Drawable.DrawInfo.Matrix * Drawable.Parent.DrawInfo.MatrixInverse;
+                    // Compute both impulse responses _before_ applying them, such that
+                    // they do not influence each other.
+                    Vector2 impulse = computeImpulse(other, Vertices[i], Normals[i]);
+                    Vector2 impulseOther = other.computeImpulse(this, Vertices[i], -Normals[i]);
 
-                    pos += vertices[i] * mat;
-                    mat = mat.Inverted();
-                    mat.Transpose();
-                    mat.M31 = mat.M32 = mat.M13 = mat.M23 = 0;
+                    ApplyImpulse(impulse, Vertices[i]);
+                    other.ApplyImpulse(impulseOther, Vertices[i]);
 
-                    normal += (normals[i] * mat - Vector2.Zero * mat).Normalized();
-                    ++amountCollisions;
+                    didCollide = true;
                 }
             }
 
-            if (amountCollisions > 0)
-            {
-                pos /= amountCollisions;
-                normal.Normalize();
-
-                handleCollision(other, pos, normal);
-                other.handleCollision(this, pos, -normal);
-
-                return true;
-            }
-
-            return false;
+            return didCollide;
         }
 
         /// <summary>
@@ -310,22 +239,27 @@ namespace osu.Framework.Physics
         /// <summary>
         /// Reads the positional and rotational state of this rigid body from its <see cref="Drawable"/>.
         /// </summary>
-        public void ReadState()
+        public virtual void ReadState()
         {
-            c = Drawable.Position;
-            r = MathHelper.DegreesToRadians(Drawable.Rotation);
-
-            computeI();
-            updateVertices();
+            I = ComputeI();
+            UpdateVertices();
         }
 
         /// <summary>
         /// Applies the positional and rotational state of this rigid body to its <see cref="Drawable"/>.
         /// </summary>
-        public void ApplyState()
+        public virtual void ApplyState()
         {
-            Drawable.Position = c;
-            Drawable.Rotation = MathHelper.RadiansToDegrees(r);
         }
+
+        /// <summary>
+        /// Axis-aligned bounding box of this body.
+        /// </summary>
+        public abstract Rectangle ScreenSpaceAABB { get; }
+
+        /// <summary>
+        /// Whether a parent-space position is contained within this body.
+        /// </summary>
+        public abstract bool Contains(Vector2 screenSpacePos);
     }
 }

--- a/osu.Framework/Physics/RigidBodySimulation.cs
+++ b/osu.Framework/Physics/RigidBodySimulation.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.MathUtils;
+using System.Collections.Generic;
+
+namespace osu.Framework.Physics
+{
+    /// <summary>
+    /// Applies rigid body simulation to the <see cref="Drawable"/>s within a given <see cref="Container"/>.
+    /// Currently, the simulation only supports <see cref="Drawable"/>s with centre origin and absolute
+    /// positioning.
+    /// </summary>
+    public class RigidBodySimulation
+    {
+        private IContainerEnumerable<Drawable> container;
+        private Dictionary<Drawable, RigidBody> states = new Dictionary<Drawable, RigidBody>();
+
+        public RigidBodySimulation(IContainerEnumerable<Drawable> container)
+        {
+            this.container = container;
+
+            foreach (Drawable d in container.InternalChildren)
+            {
+                RigidBody body = getRigidBody(d);
+                body.ApplyImpulse(new Vector2(RNG.NextSingle() - 0.5f, RNG.NextSingle() - 0.5f) * 100, body.c + new Vector2(RNG.NextSingle() - 0.5f, RNG.NextSingle() - 0.5f) * 100);
+            }
+        }
+
+        /// <summary>
+        /// Obtains the <see cref="RigidBody"/> state associated with a given <see cref="Drawable"/>.
+        /// </summary>
+        private RigidBody getRigidBody(Drawable d)
+        {
+            RigidBody body;
+            if (!states.TryGetValue(d, out body))
+                states[d] = body = new RigidBody(d);
+
+            return body;
+        }
+
+        /// <summary>
+        /// Advances the simulation by a time step.
+        /// </summary>
+        /// <param name="dt">The time step to advance the simulation by.</param>
+        public void Update(float dt)
+        {
+            // Read the new state from each drawable in question
+            foreach (Drawable d in container.InternalChildren)
+            {
+                RigidBody body = getRigidBody(d);
+                body.ReadState();
+            }
+
+            // Handle collisions between each pair of bodies.
+            foreach (Drawable d in container.InternalChildren)
+            {
+                d.Colour = Color4.White;
+                RigidBody body = getRigidBody(d);
+
+                foreach (Drawable other in container.InternalChildren)
+                {
+                    if (other == d)
+                        continue;
+                    
+                    if (body.CheckAndHandleCollisionWith(getRigidBody(other)))
+                        body.Drawable.Colour = Color4.Red;
+                }
+            }
+
+            // Advance the simulation by the given time step for each body and
+            // apply the state to each drawable in question.
+            foreach (Drawable d in container.InternalChildren)
+            {
+                RigidBody body = getRigidBody(d);
+                body.Integrate(new Vector2(0, 9.81f * body.m), 0, dt);
+                body.ApplyState();
+            }
+        }
+    }
+}

--- a/osu.Framework/Physics/RigidBodySimulation.cs
+++ b/osu.Framework/Physics/RigidBodySimulation.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Physics
             return body;
         }
 
-        private List<Drawable> toSimulate = new List<Drawable>();
+        private readonly List<Drawable> toSimulate = new List<Drawable>();
 
         /// <summary>
         /// Advances the simulation by a time step.

--- a/osu.Framework/Physics/RigidBodySimulation.cs
+++ b/osu.Framework/Physics/RigidBodySimulation.cs
@@ -18,8 +18,8 @@ namespace osu.Framework.Physics
     /// </summary>
     public class RigidBodySimulation
     {
-        private IContainerEnumerable<Drawable> container;
-        private Dictionary<Drawable, RigidBody> states = new Dictionary<Drawable, RigidBody>();
+        private readonly IContainerEnumerable<Drawable> container;
+        private readonly Dictionary<Drawable, RigidBody> states = new Dictionary<Drawable, RigidBody>();
 
         public RigidBodySimulation(IContainerEnumerable<Drawable> container)
         {
@@ -28,7 +28,7 @@ namespace osu.Framework.Physics
             foreach (Drawable d in container.InternalChildren)
             {
                 RigidBody body = getRigidBody(d);
-                body.ApplyImpulse(new Vector2(RNG.NextSingle() - 0.5f, RNG.NextSingle() - 0.5f) * 100, body.c + new Vector2(RNG.NextSingle() - 0.5f, RNG.NextSingle() - 0.5f) * 100);
+                body.ApplyImpulse(new Vector2(RNG.NextSingle() - 0.5f, RNG.NextSingle() - 0.5f) * 100, body.Centre + new Vector2(RNG.NextSingle() - 0.5f, RNG.NextSingle() - 0.5f) * 100);
             }
         }
 
@@ -75,7 +75,7 @@ namespace osu.Framework.Physics
                 {
                     if (other == d)
                         continue;
-                    
+
                     if (d != container && body.CheckAndHandleCollisionWith(getRigidBody(other)))
                         d.Colour = Color4.Red;
                 }
@@ -86,7 +86,7 @@ namespace osu.Framework.Physics
             foreach (Drawable d in toSimulate)
             {
                 RigidBody body = getRigidBody(d);
-                body.Integrate(new Vector2(0, 9.81f * body.m), 0, dt);
+                body.Integrate(new Vector2(0, 9.81f * body.Mass), 0, dt);
                 body.ApplyState();
             }
         }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -206,6 +206,8 @@
     <Compile Include="Configuration\IBindable.cs" />
     <Compile Include="Configuration\IParseable.cs" />
     <Compile Include="Audio\AudioManager.cs" />
+    <Compile Include="Physics\RigidBody.cs" />
+    <Compile Include="Physics\RigidBodySimulation.cs" />
     <Compile Include="Screens\Screen.cs" />
     <Compile Include="Graphics\Sprites\Sprite.cs" />
     <Compile Include="Graphics\Sprites\SpriteText.cs" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -206,6 +206,8 @@
     <Compile Include="Configuration\IBindable.cs" />
     <Compile Include="Configuration\IParseable.cs" />
     <Compile Include="Audio\AudioManager.cs" />
+    <Compile Include="Physics\RigidBodies\ContainerBody.cs" />
+    <Compile Include="Physics\RigidBodies\DrawableBody.cs" />
     <Compile Include="Physics\RigidBody.cs" />
     <Compile Include="Physics\RigidBodySimulation.cs" />
     <Compile Include="Screens\Screen.cs" />


### PR DESCRIPTION
[Video](https://streamable.com/7qrhz)

This commit introduces RigidBodySimulation, which allows performing
rigid body simulation on the children of a given container. For now,
the simulation is limited to impulse responses and does not support
resting contact well. Additionally, only centre origin, absolute
positioned children are permitted. Performance optimizations are
also an area of future work.

For now I'll leave the implementation at this. It is complete enough to be integrated into the game as a prototype if it becomes desired. At that point further features and optimizations can be added.