### PR TITLE
Add experimental memory pressure for FrameBuffers.

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -88,10 +88,14 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
                     return;
                 size = value;
 
+                GC.RemoveMemoryPressure(Texture.Width * Texture.Height * 4);
+
                 Texture.Width = (int)Math.Ceiling(size.X);
                 Texture.Height = (int)Math.Ceiling(size.Y);
                 Texture.SetData(new TextureUpload(new byte[0]));
                 Texture.Upload();
+
+                GC.AddMemoryPressure(Texture.Width * Texture.Height * 4);
             }
         }
 
@@ -126,6 +130,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
                 r.Size = Size;
                 r.Bind(frameBuffer);
             }
+
+            if (Texture != null)
+                GC.AddMemoryPressure(Texture.Width * Texture.Height * 4);
         }
 
         /// <summary>
@@ -141,6 +148,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
                 r.Unbind();
 
             lastFramebuffer = -1;
+
+            if (Texture != null)
+                GC.RemoveMemoryPressure(Texture.Width * Texture.Height * 4);
         }
     }
 }


### PR DESCRIPTION
Just a request for comment. It would seem we want to do this (fixes framebuffers potentially not being finalized for minutes) but we do need to ask some questions:

- This should probably be done at a TextureGL level instead.
- Will this handle correctly even though we are adding pressure for gRAM not system memory?

For what it's worth, I can find at least one other project using memory pressure in these scenarios:
https://github.com/virtualglobebook/OpenGlobe/blob/master/Source/Renderer/GL3x/Buffers/BufferGL3x.cs