### PR TITLE
Fix state not propagating to FrameStatisticDisplays

### DIFF
--- a/osu.Framework.Testing/TestCase.cs
+++ b/osu.Framework.Testing/TestCase.cs
@@ -107,23 +107,28 @@ namespace osu.Framework.Testing
         {
             loadableStep?.TriggerClick();
 
-            string text = $"{(int)Time.Current}: ".PadLeft(7);
+            string text = ".";
 
-            if (actionIndex < 0)
-                text += $"{GetType().ReadableName()}";
-            else
+            if (actionRepetition == 0)
             {
-                if (actionRepetition == 0)
-                    text += $"  Step #{actionIndex + 1}";
-                text = text.PadRight(20) + $"{loadableStep?.ToString() ?? string.Empty}";
+                text = $"{(int)Time.Current}: ".PadLeft(7);
+
+                if (actionIndex < 0)
+                    text += $"{GetType().ReadableName()}";
+                else
+                {
+                    text += $"step {actionIndex + 1}";
+                    text = text.PadRight(16) + $"{loadableStep?.ToString() ?? string.Empty}";
+                }
             }
 
-            Console.WriteLine(text);
+            Console.Write(text);
 
             actionRepetition++;
 
             if (actionRepetition > (loadableStep?.RequiredRepetitions ?? 1) - 1)
             {
+                Console.WriteLine();
                 actionIndex++;
                 actionRepetition = 0;
             }

--- a/osu.Framework/Configuration/FrameSync.cs
+++ b/osu.Framework/Configuration/FrameSync.cs
@@ -1,14 +1,20 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.ComponentModel;
+
 namespace osu.Framework.Configuration
 {
     public enum FrameSync
     {
-        VSync = 1,
-        Limit120 = 0,
-        Unlimited = 2,
-        CompletelyUnlimited = 4,
-        Custom = 5
+        VSync,
+        [Description("2x refresh rate")]
+        Limit2x,
+        [Description("4x refresh rate")]
+        Limit4x,
+        [Description("8x refresh rate")]
+        Limit8x,
+        [Description("Unlimited")]
+        Unlimited,
     }
 }

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -12,7 +12,6 @@ namespace osu.Framework.Configuration
 
         protected override void InitialiseDefaults()
         {
-#pragma warning disable CS0612 // Type or member is obsolete
             Set(FrameworkConfig.ShowLogOverlay, true);
 
             Set(FrameworkConfig.Width, 1366, 640);
@@ -29,11 +28,10 @@ namespace osu.Framework.Configuration
             Set(FrameworkConfig.Letterboxing, true);
             Set(FrameworkConfig.LetterboxPositionX, 0.0, -1.0, 1.0);
             Set(FrameworkConfig.LetterboxPositionY, 0.0, -1.0, 1.0);
-            Set(FrameworkConfig.FrameSync, FrameSync.Limit120);
+            Set(FrameworkConfig.FrameSync, FrameSync.Limit2x);
             Set(FrameworkConfig.WindowMode, WindowMode.Windowed);
             Set(FrameworkConfig.ShowUnicode, false);
             Set(FrameworkConfig.Locale, "");
-#pragma warning restore CS0612 // Type or member is obsolete
         }
 
         public FrameworkConfigManager(Storage storage)

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Graphics.Performance
         public void CreateDisplays()
         {
             foreach (GameThread t in Threads)
-                Add(new FrameStatisticsDisplay(t, atlas));
+                Add(new FrameStatisticsDisplay(t, atlas) { State = state });
         }
 
         public PerformanceOverlay()

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Configuration;
 using osu.Framework.Logging;
 using OpenTK;
+using OpenTK.Graphics;
 using OpenTK.Graphics.ES30;
 
 namespace osu.Framework.Platform
@@ -16,7 +17,7 @@ namespace osu.Framework.Platform
         internal Version GLSLVersion;
 
         protected GameWindow(int width, int height)
-            : base(width, height)
+            : base(width, height, new GraphicsMode(GraphicsMode.Default.ColorFormat, GraphicsMode.Default.Depth, GraphicsMode.Default.Stencil, GraphicsMode.Default.Samples, GraphicsMode.Default.AccumulatorFormat, 3))
         {
             Closing += (sender, e) => e.Cancel = ExitRequested?.Invoke() ?? false;
             Closed += (sender, e) => Exited?.Invoke();


### PR DESCRIPTION
If the state was set before CreateDisplays was called, their would be initialised with the wrong initial state.