### PR TITLE
Increase inactive thread update rates

### DIFF
--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -11,7 +11,7 @@ namespace osu.Framework.Threading
     public class GameThread
     {
         internal const double DEFAULT_ACTIVE_HZ = 1000;
-        internal const double DEFAULT_INACTIVE_HZ = 30;
+        internal const double DEFAULT_INACTIVE_HZ = 60;
 
         public PerformanceMonitor Monitor { get; }
         public ThrottledFrameClock Clock { get; }


### PR DESCRIPTION
30hz has always felt too low. We are at the point where running all threads at 60hz has quite a low overhead, and the boost in smoothness is definitely worth it in my opinion.

Keep in mind this is still just a sane default, and consumers of the framework can set their own update rates if deemed necessary.