### PR TITLE
Improve performance of hot path in ShaderManager

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -181,8 +181,8 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GC/@EntryIndexedValue">GC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GL/@EntryIndexedValue">GL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GLSL/@EntryIndexedValue">GLSL</s:String>
-  <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=2D/@EntryIndexedValue">2D</s:String>
-  <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=3D/@EntryIndexedValue">3D</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=2D/@EntryIndexedValue">2D</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=3D/@EntryIndexedValue">3D</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HID/@EntryIndexedValue">HID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>

--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -181,6 +181,8 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GC/@EntryIndexedValue">GC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GL/@EntryIndexedValue">GL</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=GLSL/@EntryIndexedValue">GLSL</s:String>
+  <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=2D/@EntryIndexedValue">2D</s:String>
+  <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=3D/@EntryIndexedValue">3D</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HID/@EntryIndexedValue">HID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.Graphics.Containers
         private Vector2 blurSigma = Vector2.Zero;
 
         /// <summary>
-        /// Controls the amount of blurring in two orthogonal directions (X and Y if 
+        /// Controls the amount of blurring in two orthogonal directions (X and Y if
         /// <see cref="BlurRotation"/> is zero).
         /// Blur is parametrized by a gaussian image filter. This property controls
         /// the standard deviation (sigma) of the gaussian kernel.
@@ -168,7 +168,7 @@ namespace osu.Framework.Graphics.Containers
         private void load(ShaderManager shaders)
         {
             if (blurShader == null)
-                blurShader = shaders?.Load(VertexShaderDescriptor.Texture2D, FragmentShaderDescriptor.Blur);
+                blurShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.BLUR);
         }
 
         protected override DrawNode CreateDrawNode() => new BufferedContainerDrawNode();

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.Graphics.Containers
             this.game = game;
 
             if (shader == null)
-                shader = shaders?.Load(VertexShaderDescriptor.Texture2D, FragmentShaderDescriptor.TextureRounded);
+                shader = shaders?.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
 
             // From now on, since we ourself are loaded now,
             // we actually permit children to be loaded if our

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -148,8 +148,8 @@ namespace osu.Framework.Graphics.Lines
         [BackgroundDependencyLoader]
         private void load(ShaderManager shaders)
         {
-            roundedTextureShader = shaders?.Load(VertexShaderDescriptor.Texture3D, FragmentShaderDescriptor.TextureRounded);
-            textureShader = shaders?.Load(VertexShaderDescriptor.Texture3D, FragmentShaderDescriptor.Texture);
+            roundedTextureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE_ROUNDED);
+            textureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE);
         }
 
         private Texture texture = Texture.WhitePixel;

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -69,76 +69,53 @@ namespace osu.Framework.Graphics.Shaders
 
         public Shader Load(string vertex, string fragment, bool continuousCompilation = false)
         {
-            string name = $@"{vertex}/{fragment}";
+            string name = vertex + '/' + fragment;
 
-            if (shaderCache.ContainsKey(name))
-                return shaderCache[name];
+            Shader shader;
 
-            List<ShaderPart> parts = new List<ShaderPart>
+            if (!shaderCache.TryGetValue(name, out shader))
             {
-                createShaderPart(vertex, ShaderType.VertexShader),
-                createShaderPart(fragment, ShaderType.FragmentShader)
-            };
+                List<ShaderPart> parts = new List<ShaderPart>
+                {
+                    createShaderPart(vertex, ShaderType.VertexShader),
+                    createShaderPart(fragment, ShaderType.FragmentShader)
+                };
 
-            Shader shader = new Shader(name, parts);
+                shader = new Shader(name, parts);
 
-            if (!shader.Loaded)
-            {
-                StringBuilder logContents = new StringBuilder();
-                logContents.AppendLine($@"Loading shader {name}:");
-                logContents.Append(shader.Log);
-                logContents.AppendLine(@"Parts:");
-                foreach (ShaderPart p in parts)
-                    logContents.Append(p.Log);
-                Logger.Log(logContents.ToString(), LoggingTarget.Runtime, LogLevel.Debug);
+                if (!shader.Loaded)
+                {
+                    StringBuilder logContents = new StringBuilder();
+                    logContents.AppendLine($@"Loading shader {name}:");
+                    logContents.Append(shader.Log);
+                    logContents.AppendLine(@"Parts:");
+                    foreach (ShaderPart p in parts)
+                        logContents.Append(p.Log);
+                    Logger.Log(logContents.ToString(), LoggingTarget.Runtime, LogLevel.Debug);
+                }
+
+                shaderCache[name] = shader;
             }
 
-            //#if DEBUG
-            //            if (continuousCompilation)
-            //            {
-            //                Game.Scheduler.AddDelayed(delegate
-            //                {
-            //                    parts.Clear();
-            //                    parts.Add(createShaderPart(vertex, ShaderType.VertexShader, true));
-            //                    parts.Add(createShaderPart(fragment, ShaderType.FragmentShader, true));
-            //                    shader.Compile(parts);
-
-            //                    StringBuilder cLogContents = new StringBuilder();
-            //                    cLogContents.AppendLine($@"Continuously loading shader {name}:");
-            //                    cLogContents.Append(shader.Log);
-            //                    cLogContents.AppendLine(@"Parts:");
-            //                    foreach (ShaderPart p in parts)
-            //                        cLogContents.Append(p.Log);
-
-            //                }, 1000, true);
-            //            }
-            //#endif
-
-            shaderCache[name] = shader;
             return shader;
         }
-
-        public Shader Load<T, U>(T vertexShader, U fragmentShader, bool continuousCompilation = false)
-        {
-            return Load(vertexShader.ToString(), fragmentShader.ToString(), continuousCompilation);
-        }
     }
 
-    public enum VertexShaderDescriptor
+    public static class VertexShaderDescriptor
     {
-        Texture2D,
-        Texture3D,
-        Position,
-        Colour,
+        public const string TEXTURE_2 = "Texture2D";
+        public const string TEXTURE_3 = "Texture3D";
+        public const string POSITION = "Position";
+        public const string COLOUR = "Colour";
     }
 
-    public enum FragmentShaderDescriptor
+    public static class FragmentShaderDescriptor
     {
-        Texture,
-        TextureRounded,
-        Colour,
-        ColourRounded,
-        Glow,
-        Blur,
+        public const string TEXTURE = "Texture";
+        public const string TEXTURE_ROUNDED = "TextureRounded";
+        public const string COLOUR = "Colour";
+        public const string COLOUR_ROUNDED = "ColourRounded";
+        public const string GLOW = "Glow";
+        public const string BLUR = "Blur";
     }
 }

--- a/osu.Framework/Graphics/Sprites/Sprite.cs
+++ b/osu.Framework/Graphics/Sprites/Sprite.cs
@@ -66,8 +66,8 @@ namespace osu.Framework.Graphics.Sprites
         [BackgroundDependencyLoader]
         private void load(ShaderManager shaders)
         {
-            textureShader = shaders?.Load(VertexShaderDescriptor.Texture2D, FragmentShaderDescriptor.Texture);
-            roundedTextureShader = shaders?.Load(VertexShaderDescriptor.Texture2D, FragmentShaderDescriptor.TextureRounded);
+            textureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+            roundedTextureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
         }
 
         private Texture texture;

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -61,8 +61,8 @@ namespace osu.Framework.Graphics.UserInterface
         [BackgroundDependencyLoader]
         private void load(ShaderManager shaders)
         {
-            roundedTextureShader = shaders?.Load(VertexShaderDescriptor.Texture2D, FragmentShaderDescriptor.TextureRounded);
-            textureShader = shaders?.Load(VertexShaderDescriptor.Texture2D, FragmentShaderDescriptor.Texture);
+            roundedTextureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
+            textureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
         }
 
         private Texture texture = Texture.WhitePixel;


### PR DESCRIPTION
Enum.ToString() is quite an expensive operation, and was being called twice per drawable loaded.