### PR TITLE
Avoid hard-crashing when web response gives non-json content

### DIFF
--- a/osu.Framework/IO/Network/JsonWebRequest.cs
+++ b/osu.Framework/IO/Network/JsonWebRequest.cs
@@ -26,10 +26,7 @@ namespace osu.Framework.IO.Network
             }
             catch (Exception se)
             {
-                if (e == null)
-                    e = se;
-                else
-                    e = new AggregateException(e, se);
+                e = e == null ? se : new AggregateException(e, se);
             }
 
             Finished?.Invoke(this, e);

--- a/osu.Framework/IO/Network/JsonWebRequest.cs
+++ b/osu.Framework/IO/Network/JsonWebRequest.cs
@@ -20,10 +20,24 @@ namespace osu.Framework.IO.Network
 
         private void finished(WebRequest request, Exception e)
         {
+            try
+            {
+                deserialisedResponse = JsonConvert.DeserializeObject<T>(ResponseString);
+            }
+            catch (Exception se)
+            {
+                if (e == null)
+                    e = se;
+                else
+                    e = new AggregateException(e, se);
+            }
+
             Finished?.Invoke(this, e);
         }
 
-        public T ResponseObject => JsonConvert.DeserializeObject<T>(ResponseString);
+        private T deserialisedResponse;
+
+        public T ResponseObject => deserialisedResponse;
 
         /// <summary>
         /// Request has finished with success or failure. Check exception == null for success.


### PR DESCRIPTION
This was causing the whole game to crash when a bad response is returned by the server.