### PR TITLE
Allow blocking of processing of frames in a FramedClock

### DIFF
--- a/osu.Framework/Timing/FramedClock.cs
+++ b/osu.Framework/Timing/FramedClock.cs
@@ -51,11 +51,17 @@ namespace osu.Framework.Timing
         private double timeSinceLastCalculation;
         private int framesSinceLastCalculation;
 
+        /// <summary>
+        /// Whether we should run <see cref="ProcessFrame"/> on the underlying <see cref="Source"/> (in the case it is an <see cref="IFrameBasedClock"/>).
+        /// </summary>
+        public bool ProcessSourceClockFrames = true;
+
         private const int fps_calculation_interval = 250;
 
         public virtual void ProcessFrame()
         {
-            (Source as IFrameBasedClock)?.ProcessFrame();
+            if (ProcessSourceClockFrames)
+                (Source as IFrameBasedClock)?.ProcessFrame();
 
             if (timeUntilNextCalculation <= 0)
             {


### PR DESCRIPTION
Allows for very specific clock pausing, even when the clock is a custom clock in a drawable (where ProcessFrame is being automatically called).