### PR TITLE
Add missing AlwaysReceiveInput

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -64,6 +64,7 @@ namespace osu.Framework
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
+                    AlwaysReceiveInput = true,
                 },
                 new GlobalHotkeys
                 {


### PR DESCRIPTION
Fixes mouse cursor not correctly travelling outside the window bounds.