### PR TITLE
Process the clock before running reset code

### DIFF
--- a/osu.Framework.Testing/TestCase.cs
+++ b/osu.Framework.Testing/TestCase.cs
@@ -37,6 +37,8 @@ namespace osu.Framework.Testing
 
         public virtual void Reset()
         {
+            Clock.ProcessFrame();
+
             if (content == null)
             {
                 InternalChildren = new Drawable[]


### PR DESCRIPTION
Some tests rely on the clock being up-to-date. Previously it wasn't