### PR TITLE
Scrollbar fixes

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -387,6 +387,8 @@ namespace osu.Framework.Graphics.Containers
                 ResizeTo(size, duration, easing);
             }
 
+            protected override bool OnClick(InputState state) => true;
+
             protected override bool OnHover(InputState state)
             {
                 FadeColour(hover_colour, 100);

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -410,6 +410,9 @@ namespace osu.Framework.Graphics.Containers
             {
                 //note that we are changing the colour of the box here as to not interfere with the hover effect.
                 box.FadeColour(highlight_colour, 100);
+
+                dragOffset = Position[scrollDim];
+                Dragged?.Invoke(dragOffset);
                 return true;
             }
 


### PR DESCRIPTION
Fixes:
- Disallow clicking through the scrollbar (In the osu! project you could click through the scrollbar in the song selection)
- Clicking on the scrollbar while it scrolls causes it to stop scrolling