### PR TITLE
Fixes negative delta in displayFps

### DIFF
--- a/osu.Framework/Graphics/Performance/FpsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FpsDisplay.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -51,7 +52,7 @@ namespace osu.Framework.Graphics.Performance
 
             if (!Counting) return;
 
-            displayFps = Interpolation.Damp(displayFps, clock.FramesPerSecond, 0.01, clock.ElapsedFrameTime / 1000);
+            displayFps = Interpolation.Damp(displayFps, clock.FramesPerSecond, 0.01, Math.Abs(clock.ElapsedFrameTime) / 1000);
 
             if (counter.DrawWidth != aimWidth)
             {


### PR DESCRIPTION
Fixes #696 

The only other ```Damp()``` call in the codebase, which also calculates its delta using ```ElapsedFrameTime```, uses ```Math.Abs(ElapsedFrameTime)``` to ensure positive values, Can't see any reason why it would be specific to just that call, it could potentially just be a band-aid, meaning maybe neither should use ```Math.Abs()```

The other ```Damp()``` call, for reference: https://github.com/ppy/osu-framework/blob/a8d04220c4cacdb131f9455c0defbf9220502947/osu.Framework/Timing/FramedClock.cs#L81