### PR TITLE
Fix a crash when pressing tab on a textbox

### DIFF
--- a/osu.Framework/Graphics/Containers/TabbableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContainer.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {
-            if (args.Key != Key.Tab)
+            if (TabbableContentContainer == null || args.Key != Key.Tab)
                 return false;
 
             nextTabStop(TabbableContentContainer, state.Keyboard.ShiftPressed)?.TriggerFocus();


### PR DESCRIPTION
Happens when a textbox isn't part of a tabbable container.