### PR TITLE
Fix double-call of TriggerOnFocus on mouse click

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -158,8 +158,9 @@ namespace osu.Framework.Graphics
 
         /// <summary>
         /// Contains all dependencies that can be injected into this Drawable using <see cref="BackgroundDependencyLoader"/>.
+        /// Add or override dependencies by calling <see cref="DependencyContainer.Cache{T}(T, bool, bool)"/>.
         /// </summary>
-        internal DependencyContainer Dependencies { get; private set; }
+        protected DependencyContainer Dependencies { get; private set; }
 
         /// <summary>
         /// Loads this drawable, including the gathering of dependencies and initialisation of required resources.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -64,6 +64,9 @@ namespace osu.Framework.Graphics
 
         private bool isDisposed;
 
+        /// <summary>
+        /// Disposes this drawable.
+        /// </summary>
         protected virtual void Dispose(bool isDisposing)
         {
         }
@@ -103,11 +106,16 @@ namespace osu.Framework.Graphics
         #region Loading
 
         /// <summary>
-        /// Override to add delayed load abilities (ie. using IsAlive)
+        /// Whether this Drawable is fully loaded.
+        /// Override to false for delaying the load further (e.g. using IsAlive).
         /// </summary>
         public virtual bool IsLoaded => loadState >= LoadState.Loaded;
 
         private volatile LoadState loadState;
+
+        /// <summary>
+        /// Describes the current state of this Drawable within the loading pipeline.
+        /// </summary>
         public LoadState LoadState => loadState;
 
         private Task loadTask;
@@ -117,7 +125,10 @@ namespace osu.Framework.Graphics
         /// Loads this Drawable asynchronously.
         /// </summary>
         /// <param name="game">The game to load this Drawable on.</param>
-        /// <param name="target">The target of the Drawable may eventually be loaded into.</param>
+        /// <param name="target">
+        /// The target this Drawable may eventually be loaded into.
+        /// <see cref="Clock"/> and <see cref="Dependencies"/> are inherited from the target.
+        /// </param>
         /// <param name="onLoaded">Callback to be invoked asynchronously after loading is complete.</param>
         /// <returns>The task which is used for loading and callbacks.</returns>
         internal Task LoadAsync(Game game, Drawable target, Action<Drawable> onLoaded = null)
@@ -1236,7 +1247,7 @@ namespace osu.Framework.Graphics
         private ProxyDrawable proxy;
 
         /// <summary>
-        /// Creates a proxy drawable which can be inserted elsewhere in the draw hierarchy.
+        /// Creates a proxy drawable which can be inserted elsewhere in the scene graph.
         /// Will cause the original instance to not render itself.
         /// Creating multiple proxies is not supported and will result in an
         /// <see cref="InvalidOperationException"/>.
@@ -1512,12 +1523,30 @@ namespace osu.Framework.Graphics
 
         #region Interaction / Input
 
+        /// <summary>
+        /// Triggers <see cref="OnHover(InputState state)"/> with a local version of the given <see cref="InputState"/>.
+        /// </summary>
         public bool TriggerOnHover(InputState screenSpaceState) => OnHover(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered once when this Drawable becomes hovered.
+        /// </summary>
+        /// <param name="state">The state at which the Drawable becomes hovered.</param>
+        /// <returns>True if this Drawable would like to handle the hover. If so, then
+        /// no further Drawabled down the scene graph will receive hovering events. If
+        /// false, however, then <see cref="OnHoverLost(InputState)"/> will still be
+        /// received once hover is lost.</returns>
         protected virtual bool OnHover(InputState state) => false;
 
+        /// <summary>
+        /// Triggers <see cref="OnHoverLost(InputState state)"/> with a local version of the given <see cref="InputState"/>.
+        /// </summary>
         public void TriggerOnHoverLost(InputState screenSpaceState) => OnHoverLost(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever this drawable is no longer hovered.
+        /// </summary>
+        /// <param name="state">The state at which hover is lost.</param>
         protected virtual void OnHoverLost(InputState state)
         {
         }
@@ -1527,6 +1556,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnMouseDown(InputState screenSpaceState = null, MouseDownEventArgs args = null) => OnMouseDown(createCloneInParentSpace(screenSpaceState), args);
 
+        /// <summary>
+        /// Triggered whenever a mouse button is pressed on top of this Drawable.
+        /// </summary>
+        /// <param name="state">The state after the press.</param>
+        /// <returns>True if this Drawable handled the event. If false, then the event
+        /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnMouseDown(InputState state, MouseDownEventArgs args) => false;
 
         /// <summary>
@@ -1534,6 +1569,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnMouseUp(InputState screenSpaceState = null, MouseUpEventArgs args = null) => OnMouseUp(createCloneInParentSpace(screenSpaceState), args);
 
+        /// <summary>
+        /// Triggered whenever a mouse button is released on top of this Drawable.
+        /// </summary>
+        /// <param name="state">The state after the release.</param>
+        /// <returns>True if this Drawable handled the event. If false, then the event
+        /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnMouseUp(InputState state, MouseUpEventArgs args) => false;
 
         /// <summary>
@@ -1541,6 +1582,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnClick(InputState screenSpaceState = null) => OnClick(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever a mouse click occurs on top of this Drawable.
+        /// </summary>
+        /// <param name="state">The state after the click.</param>
+        /// <returns>True if this Drawable handled the event. If false, then the event
+        /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnClick(InputState state) => false;
 
         /// <summary>
@@ -1548,6 +1595,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnDoubleClick(InputState screenSpaceState) => OnDoubleClick(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever a mouse double click occurs on top of this Drawable.
+        /// </summary>
+        /// <param name="state">The state after the double click.</param>
+        /// <returns>True if this Drawable handled the event. If false, then the event
+        /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnDoubleClick(InputState state) => false;
 
         /// <summary>
@@ -1555,6 +1608,15 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnDragStart(InputState screenSpaceState) => OnDragStart(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever this Drawable is initially dragged by a held mouse click
+        /// and subsequent movement.
+        /// </summary>
+        /// <param name="state">The state after the mouse was moved.</param>
+        /// <returns>True if this Drawable accepts being dragged. If so, then future
+        /// <see cref="OnDrag(InputState)"/> and <see cref="OnDragEnd(InputState)"/>
+        /// events will be reveiced. Otherwise, the event is propagated down the scene
+        /// graph to the next eligible Drawable.</returns>
         protected virtual bool OnDragStart(InputState state) => false;
 
         /// <summary>
@@ -1562,6 +1624,13 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnDrag(InputState screenSpaceState) => OnDrag(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever the mouse is moved while dragging.
+        /// Only is received if a drag was previously initiated by returning true
+        /// from <see cref="OnDragStart(InputState)"/>.
+        /// </summary>
+        /// <param name="state">The state after the mouse was moved.</param>
+        /// <returns>Currently unused.</returns>
         protected virtual bool OnDrag(InputState state) => false;
 
         /// <summary>
@@ -1569,6 +1638,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnDragEnd(InputState screenSpaceState) => OnDragEnd(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever a drag ended. Only is received if a drag was previously
+        /// initiated by returning true from <see cref="OnDragStart(InputState)"/>.
+        /// </summary>
+        /// <param name="state">The state after the drag ended.</param>
+        /// <returns>Currently unused.</returns>
         protected virtual bool OnDragEnd(InputState state) => false;
 
         /// <summary>
@@ -1576,6 +1651,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnWheel(InputState screenSpaceState) => OnWheel(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever the mouse wheel was turned over this Drawable.
+        /// </summary>
+        /// <param name="state">The state after the wheel was turned.</param>
+        /// <returns>True if this Drawable handled the event. If false, then the event
+        /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnWheel(InputState state) => false;
 
         /// <summary>
@@ -1584,6 +1665,15 @@ namespace osu.Framework.Graphics
         /// <param name="screenSpaceState">The input state.</param>
         public bool TriggerOnFocus(InputState screenSpaceState = null) => OnFocus(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever this Drawable can gain focus.
+        /// Focused Drawables receive keyboard input before all other Drawables,
+        /// and thus handle it first.
+        /// </summary>
+        /// <param name="state">The state after focus when focus can be gained.</param>
+        /// <returns>True if this Drawable accepts focus. If false, then the event
+        /// is propagated down the scene graph to the next eligible Drawable and
+        /// this Drawable does not gain focus.</returns>
         protected virtual bool OnFocus(InputState state) => false;
 
         /// <summary>
@@ -1592,6 +1682,10 @@ namespace osu.Framework.Graphics
         /// <param name="screenSpaceState">The input state.</param>
         public void TriggerOnFocusLost(InputState screenSpaceState = null) => OnFocusLost(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever this Drawable lost focus.
+        /// </summary>
+        /// <param name="state">The state after focus was lost.</param>
         protected virtual void OnFocusLost(InputState state)
         {
         }
@@ -1601,6 +1695,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnKeyDown(InputState screenSpaceState, KeyDownEventArgs args) => OnKeyDown(createCloneInParentSpace(screenSpaceState), args);
 
+        /// <summary>
+        /// Triggered whenever a key was pressed.
+        /// </summary>
+        /// <param name="state">The state after the key was pressed.</param>
+        /// <returns>True if this Drawable handled the event. If false, then the event
+        /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnKeyDown(InputState state, KeyDownEventArgs args) => false;
 
         /// <summary>
@@ -1608,6 +1708,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnKeyUp(InputState screenSpaceState, KeyUpEventArgs args) => OnKeyUp(createCloneInParentSpace(screenSpaceState), args);
 
+        /// <summary>
+        /// Triggered whenever a key was released.
+        /// </summary>
+        /// <param name="state">The state after the key was released.</param>
+        /// <returns>True if this Drawable handled the event. If false, then the event
+        /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnKeyUp(InputState state, KeyUpEventArgs args) => false;
 
         /// <summary>
@@ -1615,6 +1721,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public bool TriggerOnMouseMove(InputState screenSpaceState) => OnMouseMove(createCloneInParentSpace(screenSpaceState));
 
+        /// <summary>
+        /// Triggered whenever the mouse moved over this Drawable.
+        /// </summary>
+        /// <param name="state">The state after the mouse moved.</param>
+        /// <returns>True if this Drawable handled the event. If false, then the event
+        /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnMouseMove(InputState state) => false;
 
         /// <summary>
@@ -2233,17 +2345,47 @@ namespace osu.Framework.Graphics
 
     public enum BlendingMode
     {
+        /// <summary>
+        /// Inherits from parent.
+        /// </summary>
         Inherit = 0,
+        /// <summary>
+        /// Mixes with existing colour by a factor of the colour's alpha.
+        /// </summary>
         Mixture,
+        /// <summary>
+        /// Purely additive (by a factor of the colour's alpha) blending.
+        /// </summary>
         Additive,
+        /// <summary>
+        /// No alpha blending whatsoever.
+        /// </summary>
         None,
     }
 
+    /// <summary>
+    /// Possible states of s <see cref="Drawable"/> within the loading pipeline.
+    /// </summary>
     public enum LoadState
     {
+        /// <summary>
+        /// Not loaded, and no load has been initiated yet.
+        /// </summary>
         NotLoaded,
+        /// <summary>
+        /// Currently loading (possibly and usually on a background
+        /// thread via <see cref="Drawable.LoadAsync(Game, Drawable, Action{Drawable})"/>).
+        /// </summary>
         Loading,
+        /// <summary>
+        /// Loading is complete, but has not yet been finalized on the update thread
+        /// (<see cref="Drawable.LoadComplete"/> has not been called yet, which
+        /// always runs on the update thread and require <see cref="Drawable.IsLoaded"/>).
+        /// </summary>
         Loaded,
+        /// <summary>
+        /// Loading is fully completed and the Drawable is now part of the scene graph.
+        /// </summary>
         Alive
     }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1525,7 +1525,7 @@ namespace osu.Framework.Graphics
         #region Interaction / Input
 
         /// <summary>
-        /// Triggers <see cref="OnHover(InputState state)"/> with a local version of the given <see cref="InputState"/>.
+        /// Triggers <see cref="OnHover(InputState)"/> with a local version of the given <see cref="InputState"/>.
         /// </summary>
         public bool TriggerOnHover(InputState screenSpaceState) => OnHover(createCloneInParentSpace(screenSpaceState));
 
@@ -1540,7 +1540,7 @@ namespace osu.Framework.Graphics
         protected virtual bool OnHover(InputState state) => false;
 
         /// <summary>
-        /// Triggers <see cref="OnHoverLost(InputState state)"/> with a local version of the given <see cref="InputState"/>.
+        /// Triggers <see cref="OnHoverLost(InputState)"/> with a local version of the given <see cref="InputState"/>.
         /// </summary>
         public void TriggerOnHoverLost(InputState screenSpaceState) => OnHoverLost(createCloneInParentSpace(screenSpaceState));
 
@@ -1561,6 +1561,7 @@ namespace osu.Framework.Graphics
         /// Triggered whenever a mouse button is pressed on top of this Drawable.
         /// </summary>
         /// <param name="state">The state after the press.</param>
+        /// <param name="args">Specific arguments for mouse down event.</param>
         /// <returns>True if this Drawable handled the event. If false, then the event
         /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnMouseDown(InputState state, MouseDownEventArgs args) => false;
@@ -1574,6 +1575,7 @@ namespace osu.Framework.Graphics
         /// Triggered whenever a mouse button is released on top of this Drawable.
         /// </summary>
         /// <param name="state">The state after the release.</param>
+        /// <param name="args">Specific arguments for mouse up event.</param>
         /// <returns>True if this Drawable handled the event. If false, then the event
         /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnMouseUp(InputState state, MouseUpEventArgs args) => false;
@@ -1700,6 +1702,7 @@ namespace osu.Framework.Graphics
         /// Triggered whenever a key was pressed.
         /// </summary>
         /// <param name="state">The state after the key was pressed.</param>
+        /// <param name="args">Specific arguments for key down event.</param>
         /// <returns>True if this Drawable handled the event. If false, then the event
         /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnKeyDown(InputState state, KeyDownEventArgs args) => false;
@@ -1713,6 +1716,7 @@ namespace osu.Framework.Graphics
         /// Triggered whenever a key was released.
         /// </summary>
         /// <param name="state">The state after the key was released.</param>
+        /// <param name="args">Specific arguments for key up event.</param>
         /// <returns>True if this Drawable handled the event. If false, then the event
         /// is propagated down the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnKeyUp(InputState state, KeyUpEventArgs args) => false;

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -107,7 +107,7 @@ namespace osu.Framework.Graphics
 
         /// <summary>
         /// Whether this Drawable is fully loaded.
-        /// Override to false for delaying the load further (e.g. using IsAlive).
+        /// Override to false for delaying the load further (e.g. using <see cref="IsAlive"/>).
         /// </summary>
         public virtual bool IsLoaded => loadState >= LoadState.Loaded;
 
@@ -153,7 +153,7 @@ namespace osu.Framework.Graphics
         /// If not overridden, the load-time parent's dependency tree will be used.
         /// </summary>
         /// <param name="parent">The parent <see cref="DependencyContainer"/> which should be passed through if we want fallback lookups to work.</param>
-        /// <returns>A new dependency container to be stored against this Drawable.</returns>
+        /// <returns>A new dependency container to be stored for this Drawable.</returns>
         protected virtual DependencyContainer CreateLocalDependencies(DependencyContainer parent) => parent;
 
         /// <summary>
@@ -1534,7 +1534,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <param name="state">The state at which the Drawable becomes hovered.</param>
         /// <returns>True if this Drawable would like to handle the hover. If so, then
-        /// no further Drawabled down the scene graph will receive hovering events. If
+        /// no further Drawables down the scene graph will receive hovering events. If
         /// false, however, then <see cref="OnHoverLost(InputState)"/> will still be
         /// received once hover is lost.</returns>
         protected virtual bool OnHover(InputState state) => false;
@@ -2365,7 +2365,7 @@ namespace osu.Framework.Graphics
     }
 
     /// <summary>
-    /// Possible states of s <see cref="Drawable"/> within the loading pipeline.
+    /// Possible states of a <see cref="Drawable"/> within the loading pipeline.
     /// </summary>
     public enum LoadState
     {
@@ -2381,7 +2381,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Loading is complete, but has not yet been finalized on the update thread
         /// (<see cref="Drawable.LoadComplete"/> has not been called yet, which
-        /// always runs on the update thread and require <see cref="Drawable.IsLoaded"/>).
+        /// always runs on the update thread and requires <see cref="Drawable.IsLoaded"/>).
         /// </summary>
         Loaded,
         /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -145,7 +145,10 @@ namespace osu.Framework.Graphics
         /// <returns>A new dependency container to be stored against this Drawable.</returns>
         protected virtual DependencyContainer CreateLocalDependencies(DependencyContainer parent) => parent;
 
-        protected DependencyContainer Dependencies { get; private set; }
+        /// <summary>
+        /// Contains all dependencies that can be injected into this Drawable using <see cref="BackgroundDependencyLoader"/>.
+        /// </summary>
+        internal DependencyContainer Dependencies { get; private set; }
 
         /// <summary>
         /// Loads this drawable, including the gathering of dependencies and initialisation of required resources.

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Input
         /// <param name="focus">The drawable to become focused.</param>
         /// <param name="state">The <see cref="InputState"/> associated with the focusing event.</param>
         /// <returns>True iff the given drawable is now focused.</returns>
-        public bool ChangeFocus(Drawable focus, InputState state)
+        protected bool ChangeFocus(Drawable focus, InputState state)
         {
             if (focus == FocusedDrawable) return FocusedDrawable != null;
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -106,9 +106,17 @@ namespace osu.Framework.Input
         /// Usually you'd want to call TriggerFocus on the drawable directly instead.
         /// </summary>
         /// <param name="focus">The drawable to become focused.</param>
-        public void ChangeFocus(Drawable focus)
+        public bool ChangeFocus(Drawable focus) => ChangeFocus(focus, CurrentState);
+
+        /// <summary>
+        /// Handles the internal passing on focus. Note that this doesn't perform a check on the new focus drawable.
+        /// Usually you'd want to call TriggerFocus on the drawable directly instead.
+        /// </summary>
+        /// <param name="focus">The drawable to become focused.</param>
+        /// <param name="state">The <see cref="InputState"/> assiciated with the focusing event.</param>
+        public bool ChangeFocus(Drawable focus, InputState state)
         {
-            if (focus == FocusedDrawable) return;
+            if (focus == FocusedDrawable) return FocusedDrawable != null;
 
             var previousFocus = FocusedDrawable;
             FocusedDrawable = null;
@@ -134,6 +142,8 @@ namespace osu.Framework.Input
                     if (FocusedDrawable == focus) FocusedDrawable = null;
                 }
             }
+
+            return FocusedDrawable != null;
         }
 
         internal override bool BuildKeyboardInputQueue(List<Drawable> queue) => false;
@@ -534,8 +544,7 @@ namespace osu.Framework.Input
         {
             var intersectingQueue = mouseInputQueue.Intersect(mouseDownInputQueue);
 
-            var newFocus = intersectingQueue.FirstOrDefault(t => !t.HasFocus && t.TriggerOnFocus(state));
-            ChangeFocus(newFocus);
+            var newFocus = intersectingQueue.FirstOrDefault(t => !t.HasFocus && ChangeFocus(t, state));
 
             //extra check for IsAlive because we are using an outdated queue.
             if (intersectingQueue.Any(t => t.IsHovered(state.Mouse.Position) && t.TriggerOnClick(state)))

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -102,18 +102,23 @@ namespace osu.Framework.Input
         }
 
         /// <summary>
-        /// Handles the internal passing on focus. Note that this doesn't perform a check on the new focus drawable.
-        /// Usually you'd want to call TriggerFocus on the drawable directly instead.
+        /// Changes the currently-focused drawable. First unfocuses the currently-focused drawable,
+        /// then attempts to focus the given drawable if it is not null. If the given drawable is
+        /// already focused, nothing happens and no events are fired.
         /// </summary>
         /// <param name="focus">The drawable to become focused.</param>
+        /// <param name="state">The <see cref="InputState"/> associated with the focusing event.</param>
+        /// <returns>True iff the given drawable is now focused.</returns>
         public bool ChangeFocus(Drawable focus) => ChangeFocus(focus, CurrentState);
 
         /// <summary>
-        /// Handles the internal passing on focus. Note that this doesn't perform a check on the new focus drawable.
-        /// Usually you'd want to call TriggerFocus on the drawable directly instead.
+        /// Changes the currently-focused drawable. First unfocuses the currently-focused drawable,
+        /// then attempts to focus the given drawable if it is not null. If the given drawable is
+        /// already focused, nothing happens and no events are fired.
         /// </summary>
         /// <param name="focus">The drawable to become focused.</param>
-        /// <param name="state">The <see cref="InputState"/> assiciated with the focusing event.</param>
+        /// <param name="state">The <see cref="InputState"/> associated with the focusing event.</param>
+        /// <returns>True iff the given drawable is now focused.</returns>
         public bool ChangeFocus(Drawable focus, InputState state)
         {
             if (focus == FocusedDrawable) return FocusedDrawable != null;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -107,7 +107,6 @@ namespace osu.Framework.Input
         /// already focused, nothing happens and no events are fired.
         /// </summary>
         /// <param name="focus">The drawable to become focused.</param>
-        /// <param name="state">The <see cref="InputState"/> associated with the focusing event.</param>
         /// <returns>True iff the given drawable is now focused.</returns>
         public bool ChangeFocus(Drawable focus) => ChangeFocus(focus, CurrentState);
 


### PR DESCRIPTION
Previously, TriggerOnFocus was incorrectly called twice when
a drawable obtained focus via mouse click.