### PR TITLE
Add IHasFilterTerms interface and improve naming

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseSearchContainer.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSearchContainer.cs
@@ -106,7 +106,7 @@ namespace osu.Framework.VisualTests.Tests
         private class HeaderContainer : Container, IHasFilterableChildren
         {
             public string[] FilterTerms => header.FilterTerms;
-            public bool MatchingCurrentFilter
+            public bool MatchingFilter
             {
                 set
                 {
@@ -142,7 +142,7 @@ namespace osu.Framework.VisualTests.Tests
         {
             public string[] FilterTerms => new[] { Text };
 
-            public bool MatchingCurrentFilter
+            public bool MatchingFilter
             {
                 set
                 {

--- a/osu.Framework.VisualTests/Tests/TestCaseSearchContainer.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSearchContainer.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.VisualTests.Tests
                                 new HeaderContainer("Subsection 1")
                                 {
                                     AutoSizeAxes = Axes.Both,
-                                    Children = new[]
+                                    Children = new Drawable[]
                                     {
                                         new SearchableText
                                         {
@@ -59,6 +59,26 @@ namespace osu.Framework.VisualTests.Tests
                                         new SearchableText
                                         {
                                             Text = "444",
+                                        },
+                                        new FilterableFlowContainer
+                                        {
+                                            Direction = FillDirection.Horizontal,
+                                            AutoSizeAxes = Axes.Both,
+                                            Children = new []
+                                            {
+                                                new KeywordText
+                                                {
+                                                    Text = "multi",
+                                                },
+                                                new KeywordText
+                                                {
+                                                    Text = "piece",
+                                                },
+                                                new KeywordText
+                                                {
+                                                    Text = "container",
+                                                },
+                                            }
                                         },
                                         new SearchableText
                                         {
@@ -90,12 +110,14 @@ namespace osu.Framework.VisualTests.Tests
             new Dictionary<string, int>
             {
                 { "test", 2 },
-                { "sUbSeCtIoN 1", 5 },
+                { "sUbSeCtIoN 1", 6 },
                 { "€", 1 },
                 { "èê", 1 },
                 { "321", 0 },
-                { "header", 7 }
-            }.ToList().ForEach(term => {
+                { "mul pi", 1},
+                { "header", 8 }
+            }.ToList().ForEach(term =>
+            {
                 AddStep("Search term: " + term.Key, () => search.SearchTerm = term.Key);
                 AddAssert("Visible end-children: " + term.Value, () => term.Value == search.Children.SelectMany(container => container.Children.Cast<Container>()).SelectMany(container => container.Children).Count(drawable => drawable.IsPresent));
             });
@@ -106,6 +128,7 @@ namespace osu.Framework.VisualTests.Tests
         private class HeaderContainer : Container, IHasFilterableChildren
         {
             public string[] FilterTerms => header.FilterTerms;
+
             public bool MatchingFilter
             {
                 set
@@ -116,6 +139,7 @@ namespace osu.Framework.VisualTests.Tests
                         FadeOut();
                 }
             }
+
             public IEnumerable<IFilterable> FilterableChildren => Children.OfType<IFilterable>();
 
             protected override Container<Drawable> Content => flowContainer;
@@ -135,6 +159,27 @@ namespace osu.Framework.VisualTests.Tests
                     AutoSizeAxes = Axes.Both,
                     Direction = FillDirection.Vertical,
                 });
+            }
+        }
+
+        private class KeywordText : SpriteText, IHasFilterTerms
+        {
+            public string[] FilterTerms => new[] { Text };
+        }
+
+        private class FilterableFlowContainer : FillFlowContainer, IFilterable
+        {
+            public string[] FilterTerms => Children.OfType<IHasFilterTerms>().SelectMany(d => d.FilterTerms).ToArray();
+
+            public bool MatchingFilter
+            {
+                set
+                {
+                    if (value)
+                        Show();
+                    else
+                        Hide();
+                }
             }
         }
 

--- a/osu.Framework/Graphics/Containers/IFilterable.cs
+++ b/osu.Framework/Graphics/Containers/IFilterable.cs
@@ -3,16 +3,11 @@
 
 namespace osu.Framework.Graphics.Containers
 {
-    public interface IFilterable
+    public interface IFilterable : IHasFilterTerms
     {
-        /// <summary>
-        /// An array of relevant terms which match the current object in a filtered scenario.
-        /// </summary>
-        string[] FilterTerms { get; }
-
         /// <summary>
         /// Whether the current object is matching (ie. visible) given the current filter criteria of a parent.
         /// </summary>
-        bool MatchingCurrentFilter { set; }
+        bool MatchingFilter { set; }
     }
 }

--- a/osu.Framework/Graphics/Containers/IHasFilterTerms.cs
+++ b/osu.Framework/Graphics/Containers/IHasFilterTerms.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// An interface to expose a number of keywords with the intent of helping a parent filter results.
+    /// See <see cref="IFilterable"/> for an interface which adds a callback on matching keywords.
+    /// </summary>
+    public interface IHasFilterTerms
+    {
+        /// <summary>
+        /// An array of relevant terms which match the current object in a filtered scenario.
+        /// </summary>
+        string[] FilterTerms { get; }
+    }
+}

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Graphics.Containers
                 foreach (IFilterable searchableChildren in hasFilterableChildren.FilterableChildren)
                     matching |= match(searchableChildren, childTerms);
 
-            return filterable.MatchingCurrentFilter = matching;
+            return filterable.MatchingFilter = matching;
         }
     }
 }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Graphics\Containers\FillFlowContainer.cs" />
     <Compile Include="Graphics\Containers\IFilterable.cs" />
     <Compile Include="Graphics\Containers\IHasFilterableChildren.cs" />
+    <Compile Include="Graphics\Containers\IHasFilterTerms.cs" />
     <Compile Include="Graphics\Containers\SearchContainer.cs" />
     <Compile Include="Graphics\Containers\TabbableContainer.cs" />
     <Compile Include="Graphics\UserInterface\BasicCheckbox.cs" />


### PR DESCRIPTION
Sometimes we want drawables to expose terms but not handle matching themselves (one of their parents may be the one reacting to a filter).

Closes #699