### PR TITLE
Make InternalChildren an IEnumerable<Drawable>

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -224,7 +224,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>The amount of removed children.</returns>
         public int RemoveAll(Predicate<T> pred)
         {
-            List<T> toRemove = Children.Where(d => pred.Invoke(d)).ToList();
+            var toRemove = Children.Where(pred.Invoke).ToList();
             foreach (T removable in toRemove)
                 Remove(removable);
 
@@ -297,11 +297,11 @@ namespace osu.Framework.Graphics.Containers
 
         /// <summary>
         /// Adds a range of children to <see cref="InternalChildren"/>. This is equivalent to calling
-        /// <see cref="AddInternal(T)"/> on each element of the range in order.
+        /// <see cref="AddInternal(Drawable)"/> on each element of the range in order.
         /// </summary>
         protected void AddInternal(IEnumerable<Drawable> range)
         {
-            foreach (T d in range)
+            foreach (Drawable d in range)
                 AddInternal(d);
         }
 
@@ -1029,7 +1029,7 @@ namespace osu.Framework.Graphics.Containers
                 Vector2 maxBoundSize = Vector2.Zero;
 
                 // Find the maximum width/height of children
-                foreach (T c in AliveInternalChildren)
+                foreach (Drawable c in AliveInternalChildren)
                 {
                     if (!c.IsPresent)
                         continue;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -224,11 +224,27 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>The amount of removed children.</returns>
         public int RemoveAll(Predicate<T> pred)
         {
-            var toRemove = Children.Where(pred.Invoke).ToList();
-            foreach (T removable in toRemove)
-                Remove(removable);
+            if (Content != this)
+                return Content.RemoveAll(pred);
 
-            return toRemove.Count;
+            int removedCount = 0;
+
+            for (int i = 0; i < internalChildren.Count; i++)
+            {
+                var tChild = internalChildren[i] as T;
+
+                if (tChild == null)
+                    continue;
+
+                if (pred.Invoke(tChild))
+                {
+                    Remove(tChild);
+                    removedCount++;
+                    i--;
+                }
+            }
+
+            return removedCount;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public IEnumerable<T> Children
         {
-            get { return Content != this ? Content.Children : internalChildren.OfType<T>(); }
+            get { return Content != this ? Content.Children : internalChildren.Cast<T>(); }
 
             set
             {
@@ -299,8 +299,12 @@ namespace osu.Framework.Graphics.Containers
         {
             if (drawable == null)
                 throw new ArgumentNullException(nameof(drawable), "null Drawables may not be added to Containers.");
+
             if (drawable == this)
                 throw new InvalidOperationException("Container may not be added to itself.");
+
+            if (Content == this && !(drawable is T))
+                throw new ArgumentException($"Only {typeof(T).Name} type drawables may be added to a container of type {this.GetType().Name} which does not redirect {nameof(Content)}.");
 
             if (drawable.IsLoaded)
                 drawable.Parent = this;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -313,7 +313,7 @@ namespace osu.Framework.Graphics.Containers
                 throw new InvalidOperationException("Container may not be added to itself.");
 
             if (Content == this && !(drawable is T))
-                throw new InvalidOperationException($"Only {typeof(T).ReadableName()} type drawables may be added to a container of type {this.GetType().ReadableName()} which does not redirect {nameof(Content)}.");
+                throw new InvalidOperationException($"Only {typeof(T).ReadableName()} type drawables may be added to a container of type {GetType().ReadableName()} which does not redirect {nameof(Content)}.");
 
             if (drawable.IsLoaded)
                 drawable.Parent = this;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -18,6 +18,7 @@ using osu.Framework.Timing;
 using osu.Framework.Caching;
 using System.Threading.Tasks;
 using System.Linq;
+using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -312,7 +313,7 @@ namespace osu.Framework.Graphics.Containers
                 throw new InvalidOperationException("Container may not be added to itself.");
 
             if (Content == this && !(drawable is T))
-                throw new ArgumentException($"Only {typeof(T).Name} type drawables may be added to a container of type {this.GetType().Name} which does not redirect {nameof(Content)}.");
+                throw new InvalidOperationException($"Only {typeof(T).ReadableName()} type drawables may be added to a container of type {this.GetType().ReadableName()} which does not redirect {nameof(Content)}.");
 
             if (drawable.IsLoaded)
                 drawable.Parent = this;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -908,7 +908,7 @@ namespace osu.Framework.Graphics.Containers
         /// It is not allowed to manually set <see cref="Size"/> (or <see cref="Width"/> / <see cref="Height"/>)
         /// on any <see cref="Axes"/> which are automatically sized.
         /// </summary>
-        public Axes AutoSizeAxes
+        public virtual Axes AutoSizeAxes
         {
             get { return autoSizeAxes; }
             set

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -118,8 +118,16 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public IEnumerable<T> Children
         {
-            get { return Content != this ? Content.Children : internalChildren.Cast<T>(); }
+            get
+            {
+                if (Content != this)
+                    return Content.Children;
 
+                if (typeof(T) == typeof(Drawable))
+                    return (IEnumerable<T>)internalChildren;
+
+                return internalChildren.Cast<T>();
+            }
             set
             {
                 Clear();

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -256,7 +256,7 @@ namespace osu.Framework.Graphics.Containers
                 return;
             }
 
-            foreach (T t in internalChildren)
+            foreach (Drawable t in internalChildren)
             {
                 if (disposeChildren)
                 {
@@ -331,7 +331,7 @@ namespace osu.Framework.Graphics.Containers
                 return;
 
             base.UpdateClock(clock);
-            foreach (T child in InternalChildren)
+            foreach (Drawable child in internalChildren)
                 child.UpdateClock(Clock);
         }
 
@@ -355,7 +355,7 @@ namespace osu.Framework.Graphics.Containers
             // for children, as they should never affect our present status.
             if (!IsPresent || !RequiresChildrenUpdate) return false;
 
-            foreach (T child in internalChildren.AliveItems)
+            foreach (Drawable child in internalChildren.AliveItems)
                 if (child.IsLoaded) child.UpdateSubTree();
 
             UpdateAfterChildren();
@@ -641,7 +641,7 @@ namespace osu.Framework.Graphics.Containers
                 return false;
 
             //don't use AliveInternalChildren here as it will cause too many allocations (IEnumerable).
-            foreach (T d in internalChildren.AliveItems)
+            foreach (Drawable d in internalChildren.AliveItems)
                 d.BuildKeyboardInputQueue(queue);
 
             return true;
@@ -653,7 +653,7 @@ namespace osu.Framework.Graphics.Containers
                 return false;
 
             //don't use AliveInternalChildren here as it will cause too many allocations (IEnumerable).
-            foreach (T d in internalChildren.AliveItems)
+            foreach (Drawable d in internalChildren.AliveItems)
                 d.BuildMouseInputQueue(screenSpaceMousePos, queue);
 
             return true;
@@ -831,7 +831,7 @@ namespace osu.Framework.Graphics.Containers
                 padding = value;
                 padding.ThrowIfNegative();
 
-                foreach (T c in internalChildren)
+                foreach (Drawable c in internalChildren)
                     c.Invalidate(Invalidation.Geometry);
             }
         }
@@ -865,7 +865,7 @@ namespace osu.Framework.Graphics.Containers
                     return;
                 relativeCoordinateSpace = value;
 
-                foreach (T c in internalChildren)
+                foreach (Drawable c in internalChildren)
                     c.Invalidate(Invalidation.Geometry);
             }
         }

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.Containers
     /// <see cref="Drawable.Anchor"/> is to the top or centered vertically.
     /// They are arranged from bottom-to-top otherwise.
     /// If non-<see cref="Drawable"/> <see cref="Container{T}.Children"/> are desired, use
-    /// <see cref="FillFlowContainer{T}"/>. 
+    /// <see cref="FillFlowContainer{T}"/>.
     /// </summary>
     public class FillFlowContainer : FillFlowContainer<Drawable>
     {
@@ -99,7 +99,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Vector2 spacingFactor(T c)
+        private Vector2 spacingFactor(Drawable c)
         {
             Vector2 result = c.RelativeOriginPosition;
             if ((c.Anchor & Anchor.x2) > 0)
@@ -145,7 +145,7 @@ namespace osu.Framework.Graphics.Containers
             Vector2 size = Vector2.Zero;
             for (int i = 0; i < children.Length; ++i)
             {
-                T c = children[i];
+                Drawable c = children[i];
 
                 // Populate running variables with sane initial values.
                 if (i == 0)

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -92,7 +92,7 @@ namespace osu.Framework.Graphics.Containers
             base.InvalidateFromChild(invalidation);
         }
 
-        protected virtual IEnumerable<T> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent);
+        protected virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent);
 
         protected abstract IEnumerable<Vector2> ComputeLayoutPositions();
 

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Graphics.Containers
     public interface IContainerEnumerable<out T> : IContainer
         where T : IDrawable
     {
-        IEnumerable<T> InternalChildren { get; }
+        IEnumerable<Drawable> InternalChildren { get; }
         IEnumerable<T> Children { get; }
 
         int RemoveAll(Predicate<T> match);
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.Containers
     public interface IContainerCollection<in T> : IContainer
         where T : IDrawable
     {
-        IEnumerable<T> InternalChildren { set; }
+        IEnumerable<Drawable> InternalChildren { set; }
         IEnumerable<T> Children { set; }
 
         void Add(T drawable);

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -236,7 +236,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             protected override IComparer<Drawable> DepthComparer => new ReverseCreationOrderDepthComparer();
 
-            protected override IEnumerable<U> FlowingChildren => base.FlowingChildren.Reverse();
+            protected override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
 
             protected override IEnumerable<Vector2> ComputeLayoutPositions()
             {
@@ -245,7 +245,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 var result = base.ComputeLayoutPositions().ToArray();
                 int i = 0;
-                foreach (var child in FlowingChildren)
+                foreach (var child in FlowingChildren.OfType<U>())
                 {
                     updateChildIfNeeded(child, result[i].Y == 0);
                     ++i;


### PR DESCRIPTION
There are many cases in which it is desired to expose a generic `Container.Add(T)`, but have the ability to add children from inside the container that are not of type `T`. Since `InternalChildren` and `AddInternal` are protected functions, it seems fair to allow `AddInternal = new Drawable[]` in this sort of use case.

An example of such a use case is as follows:

```
public class MyContainer : Container<MyType>
{
	protected override Container<MyType> Content => content;
	private Container<MyType> content;

	public MyContainer()
	{
		// This line would previously fail due to AddInternal(MyType drawable)
		AddInternal(content = new Container<Mytype>());
	}
}
```