### PR TITLE
Generalize several tests to GridTestCase and improve TestCaseInputResampler

### DIFF
--- a/osu.Framework.Testing/GridTestCase.cs
+++ b/osu.Framework.Testing/GridTestCase.cs
@@ -8,13 +8,29 @@ using System.Linq;
 
 namespace osu.Framework.Testing
 {
+    /// <summary>
+    /// An abstract test case which exposes small cells arranged in a grid.
+    /// Useful for displaying multiple configurations of a tested component at a glance.
+    /// </summary>
     public abstract class GridTestCase : TestCase
     {
         private FillFlowContainer<Container> testContainer;
 
+        /// <summary>
+        /// The amount of rows of the grid.
+        /// </summary>
         protected int Rows { get; }
+
+        /// <summary>
+        /// The amount of columns of the grid.
+        /// </summary>
         protected int Cols { get; }
 
+        /// <summary>
+        /// Constructs a grid test case with the given dimensions.
+        /// </summary>
+        /// <param name="rows">The amount of rows of the grid.</param>
+        /// <param name="cols">The amount of columns of the grid.</param>
         public GridTestCase(int rows, int cols)
         {
             Rows = rows;
@@ -38,8 +54,14 @@ namespace osu.Framework.Testing
             Add(testContainer);
         }
 
+        /// <summary>
+        /// Access a cell by its index. Valid indices range from 0 to <see cref="Rows"/> * <see cref="Cols"/> - 1.
+        /// </summary>
         protected Container Cell(int index) => testContainer.Children.ElementAt(index);
 
+        /// <summary>
+        /// Access a cell by its row and column.
+        /// </summary>
         protected Container Cell(int row, int col) => Cell(col + row * Cols);
     }
 }

--- a/osu.Framework.Testing/GridTestCase.cs
+++ b/osu.Framework.Testing/GridTestCase.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using System.Linq;
+
+namespace osu.Framework.Testing
+{
+    public abstract class GridTestCase : TestCase
+    {
+        private FillFlowContainer<Container> testContainer;
+
+        protected int Rows { get; }
+        protected int Cols { get; }
+
+        public GridTestCase(int rows, int cols)
+        {
+            Rows = rows;
+            Cols = cols;
+        }
+
+        private Container createCell() => new Container
+        {
+            RelativeSizeAxes = Axes.Both,
+            Size = new Vector2(1.0f / Cols, 1.0f / Rows),
+        };
+
+        public override void Reset()
+        {
+            base.Reset();
+
+            testContainer = new FillFlowContainer<Container> { RelativeSizeAxes = Axes.Both };
+            for (int i = 0; i < Rows * Cols; ++i)
+                testContainer.Add(createCell());
+
+            Add(testContainer);
+        }
+
+        protected Container Cell(int index) => testContainer.Children.ElementAt(index);
+
+        protected Container Cell(int row, int col) => Cell(col + row * Cols);
+    }
+}

--- a/osu.Framework.Testing/GridTestCase.cs
+++ b/osu.Framework.Testing/GridTestCase.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Testing
         /// </summary>
         /// <param name="rows">The amount of rows of the grid.</param>
         /// <param name="cols">The amount of columns of the grid.</param>
-        public GridTestCase(int rows, int cols)
+        protected GridTestCase(int rows, int cols)
         {
             Rows = rows;
             Cols = cols;

--- a/osu.Framework.Testing/TestBrowser.cs
+++ b/osu.Framework.Testing/TestBrowser.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Testing
         {
             //we want to build the lists here because we're interested in the assembly we were *created* on.
             Assembly asm = Assembly.GetCallingAssembly();
-            foreach (Type type in asm.GetLoadableTypes().Where(t => t.IsSubclassOf(typeof(TestCase))))
+            foreach (Type type in asm.GetLoadableTypes().Where(t => t.IsSubclassOf(typeof(TestCase)) && !t.IsAbstract))
                 Tests.Add((TestCase)Activator.CreateInstance(type));
 
             Tests.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.Ordinal));

--- a/osu.Framework.Testing/osu.Framework.Testing.csproj
+++ b/osu.Framework.Testing/osu.Framework.Testing.csproj
@@ -46,6 +46,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GridTestCase.cs" />
     <Compile Include="TestRunner.cs" />
     <Compile Include="Drawables\StepButtons\AssertButton.cs" />
     <Compile Include="Drawables\StepButtons\SingleStepButton.cs" />

--- a/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.VisualTests.Tests
                 },
             };
 
-            string[] labels = new string[]
+            string[] labels =
             {
                 "Colours",
                 "White to black (linear brightness gradient)",

--- a/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
@@ -11,8 +11,12 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {
-    internal class TestCaseColourGradient : TestCase
+    internal class TestCaseColourGradient : GridTestCase
     {
+        public TestCaseColourGradient() : base(2, 2)
+        {
+        }
+
         public override string Description => @"Various cases of colour gradients.";
 
         private readonly Box[] boxes = new Box[4];
@@ -55,111 +59,34 @@ namespace osu.Framework.VisualTests.Tests
                 },
             };
 
-            Add(new Container
+            string[] labels = new string[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new[]
+                "Colours",
+                "White to black (linear brightness gradient)",
+                "White to transparent white (sRGB brightness gradient)",
+                "White to transparent black (mixed brightness gradient)",
+            };
+
+            for (int i = 0; i < Rows * Cols; ++i)
+            {
+                Cell(i).Add(new Drawable[]
                 {
-                    new FillFlowContainer
+                    new SpriteText
+                    {
+                        Text = labels[i],
+                        TextSize = 20,
+                        ColourInfo = colours[0],
+                    },
+                    boxes[i] = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Children = new[]
-                        {
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "Colours",
-                                        TextSize = 20,
-                                        ColourInfo = colours[0],
-                                    },
-                                    boxes[0] = new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Size = new Vector2(0.5f),
-                                        ColourInfo = colours[0],
-                                    }
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "White to black (linear brightness gradient)",
-                                        TextSize = 20,
-                                        ColourInfo = colours[0],
-                                    },
-                                    boxes[1] = new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.White,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Size = new Vector2(0.5f),
-                                        ColourInfo = colours[1],
-                                    }
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "White to transparent white (sRGB brightness gradient)",
-                                        TextSize = 20,
-                                        ColourInfo = colours[0],
-                                    },
-                                    boxes[2] = new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.White,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Size = new Vector2(0.5f),
-                                        ColourInfo = colours[2],
-                                    }
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "White to transparent black (mixed brightness gradient)",
-                                        TextSize = 20,
-                                        ColourInfo = colours[0],
-                                    },
-                                    boxes[3] = new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.White,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Size = new Vector2(0.5f),
-                                        ColourInfo = colours[3],
-                                    }
-                                }
-                            },
-                        }
-                    }
-                }
-            });
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(0.5f),
+                        ColourInfo = colours[i],
+                    },
+                });
+            }
         }
 
         protected override void Update()

--- a/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;

--- a/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
@@ -15,8 +15,19 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {
-    internal class TestCaseDrawablePath : TestCase
+    internal class TestCaseDrawablePath : GridTestCase
     {
+        public TestCaseDrawablePath() : base(2, 2)
+        {
+        }
+
+        private Drawable createLabel(string text) => new SpriteText
+        {
+            Text = text,
+            TextSize = 20,
+            Colour = Color4.White,
+        };
+
         public override string Description => @"Various cases of drawable paths.";
 
         public override void Reset()
@@ -37,120 +48,69 @@ namespace osu.Framework.VisualTests.Tests
             }
             gradientTexture.SetData(new TextureUpload(data));
 
-            Add(new Container
+            Cell(0).Add(new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new[]
+                createLabel("Simple path"),
+                new Path
                 {
-                    new FillFlowContainer
+                    RelativeSizeAxes = Axes.Both,
+                    Positions = new List<Vector2> { Vector2.One * 50, Vector2.One * 100 },
+                    Texture = gradientTexture,
+                    Colour = Color4.Green,
+                },
+            });
+
+            Cell(1).Add(new Drawable[]
+            {
+                createLabel("Curved path"),
+                new Path
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Positions = new List<Vector2>
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Children = new[]
-                        {
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "Simple path",
-                                        TextSize = 20,
-                                        Colour = Color4.White,
-                                    },
-                                    new Path
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Positions = new List<Vector2> { Vector2.One * 50, Vector2.One * 100 },
-                                        Texture = gradientTexture,
-                                        Colour = Color4.Green,
-                                    },
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "Curved path",
-                                        TextSize = 20,
-                                        Colour = Color4.White,
-                                    },
-                                    new Path
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Positions = new List<Vector2>
-                                        {
-                                            new Vector2(50, 50),
-                                            new Vector2(50, 250),
-                                            new Vector2(250, 250),
-                                            new Vector2(250, 50),
-                                            new Vector2(50, 50),
-                                        },
-                                        Texture = gradientTexture,
-                                        Colour = Color4.Blue,
-                                    },
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "Self-overlapping path",
-                                        TextSize = 20,
-                                        Colour = Color4.White,
-                                    },
-                                    new Path
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Positions = new List<Vector2>
-                                        {
-                                            new Vector2(50, 50),
-                                            new Vector2(50, 250),
-                                            new Vector2(250, 250),
-                                            new Vector2(250, 150),
-                                            new Vector2(20, 150),
-                                        },
-                                        Texture = gradientTexture,
-                                        Colour = Color4.Red,
-                                    },
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "Draw something ;)",
-                                        TextSize = 20,
-                                        Colour = Color4.White,
-                                    },
-                                    new DrawablePath
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Texture = gradientTexture,
-                                        Colour = Color4.White,
-                                    },
-                                }
-                            },
-                        }
-                    }
-                }
+                        new Vector2(50, 50),
+                        new Vector2(50, 250),
+                        new Vector2(250, 250),
+                        new Vector2(250, 50),
+                        new Vector2(50, 50),
+                    },
+                    Texture = gradientTexture,
+                    Colour = Color4.Blue,
+                },
+            });
+
+            Cell(2).Add(new Drawable[]
+            {
+                createLabel("Self-overlapping path"),
+                new Path
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Positions = new List<Vector2>
+                    {
+                        new Vector2(50, 50),
+                        new Vector2(50, 250),
+                        new Vector2(250, 250),
+                        new Vector2(250, 150),
+                        new Vector2(20, 150),
+                    },
+                    Texture = gradientTexture,
+                    Colour = Color4.Red,
+                },
+            });
+
+            Cell(3).Add(new Drawable[]
+            {
+                createLabel("Draw something ;)"),
+                new UserDrawnPath
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Texture = gradientTexture,
+                    Colour = Color4.White,
+                },
             });
         }
 
-        private class DrawablePath : Path
+        private class UserDrawnPath : Path
         {
             public override bool HandleInput => true;
 

--- a/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.VisualTests.Tests
             }
             gradientTexture.SetData(new TextureUpload(data));
 
-            Cell(0).Add(new Drawable[]
+            Cell(0).Add(new[]
             {
                 createLabel("Simple path"),
                 new Path
@@ -59,7 +59,7 @@ namespace osu.Framework.VisualTests.Tests
                 },
             });
 
-            Cell(1).Add(new Drawable[]
+            Cell(1).Add(new[]
             {
                 createLabel("Curved path"),
                 new Path
@@ -78,7 +78,7 @@ namespace osu.Framework.VisualTests.Tests
                 },
             });
 
-            Cell(2).Add(new Drawable[]
+            Cell(2).Add(new[]
             {
                 createLabel("Self-overlapping path"),
                 new Path
@@ -97,7 +97,7 @@ namespace osu.Framework.VisualTests.Tests
                 },
             });
 
-            Cell(3).Add(new Drawable[]
+            Cell(3).Add(new[]
             {
                 createLabel("Draw something ;)"),
                 new UserDrawnPath

--- a/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseDrawablePath.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;

--- a/osu.Framework.VisualTests/Tests/TestCaseFillModes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFillModes.cs
@@ -13,8 +13,12 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {
-    internal class TestCaseFillModes : TestCase
+    internal class TestCaseFillModes : GridTestCase
     {
+        public TestCaseFillModes() : base(2, 2)
+        {
+        }
+
         public override string Description => @"Test sprite display and fill modes";
 
         private Texture sampleTexture;
@@ -29,147 +33,48 @@ namespace osu.Framework.VisualTests.Tests
         {
             base.Reset();
 
-            Children = new Drawable[]
+            FillMode[] fillModes =
             {
-                new FillFlowContainer
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
-                    {
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"FillMode.None" },
-                                new Container
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.5f),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Masking = true,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.Blue,
-                                        },
-                                        new Sprite
-                                        {
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Texture = sampleTexture
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"FillMode.Stretch" },
-                                new Container
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.5f),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Masking = true,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.Blue,
-                                        },
-                                        new Sprite
-                                        {
-                                            FillMode = FillMode.Stretch,
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Texture = sampleTexture
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"FillMode.Fill" },
-                                new Container
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.5f),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Masking = true,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.Blue,
-                                        },
-                                        new Sprite
-                                        {
-                                            FillMode = FillMode.Fill,
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Texture = sampleTexture
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"FillMode.Fit" },
-                                new Container
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.5f),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Masking = true,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.Blue,
-                                        },
-                                        new Sprite
-                                        {
-                                            FillMode = FillMode.Fit,
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Texture = sampleTexture
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                    }
-                }
+                FillMode.None,
+                FillMode.Stretch,
+                FillMode.Fit,
+                FillMode.Fill,
             };
+
+            for (int i = 0; i < Rows * Cols; ++i)
+            {
+                Cell(i).Add(new Drawable[]
+                {
+                    new SpriteText
+                    {
+                        Text = $"{nameof(FillMode)}=FillMode.{fillModes[i]}",
+                        TextSize = 20,
+                    },
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(0.5f),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Masking = true,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4.Blue,
+                            },
+                            new Sprite
+                            {
+                                FillMode = fillModes[i],
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Texture = sampleTexture
+                            }
+                        }
+                    }
+                });
+            }
         }
 
         private class PaddedBox : Container

--- a/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
@@ -32,12 +32,13 @@ namespace osu.Framework.VisualTests.Tests
 
         private FillFlowContainer fillContainer;
         private ScheduledDelegate scheduledAdder;
-        private bool addChildren;
+        private bool doNotAddChildren;
 
         public override void Reset()
         {
             base.Reset();
 
+            doNotAddChildren = false;
             scheduledAdder?.Cancel();
 
             Add(new Container
@@ -292,7 +293,7 @@ namespace osu.Framework.VisualTests.Tests
                 }
             });
 
-            AddToggleStep("Stop adding children", state => { addChildren = state; });
+            AddToggleStep("Stop adding children", state => { doNotAddChildren = state; });
 
             scheduledAdder?.Cancel();
             scheduledAdder = Scheduler.AddDelayed(
@@ -301,12 +302,12 @@ namespace osu.Framework.VisualTests.Tests
                     if (fillContainer.Parent == null)
                         scheduledAdder.Cancel();
 
-                    if (addChildren)
+                    if (doNotAddChildren)
                     {
                         fillContainer.Invalidate();
                     }
 
-                    if (fillContainer.Children.Count() < 1000 && !addChildren)
+                    if (fillContainer.Children.Count() < 1000 && !doNotAddChildren)
                     {
                         fillContainer.Add(new Container
                         {

--- a/osu.Framework.VisualTests/Tests/TestCaseHollowEdgeEffect.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseHollowEdgeEffect.cs
@@ -58,14 +58,6 @@ namespace osu.Framework.VisualTests.Tests
                 },
             };
 
-            string[] labels = new string[]
-            {
-                "Colours",
-                "White to black (linear brightness gradient)",
-                "White to transparent white (sRGB brightness gradient)",
-                "White to transparent black (mixed brightness gradient)",
-            };
-
             for (int i = 0; i < Rows * Cols; ++i)
             {
                 Cell(i).Add(new Drawable[]

--- a/osu.Framework.VisualTests/Tests/TestCaseHollowEdgeEffect.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseHollowEdgeEffect.cs
@@ -10,184 +10,93 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.VisualTests.Tests
 {
-    public class TestCaseHollowEdgeEffect : TestCase
+    public class TestCaseHollowEdgeEffect : GridTestCase
     {
+        public TestCaseHollowEdgeEffect() : base(2, 2)
+        {
+        }
+
         public override string Description => @"Hollow Container with EdgeEffect";
 
         public override void Reset()
         {
             base.Reset();
 
-            Children = new Drawable[]
+            const float size = 60;
+
+            float[] cornerRadii = { 0, 0.5f, 0, 0.5f };
+            float[] alphas = { 0.5f, 0.5f, 0, 0 };
+            EdgeEffect[] edgeEffects =
             {
-                new FillFlowContainer
+                new EdgeEffect
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
-                    {
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"Corner 0f | 0.5f Transparency" },
-                                new Container
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.5f),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Children = new Drawable[]
-                                    {
-                                        new Container()
-                                        {
-                                            Size = new Vector2(200f, 100f),
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-
-                                            Masking = true,
-                                            EdgeEffect = new EdgeEffect()
-                                            {
-                                                Type = EdgeEffectType.Glow,
-                                                Colour = Color4.Khaki,
-                                                Radius = 100f,
-                                                Hollow = true
-                                            },
-                                            CornerRadius = 0f,
-
-                                            Children = new Drawable[]
-                                            {
-                                                new Box()
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = Color4.Aqua,
-                                                    Alpha = 0.5f
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"Corner 50f | 0.5f Transparency" },
-                                new Container
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.5f),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Children = new Drawable[]
-                                    {
-                                        new Container()
-                                        {
-                                            Size = new Vector2(100f),
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-
-                                            Masking = true,
-                                            EdgeEffect = new EdgeEffect()
-                                            {
-                                                Type = EdgeEffectType.Glow,
-                                                Colour = Color4.Khaki,
-                                                Radius = 100f,
-                                                Hollow = true
-                                            },
-                                            CornerRadius = 50f,
-
-                                            Children = new Drawable[]
-                                            {
-                                                new Box()
-                                                {
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Colour = Color4.Aqua,
-                                                    Alpha = 0.5f
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"Corner 0f | No fill" },
-                                new Container
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.5f),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Children = new Drawable[]
-                                    {
-                                        new Container()
-                                        {
-                                            Size = new Vector2(200f, 100f),
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-
-                                            Masking = true,
-                                            EdgeEffect = new EdgeEffect()
-                                            {
-                                                Type = EdgeEffectType.Glow,
-                                                Colour = Color4.Khaki,
-                                                Radius = 100f,
-                                                Hollow = true
-                                            },
-                                            CornerRadius = 0f
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"Corner 50f | No fill" },
-                                new Container
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.5f),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Children = new Drawable[]
-                                    {
-                                        new Container()
-                                        {
-                                            Size = new Vector2(100f),
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-
-                                            Masking = true,
-                                            EdgeEffect = new EdgeEffect()
-                                            {
-                                                Type = EdgeEffectType.Glow,
-                                                Colour = Color4.Khaki,
-                                                Radius = 100f,
-                                                Hollow = true
-                                            },
-                                            CornerRadius = 50f
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                    }
-                }
+                    Type = EdgeEffectType.Glow,
+                    Colour = Color4.Khaki,
+                    Radius = size,
+                    Hollow = true,
+                },
+                new EdgeEffect
+                {
+                    Type = EdgeEffectType.Glow,
+                    Colour = Color4.Khaki,
+                    Radius = size,
+                    Hollow = true,
+                },
+                new EdgeEffect
+                {
+                    Type = EdgeEffectType.Glow,
+                    Colour = Color4.Khaki,
+                    Radius = size,
+                    Hollow = true,
+                },
+                new EdgeEffect
+                {
+                    Type = EdgeEffectType.Glow,
+                    Colour = Color4.Khaki,
+                    Radius = size,
+                    Hollow = true,
+                },
             };
+
+            string[] labels = new string[]
+            {
+                "Colours",
+                "White to black (linear brightness gradient)",
+                "White to transparent white (sRGB brightness gradient)",
+                "White to transparent black (mixed brightness gradient)",
+            };
+
+            for (int i = 0; i < Rows * Cols; ++i)
+            {
+                Cell(i).Add(new Drawable[]
+                {
+                    new SpriteText
+                    {
+                        Text = $"{nameof(CornerRadius)}={cornerRadii[i]} {nameof(Alpha)}={alphas[i]}",
+                        TextSize = 20,
+                    },
+                    new Container()
+                    {
+                        Size = new Vector2(size),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+
+                        Masking = true,
+                        EdgeEffect = edgeEffects[i],
+                        CornerRadius = cornerRadii[i] * size,
+
+                        Children = new Drawable[]
+                        {
+                            new Box()
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = Color4.Aqua,
+                                Alpha = alphas[i],
+                            },
+                        },
+                    },
+                });
+            }
         }
     }
 }

--- a/osu.Framework.VisualTests/Tests/TestCaseInputResampler.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseInputResampler.cs
@@ -15,20 +15,31 @@ using System;
 
 namespace osu.Framework.VisualTests.Tests
 {
-    internal class TestCaseInputResampler : TestCase
+    internal class TestCaseInputResampler : GridTestCase
     {
+        public TestCaseInputResampler() : base(3, 3)
+        {
+        }
+
+        private SpriteText createLabel(string text) => new SpriteText
+        {
+            Text = text,
+            TextSize = 14,
+            Colour = Color4.White,
+        };
+
         public override string Description => @"Live optimizing paths to relevant nodes.";
 
         public override void Reset()
         {
             base.Reset();
 
-            const int width = 20;
+            const int width = 2;
             Texture gradientTexture = new Texture(width, 1, true);
             byte[] data = new byte[width * 4];
             for (int i = 0; i < width; ++i)
             {
-                float brightness = (float)i / (width - 1);
+                float brightness = (float)i / (width - 1); ;
                 int index = i * 4;
                 data[index + 0] = (byte)(brightness * 255);
                 data[index + 1] = (byte)(brightness * 255);
@@ -37,105 +48,105 @@ namespace osu.Framework.VisualTests.Tests
             }
             gradientTexture.SetData(new TextureUpload(data));
 
-            SpriteText arc1Text, arc2Text, arc3Text;
-            SpriteText drawText;
+            SpriteText[] text = new SpriteText[6];
 
-            Add(new Container
+            Cell(0, 0).Add(new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new[]
+                text[0] = createLabel("Raw"),
+                new ArcPath(true, true, new InputResampler(), gradientTexture, Color4.Green, text[0]),
+            });
+
+            Cell(0, 1).Add(new Drawable[]
+            {
+                text[1] = createLabel("Rounded (resembles mouse input)"),
+                new ArcPath(true, false, new InputResampler(), gradientTexture, Color4.Blue, text[1]),
+            });
+
+            Cell(0, 2).Add(new Drawable[]
+            {
+                text[2] = createLabel("Custom: Smoothed=0, Raw=0"),
+                new UserDrawnPath
                 {
-                    new FillFlowContainer
+                    DrawText = text[2],
+                    RelativeSizeAxes = Axes.Both,
+                    Texture = gradientTexture,
+                    Colour = Color4.White,
+                },
+            });
+
+            Cell(1, 0).Add(new Drawable[]
+            {
+                text[3] = createLabel("Smoothed raw"),
+                new ArcPath(false, true, new InputResampler(), gradientTexture, Color4.Green, text[3]),
+            });
+
+            Cell(1, 1).Add(new Drawable[]
+            {
+                text[4] = createLabel("Smoothed rounded"),
+                new ArcPath(false, false, new InputResampler(), gradientTexture, Color4.Blue, text[4]),
+            });
+
+            Cell(1, 2).Add(new Drawable[]
+            {
+                text[5] = createLabel("Smoothed custom: Smoothed=0, Raw=0"),
+                new SmoothedUserDrawnPath
+                {
+                    DrawText = text[5],
+                    RelativeSizeAxes = Axes.Both,
+                    Texture = gradientTexture,
+                    Colour = Color4.White,
+                    InputResampler = new InputResampler(),
+                },
+            });
+
+            Cell(2, 0).Add(new Drawable[]
+            {
+                text[3] = createLabel("Force-smoothed raw"),
+                new ArcPath(false, true, new InputResampler() { ResampleRawInput = true }, gradientTexture, Color4.Green, text[3]),
+            });
+
+            Cell(2, 1).Add(new Drawable[]
+            {
+                text[4] = createLabel("Force-smoothed rounded"),
+                new ArcPath(false, false, new InputResampler() { ResampleRawInput = true }, gradientTexture, Color4.Blue, text[4]),
+            });
+
+            Cell(2, 2).Add(new Drawable[]
+            {
+                text[5] = createLabel("Force-smoothed custom: Smoothed=0, Raw=0"),
+                new SmoothedUserDrawnPath
+                {
+                    DrawText = text[5],
+                    RelativeSizeAxes = Axes.Both,
+                    Texture = gradientTexture,
+                    Colour = Color4.White,
+                    InputResampler = new InputResampler()
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Children = new[]
-                        {
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    arc1Text = new SpriteText
-                                    {
-                                        Text = "Raw Arc",
-                                        TextSize = 20,
-                                        Colour = Color4.White,
-                                    },
-                                    new ArcPath(true, new InputResampler(), gradientTexture, Color4.Green, arc1Text),
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    arc2Text = new SpriteText
-                                    {
-                                        Text = "Smoothed Arc",
-                                        TextSize = 20,
-                                        Colour = Color4.White,
-                                    },
-                                    new ArcPath(false, new InputResampler(), gradientTexture, Color4.Blue, arc2Text),
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    arc3Text = new SpriteText
-                                    {
-                                        Text = "Smoothed Raw Arc",
-                                        TextSize = 20,
-                                        Colour = Color4.White,
-                                    },
-                                    new ArcPath(true, new InputResampler
-                                        {
-                                            ResampleRawInput = true
-                                        }, gradientTexture, Color4.Red, arc3Text),
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    drawText = new SpriteText
-                                    {
-                                        Text = "Custom Smoothed Drawn: Smoothed=0, Raw=0",
-                                        TextSize = 20,
-                                        Colour = Color4.White,
-                                    },
-                                    new DrawablePath
-                                    {
-                                        DrawText = drawText,
-                                        RelativeSizeAxes = Axes.Both,
-                                        Texture = gradientTexture,
-                                        Colour = Color4.White,
-                                        InputResampler = new InputResampler()
-                                        {
-                                            ResampleRawInput = true
-                                        },
-                                    },
-                                }
-                            },
-                        }
-                    }
-                }
+                        ResampleRawInput = true
+                    },
+                },
             });
         }
 
         private class SmoothedPath : Path
         {
+            public SmoothedPath()
+            {
+                PathWidth = 2;
+            }
+
             public InputResampler InputResampler { get; set; } = new InputResampler();
 
             protected int NumVertices { get; set; }
 
             protected int NumRaw { get; set; }
+
+            protected void AddRawVertex(Vector2 pos)
+            {
+                NumRaw++;
+                AddVertex(pos);
+                NumVertices++;
+            }
 
             protected bool AddSmoothedVertex(Vector2 pos)
             {
@@ -153,7 +164,7 @@ namespace osu.Framework.VisualTests.Tests
 
         private class ArcPath : SmoothedPath
         {
-            public ArcPath(bool raw, InputResampler inputResampler, Texture texture, Color4 colour, SpriteText output)
+            public ArcPath(bool raw, bool keepFraction, InputResampler inputResampler, Texture texture, Color4 colour, SpriteText output)
             {
                 InputResampler = inputResampler;
                 const int target_raw = 1024;
@@ -165,37 +176,48 @@ namespace osu.Framework.VisualTests.Tests
                 {
                     float x = (float) (Math.Sin(i / (double) target_raw * (Math.PI * 0.5)) * 200) + 50.5f;
                     float y = (float) (Math.Cos(i / (double) target_raw * (Math.PI * 0.5)) * 200) + 50.5f;
-                    if (!raw)
-                    {
-                        x = (int) x;
-                        y = (int) y;
-                    }
-                    AddSmoothedVertex(new Vector2(x, y));
+                    Vector2 v;
+                    if (keepFraction)
+                        v = new Vector2(x, y);
+                    else
+                        v = new Vector2((int)x, (int)y);
+
+                    if (raw)
+                        AddRawVertex(v);
+                    else
+                        AddSmoothedVertex(v);
                 }
 
                 output.Text += ": Smoothed=" + NumVertices + ", Raw=" + NumRaw;
             }
         }
 
-        private class DrawablePath : SmoothedPath
+        private class UserDrawnPath : SmoothedPath
         {
             public override bool HandleInput => true;
 
             public SpriteText DrawText;
 
+            protected virtual void AddUserVertex(Vector2 v) => AddRawVertex(v);
+
             protected override bool OnDragStart(InputState state)
             {
-                AddSmoothedVertex(state.Mouse.Position);
+                AddUserVertex(state.Mouse.Position);
                 DrawText.Text = "Custom Smoothed Drawn: Smoothed=" + NumVertices + ", Raw=" + NumRaw;
                 return true;
             }
 
             protected override bool OnDrag(InputState state)
             {
-                AddSmoothedVertex(state.Mouse.Position);
+                AddUserVertex(state.Mouse.Position);
                 DrawText.Text = "Custom Smoothed Drawn: Smoothed=" + NumVertices + ", Raw=" + NumRaw;
                 return base.OnDrag(state);
             }
+        }
+
+        private class SmoothedUserDrawnPath : UserDrawnPath
+        {
+            protected override void AddUserVertex(Vector2 v) => AddSmoothedVertex(v);
         }
     }
 }

--- a/osu.Framework.VisualTests/Tests/TestCaseInputResampler.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseInputResampler.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.VisualTests.Tests
             byte[] data = new byte[width * 4];
             for (int i = 0; i < width; ++i)
             {
-                float brightness = (float)i / (width - 1); ;
+                float brightness = (float)i / (width - 1);
                 int index = i * 4;
                 data[index + 0] = (byte)(brightness * 255);
                 data[index + 1] = (byte)(brightness * 255);
@@ -129,7 +129,7 @@ namespace osu.Framework.VisualTests.Tests
 
         private class SmoothedPath : Path
         {
-            public SmoothedPath()
+            protected SmoothedPath()
             {
                 PathWidth = 2;
             }
@@ -175,12 +175,7 @@ namespace osu.Framework.VisualTests.Tests
                 {
                     float x = (float) (Math.Sin(i / (double) target_raw * (Math.PI * 0.5)) * 200) + 50.5f;
                     float y = (float) (Math.Cos(i / (double) target_raw * (Math.PI * 0.5)) * 200) + 50.5f;
-                    Vector2 v;
-                    if (keepFraction)
-                        v = new Vector2(x, y);
-                    else
-                        v = new Vector2((int)x, (int)y);
-
+                    Vector2 v = keepFraction ? new Vector2(x, y) : new Vector2((int)x, (int)y);
                     if (raw)
                         AddRawVertex(v);
                     else

--- a/osu.Framework.VisualTests/Tests/TestCaseInputResampler.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseInputResampler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;

--- a/osu.Framework.VisualTests/Tests/TestCasePadding.cs
+++ b/osu.Framework.VisualTests/Tests/TestCasePadding.cs
@@ -11,200 +11,173 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests
 {
-    internal class TestCasePadding : TestCase
+    internal class TestCasePadding : GridTestCase
     {
+        public TestCasePadding() : base(2, 2)
+        {
+        }
+
         public override string Description => @"Add fixed padding via a PaddingContainer";
 
         public override void Reset()
         {
             base.Reset();
 
-            Children = new Drawable[]
+            Cell(0).Add(new Drawable[]
             {
-                new FillFlowContainer
+                new SpriteText { Text = @"Padding - 20 All Sides" },
+                new Container
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
                     Children = new Drawable[]
                     {
-                        new Container
+                        new Box
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
+                            Colour = Color4.White,
+                        },
+                        new PaddedBox(Color4.Blue)
+                        {
+                            Padding = new MarginPadding(20),
+                            Size = new Vector2(200),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
                             Masking = true,
                             Children = new Drawable[]
                             {
-                                new SpriteText { Text = @"Padding - 20 All Sides" },
-                                new Container
+                                new PaddedBox(Color4.DarkSeaGreen)
                                 {
-                                    AutoSizeAxes = Axes.Both,
-                                    Anchor = Anchor.Centre,
+                                    Padding = new MarginPadding(40),
+                                    RelativeSizeAxes = Axes.Both,
                                     Origin = Anchor.Centre,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.White,
-                                        },
-                                        new PaddedBox(Color4.Blue)
-                                        {
-                                            Padding = new MarginPadding(20),
-                                            Size = new Vector2(200),
-                                            Origin = Anchor.Centre,
-                                            Anchor = Anchor.Centre,
-                                            Masking = true,
-                                            Children = new Drawable[]
-                                            {
-                                                new PaddedBox(Color4.DarkSeaGreen)
-                                                {
-                                                    Padding = new MarginPadding(40),
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Origin = Anchor.Centre,
-                                                    Anchor = Anchor.Centre
-                                                }
-                                            }
-                                        }
-                                    }
+                                    Anchor = Anchor.Centre
                                 }
                             }
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"Padding - 20 Top, Left" },
-                                new Container
-                                {
-                                    AutoSizeAxes = Axes.Both,
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.White,
-                                        },
-                                        new PaddedBox(Color4.Blue)
-                                        {
-                                            Padding = new MarginPadding
-                                            {
-                                                Top = 20,
-                                                Left = 20,
-                                            },
-                                            Size = new Vector2(200),
-                                            Origin = Anchor.Centre,
-                                            Anchor = Anchor.Centre,
-                                            Masking = true,
-                                            Children = new Drawable[]
-                                            {
-                                                new PaddedBox(Color4.DarkSeaGreen)
-                                                {
-                                                    Padding = new MarginPadding(40),
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Origin = Anchor.Centre,
-                                                    Anchor = Anchor.Centre
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"Margin - 20 All Sides" },
-                                new Container
-                                {
-                                    AutoSizeAxes = Axes.Both,
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.White,
-                                        },
-                                        new PaddedBox(Color4.Blue)
-                                        {
-                                            Margin = new MarginPadding(20),
-                                            Size = new Vector2(200),
-                                            Origin = Anchor.Centre,
-                                            Anchor = Anchor.Centre,
-                                            Masking = true,
-                                            Children = new Drawable[]
-                                            {
-                                                new PaddedBox(Color4.DarkSeaGreen)
-                                                {
-                                                    Padding = new MarginPadding(20),
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Origin = Anchor.Centre,
-                                                    Anchor = Anchor.Centre
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.5f),
-                            Masking = true,
-                            Children = new Drawable[]
-                            {
-                                new SpriteText { Text = @"Margin - 20 Top, Left" },
-                                new Container
-                                {
-                                    AutoSizeAxes = Axes.Both,
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.White,
-                                        },
-                                        new PaddedBox(Color4.Blue)
-                                        {
-                                            Margin = new MarginPadding
-                                            {
-                                                Top = 20,
-                                                Left = 20,
-                                            },
-                                            Size = new Vector2(200),
-                                            Origin = Anchor.Centre,
-                                            Anchor = Anchor.Centre,
-                                            Masking = true,
-                                            Children = new Drawable[]
-                                            {
-                                                new PaddedBox(Color4.DarkSeaGreen)
-                                                {
-                                                    Padding = new MarginPadding(40),
-                                                    RelativeSizeAxes = Axes.Both,
-                                                    Origin = Anchor.Centre,
-                                                    Anchor = Anchor.Centre
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
+                        }
                     }
                 }
-            };
+            });
+
+            Cell(1).Add(new Drawable[]
+            {
+                new SpriteText { Text = @"Padding - 20 Top, Left" },
+                new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.White,
+                        },
+                        new PaddedBox(Color4.Blue)
+                        {
+                            Padding = new MarginPadding
+                            {
+                                Top = 20,
+                                Left = 20,
+                            },
+                            Size = new Vector2(200),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                new PaddedBox(Color4.DarkSeaGreen)
+                                {
+                                    Padding = new MarginPadding(40),
+                                    RelativeSizeAxes = Axes.Both,
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            Cell(2).Add(new Drawable[]
+            {
+                new SpriteText { Text = @"Margin - 20 All Sides" },
+                new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.White,
+                        },
+                        new PaddedBox(Color4.Blue)
+                        {
+                            Margin = new MarginPadding(20),
+                            Size = new Vector2(200),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                new PaddedBox(Color4.DarkSeaGreen)
+                                {
+                                    Padding = new MarginPadding(20),
+                                    RelativeSizeAxes = Axes.Both,
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            Cell(3).Add(new Drawable[]
+            {
+                new SpriteText { Text = @"Margin - 20 Top, Left" },
+                new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.White,
+                        },
+                        new PaddedBox(Color4.Blue)
+                        {
+                            Margin = new MarginPadding
+                            {
+                                Top = 20,
+                                Left = 20,
+                            },
+                            Size = new Vector2(200),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                new PaddedBox(Color4.DarkSeaGreen)
+                                {
+                                    Padding = new MarginPadding(40),
+                                    RelativeSizeAxes = Axes.Both,
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre
+                                }
+                            }
+                        }
+                    }
+                }
+            });
         }
 
         private class PaddedBox : Container

--- a/osu.Framework.VisualTests/Tests/TestCasePadding.cs
+++ b/osu.Framework.VisualTests/Tests/TestCasePadding.cs
@@ -241,7 +241,11 @@ namespace osu.Framework.VisualTests.Tests
                 return base.Invalidate(invalidation, source, shallPropagate);
             }
 
-            protected override bool OnDrag(InputState state) => true;
+            protected override bool OnDrag(InputState state)
+            {
+                Position += state.Mouse.Delta;
+                return true;
+            }
 
             protected override bool OnDragEnd(InputState state) => true;
 

--- a/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
@@ -10,8 +10,12 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.VisualTests.Tests
 {
-    internal class TestCaseSmoothedEdges : TestCase
+    internal class TestCaseSmoothedEdges : GridTestCase
     {
+        public TestCaseSmoothedEdges() : base(2, 2)
+        {
+        }
+
         public override string Description => @"Boxes with automatically smoothed edges (no anti-aliasing).";
 
         private readonly Box[] boxes = new Box[4];
@@ -20,108 +24,34 @@ namespace osu.Framework.VisualTests.Tests
         {
             base.Reset();
 
-            Add(new Container
+            Vector2[] smoothnesses =
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new[]
+                new Vector2(0, 0),
+                new Vector2(0, 2),
+                new Vector2(1, 1),
+                new Vector2(2, 2),
+            };
+
+            for (int i = 0; i < Rows * Cols; ++i)
+            {
+                Cell(i).Add(new Drawable[]
                 {
-                    new FillFlowContainer
+                    new SpriteText
+                    {
+                        Text = $"{nameof(Sprite.EdgeSmoothness)}={smoothnesses[i]}",
+                        TextSize = 20,
+                    },
+                    boxes[i] = new Box
                     {
                         RelativeSizeAxes = Axes.Both,
-                        Children = new[]
-                        {
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "No smoothing",
-                                        TextSize = 20,
-                                    },
-                                    boxes[0] = new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.White,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Size = new Vector2(0.5f),
-                                        EdgeSmoothness = Vector2.Zero,
-                                    }
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "2-smoothing perpendicular to Y",
-                                        TextSize = 20,
-                                    },
-                                    boxes[1] = new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.White,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Size = new Vector2(0.5f),
-                                        EdgeSmoothness = new Vector2(0, 2),
-                                    }
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "1-smoothing",
-                                        TextSize = 20,
-                                    },
-                                    boxes[2] = new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.White,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Size = new Vector2(0.5f),
-                                        EdgeSmoothness = Vector2.One,
-                                    }
-                                }
-                            },
-                            new Container
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Size = new Vector2(0.5f),
-                                Children = new Drawable[]
-                                {
-                                    new SpriteText
-                                    {
-                                        Text = "2-smoothing",
-                                        TextSize = 20,
-                                    },
-                                    boxes[3] = new Box
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Colour = Color4.White,
-                                        Anchor = Anchor.Centre,
-                                        Origin = Anchor.Centre,
-                                        Size = new Vector2(0.5f),
-                                        EdgeSmoothness = Vector2.One * 2,
-                                    }
-                                }
-                            },
-                        }
-                    }
-                }
-            });
+                        Colour = Color4.White,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Size = new Vector2(0.5f),
+                        EdgeSmoothness = smoothnesses[i],
+                    },
+                });
+            }
         }
 
         protected override void Update()

--- a/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using OpenTK;


### PR DESCRIPTION
This pull request adds an abstract `GridTestCase` helper class, which tests can derive from to facilitate easy display of multiple configurations of the tested component in a grid.

Also makes `TestCaseInputResampler` significantly more understandable and comprehensive.