### PR TITLE
More relative coordinate space

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
@@ -41,7 +41,6 @@ namespace osu.Framework.VisualTests.Tests
             switch (i)
             {
                 case 0:
-                    h.RelativeCoordinateSpace = new RectangleF(0, 0, 1, 1);
                     h.CreateMarkerAt(-0.1f);
                     h.CreateMarkerAt(0);
                     h.CreateMarkerAt(0.1f);
@@ -52,7 +51,7 @@ namespace osu.Framework.VisualTests.Tests
                     h.CreateMarkerAt(1.1f);
                     break;
                 case 1:
-                    h.RelativeCoordinateSpace = new RectangleF(0, 0, 150, 1);
+                    h.RelativeChildSize = new Vector2(150, 1);
                     h.CreateMarkerAt(0);
                     h.CreateMarkerAt(50);
                     h.CreateMarkerAt(100);
@@ -61,7 +60,8 @@ namespace osu.Framework.VisualTests.Tests
                     h.CreateMarkerAt(250);
                     break;
                 case 2:
-                    h.RelativeCoordinateSpace = new RectangleF(50, 0, 150, 1);
+                    h.RelativeChildOffset = new Vector2(50, 0);
+                    h.RelativeChildSize = new Vector2(150, 1);
                     h.CreateMarkerAt(0);
                     h.CreateMarkerAt(50);
                     h.CreateMarkerAt(100);
@@ -70,7 +70,8 @@ namespace osu.Framework.VisualTests.Tests
                     h.CreateMarkerAt(250);
                     break;
                 case 3:
-                    h.RelativeCoordinateSpace = RectangleF.FromLTRB(150, 0, -50, 1);
+                    h.RelativeChildOffset = new Vector2(150, 0);
+                    h.RelativeChildSize = new Vector2(-200, 1);
                     h.CreateMarkerAt(0);
                     h.CreateMarkerAt(50);
                     h.CreateMarkerAt(100);
@@ -79,7 +80,8 @@ namespace osu.Framework.VisualTests.Tests
                     h.CreateMarkerAt(250);
                     break;
                 case 4:
-                    h.RelativeCoordinateSpace = RectangleF.FromLTRB(-250, 0, 250, 1);
+                    h.RelativeChildOffset = new Vector2(-250, 0);
+                    h.RelativeChildSize = new Vector2(500, 1);
                     h.CreateMarkerAt(-300);
                     h.CreateMarkerAt(-200);
                     h.CreateMarkerAt(-100);
@@ -97,17 +99,23 @@ namespace osu.Framework.VisualTests.Tests
             {
                 base.Update();
 
-                Left.Text = $"X = {RelativeCoordinateSpace.Left.ToString(CultureInfo.InvariantCulture)}";
-                Right.Text = $"X = {RelativeCoordinateSpace.Right.ToString(CultureInfo.InvariantCulture)}";
+                Left.Text = $"X = {RelativeChildOffset.X.ToString(CultureInfo.InvariantCulture)}";
+                Right.Text = $"X = {(RelativeChildOffset.X + RelativeChildSize.X).ToString(CultureInfo.InvariantCulture)}";
             }
         }
 
         private abstract class Visualiser : Container
         {
-            public new RectangleF RelativeCoordinateSpace
+            public new Vector2 RelativeChildSize
             {
-                protected get { return innerContainer.RelativeCoordinateSpace; }
-                set { innerContainer.RelativeCoordinateSpace = value; }
+                protected get { return innerContainer.RelativeChildSize; }
+                set { innerContainer.RelativeChildSize = value; }
+            }
+
+            public new Vector2 RelativeChildOffset
+            {
+                protected get { return innerContainer.RelativeChildOffset; }
+                set { innerContainer.RelativeChildOffset = value; }
             }
 
             private readonly Container innerContainer;

--- a/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
@@ -4,8 +4,10 @@
 using System;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
@@ -14,234 +16,189 @@ namespace osu.Framework.VisualTests.Tests
 {
     public class TestCaseCoordinateSpaces : TestCase
     {
-        private const float coordinate_space_step = 25;
-        private const float coordinate_space_max = 200;
-        private const double scroll_time = 2000;
-
         public override void Reset()
         {
             base.Reset();
 
-            for (float c = coordinate_space_step; c <= coordinate_space_max; c += coordinate_space_step)
-            {
-                float tempC = c;
-                AddStep($"{tempC} coordinate space", () => loadGridTest(tempC));
-            }
-
-            AddStep("Scrolling test", loadScrollingTest);
-            AddWaitStep((int)Math.Ceiling(scroll_time / TimePerAction) + 2);
+            AddStep("0-1 space", () => loadCase(0));
+            AddStep("0-150 space", () => loadCase(1));
+            AddStep("50-200 space", () => loadCase(2));
+            AddStep("150-(-50) space", () => loadCase(3));
+            AddStep("0-300 space", () => loadCase(4));
+            AddStep("-250-250 space", () => loadCase(4));
         }
 
-        private void loadGridTest(float coordinateSpace)
+        private void loadCase(int i)
         {
             Clear();
 
-            Container c;
-            Add(c = new Container
+            HorizontalVisualiser h;
+            Add(h = new HorizontalVisualiser
             {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.Both,
-                Size = new Vector2(0.8f),
-                RelativeCoordinateSpace = new Vector2(coordinateSpace),
-                Children = new Drawable[]
-                {
-                    new Container
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Size = new Vector2(coordinateSpace),
-                        Masking = true,
-                        BorderColour = Color4.Green,
-                        BorderThickness = 5,
-                        Children = new[]
-                        {
-                            new Box
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Alpha = 0,
-                                AlwaysPresent = true
-                            },
-                            new Box
-                            {
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
-                                RelativeSizeAxes = Axes.Y,
-                                Width = 5,
-                                Colour = Color4.Green
-                            },
-                            new Box
-                            {
-                                Anchor = Anchor.CentreLeft,
-                                Origin = Anchor.CentreLeft,
-                                RelativeSizeAxes = Axes.X,
-                                Height = 5,
-                                Colour = Color4.Green
-                            }
-                        }
-                    },
-                    // Centre crosshair
-                    new Marker
-                    {
-                        Anchor = Anchor.Centre
-                    },
-                    new Marker
-                    {
-                        Anchor = Anchor.Centre,
-                        Position = new Vector2(10, 0)
-                    },
-                    new Marker
-                    {
-                        Anchor = Anchor.Centre,
-                        Position = new Vector2(-10, 0)
-                    },
-                    new Marker
-                    {
-                        Anchor = Anchor.Centre,
-                        Position = new Vector2(0, 10)
-                    },
-                    new Marker
-                    {
-                        Anchor = Anchor.Centre,
-                        Position = new Vector2(0, -10)
-                    }
-                }
+                Size = new Vector2(200, 50),
+                X = 150
             });
 
-            for (float i = coordinate_space_max / 2; i >= 0; i -= coordinate_space_step)
+            switch (i)
             {
-                c.Add(new Marker
-                {
-                    Anchor = Anchor.TopLeft,
-                    Position = new Vector2(i)
-                });
-
-                c.Add(new Marker
-                {
-                    Anchor = Anchor.TopRight,
-                    Position = new Vector2(-i, i)
-                });
-
-                c.Add(new Marker
-                {
-                    Anchor = Anchor.BottomLeft,
-                    Position = new Vector2(i, -i)
-                });
-
-                c.Add(new Marker
-                {
-                    Anchor = Anchor.BottomRight,
-                    Position = new Vector2(-i, -i)
-                });
+                case 0:
+                    h.RelativeCoordinateSpace = new RectangleF(0, 0, 1, 1);
+                    h.CreateMarkerAt(-0.1f);
+                    h.CreateMarkerAt(0);
+                    h.CreateMarkerAt(0.1f);
+                    h.CreateMarkerAt(0.3f);
+                    h.CreateMarkerAt(0.7f);
+                    h.CreateMarkerAt(0.9f);
+                    h.CreateMarkerAt(1f);
+                    h.CreateMarkerAt(1.1f);
+                    break;
+                case 1:
+                    h.RelativeCoordinateSpace = new RectangleF(0, 0, 150, 1);
+                    h.CreateMarkerAt(0);
+                    h.CreateMarkerAt(50);
+                    h.CreateMarkerAt(100);
+                    h.CreateMarkerAt(150);
+                    h.CreateMarkerAt(200);
+                    h.CreateMarkerAt(250);
+                    break;
+                case 2:
+                    h.RelativeCoordinateSpace = new RectangleF(50, 0, 150, 1);
+                    h.CreateMarkerAt(0);
+                    h.CreateMarkerAt(50);
+                    h.CreateMarkerAt(100);
+                    h.CreateMarkerAt(150);
+                    h.CreateMarkerAt(200);
+                    h.CreateMarkerAt(250);
+                    break;
+                case 3:
+                    h.RelativeCoordinateSpace = RectangleF.FromLTRB(150, 0, -50, 1);
+                    h.CreateMarkerAt(0);
+                    h.CreateMarkerAt(50);
+                    h.CreateMarkerAt(100);
+                    h.CreateMarkerAt(150);
+                    h.CreateMarkerAt(200);
+                    h.CreateMarkerAt(250);
+                    break;
+                case 4:
+                    h.RelativeCoordinateSpace = RectangleF.FromLTRB(-250, 0, 250, 1);
+                    h.CreateMarkerAt(-300);
+                    h.CreateMarkerAt(-200);
+                    h.CreateMarkerAt(-100);
+                    h.CreateMarkerAt(0);
+                    h.CreateMarkerAt(100);
+                    h.CreateMarkerAt(200);
+                    h.CreateMarkerAt(300);
+                    break;
             }
         }
 
-        private void loadScrollingTest()
-        {
-            const float duration = (float)scroll_time / 4;
-
-            // The amount of time which the area that the box scrolls through spans.
-            // Nothing special is done by subtracting the duration here - scrollingBox is BottomCentre origin with Height = duration
-            // and it should be outside of the container at Y = scroll_time for the purpose of demonstrating this test
-            const float time_span = (float)scroll_time - duration;
-
-            Clear();
-
-            Add(new Container
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                RelativeSizeAxes = Axes.Y,
-                Size = new Vector2(100, 0.8f),
-                RelativeCoordinateSpace = new Vector2(1, time_span),
-                Masking = true,
-                Clock = new FramedClock(),
-                Children = new Drawable[]
-                {
-                    new Container
-                    {
-                        Name = "Background",
-                        RelativeSizeAxes = Axes.Both,
-                        Size = new Vector2(1, time_span),
-                        Children = new[]
-                        {
-                            new Box
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Colour = Color4.White,
-                                Alpha = 0.1f
-                            }
-                        }
-                    },
-                    new TimeScrollingBox
-                    {
-                        Name = "Scrolling box",
-                        Anchor = Anchor.TopCentre,
-                        Origin = Anchor.BottomCentre,
-                        RelativePositionAxes = Axes.Y,
-                        RelativeSizeAxes = Axes.Both,
-                        Height = duration
-                    }
-                }
-            });
-        }
-
-        /// <summary>
-        /// A box that scrolls using the current time as its Y-position.
-        /// </summary>
-        private class TimeScrollingBox : Box
+        private class HorizontalVisualiser : Visualiser
         {
             protected override void Update()
             {
-                Y = (float)Clock.CurrentTime;
+                base.Update();
+
+                Left.Text = $"X = {RelativeCoordinateSpace.Left.ToString()}";
+                Right.Text = $"X = {RelativeCoordinateSpace.Right.ToString()}";
             }
         }
 
-        /// <summary>
-        /// A drawable which marks a point in a space with a description of its position.
-        /// </summary>
-        private class Marker : Container
+        private abstract class Visualiser : Container
         {
-            private readonly SpriteText descriptionText;
-
-            public Marker()
+            public new RectangleF RelativeCoordinateSpace
             {
-                Origin = Anchor.Centre;
-                RelativePositionAxes = Axes.Both;
+                get { return innerContainer.RelativeCoordinateSpace; }
+                set { innerContainer.RelativeCoordinateSpace = value; }
+            }
 
-                Size = new Vector2(32);
+            private readonly Container innerContainer;
 
-                Children = new Drawable[]
+            protected readonly SpriteText Left;
+            protected readonly SpriteText Right;
+
+            public Visualiser()
+            {
+                Height = 50;
+
+                InternalChildren = new Drawable[]
                 {
                     new Box
                     {
-                        Anchor = Anchor.TopCentre,
-                        Origin = Anchor.TopCentre,
+                        Name = "Left marker",
+                        Colour = Color4.Gray,
                         RelativeSizeAxes = Axes.Y,
-                        Width = 2,
-                        Colour = Color4.Red
+                    },
+                    Left = new SpriteText
+                    {
+                        Anchor = Anchor.BottomLeft,
+                        Origin = Anchor.TopCentre,
+                        Y = 6
                     },
                     new Box
                     {
+                        Name = "Centre line",
                         Anchor = Anchor.CentreLeft,
                         Origin = Anchor.CentreLeft,
-                        RelativeSizeAxes = Axes.X,
-                        Height = 2,
-                        Colour = Color4.Red
+                        Colour = Color4.Gray,
+                        RelativeSizeAxes = Axes.X
                     },
-                    descriptionText = new SpriteText
+                    innerContainer = new Container
                     {
-                        Anchor = Anchor.TopCentre,
+                        RelativeSizeAxes = Axes.Both
+                    },
+                    new Box
+                    {
+                        Name = "Right marker",
+                        Anchor = Anchor.TopRight,
+                        Origin = Anchor.TopRight,
+                        Colour = Color4.Gray,
+                        RelativeSizeAxes = Axes.Y
+                    },
+                    Right = new SpriteText
+                    {
+                        Anchor = Anchor.BottomRight,
                         Origin = Anchor.TopCentre,
-                        BypassAutoSizeAxes = Axes.Both,
-                        Y = -18,
-                        TextSize = 18
-                    }
+                        Y = 6
+                    },
                 };
             }
 
-            protected override void Update()
+            public void CreateMarkerAt(float x)
             {
-                descriptionText.Text = $"{Anchor.ToString()} @ {Position.ToString()} (rel: {RelativePositionAxes.ToString()})";
+                innerContainer.Add(new Container
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.Centre,
+                    RelativePositionAxes = Axes.Both,
+                    AutoSizeAxes = Axes.Both,
+                    X = x,
+                    Colour = Color4.Yellow,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Name = "Centre marker horizontal",
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(8, 1)
+                        },
+                        new Box
+                        {
+                            Name = "Centre marker vertical",
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(1, 8)
+                        },
+                        new SpriteText
+                        {
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.TopCentre,
+                            Y = 6,
+                            BypassAutoSizeAxes = Axes.Both,
+                            Text = x.ToString()
+                        }
+                    }
+                });
             }
         }
     }

--- a/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
@@ -7,7 +7,6 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 

--- a/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
@@ -1,16 +1,15 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
+
+using System.Globalization;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
-using osu.Framework.Timing;
 
 namespace osu.Framework.VisualTests.Tests
 {
@@ -98,8 +97,8 @@ namespace osu.Framework.VisualTests.Tests
             {
                 base.Update();
 
-                Left.Text = $"X = {RelativeCoordinateSpace.Left.ToString()}";
-                Right.Text = $"X = {RelativeCoordinateSpace.Right.ToString()}";
+                Left.Text = $"X = {RelativeCoordinateSpace.Left.ToString(CultureInfo.InvariantCulture)}";
+                Right.Text = $"X = {RelativeCoordinateSpace.Right.ToString(CultureInfo.InvariantCulture)}";
             }
         }
 
@@ -107,7 +106,7 @@ namespace osu.Framework.VisualTests.Tests
         {
             public new RectangleF RelativeCoordinateSpace
             {
-                get { return innerContainer.RelativeCoordinateSpace; }
+                protected get { return innerContainer.RelativeCoordinateSpace; }
                 set { innerContainer.RelativeCoordinateSpace = value; }
             }
 
@@ -116,7 +115,7 @@ namespace osu.Framework.VisualTests.Tests
             protected readonly SpriteText Left;
             protected readonly SpriteText Right;
 
-            public Visualiser()
+            protected Visualiser()
             {
                 Height = 50;
 
@@ -195,7 +194,7 @@ namespace osu.Framework.VisualTests.Tests
                             Origin = Anchor.TopCentre,
                             Y = 6,
                             BypassAutoSizeAxes = Axes.Both,
-                            Text = x.ToString()
+                            Text = x.ToString(CultureInfo.InvariantCulture)
                         }
                     }
                 });

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -878,18 +878,38 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public Vector2 ChildOffset => new Vector2(Padding.Left, Padding.Top);
 
-        private RectangleF relativeCoordinateSpace = new RectangleF(0, 0, 1, 1);
+        private Vector2 relativeChildSize = Vector2.One;
         /// <summary>
-        /// The coordinate space revealed to relatively-positioned and/or relatively-sized children in this container.
+        /// The size of the relative position/size coordinate space of children of this container.
+        /// Children positioned at this size will appear as if they were positioned at <see cref="Drawable.Position"/> = <see cref="OpenTK.Vector2.One"/> in this container.
         /// </summary>
-        public RectangleF RelativeCoordinateSpace
+        public Vector2 RelativeChildSize
         {
-            get { return relativeCoordinateSpace; }
+            get { return relativeChildSize; }
             set
             {
-                if (relativeCoordinateSpace == value)
+                if (relativeChildSize == value)
                     return;
-                relativeCoordinateSpace = value;
+                relativeChildSize = value;
+
+                foreach (Drawable c in internalChildren)
+                    c.Invalidate(Invalidation.Geometry);
+            }
+        }
+
+        private Vector2 relativeChildOffset = Vector2.Zero;
+        /// <summary>
+        /// The offset of the relative position/size coordinate space of children of this container.
+        /// Children positioned at this offset will appear as if they were positioned at <see cref="Drawable.Position"/> = <see cref="OpenTK.Vector2.Zero"/> in this container.
+        /// </summary>
+        public Vector2 RelativeChildOffset
+        {
+            get { return relativeChildOffset; }
+            set
+            {
+                if (relativeChildOffset == value)
+                    return;
+                relativeChildOffset = value;
 
                 foreach (Drawable c in internalChildren)
                     c.Invalidate(Invalidation.Geometry);
@@ -899,22 +919,28 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Conversion factor from relative to absolute coordinates in our space.
         /// </summary>
-        public Vector2 RelativeToAbsoluteFactor => Vector2.Divide(ChildSize, RelativeCoordinateSpace.Size);
+        public Vector2 RelativeToAbsoluteFactor => Vector2.Divide(ChildSize, RelativeChildSize);
 
         /// <summary>
-        /// The positional offset for relatively-positioned children inside this container.
+        /// Tweens the <see cref="RelativeChildSize"/> of this container.
         /// </summary>
-        public Vector2 RelativePositionOffset => RelativeCoordinateSpace.Location;
-
-        /// <summary>
-        /// Tweens the RelativeCoordinateSpace of this container.
-        /// </summary>
-        /// <param name="newCoordinateSpace">The coordinate space to tween to.</param>
+        /// <param name="newSize">The coordinate space to tween to.</param>
         /// <param name="duration">The tween duration.</param>
         /// <param name="easing">The tween easing.</param>
-        public void TransformRelativeCoordinateSpaceTo(RectangleF newCoordinateSpace, double duration = 0, EasingTypes easing = EasingTypes.None)
+        public void TransformRelativeChildSizeTo(Vector2 newSize, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
-            TransformTo(() => RelativeCoordinateSpace, newCoordinateSpace, duration, easing, new TransformRelativeCoordinateSpace());
+            TransformTo(() => RelativeChildSize, newSize, duration, easing, new TransformRelativeChildSize());
+        }
+
+        /// <summary>
+        /// Tweens the <see cref="RelativeChildOffset"/> of this container.
+        /// </summary>
+        /// <param name="newOffset">The coordinate space to tween to.</param>
+        /// <param name="duration">The tween duration.</param>
+        /// <param name="easing">The tween easing.</param>
+        public void TransformRelativeChildOffsetTo(Vector2 newOffset, double duration = 0, EasingTypes easing = EasingTypes.None)
+        {
+            TransformTo(() => RelativeChildOffset, newOffset, duration, easing, new TransformRelativeChildOffset());
         }
 
         public override Axes RelativeSizeAxes
@@ -1158,9 +1184,9 @@ namespace osu.Framework.Graphics.Containers
 
         #endregion
 
-        private class TransformRelativeCoordinateSpace : Transform<RectangleF>
+        private class TransformRelativeChildSize : TransformVector
         {
-            public override RectangleF CurrentValue
+            public override Vector2 CurrentValue
             {
                 get
                 {
@@ -1177,7 +1203,30 @@ namespace osu.Framework.Graphics.Containers
                 base.Apply(d);
 
                 var c = (Container<T>)d;
-                c.RelativeCoordinateSpace = CurrentValue;
+                c.RelativeChildSize = CurrentValue;
+            }
+        }
+
+        private class TransformRelativeChildOffset : TransformVector
+        {
+            public override Vector2 CurrentValue
+            {
+                get
+                {
+                    double time = Time?.Current ?? 0;
+                    if (time < StartTime) return StartValue;
+                    if (time >= EndTime) return EndValue;
+
+                    return Interpolation.ValueAt(time, StartValue, EndValue, StartTime, EndTime, Easing);
+                }
+            }
+
+            public override void Apply(Drawable d)
+            {
+                base.Apply(d);
+
+                var c = (Container<T>)d;
+                c.RelativeChildOffset = CurrentValue;
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -904,7 +904,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The positional offset for relatively-positioned children inside this container.
         /// </summary>
-        public Vector2 RelativeChildOffset => RelativeCoordinateSpace.Location;
+        public Vector2 RelativePositionOffset => RelativeCoordinateSpace.Location;
 
         /// <summary>
         /// Tweens the RelativeCoordinateSpace of this container.

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Containers
         Vector2 ChildSize { get; }
         Vector2 ChildOffset { get; }
         Vector2 RelativeToAbsoluteFactor { get; }
-        Vector2 RelativeChildOffset { get; }
+        Vector2 RelativePositionOffset { get; }
 
         float CornerRadius { get; }
 

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Containers
         Vector2 ChildSize { get; }
         Vector2 ChildOffset { get; }
         Vector2 RelativeToAbsoluteFactor { get; }
-        Vector2 RelativePositionOffset { get; }
+        Vector2 RelativeChildOffset { get; }
 
         float CornerRadius { get; }
 

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -12,6 +12,7 @@ namespace osu.Framework.Graphics.Containers
         Vector2 ChildSize { get; }
         Vector2 ChildOffset { get; }
         Vector2 RelativeToAbsoluteFactor { get; }
+        Vector2 RelativeChildOffset { get; }
 
         float CornerRadius { get; }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -512,7 +512,7 @@ namespace osu.Framework.Graphics
         /// Absolute positional offset of <see cref="Origin"/> to <see cref="RelativeAnchorPosition"/>
         /// in the <see cref="Parent"/>'s coordinate system.
         /// </summary>
-        public Vector2 DrawPosition => applyRelativeAxes(RelativePositionAxes, Position - relativeOffset);
+        public Vector2 DrawPosition => applyRelativeAxes(RelativePositionAxes, Position - relativePositionOffset);
 
         private Vector2 size
         {
@@ -717,14 +717,14 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// The offset to be added to relative coordinates before they're converted to absolute coordinates.
         /// </summary>
-        private Vector2 relativeOffset
+        private Vector2 relativePositionOffset
         {
             get
             {
                 if (Parent == null || RelativePositionAxes == Axes.None)
                     return Vector2.Zero;
 
-                Vector2 offset = Parent.RelativeChildOffset;
+                Vector2 offset = Parent.RelativePositionOffset;
 
                 if ((RelativePositionAxes & Axes.X) == 0)
                     offset.X = 0;

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -512,7 +512,7 @@ namespace osu.Framework.Graphics
         /// Absolute positional offset of <see cref="Origin"/> to <see cref="RelativeAnchorPosition"/>
         /// in the <see cref="Parent"/>'s coordinate system.
         /// </summary>
-        public Vector2 DrawPosition => applyRelativeAxes(RelativePositionAxes, Position);
+        public Vector2 DrawPosition => applyRelativeAxes(RelativePositionAxes, Position - relativeOffset);
 
         private Vector2 size
         {
@@ -713,6 +713,28 @@ namespace osu.Framework.Graphics
         /// Conversion factor from relative to absolute coordinates in the <see cref="Parent"/>'s space.
         /// </summary>
         private Vector2 relativeToAbsoluteFactor => Parent?.RelativeToAbsoluteFactor ?? Vector2.One;
+
+        /// <summary>
+        /// The offset to be added to relative coordinates before they're converted to absolute coordinates.
+        /// </summary>
+        private Vector2 relativeOffset
+        {
+            get
+            {
+                if (Parent == null || RelativePositionAxes == Axes.None)
+                    return Vector2.Zero;
+
+                Vector2 offset = Parent.RelativeChildOffset;
+
+                if ((RelativePositionAxes & Axes.X) == 0)
+                    offset.X = 0;
+
+                if ((RelativePositionAxes & Axes.Y) == 0)
+                    offset.Y = 0;
+
+                return offset;
+            }
+        }
 
         private Axes bypassAutoSizeAxes;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -512,7 +512,25 @@ namespace osu.Framework.Graphics
         /// Absolute positional offset of <see cref="Origin"/> to <see cref="RelativeAnchorPosition"/>
         /// in the <see cref="Parent"/>'s coordinate system.
         /// </summary>
-        public Vector2 DrawPosition => applyRelativeAxes(RelativePositionAxes, Position - relativePositionOffset);
+        public Vector2 DrawPosition
+        {
+            get
+            {
+                Vector2 offset = Vector2.Zero;
+                if (Parent != null || RelativePositionAxes != Axes.None)
+                {
+                    offset = Parent.RelativePositionOffset;
+
+                    if ((RelativePositionAxes & Axes.X) == 0)
+                        offset.X = 0;
+
+                    if ((RelativePositionAxes & Axes.Y) == 0)
+                        offset.Y = 0;
+                }
+
+                return applyRelativeAxes(RelativePositionAxes, Position - offset);
+            }
+        }
 
         private Vector2 size
         {
@@ -713,28 +731,6 @@ namespace osu.Framework.Graphics
         /// Conversion factor from relative to absolute coordinates in the <see cref="Parent"/>'s space.
         /// </summary>
         private Vector2 relativeToAbsoluteFactor => Parent?.RelativeToAbsoluteFactor ?? Vector2.One;
-
-        /// <summary>
-        /// The offset to be added to relative coordinates before they're converted to absolute coordinates.
-        /// </summary>
-        private Vector2 relativePositionOffset
-        {
-            get
-            {
-                if (Parent == null || RelativePositionAxes == Axes.None)
-                    return Vector2.Zero;
-
-                Vector2 offset = Parent.RelativePositionOffset;
-
-                if ((RelativePositionAxes & Axes.X) == 0)
-                    offset.X = 0;
-
-                if ((RelativePositionAxes & Axes.Y) == 0)
-                    offset.Y = 0;
-
-                return offset;
-            }
-        }
 
         private Axes bypassAutoSizeAxes;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -517,7 +517,7 @@ namespace osu.Framework.Graphics
             get
             {
                 Vector2 offset = Vector2.Zero;
-                if (Parent != null || RelativePositionAxes != Axes.None)
+                if (Parent != null && RelativePositionAxes != Axes.None)
                 {
                     offset = Parent.RelativePositionOffset;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -519,7 +519,7 @@ namespace osu.Framework.Graphics
                 Vector2 offset = Vector2.Zero;
                 if (Parent != null && RelativePositionAxes != Axes.None)
                 {
-                    offset = Parent.RelativePositionOffset;
+                    offset = Parent.RelativeChildOffset;
 
                     if ((RelativePositionAxes & Axes.X) == 0)
                         offset.X = 0;

--- a/osu.Framework/Graphics/Primitives/RectangleF.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleF.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.Primitives
     /// <summary>Stores a set of four floating-point numbers that represent the location and size of a rectangle. For more advanced region functions, use a <see cref="T:System.Drawing.Region"></see> object.</summary>
     /// <filterpriority>1</filterpriority>
     [Serializable, StructLayout(LayoutKind.Sequential)]
-    public struct RectangleF
+    public struct RectangleF : IEquatable<RectangleF>
     {
         /// <summary>Represents an instance of the <see cref="T:System.Drawing.RectangleF"></see> class with its members uninitialized.</summary>
         /// <filterpriority>1</filterpriority>
@@ -59,12 +59,12 @@ namespace osu.Framework.Graphics.Primitives
         public static RectangleF FromLTRB(float left, float top, float right, float bottom) => new RectangleF(left, top, right - left, bottom - top);
 
         /// <summary>Gets or sets the coordinates of the upper-left corner of this <see cref="T:System.Drawing.RectangleF"></see> structure.</summary>
-        /// <returns>A <see cref="T:System.Drawing.PointF"></see> that represents the upper-left corner of this <see cref="T:System.Drawing.RectangleF"></see> structure.</returns>
+        /// <returns>A <see cref="OpenTK.Vector2"/> that represents the upper-left corner of this <see cref="T:System.Drawing.RectangleF"></see> structure.</returns>
         /// <filterpriority>1</filterpriority>
         [Browsable(false)]
-        public PointF Location
+        public Vector2 Location
         {
-            get { return new PointF(X, Y); }
+            get { return new Vector2(X, Y); }
             set
             {
                 X = value.X;
@@ -73,7 +73,7 @@ namespace osu.Framework.Graphics.Primitives
         }
 
         /// <summary>Gets or sets the size of this <see cref="T:System.Drawing.RectangleF"></see>.</summary>
-        /// <returns>A <see cref="T:System.Drawing.SizeF"></see> that represents the width and height of this <see cref="T:System.Drawing.RectangleF"></see> structure.</returns>
+        /// <returns>A <see cref="OpenTK.Vector2"/> that represents the width and height of this <see cref="T:System.Drawing.RectangleF"></see> structure.</returns>
         /// <filterpriority>1</filterpriority>
         [Browsable(false)]
         public Vector2 Size
@@ -475,5 +475,7 @@ namespace osu.Framework.Graphics.Primitives
                    && c * yQmin - s * xQmax >= -yPdif
                    && c * yQmax - s * xQmin <= yPdif;
         }
+
+        public bool Equals(RectangleF other) => X == other.X && Y == other.Y && Width == other.Width && Height == other.Height;
     }
 }


### PR DESCRIPTION
This is a requisite for TimingChanges. Imagine a timing change which has start time = 5000, and a hitobject that is to be positioned inside that container with start time = 7500. Since the hit object will become relatively positioned to the container, the hitobject has to be offset backwards by the timing change start time.
This gets problematic because there is no really easy way to do this while supporting moving hit objects around in the editor.

So this allows defining the relative coordinate space as a range with a `RectangleF`. The above scenario could be achieved by:
```
new TimingPointContainer
{
    RelativeCoordinateSpace = new RectangleF(0, TimingPoint.StartTime, 0, N),
    Children = new[]
    {
        new HitObjectContainer { Y = HitObject.StartTime }
    }
}
```
Where N, in the TimingChange branch, would be calculated as the total height of all the children of the container (which is going to be a summation of HitObject start times + durations).

Am super interested at what @Tom94 thinks of this. Not sure if this is too much pollution into Drawable - if so got any better suggestions? We can't use ChildOffset here because that's applied as an absolute position.