### PR TITLE
Do not lose focus when commiting in TextBox

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -55,6 +55,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         public bool ReadOnly;
 
+        public bool ReleaseFocusOnCommit = true;
+
         private ITextInputSource textInput;
         private Clipboard clipboard;
 
@@ -561,6 +563,8 @@ namespace osu.Framework.Graphics.UserInterface
 
                         audio.Sample.Get(@"Keyboard/key-confirm")?.Play();
                         OnCommit?.Invoke(this, true);
+                        if (ReleaseFocusOnCommit)
+                            inputManager.ChangeFocus(null);
                     }
                     return true;
                 case Key.Delete:

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -553,7 +553,15 @@ namespace osu.Framework.Graphics.UserInterface
                         return true;
                     }
                 case Key.Enter:
-                    if (HasFocus) inputManager.ChangeFocus(null);
+                    if (HasFocus)
+                    {
+                        Background.Colour = BackgroundFocused;
+                        Background.ClearTransforms();
+                        Background.FlashColour(BackgroundCommit, 400);
+
+                        audio.Sample.Get(@"Keyboard/key-confirm")?.Play();
+                        OnCommit?.Invoke(this, true);
+                    }
                     return true;
                 case Key.Delete:
                     if (selectionLength == 0)
@@ -752,21 +760,9 @@ namespace osu.Framework.Graphics.UserInterface
 
             Caret.ClearTransforms();
             Caret.FadeOut(200);
-
-            if (!Current.Disabled && state.Keyboard.Keys.Contains(Key.Enter))
-            {
-                Background.Colour = BackgroundUnfocused;
-                Background.ClearTransforms();
-                Background.FlashColour(BackgroundCommit, 400);
-
-                audio.Sample.Get(@"Keyboard/key-confirm")?.Play();
-                OnCommit?.Invoke(this, true);
-            }
-            else
-            {
-                Background.ClearTransforms();
-                Background.FadeColour(BackgroundUnfocused, 200, EasingTypes.OutExpo);
-            }
+            
+            Background.ClearTransforms();
+            Background.FadeColour(BackgroundUnfocused, 200, EasingTypes.OutExpo);
 
             cursorAndLayout.Invalidate();
         }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -557,14 +557,15 @@ namespace osu.Framework.Graphics.UserInterface
                 case Key.Enter:
                     if (HasFocus)
                     {
-                        Background.Colour = BackgroundFocused;
+                        if (ReleaseFocusOnCommit)
+                            inputManager.ChangeFocus(null);
+
+                        Background.Colour = ReleaseFocusOnCommit ? BackgroundUnfocused : BackgroundFocused;
                         Background.ClearTransforms();
                         Background.FlashColour(BackgroundCommit, 400);
 
                         audio.Sample.Get(@"Keyboard/key-confirm")?.Play();
                         OnCommit?.Invoke(this, true);
-                        if (ReleaseFocusOnCommit)
-                            inputManager.ChangeFocus(null);
                     }
                     return true;
                 case Key.Delete:
@@ -764,6 +765,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             Caret.ClearTransforms();
             Caret.FadeOut(200);
+
 
             Background.ClearTransforms();
             Background.FadeColour(BackgroundUnfocused, 200, EasingTypes.OutExpo);

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -764,7 +764,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             Caret.ClearTransforms();
             Caret.FadeOut(200);
-            
+
             Background.ClearTransforms();
             Background.FadeColour(BackgroundUnfocused, 200, EasingTypes.OutExpo);
 


### PR DESCRIPTION
When a user hits Enter to commit the contents of a TextBox, this used
to trigger a loss of focus for the TextBox, and then OnFocusLost used
to invoke the OnCommit-Handler on the condition that the enter key
is held. Now, hitting the enter key directly invokes OnCommit if the
TextBox is currently focused and only removes focus from the
TextBox if the ReleaseFocusOnCommit flag is set.