### PR TITLE
Make the inside edge of hollow edge effects smooth

### DIFF
--- a/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
@@ -157,7 +157,13 @@ namespace osu.Framework.Graphics.Containers
             colour.TopRight.MultiplyAlpha(DrawInfo.Colour.TopRight.Linear.A);
             colour.BottomRight.MultiplyAlpha(DrawInfo.Colour.BottomRight.Linear.A);
 
-            Texture.WhitePixel.DrawQuad(ScreenSpaceMaskingQuad.Value, colour, null, null, null, new Vector2(MaskingInfo.Value.BlendRange));
+            Texture.WhitePixel.DrawQuad(
+                ScreenSpaceMaskingQuad.Value,
+                colour, null, null, null,
+                // HACK HACK HACK. We re-use the unused vertex blend range to store the original
+                // masking blend range when rendering edge effects. This is needed for smooth inner edges
+                // with a hollow edge effect.
+                new Vector2(MaskingInfo.Value.BlendRange));
 
             Shader.Unbind();
 

--- a/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
@@ -141,6 +141,8 @@ namespace osu.Framework.Graphics.Containers
             edgeEffectMaskingInfo.ScreenSpaceAABB = ScreenSpaceMaskingQuad.Value.AABB;
             edgeEffectMaskingInfo.CornerRadius += EdgeEffect.Radius + EdgeEffect.Roundness;
             edgeEffectMaskingInfo.BorderThickness = 0;
+            // HACK HACK HACK. We abuse blend range to give us the linear alpha gradient of
+            // the edge effect along its radius using the same rounded-corners shader.
             edgeEffectMaskingInfo.BlendRange = EdgeEffect.Radius;
             edgeEffectMaskingInfo.AlphaExponent = 2;
             edgeEffectMaskingInfo.Hollow = EdgeEffect.Hollow;

--- a/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
@@ -157,7 +157,7 @@ namespace osu.Framework.Graphics.Containers
             colour.TopRight.MultiplyAlpha(DrawInfo.Colour.TopRight.Linear.A);
             colour.BottomRight.MultiplyAlpha(DrawInfo.Colour.BottomRight.Linear.A);
 
-            Texture.WhitePixel.DrawQuad(ScreenSpaceMaskingQuad.Value, colour);
+            Texture.WhitePixel.DrawQuad(ScreenSpaceMaskingQuad.Value, colour, null, null, null, new Vector2(MaskingInfo.Value.BlendRange));
 
             Shader.Unbind();
 

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <summary>
         /// Blit a quad to OpenGL display with specified parameters.
         /// </summary>
-        public abstract void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null);
+        public abstract void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null);
 
         /// <summary>
         /// Bind as active texture.

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -207,7 +207,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             FrameStatistics.Increment(StatisticsCounterType.KiloPixels, (long)vertexTriangle.ConservativeArea);
         }
 
-        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null)
+        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
         {
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not draw a quad with a disposed texture.");
@@ -215,6 +215,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             RectangleF texRect = GetTextureRect(textureRect);
             Vector2 inflationAmount = inflationPercentage.HasValue ? new Vector2(inflationPercentage.Value.X * texRect.Width, inflationPercentage.Value.Y * texRect.Height) : Vector2.Zero;
             RectangleF inflatedTexRect = texRect.Inflate(inflationAmount);
+            Vector2 blendRange = blendRangeOverride ?? inflationAmount;
 
             if (vertexAction == null)
             {
@@ -228,7 +229,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 Position = vertexQuad.BottomLeft,
                 TexturePosition = new Vector2(inflatedTexRect.Left, inflatedTexRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
-                BlendRange = inflationAmount,
+                BlendRange = blendRange,
                 Colour = drawColour.BottomLeft.Linear,
             });
             vertexAction(new TexturedVertex2D
@@ -236,7 +237,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 Position = vertexQuad.BottomRight,
                 TexturePosition = new Vector2(inflatedTexRect.Right, inflatedTexRect.Bottom),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
-                BlendRange = inflationAmount,
+                BlendRange = blendRange,
                 Colour = drawColour.BottomRight.Linear,
             });
             vertexAction(new TexturedVertex2D
@@ -244,7 +245,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 Position = vertexQuad.TopRight,
                 TexturePosition = new Vector2(inflatedTexRect.Right, inflatedTexRect.Top),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
-                BlendRange = inflationAmount,
+                BlendRange = blendRange,
                 Colour = drawColour.TopRight.Linear,
             });
             vertexAction(new TexturedVertex2D
@@ -252,7 +253,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 Position = vertexQuad.TopLeft,
                 TexturePosition = new Vector2(inflatedTexRect.Left, inflatedTexRect.Top),
                 TextureRect = new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
-                BlendRange = inflationAmount,
+                BlendRange = blendRange,
                 Colour = drawColour.TopLeft.Linear,
             });
 

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
@@ -69,9 +69,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             parent.DrawTriangle(vertexTriangle, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage);
         }
 
-        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null)
+        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
         {
-            parent.DrawQuad(vertexQuad, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage);
+            parent.DrawQuad(vertexQuad, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage, blendRangeOverride);
         }
 
         internal override bool Upload()

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -196,11 +196,11 @@ namespace osu.Framework.Graphics.Textures
             TextureGL.DrawTriangle(vertexTriangle, TextureBounds(textureRect), colour, vertexAction, inflationPercentage);
         }
 
-        public void DrawQuad(Quad vertexQuad, ColourInfo colour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null)
+        public void DrawQuad(Quad vertexQuad, ColourInfo colour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
         {
             if (TextureGL == null || !TextureGL.Bind()) return;
 
-            TextureGL.DrawQuad(vertexQuad, TextureBounds(textureRect), colour, vertexAction, inflationPercentage);
+            TextureGL.DrawQuad(vertexQuad, TextureBounds(textureRect), colour, vertexAction, inflationPercentage, blendRangeOverride);
         }
     }
 

--- a/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
@@ -67,7 +67,8 @@ void main(void)
 	if (g_DiscardInner)
 	{
 		// v_BlendRange is set from outside in a hacky way to tell us the g_MaskingBlendRange used for the rounded
-		// corners of the glowing container itself. We can then derive the alpha factor for smooth inner glow from that.
+		// corners of the edge effect container itself. We can then derive the alpha factor for smooth inner edge
+		// effect from that.
 		float innerBlendFactor = (g_CornerRadius - g_MaskingBlendRange - dist) / v_BlendRange.x;
 		if (innerBlendFactor > 1.0)
 		{

--- a/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
@@ -61,12 +61,22 @@ float distanceFromDrawingRect()
 void main(void)
 {
 	float dist = distanceFromRoundedRect();
+	float alphaFactor = 1.0;
 
 	// Discard inner pixels
-	if (g_DiscardInner && dist <= g_CornerRadius - g_MaskingBlendRange - 1.0)    // -1 for getting rid of some ugly inner-edges
+	if (g_DiscardInner)
 	{
-		gl_FragColor = vec4(0.0);
-		return;
+		// v_BlendRange is set from outside in a hacky way to tell us the g_MaskingBlendRange used for the rounded
+		// corners of the glowing container itself. We can then derive the alpha factor for smooth inner glow from that.
+		float innerBlendFactor = (g_CornerRadius - g_MaskingBlendRange - dist) / v_BlendRange.x;
+		if (innerBlendFactor > 1.0)
+		{
+			gl_FragColor = vec4(0.0);
+			return;
+		}
+
+		// We exponentiate our factor to exactly counteract the later exponentiation by g_AlphaExponent for a smoother inner border.
+		alphaFactor *= pow(min(1.0 - innerBlendFactor, 1.0), 1.0 / g_AlphaExponent);
 	}
 
 	dist /= g_MaskingBlendRange;
@@ -74,7 +84,7 @@ void main(void)
 	// This correction is needed to avoid fading of the alpha value for radii below 1px.
 	float radiusCorrection = g_CornerRadius <= 0.0 ? g_MaskingBlendRange : max(0.0, g_MaskingBlendRange - g_CornerRadius);
 	float fadeStart = (g_CornerRadius + radiusCorrection) / g_MaskingBlendRange;
-	float alphaFactor = min(fadeStart - dist, 1.0);
+	alphaFactor *= min(fadeStart - dist, 1.0);
 
 	if (v_BlendRange.x > 0.0 || v_BlendRange.y > 0.0)
 		alphaFactor *= clamp(1.0 - distanceFromDrawingRect(), 0.0, 1.0);


### PR DESCRIPTION
Makes hollow inner edge effect smooth. Also documents an old hack better, and adds a new one to make this even work.