### PR TITLE
Fix various cases of mouse delta values being incorrect

### DIFF
--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKEventMouseState.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKEventMouseState.cs
@@ -1,0 +1,15 @@
+using OpenTK;
+
+namespace osu.Framework.Desktop.Input.Handlers.Mouse
+{
+    /// <summary>
+    /// An OpenTK state which came from an event callback.
+    /// </summary>
+    internal class OpenTKEventMouseState : OpenTKMouseState
+    {
+        public OpenTKEventMouseState(OpenTK.Input.MouseState tkState, bool active, Vector2? mappedPosition)
+            : base(tkState, active, mappedPosition)
+        {
+        }
+    }
+}

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKEventMouseState.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKEventMouseState.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
 using OpenTK;
 
 namespace osu.Framework.Desktop.Input.Handlers.Mouse

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
@@ -44,9 +44,14 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
                         if (mouseInWindow || !host.Window.Visible) return;
 
                         var state = OpenTK.Input.Mouse.GetCursorState();
+
+                        if (state.Equals(lastState)) return;
+
+                        lastState = state;
+
                         var mapped = host.Window.PointToClient(new Point(state.X, state.Y));
 
-                        handleState(state, new Vector2(mapped.X, mapped.Y));
+                        handleState(new OpenTKPollMouseState(state, host.IsActive, new Vector2(mapped.X, mapped.Y)));
                     }, 0, 1000.0 / 60));
                 }
                 else
@@ -70,16 +75,12 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
             if (!mouseInWindow)
                 return;
 
-            handleState(e.Mouse);
+            handleState(new OpenTKEventMouseState(e.Mouse, host.IsActive, null));
         }
 
-        private void handleState(OpenTK.Input.MouseState state, Vector2? mappedPosition = null)
+        private void handleState(MouseState state)
         {
-            if (state.Equals(lastState)) return;
-
-            lastState = state;
-
-            PendingStates.Enqueue(new InputState { Mouse = new OpenTKMouseState(state, host.IsActive, mappedPosition) });
+            PendingStates.Enqueue(new InputState { Mouse = state });
             FrameStatistics.Increment(StatisticsCounterType.MouseEvents);
         }
 

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseState.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseState.cs
@@ -7,13 +7,13 @@ using MouseState = osu.Framework.Input.MouseState;
 
 namespace osu.Framework.Desktop.Input.Handlers.Mouse
 {
-    internal class OpenTKMouseState : MouseState
+    internal abstract class OpenTKMouseState : MouseState
     {
         public readonly bool WasActive;
 
         public override int WheelDelta => WasActive ? base.WheelDelta : 0;
 
-        public OpenTKMouseState(OpenTK.Input.MouseState tkState, bool active, Vector2? mappedPosition)
+        protected OpenTKMouseState(OpenTK.Input.MouseState tkState, bool active, Vector2? mappedPosition)
         {
             WasActive = active;
 

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKPollMouseState.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKPollMouseState.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
 using OpenTK;
 
 namespace osu.Framework.Desktop.Input.Handlers.Mouse

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKPollMouseState.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKPollMouseState.cs
@@ -1,0 +1,15 @@
+using OpenTK;
+
+namespace osu.Framework.Desktop.Input.Handlers.Mouse
+{
+    /// <summary>
+    /// An OpenTK state which was retrieved via polling.
+    /// </summary>
+    internal class OpenTKPollMouseState : OpenTKMouseState
+    {
+        public OpenTKPollMouseState(OpenTK.Input.MouseState tkState, bool active, Vector2? mappedPosition)
+            : base(tkState, active, mappedPosition)
+        {
+        }
+    }
+}

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
@@ -73,13 +73,18 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
                             currentPosition = new Vector2(screenPoint.X, screenPoint.Y);
                         }
 
-                        lastState = state;
-
                         // While not focused, let's silently ignore everything but position.
-                        if (!host.Window.Focused)
+                        if (host.Window.Focused)
+                        {
+                            lastState = state;
+                        }
+                        else
+                        {
+                            lastState = null;
                             state = new OpenTK.Input.MouseState();
+                        }
 
-                        PendingStates.Enqueue(new InputState { Mouse = new OpenTKMouseState(state, host.IsActive, currentPosition) });
+                        PendingStates.Enqueue(new InputState { Mouse = new OpenTKPollMouseState(state, host.IsActive, currentPosition) });
 
                         FrameStatistics.Increment(StatisticsCounterType.MouseEvents);
                     }, 0, 0));

--- a/osu.Framework.Desktop/osu.Framework.Desktop.csproj
+++ b/osu.Framework.Desktop/osu.Framework.Desktop.csproj
@@ -64,6 +64,8 @@
     <Compile Include="Host.cs" />
     <Compile Include="Input\GameWindowTextInput.cs" />
     <Compile Include="Input\Handlers\Keyboard\OpenTKKeyboardHandler.cs" />
+    <Compile Include="Input\Handlers\Mouse\OpenTKEventMouseState.cs" />
+    <Compile Include="Input\Handlers\Mouse\OpenTKPollMouseState.cs" />
     <Compile Include="Input\Handlers\Mouse\OpenTKRawMouseHandler.cs" />
     <Compile Include="Input\Handlers\Mouse\OpenTKMouseHandler.cs" />
     <Compile Include="Input\Handlers\Mouse\OpenTKMouseState.cs" />

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1864,11 +1864,14 @@ namespace osu.Framework.Graphics
         {
             public IMouseState NativeState { get; }
 
+            public IMouseState LastState { get; set; }
+
             private readonly Drawable us;
 
             public LocalMouseState(IMouseState state, Drawable us)
             {
                 NativeState = state;
+                LastState = null;
                 this.us = us;
             }
 
@@ -1878,7 +1881,12 @@ namespace osu.Framework.Graphics
 
             public Vector2 LastPosition => us.Parent?.ToLocalSpace(NativeState.LastPosition) ?? NativeState.LastPosition;
 
-            public Vector2? PositionMouseDown => NativeState.PositionMouseDown == null ? null : us.Parent?.ToLocalSpace(NativeState.PositionMouseDown.Value) ?? NativeState.PositionMouseDown;
+            public Vector2? PositionMouseDown
+            {
+                get { return NativeState.PositionMouseDown == null ? null : us.Parent?.ToLocalSpace(NativeState.PositionMouseDown.Value) ?? NativeState.PositionMouseDown; }
+                set { throw new NotImplementedException(); }
+            }
+
             public bool HasMainButtonPressed => NativeState.HasMainButtonPressed;
             public int Wheel => NativeState.Wheel;
             public int WheelDelta => NativeState.WheelDelta;

--- a/osu.Framework/Input/IMouseState.cs
+++ b/osu.Framework/Input/IMouseState.cs
@@ -10,12 +10,14 @@ namespace osu.Framework.Input
     {
         IMouseState NativeState { get; }
 
+        IMouseState LastState { get; set; }
+
         Vector2 Delta { get; }
         Vector2 Position { get; }
 
         Vector2 LastPosition { get; }
 
-        Vector2? PositionMouseDown { get; }
+        Vector2? PositionMouseDown { get; set; }
 
         bool HasMainButtonPressed { get; }
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -191,7 +191,6 @@ namespace osu.Framework.Input
                 // state potentially from a different input source.
                 if (last.Mouse != null && s.Mouse != null && last.Mouse.GetType() == s.Mouse.GetType())
                 {
-                    //necessary for now as last state is used internally for stuff
                     last.Mouse.LastState = null;
                     s.Mouse.LastState = last.Mouse;
                     s.Mouse.PositionMouseDown = last.Mouse.PositionMouseDown;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -189,8 +189,13 @@ namespace osu.Framework.Input
                 // we only want to set a last state if both the new and old state are of the same type.
                 // this avoids giving the new state a false impression of being able to calculate delta values based on a last
                 // state potentially from a different input source.
-                if (last.Mouse?.GetType() == s.Mouse?.GetType())
-                    (s.Mouse as MouseState)?.SetLast(last.Mouse); //necessary for now as last state is used internally for stuff
+                if (last.Mouse != null && s.Mouse != null && last.Mouse.GetType() == s.Mouse.GetType())
+                {
+                    //necessary for now as last state is used internally for stuff
+                    last.Mouse.LastState = null;
+                    s.Mouse.LastState = last.Mouse;
+                    s.Mouse.PositionMouseDown = last.Mouse.PositionMouseDown;
+                }
 
                 //hover could change even when the mouse state has not.
                 updateHoverEvents(CurrentState);

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -186,7 +186,11 @@ namespace osu.Framework.Input
                 //move above?
                 updateInputQueues(CurrentState);
 
-                (s.Mouse as MouseState)?.SetLast(last.Mouse); //necessary for now as last state is used internally for stuff
+                // we only want to set a last state if both the new and old state are of the same type.
+                // this avoids giving the new state a false impression of being able to calculate delta values based on a last
+                // state potentially from a different input source.
+                if (last.Mouse?.GetType() == s.Mouse?.GetType())
+                    (s.Mouse as MouseState)?.SetLast(last.Mouse); //necessary for now as last state is used internally for stuff
 
                 //hover could change even when the mouse state has not.
                 updateHoverEvents(CurrentState);

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Input
 
         public IMouseState NativeState => this;
 
-        public IMouseState LastState;
+        public IMouseState LastState { get; set; }
 
         public virtual int WheelDelta => (Wheel - LastState?.Wheel) ?? 0;
 
@@ -32,16 +32,7 @@ namespace osu.Framework.Input
 
         public Vector2 LastPosition => LastState?.Position ?? Position;
 
-        public Vector2? PositionMouseDown { get; internal set; }
-
-        public void SetLast(IMouseState last)
-        {
-            (last as MouseState)?.SetLast(null);
-
-            LastState = last;
-            if (last != null)
-                PositionMouseDown = last.PositionMouseDown;
-        }
+        public Vector2? PositionMouseDown { get; set; }
 
         public IMouseState Clone()
         {

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Input
 
         public IMouseState LastState { get; set; }
 
-        public virtual int WheelDelta => (Wheel - LastState?.Wheel) ?? 0;
+        public virtual int WheelDelta => Wheel - LastState?.Wheel ?? 0;
 
         public int Wheel { get; set; }
 

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -10,23 +10,23 @@ namespace osu.Framework.Input
 {
     public class MouseState : IMouseState
     {
-        public IMouseState LastState;
-
         private const int mouse_button_count = (int)MouseButton.LastButton;
 
         public bool[] PressedButtons = new bool[mouse_button_count];
 
         public IMouseState NativeState => this;
 
-        public virtual int WheelDelta => Wheel - (LastState?.Wheel ?? 0);
+        public IMouseState LastState;
+
+        public virtual int WheelDelta => (Wheel - LastState?.Wheel) ?? 0;
 
         public int Wheel { get; set; }
 
-        public bool HasMainButtonPressed => IsPressed(MouseButton.Left )|| IsPressed(MouseButton.Right);
+        public bool HasMainButtonPressed => IsPressed(MouseButton.Left) || IsPressed(MouseButton.Right);
 
         public bool HasAnyButtonPressed => PressedButtons.Any(b => b);
 
-        public Vector2 Delta => Position - (LastState?.Position ?? Vector2.Zero);
+        public Vector2 Delta => Position - LastPosition;
 
         public Vector2 Position { get; protected set; }
 


### PR DESCRIPTION
There are scenarios where we don't want the LastState to be set on a newly arriving MouseState. This covers those cases, and fixes some bugs along the way.

- InputManager now only assigns the `LastState` when both the last and current MouseState are of the same type (ie. coming from the same InputHandler source).
- Fixed multiple bugs with window focus and delta computations.