### PR TITLE
Make Drawable.Schedule methods protected

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -632,7 +632,7 @@ namespace osu.Framework.Graphics.Containers
             return this;
         }
 
-        public ScheduledDelegate ScheduleAfterChildren(Action action) => SchedulerAfterChildren.AddDelayed(action, TransformDelay);
+        protected ScheduledDelegate ScheduleAfterChildren(Action action) => SchedulerAfterChildren.AddDelayed(action, TransformDelay);
 
         public override void Flush(bool propagateChildren = false, Type flushType = null)
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1947,7 +1947,7 @@ namespace osu.Framework.Graphics
             return this;
         }
 
-        public ScheduledDelegate Schedule(Action action) => Scheduler.AddDelayed(action, TransformDelay);
+        protected ScheduledDelegate Schedule(Action action) => Scheduler.AddDelayed(action, TransformDelay);
 
         /// <summary>
         /// Flush specified transforms, using the last available values (ignoring current clock time).


### PR DESCRIPTION
Scheduling should never be done from a parent. There's basically no reason to do this.