### PR TITLE
Rework invalidation rules to avoid unnecessary computations

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -86,13 +86,6 @@ namespace osu.Framework
             }, AddInternal);
         }
 
-        public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
-        {
-            if (!base.Invalidate(invalidation, source, shallPropagate)) return false;
-
-            return true;
-        }
-
         /// <summary>
         /// As Load is run post host creation, you can override this method to alter properties of the host before it makes itself visible to the user.
         /// </summary>

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.Graphics.Containers
                 if (maximumSize == value) return;
 
                 maximumSize = value;
-                Invalidate(Invalidation.Geometry);
+                Invalidate(Invalidation.DrawSize);
             }
         }
 
@@ -66,7 +66,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
-            if ((invalidation & Invalidation.SizeInParentSpace) > 0)
+            if ((invalidation & Invalidation.DrawSize) > 0)
                 InvalidateLayout();
 
             return base.Invalidate(invalidation, source, shallPropagate);
@@ -86,7 +86,7 @@ namespace osu.Framework.Graphics.Containers
         {
             //Colour captures potential changes in IsPresent. If this ever becomes a bottleneck,
             //Invalidation could be further separated into presence changes.
-            if ((invalidation & (Invalidation.SizeInParentSpace | Invalidation.Colour)) > 0)
+            if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
                 InvalidateLayout();
 
             base.InvalidateFromChild(invalidation);

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -103,7 +103,8 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
-            layout.Invalidate();
+            if ((invalidation & Invalidation.DrawSize) > 0)
+                layout.Invalidate();
             return base.Invalidate(invalidation, source, shallPropagate);
         }
 

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics.Lines
                 positions = value;
                 recomputeBounds();
 
-                Invalidate(Invalidation.Geometry);
+                Invalidate(Invalidation.DrawNode);
             }
         }
 
@@ -37,7 +37,10 @@ namespace osu.Framework.Graphics.Lines
             positions.Clear();
             resetBounds();
 
-            Invalidate(Invalidation.Geometry);
+            if ((RelativeSizeAxes & Axes.X) == 0) Width = 0;
+            if ((RelativeSizeAxes & Axes.Y) == 0) Height = 0;
+
+            Invalidate(Invalidation.DrawNode);
         }
 
         public void AddVertex(Vector2 pos)
@@ -45,7 +48,7 @@ namespace osu.Framework.Graphics.Lines
             positions.Add(pos);
             expandBounds(pos);
 
-            Invalidate(Invalidation.Geometry);
+            Invalidate(Invalidation.DrawNode);
         }
 
         private float minX;
@@ -91,7 +94,7 @@ namespace osu.Framework.Graphics.Lines
                 pathWidth = value;
                 recomputeBounds();
 
-                Invalidate(Invalidation.Geometry);
+                Invalidate(Invalidation.DrawNode);
             }
         }
 


### PR DESCRIPTION
This change stops propagating down layout / autosize invalidations if `DrawSize` hasn't been changed and the child does not have `RelativeSizeAxes`. Results in huge speedups in certain cases such as `TestCaseSpriteText` where I observe up to 5x.