### PR TITLE
Make InputManager abstract

### DIFF
--- a/osu.Framework/Input/CustomInputManager.cs
+++ b/osu.Framework/Input/CustomInputManager.cs
@@ -1,3 +1,6 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
 using System.Collections.Generic;
 using osu.Framework.Input.Handlers;
 

--- a/osu.Framework/Input/CustomInputManager.cs
+++ b/osu.Framework/Input/CustomInputManager.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using osu.Framework.Input.Handlers;
+
+namespace osu.Framework.Input
+{
+    /// <summary>
+    /// An <see cref="InputManager"/> implementation which allows managing of <see cref="InputHandler"/>s manually.
+    /// </summary>
+    public class CustomInputManager : InputManager
+    {
+        protected override IEnumerable<InputHandler> InputHandlers => inputHandlers;
+
+        private readonly List<InputHandler> inputHandlers = new List<InputHandler>();
+
+        protected void AddHandler(InputHandler handler)
+        {
+            if (!handler.Initialize(Host)) return;
+
+            int index = inputHandlers.BinarySearch(handler, new InputHandlerComparer());
+            if (index < 0)
+            {
+                index = ~index;
+            }
+
+            inputHandlers.Insert(index, handler);
+        }
+
+        protected void RemoveHandler(InputHandler handler) => inputHandlers.Remove(handler);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            foreach (var h in inputHandlers)
+                h.Dispose();
+
+            base.Dispose(isDisposing);
+        }
+    }
+}

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -7,7 +7,7 @@ using OpenTK;
 
 namespace osu.Framework.Input
 {
-    public class PassThroughInputManager : InputManager
+    public class PassThroughInputManager : CustomInputManager
     {
         /// <summary>
         /// If there's an InputManager above us, decide whether we should use their available state.

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Collections.Generic;
 using osu.Framework.Input.Handlers;
-using osu.Framework.Allocation;
 
 namespace osu.Framework.Input
 {
@@ -13,14 +13,6 @@ namespace osu.Framework.Input
             AlwaysReceiveInput = true;
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
-        {
-            if (Host != null)
-            {
-                foreach (InputHandler h in Host.AvailableInputHandlers)
-                    AddHandler(h);
-            }
-        }
+        protected override IEnumerable<InputHandler> InputHandlers => Host.AvailableInputHandlers;
     }
 }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Graphics\Sprites\EquilateralTriangle.cs" />
     <Compile Include="Graphics\UserInterface\TabControl.cs" />
     <Compile Include="Graphics\UserInterface\TabItem.cs" />
+    <Compile Include="Input\CustomInputManager.cs" />
     <Compile Include="Input\GlobalHotkeys.cs" />
     <Compile Include="Input\Handlers\IHasCursorSensitivity.cs" />
     <Compile Include="Input\KeyUpEventArgs.cs" />


### PR DESCRIPTION
- Makes InputHandler list a property, and removes the ability to add/remove by default.
- Moves initialisation on InputHandlers to GameHost.
- Adds a method to reset to a sane default by completely disposing and recreating handlers.
- Fixes UserInputManager not getting InputHandler changes (new added or existing removed) from its underlying GameHost.