### PR TITLE
Add simplified API for applying visual effects to drawables

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
@@ -1,4 +1,7 @@
-﻿using OpenTK;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
@@ -43,8 +43,9 @@ namespace osu.Framework.VisualTests.Tests
                         TextSize = 32f
                     }.WithEffect(new BlurEffect
                     {
-                        Sigma = new Vector2(2f, 2f),
-                        Strength = 2f
+                        Sigma = new Vector2(2f, 0f),
+                        Strength = 2f,
+                        BlurRotation = 45f,
                     }),
                     new SpriteText
                     {

--- a/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
@@ -1,0 +1,104 @@
+﻿using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Framework.VisualTests.Tests
+{
+    internal class TestCaseEffects : TestCase
+    {
+        public override string Description => "Tests classes implement the IEffect interface.";
+
+        public override void Reset()
+        {
+            base.Reset();
+
+            var effect = new EdgeEffect
+            {
+                CornerRadius = 3f,
+                Parameters = new EdgeEffectParameters
+                {
+                    Colour = Color4.LightBlue,
+                    Hollow = true,
+                    Radius = 5f,
+                    Type = EdgeEffectType.Glow
+                }
+            };
+            Add(new FillFlowContainer
+            {
+                Position = new Vector2(10f, 10f),
+                Spacing = new Vector2(25f, 25f),
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new SpriteText
+                    {
+                        Text = "Blur Test",
+                        TextSize = 32f
+                    }.WithEffect(new BlurEffect
+                    {
+                        Sigma = new Vector2(2f, 2f),
+                        Strength = 2f
+                    }),
+                    new SpriteText
+                    {
+                        Text = "EdgeEffect Test",
+                        TextSize = 32f
+                    }.WithEffect(new EdgeEffect
+                    {
+                        CornerRadius = 3f,
+                        Parameters = new EdgeEffectParameters
+                        {
+                            Colour = Color4.Yellow,
+                            Hollow = true,
+                            Radius = 5f,
+                            Type = EdgeEffectType.Shadow
+                        }
+                    }),
+                    new SpriteText
+                    {
+                        Text = "Repeated usage of same effect test",
+                        TextSize = 32f
+                    }.WithEffect(effect),
+                    new SpriteText
+                    {
+                        Text = "Repeated usage of same effect test",
+                        TextSize = 32f
+                    }.WithEffect(effect),
+                    new SpriteText
+                    {
+                        Text = "Repeated usage of same effect test",
+                        TextSize = 32f
+                    }.WithEffect(effect),
+                    new SpriteText
+                    {
+                        Text = "Multiple effects Test",
+                        TextSize = 32f
+                    }.WithEffect(new BlurEffect
+                    {
+                        Sigma = new Vector2(2f, 2f),
+                        Strength = 2f
+                    }).WithEffect(new EdgeEffect
+                    {
+                        CornerRadius = 3f,
+                        Parameters = new EdgeEffectParameters
+                        {
+                            Colour = Color4.Yellow,
+                            Hollow = true,
+                            Radius = 5f,
+                            Type = EdgeEffectType.Shadow
+                        }
+                    }),
+                }
+            });
+        }
+    }
+}

--- a/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
@@ -8,11 +8,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace osu.Framework.VisualTests.Tests
 {

--- a/osu.Framework.VisualTests/Tests/TestCaseHollowEdgeEffect.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseHollowEdgeEffect.cs
@@ -26,30 +26,30 @@ namespace osu.Framework.VisualTests.Tests
 
             float[] cornerRadii = { 0, 0.5f, 0, 0.5f };
             float[] alphas = { 0.5f, 0.5f, 0, 0 };
-            EdgeEffect[] edgeEffects =
+            EdgeEffectParameters[] edgeEffects =
             {
-                new EdgeEffect
+                new EdgeEffectParameters
                 {
                     Type = EdgeEffectType.Glow,
                     Colour = Color4.Khaki,
                     Radius = size,
                     Hollow = true,
                 },
-                new EdgeEffect
+                new EdgeEffectParameters
                 {
                     Type = EdgeEffectType.Glow,
                     Colour = Color4.Khaki,
                     Radius = size,
                     Hollow = true,
                 },
-                new EdgeEffect
+                new EdgeEffectParameters
                 {
                     Type = EdgeEffectType.Glow,
                     Colour = Color4.Khaki,
                     Radius = size,
                     Hollow = true,
                 },
-                new EdgeEffect
+                new EdgeEffectParameters
                 {
                     Type = EdgeEffectType.Glow,
                     Colour = Color4.Khaki,

--- a/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.VisualTests.Tests
                             CornerRadius = 100,
                             BorderColour = Color4.Aquamarine,
                             BorderThickness = 3,
-                            EdgeEffect = new EdgeEffect
+                            EdgeEffect = new EdgeEffectParameters
                             {
                                 Type = EdgeEffectType.Shadow,
                                 Radius = 100,
@@ -191,7 +191,7 @@ namespace osu.Framework.VisualTests.Tests
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            EdgeEffect = new EdgeEffect
+                            EdgeEffect = new EdgeEffectParameters
                             {
                                 Type = EdgeEffectType.Glow,
                                 Radius = 100,

--- a/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
+++ b/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Tests\TestCaseColourGradient.cs" />
     <Compile Include="Tests\TestCaseCoordinateSpaces.cs" />
     <Compile Include="Tests\TestCaseDrawablePath.cs" />
+    <Compile Include="Tests\TestCaseEffects.cs" />
     <Compile Include="Tests\TestCaseFillModes.cs" />
     <Compile Include="Tests\TestCaseFlow.cs" />
     <Compile Include="Tests\TestCaseHollowEdgeEffect.cs" />

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics.Shaders;
 using System;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Vertices;
+using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -88,26 +89,6 @@ namespace osu.Framework.Graphics.Containers
             if (frameBuffer.Texture.Bind())
                 // Color was already applied by base.Draw(); no need to re-apply. Thus we use White here.
                 frameBuffer.Texture.DrawQuad(drawRectangle, textureRect, colourInfo);
-        }
-
-        private double evalGaussian(float x, float sigma)
-        {
-            const double inv_sqrt_2_pi = 0.39894;
-            return inv_sqrt_2_pi * Math.Exp(-0.5 * x * x / (sigma * sigma)) / sigma;
-        }
-
-        private int findBlurRadius(float sigma)
-        {
-            const float gauss_threshold = 0.1f;
-            const int max_radius = 200;
-
-            double center = evalGaussian(0, sigma);
-            double threshold = gauss_threshold * center;
-            for (int i = 0; i < max_radius; ++i)
-                if (evalGaussian(i, sigma) < threshold)
-                    return Math.Max(i - 1, 0);
-
-            return max_radius;
         }
 
         private void drawChildren(Action<TexturedVertex2D> vertexAction, Vector2 frameBufferSize)
@@ -187,8 +168,8 @@ namespace osu.Framework.Graphics.Containers
                     drawChildren(vertexAction, frameBufferSize);
 
                     // Blur post-processing in case a blur radius is defined.
-                    int radiusX = BlurSigma.X > 0 ? findBlurRadius(BlurSigma.X) : 0;
-                    int radiusY = BlurSigma.Y > 0 ? findBlurRadius(BlurSigma.Y) : 0;
+                    int radiusX = Blur.KernelSize(BlurSigma.X);
+                    int radiusY = Blur.KernelSize(BlurSigma.Y);
 
                     if (radiusX > 0 || radiusY > 0)
                     {

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -829,14 +829,14 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private EdgeEffect edgeEffect;
+        private EdgeEffectParameters edgeEffect;
 
         /// <summary>
         /// Determines an edge effect of this container.
         /// Edge effects are e.g. glow or a shadow.
         /// Only has an effect when <see cref="Masking"/> is true.
         /// </summary>
-        public virtual EdgeEffect EdgeEffect
+        public virtual EdgeEffectParameters EdgeEffect
         {
             get { return edgeEffect; }
             set

--- a/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/ContainerDrawNode.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Graphics.Containers
     /// <summary>
     /// Parametrizes the appearance of an edge effect.
     /// </summary>
-    public struct EdgeEffect : IEquatable<EdgeEffect>
+    public struct EdgeEffectParameters : IEquatable<EdgeEffectParameters>
     {
         /// <summary>
         /// Colour of the edge effect.
@@ -62,7 +62,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public bool Hollow;
 
-        public bool Equals(EdgeEffect other) =>
+        public bool Equals(EdgeEffectParameters other) =>
             Colour.Equals(other.Colour) &&
             Offset == other.Offset &&
             Type == other.Type &&
@@ -115,7 +115,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Information about how the edge effect should be rendered.
         /// </summary>
-        public EdgeEffect EdgeEffect;
+        public EdgeEffectParameters EdgeEffect;
 
         /// <summary>
         /// Shared data between all <see cref="ContainerDrawNode"/>s corresponding to the same

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Graphics.Cursor
                 BorderColour = new Color4(247, 99, 164, 255);
 
                 Masking = true;
-                EdgeEffect = new EdgeEffect
+                EdgeEffect = new EdgeEffectParameters
                 {
                     Type = EdgeEffectType.Glow,
                     Colour = new Color4(247, 99, 164, 6),

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2281,8 +2281,7 @@ namespace osu.Framework.Graphics
         public T WithEffect<T>(IEffect<T> effect, Action<T> initializationAction = null) where T : Drawable
         {
             var result = effect.ApplyTo(this);
-            if (initializationAction != null)
-                initializationAction(result);
+            initializationAction?.Invoke(result);
             return result;
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -24,6 +24,7 @@ using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Input;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Effects;
 
 namespace osu.Framework.Graphics
 {
@@ -2264,6 +2265,26 @@ namespace osu.Framework.Graphics
         }
 
         #endregion
+
+        #endregion
+
+        #region Effects
+
+        /// <summary>
+        /// Returns the drawable created by applying the given effect to this drawable. This method may add this drawable to a container.
+        /// If this drawable should be the child of another container, make sure to add the created drawable to the container instead of this drawable.
+        /// </summary>
+        /// <typeparam name="T">The type of the drawable that results from applying the given effect.</typeparam>
+        /// <param name="effect">The effect to apply to this drawable.</param>
+        /// <param name="initializationAction">The action that should get called to initialize the created drawable before it is returned.</param>
+        /// <returns>The drawable created by applying the given effect to this drawable.</returns>
+        public T WithEffect<T>(IEffect<T> effect, Action<T> initializationAction = null) where T : Drawable
+        {
+            var result = effect.ApplyTo(this);
+            if (initializationAction != null)
+                initializationAction(result);
+            return result;
+        }
 
         #endregion
 

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -1,0 +1,50 @@
+﻿using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.MathUtils;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Graphics.Effects
+{
+    /// <summary>
+    /// A blur effect that wraps a drawable in a <see cref="BufferedContainer"/> which applies a blur effect to it.
+    /// </summary>
+    public class BlurEffect : IEffect<BufferedContainer>
+    {
+        /// <summary>
+        /// The strength of the blur. Default is 1.
+        /// </summary>
+        public float Strength { get; set; } = 1f;
+        /// <summary>
+        /// The sigma of the blur. Default is (2, 2).
+        /// </summary>
+        public Vector2 Sigma { get; set; } = new Vector2(2f, 2f);
+
+        public BufferedContainer ApplyTo(Drawable drawable)
+        {
+            return new BufferedContainer
+            {
+                RelativeSizeAxes = drawable.RelativeSizeAxes,
+                AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
+                BlurSigma = Sigma,
+                Anchor = drawable.Anchor,
+                Origin = drawable.Origin,
+                Padding = new MarginPadding
+                {
+                    Horizontal = Blur.KernelSize(Sigma.X),
+                    Vertical = Blur.KernelSize(Sigma.Y)
+                },
+                Alpha = Strength,
+                Children = new[]
+                {
+                    drawable
+                }
+            };
+        }
+    }
+}

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics.Effects
         /// <summary>
         /// The rotation of the blur. Default is 0.
         /// </summary>
-        public float BlurRotation { get; set; } = 0f;
+        public float BlurRotation { get; set; }
 
         public BufferedContainer ApplyTo(Drawable drawable)
         {

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -1,4 +1,7 @@
-﻿using OpenTK;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -20,6 +20,10 @@ namespace osu.Framework.Graphics.Effects
         /// The sigma of the blur. Default is (2, 2).
         /// </summary>
         public Vector2 Sigma { get; set; } = new Vector2(2f, 2f);
+        /// <summary>
+        /// The rotation of the blur. Default is 0.
+        /// </summary>
+        public float BlurRotation { get; set; } = 0f;
 
         public BufferedContainer ApplyTo(Drawable drawable)
         {
@@ -30,6 +34,7 @@ namespace osu.Framework.Graphics.Effects
                 BlurSigma = Sigma,
                 Anchor = drawable.Anchor,
                 Origin = drawable.Origin,
+                BlurRotation = BlurRotation,
                 Padding = new MarginPadding
                 {
                     Horizontal = Blur.KernelSize(Sigma.X),

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -2,15 +2,8 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using OpenTK;
-using OpenTK.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.MathUtils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace osu.Framework.Graphics.Effects
 {

--- a/osu.Framework/Graphics/Effects/EdgeEffect.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffect.cs
@@ -1,4 +1,7 @@
-﻿using osu.Framework.Graphics.Containers;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics.Containers;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/osu.Framework/Graphics/Effects/EdgeEffect.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffect.cs
@@ -6,12 +6,18 @@ using osu.Framework.Graphics.Containers;
 namespace osu.Framework.Graphics.Effects
 {
     /// <summary>
-    /// 
+    /// An effect applied around the edge of the target drawable.
     /// </summary>
     public class EdgeEffect : IEffect<Container>
     {
+        /// <summary>
+        /// The parameters of the edge effect.
+        /// </summary>
         public EdgeEffectParameters Parameters { get; set; }
 
+        /// <summary>
+        /// Determines how large a radius is masked away around the corners.
+        /// </summary>
         public float CornerRadius { get; set; }
 
         public Container ApplyTo(Drawable drawable)

--- a/osu.Framework/Graphics/Effects/EdgeEffect.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffect.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics.Containers;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace osu.Framework.Graphics.Effects
 {

--- a/osu.Framework/Graphics/Effects/EdgeEffect.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffect.cs
@@ -1,0 +1,34 @@
+﻿using osu.Framework.Graphics.Containers;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Graphics.Effects
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class EdgeEffect : IEffect<Container>
+    {
+        public EdgeEffectParameters Parameters { get; set; }
+
+        public float CornerRadius { get; set; }
+
+        public Container ApplyTo(Drawable drawable)
+        {
+            return new Container
+            {
+                Masking = true,
+                EdgeEffect = Parameters,
+                CornerRadius = CornerRadius,
+                Anchor = drawable.Anchor,
+                Origin = drawable.Origin,
+                RelativeSizeAxes = drawable.RelativeSizeAxes,
+                AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
+                Children = new[] { drawable }
+            };
+        }
+    }
+}

--- a/osu.Framework/Graphics/Effects/EffectExtensions.cs
+++ b/osu.Framework/Graphics/Effects/EffectExtensions.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/osu.Framework/Graphics/Effects/EffectExtensions.cs
+++ b/osu.Framework/Graphics/Effects/EffectExtensions.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace osu.Framework.Graphics.Effects
 {

--- a/osu.Framework/Graphics/Effects/EffectExtensions.cs
+++ b/osu.Framework/Graphics/Effects/EffectExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Graphics.Effects
+{
+    /// <summary>
+    /// This class holds extension methods for effects.
+    /// </summary>
+    public static class EffectExtensions
+    {
+        /// <summary>
+        /// Applies the given effect to the given drawable and optionally initializes the created drawable with the given initializationAction.
+        /// </summary>
+        /// <typeparam name="T">The type of the drawable that results from applying the given effect.</typeparam>
+        /// <param name="effect">The effect to apply to the drawable.</param>
+        /// <param name="drawable">The drawable to apply the effect to.</param>
+        /// <param name="initializationAction">The action that should get called to initialize the created drawable before it is returned.</param>
+        /// <returns>The drawable created by applying the given effect to this drawable.</returns>
+        public static T ApplyTo<T>(this IEffect<T> effect, Drawable drawable, Action<T> initializationAction = null) where T : Drawable
+            => drawable.WithEffect(effect, initializationAction);
+    }
+}

--- a/osu.Framework/Graphics/Effects/IEffect.cs
+++ b/osu.Framework/Graphics/Effects/IEffect.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/osu.Framework/Graphics/Effects/IEffect.cs
+++ b/osu.Framework/Graphics/Effects/IEffect.cs
@@ -1,11 +1,6 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace osu.Framework.Graphics.Effects
 {

--- a/osu.Framework/Graphics/Effects/IEffect.cs
+++ b/osu.Framework/Graphics/Effects/IEffect.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Graphics.Effects
+{
+    /// <summary>
+    /// Represents an effect that can be applied to a drawable.
+    /// </summary>
+    /// <typeparam name="T">The type of the drawable that is created as a result of applying the effect to a drawable.</typeparam>
+    public interface IEffect<out T> where T : Drawable
+    {
+        /// <summary>
+        /// Applies this effect to the given drawable.
+        /// </summary>
+        /// <param name="drawable">The drawable to apply this effect to.</param>
+        /// <returns>A new drawable derived from the given drawable with the effect applied.</returns>
+        T ApplyTo(Drawable drawable);
+    }
+}

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Transforms
             base.Apply(d);
             Container c = (Container)d;
 
-            EdgeEffect e = c.EdgeEffect;
+            EdgeEffectParameters e = c.EdgeEffect;
             e.Colour.Linear.A = CurrentValue;
             c.EdgeEffect = e;
         }

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Graphics.Transforms
             base.Apply(d);
             Container c = (Container)d;
 
-            EdgeEffect e = c.EdgeEffect;
+            EdgeEffectParameters e = c.EdgeEffect;
             e.Colour = CurrentValue;
             c.EdgeEffect = e;
         }

--- a/osu.Framework/MathUtils/Blur.cs
+++ b/osu.Framework/MathUtils/Blur.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/osu.Framework/MathUtils/Blur.cs
+++ b/osu.Framework/MathUtils/Blur.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace osu.Framework.MathUtils
+{
+    /// <summary>
+    /// Helper methods for blur calculations.
+    /// </summary>
+    public static class Blur
+    {
+        /// <summary>
+        /// Evaluates a 1-D gaussian distribution with 0 mean and sigma standard deviation at position x.
+        /// </summary>
+        /// <param name="x">The position to evaluate the distribution at.</param>
+        /// <param name="sigma">Standard deviation of the distribution.</param>
+        /// <returns>The probability density of the distribution at x.</returns>
+        public static double EvalGaussian(float x, float sigma)
+        {
+            const double inv_sqrt_2_pi = 0.39894;
+            return inv_sqrt_2_pi * Math.Exp(-0.5 * x * x / (sigma * sigma)) / sigma;
+        }
+
+        /// <summary>
+        /// Finds the guassian blur kernel size where the magnitude of the gaussian distribution within the kernel
+        /// is greater than or equal to cutoffThreshold times the maximum of the distribution.
+        /// </summary>
+        /// <param name="sigma">Standard deviation of the distribution.</param>
+        /// <param name="cutoffThreshold">The threshold that defines the kernel size.</param>
+        /// <returns>The size of the kernel satisfying the requested threshold.</returns>
+        public static int KernelSize(float sigma, float cutoffThreshold = 0.1f)
+        {
+            if (sigma == 0)
+                return 0;
+
+            const int max_radius = 200;
+
+            double center = EvalGaussian(0, sigma);
+            double threshold = cutoffThreshold * center;
+            for (int i = 0; i < max_radius; ++i)
+                if (EvalGaussian(i, sigma) < threshold)
+                    return Math.Max(i - 1, 0);
+
+            return max_radius;
+        }
+    }
+}

--- a/osu.Framework/MathUtils/Blur.cs
+++ b/osu.Framework/MathUtils/Blur.cs
@@ -2,10 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace osu.Framework.MathUtils
 {

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -120,6 +120,9 @@
     <Compile Include="Graphics\Containers\TabbableContainer.cs" />
     <Compile Include="Graphics\Cursor\IHasTooltip.cs" />
     <Compile Include="Graphics\Cursor\TooltipContainer.cs" />
+    <Compile Include="Graphics\Effects\BlurEffect.cs" />
+    <Compile Include="Graphics\Effects\EffectExtensions.cs" />
+    <Compile Include="Graphics\Effects\IEffect.cs" />
     <Compile Include="Graphics\OpenGL\Vertices\ParticleVertex2D.cs" />
     <Compile Include="Graphics\OpenGL\Vertices\TexturedVertex2D.cs" />
     <Compile Include="Graphics\OpenGL\Vertices\TexturedVertex3D.cs" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Graphics\Cursor\IHasTooltip.cs" />
     <Compile Include="Graphics\Cursor\TooltipContainer.cs" />
     <Compile Include="Graphics\Effects\BlurEffect.cs" />
+    <Compile Include="Graphics\Effects\EdgeEffect.cs" />
     <Compile Include="Graphics\Effects\EffectExtensions.cs" />
     <Compile Include="Graphics\Effects\IEffect.cs" />
     <Compile Include="Graphics\OpenGL\Vertices\ParticleVertex2D.cs" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Localisation\UnicodeBindableString.cs" />
     <Compile Include="Localisation\VaraintFormattableString.cs" />
     <Compile Include="Logging\Logger.cs" />
+    <Compile Include="MathUtils\Blur.cs" />
     <Compile Include="MathUtils\Precision.cs" />
     <Compile Include="MathUtils\RNG.cs" />
     <Compile Include="Configuration\Bindable.cs" />


### PR DESCRIPTION
An initial draft and a few useful/encouraging examples for an API to allow application of effects to drawables.

The basic idea is to have an Effect object that when applied to a drawable, returns a new drawable (fe a container containing the target drawable) that displays the original drawable with the effect.

This design was chosen after some discussion with @Tom94.
His idea was originally to simply have Containers that wrap drawables, to make the resulting draw graph more obvious. However, this prevents easy re-use of effects (since the Containers have to ensure that only one drawable is contained by them) for no particular gain other than being able to use the initialization syntax when creating a big draw graph.
To allow having a markup-esque structure with effects, the example of TextFlowContainer was used, that is, when applying an effect, there is an additional delegate parameter that can be used to make further changes to the created drawable.