### PR TITLE
Make Active bindable in TabItem, managed by TabControl

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -103,7 +103,7 @@ namespace osu.Framework.Graphics.UserInterface
             Current.ValueChanged += newSelection =>
             {
                 if (IsLoaded)
-                    selectTab(tabMap[Current]);
+                    SelectTab(tabMap[Current]);
                 else
                     //will be handled in LoadComplete
                     SelectedTab = tabMap[Current];
@@ -125,9 +125,9 @@ namespace osu.Framework.Graphics.UserInterface
         protected override void LoadComplete()
         {
             if (SelectedTab != null)
-                selectTab(SelectedTab);
+                SelectTab(SelectedTab);
             else if (TabContainer.Children.Any())
-                TabContainer.Children.First().Active = true;
+                SelectTab(TabContainer.Children.First());
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             // Do not allow duplicate adding
             if (tabMap.ContainsKey(value))
-                return null;
+                throw new InvalidOperationException($"Item {value} has already been added to this {nameof(TabControl<T>)}");
 
             var tab = CreateTabItem(value);
             AddTabItem(tab, addToDropdown);
@@ -179,8 +179,8 @@ namespace osu.Framework.Graphics.UserInterface
         /// <param name="addToDropdown">Whether the tab should be added to the Dropdown if supported by the <see cref="TabControl{T}"/> implementation</param>
         protected void AddTabItem(TabItem<T> tab, bool addToDropdown = true)
         {
-            tab.PinnedChanged += resortTab;
-            tab.SelectAction += selectTab;
+            tab.PinnedChanged += performTabSort;
+            tab.ActivationRequested += SelectTab;
 
             tabMap[tab.Value] = tab;
             if (addToDropdown)
@@ -200,27 +200,27 @@ namespace osu.Framework.Graphics.UserInterface
                 Dropdown?.ShowItem(tab.Value);
         }
 
-        private void selectTab(TabItem<T> tab)
+        protected virtual void SelectTab(TabItem<T> tab)
         {
             // Only reorder if not pinned and not showing
             if (AutoSort && !tab.IsPresent && !tab.Pinned)
-                resortTab(tab);
+                performTabSort(tab);
 
             // Deactivate previously selected tab
-            if (SelectedTab != null && SelectedTab != tab) SelectedTab.Active = false;
+            if (SelectedTab != null && SelectedTab != tab) SelectedTab.Active.Value = false;
 
             SelectedTab = tab;
-            SelectedTab.Active = true;
+            SelectedTab.Active.Value = true;
 
             Current.Value = SelectedTab.Value;
         }
 
-        private void resortTab(TabItem<T> tab)
+        private void performTabSort(TabItem<T> tab)
         {
             if (IsLoaded)
                 TabContainer.Remove(tab);
 
-            tab.Depth = tab.Pinned ? float.MaxValue : ++depthCounter;
+            tab.Depth = getTabDepth(tab);
 
             // IsPresent of TabItems is based on Y position.
             // We reset it here to allow tabs to get a correct initial position.
@@ -229,6 +229,8 @@ namespace osu.Framework.Graphics.UserInterface
             if (IsLoaded)
                 TabContainer.Add(tab);
         }
+
+        private float getTabDepth(TabItem<T> tab) => tab.Pinned ? float.MinValue : --depthCounter;
 
         public class TabFillFlowContainer<U> : FillFlowContainer<U> where U : TabItem
         {

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -179,7 +179,12 @@ namespace osu.Framework.Graphics.UserInterface
         /// <param name="addToDropdown">Whether the tab should be added to the Dropdown if supported by the <see cref="TabControl{T}"/> implementation</param>
         protected void AddTabItem(TabItem<T> tab, bool addToDropdown = true)
         {
-            tab.PinnedChanged += performTabSort;
+            tab.PinnedChanged += t =>
+            {
+                // Todo: This schedule is a temporary fix for https://github.com/ppy/osu-framework/issues/821
+                Schedule(() => performTabSort(t));
+            };
+
             tab.ActivationRequested += SelectTab;
 
             tabMap[tab.Value] = tab;

--- a/osu.Framework/Graphics/UserInterface/TabItem.cs
+++ b/osu.Framework/Graphics/UserInterface/TabItem.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 
@@ -11,9 +12,9 @@ namespace osu.Framework.Graphics.UserInterface
     {
     }
 
-    public class TabItem<T> : TabItem
+    public abstract class TabItem<T> : TabItem
     {
-        internal Action<TabItem<T>> SelectAction;
+        internal Action<TabItem<T>> ActivationRequested;
 
         internal Action<TabItem<T>> PinnedChanged;
 
@@ -21,9 +22,19 @@ namespace osu.Framework.Graphics.UserInterface
 
         public readonly T Value;
 
-        public TabItem(T value)
+        protected TabItem(T value)
         {
             Value = value;
+
+            Active.ValueChanged += active_ValueChanged;
+        }
+
+        private void active_ValueChanged(bool newValue)
+        {
+            if (newValue)
+                OnActivated();
+            else
+                OnDeactivated();
         }
 
         private bool pinned;
@@ -40,26 +51,18 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        private bool active;
+        protected abstract void OnActivated();
+        protected abstract void OnDeactivated();
 
-        public virtual bool Active
-        {
-            get { return active; }
-            set
-            {
-                if (active == value) return;
-
-                active = value;
-                if (active)
-                    SelectAction?.Invoke(this);
-            }
-        }
+        public readonly BindableBool Active = new BindableBool();
 
         protected override bool OnClick(InputState state)
         {
             base.OnClick(state);
-            Active = true;
+            ActivationRequested?.Invoke(this);
             return true;
         }
+
+        public override string ToString() => $"{base.ToString()} value: {Value}";
     }
 }


### PR DESCRIPTION
A much better flow than having tabs always set themselves as active. Didn't allow enough flexibility.