### PR TITLE
Add Drawable.OnSizingChanged

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -1010,6 +1010,7 @@ namespace osu.Framework.Graphics.Containers
 
                 autoSizeAxes = value;
                 childrenSizeDependencies.Invalidate();
+                OnSizingChanged();
             }
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -631,6 +631,7 @@ namespace osu.Framework.Graphics
                 if ((relativeSizeAxes & Axes.X) > 0 && Width == 0) Width = 1;
                 if ((relativeSizeAxes & Axes.Y) > 0 && Height == 0) Height = 1;
 
+                OnSizingChanged();
                 // No invalidation necessary as DrawSize remains invariant.
             }
         }
@@ -758,6 +759,11 @@ namespace osu.Framework.Graphics
         /// Computes the bounding box of this drawable in its parent's space.
         /// </summary>
         public virtual RectangleF BoundingBox => ToParentSpace(LayoutRectangle).AABBFloat;
+
+        /// <summary>
+        /// Called whenever the <see cref="RelativeSizeAxes"/> of this drawable is changed, or when the <see cref="Container{T}.AutoSizeAxes"/> are changed if this drawable is a <see cref="Container{T}"/>.
+        /// </summary>
+        protected virtual void OnSizingChanged() { }
 
         #endregion
 


### PR DESCRIPTION
The OnSizingChanged() method is a callback method that can be used by
subclasses to react to changes of the RelativeSizeAxes and AutoSizeAxes
properties that Drawable and Container expose, respectively.