### PR TITLE
Fix for Raw Input cursor leaving the window

### DIFF
--- a/SampleGame/SampleGame.cs
+++ b/SampleGame/SampleGame.cs
@@ -5,7 +5,7 @@ using osu.Framework;
 using osu.Framework.Graphics;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Allocation;
 
 namespace SampleGame

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
@@ -9,6 +9,7 @@ using osu.Framework.Platform;
 using osu.Framework.Threading;
 using OpenTK;
 using osu.Framework.Statistics;
+using osu.Framework.Desktop.Platform;
 using MouseState = OpenTK.Input.MouseState;
 
 namespace osu.Framework.Desktop.Input.Handlers.Mouse
@@ -27,12 +28,20 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
 
         public BindableDouble Sensitivity => sensitivity;
 
+        private ConfineMouseMode confineMode;
+
+        private WindowMode windowMode;
+
+        private DesktopGameWindow desktopWindow;
+
         public override bool Initialize(GameHost host)
         {
             host.Window.MouseEnter += window_MouseEnter;
             host.Window.MouseLeave += window_MouseLeave;
 
             mouseInWindow = host.Window.CursorInWindow;
+
+            
 
             Enabled.ValueChanged += enabled =>
             {
@@ -63,6 +72,28 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
                             else
                             {
                                 currentPosition += new Vector2(state.X - lastState.Value.X, state.Y - lastState.Value.Y) * (float)sensitivity.Value;
+
+                                //Get the bindables we need to determine whether to confine the mouse to window or not{
+                                desktopWindow = host.Window as DesktopGameWindow;
+                                if (desktopWindow != null)
+                                {
+                                    confineMode = desktopWindow.confineMouseMode;
+                                    windowMode = desktopWindow.windowMode;
+                                }
+
+                                if (confineMode == ConfineMouseMode.Always ||
+                                   (confineMode == ConfineMouseMode.Fullscreen) && (windowMode == WindowMode.Fullscreen) )
+                                {
+                                    if (currentPosition.X < 0)
+                                        currentPosition.X = 0;
+                                    if (currentPosition.X > host.Window.Width)
+                                        currentPosition.X = host.Window.Width;
+
+                                    if (currentPosition.Y < 0)
+                                        currentPosition.Y = 0;
+                                    if (currentPosition.Y > host.Window.Height)
+                                        currentPosition.Y = host.Window.Height;
+                                }
 
                                 // update the windows cursor to match our raw cursor position.
                                 // this is important when sensitivity is decreased below 1.0, where we need to ensure the cursor stays withing the window.

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Drawing;

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
@@ -41,8 +41,6 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
 
             mouseInWindow = host.Window.CursorInWindow;
 
-            
-
             Enabled.ValueChanged += enabled =>
             {
                 if (enabled)
@@ -77,12 +75,12 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
                                 desktopWindow = host.Window as DesktopGameWindow;
                                 if (desktopWindow != null)
                                 {
-                                    confineMode = desktopWindow.confineMouseMode;
-                                    windowMode = desktopWindow.windowMode;
+                                    confineMode = desktopWindow.ConfineMouseMode;
+                                    windowMode = desktopWindow.WindowMode;
                                 }
 
                                 if (confineMode == ConfineMouseMode.Always ||
-                                   (confineMode == ConfineMouseMode.Fullscreen) && (windowMode == WindowMode.Fullscreen) )
+                                   confineMode == ConfineMouseMode.Fullscreen && windowMode == WindowMode.Fullscreen)
                                 {
                                     if (currentPosition.X < 0)
                                         currentPosition.X = 0;

--- a/osu.Framework.Desktop/Platform/DesktopGameWindow.cs
+++ b/osu.Framework.Desktop/Platform/DesktopGameWindow.cs
@@ -29,9 +29,9 @@ namespace osu.Framework.Desktop.Platform
         private readonly BindableDouble windowPositionX = new BindableDouble();
         private readonly BindableDouble windowPositionY = new BindableDouble();
 
-        public readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
+        public readonly Bindable<WindowMode> WindowMode = new Bindable<WindowMode>();
 
-        public readonly Bindable<ConfineMouseMode> confineMouseMode = new Bindable<ConfineMouseMode>();
+        public readonly Bindable<ConfineMouseMode> ConfineMouseMode = new Bindable<ConfineMouseMode>();
 
         public DesktopGameWindow()
             : base(default_width, default_height)
@@ -49,15 +49,15 @@ namespace osu.Framework.Desktop.Platform
             config.BindWith(FrameworkSetting.WindowedPositionX, windowPositionX);
             config.BindWith(FrameworkSetting.WindowedPositionY, windowPositionY);
 
-            config.BindWith(FrameworkSetting.ConfineMouseMode, confineMouseMode);
+            config.BindWith(FrameworkSetting.ConfineMouseMode, ConfineMouseMode);
 
-            confineMouseMode.ValueChanged += confineMouseMode_ValueChanged;
-            confineMouseMode.TriggerChange();
+            ConfineMouseMode.ValueChanged += confineMouseMode_ValueChanged;
+            ConfineMouseMode.TriggerChange();
 
-            config.BindWith(FrameworkSetting.WindowMode, windowMode);
+            config.BindWith(FrameworkSetting.WindowMode, WindowMode);
 
-            windowMode.ValueChanged += windowMode_ValueChanged;
-            windowMode.TriggerChange();
+            WindowMode.ValueChanged += windowMode_ValueChanged;
+            WindowMode.TriggerChange();
 
             Exited += onExit;
         }
@@ -65,9 +65,9 @@ namespace osu.Framework.Desktop.Platform
         protected override void OnResize(EventArgs e)
         {
             base.OnResize(e);
-            switch (windowMode.Value)
+            switch (WindowMode.Value)
             {
-                case WindowMode.Windowed:
+                case Configuration.WindowMode.Windowed:
                     width.Value = ClientSize.Width;
                     height.Value = ClientSize.Height;
                     break;
@@ -80,10 +80,10 @@ namespace osu.Framework.Desktop.Platform
 
             switch (newValue)
             {
-                case ConfineMouseMode.Fullscreen:
-                    confine = windowMode.Value != WindowMode.Windowed;
+                case Framework.Input.ConfineMouseMode.Fullscreen:
+                    confine = WindowMode.Value != Configuration.WindowMode.Windowed;
                     break;
-                case ConfineMouseMode.Always:
+                case Framework.Input.ConfineMouseMode.Always:
                     confine = true;
                     break;
             }
@@ -98,16 +98,16 @@ namespace osu.Framework.Desktop.Platform
         {
             switch (newMode)
             {
-                case WindowMode.Fullscreen:
+                case Configuration.WindowMode.Fullscreen:
                     DisplayResolution newResolution = DisplayDevice.Default.SelectResolution(widthFullscreen, heightFullscreen, 0, DisplayDevice.Default.RefreshRate);
                     DisplayDevice.Default.ChangeResolution(newResolution);
 
-                    WindowState = WindowState.Fullscreen;
+                    base.WindowState = WindowState.Fullscreen;
                     break;
-                case WindowMode.Borderless:
+                case Configuration.WindowMode.Borderless:
                     DisplayDevice.Default.RestoreResolution();
 
-                    WindowState = WindowState.Maximized;
+                    base.WindowState = WindowState.Maximized;
                     WindowBorder = WindowBorder.Hidden;
 
                     //must add 1 to enter borderless
@@ -117,7 +117,7 @@ namespace osu.Framework.Desktop.Platform
                 default:
                     DisplayDevice.Default.RestoreResolution();
 
-                    WindowState = WindowState.Normal;
+                    base.WindowState = WindowState.Normal;
                     WindowBorder = WindowBorder.Resizable;
 
                     ClientSize = new Size(width, height);
@@ -125,18 +125,18 @@ namespace osu.Framework.Desktop.Platform
                     break;
             }
 
-            confineMouseMode.TriggerChange();
+            ConfineMouseMode.TriggerChange();
         }
 
         private void onExit()
         {
-            switch (windowMode.Value)
+            switch (WindowMode.Value)
             {
-                case WindowMode.Fullscreen:
+                case Configuration.WindowMode.Fullscreen:
                     widthFullscreen.Value = ClientSize.Width;
                     heightFullscreen.Value = ClientSize.Height;
                     break;
-                case WindowMode.Windowed:
+                case Configuration.WindowMode.Windowed:
                     windowPositionX.Value = Position.X;
                     windowPositionY.Value = Position.Y;
                     break;
@@ -163,16 +163,16 @@ namespace osu.Framework.Desktop.Platform
 
         public override void CycleMode()
         {
-            switch (windowMode.Value)
+            switch (WindowMode.Value)
             {
-                case WindowMode.Windowed:
-                    windowMode.Value = WindowMode.Borderless;
+                case Configuration.WindowMode.Windowed:
+                    WindowMode.Value = Configuration.WindowMode.Borderless;
                     break;
-                case WindowMode.Borderless:
-                    windowMode.Value = WindowMode.Fullscreen;
+                case Configuration.WindowMode.Borderless:
+                    WindowMode.Value = Configuration.WindowMode.Fullscreen;
                     break;
                 default:
-                    windowMode.Value = WindowMode.Windowed;
+                    WindowMode.Value = Configuration.WindowMode.Windowed;
                     break;
             }
         }

--- a/osu.Framework.Desktop/Platform/DesktopGameWindow.cs
+++ b/osu.Framework.Desktop/Platform/DesktopGameWindow.cs
@@ -29,9 +29,9 @@ namespace osu.Framework.Desktop.Platform
         private readonly BindableDouble windowPositionX = new BindableDouble();
         private readonly BindableDouble windowPositionY = new BindableDouble();
 
-        private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
+        public readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
 
-        private readonly Bindable<ConfineMouseMode> confineMouseMode = new Bindable<ConfineMouseMode>();
+        public readonly Bindable<ConfineMouseMode> confineMouseMode = new Bindable<ConfineMouseMode>();
 
         public DesktopGameWindow()
             : base(default_width, default_height)

--- a/osu.Framework.Testing/Drawables/TestCaseButton.cs
+++ b/osu.Framework.Testing/Drawables/TestCaseButton.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using OpenTK;

--- a/osu.Framework.Testing/TestBrowser.cs
+++ b/osu.Framework.Testing/TestBrowser.cs
@@ -10,6 +10,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
 using osu.Framework.Screens;

--- a/osu.Framework.Testing/TestCase.cs
+++ b/osu.Framework.Testing/TestCase.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing.Drawables.StepButtons;
 using osu.Framework.Threading;
 using OpenTK;

--- a/osu.Framework.VisualTests/Tests/TestCaseAnimation.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseAnimation.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Animations;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Testing;
+
+namespace osu.Framework.VisualTests.Tests
+{
+    internal class TestCaseAnimation : TestCase
+    {
+        private DrawableAnimation drawableAnimation;
+
+        public override string Description => "Various frame-based animations";
+
+        public override void Reset()
+        {
+            base.Reset();
+
+            Add(new Container
+            {
+                Position = new Vector2(10f, 10f),
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new DelayedLoadWrapper(new AvatarAnimation
+                    {
+                        AutoSizeAxes = Axes.None,
+                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(0.25f)
+                    }),
+                    drawableAnimation = new DrawableAnimation
+                    {
+                        RelativePositionAxes = Axes.Both,
+                        Position = new Vector2(0f, 0.3f),
+                        AutoSizeAxes = Axes.None,
+                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(0.25f)
+                    }
+                }
+            });
+
+            drawableAnimation.AddFrames(new[]
+            {
+                new FrameData<Drawable>(new Box { Size = new Vector2(50f), Colour = Color4.Red }, 500),
+                new FrameData<Drawable>(new Box { Size = new Vector2(50f), Colour = Color4.Green }, 500),
+                new FrameData<Drawable>(new Box { Size = new Vector2(50f), Colour = Color4.Blue }, 500),
+            });
+        }
+
+        private class AvatarAnimation : TextureAnimation
+        {
+            [BackgroundDependencyLoader]
+            private void load(TextureStore textures)
+            {
+                AddFrame(textures.Get("https://a.ppy.sh/2"), 500);
+                AddFrame(textures.Get("https://a.ppy.sh/3"), 500);
+                AddFrame(textures.Get("https://a.ppy.sh/1876669"), 500);
+            }
+        }
+    }
+}

--- a/osu.Framework.VisualTests/Tests/TestCaseAnimation.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseAnimation.cs
@@ -7,7 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Testing;
 

--- a/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Colour;

--- a/osu.Framework.VisualTests/Tests/TestCaseContextMenu.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseContextMenu.cs
@@ -6,7 +6,7 @@ using OpenTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;

--- a/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCoordinateSpaces.cs
@@ -7,6 +7,7 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 

--- a/osu.Framework.VisualTests/Tests/TestCaseFillModes.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFillModes.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Testing;

--- a/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reflection;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;

--- a/osu.Framework.VisualTests/Tests/TestCaseHollowEdgeEffect.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseHollowEdgeEffect.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using OpenTK;

--- a/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseMasking.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;

--- a/osu.Framework.VisualTests/Tests/TestCaseNestedHover.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseNestedHover.cs
@@ -3,10 +3,10 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests

--- a/osu.Framework.VisualTests/Tests/TestCasePadding.cs
+++ b/osu.Framework.VisualTests/Tests/TestCasePadding.cs
@@ -6,6 +6,7 @@ using OpenTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 

--- a/osu.Framework.VisualTests/Tests/TestCaseScreen.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseScreen.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Screens;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.MathUtils;

--- a/osu.Framework.VisualTests/Tests/TestCaseScrollableFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseScrollableFlow.cs
@@ -7,7 +7,7 @@ using osu.Framework.MathUtils;
 using osu.Framework.Threading;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests.Tests

--- a/osu.Framework.VisualTests/Tests/TestCaseSizing.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSizing.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Testing;

--- a/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSmoothedEdges.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;

--- a/osu.Framework.VisualTests/Tests/TestCaseTabControl.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTabControl.cs
@@ -9,6 +9,7 @@ using OpenTK.Graphics;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;

--- a/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
@@ -6,6 +6,7 @@ using OpenTK.Graphics;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;

--- a/osu.Framework.VisualTests/Tests/TestCaseTriangles.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTriangles.cs
@@ -3,7 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using osu.Framework.Testing;
 using OpenTK;

--- a/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
+++ b/osu.Framework.VisualTests/osu.Framework.VisualTests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="AutomatedVisualTestGame.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Tests\TestCaseAnimation.cs" />
     <Compile Include="Tests\TestCaseCheckboxes.cs" />
     <Compile Include="Tests\TestCaseCircularProgress.cs" />
     <Compile Include="Tests\TestCaseColourGradient.cs" />

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Audio
         /// <summary>
         /// The thread audio operations (mainly Bass calls) are ran on.
         /// </summary>
-        internal GameThread Thread;
+        internal AudioThread Thread;
 
         private List<DeviceInfo> audioDevices = new List<DeviceInfo>();
         private List<string> audioDeviceNames = new List<string>();
@@ -99,7 +99,7 @@ namespace osu.Framework.Audio
             sampleStore.AddExtension(@"wav");
             sampleStore.AddExtension(@"mp3");
 
-            Thread = new GameThread(Update, @"Audio");
+            Thread = new AudioThread(Update, @"Audio");
             Thread.Start();
 
             scheduler.Add(() =>

--- a/osu.Framework/Audio/Track/TrackAmplitudes.cs
+++ b/osu.Framework/Audio/Track/TrackAmplitudes.cs
@@ -13,5 +13,10 @@ namespace osu.Framework.Audio.Track
         public float Maximum => Math.Max(LeftChannel, RightChannel);
 
         public float Average => (LeftChannel + RightChannel) / 2;
+
+        /// <summary>
+        /// 256 length array of bins containing the average frequency of both channels at every ~78Hz step of the audible spectrum (0Hz - 20,000Hz).
+        /// </summary>
+        public float[] FrequencyAmplitudes;
     }
 }

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -107,6 +107,10 @@ namespace osu.Framework.Audio.Track
             tempLevel = Bass.ChannelGetLevelRight(activeStream) / 32768f;
             currentAmplitudes.RightChannel = tempLevel == -1 ? 1 : tempLevel;
 
+            float[] tempFrequencyData = new float[256];
+            Bass.ChannelGetData(activeStream, tempFrequencyData, (int)DataFlags.FFT512);
+            currentAmplitudes.FrequencyAmplitudes = tempFrequencyData;
+
             base.Update();
         }
 

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics.Containers;
+using System.Collections.Generic;
+
+namespace osu.Framework.Graphics.Animations
+{
+    /// <summary>
+    /// Represents a generic, frame-based animation. Inherit this class if you need custom animations.
+    /// </summary>
+    /// <typeparam name="T">The type of content in the frames of the animation.</typeparam>
+    public abstract class Animation<T> : Container, IAnimation
+    {
+        /// <summary>
+        /// The duration in milliseconds of a newly added frame, if no duration is explicitly specified when adding the frame.
+        /// </summary>
+        public double DefaultFrameLength = 1000.0 / 60.0;
+
+        private readonly List<FrameData<T>> frameData;
+        private int currentFrameIndex;
+
+        private double currentFrameTime;
+
+        /// <summary>
+        /// The number of frames this animation has.
+        /// </summary>
+        public int FrameCount => frameData.Count;
+
+        /// <summary>
+        /// True if the animation is playing, false otherwise.
+        /// </summary>
+        public bool IsPlaying { get; set; }
+
+        /// <summary>
+        /// True if the animation should start over from the first frame after finishing. False if it should stop playing and keep displaying the last frame when finishing.
+        /// </summary>
+        public bool Repeat { get; set; }
+
+
+        protected Animation()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            frameData = new List<FrameData<T>>();
+            IsPlaying = true;
+            Repeat = true;
+        }
+
+        /// <summary>
+        /// Displays the frame with the given zero-based frame index.
+        /// </summary>
+        /// <param name="frameIndex">The zero-based index of the frame to display.</param>
+        public void GotoFrame(int frameIndex)
+        {
+            if (frameIndex < 0)
+                frameIndex = 0;
+            else if (frameIndex >= frameData.Count)
+                frameIndex = frameData.Count - 1;
+
+            currentFrameIndex = frameIndex;
+            displayFrame(currentFrameIndex);
+        }
+
+        /// <summary>
+        /// Adds a new frame with the given content and display duration (in milliseconds) to this animation.
+        /// </summary>
+        /// <param name="content">The content of the new frame.</param>
+        /// <param name="displayDuration">The duration the new frame should be displayed for.</param>
+        public void AddFrame(T content, double? displayDuration = null)
+        {
+            AddFrame(new FrameData<T>()
+            {
+                Duration = displayDuration ?? DefaultFrameLength, // 60 fps by default
+                Content = content
+            });
+        }
+
+        public void AddFrame(FrameData<T> frame)
+        {
+            frameData.Add(frame);
+            OnFrameAdded(frame.Content, frame.Duration);
+
+            if (frameData.Count == 1)
+                displayFrame(0);
+        }
+
+        /// <summary>
+        /// Adds a new frame for each element in the given enumerable. Every frame will be displayed for 1/60th of a second.
+        /// </summary>
+        /// <param name="contents">The contents to use for creating new frames.</param>
+        public void AddFrames(IEnumerable<T> contents)
+        {
+            foreach (var t in contents)
+                AddFrame(t);
+        }
+
+        /// <summary>
+        /// Adds a new frame for each element in the given enumerable. Every frame will be displayed for the given number of milliseconds.
+        /// </summary>
+        /// <param name="frames">The contents and display durations to use for creating new frames.</param>
+        public void AddFrames(IEnumerable<FrameData<T>> frames)
+        {
+            foreach (var t in frames)
+                AddFrame(t.Content, t.Duration);
+        }
+
+        private void displayFrame(int index) => DisplayFrame(frameData[index].Content);
+
+        /// <summary>
+        /// Displays the given contents.
+        /// </summary>
+        /// <remarks>This method will only be called after <see cref="OnFrameAdded(T, double)"/> has been called at least once.</remarks>
+        /// <param name="content">The content that will be displayed.</param>
+        protected abstract void DisplayFrame(T content);
+
+        /// <summary>
+        /// Called whenever a new frame was added to this animation.
+        /// </summary>
+        /// <param name="content">The content of the new frame.</param>
+        /// <param name="displayDuration">The display duration of the new frame.</param>
+        protected virtual void OnFrameAdded(T content, double displayDuration) { }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (IsPlaying && frameData.Count > 0)
+            {
+                currentFrameTime += Time.Elapsed;
+                while (currentFrameTime > frameData[currentFrameIndex].Duration)
+                {
+                    currentFrameTime -= frameData[currentFrameIndex].Duration;
+                    ++currentFrameIndex;
+                    if (currentFrameIndex >= frameData.Count)
+                    {
+                        if (Repeat)
+                        {
+                            currentFrameIndex = 0;
+                        }
+                        else
+                        {
+                            currentFrameIndex = frameData.Count - 1;
+                            IsPlaying = false;
+                            break;
+                        }
+                    }
+                }
+                displayFrame(currentFrameIndex);
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Animations/AnimationExtensions.cs
+++ b/osu.Framework/Graphics/Animations/AnimationExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics.Animations
+{
+    /// <summary>
+    /// This class holds various extension methods for the <see cref="IAnimation"/> interface.
+    /// </summary>
+    public static class AnimationExtensions
+    {
+        /// <summary>
+        /// Displays the frame with the given zero-based frame index and stops the animation at that frame.
+        /// </summary>
+        /// <param name="animation">The animation that should seek the frame and stop playing.</param>
+        /// <param name="frameIndex">The zero-based index of the frame to display.</param>
+        public static void GotoAndStop(this IAnimation animation, int frameIndex)
+        {
+            animation.GotoFrame(frameIndex);
+            animation.IsPlaying = false;
+        }
+
+        /// <summary>
+        /// Displays the frame with the given zero-based frame index and plays the animation from that frame.
+        /// </summary>
+        /// <param name="animation">The animation that should seek the frame and start playing.</param>
+        /// <param name="frameIndex">The zero-based index of the frame to display.</param>
+        public static void GotoAndPlay(this IAnimation animation, int frameIndex)
+        {
+            animation.GotoFrame(frameIndex);
+            animation.IsPlaying = true;
+        }
+
+        /// <summary>
+        /// Resumes playing the animation.
+        /// </summary>
+        /// <param name="animation">The animation to play.</param>
+        public static void Play(this IAnimation animation) => animation.IsPlaying = true;
+
+        /// <summary>
+        /// Stops playing the animation.
+        /// </summary>
+        /// <param name="animation">The animation to stop playing.</param>
+        public static void Stop(this IAnimation animation) => animation.IsPlaying = false;
+
+        /// <summary>
+        /// Restarts the animation.
+        /// </summary>
+        /// <param name="animation">The animation to restart.</param>
+        public static void Restart(this IAnimation animation) => animation.GotoAndPlay(0);
+    }
+}

--- a/osu.Framework/Graphics/Animations/DrawableAnimation.cs
+++ b/osu.Framework/Graphics/Animations/DrawableAnimation.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics.Animations
+{
+    /// <summary>
+    /// An animation that switches the displayed drawable when a new frame is displayed.
+    /// </summary>
+    public class DrawableAnimation : Animation<Drawable>
+    {
+        protected override void DisplayFrame(Drawable content)
+        {
+            Clear(false);
+            Add(content);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Animations/FrameData.cs
+++ b/osu.Framework/Graphics/Animations/FrameData.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics.Animations
+{
+    /// <summary>
+    /// Represents all data necessary to describe a single frame of an <see cref="Animation{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of animation the frame data is for.</typeparam>
+    public struct FrameData<T>
+    {
+        /// <summary>
+        /// The contents to display for the frame.
+        /// </summary>
+        public T Content { get; set; }
+
+        /// <summary>
+        /// The duration to display the frame for.
+        /// </summary>
+        public double Duration { get; set; }
+
+        /// <summary>
+        /// Constructs new frame data with the given content and duration.
+        /// </summary>
+        /// <param name="content">The content of the frame.</param>
+        /// <param name="duration">The duration the frame will be displayed for.</param>
+        public FrameData(T content, double duration)
+        {
+            Content = content;
+            Duration = duration;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Animations/IAnimation.cs
+++ b/osu.Framework/Graphics/Animations/IAnimation.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+
+namespace osu.Framework.Graphics.Animations
+{
+    /// <summary>
+    /// Represents a generic, frame-based animation.
+    /// </summary>
+    public interface IAnimation
+    {
+        /// <summary>
+        /// The number of frames this animation has.
+        /// </summary>
+        int FrameCount { get; }
+
+        /// <summary>
+        /// True if the animation is playing, false otherwise.
+        /// </summary>
+        bool IsPlaying { get; set; }
+
+        /// <summary>
+        /// True if the animation should start over from the first frame after finishing. False if it should stop playing and keep displaying the last frame when finishing.
+        /// </summary>
+        bool Repeat { get; set; }
+
+        /// <summary>
+        /// Displays the frame with the given zero-based frame index.
+        /// </summary>
+        /// <param name="frameIndex">The zero-based index of the frame to display.</param>
+        void GotoFrame(int frameIndex);
+    }
+}

--- a/osu.Framework/Graphics/Animations/TextureAnimation.cs
+++ b/osu.Framework/Graphics/Animations/TextureAnimation.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+
+namespace osu.Framework.Graphics.Animations
+{
+    /// <summary>
+    /// An animation that switches the displayed texture when a new frame is displayed.
+    /// </summary>
+    public class TextureAnimation : Animation<Texture>
+    {
+        private readonly Sprite textureHolder;
+        private Vector2 maxTextureSize = Vector2.Zero;
+
+        public TextureAnimation()
+        {
+            Children = new[]
+            {
+                textureHolder = new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            };
+        }
+
+        protected override void OnFrameAdded(Texture content, double displayDuration)
+        {
+            base.OnFrameAdded(content, displayDuration);
+            maxTextureSize = Vector2.ComponentMax(new Vector2(content.DisplayWidth, content.DisplayHeight), maxTextureSize);
+        }
+
+        protected override void DisplayFrame(Texture content)
+        {
+            textureHolder.Texture = content;
+            updateTextureHolderSize();
+        }
+
+        protected override void OnSizingChanged()
+        {
+            base.OnSizingChanged();
+
+            if (textureHolder == null)
+                return;
+
+            textureHolder.RelativeSizeAxes = ~AutoSizeAxes;
+            updateTextureHolderSize();
+        }
+
+        private void updateTextureHolderSize()
+        {
+            var newSize = Vector2.Zero;
+            var content = textureHolder.Texture;
+            if (content == null)
+                return;
+
+            if ((AutoSizeAxes & Axes.X) != 0)
+                newSize.X = content.DisplayWidth;
+            else
+                newSize.X = content.DisplayWidth / maxTextureSize.X;
+
+            if ((AutoSizeAxes & Axes.Y) != 0)
+                newSize.Y = content.DisplayHeight;
+            else
+                newSize.Y = content.DisplayHeight / maxTextureSize.Y;
+
+            textureHolder.Size = newSize;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -255,7 +255,7 @@ namespace osu.Framework.Graphics.Containers
         //}
 
         /// <summary>
-        /// Helper function for creating and adding a <see cref="Transform{T}"/> that blurs
+        /// Helper function for creating and adding a <see cref="Transform{TValue, T}"/> that blurs
         /// the buffered container.
         /// </summary>
         public void BlurTo(Vector2 newBlurSigma, double duration = 0, EasingTypes easing = EasingTypes.None)

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -127,6 +127,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The publicly accessible list of children. Forwards to the children of <see cref="Content"/>.
         /// If <see cref="Content"/> is this container, then returns <see cref="InternalChildren"/>.
+        /// Assigning to this property will dispose all existing children of this Container.
         /// </summary>
         public IEnumerable<T> Children
         {
@@ -150,7 +151,7 @@ namespace osu.Framework.Graphics.Containers
         private readonly LifetimeList<Drawable> internalChildren;
 
         /// <summary>
-        /// This container's own list of children.
+        /// This container's own list of children. Assigning to this property will dispose all existing internal children of this Container.
         /// </summary>
         public IEnumerable<Drawable> InternalChildren
         {

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -663,7 +663,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Helper function for creating and adding a <see cref="Transform{T}"/> that fades the current <see cref="EdgeEffect"/>.
+        /// Helper function for creating and adding a <see cref="Transform{TValue, T}"/> that fades the current <see cref="EdgeEffect"/>.
         /// </summary>
         public void FadeEdgeEffectTo(float newAlpha, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
@@ -672,7 +672,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Helper function for creating and adding a <see cref="Transform{T}"/> that fades the current <see cref="EdgeEffect"/>.
+        /// Helper function for creating and adding a <see cref="Transform{TValue, T}"/> that fades the current <see cref="EdgeEffect"/>.
         /// </summary>
         public void FadeEdgeEffectTo(Color4 newColour, double duration = 0, EasingTypes easing = EasingTypes.None)
         {

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -1010,6 +1010,7 @@ namespace osu.Framework.Graphics.Containers
 
                 autoSizeAxes = value;
                 childrenSizeDependencies.Invalidate();
+                OnSizingChanged();
             }
         }
 

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -14,6 +14,7 @@ namespace osu.Framework.Graphics.Containers
         Vector2 RelativeToAbsoluteFactor { get; }
         Vector2 RelativeChildOffset { get; }
 
+        EdgeEffectParameters EdgeEffect { get; set; }
         float CornerRadius { get; }
 
         void InvalidateFromChild(Invalidation invalidation);

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -7,7 +7,7 @@ using osu.Framework.Input;
 using osu.Framework.MathUtils;
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.Containers
 {

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using OpenTK;
-using osu.Framework.Graphics.Sprites;
 using OpenTK.Graphics;
 
 namespace osu.Framework.Graphics.Cursor

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -6,6 +6,7 @@ using OpenTK.Graphics;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Threading;

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Input;
-using osu.Framework.Lists;
 using osu.Framework.Logging;
 using osu.Framework.Statistics;
 using osu.Framework.Threading;
@@ -40,7 +39,7 @@ namespace osu.Framework.Graphics
     /// Drawables are always rectangular in shape in their local coordinate system,
     /// which makes them quad-shaped in arbitrary (linearly transformed) coordinate systems.
     /// </summary>
-    public abstract class Drawable : IDisposable, IDrawable
+    public abstract class Drawable : Transformable<Drawable>, IDisposable, IDrawable
     {
         #region Construction and disposal
 
@@ -323,45 +322,6 @@ namespace osu.Framework.Graphics
         /// </summary>
         protected Scheduler Scheduler => scheduler ?? (scheduler = new Scheduler(MainThread));
 
-        private LifetimeList<ITransform> transforms;
-
-        /// <summary>
-        /// A lazily-initialized list of <see cref="ITransform"/>s applied to this Drawable.
-        /// <see cref="ITransform"/>s are applied right before the <see cref="Update"/> method is called.
-        /// </summary>
-        public LifetimeList<ITransform> Transforms
-        {
-            get
-            {
-                if (transforms == null)
-                {
-                    transforms = new LifetimeList<ITransform>(new TransformTimeComparer());
-                    transforms.Removed += transforms_OnRemoved;
-                }
-
-                return transforms;
-            }
-        }
-
-        /// <summary>
-        /// Process updates to this drawable based on loaded transforms.
-        /// </summary>
-        /// <returns>Whether we should draw this drawable.</returns>
-        private void updateTransforms()
-        {
-            if (transforms == null || transforms.Count == 0) return;
-
-            transforms.Update(Time);
-
-            foreach (ITransform t in transforms.AliveItems)
-                t.Apply(this);
-        }
-
-        private void transforms_OnRemoved(ITransform t)
-        {
-            t.Apply(this); //make sure we apply one last time.
-        }
-
         /// <summary>
         /// Updates this Drawable and all Drawables further down the scene graph.
         /// Called once every frame.
@@ -378,10 +338,10 @@ namespace osu.Framework.Graphics
             if (loadState < LoadState.Alive)
                 if (!loadComplete()) return false;
 
-            TransformDelay = 0;
+            DelayReset();
 
             //todo: this should be moved to after the IsVisible condition once we have TOL for transforms (and some better logic).
-            updateTransforms();
+            UpdateTransforms();
 
             if (!IsPresent)
                 return true;
@@ -1159,7 +1119,7 @@ namespace osu.Framework.Graphics
         /// If set, then the provided value is used as a custom clock and the
         /// <see cref="Parent"/>'s clock is ignored.
         /// </summary>
-        public IFrameBasedClock Clock
+        public override IFrameBasedClock Clock
         {
             get { return clock; }
             set
@@ -1178,11 +1138,6 @@ namespace osu.Framework.Graphics
         {
             this.clock = customClock ?? clock;
         }
-
-        /// <summary>
-        /// The current frame's time as observed by this drawable's <see cref="Clock"/>.
-        /// </summary>
-        public FrameTimeInfo Time => Clock.TimeInfo;
 
         /// <summary>
         /// The time at which this drawable becomes valid (and is considered for drawing).
@@ -1951,84 +1906,7 @@ namespace osu.Framework.Graphics
 
         #region Transforms
 
-        internal double TransformDelay { get; private set; }
-
-        public virtual void ClearTransforms(bool propagateChildren = false)
-        {
-            DelayReset();
-            transforms?.Clear();
-        }
-
-        public virtual Drawable Delay(double duration, bool propagateChildren = false)
-        {
-            if (duration == 0) return this;
-
-            TransformDelay += duration;
-            return this;
-        }
-
         protected ScheduledDelegate Schedule(Action action) => Scheduler.AddDelayed(action, TransformDelay);
-
-        /// <summary>
-        /// Flush specified transforms, using the last available values (ignoring current clock time).
-        /// </summary>
-        /// <param name="propagateChildren">Whether we also flush down the child tree.</param>
-        /// <param name="flushType">An optional type of transform to flush. Null for all types.</param>
-        public virtual void Flush(bool propagateChildren = false, Type flushType = null)
-        {
-            var operateTransforms = flushType == null ? Transforms : Transforms.FindAll(t => t.GetType() == flushType);
-
-            double maxTime = double.MinValue;
-            foreach (ITransform t in operateTransforms)
-                if (t.EndTime > maxTime)
-                    maxTime = t.EndTime;
-
-            FrameTimeInfo maxTimeInfo = new FrameTimeInfo { Current = maxTime };
-
-            foreach (ITransform t in operateTransforms)
-            {
-                t.UpdateTime(maxTimeInfo);
-                t.Apply(this);
-            }
-
-            if (flushType == null)
-                ClearTransforms();
-            else
-                Transforms.RemoveAll(t => t.GetType() == flushType);
-        }
-
-        public virtual Drawable DelayReset()
-        {
-            Delay(-TransformDelay);
-            return this;
-        }
-
-        /// <summary>
-        /// Start a sequence of transforms with a (cumulative) relative delay applied.
-        /// </summary>
-        /// <param name="delay">The offset in milliseconds from current time. Note that this stacks with other nested sequences.</param>
-        /// <param name="recursive">Whether this should be applied to all children.</param>
-        /// <returns>A <see cref="TransformSequence" /> to be used in a using() statement.</returns>
-        public TransformSequence BeginDelayedSequence(double delay, bool recursive = false) => new TransformSequence(this, delay, recursive);
-
-        /// <summary>
-        /// Start a sequence of transforms from an absolute time value.
-        /// </summary>
-        /// <param name="startOffset">The offset in milliseconds from absolute zero.</param>
-        /// <param name="recursive">Whether this should be applied to all children.</param>
-        /// <returns>A <see cref="TransformSequence" /> to be used in a using() statement.</returns>
-        /// <exception cref="InvalidOperationException">Absolute sequences should never be nested inside another existing sequence.</exception>
-        public TransformSequence BeginAbsoluteSequence(double startOffset = 0, bool recursive = false)
-        {
-            if (TransformDelay != 0) throw new InvalidOperationException($"Cannot use {nameof(BeginAbsoluteSequence)} with a non-zero transform delay already present");
-            return new TransformSequence(this, -(Clock?.CurrentTime ?? 0) + startOffset, recursive);
-        }
-
-        public void Loop(float delay = 0)
-        {
-            foreach (var t in Transforms)
-                t.Loop(Math.Max(0, TransformDelay + delay - t.Duration));
-        }
 
         /// <summary>
         /// Make this drawable automatically clean itself up after all transforms have finished playing.
@@ -2044,28 +1922,16 @@ namespace osu.Framework.Graphics
 
             //expiry should happen either at the end of the last transform or using the current sequence delay (whichever is highest).
             double max = TransformStartTime;
-            foreach (ITransform t in Transforms)
+            foreach (ITransform<Drawable> t in Transforms)
                 if (t.EndTime > max) max = t.EndTime + 1; //adding 1ms here ensures we can expire on the current frame without issue.
             LifetimeEnd = max;
 
             if (calculateLifetimeStart)
             {
                 double min = double.MaxValue;
-                foreach (ITransform t in Transforms)
+                foreach (ITransform<Drawable> t in Transforms)
                     if (t.StartTime < min) min = t.StartTime;
                 LifetimeStart = min < int.MaxValue ? min : int.MinValue;
-            }
-        }
-
-        public void TimeWarp(double change)
-        {
-            if (change == 0)
-                return;
-
-            foreach (ITransform t in Transforms)
-            {
-                t.StartTime += change;
-                t.EndTime += change;
             }
         }
 
@@ -2084,78 +1950,6 @@ namespace osu.Framework.Graphics
         public virtual void Show()
         {
             FadeIn();
-        }
-
-        /// <summary>
-        /// The time to use for starting transforms which support <see cref="Delay(double, bool)"/>
-        /// </summary>
-        protected double TransformStartTime => (Clock?.CurrentTime ?? 0) + TransformDelay;
-
-        public void TransformTo<TValue>(Func<TValue> currentValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue> transform) where TValue : struct, IEquatable<TValue>
-        {
-            Type type = transform.GetType();
-
-            double startTime = TransformStartTime;
-
-            //For simplicity let's just update *all* transforms.
-            //The commented (more optimised code) below doesn't consider past "removed" transforms, which can cause discrepancies.
-            updateTransforms();
-
-            //foreach (ITransform t in Transforms.AliveItems)
-            //    if (t.GetType() == type)
-            //        t.Apply(this);
-
-            TValue startValue = currentValue();
-
-            if (TransformDelay == 0)
-            {
-                Transforms.RemoveAll(t => t.GetType() == type);
-
-                if (startValue.Equals(newValue))
-                    return;
-            }
-            else
-            {
-                var last = Transforms.FindLast(t => t.GetType() == type) as Transform<TValue>;
-                if (last != null)
-                {
-                    //we may be in the middle of an existing transform, so let's update it to the start time of our new transform.
-                    last.UpdateTime(new FrameTimeInfo { Current = startTime });
-                    startValue = last.CurrentValue;
-                }
-            }
-
-            transform.StartTime = startTime;
-            transform.EndTime = startTime + duration;
-            transform.StartValue = startValue;
-            transform.EndValue = newValue;
-            transform.Easing = easing;
-
-            addTransform(transform);
-        }
-
-        private void addTransform(ITransform transform)
-        {
-            if (Clock == null)
-            {
-                transform.UpdateTime(new FrameTimeInfo { Current = transform.EndTime });
-                transform.Apply(this);
-                return;
-            }
-
-            //we have no duration and do not need to be delayed, so we can just apply ourselves and be gone.
-            bool canApplyInstant = transform.Duration == 0 && TransformDelay == 0;
-
-            //we should also immediately apply any transforms that have already started to avoid potentially applying them one frame too late.
-            if (canApplyInstant || transform.StartTime < Time.Current)
-            {
-                transform.UpdateTime(Time);
-                transform.Apply(this);
-                if (canApplyInstant)
-                    return;
-            }
-
-            Transforms.Add(transform);
         }
 
         #region Helpers
@@ -2306,49 +2100,6 @@ namespace osu.Framework.Graphics
                 shortClass = $@"{Name} ({shortClass})";
 
             return $@"{shortClass} ({DrawPosition.X:#,0},{DrawPosition.Y:#,0}) {DrawSize.X:#,0}x{DrawSize.Y:#,0}";
-        }
-
-        /// <summary>
-        /// A disposable-pattern object to handle isolated sequences of transforms. Should only be used in using blocks.
-        /// </summary>
-        public class TransformSequence : IDisposable
-        {
-            private readonly Drawable us;
-            private readonly bool recursive;
-            private readonly double adjust;
-
-            public TransformSequence(Drawable us, double adjust, bool recursive = false)
-            {
-                this.recursive = recursive;
-                this.us = us;
-                this.adjust = adjust;
-
-                us.Delay(adjust, recursive);
-            }
-
-            #region IDisposable Support
-            private bool disposed;
-
-            protected virtual void Dispose(bool disposing)
-            {
-                if (!disposed)
-                {
-                    us.Delay(-adjust, recursive);
-                    disposed = true;
-                }
-            }
-
-            ~TransformSequence()
-            {
-                Dispose(false);
-            }
-
-            public void Dispose()
-            {
-                Dispose(true);
-                GC.SuppressFinalize(this);
-            }
-            #endregion
         }
     }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -631,6 +631,7 @@ namespace osu.Framework.Graphics
                 if ((relativeSizeAxes & Axes.X) > 0 && Width == 0) Width = 1;
                 if ((relativeSizeAxes & Axes.Y) > 0 && Height == 0) Height = 1;
 
+                OnSizingChanged();
                 // No invalidation necessary as DrawSize remains invariant.
             }
         }
@@ -758,6 +759,11 @@ namespace osu.Framework.Graphics
         /// Computes the bounding box of this drawable in its parent's space.
         /// </summary>
         public virtual RectangleF BoundingBox => ToParentSpace(LayoutRectangle).AABBFloat;
+
+        /// <summary>
+        /// Called whenever the <see cref="RelativeSizeAxes"/> of this drawable is changed, or when the <see cref="Container{T}.AutoSizeAxes"/> are changed if this drawable is a <see cref="Container{T}"/>.
+        /// </summary>
+        protected virtual void OnSizingChanged() { }
 
         #endregion
 

--- a/osu.Framework/Graphics/IDrawable.cs
+++ b/osu.Framework/Graphics/IDrawable.cs
@@ -5,8 +5,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Lists;
 using osu.Framework.Timing;
 using OpenTK;
-using osu.Framework.Graphics.Transforms;
-using System;
 
 namespace osu.Framework.Graphics
 {
@@ -65,16 +63,5 @@ namespace osu.Framework.Graphics
         /// Whether this Drawable is currently hovered over.
         /// </summary>
         bool Hovering { get; }
-
-        /// <summary>
-        /// Applies a transform to this drawable object.
-        /// </summary>
-        /// <typeparam name="TValue">The value type upon which the transform acts.</typeparam>
-        /// <param name="currentValue">A function to get the current value to transform from.</param>
-        /// <param name="newValue">The value to transform to.</param>
-        /// <param name="duration">The transform duration.</param>
-        /// <param name="easing">The transform easing.</param>
-        /// <param name="transform">The transform to use.</param>
-        void TransformTo<TValue>(Func<TValue> currentValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue> transform) where TValue : struct, IEquatable<TValue>;
     }
 }

--- a/osu.Framework/Graphics/Performance/FpsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FpsDisplay.cs
@@ -3,6 +3,7 @@
 
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.MathUtils;
 using osu.Framework.Timing;

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;

--- a/osu.Framework/Graphics/Shapes/Box.cs
+++ b/osu.Framework/Graphics/Shapes/Box.cs
@@ -1,9 +1,10 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 
-namespace osu.Framework.Graphics.Sprites
+namespace osu.Framework.Graphics.Shapes
 {
     /// <summary>
     /// A simple rectangular box. Can be colored using the <see cref="Drawable.Colour"/> property.

--- a/osu.Framework/Graphics/Shapes/Circle.cs
+++ b/osu.Framework/Graphics/Shapes/Circle.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Graphics.Shapes
+{
+    /// <summary>
+    /// A simple <see cref="CircularContainer"/> with a fill using a <see cref="Box"/>. Can be coloured using the <see cref="Drawable.Colour"/> property.
+    /// </summary>
+    public class Circle : CircularContainer
+    {
+        public Circle()
+        {
+            Masking = true;
+
+            AddInternal(new Box()
+            {
+                RelativeSizeAxes = Axes.Both,
+            });
+        }
+    }
+}

--- a/osu.Framework/Graphics/Shapes/EquilateralTriangle.cs
+++ b/osu.Framework/Graphics/Shapes/EquilateralTriangle.cs
@@ -3,7 +3,7 @@
 
 using OpenTK;
 
-namespace osu.Framework.Graphics.Sprites
+namespace osu.Framework.Graphics.Shapes
 {
     /// <summary>
     /// A triangle which has all side lengths and angles equal.

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -6,8 +6,9 @@ using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Textures;
 using OpenTK;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Sprites;
 
-namespace osu.Framework.Graphics.Sprites
+namespace osu.Framework.Graphics.Shapes
 {
     /// <summary>
     /// Represents a sprite that is drawn in a triangle shape, instead of a rectangle shape.

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -13,6 +13,7 @@ using osu.Framework.Allocation;
 using osu.Framework.IO.Stores;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Configuration;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.Sprites
 {

--- a/osu.Framework/Graphics/Transforms/ITransform.cs
+++ b/osu.Framework/Graphics/Transforms/ITransform.cs
@@ -7,17 +7,17 @@ using osu.Framework.Lists;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public interface ITransform : IHasLifetime
+    public interface ITransform<in T> : IHasLifetime
     {
         double Duration { get; }
 
         double StartTime { get; set; }
         double EndTime { get; set; }
 
-        void Apply(Drawable d);
+        void Apply(T d);
 
-        ITransform Clone();
-        ITransform CloneReverse();
+        ITransform<T> Clone();
+        ITransform<T> CloneReverse();
 
         void Reverse();
         void Loop(double delay, int loopCount = -1);
@@ -29,9 +29,9 @@ namespace osu.Framework.Graphics.Transforms
         void Shift(double offset);
     }
 
-    public class TransformTimeComparer : IComparer<ITransform>
+    public class TransformTimeComparer<T> : IComparer<ITransform<T>>
     {
-        public int Compare(ITransform x, ITransform y)
+        public int Compare(ITransform<T> x, ITransform<T> y)
         {
             if (x == null) throw new ArgumentNullException(nameof(x));
             if (y == null) throw new ArgumentNullException(nameof(y));

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -5,13 +5,14 @@ using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public abstract class Transform<T> : ITransform
+    public abstract class Transform<TValue, T> : ITransform<T>
     {
         public double StartTime { get; set; }
         public double EndTime { get; set; }
 
-        public T StartValue { get; set; }
-        public T EndValue { get; set; }
+        public TValue StartValue { get; set; }
+        public abstract TValue CurrentValue { get; }
+        public TValue EndValue { get; set; }
 
         public double LoopDelay;
         public int LoopCount;
@@ -40,14 +41,14 @@ namespace osu.Framework.Graphics.Transforms
             }
         }
 
-        public ITransform Clone()
+        public ITransform<T> Clone()
         {
-            return (ITransform)MemberwiseClone();
+            return (ITransform<T>)MemberwiseClone();
         }
 
-        public ITransform CloneReverse()
+        public ITransform<T> CloneReverse()
         {
-            ITransform t = Clone();
+            ITransform<T> t = Clone();
             t.Reverse();
             return t;
         }
@@ -65,8 +66,6 @@ namespace osu.Framework.Graphics.Transforms
             LoopCount = loopCount;
         }
 
-        public abstract T CurrentValue { get; }
-
         public double LifetimeStart => StartTime;
 
         public double LifetimeEnd => EndTime;
@@ -77,7 +76,7 @@ namespace osu.Framework.Graphics.Transforms
 
         public bool IsLoaded => true;
 
-        public virtual void Apply(Drawable d)
+        public virtual void Apply(T d)
         {
             if (Time?.Current > EndTime && LoopCount != CurrentLoopCount)
             {
@@ -90,7 +89,7 @@ namespace osu.Framework.Graphics.Transforms
 
         public override string ToString()
         {
-            return string.Format("Transform({2}) {0}-{1}", StartTime, EndTime, typeof(T));
+            return string.Format("Transform({2}) {0}-{1}", StartTime, EndTime, typeof(TValue));
         }
 
         public void Load()

--- a/osu.Framework/Graphics/Transforms/TransformAlpha.cs
+++ b/osu.Framework/Graphics/Transforms/TransformAlpha.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformAlpha : TransformFloat
+    public class TransformAlpha : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformColour.cs
+++ b/osu.Framework/Graphics/Transforms/TransformColour.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Graphics.Transforms
     /// <summary>
     /// Transforms colour value in linear colour space.
     /// </summary>
-    public class TransformColour : Transform<Color4>
+    public class TransformColour : Transform<Color4, Drawable>
     {
         /// <summary>
         /// Current value of the transformed colour in linear colour space.

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Graphics.Transforms
         public override void Apply(Drawable d)
         {
             base.Apply(d);
-            Container c = (Container)d;
+            IContainer c = (IContainer)d;
 
             EdgeEffectParameters e = c.EdgeEffect;
             e.Colour.Linear.A = CurrentValue;

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
@@ -5,7 +5,7 @@ using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformEdgeEffectAlpha : TransformFloat
+    public class TransformEdgeEffectAlpha : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
@@ -7,7 +7,7 @@ using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformEdgeEffectColour : Transform<Color4>
+    public class TransformEdgeEffectColour : Transform<Color4, Drawable>
     {
         /// <summary>
         /// Current value of the transformed colour in linear colour space.

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Graphics.Transforms
         public override void Apply(Drawable d)
         {
             base.Apply(d);
-            Container c = (Container)d;
+            IContainer c = (IContainer)d;
 
             EdgeEffectParameters e = c.EdgeEffect;
             e.Colour = CurrentValue;

--- a/osu.Framework/Graphics/Transforms/TransformFloat.cs
+++ b/osu.Framework/Graphics/Transforms/TransformFloat.cs
@@ -5,7 +5,7 @@ using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public abstract class TransformFloat : Transform<float>
+    public abstract class TransformFloat<T> : Transform<float, T>
     {
         public override float CurrentValue
         {

--- a/osu.Framework/Graphics/Transforms/TransformPositionX.cs
+++ b/osu.Framework/Graphics/Transforms/TransformPositionX.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformPositionX : TransformFloat
+    public class TransformPositionX : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformPositionY.cs
+++ b/osu.Framework/Graphics/Transforms/TransformPositionY.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformPositionY : TransformFloat
+    public class TransformPositionY : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformRotation.cs
+++ b/osu.Framework/Graphics/Transforms/TransformRotation.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformRotation : TransformFloat
+    public class TransformRotation : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformSize.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSize.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Transforms
         }
     }
 
-    public class TransformWidth : TransformFloat
+    public class TransformWidth : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {
@@ -21,7 +21,7 @@ namespace osu.Framework.Graphics.Transforms
         }
     }
 
-    public class TransformHeight : TransformFloat
+    public class TransformHeight : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformVector.cs
+++ b/osu.Framework/Graphics/Transforms/TransformVector.cs
@@ -6,7 +6,7 @@ using OpenTK;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public abstract class TransformVector : Transform<Vector2>
+    public abstract class TransformVector : Transform<Vector2, Drawable>
     {
         public override Vector2 CurrentValue
         {

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -1,0 +1,295 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using osu.Framework.Lists;
+using osu.Framework.Timing;
+
+namespace osu.Framework.Graphics.Transforms
+{
+    public abstract class Transformable<T>
+        where T : Transformable<T>
+    {
+        public abstract IFrameBasedClock Clock { get; set; }
+
+        /// <summary>
+        /// The current frame's time as observed by this class's <see cref="Clock"/>.
+        /// </summary>
+        public FrameTimeInfo Time => Clock.TimeInfo;
+
+        /// <summary>
+        /// The time to use for starting transforms which support <see cref="Delay(double, bool)"/>
+        /// </summary>
+        protected double TransformStartTime => (Clock?.CurrentTime ?? 0) + TransformDelay;
+
+        /// <summary>
+        /// Delay until the transformations are started, in milliseconds.
+        /// </summary>
+        protected double TransformDelay { get; private set; }
+
+        private LifetimeList<ITransform<T>> transforms;
+
+        /// <summary>
+        /// A lazily-initialized list of <see cref="ITransform{T}"/>s applied to this class.
+        /// </summary>
+        public LifetimeList<ITransform<T>> Transforms
+        {
+            get
+            {
+                if (transforms == null)
+                {
+                    transforms = new LifetimeList<ITransform<T>>(new TransformTimeComparer<T>());
+                    transforms.Removed += transforms_OnRemoved;
+                }
+
+                return transforms;
+            }
+        }
+
+        private void transforms_OnRemoved(ITransform<T> t)
+        {
+            t.Apply((T)this); //make sure we apply one last time.
+        }
+
+        /// <summary>
+        /// Process updates to this class based on loaded transforms.
+        /// </summary>
+        protected void UpdateTransforms()
+        {
+            if (transforms == null || transforms.Count == 0) return;
+
+            transforms.Update(Time);
+
+            foreach (ITransform<T> t in transforms.AliveItems)
+                t.Apply((T)this);
+        }
+
+        /// <summary>
+        /// Clear all transformations and resets <see cref="TransformDelay"/>.
+        /// </summary>
+        /// <param name="propagateChildren">Whether we also clear down the child tree.</param>
+        public virtual void ClearTransforms(bool propagateChildren = false)
+        {
+            DelayReset();
+            transforms?.Clear();
+        }
+
+        /// <summary>
+        /// Add a delay duration to <see cref="TransformDelay"/>, in milliseconds.
+        /// </summary>
+        /// <param name="duration">The delay duration to add.</param>
+        /// <param name="propagateChildren">Whether we also delay down the child tree.</param>
+        /// <returns>This</returns>
+        public virtual T Delay(double duration, bool propagateChildren = false)
+        {
+            if (duration == 0) return (T)this;
+
+            TransformDelay += duration;
+            return (T)this;
+        }
+
+        /// <summary>
+        /// Reset <see cref="TransformDelay"/>.
+        /// </summary>
+        /// <returns>This</returns>
+        public virtual T DelayReset()
+        {
+            Delay(-TransformDelay);
+            return (T)this;
+        }
+
+        /// <summary>
+        /// Flush specified transforms, using the last available values (ignoring current clock time).
+        /// </summary>
+        /// <param name="propagateChildren">Whether we also flush down the child tree.</param>
+        /// <param name="flushType">An optional type of transform to flush. Null for all types.</param>
+        public virtual void Flush(bool propagateChildren = false, Type flushType = null)
+        {
+            var operateTransforms = flushType == null ? Transforms : Transforms.FindAll(t => t.GetType() == flushType);
+
+            double maxTime = double.MinValue;
+            foreach (ITransform<T> t in operateTransforms)
+                if (t.EndTime > maxTime)
+                    maxTime = t.EndTime;
+
+            FrameTimeInfo maxTimeInfo = new FrameTimeInfo { Current = maxTime };
+
+            foreach (ITransform<T> t in operateTransforms)
+            {
+                t.UpdateTime(maxTimeInfo);
+                t.Apply((T)this);
+            }
+
+            if (flushType == null)
+                ClearTransforms();
+            else
+                Transforms.RemoveAll(t => t.GetType() == flushType);
+        }
+
+        /// <summary>
+        /// Start a sequence of transforms with a (cumulative) relative delay applied.
+        /// </summary>
+        /// <param name="delay">The offset in milliseconds from current time. Note that this stacks with other nested sequences.</param>
+        /// <param name="recursive">Whether this should be applied to all children.</param>
+        /// <returns>A <see cref="TransformSequence" /> to be used in a using() statement.</returns>
+        public TransformSequence BeginDelayedSequence(double delay, bool recursive = false) => new TransformSequence(this, delay, recursive);
+
+        /// <summary>
+        /// Start a sequence of transforms from an absolute time value.
+        /// </summary>
+        /// <param name="startOffset">The offset in milliseconds from absolute zero.</param>
+        /// <param name="recursive">Whether this should be applied to all children.</param>
+        /// <returns>A <see cref="TransformSequence" /> to be used in a using() statement.</returns>
+        /// <exception cref="InvalidOperationException">Absolute sequences should never be nested inside another existing sequence.</exception>
+        public TransformSequence BeginAbsoluteSequence(double startOffset = 0, bool recursive = false)
+        {
+            if (TransformDelay != 0) throw new InvalidOperationException($"Cannot use {nameof(BeginAbsoluteSequence)} with a non-zero transform delay already present");
+            return new TransformSequence(this, -(Clock?.CurrentTime ?? 0) + startOffset, recursive);
+        }
+
+        /// <summary>
+        /// Set the loop interval of all transformations contained in <see cref="Transforms"/>.
+        /// </summary>
+        /// <param name="delay">The loop interval to set, in milliseconds.</param>
+        public void Loop(float delay = 0)
+        {
+            foreach (var t in Transforms)
+                t.Loop(Math.Max(0, TransformDelay + delay - t.Duration));
+        }
+
+        /// <summary>
+        /// Warp the time for all transformations contained in <see cref="Transforms"/>.
+        /// </summary>
+        /// <param name="timeSpan">The time span to warp, in milliseconds.</param>
+        public void TimeWarp(double timeSpan)
+        {
+            if (timeSpan == 0)
+                return;
+
+            foreach (ITransform<T> t in Transforms)
+            {
+                t.StartTime += timeSpan;
+                t.EndTime += timeSpan;
+            }
+        }
+
+        /// <summary>
+        /// Applies a transform to this object.
+        /// </summary>
+        /// <typeparam name="TValue">The value type upon which the transform acts.</typeparam>
+        /// <param name="currentValue">A function to get the current value to transform from.</param>
+        /// <param name="newValue">The value to transform to.</param>
+        /// <param name="duration">The transform duration.</param>
+        /// <param name="easing">The transform easing.</param>
+        /// <param name="transform">The transform to use.</param>
+        public void TransformTo<TValue>(Func<TValue> currentValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue, T> transform) where TValue : struct, IEquatable<TValue>
+        {
+            Type type = transform.GetType();
+
+            double startTime = TransformStartTime;
+
+            //For simplicity let's just update *all* transforms.
+            //The commented (more optimised code) below doesn't consider past "removed" transforms, which can cause discrepancies.
+            UpdateTransforms();
+
+            //foreach (ITransform t in Transforms.AliveItems)
+            //    if (t.GetType() == type)
+            //        t.Apply(this);
+
+            TValue startValue = currentValue();
+
+            if (TransformDelay == 0)
+            {
+                Transforms.RemoveAll(t => t.GetType() == type);
+
+                if (startValue.Equals(newValue))
+                    return;
+            }
+            else
+            {
+                var last = Transforms.FindLast(t => t.GetType() == type) as Transform<TValue, T>;
+                if (last != null)
+                {
+                    //we may be in the middle of an existing transform, so let's update it to the start time of our new transform.
+                    last.UpdateTime(new FrameTimeInfo { Current = startTime });
+                    startValue = last.CurrentValue;
+                }
+            }
+
+            transform.StartTime = startTime;
+            transform.EndTime = startTime + duration;
+            transform.StartValue = startValue;
+            transform.EndValue = newValue;
+            transform.Easing = easing;
+
+            addTransform(transform);
+        }
+
+        private void addTransform(ITransform<T> transform)
+        {
+            if (Clock == null)
+            {
+                transform.UpdateTime(new FrameTimeInfo { Current = transform.EndTime });
+                transform.Apply((T)this);
+                return;
+            }
+
+            //we have no duration and do not need to be delayed, so we can just apply ourselves and be gone.
+            bool canApplyInstant = transform.Duration == 0 && TransformDelay == 0;
+
+            //we should also immediately apply any transforms that have already started to avoid potentially applying them one frame too late.
+            if (canApplyInstant || transform.StartTime < Time.Current)
+            {
+                transform.UpdateTime(Time);
+                transform.Apply((T)this);
+                if (canApplyInstant)
+                    return;
+            }
+
+            Transforms.Add(transform);
+        }
+
+        /// <summary>
+        /// A disposable-pattern object to handle isolated sequences of transforms. Should only be used in using blocks.
+        /// </summary>
+        public class TransformSequence : IDisposable
+        {
+            private readonly Transformable<T> us;
+            private readonly bool recursive;
+            private readonly double adjust;
+
+            public TransformSequence(Transformable<T> us, double adjust, bool recursive = false)
+            {
+                this.recursive = recursive;
+                this.us = us;
+                this.adjust = adjust;
+
+                us.Delay(adjust, recursive);
+            }
+
+            #region IDisposable Support
+            private bool disposed;
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!disposed)
+                {
+                    us.Delay(-adjust, recursive);
+                    disposed = true;
+                }
+            }
+
+            ~TransformSequence()
+            {
+                Dispose(false);
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+            #endregion
+        }
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/BasicCheckbox.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicCheckbox.cs
@@ -4,6 +4,7 @@
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Graphics.UserInterface

--- a/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.UserInterface
 {

--- a/osu.Framework/Graphics/UserInterface/Button.cs
+++ b/osu.Framework/Graphics/UserInterface/Button.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using OpenTK.Graphics;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.UserInterface
 {

--- a/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
@@ -3,7 +3,7 @@
 
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 
 namespace osu.Framework.Graphics.UserInterface

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -4,9 +4,9 @@
 using System;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.UserInterface
 {

--- a/osu.Framework/Graphics/UserInterface/MenuItem.cs
+++ b/osu.Framework/Graphics/UserInterface/MenuItem.cs
@@ -3,7 +3,7 @@
 
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 
 namespace osu.Framework.Graphics.UserInterface

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -18,6 +18,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Configuration;
 using osu.Framework.Platform;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.UserInterface
 {

--- a/osu.Framework/Graphics/Visualisation/FlashyBox.cs
+++ b/osu.Framework/Graphics/Visualisation/FlashyBox.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics.Primitives;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
 using System;
 
 namespace osu.Framework.Graphics.Visualisation

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -11,6 +11,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Input;
 using osu.Framework.Timing;
 using OpenTK.Input;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.Visualisation
 {

--- a/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.Visualisation
 {

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.Visualisation
 {

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -11,6 +11,7 @@ using OpenTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
 using System.Collections.Generic;
 using OpenTK.Input;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.Visualisation
 {

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Threading
+{
+    public class AudioThread : GameThread
+    {
+        public AudioThread(Action onNewFrame, string threadName)
+            : base(onNewFrame, threadName)
+        {
+        }
+
+        public override void Exit()
+        {
+            base.Exit();
+
+            ManagedBass.Bass.Free();
+        }
+    }
+}

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Threading
 
         public bool Running => Thread.IsAlive;
 
-        public void Exit() => exitRequested = true;
+        public virtual void Exit() => exitRequested = true;
 
         private volatile bool exitRequested;
 

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -297,6 +297,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\Shaders\Uniform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\Shaders\UniformBase.cs" />
     <Compile Include="Graphics\EasingTypes.cs" />
+    <Compile Include="Graphics\Transforms\Transformable.cs" />
     <Compile Include="Graphics\Transforms\Transform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lists\IHasLifetime.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lists\LifetimeList.cs" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -119,6 +119,7 @@
     <Compile Include="Graphics\Animations\TextureAnimation.cs" />
     <Compile Include="Graphics\Containers\AsyncLoadWrapper.cs" />
     <Compile Include="Graphics\Containers\DelayedLoadWrapper.cs" />
+    <Compile Include="Graphics\Shapes\Circle.cs" />
     <Compile Include="Graphics\Containers\FillFlowContainer.cs" />
     <Compile Include="Graphics\Containers\IFilterable.cs" />
     <Compile Include="Graphics\Containers\IHasFilterableChildren.cs" />
@@ -147,7 +148,7 @@
     <Compile Include="Graphics\UserInterface\IHasCurrentValue.cs" />
     <Compile Include="Graphics\UserInterface\MenuItem.cs" />
     <Compile Include="Graphics\UserInterface\Menu.cs" />
-    <Compile Include="Graphics\Sprites\EquilateralTriangle.cs" />
+    <Compile Include="Graphics\Shapes\EquilateralTriangle.cs" />
     <Compile Include="Graphics\UserInterface\TabControl.cs" />
     <Compile Include="Graphics\UserInterface\TabItem.cs" />
     <Compile Include="Input\CustomInputManager.cs" />
@@ -178,10 +179,10 @@
     <Compile Include="Graphics\Lines\Path.cs" />
     <Compile Include="Graphics\Lines\PathDrawNode.cs" />
     <Compile Include="Graphics\ProxyDrawable.cs" />
-    <Compile Include="Graphics\Sprites\Box.cs" />
+    <Compile Include="Graphics\Shapes\Box.cs" />
     <Compile Include="Graphics\OpenGL\Textures\TextureGLAtlas.cs" />
     <Compile Include="Graphics\OpenGL\Textures\TextureGLAtlasWhite.cs" />
-    <Compile Include="Graphics\Sprites\Triangle.cs" />
+    <Compile Include="Graphics\Shapes\Triangle.cs" />
     <Compile Include="Graphics\Transforms\TransformEdgeEffectAlpha.cs" />
     <Compile Include="Graphics\Transforms\TransformEdgeEffectColour.cs" />
     <Compile Include="Graphics\Transforms\TransformSize.cs" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -111,6 +111,12 @@
     <Compile Include="Extensions\ExtensionMethods.cs" />
     <Compile Include="Extensions\IEnumerableExtensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\TypeExtensions\TypeExtensions.cs" />
+    <Compile Include="Graphics\Animations\Animation.cs" />
+    <Compile Include="Graphics\Animations\AnimationExtensions.cs" />
+    <Compile Include="Graphics\Animations\DrawableAnimation.cs" />
+    <Compile Include="Graphics\Animations\FrameData.cs" />
+    <Compile Include="Graphics\Animations\IAnimation.cs" />
+    <Compile Include="Graphics\Animations\TextureAnimation.cs" />
     <Compile Include="Graphics\Containers\AsyncLoadWrapper.cs" />
     <Compile Include="Graphics\Containers\DelayedLoadWrapper.cs" />
     <Compile Include="Graphics\Containers\FillFlowContainer.cs" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -359,6 +359,7 @@
     <Compile Include="Graphics\UserInterface\CircularProgressDrawNode.cs" />
     <Compile Include="Graphics\Containers\TextFlowContainer.cs" />
     <Compile Include="Graphics\UserInterface\CircularProgress.cs" />
+    <Compile Include="Threading\AudioThread.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\osu-framework.licenseheader">


### PR DESCRIPTION
It appears the OpenTK MouseState for Raw Input does not map the
coordinates received to the window, so a quick check against the bounds
of the current window allows for proper readjustment. This fix does not
work on windowed programs, but that is beneficial as the cursor
seamlessly follows the OS cursor.

This fixes issue #811.