### PR TITLE
Split the drawable's transformation logic into its own class for reuse purposes

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -255,7 +255,7 @@ namespace osu.Framework.Graphics.Containers
         //}
 
         /// <summary>
-        /// Helper function for creating and adding a <see cref="Transform{T}"/> that blurs
+        /// Helper function for creating and adding a <see cref="Transform{TValue, T}"/> that blurs
         /// the buffered container.
         /// </summary>
         public void BlurTo(Vector2 newBlurSigma, double duration = 0, EasingTypes easing = EasingTypes.None)

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -662,7 +662,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Helper function for creating and adding a <see cref="Transform{T}"/> that fades the current <see cref="EdgeEffect"/>.
+        /// Helper function for creating and adding a <see cref="Transform{TValue, T}"/> that fades the current <see cref="EdgeEffect"/>.
         /// </summary>
         public void FadeEdgeEffectTo(float newAlpha, double duration = 0, EasingTypes easing = EasingTypes.None)
         {
@@ -671,7 +671,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Helper function for creating and adding a <see cref="Transform{T}"/> that fades the current <see cref="EdgeEffect"/>.
+        /// Helper function for creating and adding a <see cref="Transform{TValue, T}"/> that fades the current <see cref="EdgeEffect"/>.
         /// </summary>
         public void FadeEdgeEffectTo(Color4 newColour, double duration = 0, EasingTypes easing = EasingTypes.None)
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Graphics
     /// Drawables are always rectangular in shape in their local coordinate system,
     /// which makes them quad-shaped in arbitrary (linearly transformed) coordinate systems.
     /// </summary>
-    public abstract class Drawable : IDisposable, IDrawable
+    public abstract class Drawable : Transformable<Drawable>, IDisposable, IDrawable
     {
         #region Construction and disposal
 
@@ -323,45 +323,6 @@ namespace osu.Framework.Graphics
         /// </summary>
         protected Scheduler Scheduler => scheduler ?? (scheduler = new Scheduler(MainThread));
 
-        private LifetimeList<ITransform> transforms;
-
-        /// <summary>
-        /// A lazily-initialized list of <see cref="ITransform"/>s applied to this Drawable.
-        /// <see cref="ITransform"/>s are applied right before the <see cref="Update"/> method is called.
-        /// </summary>
-        public LifetimeList<ITransform> Transforms
-        {
-            get
-            {
-                if (transforms == null)
-                {
-                    transforms = new LifetimeList<ITransform>(new TransformTimeComparer());
-                    transforms.Removed += transforms_OnRemoved;
-                }
-
-                return transforms;
-            }
-        }
-
-        /// <summary>
-        /// Process updates to this drawable based on loaded transforms.
-        /// </summary>
-        /// <returns>Whether we should draw this drawable.</returns>
-        private void updateTransforms()
-        {
-            if (transforms == null || transforms.Count == 0) return;
-
-            transforms.Update(Time);
-
-            foreach (ITransform t in transforms.AliveItems)
-                t.Apply(this);
-        }
-
-        private void transforms_OnRemoved(ITransform t)
-        {
-            t.Apply(this); //make sure we apply one last time.
-        }
-
         /// <summary>
         /// Updates this Drawable and all Drawables further down the scene graph.
         /// Called once every frame.
@@ -378,7 +339,7 @@ namespace osu.Framework.Graphics
             if (loadState < LoadState.Alive)
                 if (!loadComplete()) return false;
 
-            TransformDelay = 0;
+            DelayReset();
 
             //todo: this should be moved to after the IsVisible condition once we have TOL for transforms (and some better logic).
             updateTransforms();
@@ -1153,7 +1114,7 @@ namespace osu.Framework.Graphics
         /// If set, then the provided value is used as a custom clock and the
         /// <see cref="Parent"/>'s clock is ignored.
         /// </summary>
-        public IFrameBasedClock Clock
+        public override IFrameBasedClock Clock
         {
             get { return clock; }
             set
@@ -1172,11 +1133,6 @@ namespace osu.Framework.Graphics
         {
             this.clock = customClock ?? clock;
         }
-
-        /// <summary>
-        /// The current frame's time as observed by this drawable's <see cref="Clock"/>.
-        /// </summary>
-        public FrameTimeInfo Time => Clock.TimeInfo;
 
         /// <summary>
         /// The time at which this drawable becomes valid (and is considered for drawing).
@@ -1945,84 +1901,7 @@ namespace osu.Framework.Graphics
 
         #region Transforms
 
-        internal double TransformDelay { get; private set; }
-
-        public virtual void ClearTransforms(bool propagateChildren = false)
-        {
-            DelayReset();
-            transforms?.Clear();
-        }
-
-        public virtual Drawable Delay(double duration, bool propagateChildren = false)
-        {
-            if (duration == 0) return this;
-
-            TransformDelay += duration;
-            return this;
-        }
-
         protected ScheduledDelegate Schedule(Action action) => Scheduler.AddDelayed(action, TransformDelay);
-
-        /// <summary>
-        /// Flush specified transforms, using the last available values (ignoring current clock time).
-        /// </summary>
-        /// <param name="propagateChildren">Whether we also flush down the child tree.</param>
-        /// <param name="flushType">An optional type of transform to flush. Null for all types.</param>
-        public virtual void Flush(bool propagateChildren = false, Type flushType = null)
-        {
-            var operateTransforms = flushType == null ? Transforms : Transforms.FindAll(t => t.GetType() == flushType);
-
-            double maxTime = double.MinValue;
-            foreach (ITransform t in operateTransforms)
-                if (t.EndTime > maxTime)
-                    maxTime = t.EndTime;
-
-            FrameTimeInfo maxTimeInfo = new FrameTimeInfo { Current = maxTime };
-
-            foreach (ITransform t in operateTransforms)
-            {
-                t.UpdateTime(maxTimeInfo);
-                t.Apply(this);
-            }
-
-            if (flushType == null)
-                ClearTransforms();
-            else
-                Transforms.RemoveAll(t => t.GetType() == flushType);
-        }
-
-        public virtual Drawable DelayReset()
-        {
-            Delay(-TransformDelay);
-            return this;
-        }
-
-        /// <summary>
-        /// Start a sequence of transforms with a (cumulative) relative delay applied.
-        /// </summary>
-        /// <param name="delay">The offset in milliseconds from current time. Note that this stacks with other nested sequences.</param>
-        /// <param name="recursive">Whether this should be applied to all children.</param>
-        /// <returns>A <see cref="TransformSequence" /> to be used in a using() statement.</returns>
-        public TransformSequence BeginDelayedSequence(double delay, bool recursive = false) => new TransformSequence(this, delay, recursive);
-
-        /// <summary>
-        /// Start a sequence of transforms from an absolute time value.
-        /// </summary>
-        /// <param name="startOffset">The offset in milliseconds from absolute zero.</param>
-        /// <param name="recursive">Whether this should be applied to all children.</param>
-        /// <returns>A <see cref="TransformSequence" /> to be used in a using() statement.</returns>
-        /// <exception cref="InvalidOperationException">Absolute sequences should never be nested inside another existing sequence.</exception>
-        public TransformSequence BeginAbsoluteSequence(double startOffset = 0, bool recursive = false)
-        {
-            if (TransformDelay != 0) throw new InvalidOperationException($"Cannot use {nameof(BeginAbsoluteSequence)} with a non-zero transform delay already present");
-            return new TransformSequence(this, -(Clock?.CurrentTime ?? 0) + startOffset, recursive);
-        }
-
-        public void Loop(float delay = 0)
-        {
-            foreach (var t in Transforms)
-                t.Loop(Math.Max(0, TransformDelay + delay - t.Duration));
-        }
 
         /// <summary>
         /// Make this drawable automatically clean itself up after all transforms have finished playing.
@@ -2038,28 +1917,16 @@ namespace osu.Framework.Graphics
 
             //expiry should happen either at the end of the last transform or using the current sequence delay (whichever is highest).
             double max = TransformStartTime;
-            foreach (ITransform t in Transforms)
+            foreach (ITransform<Drawable> t in Transforms)
                 if (t.EndTime > max) max = t.EndTime + 1; //adding 1ms here ensures we can expire on the current frame without issue.
             LifetimeEnd = max;
 
             if (calculateLifetimeStart)
             {
                 double min = double.MaxValue;
-                foreach (ITransform t in Transforms)
+                foreach (ITransform<Drawable> t in Transforms)
                     if (t.StartTime < min) min = t.StartTime;
                 LifetimeStart = min < int.MaxValue ? min : int.MinValue;
-            }
-        }
-
-        public void TimeWarp(double change)
-        {
-            if (change == 0)
-                return;
-
-            foreach (ITransform t in Transforms)
-            {
-                t.StartTime += change;
-                t.EndTime += change;
             }
         }
 
@@ -2078,78 +1945,6 @@ namespace osu.Framework.Graphics
         public virtual void Show()
         {
             FadeIn();
-        }
-
-        /// <summary>
-        /// The time to use for starting transforms which support <see cref="Delay(double, bool)"/>
-        /// </summary>
-        protected double TransformStartTime => (Clock?.CurrentTime ?? 0) + TransformDelay;
-
-        public void TransformTo<TValue>(Func<TValue> currentValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue> transform) where TValue : struct, IEquatable<TValue>
-        {
-            Type type = transform.GetType();
-
-            double startTime = TransformStartTime;
-
-            //For simplicity let's just update *all* transforms.
-            //The commented (more optimised code) below doesn't consider past "removed" transforms, which can cause discrepancies.
-            updateTransforms();
-
-            //foreach (ITransform t in Transforms.AliveItems)
-            //    if (t.GetType() == type)
-            //        t.Apply(this);
-
-            TValue startValue = currentValue();
-
-            if (TransformDelay == 0)
-            {
-                Transforms.RemoveAll(t => t.GetType() == type);
-
-                if (startValue.Equals(newValue))
-                    return;
-            }
-            else
-            {
-                var last = Transforms.FindLast(t => t.GetType() == type) as Transform<TValue>;
-                if (last != null)
-                {
-                    //we may be in the middle of an existing transform, so let's update it to the start time of our new transform.
-                    last.UpdateTime(new FrameTimeInfo { Current = startTime });
-                    startValue = last.CurrentValue;
-                }
-            }
-
-            transform.StartTime = startTime;
-            transform.EndTime = startTime + duration;
-            transform.StartValue = startValue;
-            transform.EndValue = newValue;
-            transform.Easing = easing;
-
-            addTransform(transform);
-        }
-
-        private void addTransform(ITransform transform)
-        {
-            if (Clock == null)
-            {
-                transform.UpdateTime(new FrameTimeInfo { Current = transform.EndTime });
-                transform.Apply(this);
-                return;
-            }
-
-            //we have no duration and do not need to be delayed, so we can just apply ourselves and be gone.
-            bool canApplyInstant = transform.Duration == 0 && TransformDelay == 0;
-
-            //we should also immediately apply any transforms that have already started to avoid potentially applying them one frame too late.
-            if (canApplyInstant || transform.StartTime < Time.Current)
-            {
-                transform.UpdateTime(Time);
-                transform.Apply(this);
-                if (canApplyInstant)
-                    return;
-            }
-
-            Transforms.Add(transform);
         }
 
         #region Helpers
@@ -2300,49 +2095,6 @@ namespace osu.Framework.Graphics
                 shortClass = $@"{Name} ({shortClass})";
 
             return $@"{shortClass} ({DrawPosition.X:#,0},{DrawPosition.Y:#,0}) {DrawSize.X:#,0}x{DrawSize.Y:#,0}";
-        }
-
-        /// <summary>
-        /// A disposable-pattern object to handle isolated sequences of transforms. Should only be used in using blocks.
-        /// </summary>
-        public class TransformSequence : IDisposable
-        {
-            private readonly Drawable us;
-            private readonly bool recursive;
-            private readonly double adjust;
-
-            public TransformSequence(Drawable us, double adjust, bool recursive = false)
-            {
-                this.recursive = recursive;
-                this.us = us;
-                this.adjust = adjust;
-
-                us.Delay(adjust, recursive);
-            }
-
-            #region IDisposable Support
-            private bool disposed;
-
-            protected virtual void Dispose(bool disposing)
-            {
-                if (!disposed)
-                {
-                    us.Delay(-adjust, recursive);
-                    disposed = true;
-                }
-            }
-
-            ~TransformSequence()
-            {
-                Dispose(false);
-            }
-
-            public void Dispose()
-            {
-                Dispose(true);
-                GC.SuppressFinalize(this);
-            }
-            #endregion
         }
     }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Input;
-using osu.Framework.Lists;
 using osu.Framework.Logging;
 using osu.Framework.Statistics;
 using osu.Framework.Threading;

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -341,7 +341,7 @@ namespace osu.Framework.Graphics
             DelayReset();
 
             //todo: this should be moved to after the IsVisible condition once we have TOL for transforms (and some better logic).
-            updateTransforms();
+            UpdateTransforms();
 
             if (!IsPresent)
                 return true;

--- a/osu.Framework/Graphics/IDrawable.cs
+++ b/osu.Framework/Graphics/IDrawable.cs
@@ -65,16 +65,5 @@ namespace osu.Framework.Graphics
         /// Whether this Drawable is currently hovered over.
         /// </summary>
         bool Hovering { get; }
-
-        /// <summary>
-        /// Applies a transform to this drawable object.
-        /// </summary>
-        /// <typeparam name="TValue">The value type upon which the transform acts.</typeparam>
-        /// <param name="currentValue">A function to get the current value to transform from.</param>
-        /// <param name="newValue">The value to transform to.</param>
-        /// <param name="duration">The transform duration.</param>
-        /// <param name="easing">The transform easing.</param>
-        /// <param name="transform">The transform to use.</param>
-        void TransformTo<TValue>(Func<TValue> currentValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue> transform) where TValue : struct, IEquatable<TValue>;
     }
 }

--- a/osu.Framework/Graphics/IDrawable.cs
+++ b/osu.Framework/Graphics/IDrawable.cs
@@ -5,8 +5,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Lists;
 using osu.Framework.Timing;
 using OpenTK;
-using osu.Framework.Graphics.Transforms;
-using System;
 
 namespace osu.Framework.Graphics
 {

--- a/osu.Framework/Graphics/Transforms/ITransform.cs
+++ b/osu.Framework/Graphics/Transforms/ITransform.cs
@@ -7,17 +7,17 @@ using osu.Framework.Lists;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public interface ITransform : IHasLifetime
+    public interface ITransform<T> : IHasLifetime
     {
         double Duration { get; }
 
         double StartTime { get; set; }
         double EndTime { get; set; }
 
-        void Apply(Drawable d);
+        void Apply(T d);
 
-        ITransform Clone();
-        ITransform CloneReverse();
+        ITransform<T> Clone();
+        ITransform<T> CloneReverse();
 
         void Reverse();
         void Loop(double delay, int loopCount = -1);
@@ -29,9 +29,9 @@ namespace osu.Framework.Graphics.Transforms
         void Shift(double offset);
     }
 
-    public class TransformTimeComparer : IComparer<ITransform>
+    public class TransformTimeComparer<T> : IComparer<ITransform<T>>
     {
-        public int Compare(ITransform x, ITransform y)
+        public int Compare(ITransform<T> x, ITransform<T> y)
         {
             if (x == null) throw new ArgumentNullException(nameof(x));
             if (y == null) throw new ArgumentNullException(nameof(y));

--- a/osu.Framework/Graphics/Transforms/ITransform.cs
+++ b/osu.Framework/Graphics/Transforms/ITransform.cs
@@ -7,7 +7,7 @@ using osu.Framework.Lists;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public interface ITransform<T> : IHasLifetime
+    public interface ITransform<in T> : IHasLifetime
     {
         double Duration { get; }
 

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -11,6 +11,7 @@ namespace osu.Framework.Graphics.Transforms
         public double EndTime { get; set; }
 
         public TValue StartValue { get; set; }
+        public abstract TValue CurrentValue { get; }
         public TValue EndValue { get; set; }
 
         public double LoopDelay;
@@ -65,8 +66,6 @@ namespace osu.Framework.Graphics.Transforms
             LoopCount = loopCount;
         }
 
-        public abstract TValue CurrentValue { get; }
-
         public double LifetimeStart => StartTime;
 
         public double LifetimeEnd => EndTime;
@@ -90,7 +89,7 @@ namespace osu.Framework.Graphics.Transforms
 
         public override string ToString()
         {
-            return string.Format("Transform({2}) {0}-{1}", StartTime, EndTime, typeof(T));
+            return string.Format("Transform({2}) {0}-{1}", StartTime, EndTime, typeof(TValue));
         }
 
         public void Load()

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -5,13 +5,13 @@ using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public abstract class Transform<T> : ITransform
+    public abstract class Transform<TValue, T> : ITransform<T>
     {
         public double StartTime { get; set; }
         public double EndTime { get; set; }
 
-        public T StartValue { get; set; }
-        public T EndValue { get; set; }
+        public TValue StartValue { get; set; }
+        public TValue EndValue { get; set; }
 
         public double LoopDelay;
         public int LoopCount;
@@ -40,14 +40,14 @@ namespace osu.Framework.Graphics.Transforms
             }
         }
 
-        public ITransform Clone()
+        public ITransform<T> Clone()
         {
-            return (ITransform)MemberwiseClone();
+            return (ITransform<T>)MemberwiseClone();
         }
 
-        public ITransform CloneReverse()
+        public ITransform<T> CloneReverse()
         {
-            ITransform t = Clone();
+            ITransform<T> t = Clone();
             t.Reverse();
             return t;
         }
@@ -65,7 +65,7 @@ namespace osu.Framework.Graphics.Transforms
             LoopCount = loopCount;
         }
 
-        public abstract T CurrentValue { get; }
+        public abstract TValue CurrentValue { get; }
 
         public double LifetimeStart => StartTime;
 
@@ -77,7 +77,7 @@ namespace osu.Framework.Graphics.Transforms
 
         public bool IsLoaded => true;
 
-        public virtual void Apply(Drawable d)
+        public virtual void Apply(T d)
         {
             if (Time?.Current > EndTime && LoopCount != CurrentLoopCount)
             {

--- a/osu.Framework/Graphics/Transforms/TransformAlpha.cs
+++ b/osu.Framework/Graphics/Transforms/TransformAlpha.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformAlpha : TransformFloat
+    public class TransformAlpha : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformColour.cs
+++ b/osu.Framework/Graphics/Transforms/TransformColour.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Graphics.Transforms
     /// <summary>
     /// Transforms colour value in linear colour space.
     /// </summary>
-    public class TransformColour : Transform<Color4>
+    public class TransformColour : Transform<Color4, Drawable>
     {
         /// <summary>
         /// Current value of the transformed colour in linear colour space.

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
@@ -5,7 +5,7 @@ using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformEdgeEffectAlpha : TransformFloat
+    public class TransformEdgeEffectAlpha : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
@@ -7,7 +7,7 @@ using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformEdgeEffectColour : Transform<Color4>
+    public class TransformEdgeEffectColour : Transform<Color4, Drawable>
     {
         /// <summary>
         /// Current value of the transformed colour in linear colour space.

--- a/osu.Framework/Graphics/Transforms/TransformFloat.cs
+++ b/osu.Framework/Graphics/Transforms/TransformFloat.cs
@@ -5,7 +5,7 @@ using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public abstract class TransformFloat : Transform<float>
+    public abstract class TransformFloat<T> : Transform<float, T>
     {
         public override float CurrentValue
         {

--- a/osu.Framework/Graphics/Transforms/TransformPositionX.cs
+++ b/osu.Framework/Graphics/Transforms/TransformPositionX.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformPositionX : TransformFloat
+    public class TransformPositionX : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformPositionY.cs
+++ b/osu.Framework/Graphics/Transforms/TransformPositionY.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformPositionY : TransformFloat
+    public class TransformPositionY : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformRotation.cs
+++ b/osu.Framework/Graphics/Transforms/TransformRotation.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public class TransformRotation : TransformFloat
+    public class TransformRotation : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformSize.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSize.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Transforms
         }
     }
 
-    public class TransformWidth : TransformFloat
+    public class TransformWidth : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {
@@ -21,7 +21,7 @@ namespace osu.Framework.Graphics.Transforms
         }
     }
 
-    public class TransformHeight : TransformFloat
+    public class TransformHeight : TransformFloat<Drawable>
     {
         public override void Apply(Drawable d)
         {

--- a/osu.Framework/Graphics/Transforms/TransformVector.cs
+++ b/osu.Framework/Graphics/Transforms/TransformVector.cs
@@ -6,7 +6,7 @@ using OpenTK;
 
 namespace osu.Framework.Graphics.Transforms
 {
-    public abstract class TransformVector : Transform<Vector2>
+    public abstract class TransformVector : Transform<Vector2, Drawable>
     {
         public override Vector2 CurrentValue
         {

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -1,0 +1,273 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using osu.Framework.Lists;
+using osu.Framework.Timing;
+
+namespace osu.Framework.Graphics.Transforms
+{
+    public abstract class Transformable<T>
+        where T : Transformable<T>
+    {
+        public abstract IFrameBasedClock Clock { get; set; }
+
+
+        private LifetimeList<ITransform<T>> transforms;
+
+        /// <summary>
+        /// A lazily-initialized list of <see cref="ITransform"/>s applied to this class.
+        /// <see cref="ITransform"/>s are applied right before the <see cref="Update"/> method is called.
+        /// </summary>
+        public LifetimeList<ITransform<T>> Transforms
+        {
+            get
+            {
+                if (transforms == null)
+                {
+                    transforms = new LifetimeList<ITransform<T>>(new TransformTimeComparer<T>());
+                    transforms.Removed += transforms_OnRemoved;
+                }
+
+                return transforms;
+            }
+        }
+
+        /// <summary>
+        /// The current frame's time as observed by this class's <see cref="Clock"/>.
+        /// </summary>
+        public FrameTimeInfo Time => Clock.TimeInfo;
+
+        /// <summary>
+        /// The time to use for starting transforms which support <see cref="Delay(double, bool)"/>
+        /// </summary>
+        protected double TransformStartTime => (Clock?.CurrentTime ?? 0) + TransformDelay;
+
+        /// <summary>
+        /// Process updates to this class based on loaded transforms.
+        /// </summary>
+        protected void updateTransforms()
+        {
+            if (transforms == null || transforms.Count == 0) return;
+
+            transforms.Update(Time);
+
+            foreach (ITransform<T> t in transforms.AliveItems)
+                t.Apply((T) this);
+        }
+
+        private void transforms_OnRemoved(ITransform<T> t)
+        {
+            t.Apply((T) this); //make sure we apply one last time.
+        }
+
+
+        internal double TransformDelay { get; private set; }
+
+        public virtual void ClearTransforms(bool propagateChildren = false)
+        {
+            DelayReset();
+            transforms?.Clear();
+        }
+
+        public virtual T Delay(double duration, bool propagateChildren = false)
+        {
+            if (duration == 0) return (T) this;
+
+            TransformDelay += duration;
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Flush specified transforms, using the last available values (ignoring current clock time).
+        /// </summary>
+        /// <param name="propagateChildren">Whether we also flush down the child tree.</param>
+        /// <param name="flushType">An optional type of transform to flush. Null for all types.</param>
+        public virtual void Flush(bool propagateChildren = false, Type flushType = null)
+        {
+            var operateTransforms = flushType == null ? Transforms : Transforms.FindAll(t => t.GetType() == flushType);
+
+            double maxTime = double.MinValue;
+            foreach (ITransform<T> t in operateTransforms)
+                if (t.EndTime > maxTime)
+                    maxTime = t.EndTime;
+
+            FrameTimeInfo maxTimeInfo = new FrameTimeInfo { Current = maxTime };
+
+            foreach (ITransform<T> t in operateTransforms)
+            {
+                t.UpdateTime(maxTimeInfo);
+                t.Apply((T) this);
+            }
+
+            if (flushType == null)
+                ClearTransforms();
+            else
+                Transforms.RemoveAll(t => t.GetType() == flushType);
+        }
+
+        public virtual T DelayReset()
+        {
+            Delay(-TransformDelay);
+            return (T) this;
+        }
+
+        /// <summary>
+        /// Start a sequence of transforms with a (cumulative) relative delay applied.
+        /// </summary>
+        /// <param name="delay">The offset in milliseconds from current time. Note that this stacks with other nested sequences.</param>
+        /// <param name="recursive">Whether this should be applied to all children.</param>
+        /// <returns>A <see cref="TransformSequence" /> to be used in a using() statement.</returns>
+        public TransformSequence BeginDelayedSequence(double delay, bool recursive = false) => new TransformSequence(this, delay, recursive);
+
+        /// <summary>
+        /// Start a sequence of transforms from an absolute time value.
+        /// </summary>
+        /// <param name="startOffset">The offset in milliseconds from absolute zero.</param>
+        /// <param name="recursive">Whether this should be applied to all children.</param>
+        /// <returns>A <see cref="TransformSequence" /> to be used in a using() statement.</returns>
+        /// <exception cref="InvalidOperationException">Absolute sequences should never be nested inside another existing sequence.</exception>
+        public TransformSequence BeginAbsoluteSequence(double startOffset = 0, bool recursive = false)
+        {
+            if (TransformDelay != 0) throw new InvalidOperationException($"Cannot use {nameof(BeginAbsoluteSequence)} with a non-zero transform delay already present");
+            return new TransformSequence(this, -(Clock?.CurrentTime ?? 0) + startOffset, recursive);
+        }
+
+        public void Loop(float delay = 0)
+        {
+            foreach (var t in Transforms)
+                t.Loop(Math.Max(0, TransformDelay + delay - t.Duration));
+        }
+
+        public void TimeWarp(double change)
+        {
+            if (change == 0)
+                return;
+
+            foreach (ITransform<T> t in Transforms)
+            {
+                t.StartTime += change;
+                t.EndTime += change;
+            }
+        }
+
+        /// <summary>
+        /// Applies a transform to this object.
+        /// </summary>
+        /// <typeparam name="TValue">The value type upon which the transform acts.</typeparam>
+        /// <param name="currentValue">A function to get the current value to transform from.</param>
+        /// <param name="newValue">The value to transform to.</param>
+        /// <param name="duration">The transform duration.</param>
+        /// <param name="easing">The transform easing.</param>
+        /// <param name="transform">The transform to use.</param>
+        public void TransformTo<TValue>(Func<TValue> currentValue, TValue newValue, double duration, EasingTypes easing, Transform<TValue, T> transform) where TValue : struct, IEquatable<TValue>
+        {
+            Type type = transform.GetType();
+
+            double startTime = TransformStartTime;
+
+            //For simplicity let's just update *all* transforms.
+            //The commented (more optimised code) below doesn't consider past "removed" transforms, which can cause discrepancies.
+            updateTransforms();
+
+            //foreach (ITransform t in Transforms.AliveItems)
+            //    if (t.GetType() == type)
+            //        t.Apply(this);
+
+            TValue startValue = currentValue();
+
+            if (TransformDelay == 0)
+            {
+                Transforms.RemoveAll(t => t.GetType() == type);
+
+                if (startValue.Equals(newValue))
+                    return;
+            }
+            else
+            {
+                var last = Transforms.FindLast(t => t.GetType() == type) as Transform<TValue, T>;
+                if (last != null)
+                {
+                    //we may be in the middle of an existing transform, so let's update it to the start time of our new transform.
+                    last.UpdateTime(new FrameTimeInfo { Current = startTime });
+                    startValue = last.CurrentValue;
+                }
+            }
+
+            transform.StartTime = startTime;
+            transform.EndTime = startTime + duration;
+            transform.StartValue = startValue;
+            transform.EndValue = newValue;
+            transform.Easing = easing;
+
+            addTransform(transform);
+        }
+
+        private void addTransform(ITransform<T> transform)
+        {
+            if (Clock == null)
+            {
+                transform.UpdateTime(new FrameTimeInfo { Current = transform.EndTime });
+                transform.Apply((T) this);
+                return;
+            }
+
+            //we have no duration and do not need to be delayed, so we can just apply ourselves and be gone.
+            bool canApplyInstant = transform.Duration == 0 && TransformDelay == 0;
+
+            //we should also immediately apply any transforms that have already started to avoid potentially applying them one frame too late.
+            if (canApplyInstant || transform.StartTime < Time.Current)
+            {
+                transform.UpdateTime(Time);
+                transform.Apply((T) this);
+                if (canApplyInstant)
+                    return;
+            }
+
+            Transforms.Add(transform);
+        }
+
+        /// <summary>
+        /// A disposable-pattern object to handle isolated sequences of transforms. Should only be used in using blocks.
+        /// </summary>
+        public class TransformSequence : IDisposable
+        {
+            private readonly Transformable<T> us;
+            private readonly bool recursive;
+            private readonly double adjust;
+
+            public TransformSequence(Transformable<T> us, double adjust, bool recursive = false)
+            {
+                this.recursive = recursive;
+                this.us = us;
+                this.adjust = adjust;
+
+                us.Delay(adjust, recursive);
+            }
+
+            #region IDisposable Support
+            private bool disposed;
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (!disposed)
+                {
+                    us.Delay(-adjust, recursive);
+                    disposed = true;
+                }
+            }
+
+            ~TransformSequence()
+            {
+                Dispose(false);
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+            #endregion
+        }
+    }
+}

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -12,7 +12,6 @@ namespace osu.Framework.Graphics.Transforms
     {
         public abstract IFrameBasedClock Clock { get; set; }
 
-
         private LifetimeList<ITransform<T>> transforms;
 
         /// <summary>

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Graphics.Transforms
         }
 
         /// <summary>
-        /// Reset <see cref="TransfThormDelay"/>.
+        /// Reset <see cref="TransformDelay"/>.
         /// </summary>
         /// <returns>This</returns>
         public virtual T DelayReset()
@@ -160,16 +160,16 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// Warp the time for all transformations contained in <see cref="Transforms"/>.
         /// </summary>
-        /// <param name="delay">The time span to warp, in milliseconds.</param>
-        public void TimeWarp(double change)
+        /// <param name="timeSpan">The time span to warp, in milliseconds.</param>
+        public void TimeWarp(double timeSpan)
         {
-            if (change == 0)
+            if (timeSpan == 0)
                 return;
 
             foreach (ITransform<T> t in Transforms)
             {
-                t.StartTime += change;
-                t.EndTime += change;
+                t.StartTime += timeSpan;
+                t.EndTime += timeSpan;
             }
         }
 

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -15,8 +15,7 @@ namespace osu.Framework.Graphics.Transforms
         private LifetimeList<ITransform<T>> transforms;
 
         /// <summary>
-        /// A lazily-initialized list of <see cref="ITransform"/>s applied to this class.
-        /// <see cref="ITransform"/>s are applied right before the <see cref="Update"/> method is called.
+        /// A lazily-initialized list of <see cref="ITransform{T}"/>s applied to this class.
         /// </summary>
         public LifetimeList<ITransform<T>> Transforms
         {
@@ -45,7 +44,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// Process updates to this class based on loaded transforms.
         /// </summary>
-        protected void updateTransforms()
+        protected void UpdateTransforms()
         {
             if (transforms == null || transforms.Count == 0) return;
 
@@ -167,7 +166,7 @@ namespace osu.Framework.Graphics.Transforms
 
             //For simplicity let's just update *all* transforms.
             //The commented (more optimised code) below doesn't consider past "removed" transforms, which can cause discrepancies.
-            updateTransforms();
+            UpdateTransforms();
 
             //foreach (ITransform t in Transforms.AliveItems)
             //    if (t.GetType() == type)

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Graphics.Transforms
             transforms.Update(Time);
 
             foreach (ITransform<T> t in transforms.AliveItems)
-                t.Apply((T) this);
+                t.Apply((T)this);
         }
 
         /// <summary>
@@ -82,10 +82,10 @@ namespace osu.Framework.Graphics.Transforms
         /// <returns>This</returns>
         public virtual T Delay(double duration, bool propagateChildren = false)
         {
-            if (duration == 0) return (T) this;
+            if (duration == 0) return (T)this;
 
             TransformDelay += duration;
-            return (T) this;
+            return (T)this;
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace osu.Framework.Graphics.Transforms
             foreach (ITransform<T> t in operateTransforms)
             {
                 t.UpdateTime(maxTimeInfo);
-                t.Apply((T) this);
+                t.Apply((T)this);
             }
 
             if (flushType == null)
@@ -230,7 +230,7 @@ namespace osu.Framework.Graphics.Transforms
             if (Clock == null)
             {
                 transform.UpdateTime(new FrameTimeInfo { Current = transform.EndTime });
-                transform.Apply((T) this);
+                transform.Apply((T)this);
                 return;
             }
 
@@ -241,7 +241,7 @@ namespace osu.Framework.Graphics.Transforms
             if (canApplyInstant || transform.StartTime < Time.Current)
             {
                 transform.UpdateTime(Time);
-                transform.Apply((T) this);
+                transform.Apply((T)this);
                 if (canApplyInstant)
                     return;
             }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -291,6 +291,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\Shaders\Uniform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Graphics\Shaders\UniformBase.cs" />
     <Compile Include="Graphics\EasingTypes.cs" />
+    <Compile Include="Graphics\Transforms\Transformable.cs" />
     <Compile Include="Graphics\Transforms\Transform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lists\IHasLifetime.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lists\LifetimeList.cs" />


### PR DESCRIPTION
To use it for example in `AdjustableAudioComponent` in the future. 