### PR TITLE
Use IContainer instead of Container in EdgeEffect transforms

### DIFF
--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -14,6 +14,7 @@ namespace osu.Framework.Graphics.Containers
         Vector2 RelativeToAbsoluteFactor { get; }
         Vector2 RelativeChildOffset { get; }
 
+        EdgeEffectParameters EdgeEffect { get; set; }
         float CornerRadius { get; }
 
         void InvalidateFromChild(Invalidation invalidation);

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectAlpha.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Graphics.Transforms
         public override void Apply(Drawable d)
         {
             base.Apply(d);
-            Container c = (Container)d;
+            IContainer c = (IContainer)d;
 
             EdgeEffectParameters e = c.EdgeEffect;
             e.Colour.Linear.A = CurrentValue;

--- a/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
+++ b/osu.Framework/Graphics/Transforms/TransformEdgeEffectColour.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Graphics.Transforms
         public override void Apply(Drawable d)
         {
             base.Apply(d);
-            Container c = (Container)d;
+            IContainer c = (IContainer)d;
 
             EdgeEffectParameters e = c.EdgeEffect;
             e.Colour = CurrentValue;


### PR DESCRIPTION
Really not sure why `TransformEdgeEffectAlpha` and `TransformEdgeEffectColour` casts the drawable to a `Container`, which won't allow transforming other container EdgeEffects such as `Container<Box>`.