### PR TITLE
Fix mouse wheel state retention regression

### DIFF
--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKEventMouseState.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKEventMouseState.cs
@@ -1,0 +1,18 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+
+namespace osu.Framework.Desktop.Input.Handlers.Mouse
+{
+    /// <summary>
+    /// An OpenTK state which came from an event callback.
+    /// </summary>
+    internal class OpenTKEventMouseState : OpenTKMouseState
+    {
+        public OpenTKEventMouseState(OpenTK.Input.MouseState tkState, bool active, Vector2? mappedPosition)
+            : base(tkState, active, mappedPosition)
+        {
+        }
+    }
+}

--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
 
                         var mapped = host.Window.PointToClient(new Point(state.X, state.Y));
 
-                        handleState(new OpenTKBasicMouseState(state, host.IsActive, new Vector2(mapped.X, mapped.Y)));
+                        handleState(new OpenTKPollMouseState(state, host.IsActive, new Vector2(mapped.X, mapped.Y)));
                     }, 0, 1000.0 / 60));
                 }
                 else
@@ -77,7 +77,7 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
             if (!mouseInWindow)
                 return;
 
-            handleState(new OpenTKBasicMouseState(e.Mouse, host.IsActive, null));
+            handleState(new OpenTKEventMouseState(e.Mouse, host.IsActive, null));
         }
 
         private void handleState(MouseState state)
@@ -95,17 +95,6 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
         /// Lowest priority. We want the normal mouse handler to only kick in if all other handlers don't do anything.
         /// </summary>
         public override int Priority => 0;
-
-        /// <summary>
-        /// An OpenTK state which came from an event callback.
-        /// </summary>
-        internal class OpenTKBasicMouseState : OpenTKMouseState
-        {
-            public OpenTKBasicMouseState(OpenTK.Input.MouseState tkState, bool active, Vector2? mappedPosition)
-                : base(tkState, active, mappedPosition)
-            {
-            }
-        }
     }
 }
 

--- a/osu.Framework.Desktop/osu.Framework.Desktop.csproj
+++ b/osu.Framework.Desktop/osu.Framework.Desktop.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Host.cs" />
     <Compile Include="Input\GameWindowTextInput.cs" />
     <Compile Include="Input\Handlers\Keyboard\OpenTKKeyboardHandler.cs" />
+    <Compile Include="Input\Handlers\Mouse\OpenTKEventMouseState.cs" />
     <Compile Include="Input\Handlers\Mouse\OpenTKPollMouseState.cs" />
     <Compile Include="Input\Handlers\Mouse\OpenTKRawMouseHandler.cs" />
     <Compile Include="Input\Handlers\Mouse\OpenTKMouseHandler.cs" />

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1889,6 +1889,9 @@ namespace osu.Framework.Graphics
             }
 
             public bool HasMainButtonPressed => NativeState.HasMainButtonPressed;
+
+            public bool HasAnyButtonPressed => NativeState.HasAnyButtonPressed;
+
             public int Wheel => NativeState.Wheel;
             public int WheelDelta => NativeState.WheelDelta;
 

--- a/osu.Framework/Input/IMouseState.cs
+++ b/osu.Framework/Input/IMouseState.cs
@@ -21,6 +21,8 @@ namespace osu.Framework.Input
 
         bool HasMainButtonPressed { get; }
 
+        bool HasAnyButtonPressed { get; }
+
         bool IsPressed(MouseButton button);
 
         void SetPressed(MouseButton button, bool pressed);

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -189,11 +189,16 @@ namespace osu.Framework.Input
                 // we only want to set a last state if both the new and old state are of the same type.
                 // this avoids giving the new state a false impression of being able to calculate delta values based on a last
                 // state potentially from a different input source.
-                if (last.Mouse != null && s.Mouse != null && last.Mouse.GetType() == s.Mouse.GetType())
+                if (last.Mouse != null && s.Mouse != null)
                 {
-                    last.Mouse.LastState = null;
-                    s.Mouse.LastState = last.Mouse;
-                    s.Mouse.PositionMouseDown = last.Mouse.PositionMouseDown;
+                    if (last.Mouse.GetType() == s.Mouse.GetType())
+                    {
+                        last.Mouse.LastState = null;
+                        s.Mouse.LastState = last.Mouse;
+                    }
+
+                    if (s.Mouse.HasAnyButtonPressed)
+                        s.Mouse.PositionMouseDown = last.Mouse.PositionMouseDown;
                 }
 
                 //hover could change even when the mouse state has not.


### PR DESCRIPTION
Reverts a chance which caused the mouse wheel to act weird when the mouse enters the window (and raw input is disabled).

Adds a special case for `PositionMouseDown` which covers the scenario which the reverted fix was implemented to fix.