### PR TITLE
Remove the need for AlwaysReceiveInput

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -54,7 +54,6 @@ namespace osu.Framework
 
         protected Game()
         {
-            AlwaysReceiveInput = true;
             RelativeSizeAxes = Axes.Both;
 
             AddInternal(new Drawable[]
@@ -64,7 +63,6 @@ namespace osu.Framework
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
-                    AlwaysReceiveInput = true,
                 },
                 new GlobalHotkeys
                 {

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -718,7 +718,7 @@ namespace osu.Framework.Graphics.Containers
 
         internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
         {
-            if (!base.BuildMouseInputQueue(screenSpaceMousePos, queue))
+            if (!base.BuildMouseInputQueue(screenSpaceMousePos, queue) && (!CanReceiveInput || Masking))
                 return false;
 
             //don't use AliveInternalChildren here as it will cause too many allocations (IEnumerable).

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -694,13 +694,13 @@ namespace osu.Framework.Graphics.Containers
         // TODO: Evaluate effects of this on performance and address.
         public override bool HandleInput => true;
 
-        protected override bool InternalContains(Vector2 screenSpacePos)
+        public override bool Contains(Vector2 screenSpacePos)
         {
             float cRadius = CornerRadius;
 
             // Select a cheaper contains method when we don't need rounded edges.
             if (cRadius == 0.0f)
-                return base.InternalContains(screenSpacePos);
+                return base.Contains(screenSpacePos);
             return DrawRectangle.Shrink(cRadius).DistanceSquared(ToLocalSpace(screenSpacePos)) <= cRadius * cRadius;
         }
 

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -22,7 +22,6 @@ namespace osu.Framework.Graphics.Cursor
 
         public CursorContainer()
         {
-            AlwaysReceiveInput = true;
             Depth = float.MinValue;
             RelativeSizeAxes = Axes.Both;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1786,19 +1786,12 @@ namespace osu.Framework.Graphics
         public bool Hovering { get; internal set; }
 
         /// <summary>
-        /// Receive input even if the cursor is not contained within our <see cref="Drawable.DrawRectangle"/>.
-        /// Setting this to true will completely bypass this container's <see cref="Contains(Vector2)"/> check.
-        /// Note that this only applied from the current container onwards (ie. if a parent is masking us we will still not receive input).
-        /// </summary>
-        public bool AlwaysReceiveInput;
-
-        /// <summary>
         /// Computes whether a given screen-space position is contained within this drawable.
         /// Mouse input events are only received when this function is true, or when the drawable
         /// is in focus.
         /// </summary>
         /// <param name="screenSpacePos">The screen space position to be checked against this drawable.</param>
-        public bool Contains(Vector2 screenSpacePos) => AlwaysReceiveInput || InternalContains(screenSpacePos);
+        public bool Contains(Vector2 screenSpacePos) => InternalContains(screenSpacePos);
 
         /// <summary>
         /// Computes whether a given screen-space position is contained within this drawable.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1791,15 +1791,7 @@ namespace osu.Framework.Graphics
         /// is in focus.
         /// </summary>
         /// <param name="screenSpacePos">The screen space position to be checked against this drawable.</param>
-        public bool Contains(Vector2 screenSpacePos) => InternalContains(screenSpacePos);
-
-        /// <summary>
-        /// Computes whether a given screen-space position is contained within this drawable.
-        /// Mouse input events are only received when this function is true, or when the drawable
-        /// is in focus.
-        /// </summary>
-        /// <param name="screenSpacePos">The screen space position to be checked against this drawable.</param>
-        protected virtual bool InternalContains(Vector2 screenSpacePos) => DrawRectangle.Contains(ToLocalSpace(screenSpacePos));
+        public virtual bool Contains(Vector2 screenSpacePos) => DrawRectangle.Contains(ToLocalSpace(screenSpacePos));
 
         /// <summary>
         /// Whether this Drawable can receive input, taking into account all optimizations and masking.

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Graphics.Shapes
             q.BottomLeft,
             q.BottomRight);
 
-        protected override bool InternalContains(Vector2 screenSpacePos)
+        public override bool Contains(Vector2 screenSpacePos)
         {
             return toTriangle(ScreenSpaceDrawQuad).Contains(screenSpacePos);
         }

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// We need a special case here to allow for the dropdown "overflowing" our own bounds.
         /// </summary>
-        protected override bool InternalContains(Vector2 screenSpacePos) => base.InternalContains(screenSpacePos) || (Dropdown?.Contains(screenSpacePos) ?? false);
+        public override bool Contains(Vector2 screenSpacePos) => base.Contains(screenSpacePos) || (Dropdown?.Contains(screenSpacePos) ?? false);
 
         protected Dropdown<T> Dropdown;
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -10,7 +10,6 @@ namespace osu.Framework.Input
     {
         public UserInputManager()
         {
-            AlwaysReceiveInput = true;
         }
 
         protected override IEnumerable<InputHandler> InputHandlers => Host.AvailableInputHandlers;

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -8,10 +8,6 @@ namespace osu.Framework.Input
 {
     public class UserInputManager : InputManager
     {
-        public UserInputManager()
-        {
-        }
-
         protected override IEnumerable<InputHandler> InputHandlers => Host.AvailableInputHandlers;
     }
 }


### PR DESCRIPTION
The idea for this came when discussing with @default0 about how you can accidentally get weird side-effects by using `AlwaysReceiveInput` in combination with existing classes that handle certain input events.

Turns out, we don't need it and can simply handle input correctly for _all_ visible drawables _all the time_. In fact, this fix sometimes _avoids_ unnecessary input events from firing, while making the code substantially nicer.