### PR TITLE
Change Children to a IReadOnlyList

### DIFF
--- a/osu.Framework.Testing/GridTestCase.cs
+++ b/osu.Framework.Testing/GridTestCase.cs
@@ -4,7 +4,6 @@
 using OpenTK;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using System.Linq;
 
 namespace osu.Framework.Testing
 {

--- a/osu.Framework.Testing/GridTestCase.cs
+++ b/osu.Framework.Testing/GridTestCase.cs
@@ -57,7 +57,7 @@ namespace osu.Framework.Testing
         /// <summary>
         /// Access a cell by its index. Valid indices range from 0 to <see cref="Rows"/> * <see cref="Cols"/> - 1.
         /// </summary>
-        protected Container Cell(int index) => testContainer.Children.ElementAt(index);
+        protected Container Cell(int index) => testContainer.Children[index];
 
         /// <summary>
         /// Access a cell by its row and column.

--- a/osu.Framework.Testing/TestCase.cs
+++ b/osu.Framework.Testing/TestCase.cs
@@ -134,7 +134,7 @@ namespace osu.Framework.Testing
                 actionRepetition = 0;
             }
 
-            if (actionIndex > StepsContainer.Children.Count() - 1)
+            if (actionIndex > StepsContainer.Children.Count - 1)
             {
                 onCompletion?.Invoke();
                 return;

--- a/osu.Framework.Testing/TestCase.cs
+++ b/osu.Framework.Testing/TestCase.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.Testing
             runNextStep(onCompletion);
         }
 
-        private StepButton loadableStep => actionIndex >= 0 ? StepsContainer.Children.Skip(actionIndex).FirstOrDefault() : null;
+        private StepButton loadableStep => actionIndex >= 0 ? StepsContainer.Children.ElementAtOrDefault(actionIndex) : null;
 
         protected virtual double TimePerAction => 200;
 

--- a/osu.Framework.Testing/TestRunner.cs
+++ b/osu.Framework.Testing/TestRunner.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Testing
 
         private int testIndex;
 
-        private TestCase loadableTest => testIndex >= 0 ? browser.Tests.Skip(testIndex).FirstOrDefault() : null;
+        private TestCase loadableTest => testIndex >= 0 ? browser.Tests.ElementAtOrDefault(testIndex) : null;
 
         private readonly TestBrowser browser;
         private GameHost host;

--- a/osu.Framework.VisualTests/Tests/TestCaseDropdownBox.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseDropdownBox.cs
@@ -51,13 +51,13 @@ namespace osu.Framework.VisualTests.Tests
             AddRepeatStep("add item", () => styledDropdownMenu.AddDropdownItem(@"test " + i, @"test " + i++), items_to_add);
             AddAssert("item count is correct", () => styledDropdownMenu.Items.Count() == items_to_add * 2);
 
-            AddStep("click item 13", () => getMenuFromDropdown(styledDropdownMenu).ItemsContainer.Children.Skip(13).First().TriggerOnClick());
+            AddStep("click item 13", () => getMenuFromDropdown(styledDropdownMenu).ItemsContainer.Children[13].TriggerOnClick());
 
             AddAssert("dropdown1 is closed", () => getMenuFromDropdown(styledDropdownMenu).State == MenuState.Closed);
-            AddAssert("item 13 is selected", () => styledDropdownMenu.Current == styledDropdownMenu.Items.Skip(13).First().Value);
+            AddAssert("item 13 is selected", () => styledDropdownMenu.Current == styledDropdownMenu.Items.ElementAt(13).Value);
 
-            AddStep("select item 15", () => styledDropdownMenu.Current.Value = styledDropdownMenu.Items.Skip(15).First().Value);
-            AddAssert("item 15 is selected", () => styledDropdownMenu.Current == styledDropdownMenu.Items.Skip(15).First().Value);
+            AddStep("select item 15", () => styledDropdownMenu.Current.Value = styledDropdownMenu.Items.ElementAt(15).Value);
+            AddAssert("item 15 is selected", () => styledDropdownMenu.Current == styledDropdownMenu.Items.ElementAt(15).Value);
 
             AddStep("click dropdown1", () => toggleDropdownViaClick(styledDropdownMenu));
             AddAssert("dropdown1 is open", () => getMenuFromDropdown(styledDropdownMenu).State == MenuState.Opened);
@@ -68,7 +68,7 @@ namespace osu.Framework.VisualTests.Tests
             AddAssert("dropdown2 is open", () => getMenuFromDropdown(styledDropdownMenu2).State == MenuState.Opened);
         }
 
-        private Menu getMenuFromDropdown(StyledDropdownMenu dropdown) => (Menu)dropdown.Children.Skip(1).First();
+        private Menu getMenuFromDropdown(StyledDropdownMenu dropdown) => (Menu)dropdown.Children[1];
 
         private void toggleDropdownViaClick(StyledDropdownMenu dropdown) => dropdown.Children.First().TriggerOnClick();
 

--- a/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseFlow.cs
@@ -308,7 +308,7 @@ namespace osu.Framework.VisualTests.Tests
                         fillContainer.Invalidate();
                     }
 
-                    if (fillContainer.Children.Count() < 1000 && !doNotAddChildren)
+                    if (fillContainer.Children.Count < 1000 && !doNotAddChildren)
                     {
                         fillContainer.Add(new Container
                         {
@@ -329,7 +329,7 @@ namespace osu.Framework.VisualTests.Tests
                                     RelativePositionAxes = Axes.Both,
                                     Position = new Vector2(0.5f, 0.5f),
                                     Origin = Anchor.Centre,
-                                    Text = fillContainer.Children.Count().ToString()
+                                    Text = fillContainer.Children.Count.ToString()
                                 }
                             }
                         });

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -17,7 +17,6 @@ using osu.Framework.Graphics.Transforms;
 using osu.Framework.Timing;
 using osu.Framework.Caching;
 using System.Threading.Tasks;
-using System.Linq;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.MathUtils;
 using osu.Framework.Threading;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -59,6 +59,11 @@ namespace osu.Framework.Graphics.Containers
             {
                 if (obj.DisposeOnDeathRemoval) obj.Dispose();
             };
+
+            if (typeof(T) == typeof(Drawable))
+                internalChildrenAsT = (IReadOnlyList<T>)internalChildren;
+            else
+                internalChildrenAsT = new LazyList<Drawable, T>(internalChildren, c => (T)c);
         }
 
         private Game game;
@@ -129,18 +134,26 @@ namespace osu.Framework.Graphics.Containers
         /// If <see cref="Content"/> is this container, then returns <see cref="InternalChildren"/>.
         /// Assigning to this property will dispose all existing children of this Container.
         /// </summary>
-        public IEnumerable<T> Children
+        public IReadOnlyList<T> Children
         {
             get
             {
                 if (Content != this)
                     return Content.Children;
 
-                if (typeof(T) == typeof(Drawable))
-                    return (IEnumerable<T>)internalChildren;
-
-                return internalChildren.Cast<T>();
+                return internalChildrenAsT;
             }
+            set
+            {
+                ChildrenEnumerable = value;
+            }
+        }
+
+        /// <summary>
+        /// Sets all children of this container to the elements contained in the enumerable.
+        /// </summary>
+        public IEnumerable<T> ChildrenEnumerable
+        {
             set
             {
                 Clear();
@@ -149,14 +162,23 @@ namespace osu.Framework.Graphics.Containers
         }
 
         private readonly LifetimeList<Drawable> internalChildren;
+        private readonly IReadOnlyList<T> internalChildrenAsT;
 
         /// <summary>
         /// This container's own list of children. Assigning to this property will dispose all existing internal children of this Container.
         /// </summary>
-        public IEnumerable<Drawable> InternalChildren
+        public IReadOnlyList<Drawable> InternalChildren
         {
             get { return internalChildren; }
 
+            set { InternalChildrenEnumerable = value; }
+        }
+
+        /// <summary>
+        /// Sets all internal children of this container to the elements contained in the enumerable.
+        /// </summary>
+        public IEnumerable<Drawable> InternalChildrenEnumerable
+        {
             set
             {
                 Clear();

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -27,8 +27,8 @@ namespace osu.Framework.Graphics.Containers
     public interface IContainerEnumerable<out T> : IContainer
         where T : IDrawable
     {
-        IEnumerable<Drawable> InternalChildren { get; }
-        IEnumerable<T> Children { get; }
+        IReadOnlyList<Drawable> InternalChildren { get; }
+        IReadOnlyList<T> Children { get; }
 
         int RemoveAll(Predicate<T> match);
     }
@@ -36,8 +36,8 @@ namespace osu.Framework.Graphics.Containers
     public interface IContainerCollection<in T> : IContainer
         where T : IDrawable
     {
-        IEnumerable<Drawable> InternalChildren { set; }
-        IEnumerable<T> Children { set; }
+        IReadOnlyList<Drawable> InternalChildren { set; }
+        IReadOnlyList<T> Children { set; }
 
         void Add(T drawable);
         void Add(IEnumerable<T> collection);

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -153,13 +153,14 @@ namespace osu.Framework.Graphics.Performance
                                                 Direction = FillDirection.Horizontal,
                                                 AutoSizeAxes = Axes.X,
                                                 RelativeSizeAxes = Axes.Y,
-                                                Children = from StatisticsCounterType t in Enum.GetValues(typeof(StatisticsCounterType))
-                                                           where t < StatisticsCounterType.AmountTypes && monitor.Counters[(int)t] != null
-                                                           select counterBars[t] = new CounterBar
-                                                           {
-                                                               Colour = getColour(t),
-                                                               Label = t.ToString(),
-                                                           },
+                                                ChildrenEnumerable =
+                                                    from StatisticsCounterType t in Enum.GetValues(typeof(StatisticsCounterType))
+                                                    where t < StatisticsCounterType.AmountTypes && monitor.Counters[(int)t] != null
+                                                    select counterBars[t] = new CounterBar
+                                                    {
+                                                        Colour = getColour(t),
+                                                        Label = t.ToString(),
+                                                    },
                                             },
                                         }
                                     }
@@ -199,14 +200,15 @@ namespace osu.Framework.Graphics.Performance
                                             AutoSizeAxes = Axes.Both,
                                             Spacing = new Vector2(5, 1),
                                             Padding = new MarginPadding { Right = 5 },
-                                            Children = from PerformanceCollectionType t in Enum.GetValues(typeof(PerformanceCollectionType))
-                                                       where t < PerformanceCollectionType.AmountTypes
-                                                       select legendMapping[(int)t] = new SpriteText
-                                                       {
-                                                           Colour = getColour(t),
-                                                           Text = t.ToString(),
-                                                           Alpha = 0
-                                                       },
+                                            ChildrenEnumerable =
+                                                from PerformanceCollectionType t in Enum.GetValues(typeof(PerformanceCollectionType))
+                                                where t < PerformanceCollectionType.AmountTypes
+                                                select legendMapping[(int)t] = new SpriteText
+                                                {
+                                                    Colour = getColour(t),
+                                                    Text = t.ToString(),
+                                                    Alpha = 0
+                                                },
                                         },
                                         new SpriteText
                                         {

--- a/osu.Framework/Graphics/UserInterface/ContextMenu.cs
+++ b/osu.Framework/Graphics/UserInterface/ContextMenu.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             set
             {
-                menu.ItemsContainer.Children = value;
+                menu.ItemsContainer.ChildrenEnumerable = value;
 
                 foreach (var item in Items)
                     item.Action += Close;

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -97,7 +97,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Depth = -1,
                 Masking = true,
                 TabVisibilityChanged = updateDropdown,
-                Children = tabMap.Values
+                ChildrenEnumerable = tabMap.Values
             });
 
             Current.ValueChanged += newSelection =>

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -231,8 +231,8 @@ namespace osu.Framework.Graphics.UserInterface
             if (index > 0)
             {
                 if (index < text.Length)
-                    return TextFlow.Children.ElementAt(index).DrawPosition.X + TextFlow.DrawPosition.X;
-                var d = TextFlow.Children.ElementAt(index - 1);
+                    return TextFlow.Children[index].DrawPosition.X + TextFlow.DrawPosition.X;
+                var d = TextFlow.Children[index - 1];
                 return d.DrawPosition.X + d.DrawSize.X + TextFlow.Spacing.X + TextFlow.DrawPosition.X;
             }
             return 0;

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Linq;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -274,7 +274,7 @@ namespace osu.Framework.Graphics.Visualisation
             previewBox.Alpha = Math.Max(0.2f, Target.Alpha);
             previewBox.ColourInfo = Target.ColourInfo;
 
-            int childCount = (Target as IContainerEnumerable<Drawable>)?.Children.Count() ?? 0;
+            int childCount = (Target as IContainerEnumerable<Drawable>)?.Children.Count ?? 0;
 
             text.Text = Target + (!isExpanded && childCount > 0 ? $@" ({childCount} children)" : string.Empty);
         }
@@ -283,7 +283,7 @@ namespace osu.Framework.Graphics.Visualisation
         {
             updateSpecifics();
 
-            text.Colour = !isExpanded && ((Target as IContainerEnumerable<Drawable>)?.Children.Count() ?? 0) > 0 ? Color4.LightBlue : Color4.White;
+            text.Colour = !isExpanded && ((Target as IContainerEnumerable<Drawable>)?.Children.Count ?? 0) > 0 ? Color4.LightBlue : Color4.White;
             base.Update();
         }
 

--- a/osu.Framework/Lists/LazyList.cs
+++ b/osu.Framework/Lists/LazyList.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Framework.Lists
+{
+    /// <summary>
+    /// A list that lazily applies a transformation to elements of a source list to a target type when its indexed or iterated.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the source elements.</typeparam>
+    /// <typeparam name="TTarget">The type of the target elements.</typeparam>
+    public class LazyList<TSource, TTarget> : IReadOnlyList<TTarget>
+    {
+        private readonly IReadOnlyList<TSource> source;
+        private readonly Func<TSource, TTarget> map;
+
+        /// <summary>
+        /// Gets the element at the specified index from source, applies the transformation to it and returns the transformed element.
+        /// </summary>
+        /// <param name="index">The index of the element.</param>
+        /// <returns>The transformed element at the specified index.</returns>
+        public TTarget this[int index] => map(source[index]);
+
+        /// <summary>
+        /// The number of elements in this lazy list.
+        /// </summary>
+        public int Count => source.Count;
+
+        /// <summary>
+        /// Constructs a new lazy list from the given source list and with the given transformation.
+        /// </summary>
+        /// <param name="source">The source list to get elements from.</param>
+        /// <param name="map"></param>
+        public LazyList(IReadOnlyList<TSource> source, Func<TSource, TTarget> map)
+        {
+            this.source = source;
+            this.map = map;
+        }
+
+        IEnumerator<TTarget> IEnumerable<TTarget>.GetEnumerator() => source.Select(s => map(s)).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable<TTarget>)this).GetEnumerator();
+    }
+}

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -230,6 +230,7 @@
     <Compile Include="IO\Stores\OnlineStore.cs" />
     <Compile Include="IO\Stores\StorageBackedResourceStore.cs" />
     <Compile Include="IStateful.cs" />
+    <Compile Include="Lists\LazyList.cs" />
     <Compile Include="Lists\SortedList.cs" />
     <Compile Include="Lists\WeakList.cs" />
     <Compile Include="Localisation\FormattableString.cs" />


### PR DESCRIPTION
Allows for convenient access of children by index and to get other
information such as the number of children in a container.