### PR TITLE
DrawVis improvements

### DIFF
--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -179,8 +179,12 @@ namespace osu.Framework.Graphics.Visualisation
 
             if (targetDrawable != null)
             {
-                treeContainer.Remove(targetDrawable);
-                targetDrawable.Dispose();
+                if (targetDrawable.Parent != null)
+                {
+                    // targetDrawable may have gotten purged from the TreeContainer
+                    treeContainer.Remove(targetDrawable);
+                    targetDrawable.Dispose();
+                }
                 targetDrawable = null;
             }
         }

--- a/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
@@ -166,7 +166,7 @@ namespace osu.Framework.Graphics.Visualisation
                 {
                     value = getValue() ?? "<null>";
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
                     value = $@"<{((e as TargetInvocationException)?.InnerException ?? e).GetType().ReadableName()} occured during evaluation>";
                 }

--- a/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Sprites;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Graphics.Visualisation
 {
@@ -52,7 +53,7 @@ namespace osu.Framework.Graphics.Visualisation
 
             Type type = source.GetType();
 
-            Add(((IEnumerable<MemberInfo>)type.GetProperties(BindingFlags.Instance | BindingFlags.Public)) // Get all properties
+            Add(((IEnumerable<MemberInfo>)type.GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(p => p.GetMethod != null)) // Get all properties that can have a value
                 .Concat(type.GetFields(BindingFlags.Instance | BindingFlags.Public)) // And all fields
                 .OrderBy(member => member.Name)
                 .Concat(type.GetFields(BindingFlags.Instance | BindingFlags.NonPublic).OrderBy(field => field.Name)) // Include non-public fields at the end
@@ -165,9 +166,9 @@ namespace osu.Framework.Graphics.Visualisation
                 {
                     value = getValue() ?? "<null>";
                 }
-                catch
+                catch(Exception e)
                 {
-                    value = @"<Cannot evaluate>";
+                    value = $@"<{((e as TargetInvocationException)?.InnerException ?? e).GetType().ReadableName()} occured during evaluation>";
                 }
 
                 if (!value.Equals(lastValue))


### PR DESCRIPTION
This fixes a bug with the draw visualiser and improves on the property display.

The bug that was fixed can be reproduced as follows:
-Locate a dropdown
-Select the dropdown
-Go up the hierarchy until you can see the menu subtree toggling as you toggle the dropdown
-Open the dropdown menu
-Double-click a drawable in the subtree of the menu
-Hit "up one parent"

Basically whats happening is that the draw visualiser doesnt properly deal with the case that the drawable currently selected as the root node gets removed by user code.

The other improvement revolves around the property display: Write-only properties are now excluded (ChildrenEnumerable, fe) and if an exception occurs during evaluation, the type of exception that occured is written out instead of just the message "<Cannot evaluate>".