### PR TITLE
Various small improvements to mouse input

### DIFF
--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Cursor
 
         protected virtual Drawable CreateCursor() => new Cursor();
 
-        public override bool Contains(Vector2 screenSpacePos) => true;
+        public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => true;
 
         protected override bool OnMouseMove(InputState state)
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1790,6 +1790,14 @@ namespace osu.Framework.Graphics
         public bool Hovering { get; internal set; }
 
         /// <summary>
+        /// Determines whether this drawable receives mouse input when the mouse is at the
+        /// given screen-space position.
+        /// </summary>
+        /// <param name="screenSpacePos">The screen-space position where input could be received.</param>
+        /// <returns>True iff input is received at the given screen-space position.</returns>
+        public virtual bool ReceiveMouseInputAt(Vector2 screenSpacePos) => Contains(screenSpacePos);
+
+        /// <summary>
         /// Computes whether a given screen-space position is contained within this drawable.
         /// Mouse input events are only received when this function is true, or when the drawable
         /// is in focus.
@@ -1807,7 +1815,7 @@ namespace osu.Framework.Graphics
         /// taking into account whether this Drawable can receive input.
         /// </summary>
         /// <param name="screenSpaceMousePos">The mouse position to be checked.</param>
-        internal bool IsHovered(Vector2 screenSpaceMousePos) => CanReceiveInput && Contains(screenSpaceMousePos);
+        internal bool IsHovered(Vector2 screenSpaceMousePos) => CanReceiveInput && ReceiveMouseInputAt(screenSpaceMousePos);
 
         /// <summary>
         /// Creates a new InputState with mouse coodinates converted to the coordinate space of our parent.

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -30,10 +30,7 @@ namespace osu.Framework.Graphics.Shapes
             q.BottomLeft,
             q.BottomRight);
 
-        public override bool Contains(Vector2 screenSpacePos)
-        {
-            return toTriangle(ScreenSpaceDrawQuad).Contains(screenSpacePos);
-        }
+        public override bool Contains(Vector2 screenSpacePos) => toTriangle(ScreenSpaceDrawQuad).Contains(screenSpacePos);
 
         protected override DrawNode CreateDrawNode() => new TriangleDrawNode();
 

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -33,11 +33,6 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         public bool AutoSort { set; get; }
 
-        /// <summary>
-        /// We need a special case here to allow for the dropdown "overflowing" our own bounds.
-        /// </summary>
-        public override bool Contains(Vector2 screenSpacePos) => base.Contains(screenSpacePos) || (Dropdown?.Contains(screenSpacePos) ?? false);
-
         protected Dropdown<T> Dropdown;
 
         protected TabFillFlowContainer<TabItem<T>> TabContainer;

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -136,9 +136,9 @@ namespace osu.Framework.Graphics.Visualisation
 
             bool containsCursor = d.ScreenSpaceDrawQuad.Contains(state.Mouse.NativeState.Position);
             // This is an optimization: We don't need to consider drawables which we don't hover, and which do not
-            // forward input further to children (via d.Contains). If they do forward input to children, then there
+            // forward input further to children (via d.ReceiveMouseInputAt). If they do forward input to children, then there
             // is a good chance they have children poking out of their bounds, which we need to catch.
-            if (!containsCursor && !d.Contains(state.Mouse.NativeState.Position))
+            if (!containsCursor && !d.ReceiveMouseInputAt(state.Mouse.NativeState.Position))
                 return null;
 
             var dAsContainer = d as IContainerEnumerable<Drawable>;

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -204,7 +204,7 @@ namespace osu.Framework.Graphics.Visualisation
             base.OnHoverLost(state);
         }
 
-        protected override bool OnDragStart(InputState state) => titleBar.Contains(state.Mouse.NativeState.Position);
+        protected override bool OnDragStart(InputState state) => titleBar.ReceiveMouseInputAt(state.Mouse.NativeState.Position);
 
         protected override bool OnDrag(InputState state)
         {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -84,7 +84,7 @@ namespace osu.Framework.Input
         /// Top-down in this case means reverse draw order, i.e. the front-most visible
         /// <see cref="Drawable"/> first, and <see cref="Container"/>s after their children.
         /// </summary>
-        public IEnumerable<Drawable> HoveredDrawables => hoveredDrawables;
+        public IReadOnlyList<Drawable> HoveredDrawables => hoveredDrawables;
 
         protected InputManager()
         {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -76,6 +76,7 @@ namespace osu.Framework.Input
         private readonly List<Drawable> keyboardInputQueue = new List<Drawable>();
 
         private Drawable draggingDrawable;
+        private readonly List<Drawable> lastHoveredDrawables = new List<Drawable>();
         private readonly List<Drawable> hoveredDrawables = new List<Drawable>();
         private Drawable hoverHandledDrawable;
 
@@ -352,7 +353,8 @@ namespace osu.Framework.Input
             Drawable lastHoverHandledDrawable = hoverHandledDrawable;
             hoverHandledDrawable = null;
 
-            List<Drawable> lastHoveredDrawables = new List<Drawable>(hoveredDrawables);
+            lastHoveredDrawables.Clear();
+            lastHoveredDrawables.AddRange(hoveredDrawables);
             hoveredDrawables.Clear();
 
             // First, we need to construct hoveredDrawables for the current frame

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -76,12 +76,30 @@ namespace osu.Framework.Input
         private readonly List<Drawable> keyboardInputQueue = new List<Drawable>();
 
         private Drawable draggingDrawable;
+
+        /// <summary>
+        /// Contains the previously hovered <see cref="Drawable"/>s prior to when
+        /// <see cref="hoveredDrawables"/> got updated.
+        /// </summary>
         private readonly List<Drawable> lastHoveredDrawables = new List<Drawable>();
+
+        /// <summary>
+        /// Contains all hovered <see cref="Drawable"/>s in top-down order up to the first
+        /// which returned true in its <see cref="Drawable.OnHover(InputState)"/> method.
+        /// Top-down in this case means reverse draw order, i.e. the front-most visible
+        /// <see cref="Drawable"/> first, and <see cref="Container"/>s after their children.
+        /// </summary>
         private readonly List<Drawable> hoveredDrawables = new List<Drawable>();
+
+        /// <summary>
+        /// The <see cref="Drawable"/> which returned true in its
+        /// <see cref="Drawable.OnHover(InputState)"/> method, or null if none did so.
+        /// </summary>
         private Drawable hoverHandledDrawable;
 
         /// <summary>
-        /// Contains all hovered <see cref="Drawable"/>s in top-down order.
+        /// Contains all hovered <see cref="Drawable"/>s in top-down order up to the first
+        /// which returned true in its <see cref="Drawable.OnHover(InputState)"/> method.
         /// Top-down in this case means reverse draw order, i.e. the front-most visible
         /// <see cref="Drawable"/> first, and <see cref="Container"/>s after their children.
         /// </summary>


### PR DESCRIPTION
- Makes `InputManager.HoveredDrawables` a `IReadOnlyList`
- Adds an overridable `Drawable.ReceiveMouseInputAt` method to decouple input from `Contains`
- Avoids a significant heap allocation every frame from `lastHoveredDrawables`
- Documents `hoveredDrawables` et al. a bit better

More details in individual commit messages.