### PR TITLE
Simplify caching of properties

### DIFF
--- a/osu.Framework/Caching/Cached.cs
+++ b/osu.Framework/Caching/Cached.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Statistics;
-using System;
 
 namespace osu.Framework.Caching
 {

--- a/osu.Framework/Caching/Cached.cs
+++ b/osu.Framework/Caching/Cached.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Statistics;
+using System;
 
 namespace osu.Framework.Caching
 {
@@ -16,7 +17,13 @@ namespace osu.Framework.Caching
 
         public T Value
         {
-            get { return value; }
+            get
+            {
+                if (!isValid)
+                    throw new InvalidOperationException($"May not query {nameof(Value)} of an invalid {nameof(Cached<T>)}.");
+                return value;
+            }
+
             set
             {
                 this.value = value;

--- a/osu.Framework/Caching/Cached.cs
+++ b/osu.Framework/Caching/Cached.cs
@@ -13,60 +13,24 @@ namespace osu.Framework.Caching
 
     public struct Cached<T>
     {
-        public delegate T PropertyUpdater();
+        private T value;
+
+        public T Value
+        {
+            get { return value; }
+            set
+            {
+                this.value = value;
+                isValid = true;
+                FrameStatistics.Increment(StatisticsCounterType.Refreshes);
+            }
+        }
 
         private bool isValid;
 
         public bool IsValid => !StaticCached.BypassCache && isValid;
 
-        private PropertyUpdater updateDelegate;
-
-        public static implicit operator T(Cached<T> value)
-        {
-            return value.Value;
-        }
-
-        /// <summary>
-        /// Refresh this cached object with a custom delegate.
-        /// </summary>
-        /// <param name="providedDelegate"></param>
-        public T Refresh(PropertyUpdater providedDelegate)
-        {
-            updateDelegate = updateDelegate ?? providedDelegate;
-            return MakeValidOrDefault();
-        }
-
-        /// <summary>
-        /// Refresh this property.
-        /// </summary>
-        public T MakeValidOrDefault()
-        {
-            if (IsValid) return value;
-
-            if (!EnsureValid())
-                return default(T);
-
-            return value;
-        }
-
-        /// <summary>
-        /// Refresh using a cached delegate.
-        /// </summary>
-        /// <returns>Whether refreshing was possible.</returns>
-        public bool EnsureValid()
-        {
-            if (IsValid) return true;
-
-            if (updateDelegate == null)
-                return false;
-
-            value = updateDelegate();
-            isValid = true;
-
-            FrameStatistics.Increment(StatisticsCounterType.Refreshes);
-
-            return true;
-        }
+        public static implicit operator T(Cached<T> value) => value.Value;
 
         /// <summary>
         /// Invalidate the cache of this object.
@@ -82,62 +46,14 @@ namespace osu.Framework.Caching
             }
 
             return false;
-        }
-
-        private T value;
-
-        public T Value
-        {
-            get
-            {
-                if (!isValid)
-                    MakeValidOrDefault();
-
-                return value;
-            }
-
-            set { throw new NotSupportedException("Can't manually update value!"); }
         }
     }
 
     public struct Cached
     {
-        public delegate void PropertyUpdater();
-
         private bool isValid;
 
         public bool IsValid => !StaticCached.BypassCache && isValid;
-
-        private PropertyUpdater updateDelegate;
-
-        /// <summary>
-        /// Refresh this cached object with a custom delegate.
-        /// </summary>
-        /// <param name="providedDelegate"></param>
-        public void Refresh(PropertyUpdater providedDelegate)
-        {
-            updateDelegate = updateDelegate ?? providedDelegate;
-            EnsureValid();
-        }
-
-        /// <summary>
-        /// Refresh using a cached delegate.
-        /// </summary>
-        /// <returns>Whether refreshing was possible.</returns>
-        public bool EnsureValid()
-        {
-            if (IsValid) return true;
-
-            if (updateDelegate == null)
-                return false;
-
-            updateDelegate();
-            isValid = true;
-
-            FrameStatistics.Increment(StatisticsCounterType.Refreshes);
-
-            return true;
-        }
 
         /// <summary>
         /// Invalidate the cache of this object.
@@ -153,6 +69,12 @@ namespace osu.Framework.Caching
             }
 
             return false;
+        }
+
+        public void Validate()
+        {
+            isValid = true;
+            FrameStatistics.Increment(StatisticsCounterType.Refreshes);
         }
     }
 }

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -27,13 +27,34 @@ namespace osu.Framework.Graphics.Colour
         /// <param name="first">First factor.</param>
         /// <param name="second">Second factor.</param>
         /// <returns>Product of first and second.</returns>
-        public static SRGBColour operator *(SRGBColour first, SRGBColour second) => FromVector(first.ToVector() * second.ToVector());
+        public static SRGBColour operator *(SRGBColour first, SRGBColour second) => new SRGBColour
+        {
+            Linear = new Color4(
+                first.Linear.R * second.Linear.R,
+                first.Linear.G * second.Linear.G,
+                first.Linear.B * second.Linear.B,
+                first.Linear.A * second.Linear.A),
+        };
 
-        public static SRGBColour operator *(SRGBColour first, float second) => FromVector(first.ToVector() * second);
+        public static SRGBColour operator *(SRGBColour first, float second) => new SRGBColour
+        {
+            Linear = new Color4(
+                first.Linear.R * second,
+                first.Linear.G * second,
+                first.Linear.B * second,
+                first.Linear.A * second),
+        };
 
-        public static SRGBColour operator /(SRGBColour first, float second) => FromVector(first.ToVector() / second);
+        public static SRGBColour operator /(SRGBColour first, float second) => first * (1 / second);
 
-        public static SRGBColour operator +(SRGBColour first, SRGBColour second) => FromVector(first.ToVector() + second.ToVector());
+        public static SRGBColour operator +(SRGBColour first, SRGBColour second) => new SRGBColour
+        {
+            Linear = new Color4(
+                first.Linear.R + second.Linear.R,
+                first.Linear.G + second.Linear.G,
+                first.Linear.B + second.Linear.B,
+                first.Linear.A + second.Linear.A),
+        };
 
         public Vector4 ToVector() => new Vector4(Linear.R, Linear.G, Linear.B, Linear.A);
         public static SRGBColour FromVector(Vector4 v) => new SRGBColour { Linear = new Color4(v.X, v.Y, v.Z, v.W) };

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -1132,7 +1132,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         internal event Action OnAutoSize;
 
-        private Cached childrenSizeDependencies;
+        private Cached childrenSizeDependencies = new Cached();
 
         public override float Width
         {

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -1259,8 +1259,11 @@ namespace osu.Framework.Graphics.Containers
 
             try
             {
-                if (!childrenSizeDependencies.EnsureValid())
-                    childrenSizeDependencies.Refresh(updateAutoSize);
+                if (!childrenSizeDependencies.IsValid)
+                {
+                    updateAutoSize();
+                    childrenSizeDependencies.Validate();
+                }
             }
             finally
             {

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -1132,7 +1132,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         internal event Action OnAutoSize;
 
-        private Cached childrenSizeDependencies = new Cached();
+        private Cached childrenSizeDependencies;
 
         public override float Width
         {

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Graphics.Containers
             base.Update();
         }
 
-        private Cached<bool> isIntersectingBacking = new Cached<bool>();
+        private Cached<bool> isIntersectingBacking;
 
         private bool isIntersecting => isIntersectingBacking.IsValid ? isIntersectingBacking : (isIntersectingBacking.Value = checkScrollIntersection());
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -40,9 +40,9 @@ namespace osu.Framework.Graphics.Containers
             base.Update();
         }
 
-        private bool isIntersecting => isIntersectingBacking.EnsureValid() ? isIntersectingBacking.Value : isIntersectingBacking.Refresh(checkScrollIntersection);
-
         private Cached<bool> isIntersectingBacking = new Cached<bool>();
+
+        private bool isIntersecting => isIntersectingBacking.IsValid ? isIntersectingBacking : (isIntersectingBacking.Value = checkScrollIntersection());
 
         private bool checkScrollIntersection()
         {

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -96,47 +96,50 @@ namespace osu.Framework.Graphics.Containers
 
         protected abstract IEnumerable<Vector2> ComputeLayoutPositions();
 
+        private void performLayout()
+        {
+            OnLayout?.Invoke();
+
+            if (!Children.Any())
+                return;
+
+            var positions = ComputeLayoutPositions().ToArray();
+
+            int i = 0;
+            foreach (var d in FlowingChildren)
+            {
+                if (i > positions.Length)
+                    throw new InvalidOperationException(
+                        $"{GetType().FullName}.{nameof(ComputeLayoutPositions)} returned a total of {positions.Length} positions for {i} children. {nameof(ComputeLayoutPositions)} must return 1 position per child.");
+
+                if ((d.RelativeSizeAxes & AutoSizeAxes) != 0)
+                    throw new InvalidOperationException(
+                        "Drawables inside a flow container may not have a relative size axis that the flow container is auto sizing for." +
+                        $"The flow container is set to autosize in {AutoSizeAxes} axes and the child is set to relative size in {d.RelativeSizeAxes} axes.");
+
+                if (d.RelativePositionAxes != Axes.None)
+                    throw new InvalidOperationException($"A flow container cannot contain a child with relative positioning (it is {d.RelativePositionAxes}).");
+
+                var finalPos = positions[i];
+                if (d.Position != finalPos)
+                    d.MoveTo(finalPos, LayoutDuration, LayoutEasing);
+
+                ++i;
+            }
+
+            if (i != positions.Length)
+                throw new InvalidOperationException(
+                    $"{GetType().FullName}.{nameof(ComputeLayoutPositions)} returned a total of {positions.Length} positions for {i} children. {nameof(ComputeLayoutPositions)} must return 1 position per child.");
+        }
+
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
 
-            if (!layout.EnsureValid())
+            if (!layout.IsValid)
             {
-                layout.Refresh(delegate
-                {
-                    OnLayout?.Invoke();
-
-                    if (!Children.Any())
-                        return;
-
-                    var positions = ComputeLayoutPositions().ToArray();
-
-                    int i = 0;
-                    foreach (var d in FlowingChildren)
-                    {
-                        if (i > positions.Length)
-                            throw new InvalidOperationException(
-                                $"{GetType().FullName}.{nameof(ComputeLayoutPositions)} returned a total of {positions.Length} positions for {i} children. {nameof(ComputeLayoutPositions)} must return 1 position per child.");
-
-                        if ((d.RelativeSizeAxes & AutoSizeAxes) != 0)
-                            throw new InvalidOperationException(
-                                "Drawables inside a flow container may not have a relative size axis that the flow container is auto sizing for." +
-                                $"The flow container is set to autosize in {AutoSizeAxes} axes and the child is set to relative size in {d.RelativeSizeAxes} axes.");
-
-                        if (d.RelativePositionAxes != Axes.None)
-                            throw new InvalidOperationException($"A flow container cannot contain a child with relative positioning (it is {d.RelativePositionAxes}).");
-
-                        var finalPos = positions[i];
-                        if (d.Position != finalPos)
-                            d.MoveTo(finalPos, LayoutDuration, LayoutEasing);
-
-                        ++i;
-                    }
-
-                    if (i != positions.Length)
-                        throw new InvalidOperationException(
-                            $"{GetType().FullName}.{nameof(ComputeLayoutPositions)} returned a total of {positions.Length} positions for {i} children. {nameof(ComputeLayoutPositions)} must return 1 position per child.");
-                });
+                performLayout();
+                layout.Validate();
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Cached layout;
+        private Cached layout = new Cached();
 
         protected void InvalidateLayout() => layout.Invalidate();
 

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Cached layout = new Cached();
+        private Cached layout;
 
         protected void InvalidateLayout() => layout.Invalidate();
 

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -112,7 +112,11 @@ namespace osu.Framework.Graphics.Containers
         {
             base.UpdateAfterChildren();
 
-            if (!layout.IsValid) layout.Refresh(computeLayout);
+            if (!layout.IsValid)
+            {
+                computeLayout();
+                layout.Validate();
+            }
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -200,7 +200,7 @@ namespace osu.Framework.Graphics.Containers
             return sprites;
         }
 
-        private Cached layout = new Cached();
+        private Cached layout;
 
         private void computeLayout()
         {

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -200,7 +200,7 @@ namespace osu.Framework.Graphics.Containers
             return sprites;
         }
 
-        private Cached layout;
+        private Cached layout = new Cached();
 
         private void computeLayout()
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -599,7 +599,7 @@ namespace osu.Framework.Graphics
             }
         }
 
-        private Cached<Vector2> drawSizeBacking = new Cached<Vector2>();
+        private Cached<Vector2> drawSizeBacking;
 
         /// <summary>
         /// Absolute size of this Drawable in the <see cref="Parent"/>'s coordinate system.
@@ -1262,7 +1262,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         internal bool IsMaskedAway;
 
-        private Cached<Quad> screenSpaceDrawQuadBacking = new Cached<Quad>();
+        private Cached<Quad> screenSpaceDrawQuadBacking;
 
         protected virtual Quad ComputeScreenSpaceDrawQuad() => ToScreenSpace(DrawRectangle);
 
@@ -1272,7 +1272,7 @@ namespace osu.Framework.Graphics
         public virtual Quad ScreenSpaceDrawQuad => screenSpaceDrawQuadBacking.IsValid ? screenSpaceDrawQuadBacking : (screenSpaceDrawQuadBacking.Value = ComputeScreenSpaceDrawQuad());
 
 
-        private Cached<DrawInfo> drawInfoBacking = new Cached<DrawInfo>();
+        private Cached<DrawInfo> drawInfoBacking;
 
         private DrawInfo computeDrawInfo()
         {
@@ -1323,7 +1323,7 @@ namespace osu.Framework.Graphics
         public virtual DrawInfo DrawInfo => drawInfoBacking.IsValid ? drawInfoBacking : (drawInfoBacking.Value = computeDrawInfo());
 
 
-        private Cached<Vector2> requiredParentSizeToFitBacking = new Cached<Vector2>();
+        private Cached<Vector2> requiredParentSizeToFitBacking;
 
         private Vector2 computeRequiredParentSizeToFit()
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1321,7 +1321,7 @@ namespace osu.Framework.Graphics
         /// of this drawable.
         /// </summary>
         public virtual DrawInfo DrawInfo => drawInfoBacking.IsValid ? drawInfoBacking : (drawInfoBacking.Value = computeDrawInfo());
-        
+
 
         private Cached<Vector2> requiredParentSizeToFitBacking = new Cached<Vector2>();
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1301,6 +1301,9 @@ namespace osu.Framework.Graphics
                 di.Colour.ApplyChild(colour);
             else
             {
+                Debug.Assert(Parent != null,
+                    $"The {nameof(di)} of null parents should always have the single colour white, and therefore this branch should never be hit.");
+
                 // Cannot use ToParentSpace here, because ToParentSpace depends on DrawInfo to be completed
                 Quad interp = Quad.FromRectangle(DrawRectangle) * (di.Matrix * Parent.DrawInfo.MatrixInverse);
                 Vector2 parentSize = Parent.DrawSize;

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -95,7 +95,7 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
-        private Cached layout = new Cached();
+        private Cached layout;
 
         private float spaceWidth;
 

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -95,7 +95,7 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
-        private Cached layout;
+        private Cached layout = new Cached();
 
         private float spaceWidth;
 

--- a/osu.Framework/Graphics/UserInterface/ContextMenu.cs
+++ b/osu.Framework/Graphics/UserInterface/ContextMenu.cs
@@ -64,6 +64,22 @@ namespace osu.Framework.Graphics.UserInterface
             Add(menu = CreateMenu());
         }
 
+        private float computeMenuWidth()
+        {
+            // The menu items cannot be both relative and auto-sized to fit the entire width of the menu so they (along with the menu)
+            // are defined to be relatively-sized on the x-axis. We need to define the size ourselves to give them a valid size.
+            float textWidth = 0;
+            float contentWidth = 0;
+
+            foreach (var item in Items)
+            {
+                textWidth = Math.Max(textWidth, item.TextDrawWidth);
+                contentWidth = Math.Max(contentWidth, item.ContentDrawWidth);
+            }
+
+            return textWidth + contentWidth;
+        }
+
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
@@ -71,25 +87,21 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 // The menu items cannot be both relative and auto-sized to fit the entire width of the menu so they (along with the menu)
                 // are defined to be relatively-sized on the x-axis. We need to define the size ourselves to give them a valid size.
-                menuWidth.Refresh(() =>
+                float textWidth = 0;
+                float contentWidth = 0;
+
+                foreach (var item in Items)
                 {
-                    float textWidth = 0;
-                    float contentWidth = 0;
+                    textWidth = Math.Max(textWidth, item.TextDrawWidth);
+                    contentWidth = Math.Max(contentWidth, item.ContentDrawWidth);
+                }
 
-                    foreach (var item in Items)
-                    {
-                        textWidth = Math.Max(textWidth, item.TextDrawWidth);
-                        contentWidth = Math.Max(contentWidth, item.ContentDrawWidth);
-                    }
-
-                    return textWidth + contentWidth;
-                });
-
-                Width = menuWidth.Value;
+                Width = computeMenuWidth();
+                menuWidth.Validate();
             }
         }
 
-        private Cached<float> menuWidth = new Cached<float>();
+        private Cached menuWidth = new Cached();
 
         public override void InvalidateFromChild(Invalidation invalidation)
         {

--- a/osu.Framework/Graphics/UserInterface/ContextMenu.cs
+++ b/osu.Framework/Graphics/UserInterface/ContextMenu.cs
@@ -101,7 +101,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        private Cached menuWidth = new Cached();
+        private Cached menuWidth;
 
         public override void InvalidateFromChild(Invalidation invalidation)
         {

--- a/osu.Framework/Graphics/UserInterface/ContextMenu.cs
+++ b/osu.Framework/Graphics/UserInterface/ContextMenu.cs
@@ -101,7 +101,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        private Cached menuWidth;
+        private Cached menuWidth = new Cached();
 
         public override void InvalidateFromChild(Invalidation invalidation)
         {

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -265,7 +265,7 @@ namespace osu.Framework.Graphics.UserInterface
         private int selectionLeft => Math.Min(selectionStart, selectionEnd);
         private int selectionRight => Math.Max(selectionStart, selectionEnd);
 
-        private Cached cursorAndLayout = new Cached();
+        private Cached cursorAndLayout;
 
         private void moveSelection(int offset, bool expand)
         {

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -265,7 +265,7 @@ namespace osu.Framework.Graphics.UserInterface
         private int selectionLeft => Math.Min(selectionStart, selectionEnd);
         private int selectionRight => Math.Max(selectionStart, selectionEnd);
 
-        private Cached cursorAndLayout;
+        private Cached cursorAndLayout = new Cached();
 
         private void moveSelection(int offset, bool expand)
         {


### PR DESCRIPTION
I believe Cached was overengineered. While dumbing down the Cached interface, this PR imho makes the code simpler to understand. Further, this reduces nesting quite a bit and doesn't rely on the JIT inlining delegates, which appears to give around 10% performance.

We can get another 10-20% performance in invalidation-heavy scenarios by removing the `FrameStatistics.Increment` calls from `Cached`. We should probably do this on release builds at some point in the future.