### PR TITLE
Make TooltipContainer and ContextMenuContainer only consider children

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseContextMenu.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseContextMenu.cs
@@ -44,11 +44,18 @@ namespace osu.Framework.VisualTests.Tests
         {
             base.Reset();
 
-            Add(makeBox(Anchor.TopLeft));
-            Add(makeBox(Anchor.TopRight));
-            Add(makeBox(Anchor.BottomLeft));
-            Add(makeBox(Anchor.BottomRight));
-            Add(movingBox = makeBox(Anchor.Centre));
+            Add(new ContextMenuContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new[]
+                {
+                    makeBox(Anchor.TopLeft),
+                    makeBox(Anchor.TopRight),
+                    makeBox(Anchor.BottomLeft),
+                    makeBox(Anchor.BottomRight),
+                    movingBox = makeBox(Anchor.Centre),
+                }
+            });
 
             movingBox.Transforms.Add(new TransformPosition
             {
@@ -86,8 +93,6 @@ namespace osu.Framework.VisualTests.Tests
                 LoopCount = -1,
                 LoopDelay = duration * 3
             });
-
-            Add(new ContextMenuContainer());
         }
 
         private class ContextMenuBox : Container, IHasContextMenu

--- a/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
@@ -60,15 +60,40 @@ namespace osu.Framework.VisualTests.Tests
                             Text = "with real time updates!",
                             Size = new Vector2(400, 30),
                         },
-                        new TooltipContainer()
+                        new TooltipContainer
                         {
                             RelativeSizeAxes = Axes.None,
                             AutoSizeAxes = Axes.Both,
-                            Children = new Drawable[]
-                            {
-                                new TooltipSpriteText("Nested tooltip; uses no cursor in all cases!"),
-                            }
+                            Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases!"),
                         },
+                        new TooltipTooltipContainer("This tooltip container has a tooltip itself!")
+                        {
+                            RelativeSizeAxes = Axes.None,
+                            AutoSizeAxes = Axes.Both,
+                            Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases; parent TooltipContainer has a tooltip"),
+                        },
+                        new Container
+                        {
+                            Child = new FillFlowContainer
+                            {
+                                Direction = FillDirection.Vertical,
+                                Spacing = new Vector2(0, 8),
+                                Children = new[]
+                                {
+                                    new Container
+                                    {
+                                        Child = new Container
+                                        {
+                                            Child = new TooltipSpriteText("Tooltip within containers with zero size; i.e. parent is never hovered."),
+                                        }
+                                    },
+                                    new Container
+                                    {
+                                        Child = new TooltipSpriteText("Other tooltip within containers with zero size; different nesting; overlap."),
+                                    }
+                                }
+                            }
+                        }
                     },
                 }
             });
@@ -107,6 +132,16 @@ namespace osu.Framework.VisualTests.Tests
                         Text = tooltipText,
                     }
                 };
+            }
+        }
+
+        private class TooltipTooltipContainer : TooltipContainer, IHasTooltip
+        {
+            public string TooltipText { get; set; }
+
+            public TooltipTooltipContainer(string tooltipText)
+            {
+                TooltipText = tooltipText;
             }
         }
 

--- a/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
@@ -60,13 +60,13 @@ namespace osu.Framework.VisualTests.Tests
                             Text = "with real time updates!",
                             Size = new Vector2(400, 30),
                         },
-                        new Container()
+                        new TooltipContainer()
                         {
+                            RelativeSizeAxes = Axes.None,
                             AutoSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
                                 new TooltipSpriteText("Nested tooltip; uses no cursor in all cases!"),
-                                new TooltipContainer(),
                             }
                         },
                     },

--- a/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
@@ -35,35 +35,6 @@ namespace osu.Framework.VisualTests.Tests
         private void generateTest(bool cursorlessTooltip)
         {
             testContainer.Clear();
-            testContainer.Add(new FillFlowContainer
-            {
-                RelativeSizeAxes = Axes.Both,
-                Direction = FillDirection.Vertical,
-                Spacing = new Vector2(0, 10),
-                Children = new Drawable[]
-                {
-                    new TooltipSpriteText("this text has a tooltip!"),
-                    new TooltipSpriteText("this one too!"),
-                    new TooltipTextbox
-                    {
-                        Text = "with real time updates!",
-                        Size = new Vector2(400, 30),
-                    },
-                    new Container()
-                    {
-                        AutoSizeAxes = Axes.Both,
-                        Children = new Drawable[]
-                        {
-                            new TooltipSpriteText("Nested tooltip; uses no cursor in all cases!"),
-                            new TooltipContainer(),
-                        }
-                    },
-                },
-            });
-
-            testContainer.Add(makeBox(Anchor.BottomLeft));
-            testContainer.Add(makeBox(Anchor.TopRight));
-            testContainer.Add(makeBox(Anchor.BottomRight));
 
             CursorContainer cursor = null;
             if (!cursorlessTooltip)
@@ -72,7 +43,39 @@ namespace osu.Framework.VisualTests.Tests
                 testContainer.Add(cursor);
             }
 
-            testContainer.Add(new TooltipContainer(cursor));
+            TooltipContainer ttc;
+            testContainer.Add(ttc = new TooltipContainer(cursor)
+            {
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 10),
+                    Children = new Drawable[]
+                    {
+                        new TooltipSpriteText("this text has a tooltip!"),
+                        new TooltipSpriteText("this one too!"),
+                        new TooltipTextbox
+                        {
+                            Text = "with real time updates!",
+                            Size = new Vector2(400, 30),
+                        },
+                        new Container()
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                            {
+                                new TooltipSpriteText("Nested tooltip; uses no cursor in all cases!"),
+                                new TooltipContainer(),
+                            }
+                        },
+                    },
+                }
+            });
+
+            ttc.Add(makeBox(Anchor.BottomLeft));
+            ttc.Add(makeBox(Anchor.TopRight));
+            ttc.Add(makeBox(Anchor.BottomRight));
         }
 
         public override void Reset()

--- a/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
@@ -46,6 +46,7 @@ namespace osu.Framework.VisualTests.Tests
             TooltipContainer ttc;
             testContainer.Add(ttc = new TooltipContainer(cursor)
             {
+                RelativeSizeAxes = Axes.Both,
                 Child = new FillFlowContainer
                 {
                     RelativeSizeAxes = Axes.Both,
@@ -62,13 +63,11 @@ namespace osu.Framework.VisualTests.Tests
                         },
                         new TooltipContainer
                         {
-                            RelativeSizeAxes = Axes.None,
                             AutoSizeAxes = Axes.Both,
                             Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases!"),
                         },
                         new TooltipTooltipContainer("This tooltip container has a tooltip itself!")
                         {
-                            RelativeSizeAxes = Axes.None,
                             AutoSizeAxes = Axes.Both,
                             Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases; parent TooltipContainer has a tooltip"),
                         },

--- a/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
@@ -69,7 +69,11 @@ namespace osu.Framework.VisualTests.Tests
                         new TooltipTooltipContainer("This tooltip container has a tooltip itself!")
                         {
                             AutoSizeAxes = Axes.Both,
-                            Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases; parent TooltipContainer has a tooltip"),
+                            Child = new Container
+                            {
+                                AutoSizeAxes = Axes.Both,
+                                Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases; parent TooltipContainer has a tooltip"),
+                            }
                         },
                         new Container
                         {

--- a/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
+++ b/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
@@ -16,12 +16,10 @@ namespace osu.Framework.Graphics.Cursor
     /// If a right-click happens on a <see cref="Drawable"/> that implements <see cref="IHasContextMenu"/> and exists as a child of the same <see cref="InputManager"/> as this container,
     /// a <see cref="ContextMenu{TItem}"/> will be displayed with bottom-right origin at the right-clicked position.
     /// </summary>
-    public class ContextMenuContainer : Container
+    public class ContextMenuContainer : CursorEffectContainer<ContextMenuContainer, IHasContextMenu>
     {
-        private readonly CursorContainer cursorContainer;
         private readonly ContextMenu<ContextMenuItem> menu;
-
-        private UserInputManager inputManager;
+        
         private IHasContextMenu menuTarget;
         private Vector2 relativeCursorPosition;
 
@@ -30,22 +28,37 @@ namespace osu.Framework.Graphics.Cursor
         /// </summary>
         protected virtual ContextMenu<ContextMenuItem> CreateContextMenu() => new ContextMenu<ContextMenuItem>();
 
+        private readonly Container content;
+        protected override Container<Drawable> Content => content;
+
         /// <summary>
         /// Creates a new <see cref="ContextMenuContainer"/>.
         /// </summary>
         /// <param name="cursorContainer">The <see cref="CursorContainer"/> of which the <see cref="CursorContainer.ActiveCursor"/>
         /// shall be used for positioning. The current mouse position is used if null is provided.</param>
-        public ContextMenuContainer(CursorContainer cursorContainer = null)
+        public ContextMenuContainer()
         {
-            this.cursorContainer = cursorContainer;
-            RelativeSizeAxes = Axes.Both;
-            Add(menu = CreateContextMenu());
+            AddInternal(content = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+            });
+            AddInternal(menu = CreateContextMenu());
         }
 
-        [BackgroundDependencyLoader]
-        private void load(UserInputManager input)
+        protected override void OnSizingChanged()
         {
-            inputManager = input;
+            base.OnSizingChanged();
+
+            if (content != null)
+            {
+                // reset to none to prevent exceptions
+                content.RelativeSizeAxes = Axes.None;
+                content.AutoSizeAxes = Axes.None;
+
+                // in addition to using this.RelativeSizeAxes, sets RelativeSizeAxes on every axis that is neither relative size nor auto size
+                content.RelativeSizeAxes = Axes.Both & ~AutoSizeAxes;
+                content.AutoSizeAxes = AutoSizeAxes;
+            }
         }
 
         protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
@@ -53,7 +66,7 @@ namespace osu.Framework.Graphics.Cursor
             switch (args.Button)
             {
                 case MouseButton.Right:
-                    menuTarget = inputManager.HoveredDrawables.OfType<IHasContextMenu>().FirstOrDefault();
+                    menuTarget = FindTarget();
 
                     if (menuTarget == null)
                     {
@@ -64,7 +77,7 @@ namespace osu.Framework.Graphics.Cursor
 
                     menu.Items = menuTarget.ContextMenuItems;
 
-                    menu.Position = ToLocalSpace(cursorContainer?.ActiveCursor.ScreenSpaceDrawQuad.TopLeft ?? inputManager.CurrentState.Mouse.Position);
+                    menu.Position = state.Mouse.Position;
                     relativeCursorPosition = ToSpaceOfOtherDrawable(menu.Position, menuTarget);
                     menu.Open();
                     return true;

--- a/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
+++ b/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Cursor
     public class ContextMenuContainer : CursorEffectContainer<ContextMenuContainer, IHasContextMenu>
     {
         private readonly ContextMenu<ContextMenuItem> menu;
-        
+
         private IHasContextMenu menuTarget;
         private Vector2 relativeCursorPosition;
 

--- a/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
+++ b/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
@@ -3,11 +3,9 @@
 
 using OpenTK;
 using OpenTK.Input;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
-using System.Linq;
 
 namespace osu.Framework.Graphics.Cursor
 {
@@ -34,8 +32,6 @@ namespace osu.Framework.Graphics.Cursor
         /// <summary>
         /// Creates a new <see cref="ContextMenuContainer"/>.
         /// </summary>
-        /// <param name="cursorContainer">The <see cref="CursorContainer"/> of which the <see cref="CursorContainer.ActiveCursor"/>
-        /// shall be used for positioning. The current mouse position is used if null is provided.</param>
         public ContextMenuContainer()
         {
             AddInternal(content = new Container

--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -39,8 +39,8 @@ namespace osu.Framework.Graphics.Cursor
 
             childDrawables.Add(this);
 
-            // keep track of all hovered drawables below this and nested tooltip containers
-            // so we can decide which are valid candidates for displaying a tooltip and so
+            // keep track of all hovered drawables below this and nested effect containers
+            // so we can decide which ones are valid candidates for receiving our effect and so
             // we know when we can abort our search.
             foreach (var candidate in targetCandidates)
             {
@@ -70,21 +70,21 @@ namespace osu.Framework.Graphics.Cursor
                 // and need to be added.
                 childDrawables.UnionWith(newChildDrawables);
 
-                // Keep track of child drawables whose tooltips are managed by a nested tooltip container.
-                // Note, that nested tooltip containers themselves could implement TTarget and
+                // Keep track of child drawables whose effects are managed by a nested effect container.
+                // Note, that nested effect containers themselves could implement TTarget and
                 // are still our own responsibility to handle.
                 nestedTtcChildDrawables.UnionWith(
                     ((IEnumerable<IDrawable>)newChildDrawables).Reverse()
                     .SkipWhile(d => d.Parent == this || !(d.Parent is TSelf) && !nestedTtcChildDrawables.Contains(d.Parent)));
 
-                // Ignore drawables whose tooltips are managed by a nested tooltip container.
+                // Ignore drawables whose effects are managed by a nested effect container.
                 if (nestedTtcChildDrawables.Contains(candidate))
                     continue;
 
-                TTarget tooltipTarget = candidate as TTarget;
-                if (tooltipTarget != null && tooltipTarget.Hovering)
+                TTarget target = candidate as TTarget;
+                if (target != null && target.Hovering)
                     // We found a valid candidate; keep track of it
-                    targetChildren.Add(tooltipTarget);
+                    targetChildren.Add(target);
             }
         }
 
@@ -92,7 +92,7 @@ namespace osu.Framework.Graphics.Cursor
         {
             findTargetChildren();
 
-            // If we found any children with valid tooltips, pick the _last_ one as it
+            // If we found any valid effect targets, pick the _last_ one as it
             // represents the front-most drawn one.
             TTarget result = targetChildren.LastOrDefault();
 

--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace osu.Framework.Graphics.Cursor
+{
+    public abstract class CursorEffectContainer<TSelf, TTarget> : Container
+        where TSelf : CursorEffectContainer<TSelf, TTarget>
+        where TTarget : class, IDrawable
+    {
+        private UserInputManager inputManager;
+
+        [BackgroundDependencyLoader]
+        private void load(UserInputManager input)
+        {
+            inputManager = input;
+        }
+
+        private readonly HashSet<IDrawable> childDrawables = new HashSet<IDrawable>();
+        private readonly HashSet<IDrawable> nestedTtcChildDrawables = new HashSet<IDrawable>();
+        private readonly List<IDrawable> newChildDrawables = new List<IDrawable>();
+        private readonly List<TTarget> targetChildren = new List<TTarget>();
+
+        private void findTargetChildren()
+        {
+            Debug.Assert(childDrawables.Count == 0, $"{nameof(childDrawables)} should be empty but has {childDrawables.Count} elements.");
+            Debug.Assert(nestedTtcChildDrawables.Count == 0, $"{nameof(nestedTtcChildDrawables)} should be empty but has {nestedTtcChildDrawables.Count} elements.");
+            Debug.Assert(newChildDrawables.Count == 0, $"{nameof(newChildDrawables)} should be empty but has {newChildDrawables.Count} elements.");
+            Debug.Assert(targetChildren.Count == 0, $"{nameof(targetChildren)} should be empty but has {targetChildren.Count} elements.");
+
+            // Skip all drawables in the hierarchy prior to (and including) ourself.
+            var targetCandidates = inputManager.MouseInputQueue.Reverse().SkipWhile(d => d != this).Skip(1);
+
+            childDrawables.Add(this);
+
+            // keep track of all hovered drawables below this and nested tooltip containers
+            // so we can decide which are valid candidates for displaying a tooltip and so
+            // we know when we can abort our search.
+            foreach (var candidate in targetCandidates)
+            {
+                // Children of drawables we are responsible for transitively also fall into our subtree,
+                // and therefore we need to handle them. If they are not children of any drawables we handle,
+                // it means that we iterated beyond our subtree and may terminate.
+                IDrawable parent = candidate.Parent;
+
+                // We keep track of all drawables we found while traversing the parent chain upwards.
+                newChildDrawables.Clear();
+                newChildDrawables.Add(candidate);
+                // When we encounter a drawable we already encountered before, then there is no need
+                // to keep going upward, since we already recorded it previously. At that point we know
+                // the drawables we found are in fact children of ours.
+                while (!childDrawables.Contains(parent))
+                {
+                    // If we reach to the root node (i.e. parent == null), then we found a drawable
+                    // which is no longer a child of ours and we may terminate.
+                    if (parent == null)
+                        return;
+
+                    newChildDrawables.Add(parent);
+                    parent = parent.Parent;
+                }
+
+                // Assuming we did _not_ end up terminating, then all found drawables are children of ours
+                // and need to be added.
+                childDrawables.UnionWith(newChildDrawables);
+
+                // Keep track of child drawables whose tooltips are managed by a nested tooltip container.
+                // Note, that nested tooltip containers themselves could implement TTarget and
+                // are still our own responsibility to handle.
+                nestedTtcChildDrawables.UnionWith(
+                    ((IEnumerable<IDrawable>)newChildDrawables).Reverse()
+                    .SkipWhile(d => d.Parent == this || !(d.Parent is TSelf) && !nestedTtcChildDrawables.Contains(d.Parent)));
+
+                // Ignore drawables whose tooltips are managed by a nested tooltip container.
+                if (nestedTtcChildDrawables.Contains(candidate))
+                    continue;
+
+                TTarget tooltipTarget = candidate as TTarget;
+                if (tooltipTarget != null && tooltipTarget.Hovering)
+                    // We found a valid candidate; keep track of it
+                    targetChildren.Add(tooltipTarget);
+            }
+        }
+
+        protected TTarget FindTarget()
+        {
+            findTargetChildren();
+
+            // If we found any children with valid tooltips, pick the _last_ one as it
+            // represents the front-most drawn one.
+            TTarget result = targetChildren.LastOrDefault();
+
+            // Clean up
+            childDrawables.Clear();
+            nestedTtcChildDrawables.Clear();
+            newChildDrawables.Clear();
+            targetChildren.Clear();
+
+            return result;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -68,7 +68,7 @@ namespace osu.Framework.Graphics.Cursor
                 content.AutoSizeAxes = Axes.None;
 
                 // in addition to using this.RelativeSizeAxes, sets RelativeSizeAxes on every axis that is neither relative size nor auto size
-                content.RelativeSizeAxes = RelativeSizeAxes | (Axes.Both & ~(RelativeSizeAxes | AutoSizeAxes));
+                content.RelativeSizeAxes = Axes.Both & ~AutoSizeAxes;
                 content.AutoSizeAxes = AutoSizeAxes;
             }
         }

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -157,8 +157,8 @@ namespace osu.Framework.Graphics.Cursor
             currentlyDisplayed = null;
         }
 
-        private readonly HashSet<Drawable> pathDrawables = new HashSet<Drawable>();
-        private readonly HashSet<Drawable> nestedPathDrawables = new HashSet<Drawable>();
+        private readonly HashSet<IDrawable> pathDrawables = new HashSet<IDrawable>();
+        private readonly HashSet<IDrawable> nestedPathDrawables = new HashSet<IDrawable>();
         private void updateTooltipVisibility(InputState state)
         {
             // Nothing to do if we're still hovering a tooltipped drawable
@@ -186,7 +186,7 @@ namespace osu.Framework.Graphics.Cursor
                 IHasTooltip tooltipTarget = null;
                 foreach (var candidate in targetCandidates)
                 {
-                    if (!pathDrawables.Contains((Drawable)candidate.Parent))
+                    if (!pathDrawables.Contains(candidate.Parent))
                         break;
 
                     pathDrawables.Add(candidate);

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -213,7 +213,7 @@ namespace osu.Framework.Graphics.Cursor
                     continue;
 
                 IHasTooltip tooltipTarget = candidate as IHasTooltip;
-                if (tooltipTarget != null)
+                if (tooltipTarget != null && tooltipTarget.Hovering)
                     // We found a valid candidate; keep track of it
                     tooltippedChildren.Add(tooltipTarget);
             }

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -163,7 +163,7 @@ namespace osu.Framework.Graphics.Cursor
         private void findTooltippedChildren()
         {
             // Skip all drawables in the hierarchy prior to (and including) ourself.
-            var targetCandidates = inputManager.HoveredDrawables.Reverse().SkipWhile(d => d != this).Skip(1);
+            var targetCandidates = inputManager.MouseInputQueue.Reverse().SkipWhile(d => d != this).Skip(1);
 
             // keep track of all hovered drawables below this and nested tooltip containers
             // so we can decide which are valid candidates for displaying a tooltip and so

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -160,6 +160,66 @@ namespace osu.Framework.Graphics.Cursor
         private readonly HashSet<IDrawable> childDrawables = new HashSet<IDrawable>();
         private readonly HashSet<IDrawable> nestedTtcChildDrawables = new HashSet<IDrawable>();
         private readonly List<IDrawable> newChildDrawables = new List<IDrawable>();
+        private readonly List<IHasTooltip> tooltippedChildren = new List<IHasTooltip>();
+
+        private void findTooltippedChildren()
+        {
+            // Skip all drawables in the hierarchy prior to (and including) ourself.
+            var targetCandidates = inputManager.HoveredDrawables.Reverse().SkipWhile(d => d != this).Skip(1);
+
+            // keep track of all hovered drawables below this and nested tooltip containers
+            // so we can decide which are valid candidates for displaying a tooltip and so
+            // we know when we can abort our search.
+            childDrawables.Clear();
+            childDrawables.Add(this);
+            nestedTtcChildDrawables.Clear();
+            tooltippedChildren.Clear();
+
+            foreach (var candidate in targetCandidates)
+            {
+                // Children of drawables we are responsible for transitively also fall into our subtree,
+                // and therefore we need to handle them. If they are not children of any drawables we handle,
+                // it means that we iterated beyond our subtree and may terminate.
+                IDrawable parent = candidate.Parent;
+
+                // We keep track of all drawables we found while traversing the parent chain upwards.
+                newChildDrawables.Clear();
+                newChildDrawables.Add(candidate);
+                // When we encounter a drawable we already encountered before, then there is no need
+                // to keep going upward, since we already recorded it previously. At that point we know
+                // the drawables we found are in fact children of ours.
+                while (!childDrawables.Contains(parent))
+                {
+                    // If we reach to the root node (i.e. parent == null), then we found a drawable
+                    // which is no longer a child of ours and we may terminate.
+                    if (parent == null)
+                        return;
+
+                    newChildDrawables.Add(parent);
+                    parent = parent.Parent;
+                }
+
+                // Assuming we did _not_ end up terminating, then all found drawables are children of ours
+                // and need to be added.
+                childDrawables.UnionWith(newChildDrawables);
+
+                // Keep track of child drawables whose tooltips are managed by a nested tooltip container.
+                // Note, that nested tooltip containers themselves could implement IHasTooltip and
+                // are still our own responsibility to handle.
+                nestedTtcChildDrawables.UnionWith(
+                    ((IEnumerable<IDrawable>)newChildDrawables).Reverse()
+                    .SkipWhile(d => d.Parent == this || !(d.Parent is TooltipContainer) && !nestedTtcChildDrawables.Contains(d.Parent)));
+
+                // Ignore drawables whose tooltips are managed by a nested tooltip container.
+                if (nestedTtcChildDrawables.Contains(candidate))
+                    continue;
+
+                IHasTooltip tooltipTarget = candidate as IHasTooltip;
+                if (tooltipTarget != null)
+                    // We found a valid candidate; keep track of it
+                    tooltippedChildren.Add(tooltipTarget);
+            }
+        }
 
         private void updateTooltipVisibility(InputState state)
         {
@@ -174,63 +234,14 @@ namespace osu.Framework.Graphics.Cursor
             findTooltipTask?.Cancel();
             findTooltipTask = Scheduler.AddDelayed(delegate
             {
-                // Skip all drawables in the hierarchy prior to (and including) ourself.
-                var targetCandidates = inputManager.HoveredDrawables.Reverse().SkipWhile(d => d != this).Skip(1);
+                findTooltippedChildren();
 
-                // keep track of all hovered drawables below this and nested tooltip containers
-                // so we can decide which are valid candidates for displaying a tooltip and so
-                // we know when we can abort our search.
-                childDrawables.Clear();
-                childDrawables.Add(this);
-                nestedTtcChildDrawables.Clear();
-
-                foreach (var candidate in targetCandidates)
+                // If we found any children with valid tooltips, pick the _last_ one as it
+                // represents the front-most drawn one.
+                if (tooltippedChildren.Count > 0)
                 {
-                    // Children of drawables we are responsible for transitively also fall into our subtree,
-                    // and therefore we need to handle them. If they are not children of any drawables we handle,
-                    // it means that we iterated beyond our subtree and may terminate.
-                    IDrawable parent = candidate.Parent;
-
-                    // We keep track of all drawables we found while traversing the parent chain upwards.
-                    newChildDrawables.Clear();
-                    newChildDrawables.Add(candidate);
-                    // When we encounter a drawable we already encountered before, then there is no need
-                    // to keep going upward, since we already recorded it previously. At that point we know
-                    // the drawables we found are in fact children of ours.
-                    while (!childDrawables.Contains(parent))
-                    {
-                        // If we reach to the root node (i.e. parent == null), then we found a drawable
-                        // which is no longer a child of ours and we may terminate.
-                        if (parent == null)
-                            return;
-
-                        newChildDrawables.Add(parent);
-                        parent = parent.Parent;
-                    }
-
-                    // Assuming we did _not_ end up terminating, then all found drawables are children of ours
-                    // and need to be added.
-                    childDrawables.UnionWith(newChildDrawables);
-
-                    // Keep track of child drawables whose tooltips are managed by a nested tooltip container.
-                    // Note, that nested tooltip containers themselves could implement IHasTooltip and
-                    // are still our own responsibility to handle.
-                    nestedTtcChildDrawables.UnionWith(
-                        ((IEnumerable<IDrawable>)newChildDrawables).Reverse()
-                        .SkipWhile(d => d.Parent == this || !(d.Parent is TooltipContainer) && !nestedTtcChildDrawables.Contains(d.Parent)));
-
-                    // Ignore drawables whose tooltips are managed by a nested tooltip container.
-                    if (nestedTtcChildDrawables.Contains(candidate))
-                        continue;
-
-                    IHasTooltip tooltipTarget = candidate as IHasTooltip;
-                    if (tooltipTarget != null)
-                    {
-                        // We found a valid tooltip target
-                        currentlyDisplayed = tooltipTarget;
-                        tooltip.Show();
-                        return;
-                    }
+                    currentlyDisplayed = tooltippedChildren.Last();
+                    tooltip.Show();
                 }
 
             }, (1 - tooltip.Alpha) * AppearDelay);

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -191,10 +191,9 @@ namespace osu.Framework.Graphics.Cursor
 
                     pathDrawables.Add(candidate);
 
-                    var nestedTtc = candidate as TooltipContainer;
-                    if (nestedTtc != null || nestedPathDrawables.Contains((Drawable)candidate.Parent))
+                    if (candidate.Parent is TooltipContainer || nestedPathDrawables.Contains(candidate.Parent))
                     {
-                        nestedPathDrawables.Add(nestedTtc ?? candidate);
+                        nestedPathDrawables.Add(candidate);
                         continue;
                     }
 

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -11,8 +11,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Threading;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Framework.Graphics.Cursor
 {

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -35,6 +35,9 @@ namespace osu.Framework.Graphics.Cursor
         /// </summary>
         protected virtual Tooltip CreateTooltip() => new Tooltip();
 
+        private Container content;
+        protected override Container<Drawable> Content => content;
+
         /// <summary>
         /// Creates a tooltip container where the tooltip is positioned at the bottom-right of
         /// the <see cref="CursorContainer.ActiveCursor"/> of the given <see cref="CursorContainer"/>.
@@ -46,7 +49,22 @@ namespace osu.Framework.Graphics.Cursor
             this.cursorContainer = cursorContainer;
             AlwaysPresent = true;
             RelativeSizeAxes = Axes.Both;
-            Add(tooltip = CreateTooltip());
+            AddInternal(content = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+            });
+            AddInternal(tooltip = CreateTooltip());
+        }
+
+        protected override void OnSizingChanged()
+        {
+            base.OnSizingChanged();
+
+            if (content != null)
+            {
+                content.RelativeSizeAxes = RelativeSizeAxes;
+                content.AutoSizeAxes = AutoSizeAxes;
+            }
         }
 
         [BackgroundDependencyLoader]
@@ -146,7 +164,7 @@ namespace osu.Framework.Graphics.Cursor
             findTooltipTask?.Cancel();
             findTooltipTask = Scheduler.AddDelayed(delegate
             {
-                var tooltipTarget = inputManager.HoveredDrawables
+                var tooltipTarget = inputManager.HoveredDrawables.Reverse()
                     // Skip hovered drawables above this tooltip container
                     .SkipWhile(d => d != this)
                     .Skip(1)

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -16,7 +16,7 @@ using System.Linq;
 
 namespace osu.Framework.Graphics.Cursor
 {
-    public class TooltipContainer : Container
+    public class TooltipContainer : CursorEffectContainer<TooltipContainer, IHasTooltip>
     {
         private readonly CursorContainer cursorContainer;
         private readonly Tooltip tooltip;
@@ -155,70 +155,6 @@ namespace osu.Framework.Graphics.Cursor
             currentlyDisplayed = null;
         }
 
-        private readonly HashSet<IDrawable> childDrawables = new HashSet<IDrawable>();
-        private readonly HashSet<IDrawable> nestedTtcChildDrawables = new HashSet<IDrawable>();
-        private readonly List<IDrawable> newChildDrawables = new List<IDrawable>();
-        private readonly List<IHasTooltip> tooltippedChildren = new List<IHasTooltip>();
-
-        private void findTooltippedChildren()
-        {
-            // Skip all drawables in the hierarchy prior to (and including) ourself.
-            var targetCandidates = inputManager.MouseInputQueue.Reverse().SkipWhile(d => d != this).Skip(1);
-
-            // keep track of all hovered drawables below this and nested tooltip containers
-            // so we can decide which are valid candidates for displaying a tooltip and so
-            // we know when we can abort our search.
-            childDrawables.Clear();
-            childDrawables.Add(this);
-            nestedTtcChildDrawables.Clear();
-            tooltippedChildren.Clear();
-
-            foreach (var candidate in targetCandidates)
-            {
-                // Children of drawables we are responsible for transitively also fall into our subtree,
-                // and therefore we need to handle them. If they are not children of any drawables we handle,
-                // it means that we iterated beyond our subtree and may terminate.
-                IDrawable parent = candidate.Parent;
-
-                // We keep track of all drawables we found while traversing the parent chain upwards.
-                newChildDrawables.Clear();
-                newChildDrawables.Add(candidate);
-                // When we encounter a drawable we already encountered before, then there is no need
-                // to keep going upward, since we already recorded it previously. At that point we know
-                // the drawables we found are in fact children of ours.
-                while (!childDrawables.Contains(parent))
-                {
-                    // If we reach to the root node (i.e. parent == null), then we found a drawable
-                    // which is no longer a child of ours and we may terminate.
-                    if (parent == null)
-                        return;
-
-                    newChildDrawables.Add(parent);
-                    parent = parent.Parent;
-                }
-
-                // Assuming we did _not_ end up terminating, then all found drawables are children of ours
-                // and need to be added.
-                childDrawables.UnionWith(newChildDrawables);
-
-                // Keep track of child drawables whose tooltips are managed by a nested tooltip container.
-                // Note, that nested tooltip containers themselves could implement IHasTooltip and
-                // are still our own responsibility to handle.
-                nestedTtcChildDrawables.UnionWith(
-                    ((IEnumerable<IDrawable>)newChildDrawables).Reverse()
-                    .SkipWhile(d => d.Parent == this || !(d.Parent is TooltipContainer) && !nestedTtcChildDrawables.Contains(d.Parent)));
-
-                // Ignore drawables whose tooltips are managed by a nested tooltip container.
-                if (nestedTtcChildDrawables.Contains(candidate))
-                    continue;
-
-                IHasTooltip tooltipTarget = candidate as IHasTooltip;
-                if (tooltipTarget != null && tooltipTarget.Hovering)
-                    // We found a valid candidate; keep track of it
-                    tooltippedChildren.Add(tooltipTarget);
-            }
-        }
-
         private void updateTooltipVisibility(InputState state)
         {
             // Nothing to do if we're still hovering a tooltipped drawable
@@ -232,13 +168,10 @@ namespace osu.Framework.Graphics.Cursor
             findTooltipTask?.Cancel();
             findTooltipTask = Scheduler.AddDelayed(delegate
             {
-                findTooltippedChildren();
-
-                // If we found any children with valid tooltips, pick the _last_ one as it
-                // represents the front-most drawn one.
-                if (tooltippedChildren.Count > 0)
+                IHasTooltip target = FindTarget();
+                if (target != null)
                 {
-                    currentlyDisplayed = tooltippedChildren.Last();
+                    currentlyDisplayed = target;
                     tooltip.Show();
                 }
 

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -48,8 +48,6 @@ namespace osu.Framework.Graphics.Cursor
         public TooltipContainer(CursorContainer cursorContainer = null)
         {
             this.cursorContainer = cursorContainer;
-            AlwaysPresent = true;
-            RelativeSizeAxes = Axes.Both;
             AddInternal(content = new Container
             {
                 RelativeSizeAxes = Axes.Both,

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -183,7 +183,7 @@ namespace osu.Framework.Graphics.Cursor
                 pathDrawables.Clear();
                 pathDrawables.Add(this);
                 nestedPathDrawables.Clear();
-                IHasTooltip tooltipTarget = null;
+
                 foreach (var candidate in targetCandidates)
                 {
                     if (!pathDrawables.Contains(candidate.Parent))
@@ -197,15 +197,14 @@ namespace osu.Framework.Graphics.Cursor
                         continue;
                     }
 
-                    tooltipTarget = candidate as IHasTooltip;
+                    IHasTooltip tooltipTarget = candidate as IHasTooltip;
                     if (tooltipTarget != null)
-                        break;
+                    {
+                        currentlyDisplayed = tooltipTarget;
+                        tooltip.Show();
+                        return;
+                    }
                 }
-
-                if (tooltipTarget == null) return;
-
-                currentlyDisplayed = tooltipTarget;
-                tooltip.Show();
 
             }, (1 - tooltip.Alpha) * AppearDelay);
         }

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Graphics.Cursor
         /// </summary>
         protected virtual Tooltip CreateTooltip() => new Tooltip();
 
-        private Container content;
+        private readonly Container content;
         protected override Container<Drawable> Content => content;
 
         /// <summary>
@@ -157,8 +157,8 @@ namespace osu.Framework.Graphics.Cursor
             currentlyDisplayed = null;
         }
 
-        private HashSet<Drawable> pathDrawables = new HashSet<Drawable>();
-        private HashSet<Drawable> nestedPathDrawables = new HashSet<Drawable>();
+        private readonly HashSet<Drawable> pathDrawables = new HashSet<Drawable>();
+        private readonly HashSet<Drawable> nestedPathDrawables = new HashSet<Drawable>();
         private void updateTooltipVisibility(InputState state)
         {
             // Nothing to do if we're still hovering a tooltipped drawable
@@ -189,7 +189,7 @@ namespace osu.Framework.Graphics.Cursor
                     if (!pathDrawables.Contains((Drawable)candidate.Parent))
                         break;
 
-                    pathDrawables.Add((Drawable)candidate);
+                    pathDrawables.Add(candidate);
 
                     var nestedTtc = candidate as TooltipContainer;
                     if (nestedTtc != null || nestedPathDrawables.Contains((Drawable)candidate.Parent))

--- a/osu.Framework/Graphics/Primitives/RectangleF.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleF.cs
@@ -261,14 +261,14 @@ namespace osu.Framework.Graphics.Primitives
         /// <param name="rect">The rectangle to test. </param>
         /// <filterpriority>1</filterpriority>
         public bool IntersectsWith(RectangleF rect) =>
-            rect.X < X + Width && X < rect.X + rect.Width && rect.Y < Y + Height && Y < rect.Y + rect.Height;
+            rect.X <= X + Width && X <= rect.X + rect.Width && rect.Y <= Y + Height && Y <= rect.Y + rect.Height;
 
         /// <summary>Determines if this rectangle intersects with rect.</summary>
         /// <returns>This method returns true if there is any intersection.</returns>
         /// <param name="rect">The rectangle to test. </param>
         /// <filterpriority>1</filterpriority>
         public bool IntersectsWith(RectangleI rect) =>
-            rect.X < X + Width && X < rect.X + rect.Width && rect.Y < Y + Height && Y < rect.Y + rect.Height;
+            rect.X <= X + Width && X <= rect.X + rect.Width && rect.Y <= Y + Height && Y <= rect.Y + rect.Height;
 
         /// <summary>Creates the smallest possible third rectangle that can contain both of two rectangles that form a union.</summary>
         /// <returns>A third <see cref="T:System.Drawing.RectangleF"></see> structure that contains both of the two rectangles that form the union.</returns>

--- a/osu.Framework/Graphics/Primitives/RectangleI.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleI.cs
@@ -231,7 +231,7 @@ namespace osu.Framework.Graphics.Primitives
         /// <param name="rect">The rectangle to test. </param>
         /// <filterpriority>1</filterpriority>
         public bool IntersectsWith(RectangleI rect) =>
-            rect.X < X + Width && X < rect.X + rect.Width && rect.Y < Y + Height && Y < rect.Y + rect.Height;
+            rect.X <= X + Width && X <= rect.X + rect.Width && rect.Y <= Y + Height && Y <= rect.Y + rect.Height;
 
         /// <summary>Creates the smallest possible third rectangle that can contain both of two rectangles that form a union.</summary>
         /// <returns>A third <see cref="T:System.Drawing.RectangleI"></see> structure that contains both of the two rectangles that form the union.</returns>

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -105,6 +105,14 @@ namespace osu.Framework.Input
         /// </summary>
         public IReadOnlyList<Drawable> HoveredDrawables => hoveredDrawables;
 
+        /// <summary>
+        /// Contains all <see cref="Drawable"/>s in top-down order which are considered
+        /// for mouse input. This list is the same as <see cref="HoveredDrawables"/>, only
+        /// that the return value of <see cref="Drawable.OnHover(InputState)"/> is not taken
+        /// into account.
+        /// </summary>
+        public IReadOnlyList<Drawable> MouseInputQueue => mouseInputQueue;
+
         protected InputManager()
         {
             RelativeSizeAxes = Axes.Both;

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -118,6 +118,7 @@
     <Compile Include="Graphics\Animations\TextureAnimation.cs" />
     <Compile Include="Graphics\Containers\AsyncLoadWrapper.cs" />
     <Compile Include="Graphics\Containers\DelayedLoadWrapper.cs" />
+    <Compile Include="Graphics\Cursor\CursorEffectContainer.cs" />
     <Compile Include="Graphics\Primitives\RectangleI.cs" />
     <Compile Include="Graphics\Primitives\Vector2I.cs" />
     <Compile Include="Graphics\Shapes\Circle.cs" />


### PR DESCRIPTION
This changes the TooltipContainer API to be more reasonable:
Instead of adding the ability for its siblings and parents to have tooltips, the TooltipContainer now enables tooltips for all its children.