### PR TITLE
Add ability to use custom tooltips per drawable

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseTooltip.cs
@@ -47,57 +47,84 @@ namespace osu.Framework.VisualTests.Tests
             testContainer.Add(ttc = new TooltipContainer(cursor)
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = new FillFlowContainer
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(0, 10),
-                    Children = new Drawable[]
+                    new Container
                     {
-                        new TooltipSpriteText("this text has a tooltip!"),
-                        new TooltipSpriteText("this one too!"),
-                        new TooltipTextbox
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        AutoSizeAxes = Axes.Both,
+                        Children = new[]
                         {
-                            Text = "with real time updates!",
-                            Size = new Vector2(400, 30),
-                        },
-                        new TooltipContainer
+                            new TooltipBox
+                            {
+                                TooltipText = "Outer Tooltip",
+                                Colour = Color4.CornflowerBlue,
+                                Size = new Vector2(300, 300),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre
+                            },
+                            new TooltipBox
+                            {
+                                TooltipText = "Inner Tooltip",
+                                Size = new Vector2(150, 150),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre
+                            },
+                        }
+                    },
+                    new FillFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(0, 10),
+                        Children = new Drawable[]
                         {
-                            AutoSizeAxes = Axes.Both,
-                            Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases!"),
-                        },
-                        new TooltipTooltipContainer("This tooltip container has a tooltip itself!")
-                        {
-                            AutoSizeAxes = Axes.Both,
-                            Child = new Container
+                            new TooltipSpriteText("this text has a tooltip!"),
+                            new TooltipSpriteText("this one too!"),
+                            new TooltipTextbox
+                            {
+                                Text = "with real time updates!",
+                                Size = new Vector2(400, 30),
+                            },
+                            new TooltipContainer
                             {
                                 AutoSizeAxes = Axes.Both,
-                                Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases; parent TooltipContainer has a tooltip"),
-                            }
-                        },
-                        new Container
-                        {
-                            Child = new FillFlowContainer
+                                Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases!"),
+                            },
+                            new TooltipTooltipContainer("This tooltip container has a tooltip itself!")
                             {
-                                Direction = FillDirection.Vertical,
-                                Spacing = new Vector2(0, 8),
-                                Children = new[]
+                                AutoSizeAxes = Axes.Both,
+                                Child = new Container
                                 {
-                                    new Container
+                                    AutoSizeAxes = Axes.Both,
+                                    Child = new TooltipSpriteText("Nested tooltip; uses no cursor in all cases; parent TooltipContainer has a tooltip"),
+                                }
+                            },
+                            new Container
+                            {
+                                Child = new FillFlowContainer
+                                {
+                                    Direction = FillDirection.Vertical,
+                                    Spacing = new Vector2(0, 8),
+                                    Children = new[]
                                     {
-                                        Child = new Container
+                                        new Container
                                         {
-                                            Child = new TooltipSpriteText("Tooltip within containers with zero size; i.e. parent is never hovered."),
+                                            Child = new Container
+                                            {
+                                                Child = new TooltipSpriteText("Tooltip within containers with zero size; i.e. parent is never hovered."),
+                                            }
+                                        },
+                                        new Container
+                                        {
+                                            Child = new TooltipSpriteText("Other tooltip within containers with zero size; different nesting; overlap."),
                                         }
-                                    },
-                                    new Container
-                                    {
-                                        Child = new TooltipSpriteText("Other tooltip within containers with zero size; different nesting; overlap."),
                                     }
                                 }
                             }
-                        }
-                    },
+                        },
+                    }
                 }
             });
 

--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -82,7 +82,7 @@ namespace osu.Framework.Graphics.Cursor
                     continue;
 
                 TTarget target = candidate as TTarget;
-                if (target != null && target.Hovering)
+                if (target != null && target.IsHovered)
                     // We found a valid candidate; keep track of it
                     targetChildren.Add(target);
             }

--- a/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics.Cursor
+{
+    /// <summary>
+    /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a custom tooltip if it is the child of a <see cref="TooltipContainer"/>
+    /// </summary>
+    public interface IHasCustomTooltip : IHasTooltip
+    {
+        /// <summary>
+        /// The custom tooltip that should be displayed.
+        /// </summary>
+        /// <returns>The custom tooltip that should be displayed.</returns>
+        ITooltip GetCustomTooltip();
+    }
+}

--- a/osu.Framework/Graphics/Cursor/IHasTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasTooltip.cs
@@ -3,10 +3,14 @@
 
 namespace osu.Framework.Graphics.Cursor
 {
+    /// <summary>
+    /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a tooltip if it is the child of a <see cref="TooltipContainer"/>. The tooltip used is
+    /// dependent on the implementation of the <see cref="TooltipContainer.CreateTooltip"/> method of the <see cref="TooltipContainer"/> containing this <see cref="Drawable"/>.
+    /// </summary>
     public interface IHasTooltip : IDrawable
     {
         /// <summary>
-        /// Tooltip that shows when hovering the drawable
+        /// Tooltip that shows when hovering the drawable.
         /// </summary>
         string TooltipText { get; }
     }

--- a/osu.Framework/Graphics/Cursor/ITooltip.cs
+++ b/osu.Framework/Graphics/Cursor/ITooltip.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+
+using OpenTK;
+
+namespace osu.Framework.Graphics.Cursor
+{
+    /// <summary>
+    /// A tooltip that can be used in conjunction with a <see cref="TooltipContainer"/> and/or <see cref="IHasCustomTooltip"/> implementation.
+    /// </summary>
+    public interface ITooltip : IDrawable
+    {
+        /// <summary>
+        /// The text to display on the tooltip.
+        /// </summary>
+        string TooltipText { set; }
+
+        /// <summary>
+        /// Refreshes the tooltip, updating potential non-text elements such as textures and colours.
+        /// </summary>
+        void Refresh();
+
+        /// <summary>
+        /// Moves the tooltip to the given position. May use easing.
+        /// </summary>
+        /// <param name="pos">The position the tooltip should be moved to.</param>
+        void Move(Vector2 pos);
+    }
+}

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -142,25 +142,16 @@ namespace osu.Framework.Graphics.Cursor
             base.UpdateAfterChildren();
 
             RefreshTooltip(currentTooltip, currentlyDisplayed);
-        }
 
-        protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
-        {
-            updateTooltipVisibility(state);
-            return base.OnMouseUp(state, args);
+            if (currentlyDisplayed != null && ShallHideTooltip(currentlyDisplayed))
+                hideTooltip();
+
         }
 
         protected override bool OnMouseMove(InputState state)
         {
             updateTooltipVisibility(state);
             return base.OnMouseMove(state);
-        }
-
-        protected override void OnHoverLost(InputState state)
-        {
-            if (!state.Mouse.HasMainButtonPressed)
-                hideTooltip();
-            base.OnHoverLost(state);
         }
 
         private void hideTooltip()
@@ -175,14 +166,10 @@ namespace osu.Framework.Graphics.Cursor
         /// <param name="tooltipTarget">The target of the tooltip.</param>
         /// <param name="state">The input state.</param>
         /// <returns>True if the currently visible tooltip should be hidden, false otherwise.</returns>
-        protected virtual bool ShallHideTooltip(IHasTooltip tooltipTarget, InputState state) => !tooltipTarget.IsHovered && !tooltipTarget.IsDragged;
+        protected virtual bool ShallHideTooltip(IHasTooltip tooltipTarget) => !tooltipTarget.IsHovered && !tooltipTarget.IsDragged;
 
         private void updateTooltipVisibility(InputState state)
         {
-            // Hide if we stopped hovering and do not have any button pressed.
-            if (currentlyDisplayed != null && ShallHideTooltip(currentlyDisplayed, state))
-                hideTooltip();
-
             findTooltipTask?.Cancel();
             findTooltipTask = Scheduler.AddDelayed(delegate
             {

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -164,7 +164,6 @@ namespace osu.Framework.Graphics.Cursor
         /// Returns true if the currently visible tooltip should be hidden, false otherwise. By default, returns true if the target of the tooltip is neither hovered nor dragged.
         /// </summary>
         /// <param name="tooltipTarget">The target of the tooltip.</param>
-        /// <param name="state">The input state.</param>
         /// <returns>True if the currently visible tooltip should be hidden, false otherwise.</returns>
         protected virtual bool ShallHideTooltip(IHasTooltip tooltipTarget) => !tooltipTarget.IsHovered && !tooltipTarget.IsDragged;
 

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -150,7 +150,7 @@ namespace osu.Framework.Graphics.Cursor
 
         protected override bool OnMouseMove(InputState state)
         {
-            updateTooltipVisibility(state);
+            updateTooltipVisibility();
             return base.OnMouseMove(state);
         }
 
@@ -167,7 +167,7 @@ namespace osu.Framework.Graphics.Cursor
         /// <returns>True if the currently visible tooltip should be hidden, false otherwise.</returns>
         protected virtual bool ShallHideTooltip(IHasTooltip tooltipTarget) => !tooltipTarget.IsHovered && !tooltipTarget.IsDragged;
 
-        private void updateTooltipVisibility(InputState state)
+        private void updateTooltipVisibility()
         {
             findTooltipTask?.Cancel();
             findTooltipTask = Scheduler.AddDelayed(delegate

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1,17 +1,17 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
+using OpenTK;
+using OpenTK.Graphics;
+using OpenTK.Input;
+using osu.Framework.Allocation;
 using osu.Framework.Caching;
 using osu.Framework.DebugUtils;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Input;
@@ -19,11 +19,11 @@ using osu.Framework.Logging;
 using osu.Framework.Statistics;
 using osu.Framework.Threading;
 using osu.Framework.Timing;
-using OpenTK;
-using OpenTK.Graphics;
-using OpenTK.Input;
-using osu.Framework.Allocation;
-using osu.Framework.Graphics.Effects;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace osu.Framework.Graphics
 {
@@ -1788,7 +1788,12 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Whether this Drawable is currently hovered over.
         /// </summary>
-        public bool Hovering { get; internal set; }
+        public bool IsHovered { get; internal set; }
+
+        /// <summary>
+        /// Whether this Drawable is currently being dragged.
+        /// </summary>
+        public bool IsDragged { get; internal set; }
 
         /// <summary>
         /// Determines whether this drawable receives mouse input when the mouse is at the
@@ -1810,13 +1815,6 @@ namespace osu.Framework.Graphics
         /// Whether this Drawable can receive input, taking into account all optimizations and masking.
         /// </summary>
         public bool CanReceiveInput => HandleInput && IsPresent && !IsMaskedAway;
-
-        /// <summary>
-        /// Whether this Drawable is hovered by the given screen space mouse position,
-        /// taking into account whether this Drawable can receive input.
-        /// </summary>
-        /// <param name="screenSpaceMousePos">The mouse position to be checked.</param>
-        internal bool IsHovered(Vector2 screenSpaceMousePos) => CanReceiveInput && ReceiveMouseInputAt(screenSpaceMousePos);
 
         /// <summary>
         /// Creates a new InputState with mouse coodinates converted to the coordinate space of our parent.
@@ -1861,7 +1859,7 @@ namespace osu.Framework.Graphics
         /// <returns>Whether we have added ourself to the queue.</returns>
         internal virtual bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
         {
-            if (!IsHovered(screenSpaceMousePos))
+            if (!CanReceiveInput || !ReceiveMouseInputAt(screenSpaceMousePos))
                 return false;
 
             queue.Add(this);
@@ -1948,19 +1946,12 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Hide sprite instantly.
         /// </summary>
-        /// <returns></returns>
-        public virtual void Hide()
-        {
-            FadeOut();
-        }
+        public virtual void Hide() => FadeOut();
 
         /// <summary>
         /// Show sprite instantly.
         /// </summary>
-        public virtual void Show()
-        {
-            FadeIn();
-        }
+        public virtual void Show() => FadeIn();
 
         #region Helpers
 

--- a/osu.Framework/Graphics/IDrawable.cs
+++ b/osu.Framework/Graphics/IDrawable.cs
@@ -77,7 +77,7 @@ namespace osu.Framework.Graphics
         bool IsDragged { get; }
 
         /// <summary>
-        /// Multiplicative alpha factor applied on top of <see cref="ColourInfo"/> and its existing
+        /// Multiplicative alpha factor applied on top of <see cref="Colour.ColourInfo"/> and its existing
         /// alpha channel(s).
         /// </summary>
         float Alpha { get; }

--- a/osu.Framework/Graphics/IDrawable.cs
+++ b/osu.Framework/Graphics/IDrawable.cs
@@ -1,13 +1,20 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using OpenTK;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Lists;
 using osu.Framework.Timing;
-using OpenTK;
 
 namespace osu.Framework.Graphics
 {
+    /// <summary>
+    /// Exposes various properties that are part of the public interface of <see cref="Drawable"/>.
+    /// This interface should generally NOT be implemented by other classes than <see cref="Drawable"/>, but only used to
+    /// specify that an object is of type <see cref="Drawable"/>.
+    /// It is mostly useful in cases where you need to specify additional constraints on a <see cref="Drawable"/>, but also do not want to force inheriting from
+    /// any particular subclass of <see cref="Drawable"/>.
+    /// </summary>
     public interface IDrawable : IHasLifetime
     {
         /// <summary>
@@ -62,6 +69,27 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Whether this Drawable is currently hovered over.
         /// </summary>
-        bool Hovering { get; }
+        bool IsHovered { get; }
+
+        /// <summary>
+        /// Whether this Drawable is currently dragged.
+        /// </summary>
+        bool IsDragged { get; }
+
+        /// <summary>
+        /// Multiplicative alpha factor applied on top of <see cref="ColourInfo"/> and its existing
+        /// alpha channel(s).
+        /// </summary>
+        float Alpha { get; }
+
+        /// <summary>
+        /// Show sprite instantly.
+        /// </summary>
+        void Show();
+
+        /// <summary>
+        /// Hide sprite instantly.
+        /// </summary>
+        void Hide();
     }
 }

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -108,7 +108,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {
-            if (!Hovering)
+            if (!IsHovered)
                 return false;
 
             var step = KeyboardStep != 0 ? KeyboardStep : (Convert.ToSingle(CurrentNumber.MaxValue) - Convert.ToSingle(CurrentNumber.MinValue)) / 20;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -1,16 +1,17 @@
-// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using OpenTK;
+using OpenTK.Input;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Handlers;
-using OpenTK;
-using OpenTK.Input;
 using osu.Framework.Platform;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 
 namespace osu.Framework.Input
 {
@@ -389,7 +390,7 @@ namespace osu.Framework.Input
                 hoveredDrawables.Add(d);
 
                 // Don't need to re-hover those that are already hovered
-                if (d.Hovering)
+                if (d.IsHovered)
                 {
                     // Check if this drawable previously handled hover, and assume it would once more
                     if (d == lastHoverHandledDrawable)
@@ -401,7 +402,7 @@ namespace osu.Framework.Input
                     continue;
                 }
 
-                d.Hovering = true;
+                d.IsHovered = true;
                 if (d.TriggerOnHover(state))
                 {
                     hoverHandledDrawable = d;
@@ -412,7 +413,7 @@ namespace osu.Framework.Input
             // Unhover all previously hovered drawables which are no longer hovered.
             foreach (Drawable d in lastHoveredDrawables.Except(hoveredDrawables))
             {
-                d.Hovering = false;
+                d.IsHovered = false;
                 d.TriggerOnHoverLost(state);
             }
         }
@@ -588,7 +589,7 @@ namespace osu.Framework.Input
 
             // click pass, triggering an OnClick on all drawables up to the first which returns true.
             // an extra IsHovered check is performed because we are using an outdated queue (for valid reasons which we need to document).
-            var clickedDrawable = intersectingQueue.FirstOrDefault(t => t.IsHovered(state.Mouse.Position) && t.TriggerOnClick(state));
+            var clickedDrawable = intersectingQueue.FirstOrDefault(t => t.CanReceiveInput && t.ReceiveMouseInputAt(state.Mouse.Position) && t.TriggerOnClick(state));
 
             if (clickedDrawable != null)
             {
@@ -634,7 +635,10 @@ namespace osu.Framework.Input
 
         private bool handleMouseDragStart(InputState state)
         {
+            Trace.Assert(draggingDrawable == null, "The draggingDrawable was not set to null by handleMouseDragEnd.");
             draggingDrawable = mouseDownInputQueue?.FirstOrDefault(target => target.IsAlive && target.TriggerOnDragStart(state));
+            if (draggingDrawable != null)
+                draggingDrawable.IsDragged = true;
             return draggingDrawable != null;
         }
 
@@ -644,6 +648,7 @@ namespace osu.Framework.Input
                 return false;
 
             bool result = draggingDrawable.TriggerOnDragEnd(state);
+            draggingDrawable.IsDragged = false;
             draggingDrawable = null;
 
             return result;

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -119,6 +119,8 @@
     <Compile Include="Graphics\Containers\AsyncLoadWrapper.cs" />
     <Compile Include="Graphics\Containers\DelayedLoadWrapper.cs" />
     <Compile Include="Graphics\Cursor\CursorEffectContainer.cs" />
+    <Compile Include="Graphics\Cursor\IHasCustomTooltip.cs" />
+    <Compile Include="Graphics\Cursor\ITooltip.cs" />
     <Compile Include="Graphics\Primitives\RectangleI.cs" />
     <Compile Include="Graphics\Primitives\Vector2I.cs" />
     <Compile Include="Graphics\Shapes\Circle.cs" />


### PR DESCRIPTION
Adds an IHasCustomTooltip interface that allows Drawables to use different types of tooltips without the need to create a new TooltipContainer and nest the Drawables inside them.

The Drawable API has been changed slightly as well: Hovering has been renamed to IsHovered, and the IsHovered method has been removed and inlined. A new IsDragged property has been added to go along with IsHovered.

TooltipContainer itself now also offers two more extension points for subclasses: RefreshTooltip() and ShallHideTooltip(), where RefreshTooltip() is used to customize the update scheme of the tooltips (if live updates are undesired, for example) and ShallHideTooltip() controls when visible tooltips should be hidden.