### PR TITLE
Disallow disposal of TextureWhitePixel

### DIFF
--- a/osu.Framework/Graphics/Sprites/Sprite.cs
+++ b/osu.Framework/Graphics/Sprites/Sprite.cs
@@ -46,9 +46,10 @@ namespace osu.Framework.Graphics.Sprites
 
         protected override void Dispose(bool isDisposing)
         {
-            if (CanDisposeTexture)
+            if (CanDisposeTexture && texture != null)
             {
-                texture?.Dispose();
+                if (!(texture is TextureWhitePixel))
+                    texture.Dispose();
                 texture = null;
             }
 

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -5,7 +5,6 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
-using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Primitives;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
@@ -20,7 +19,7 @@ namespace osu.Framework.Graphics.Textures
     {
         private static TextureWhitePixel whitePixel;
 
-        public static TextureWhitePixel WhitePixel
+        public static Texture WhitePixel
         {
             get
             {
@@ -205,29 +204,5 @@ namespace osu.Framework.Graphics.Textures
         }
 
         public override string ToString() => $@"{AssetName} ({Width}, {Height})";
-    }
-
-    public class TextureWhitePixel : Texture
-    {
-        public TextureWhitePixel(TextureGL textureGl)
-            : base(textureGl)
-        {
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            if (isDisposing)
-                throw new InvalidOperationException($"May not dispose {nameof(TextureWhitePixel)} explicitly.");
-            base.Dispose(isDisposing);
-        }
-
-        protected override RectangleF TextureBounds(RectangleF? textureRect = null)
-        {
-            // We need non-zero texture bounds for EdgeSmoothness to work correctly.
-            // Let's be very conservative and use a tenth of the size of a pixel in the
-            // largest possible texture.
-            float smallestPixelTenth = 0.1f / GLWrapper.MaxTextureSize;
-            return new RectangleF(0, 0, smallestPixelTenth, smallestPixelTenth);
-        }
     }
 }

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -18,9 +18,9 @@ namespace osu.Framework.Graphics.Textures
 {
     public class Texture : IDisposable
     {
-        private static Texture whitePixel;
+        private static TextureWhitePixel whitePixel;
 
-        public static Texture WhitePixel
+        public static TextureWhitePixel WhitePixel
         {
             get
             {
@@ -76,7 +76,7 @@ namespace osu.Framework.Graphics.Textures
             GC.SuppressFinalize(this);
         }
 
-        protected void Dispose(bool isDisposing)
+        protected virtual void Dispose(bool isDisposing)
         {
             if (IsDisposed)
                 return;
@@ -212,6 +212,13 @@ namespace osu.Framework.Graphics.Textures
         public TextureWhitePixel(TextureGL textureGl)
             : base(textureGl)
         {
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+                throw new InvalidOperationException($"May not dispose {nameof(TextureWhitePixel)} explicitly.");
+            base.Dispose(isDisposing);
         }
 
         protected override RectangleF TextureBounds(RectangleF? textureRect = null)

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -103,7 +103,7 @@ namespace osu.Framework.Graphics.Textures
             }
         }
 
-        internal Texture GetWhitePixel()
+        internal TextureWhitePixel GetWhitePixel()
         {
             if (atlasTexture == null)
                 Reset();

--- a/osu.Framework/Graphics/Textures/TextureWhitePixel.cs
+++ b/osu.Framework/Graphics/Textures/TextureWhitePixel.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Textures
         {
             if (isDisposing)
                 throw new InvalidOperationException($"May not dispose {nameof(TextureWhitePixel)} explicitly.");
-            base.Dispose(isDisposing);
+            base.Dispose(false);
         }
 
         protected override RectangleF TextureBounds(RectangleF? textureRect = null)

--- a/osu.Framework/Graphics/Textures/TextureWhitePixel.cs
+++ b/osu.Framework/Graphics/Textures/TextureWhitePixel.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics.OpenGL;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Primitives;
+using System;
+
+namespace osu.Framework.Graphics.Textures
+{
+    internal class TextureWhitePixel : Texture
+    {
+        public TextureWhitePixel(TextureGL textureGl)
+            : base(textureGl)
+        {
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposing)
+                throw new InvalidOperationException($"May not dispose {nameof(TextureWhitePixel)} explicitly.");
+            base.Dispose(isDisposing);
+        }
+
+        protected override RectangleF TextureBounds(RectangleF? textureRect = null)
+        {
+            // We need non-zero texture bounds for EdgeSmoothness to work correctly.
+            // Let's be very conservative and use a tenth of the size of a pixel in the
+            // largest possible texture.
+            float smallestPixelTenth = 0.1f / GLWrapper.MaxTextureSize;
+            return new RectangleF(0, 0, smallestPixelTenth, smallestPixelTenth);
+        }
+    }
+}

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -148,6 +148,7 @@
     <Compile Include="Graphics\OpenGL\Vertices\TimedTexturedVertex2D.cs" />
     <Compile Include="Graphics\OpenGL\Vertices\UncolouredVertex2D.cs" />
     <Compile Include="Graphics\OpenGL\Vertices\Vertex2D.cs" />
+    <Compile Include="Graphics\Textures\TextureWhitePixel.cs" />
     <Compile Include="Graphics\UserInterface\BasicCheckbox.cs" />
     <Compile Include="Graphics\UserInterface\Checkbox.cs" />
     <Compile Include="Graphics\UserInterface\ContextMenu.cs" />


### PR DESCRIPTION
You really never want to manually dispose the builtin white pixel
texture as it breaks builtin features like Box and edge effects.