### PR TITLE
Remove all framework usage of RelativeMouseDrag

### DIFF
--- a/osu.Framework.Testing/TestBrowser.cs
+++ b/osu.Framework.Testing/TestBrowser.cs
@@ -66,7 +66,6 @@ namespace osu.Framework.Testing
                         {
                             RelativeSizeAxes = Axes.Both,
                             ScrollbarOverlapsContent = false,
-                            RelativeMouseDrag = true,
                             Child = leftFlowContainer = new FillFlowContainer<TestCaseButton>
                             {
                                 Padding = new MarginPadding(3),

--- a/osu.Framework.VisualTests/Tests/TestCaseScrollableFlow.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseScrollableFlow.cs
@@ -29,7 +29,6 @@ namespace osu.Framework.VisualTests.Tests
             {
                 scroll = new ScrollContainer(dir)
                 {
-                    RelativeMouseDrag = true,
                     RelativeSizeAxes = Axes.Both,
                     Children = new[]
                     {
@@ -53,14 +52,12 @@ namespace osu.Framework.VisualTests.Tests
             {
                 new ScrollContainer(Direction.Horizontal)
                 {
-                    RelativeMouseDrag = true,
                     RelativeSizeAxes = Axes.Both,
                     Padding = new MarginPadding { Left = 150 },
                     Children = new[]
                     {
                         scroll = new ScrollContainer
                         {
-                            RelativeMouseDrag = true,
                             RelativeSizeAxes = Axes.Y,
                             AutoSizeAxes = Axes.X,
                             Children = new[]

--- a/osu.Framework.VisualTests/Tests/TestCaseSpriteText.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseSpriteText.cs
@@ -20,7 +20,6 @@ namespace osu.Framework.VisualTests.Tests
             {
                 new ScrollContainer
                 {
-                    RelativeMouseDrag = true,
                     RelativeSizeAxes = Axes.Both,
                     Children = new[]
                     {

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -469,9 +469,10 @@ namespace osu.Framework.Graphics.Containers
         {
             public Action<float> Dragged;
 
-            private static readonly Color4 hover_colour = Color4.White;
-            private static readonly Color4 default_colour = Color4.Gray;
-            private static readonly Color4 highlight_colour = Color4.GreenYellow;
+            private readonly Color4 hoverColour = Color4.White;
+            private readonly Color4 defaultColour = Color4.Gray;
+            private readonly Color4 highlightColour = Color4.GreenYellow;
+
             private readonly Box box;
 
             private float dragOffset;
@@ -482,7 +483,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 scrollDim = (int)scrollDir;
                 RelativeSizeAxes = scrollDir == Direction.Horizontal ? Axes.X : Axes.Y;
-                Colour = default_colour;
+                Colour = defaultColour;
 
                 BlendingMode = BlendingMode.Additive;
 
@@ -518,13 +519,13 @@ namespace osu.Framework.Graphics.Containers
 
             protected override bool OnHover(InputState state)
             {
-                FadeColour(hover_colour, 100);
+                FadeColour(hoverColour, 100);
                 return true;
             }
 
             protected override void OnHoverLost(InputState state)
             {
-                FadeColour(default_colour, 100);
+                FadeColour(defaultColour, 100);
             }
 
             protected override bool OnDragStart(InputState state)
@@ -536,7 +537,7 @@ namespace osu.Framework.Graphics.Containers
             protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
             {
                 //note that we are changing the colour of the box here as to not interfere with the hover effect.
-                box.FadeColour(highlight_colour, 100);
+                box.FadeColour(highlightColour, 100);
 
                 dragOffset = Position[scrollDim];
                 Dragged?.Invoke(dragOffset);

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -16,8 +16,8 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Creates a scroll container.
         /// </summary>
-        /// <param name="scrollDir">The direction in which should be scrolled. Can be vertical or horizontal. Default is vertical.</param>
-        public ScrollContainer(Direction scrollDir = Direction.Vertical) : base(scrollDir)
+        /// <param name="scrollDirection">The direction in which should be scrolled. Can be vertical or horizontal. Default is vertical.</param>
+        public ScrollContainer(Direction scrollDirection = Direction.Vertical) : base(scrollDirection)
         {
         }
     }
@@ -30,12 +30,12 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public Anchor ScrollbarAnchor
         {
-            get { return scrollbar.Anchor; }
+            get { return Scrollbar.Anchor; }
 
             set
             {
-                scrollbar.Anchor = value;
-                scrollbar.Origin = value;
+                Scrollbar.Anchor = value;
+                Scrollbar.Origin = value;
                 updatePadding();
             }
         }
@@ -56,7 +56,8 @@ namespace osu.Framework.Graphics.Containers
         }
 
         private readonly Container<T> content;
-        private readonly Scrollbar scrollbar;
+
+        protected readonly ScrollbarContainer Scrollbar;
 
         private bool scrollbarOverlapsContent = true;
 
@@ -77,12 +78,12 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Size of available content (i.e. everything that can be scrolled to) in the scroll direction.
         /// </summary>
-        private float availableContent => content.DrawSize[scrollDim];
+        private float availableContent => content.DrawSize[ScrollDim];
 
         /// <summary>
         /// Size of the viewport in the scroll direction.
         /// </summary>
-        private float displayableContent => ChildSize[scrollDim];
+        private float displayableContent => ChildSize[ScrollDim];
 
         /// <summary>
         /// Controls the distance scrolled when turning the mouse wheel a single notch.
@@ -133,7 +134,14 @@ namespace osu.Framework.Graphics.Containers
         private float target;
 
         private float scrollableExtent => Math.Max(availableContent - displayableContent, 0);
-        private float clamp(float position, float extension = 0) => MathHelper.Clamp(position, -extension, scrollableExtent + extension);
+
+        /// <summary>
+        /// Clamp a value to the available scroll range.
+        /// </summary>
+        /// <param name="position">The value to clamp.</param>
+        /// <param name="extension">An extension value beyond the normal extent.</param>
+        /// <returns></returns>
+        protected float Clamp(float position, float extension = 0) => MathHelper.Clamp(position, -extension, scrollableExtent + extension);
 
         protected override Container<T> Content => content;
 
@@ -148,22 +156,29 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public Container<T> ScrollContent => content;
 
-        private bool dragging;
+        protected virtual bool IsDragging { get; set; }
 
-        private readonly Direction scrollDir;
-        private int scrollDim => (int)scrollDir;
+        /// <summary>
+        /// The direction in which scrolling is supported.
+        /// </summary>
+        protected readonly Direction ScrollDirection;
+
+        /// <summary>
+        /// The direction in which scrolling is supported, converted to an int for array index lookups.
+        /// </summary>
+        protected int ScrollDim => (int)ScrollDirection;
 
         /// <summary>
         /// Creates a scroll container.
         /// </summary>
-        /// <param name="scrollDir">The direction in which should be scrolled. Can be vertical or horizontal. Default is vertical.</param>
-        public ScrollContainer(Direction scrollDir = Direction.Vertical)
+        /// <param name="scrollDirection">The direction in which should be scrolled. Can be vertical or horizontal. Default is vertical.</param>
+        public ScrollContainer(Direction scrollDirection = Direction.Vertical)
         {
-            this.scrollDir = scrollDir;
+            ScrollDirection = scrollDirection;
 
             Masking = true;
 
-            Axes scrollAxis = scrollDir == Direction.Horizontal ? Axes.X : Axes.Y;
+            Axes scrollAxis = scrollDirection == Direction.Horizontal ? Axes.X : Axes.Y;
             AddRangeInternal(new Drawable[]
             {
                 content = new Container<T>
@@ -171,10 +186,10 @@ namespace osu.Framework.Graphics.Containers
                     RelativeSizeAxes = Axes.Both & ~scrollAxis,
                     AutoSizeAxes = scrollAxis,
                 },
-                scrollbar = new Scrollbar(scrollDir) { Dragged = onScrollbarMovement }
+                Scrollbar = new ScrollbarContainer(scrollDirection) { Dragged = onScrollbarMovement }
             });
 
-            ScrollbarAnchor = scrollDir == Direction.Vertical ? Anchor.TopRight : Anchor.BottomLeft;
+            ScrollbarAnchor = scrollDirection == Direction.Vertical ? Anchor.TopRight : Anchor.BottomLeft;
         }
 
         private float lastUpdateDisplayableContent = -1;
@@ -194,8 +209,8 @@ namespace osu.Framework.Graphics.Containers
 
         private void updateScrollbar()
         {
-            scrollbar.ResizeTo(Math.Min(1, availableContent > 0 ? displayableContent / availableContent : 0), 200, EasingTypes.OutQuint);
-            scrollbar.FadeTo(ScrollbarVisible && availableContent - 1 > displayableContent ? 1 : 0, 200);
+            Scrollbar.ResizeTo(Math.Min(1, availableContent > 0 ? displayableContent / availableContent : 0), 200, EasingTypes.OutQuint);
+            Scrollbar.FadeTo(ScrollbarVisible && availableContent - 1 > displayableContent ? 1 : 0, 200);
             updatePadding();
         }
 
@@ -205,35 +220,35 @@ namespace osu.Framework.Graphics.Containers
                 content.Padding = new MarginPadding();
             else
             {
-                if (scrollDir == Direction.Vertical)
+                if (ScrollDirection == Direction.Vertical)
                 {
                     content.Padding = ScrollbarAnchor == Anchor.TopLeft
-                        ? new MarginPadding { Left = scrollbar.Width + scrollbar.Margin.Left }
-                        : new MarginPadding { Right = scrollbar.Width + scrollbar.Margin.Right };
+                        ? new MarginPadding { Left = Scrollbar.Width + Scrollbar.Margin.Left }
+                        : new MarginPadding { Right = Scrollbar.Width + Scrollbar.Margin.Right };
                 }
                 else
                 {
                     content.Padding = ScrollbarAnchor == Anchor.TopLeft
-                        ? new MarginPadding { Top = scrollbar.Height + scrollbar.Margin.Top }
-                        : new MarginPadding { Bottom = scrollbar.Height + scrollbar.Margin.Bottom };
+                        ? new MarginPadding { Top = Scrollbar.Height + Scrollbar.Margin.Top }
+                        : new MarginPadding { Bottom = Scrollbar.Height + Scrollbar.Margin.Bottom };
                 }
             }
         }
 
         protected override bool OnDragStart(InputState state)
         {
-            if (dragging) return false;
+            if (IsDragging) return false;
 
             lastDragTime = Time.Current;
             averageDragDelta = averageDragTime = 0;
 
-            dragging = true;
+            IsDragging = true;
             return true;
         }
 
         protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
         {
-            if (dragging) return false;
+            if (IsDragging) return false;
 
             // Continue from where we currently are scrolled to.
             target = Current;
@@ -255,21 +270,21 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnDrag(InputState state)
         {
-            Trace.Assert(dragging, "We should never receive OnDrag if we are not dragging.");
+            Trace.Assert(IsDragging, "We should never receive OnDrag if we are not dragging.");
 
             double currentTime = Time.Current;
             double timeDelta = currentTime - lastDragTime;
             double decay = Math.Pow(0.95, timeDelta);
 
             averageDragTime = averageDragTime * decay + timeDelta;
-            averageDragDelta = averageDragDelta * decay - state.Mouse.Delta[scrollDim];
+            averageDragDelta = averageDragDelta * decay - state.Mouse.Delta[ScrollDim];
 
             lastDragTime = currentTime;
 
             Vector2 childDelta = ToLocalSpace(state.Mouse.NativeState.Position) - ToLocalSpace(state.Mouse.NativeState.LastPosition);
 
-            float scrollOffset = -childDelta[scrollDim];
-            float clampedScrollOffset = clamp(target + scrollOffset) - clamp(target);
+            float scrollOffset = -childDelta[ScrollDim];
+            float clampedScrollOffset = Clamp(target + scrollOffset) - Clamp(target);
 
             Trace.Assert(Precision.AlmostBigger(Math.Abs(scrollOffset), clampedScrollOffset * Math.Sign(scrollOffset)));
 
@@ -283,9 +298,9 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnDragEnd(InputState state)
         {
-            Trace.Assert(dragging, "We should never receive OnDragEnd if we are not dragging.");
+            Trace.Assert(IsDragging, "We should never receive OnDragEnd if we are not dragging.");
 
-            dragging = false;
+            IsDragging = false;
 
             if (averageDragTime <= 0.0)
                 return true;
@@ -313,7 +328,7 @@ namespace osu.Framework.Graphics.Containers
             return true;
         }
 
-        private void onScrollbarMovement(float value) => scrollTo(clamp(value / scrollbar.Size[scrollDim]), false);
+        private void onScrollbarMovement(float value) => scrollTo(Clamp(value / Scrollbar.Size[ScrollDim]), false);
 
         /// <summary>
         /// Immediately offsets the current and target scroll position.
@@ -334,7 +349,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="allowDuringDrag">Whether we should interrupt a user's active drag.</param>
         public void ScrollToEnd(bool animated = true, bool allowDuringDrag = false)
         {
-            if (!dragging || allowDuringDrag)
+            if (!IsDragging || allowDuringDrag)
                 scrollTo(scrollableExtent, animated, DistanceDecayJump);
         }
 
@@ -350,7 +365,8 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="value">The position to scroll to.</param>
         /// <param name="animated">Whether to animate the movement.</param>
-        public void ScrollTo(float value, bool animated = true) => scrollTo(value, animated, DistanceDecayJump);
+        /// <param name="distanceDecay">Controls the rate with which the target position is approached after jumping to a specific location. Default is <see cref="DistanceDecayJump"/>.</param>
+        public void ScrollTo(float value, bool animated = true, double? distanceDecay = null) => scrollTo(value, animated, distanceDecay ?? DistanceDecayJump);
 
         private void scrollTo(float value, bool animated, double distanceDecay = float.PositiveInfinity)
         {
@@ -394,7 +410,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="d">The child to get the position from.</param>
         /// <param name="offset">Positional offset in the child's space.</param>
         /// <returns>The position of the child.</returns>
-        public float GetChildPosInContent(Drawable d, Vector2 offset) => d.ToSpaceOfOtherDrawable(offset, content)[scrollDim];
+        public float GetChildPosInContent(Drawable d, Vector2 offset) => d.ToSpaceOfOtherDrawable(offset, content)[ScrollDim];
 
         /// <summary>
         /// Determines the position of a child in the content.
@@ -411,11 +427,11 @@ namespace osu.Framework.Graphics.Containers
             // then we should handle the clamping force. Note, that if the target is _within_
             // acceptable bounds, then we do not need special handling of the clamping force, as
             // we will naturally scroll back into acceptable bounds.
-            if (!dragging && Current != clamp(Current) && target != clamp(target, -0.01f))
+            if (!IsDragging && Current != Clamp(Current) && target != Clamp(target, -0.01f))
             {
                 // Firstly, we want to limit how far out the target may go to limit overly bouncy
                 // behaviour with extreme scroll velocities.
-                target = clamp(target, ClampExtension);
+                target = Clamp(target, ClampExtension);
 
                 // Secondly, we would like to quickly approach the target while we are out of bounds.
                 // This is simulating a "strong" clamping force towards the target.
@@ -423,9 +439,9 @@ namespace osu.Framework.Graphics.Containers
                     localDistanceDecay = distance_decay_clamping * 2;
 
                 // Lastly, we gradually nudge the target towards valid bounds.
-                target = (float)Interpolation.Lerp(clamp(target), target, Math.Exp(-distance_decay_clamping * Time.Elapsed));
+                target = (float)Interpolation.Lerp(Clamp(target), target, Math.Exp(-distance_decay_clamping * Time.Elapsed));
 
-                float clampedTarget = clamp(target);
+                float clampedTarget = Clamp(target);
                 if (Precision.AlmostEquals(clampedTarget, target))
                     target = clampedTarget;
             }
@@ -445,100 +461,100 @@ namespace osu.Framework.Graphics.Containers
             updateSize();
             updatePosition();
 
-            scrollbar?.MoveTo(scrollDir, Current * scrollbar.Size[scrollDim]);
-            content.MoveTo(scrollDir, -Current);
+            Scrollbar?.MoveTo(ScrollDirection, Current * Scrollbar.Size[ScrollDim]);
+            content.MoveTo(ScrollDirection, -Current);
         }
-    }
 
-    internal class Scrollbar : Container
-    {
-        public Action<float> Dragged;
-
-        private static readonly Color4 hover_colour = Color4.White;
-        private static readonly Color4 default_colour = Color4.Gray;
-        private static readonly Color4 highlight_colour = Color4.GreenYellow;
-        private readonly Box box;
-
-        private float dragOffset;
-
-        private readonly int scrollDim;
-
-        public Scrollbar(Direction scrollDir)
+        protected internal class ScrollbarContainer : Container
         {
-            scrollDim = (int)scrollDir;
-            RelativeSizeAxes = scrollDir == Direction.Horizontal ? Axes.X : Axes.Y;
-            Colour = default_colour;
+            public Action<float> Dragged;
 
-            BlendingMode = BlendingMode.Additive;
+            private static readonly Color4 hover_colour = Color4.White;
+            private static readonly Color4 default_colour = Color4.Gray;
+            private static readonly Color4 highlight_colour = Color4.GreenYellow;
+            private readonly Box box;
 
-            CornerRadius = 5;
+            private float dragOffset;
 
-            const float margin = 3;
+            private readonly int scrollDim;
 
-            Margin = new MarginPadding
+            public ScrollbarContainer(Direction scrollDir)
             {
-                Left = scrollDir == Direction.Vertical ? margin : 0,
-                Right = scrollDir == Direction.Vertical ? margin : 0,
-                Top = scrollDir == Direction.Horizontal ? margin : 0,
-                Bottom = scrollDir == Direction.Horizontal ? margin : 0,
-            };
+                scrollDim = (int)scrollDir;
+                RelativeSizeAxes = scrollDir == Direction.Horizontal ? Axes.X : Axes.Y;
+                Colour = default_colour;
 
-            Masking = true;
+                BlendingMode = BlendingMode.Additive;
 
-            Child = box = new Box { RelativeSizeAxes = Axes.Both };
+                CornerRadius = 5;
 
-            ResizeTo(1);
-        }
+                const float margin = 3;
 
-        public void ResizeTo(float val, int duration = 0, EasingTypes easing = EasingTypes.None)
-        {
-            Vector2 size = new Vector2(10)
+                Margin = new MarginPadding
+                {
+                    Left = scrollDir == Direction.Vertical ? margin : 0,
+                    Right = scrollDir == Direction.Vertical ? margin : 0,
+                    Top = scrollDir == Direction.Horizontal ? margin : 0,
+                    Bottom = scrollDir == Direction.Horizontal ? margin : 0,
+                };
+
+                Masking = true;
+
+                Child = box = new Box { RelativeSizeAxes = Axes.Both };
+
+                ResizeTo(1);
+            }
+
+            public void ResizeTo(float val, int duration = 0, EasingTypes easing = EasingTypes.None)
             {
-                [scrollDim] = val
-            };
-            ResizeTo(size, duration, easing);
-        }
+                Vector2 size = new Vector2(10)
+                {
+                    [scrollDim] = val
+                };
+                ResizeTo(size, duration, easing);
+            }
 
-        protected override bool OnClick(InputState state) => true;
+            protected override bool OnClick(InputState state) => true;
 
-        protected override bool OnHover(InputState state)
-        {
-            FadeColour(hover_colour, 100);
-            return true;
-        }
+            protected override bool OnHover(InputState state)
+            {
+                FadeColour(hover_colour, 100);
+                return true;
+            }
 
-        protected override void OnHoverLost(InputState state)
-        {
-            FadeColour(default_colour, 100);
-        }
+            protected override void OnHoverLost(InputState state)
+            {
+                FadeColour(default_colour, 100);
+            }
 
-        protected override bool OnDragStart(InputState state)
-        {
-            dragOffset = state.Mouse.Position[scrollDim] - Position[scrollDim];
-            return true;
-        }
+            protected override bool OnDragStart(InputState state)
+            {
+                dragOffset = state.Mouse.Position[scrollDim] - Position[scrollDim];
+                return true;
+            }
 
-        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
-        {
-            //note that we are changing the colour of the box here as to not interfere with the hover effect.
-            box.FadeColour(highlight_colour, 100);
+            protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
+            {
+                //note that we are changing the colour of the box here as to not interfere with the hover effect.
+                box.FadeColour(highlight_colour, 100);
 
-            dragOffset = Position[scrollDim];
-            Dragged?.Invoke(dragOffset);
-            return true;
-        }
+                dragOffset = Position[scrollDim];
+                Dragged?.Invoke(dragOffset);
+                return true;
+            }
 
-        protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
-        {
-            box.FadeColour(Color4.White, 100);
+            protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
+            {
+                box.FadeColour(Color4.White, 100);
 
-            return base.OnMouseUp(state, args);
-        }
+                return base.OnMouseUp(state, args);
+            }
 
-        protected override bool OnDrag(InputState state)
-        {
-            Dragged?.Invoke(state.Mouse.Position[scrollDim] - dragOffset);
-            return true;
+            protected override bool OnDrag(InputState state)
+            {
+                Dragged?.Invoke(state.Mouse.Position[scrollDim] - dragOffset);
+                return true;
+            }
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -117,11 +117,6 @@ namespace osu.Framework.Graphics.Containers
         public double DistanceDecayJump = 0.01;
 
         /// <summary>
-        /// Controls the rate with which the target position is approached when performing a relative drag. Default is 0.02.
-        /// </summary>
-        public double DistanceDecayRelativeDrag = 0.02;
-
-        /// <summary>
         /// Controls the rate with which the target position is approached. It is automatically set after
         /// dragging or using the mouse wheel.
         /// </summary>
@@ -317,8 +312,6 @@ namespace osu.Framework.Graphics.Containers
             offset(-MouseWheelScrollDistance * state.Mouse.WheelDelta, true, DistanceDecayWheel);
             return true;
         }
-
-        private void scrollToRelative(float value) => scrollTo(clamp((value - scrollbar.DrawSize[scrollDim] / 2) / scrollbar.Size[scrollDim]), true, DistanceDecayRelativeDrag);
 
         private void onScrollbarMovement(float value) => scrollTo(clamp(value / scrollbar.Size[scrollDim]), false);
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -156,7 +156,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public Container<T> ScrollContent => content;
 
-        protected virtual bool IsDragging { get; set; }
+        protected virtual bool IsDragging { get; private set; }
 
         /// <summary>
         /// The direction in which scrolling is supported.


### PR DESCRIPTION
Should be moved to osu! project as legacy/non-standard behaviour. See #897.