### PR TITLE
Base Scheduler on IClock instead of Stopwatch

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -312,7 +312,7 @@ namespace osu.Framework.Graphics.Containers
 
         private Scheduler schedulerAfterChildren;
 
-        protected Scheduler SchedulerAfterChildren => schedulerAfterChildren ?? (schedulerAfterChildren = new Scheduler(MainThread));
+        protected Scheduler SchedulerAfterChildren => schedulerAfterChildren ?? (schedulerAfterChildren = new Scheduler(MainThread, Clock));
 
         /// <summary>
         /// Updates the life status of <see cref="InternalChildren"/> according to their
@@ -330,7 +330,7 @@ namespace osu.Framework.Graphics.Containers
             return false;
         }
 
-        public sealed override void UpdateClock(IFrameBasedClock clock)
+        public override void UpdateClock(IFrameBasedClock clock)
         {
             if (Clock == clock)
                 return;
@@ -338,6 +338,8 @@ namespace osu.Framework.Graphics.Containers
             base.UpdateClock(clock);
             foreach (Drawable child in internalChildren)
                 child.UpdateClock(Clock);
+
+            schedulerAfterChildren?.UpdateClock(Clock);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -300,7 +300,7 @@ namespace osu.Framework.Graphics
         /// A lazily-initialized scheduler used to schedule tasks to be invoked in future <see cref="Update"/>s calls.
         /// The tasks are invoked at the beginning of the <see cref="Update"/> method before anything else.
         /// </summary>
-        protected Scheduler Scheduler => scheduler ?? (scheduler = new Scheduler(MainThread));
+        protected Scheduler Scheduler => scheduler ?? (scheduler = new Scheduler(MainThread, Clock));
 
         /// <summary>
         /// Updates this Drawable and all Drawables further down the scene graph.
@@ -1146,6 +1146,7 @@ namespace osu.Framework.Graphics
         public virtual void UpdateClock(IFrameBasedClock clock)
         {
             this.clock = customClock ?? clock;
+            scheduler?.UpdateClock(this.clock);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -18,6 +18,7 @@ using osu.Framework.Audio;
 using osu.Framework.Configuration;
 using osu.Framework.Platform;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.UserInterface
 {
@@ -132,6 +133,18 @@ namespace osu.Framework.Graphics.UserInterface
                     cursorAndLayout.Invalidate();
                 };
             }
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            textUpdateScheduler.SetCurrentThread(MainThread);
+        }
+
+        public override void UpdateClock(IFrameBasedClock clock)
+        {
+            base.UpdateClock(clock);
+            textUpdateScheduler.UpdateClock(Clock);
         }
 
         private void resetSelection()

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -84,7 +84,7 @@ namespace osu.Framework.Threading
 
             Clock = new ThrottledFrameClock();
             Monitor = new PerformanceMonitor(Clock, StatisticsCounters);
-            Scheduler = new Scheduler(null);
+            Scheduler = new Scheduler(null, Clock);
         }
 
         public void WaitUntilInitialized()

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Extensions;
+using osu.Framework.Timing;
 
 namespace osu.Framework.Threading
 {
@@ -20,7 +21,9 @@ namespace osu.Framework.Threading
         private readonly List<ScheduledDelegate> timedTasks = new List<ScheduledDelegate>();
         private readonly List<ScheduledDelegate> perUpdateTasks = new List<ScheduledDelegate>();
         private int mainThreadId;
-        private readonly Stopwatch timer = new Stopwatch();
+
+        private IClock clock;
+        private double currentTime => clock?.CurrentTime ?? 0;
 
         /// <summary>
         /// The base thread is assumed to be the the thread on which the constructor is run.
@@ -28,7 +31,7 @@ namespace osu.Framework.Threading
         public Scheduler()
         {
             SetCurrentThread();
-            timer.Start();
+            clock = new StopwatchClock(true);
         }
 
         /// <summary>
@@ -37,7 +40,32 @@ namespace osu.Framework.Threading
         public Scheduler(Thread mainThread)
         {
             SetCurrentThread(mainThread);
-            timer.Start();
+            clock = new StopwatchClock(true);
+        }
+
+        /// <summary>
+        /// The base thread is assumed to be the the thread on which the constructor is run.
+        /// </summary>
+        public Scheduler(Thread mainThread, IClock clock)
+        {
+            SetCurrentThread(mainThread);
+            this.clock = clock;
+        }
+
+        public void UpdateClock(IClock newClock)
+        {
+            if (newClock == null)
+                throw new NullReferenceException($"{nameof(newClock)} may not be null.");
+
+            if (clock == null)
+            {
+                // This is the first time we will get a valid time, so assume this is the
+                // reference point everything scheduled so far starts from.
+                foreach (var s in timedTasks)
+                    s.ExecutionTime += newClock.CurrentTime;
+            }
+
+            clock = newClock;
         }
 
         /// <summary>
@@ -53,9 +81,9 @@ namespace osu.Framework.Threading
         /// Run any pending work tasks.
         /// </summary>
         /// <returns>true if any tasks were run.</returns>
-        public int Update()
+        public virtual int Update()
         {
-            long currentTime = timer.ElapsedMilliseconds;
+            double currentTime = this.currentTime;
 
             lock (timedTasks)
             {
@@ -169,7 +197,7 @@ namespace osu.Framework.Threading
         /// <param name="repeat">Whether this task should repeat.</param>
         public ScheduledDelegate AddDelayed(Action task, double timeUntilRun, bool repeat = false)
         {
-            ScheduledDelegate del = new ScheduledDelegate(task, timer.ElapsedMilliseconds + timeUntilRun, repeat ? timeUntilRun : -1);
+            ScheduledDelegate del = new ScheduledDelegate(task, currentTime + timeUntilRun, repeat ? timeUntilRun : -1);
 
             return Add(del) ? del : null;
         }


### PR DESCRIPTION
This fixes drifting schedule times for frame-based clocks and also ensures animations which rely on Schedule work with faster and slower playback.