### PR TITLE
Allow negative margin and padding again

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -863,7 +863,6 @@ namespace osu.Framework.Graphics.Containers
                 if (padding.Equals(value)) return;
 
                 padding = value;
-                padding.ThrowIfNegative();
 
                 foreach (Drawable c in internalChildren)
                     c.Invalidate(c.InvalidationFromParentSize);

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -613,7 +613,6 @@ namespace osu.Framework.Graphics
                 if (margin.Equals(value)) return;
 
                 margin = value;
-                margin.ThrowIfNegative();
 
                 Invalidate(Invalidation.MiscGeometry);
             }

--- a/osu.Framework/Graphics/MarginPadding.cs
+++ b/osu.Framework/Graphics/MarginPadding.cs
@@ -32,12 +32,6 @@ namespace osu.Framework.Graphics
             Top = Left = Bottom = Right = allSides;
         }
 
-        public void ThrowIfNegative()
-        {
-            if (Top < 0 || Left < 0 || Bottom < 0 || Right < 0)
-                throw new InvalidOperationException($"{nameof(MarginPadding)} may not have negative values, but values are {this}.");
-        }
-
         public bool Equals(MarginPadding other)
         {
             return Top == other.Top && Left == other.Left && Bottom == other.Bottom && Right == other.Right;


### PR DESCRIPTION
I double-checked the code, and it seems like the old reasons for
forbidding negative values no longer exist. Still use with caution,
since children can easily be made to poke out of their parents,
causing potentially counterintuitive optimization patterns.