### PR TITLE
Remove Track's OnLoaded

### DIFF
--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -56,8 +56,6 @@ namespace osu.Framework.Audio.Track
 
         public virtual int? Bitrate => null;
 
-        public Action<Track> OnLoaded;
-
         /// <summary>
         /// Seek to a new position.
         /// </summary>

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -83,7 +83,6 @@ namespace osu.Framework.Audio.Track
                 bitrate = (int)Bass.ChannelGetAttribute(activeStream, ChannelAttribute.Bitrate);
 
                 isLoaded = true;
-                OnLoaded?.Invoke(this);
             });
 
             InvalidateState();


### PR DESCRIPTION
Was implemented without much consideration. Not used anywhere, so let's remove for now. "Resolves" #908.