### PR TITLE
Move LoadComponentAsync to CompositeDrawable and prevent wrong usage

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -19,6 +19,7 @@ using osu.Framework.Caching;
 using osu.Framework.MathUtils;
 using osu.Framework.Threading;
 using osu.Framework.Statistics;
+using System.Threading.Tasks;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -46,9 +47,21 @@ namespace osu.Framework.Graphics.Containers
             };
         }
 
-        [BackgroundDependencyLoader(true)]
-        private void load(ShaderManager shaders)
+        private Game game;
+
+        protected Task LoadComponentAsync<TLoadable>(TLoadable component, Action<TLoadable> onLoaded = null) where TLoadable : Drawable
         {
+            if (game == null)
+                throw new InvalidOperationException($"May not invoke {nameof(LoadComponentAsync)} prior to this {nameof(CompositeDrawable)} being loaded.");
+
+            return component.LoadAsync(game, this, onLoaded);
+        }
+
+        [BackgroundDependencyLoader(true)]
+        private void load(Game game, ShaderManager shaders)
+        {
+            this.game = game;
+
             if (shader == null)
                 shader = shaders?.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -54,7 +54,7 @@ namespace osu.Framework.Graphics.Containers
             if (game == null)
                 throw new InvalidOperationException($"May not invoke {nameof(LoadComponentAsync)} prior to this {nameof(CompositeDrawable)} being loaded.");
 
-            return component.LoadAsync(game, this, onLoaded);
+            return component.LoadAsync(game, this, () => onLoaded(component));
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -49,6 +49,14 @@ namespace osu.Framework.Graphics.Containers
 
         private Game game;
 
+        /// <summary>
+        /// Loads a future child or grand-child of this <see cref="CompositeDrawable"/> asyncronously. <see cref="Drawable.Dependencies"/>
+        /// and <see cref="Drawable.Clock"/> are inherited from this <see cref="CompositeDrawable"/>.
+        /// </summary>
+        /// <typeparam name="TLoadable">The type of the future future child or grand-child to be loaded.</typeparam>
+        /// <param name="component">The type of the future future child or grand-child to be loaded.</param>
+        /// <param name="onLoaded">Callback to be invoked on the update thread after loading is complete.</param>
+        /// <returns>The task which is used for loading and callbacks.</returns>
         protected Task LoadComponentAsync<TLoadable>(TLoadable component, Action<TLoadable> onLoaded = null) where TLoadable : Drawable
         {
             if (game == null)

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Graphics.Containers
             if (game == null)
                 throw new InvalidOperationException($"May not invoke {nameof(LoadComponentAsync)} prior to this {nameof(CompositeDrawable)} being loaded.");
 
-            return component.LoadAsync(game, this, () => onLoaded(component));
+            return component.LoadAsync(game, this, () => onLoaded?.Invoke(component));
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -4,8 +4,6 @@
 using osu.Framework.Lists;
 using System.Collections.Generic;
 using System;
-using osu.Framework.Allocation;
-using System.Threading.Tasks;
 using osu.Framework.Extensions.TypeExtensions;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Colour;
@@ -46,16 +44,6 @@ namespace osu.Framework.Graphics.Containers
             else
                 internalChildrenAsT = new LazyList<Drawable, T>(InternalChildren, c => (T)c);
         }
-
-        private Game game;
-
-        [BackgroundDependencyLoader(true)]
-        private void load(Game game)
-        {
-            this.game = game;
-        }
-
-        protected Task LoadComponentAsync<TLoadable>(TLoadable component, Action<TLoadable> onLoaded = null) where TLoadable : Drawable => component.LoadAsync(game, this, onLoaded);
 
         /// <summary>
         /// The content of this container. <see cref="Children"/> and all methods that mutate

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2249,7 +2249,7 @@ namespace osu.Framework.Graphics
         NotLoaded,
         /// <summary>
         /// Currently loading (possibly and usually on a background
-        /// thread via <see cref="Drawable.LoadAsync{T}(Game, Drawable, Action{T})"/>).
+        /// thread via <see cref="Drawable.LoadAsync(Game, Drawable, Action)"/>).
         /// </summary>
         Loading,
         /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -125,7 +125,7 @@ namespace osu.Framework.Graphics
         /// The target this Drawable may eventually be loaded into.
         /// <see cref="Clock"/> and <see cref="Dependencies"/> are inherited from the target.
         /// </param>
-        /// <param name="onLoaded">Callback to be invoked asynchronously after loading is complete.</param>
+        /// <param name="onLoaded">Callback to be invoked on the update thread after loading is complete.</param>
         /// <returns>The task which is used for loading and callbacks.</returns>
         internal Task LoadAsync(Game game, Drawable target, Action onLoaded = null)
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -127,21 +127,17 @@ namespace osu.Framework.Graphics
         /// </param>
         /// <param name="onLoaded">Callback to be invoked asynchronously after loading is complete.</param>
         /// <returns>The task which is used for loading and callbacks.</returns>
-        internal Task LoadAsync<T>(Game game, Drawable target, Action<T> onLoaded = null)
-            where T : Drawable
+        internal Task LoadAsync(Game game, Drawable target, Action onLoaded = null)
         {
             if (loadState != LoadState.NotLoaded)
                 throw new InvalidOperationException($@"{nameof(LoadAsync)} may not be called more than once on the same Drawable.");
-
-            if (!(this is T))
-                throw new InvalidOperationException($"The {nameof(T)} parameter of the {nameof(LoadAsync)} must be a subtype of {GetType().ReadableName()}.");
 
             loadState = LoadState.Loading;
 
             return loadTask = Task.Run(() => Load(target.Clock, target.Dependencies)).ContinueWith(task => game.Schedule(() =>
             {
                 task.ThrowIfFaulted();
-                onLoaded?.Invoke((T)this);
+                onLoaded?.Invoke();
                 loadTask = null;
             }));
         }


### PR DESCRIPTION
We may be able to get rid of the `game` member altogether by scheduling to the `CompositeDrawable`'s own `Scheduler`. @peppy did you ever consider this and decide against it for some reason I am missing?