### PR TITLE
Prevent dependency pollution up the scene graph

### DIFF
--- a/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
+++ b/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Allocation
+{
+    /// <summary>
+    /// Read-only interface into a dependency container capable of injective and retrieving dependencies based
+    /// on types.
+    /// </summary>
+    public interface IReadOnlyDependencyContainer
+    {
+        /// <summary>
+        /// Retrieves a cached dependency of <paramref name="type"/> if it exists and null otherwise.
+        /// </summary>
+        /// <param name="type">The dependency type to query for.</param>
+        /// <returns>The requested dependency, or null if not found.</returns>
+        object Get(Type type);
+
+        /// <summary>
+        /// Injects dependencies into the given instance.
+        /// </summary>
+        /// <typeparam name="T">The type of the instance to inject dependencies into.</typeparam>
+        /// <param name="instance">The instance to inject dependencies into.</param>
+        /// <param name="autoRegister">True if the instance should be automatically registered as injectable if it isn't already.</param>
+        /// <param name="lazy">True if the dependencies should be initialized lazily.</param>
+        void Inject<T>(T instance, bool autoRegister = true, bool lazy = false) where T : class;
+    }
+}

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -95,6 +95,11 @@ namespace osu.Framework
             host.Deactivated += () => IsActive = false;
         }
 
+        private DependencyContainer dependencies;
+
+        protected override IReadOnlyDependencyContainer CreateLocalDependencies(IReadOnlyDependencyContainer parent) =>
+            dependencies = new DependencyContainer(base.CreateLocalDependencies(parent));
+
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager config)
         {
@@ -104,7 +109,7 @@ namespace osu.Framework
 
             Textures = new TextureStore(new RawTextureLoaderStore(new NamespacedResourceStore<byte[]>(Resources, @"Textures")));
             Textures.AddStore(new RawTextureLoaderStore(new OnlineStore()));
-            Dependencies.Cache(Textures);
+            dependencies.Cache(Textures);
 
             var tracks = new ResourceStore<byte[]>(Resources);
             tracks.AddStore(new NamespacedResourceStore<byte[]>(Resources, @"Tracks"));
@@ -114,7 +119,7 @@ namespace osu.Framework
             samples.AddStore(new NamespacedResourceStore<byte[]>(Resources, @"Samples"));
             samples.AddStore(new OnlineStore());
 
-            Audio = Dependencies.Cache(new AudioManager(
+            Audio = dependencies.Cache(new AudioManager(
                 tracks,
                 samples)
             {
@@ -130,13 +135,13 @@ namespace osu.Framework
             config.BindWith(FrameworkSetting.VolumeMusic, Audio.VolumeTrack);
 
             Shaders = new ShaderManager(new NamespacedResourceStore<byte[]>(Resources, @"Shaders"));
-            Dependencies.Cache(Shaders);
+            dependencies.Cache(Shaders);
 
             Fonts = new FontStore(new GlyphStore(Resources, @"Fonts/OpenSans"))
             {
                 ScaleAdjust = 100
             };
-            Dependencies.Cache(Fonts);
+            dependencies.Cache(Fonts);
         }
 
         protected override void LoadComplete()

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -148,7 +148,7 @@ namespace osu.Framework.Graphics
         /// Create a local dependency container which will be used by ourselves and all our nested children.
         /// If not overridden, the load-time parent's dependency tree will be used.
         /// </summary>
-        /// <param name="parent">The parent <see cref="DependencyContainer"/> which should be passed through if we want fallback lookups to work.</param>
+        /// <param name="parent">The parent <see cref="IReadOnlyDependencyContainer"/> which should be passed through if we want fallback lookups to work.</param>
         /// <returns>A new dependency container to be stored for this Drawable.</returns>
         protected virtual IReadOnlyDependencyContainer CreateLocalDependencies(IReadOnlyDependencyContainer parent) => parent;
 
@@ -162,7 +162,7 @@ namespace osu.Framework.Graphics
         /// Loads this drawable, including the gathering of dependencies and initialisation of required resources.
         /// </summary>
         /// <param name="clock">The clock we should use by default.</param>
-        /// <param name="dependencies">The dependency tree we will inherit by default. May be extended via <see cref="CreateLocalDependencies(DependencyContainer)"/></param>
+        /// <param name="dependencies">The dependency tree we will inherit by default. May be extended via <see cref="CreateLocalDependencies(IReadOnlyDependencyContainer)"/></param>
         internal void Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies)
         {
             // Blocks when loading from another thread already.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -150,20 +150,20 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <param name="parent">The parent <see cref="DependencyContainer"/> which should be passed through if we want fallback lookups to work.</param>
         /// <returns>A new dependency container to be stored for this Drawable.</returns>
-        protected virtual DependencyContainer CreateLocalDependencies(DependencyContainer parent) => parent;
+        protected virtual IReadOnlyDependencyContainer CreateLocalDependencies(IReadOnlyDependencyContainer parent) => parent;
 
         /// <summary>
         /// Contains all dependencies that can be injected into this Drawable using <see cref="BackgroundDependencyLoader"/>.
         /// Add or override dependencies by calling <see cref="DependencyContainer.Cache{T}(T, bool, bool)"/>.
         /// </summary>
-        protected DependencyContainer Dependencies { get; private set; }
+        protected IReadOnlyDependencyContainer Dependencies { get; private set; }
 
         /// <summary>
         /// Loads this drawable, including the gathering of dependencies and initialisation of required resources.
         /// </summary>
         /// <param name="clock">The clock we should use by default.</param>
         /// <param name="dependencies">The dependency tree we will inherit by default. May be extended via <see cref="CreateLocalDependencies(DependencyContainer)"/></param>
-        internal void Load(IFrameBasedClock clock, DependencyContainer dependencies)
+        internal void Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies)
         {
             // Blocks when loading from another thread already.
             lock (loadLock)

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -82,6 +82,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Allocation\IReadOnlyDependencyContainer.cs" />
     <Compile Include="Audio\AudioComponent.cs" />
     <Compile Include="Audio\IBassAudio.cs" />
     <Compile Include="Audio\IHasPitchAdjust.cs" />


### PR DESCRIPTION
This PR passes down IReadOnlyDependencyContainer such that children can not cache dependencies into their parent's dependency container.