### PR TITLE
Add GlowEffect which allows making any Drawable glow

### DIFF
--- a/osu.Framework.VisualTests/Tests/TestCaseCircularProgress.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseCircularProgress.cs
@@ -155,7 +155,7 @@ namespace osu.Framework.VisualTests.Tests
                     clock.Colour = new Color4(255, 128, 128, 255);
                     break;
                 case 2:
-                    clock.ColourInfo = new ColourInfo
+                    clock.Colour = new ColourInfo
                     {
                         TopLeft = new Color4(255, 128, 128, 255),
                         TopRight = new Color4(128, 255, 128, 255),
@@ -164,7 +164,7 @@ namespace osu.Framework.VisualTests.Tests
                     };
                     break;
                 case 3:
-                    clock.ColourInfo = new ColourInfo
+                    clock.Colour = new ColourInfo
                     {
                         TopLeft = new Color4(255, 128, 128, 255),
                         TopRight = new Color4(255, 128, 128, 255),
@@ -173,7 +173,7 @@ namespace osu.Framework.VisualTests.Tests
                     };
                     break;
                 case 4:
-                    clock.ColourInfo = new ColourInfo
+                    clock.Colour = new ColourInfo
                     {
                         TopLeft = new Color4(255, 128, 128, 255),
                         TopRight = new Color4(128, 255, 128, 255),

--- a/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseColourGradient.cs
@@ -65,7 +65,7 @@ namespace osu.Framework.VisualTests.Tests
                     {
                         Text = labels[i],
                         TextSize = 20,
-                        ColourInfo = colours[0],
+                        Colour = colours[0],
                     },
                     boxes[i] = new Box
                     {
@@ -73,7 +73,7 @@ namespace osu.Framework.VisualTests.Tests
                         Anchor = Anchor.Centre,
                         Origin = Anchor.Centre,
                         Size = new Vector2(0.5f),
-                        ColourInfo = colours[i],
+                        Colour = colours[i],
                     },
                 });
             }

--- a/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
@@ -135,7 +135,7 @@ namespace osu.Framework.VisualTests.Tests
                                 TextSize = 32f,
                             }.WithEffect(new GlowEffect
                             {
-                                BlurSigma = new Vector2(5f),
+                                BlurSigma = new Vector2(3f),
                                 Strength = 3f,
                                 Colour = ColourInfo.GradientHorizontal(new Color4(1.2f, 0, 0, 1f), new Color4(0, 1f, 0, 1f)),
                                 PadExtent = true,

--- a/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
@@ -4,6 +4,7 @@
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
@@ -113,7 +114,7 @@ namespace osu.Framework.VisualTests.Tests
                             {
                                 BlurSigma = new Vector2(3f),
                                 Strength = 3f,
-                                Colour = new Color4(1f, 0f, 0f, 1f),
+                                Colour = Color4.Red,
                                 PadExtent = true,
                             })
                         }
@@ -134,9 +135,9 @@ namespace osu.Framework.VisualTests.Tests
                                 TextSize = 32f,
                             }.WithEffect(new GlowEffect
                             {
-                                BlurSigma = new Vector2(3f),
+                                BlurSigma = new Vector2(5f),
                                 Strength = 3f,
-                                Colour = new Color4(1f, 0f, 0f, 1f),
+                                Colour = ColourInfo.GradientHorizontal(new Color4(1.2f, 0, 0, 1f), new Color4(0, 1f, 0, 1f)),
                                 PadExtent = true,
                             }),
                         }

--- a/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
+++ b/osu.Framework.VisualTests/Tests/TestCaseEffects.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.VisualTests.Tests
                     {
                         Sigma = new Vector2(2f, 0f),
                         Strength = 2f,
-                        BlurRotation = 45f,
+                        Rotation = 45f,
                     }),
                     new SpriteText
                     {
@@ -109,9 +109,38 @@ namespace osu.Framework.VisualTests.Tests
                             {
                                 Text = "Outlined Text",
                                 TextSize = 32f
-                            }.WithEffect(new OutlineEffect { BlurSigma = new Vector2(3f), Strength = 3f, OutlineColour = new Color4(1f, 0f, 0f, 1f) })
+                            }.WithEffect(new OutlineEffect
+                            {
+                                BlurSigma = new Vector2(3f),
+                                Strength = 3f,
+                                Colour = new Color4(1f, 0f, 0f, 1f),
+                                PadExtent = true,
+                            })
                         }
-                    }
+                    },
+                    new Container
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                Colour = Color4.CornflowerBlue,
+                                RelativeSizeAxes = Axes.Both,
+                            },
+                            new SpriteText
+                            {
+                                Text = "Glowing Text",
+                                TextSize = 32f,
+                            }.WithEffect(new GlowEffect
+                            {
+                                BlurSigma = new Vector2(3f),
+                                Strength = 3f,
+                                Colour = new Color4(1f, 0f, 0f, 1f),
+                                PadExtent = true,
+                            }),
+                        }
+                    },
                 }
             });
         }

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -136,9 +136,7 @@ namespace osu.Framework.Graphics.Colour
             result.TopLeft.MultiplyAlpha(alpha);
 
             if (HasSingleColour)
-            {
                 result.BottomLeft = result.TopRight = result.BottomRight = result.TopLeft;
-            }
             else
             {
                 result.BottomLeft.MultiplyAlpha(alpha);

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -64,7 +64,7 @@ namespace osu.Framework.Graphics.Colour
             return result;
         }
 
-        public SRGBColour Colour
+        private SRGBColour singleColour
         {
             get
             {
@@ -93,7 +93,7 @@ namespace osu.Framework.Graphics.Colour
             }
 
             if (childColour.HasSingleColour)
-                Colour *= childColour.Colour;
+                singleColour *= childColour.singleColour;
             else
             {
                 HasSingleColour = false;
@@ -211,6 +211,9 @@ namespace osu.Framework.Graphics.Colour
         }
 
         public static implicit operator ColourInfo(SRGBColour colour) => SingleColour(colour);
+        public static implicit operator SRGBColour(ColourInfo colour) => colour.singleColour;
+
         public static implicit operator ColourInfo(Color4 colour) => (SRGBColour)colour;
+        public static implicit operator Color4(ColourInfo colour) => (SRGBColour)colour;
     }
 }

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -163,8 +163,8 @@ namespace osu.Framework.Graphics.Containers
         private EffectPlacement effectPlacement;
 
         /// <summary>
-        /// Whether the buffered effect should be drawn <see cref="EffectPlacement.Behind"/> or <see cref="EffectPlacement.InFront"/> of the original. 
-        /// <see cref="EffectPlacement.Behind"/> by default. Does not have any effect if <see cref="DrawOriginal"/> is false.
+        /// Whether the buffered effect should be drawn behind or in front of the original. 
+        /// Behind by default. Does not have any effect if <see cref="DrawOriginal"/> is false.
         /// </summary>
         public EffectPlacement EffectPlacement
         {

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -119,13 +119,13 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private SRGBColour effectColour = Color4.White;
+        private ColourInfo effectColour = Color4.White;
 
         /// <summary>
         /// The multiplicative colour of drawn buffered object after applying all effects (e.g. blur). Default is <see cref="Color4.White"/>.
         /// Does not affect the original which is drawn when <see cref="DrawOriginal"/> is true.
         /// </summary>
-        public SRGBColour EffectColour
+        public ColourInfo EffectColour
         {
             get { return effectColour; }
 

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -119,13 +119,13 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private ColourInfo effectColour = Color4.White;
+        private SRGBColour effectColour = Color4.White;
 
         /// <summary>
-        /// The colour of drawn buffered object after applying all effects (e.g. blur). Does not affect the original
-        /// which is drawn when <see cref="DrawOriginal"/> is true.
+        /// The multiplicative colour of drawn buffered object after applying all effects (e.g. blur). Default is <see cref="Color4.White"/>.
+        /// Does not affect the original which is drawn when <see cref="DrawOriginal"/> is true.
         /// </summary>
-        public ColourInfo EffectColour
+        public SRGBColour EffectColour
         {
             get { return effectColour; }
 
@@ -135,6 +135,47 @@ namespace osu.Framework.Graphics.Containers
                     return;
 
                 effectColour = value;
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+
+        private BlendingMode effectBlendingMode;
+
+        /// <summary>
+        /// The <see cref="BlendingMode"/> to use after applying all effects. Default is <see cref="BlendingMode.Inherit"/>.
+        /// <see cref="BlendingMode.Inherit"/> inherits the blending mode of the original, i.e. <see cref="Drawable.BlendingMode"/> is used.
+        /// Does not affect the original which is drawn when <see cref="DrawOriginal"/> is true.
+        /// </summary>
+        public BlendingMode EffectBlendingMode
+        {
+            get { return effectBlendingMode; }
+
+            set
+            {
+                if (effectBlendingMode.Equals(value))
+                    return;
+
+                effectBlendingMode = value;
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+
+        private EffectPlacement effectPlacement;
+
+        /// <summary>
+        /// Whether the buffered effect should be drawn <see cref="EffectPlacement.Behind"/> or <see cref="EffectPlacement.InFront"/> of the original. 
+        /// <see cref="EffectPlacement.Behind"/> by default. Does not have any effect if <see cref="DrawOriginal"/> is false.
+        /// </summary>
+        public EffectPlacement EffectPlacement
+        {
+            get { return effectPlacement; }
+
+            set
+            {
+                if (effectPlacement == value)
+                    return;
+
+                effectPlacement = value;
                 Invalidate(Invalidation.DrawNode);
             }
         }
@@ -242,7 +283,10 @@ namespace osu.Framework.Graphics.Containers
             n.DrawVersion = drawVersion;
             n.UpdateVersion = updateVersion;
             n.BackgroundColour = backgroundColour;
+
             n.EffectColour = effectColour;
+            n.EffectBlending = effectBlendingMode;
+            n.EffectPlacement = effectPlacement;
 
             n.DrawOriginal = drawOriginal;
             n.BlurSigma = blurSigma;
@@ -312,5 +356,11 @@ namespace osu.Framework.Graphics.Containers
 
         //    base.Dispose(isDisposing);
         //}
+    }
+
+    public enum EffectPlacement
+    {
+        Behind,
+        InFront,
     }
 }

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -26,6 +26,8 @@ namespace osu.Framework.Graphics.Containers
         public bool DrawOriginal;
         public Color4 BackgroundColour;
         public ColourInfo EffectColour;
+        public BlendingMode EffectBlending;
+        public EffectPlacement EffectPlacement;
 
         public Vector2 BlurSigma;
         public Vector2I BlurRadius;
@@ -199,17 +201,26 @@ namespace osu.Framework.Graphics.Containers
                 ? new RectangleF(ScreenSpaceDrawRectangle.X, ScreenSpaceDrawRectangle.Y, frameBufferSize.X, frameBufferSize.Y)
                 : ScreenSpaceDrawRectangle;
 
-            // Blit the final framebuffer to screen.
-            GLWrapper.SetBlend(DrawInfo.Blending);
-
             Shader.Bind();
+
+            if (DrawOriginal && EffectPlacement == EffectPlacement.InFront)
+            {
+                GLWrapper.SetBlend(DrawInfo.Blending);
+                drawFrameBufferToBackBuffer(FrameBuffers[originalIndex], drawRectangle, DrawInfo.Colour);
+            }
+
+            // Blit the final framebuffer to screen.
+            GLWrapper.SetBlend(EffectBlending == BlendingMode.Inherit ? DrawInfo.Blending : new BlendingInfo(EffectBlending));
 
             ColourInfo effectColour = DrawInfo.Colour;
             effectColour.ApplyChild(EffectColour);
             drawFrameBufferToBackBuffer(FrameBuffers[0], drawRectangle, effectColour);
 
-            if (DrawOriginal)
+            if (DrawOriginal && EffectPlacement == EffectPlacement.Behind)
+            {
+                GLWrapper.SetBlend(DrawInfo.Blending);
                 drawFrameBufferToBackBuffer(FrameBuffers[originalIndex], drawRectangle, DrawInfo.Colour);
+            }
 
             Shader.Unbind();
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1006,37 +1006,22 @@ namespace osu.Framework.Graphics
 
         #region Colour / Alpha / Blending
 
-        private ColourInfo colourInfo = ColourInfo.SingleColour(Color4.White);
+        private ColourInfo colour = Color4.White;
 
         /// <summary>
-        /// Colours of the individual corner vertices of this Drawable in sRGB space.
+        /// Colour of this <see cref="Drawable"/> in sRGB space. Can contain individual colours for all four
+        /// corners of this <see cref="Drawable"/>, which are then interpolated, but can also be assigned
+        /// just a single colour. Implicit casts from <see cref="SRGBColour"/> and from <see cref="Color4"/> exist.
         /// </summary>
-        public ColourInfo ColourInfo
+        public ColourInfo Colour
         {
-            get { return colourInfo; }
+            get { return colour; }
 
             set
             {
-                if (colourInfo.Equals(value)) return;
-                colourInfo = value;
+                if (colour.Equals(value)) return;
 
-                Invalidate(Invalidation.Colour);
-            }
-        }
-
-        /// <summary>
-        /// Colour of this Drawable in sRGB space. Only valid if no individual colours
-        /// have been specified for each corner vertex via <see cref="ColourInfo"/>.
-        /// </summary>
-        public SRGBColour Colour
-        {
-            get { return colourInfo.Colour; }
-
-            set
-            {
-                if (colourInfo.HasSingleColour && colourInfo.TopLeft.Equals(value)) return;
-
-                colourInfo.Colour = value;
+                colour = value;
 
                 Invalidate(Invalidation.Colour);
             }
@@ -1290,12 +1275,12 @@ namespace osu.Framework.Graphics
             di.ApplyTransform(pos, drawScale, Rotation, Shear, OriginPosition);
             di.Blending = new BlendingInfo(localBlendingMode);
 
-            ColourInfo colour = alpha != 1 ? colourInfo.MultiplyAlpha(alpha) : colourInfo;
+            ColourInfo drawInfoColour = alpha != 1 ? colour.MultiplyAlpha(alpha) : colour;
 
             // No need for a Parent null check here, because null parents always have
             // a single colour (white).
             if (di.Colour.HasSingleColour)
-                di.Colour.ApplyChild(colour);
+                di.Colour.ApplyChild(drawInfoColour);
             else
             {
                 Debug.Assert(Parent != null,
@@ -1310,7 +1295,7 @@ namespace osu.Framework.Graphics
                 interp.BottomLeft = Vector2.Divide(interp.BottomLeft, parentSize);
                 interp.BottomRight = Vector2.Divide(interp.BottomRight, parentSize);
 
-                di.Colour.ApplyChild(colour, interp);
+                di.Colour.ApplyChild(drawInfoColour, interp);
             }
 
             return di;

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -5,6 +5,7 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Effects
@@ -59,30 +60,37 @@ namespace osu.Framework.Graphics.Effects
         /// </summary>
         public bool CacheDrawnEffect;
 
-        public BufferedContainer ApplyTo(Drawable drawable) => new BufferedContainer
+        public BufferedContainer ApplyTo(Drawable drawable)
         {
-            RelativeSizeAxes = drawable.RelativeSizeAxes,
-            AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
-            Anchor = drawable.Anchor,
-            Origin = drawable.Origin,
+            Vector2 position = drawable.Position;
+            drawable.Position = Vector2.Zero;
 
-            BlurSigma = Sigma,
-            BlurRotation = Rotation,
-            EffectColour = Colour.MultiplyAlpha(Strength),
-            EffectBlendingMode = BlendingMode,
-            EffectPlacement = Placement,
-
-            DrawOriginal = DrawOriginal,
-
-            CacheDrawnFrameBuffer = CacheDrawnEffect,
-
-            Padding = !PadExtent ? new MarginPadding() : new MarginPadding
+            return new BufferedContainer
             {
-                Horizontal = Blur.KernelSize(Sigma.X),
-                Vertical = Blur.KernelSize(Sigma.Y)
-            },
+                RelativeSizeAxes = drawable.RelativeSizeAxes,
+                AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
+                Anchor = drawable.Anchor,
+                Origin = drawable.Origin,
 
-            Child = drawable
-        };
+                BlurSigma = Sigma,
+                BlurRotation = Rotation,
+                EffectColour = Colour.MultiplyAlpha(Strength),
+                EffectBlendingMode = BlendingMode,
+                EffectPlacement = Placement,
+
+                DrawOriginal = DrawOriginal,
+
+                CacheDrawnFrameBuffer = CacheDrawnEffect,
+
+                Position = position,
+                Padding = !PadExtent ? new MarginPadding() : new MarginPadding
+                {
+                    Horizontal = Blur.KernelSize(Sigma.X),
+                    Vertical = Blur.KernelSize(Sigma.Y),
+                },
+
+                Child = drawable
+            };
+        }
     }
 }

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.MathUtils;
 
@@ -15,32 +17,75 @@ namespace osu.Framework.Graphics.Effects
         /// <summary>
         /// The strength of the blur. Default is 1.
         /// </summary>
-        public float Strength { get; set; } = 1f;
+        public float Strength = 1f;
+
         /// <summary>
         /// The sigma of the blur. Default is (2, 2).
         /// </summary>
-        public Vector2 Sigma { get; set; } = new Vector2(2f, 2f);
+        public Vector2 Sigma = new Vector2(2f, 2f);
+
         /// <summary>
         /// The rotation of the blur. Default is 0.
         /// </summary>
-        public float BlurRotation { get; set; }
+        public float Rotation;
+
+        /// <summary>
+        /// The colour of the blur. Default is <see cref="Color4.White"/>.
+        /// </summary>
+        public SRGBColour Colour = Color4.White;
+
+        /// <summary>
+        /// The blending mode of the blur. Default is <see cref="BlendingMode.Inherit"/>.
+        /// </summary>
+        public BlendingMode BlendingMode;
+
+        /// <summary>
+        /// Whether to draw the blur in front or behind the original. Default is <see cref="EffectPlacement.Behind"/>.
+        /// </summary>
+        public EffectPlacement Placement;
+
+        /// <summary>
+        /// Whether to draw the original target in addition to its blurred version.
+        /// </summary>
+        public bool DrawOriginal;
+
+        /// <summary>
+        /// Whether to automatically pad by the blur extent such that no clipping occurs at the sides of the effect. Default is false.
+        /// </summary>
+        public bool PadExtent;
+
+        /// <summary>
+        /// Whether the resulting <see cref="BufferedContainer"/> should cache its drawn framebuffer.
+        /// </summary>
+        public bool CacheDrawnEffect;
 
         public BufferedContainer ApplyTo(Drawable drawable)
         {
+            SRGBColour effectColour = Colour;
+            effectColour.MultiplyAlpha(Strength);
             return new BufferedContainer
             {
                 RelativeSizeAxes = drawable.RelativeSizeAxes,
                 AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
-                BlurSigma = Sigma,
                 Anchor = drawable.Anchor,
                 Origin = drawable.Origin,
-                BlurRotation = BlurRotation,
-                Padding = new MarginPadding
+
+                BlurSigma = Sigma,
+                BlurRotation = Rotation,
+                EffectColour = effectColour,
+                EffectBlendingMode = BlendingMode,
+                EffectPlacement = Placement,
+
+                DrawOriginal = DrawOriginal,
+
+                CacheDrawnFrameBuffer = CacheDrawnEffect,
+
+                Padding = !PadExtent ? new MarginPadding() : new MarginPadding
                 {
                     Horizontal = Blur.KernelSize(Sigma.X),
                     Vertical = Blur.KernelSize(Sigma.Y)
                 },
-                Alpha = Strength,
+
                 Child = drawable
             };
         }

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -35,12 +35,12 @@ namespace osu.Framework.Graphics.Effects
         public SRGBColour Colour = Color4.White;
 
         /// <summary>
-        /// The blending mode of the blur. Default is <see cref="BlendingMode.Inherit"/>.
+        /// The blending mode of the blur. Default is inheriting from the target drawable.
         /// </summary>
         public BlendingMode BlendingMode;
 
         /// <summary>
-        /// Whether to draw the blur in front or behind the original. Default is <see cref="EffectPlacement.Behind"/>.
+        /// Whether to draw the blur in front or behind the original. Default is behind.
         /// </summary>
         public EffectPlacement Placement;
 

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -5,7 +5,6 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Primitives;
 using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Effects

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Effects
         /// <summary>
         /// The colour of the blur. Default is <see cref="Color4.White"/>.
         /// </summary>
-        public SRGBColour Colour = Color4.White;
+        public ColourInfo Colour = Color4.White;
 
         /// <summary>
         /// The blending mode of the blur. Default is inheriting from the target drawable.
@@ -59,35 +59,30 @@ namespace osu.Framework.Graphics.Effects
         /// </summary>
         public bool CacheDrawnEffect;
 
-        public BufferedContainer ApplyTo(Drawable drawable)
+        public BufferedContainer ApplyTo(Drawable drawable) => new BufferedContainer
         {
-            SRGBColour effectColour = Colour;
-            effectColour.MultiplyAlpha(Strength);
-            return new BufferedContainer
+            RelativeSizeAxes = drawable.RelativeSizeAxes,
+            AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
+            Anchor = drawable.Anchor,
+            Origin = drawable.Origin,
+
+            BlurSigma = Sigma,
+            BlurRotation = Rotation,
+            EffectColour = Colour.MultiplyAlpha(Strength),
+            EffectBlendingMode = BlendingMode,
+            EffectPlacement = Placement,
+
+            DrawOriginal = DrawOriginal,
+
+            CacheDrawnFrameBuffer = CacheDrawnEffect,
+
+            Padding = !PadExtent ? new MarginPadding() : new MarginPadding
             {
-                RelativeSizeAxes = drawable.RelativeSizeAxes,
-                AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
-                Anchor = drawable.Anchor,
-                Origin = drawable.Origin,
+                Horizontal = Blur.KernelSize(Sigma.X),
+                Vertical = Blur.KernelSize(Sigma.Y)
+            },
 
-                BlurSigma = Sigma,
-                BlurRotation = Rotation,
-                EffectColour = effectColour,
-                EffectBlendingMode = BlendingMode,
-                EffectPlacement = Placement,
-
-                DrawOriginal = DrawOriginal,
-
-                CacheDrawnFrameBuffer = CacheDrawnEffect,
-
-                Padding = !PadExtent ? new MarginPadding() : new MarginPadding
-                {
-                    Horizontal = Blur.KernelSize(Sigma.X),
-                    Vertical = Blur.KernelSize(Sigma.Y)
-                },
-
-                Child = drawable
-            };
-        }
+            Child = drawable
+        };
     }
 }

--- a/osu.Framework/Graphics/Effects/EdgeEffect.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffect.cs
@@ -13,12 +13,12 @@ namespace osu.Framework.Graphics.Effects
         /// <summary>
         /// The parameters of the edge effect.
         /// </summary>
-        public EdgeEffectParameters Parameters { get; set; }
+        public EdgeEffectParameters Parameters;
 
         /// <summary>
-        /// Determines how large a radius is masked away around the corners.
+        /// Determines how large a radius is masked away around the corners. Default is 0.
         /// </summary>
-        public float CornerRadius { get; set; }
+        public float CornerRadius;
 
         public Container ApplyTo(Drawable drawable)
         {

--- a/osu.Framework/Graphics/Effects/EdgeEffect.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffect.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using OpenTK;
 using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Graphics.Effects
@@ -22,6 +23,9 @@ namespace osu.Framework.Graphics.Effects
 
         public Container ApplyTo(Drawable drawable)
         {
+            Vector2 position = drawable.Position;
+            drawable.Position = Vector2.Zero;
+
             return new Container
             {
                 Masking = true,
@@ -31,6 +35,7 @@ namespace osu.Framework.Graphics.Effects
                 Origin = drawable.Origin,
                 RelativeSizeAxes = drawable.RelativeSizeAxes,
                 AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
+                Position = position,
                 Child = drawable
             };
         }

--- a/osu.Framework/Graphics/Effects/GlowEffect.cs
+++ b/osu.Framework/Graphics/Effects/GlowEffect.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using OpenTK.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Graphics.Effects
+{
+    /// <summary>
+    /// Creates a glow around the drawable this effect gets applied to.
+    /// </summary>
+    public class GlowEffect : IEffect<BufferedContainer>
+    {
+        /// <summary>
+        /// The strength of the glow. A higher strength means that the glow fades outward slower. Default is 1.
+        /// </summary>
+        public float Strength = 1f;
+
+        /// <summary>
+        /// The sigma value for the blur of the glow. This controls how spread out the glow is. Default is 5 in both X and Y.
+        /// </summary>
+        public Vector2 BlurSigma = new Vector2(5);
+
+        /// <summary>
+        /// The color of the outline. Default is <see cref="Color4.White"/>.
+        /// </summary>
+        public SRGBColour Colour = Color4.White;
+
+        /// <summary>
+        /// The blending mode of the glow. Default is <see cref="BlendingMode.Additive"/>.
+        /// </summary>
+        public BlendingMode BlendingMode = BlendingMode.Additive;
+
+        /// <summary>
+        /// Whether to draw the glow <see cref="EffectPlacement.InFront"/> or <see cref="EffectPlacement.Behind"/> the glowing
+        /// <see cref="Drawable"/>. Default is <see cref="EffectPlacement.InFront"/>.
+        /// </summary>
+        public EffectPlacement Placement = EffectPlacement.InFront;
+
+        /// <summary>
+        /// Whether to automatically pad by the glow extent such that no clipping occurs at the sides of the effect. Default is false.
+        /// </summary>
+        public bool PadExtent;
+
+        /// <summary>
+        /// True if the effect should be cached. This is an optimization, but can cause issues if the drawable changes the way it looks without changing its size.
+        /// Turned off by default.
+        /// </summary>
+        public bool CacheDrawnEffect;
+
+        public BufferedContainer ApplyTo(Drawable drawable) => drawable.WithEffect(new BlurEffect
+        {
+            Strength = Strength,
+            Sigma = BlurSigma,
+            Colour = Colour,
+            BlendingMode = BlendingMode,
+            Placement = Placement,
+            PadExtent = PadExtent,
+            CacheDrawnEffect = CacheDrawnEffect,
+
+            DrawOriginal = true,
+        });
+    }
+}

--- a/osu.Framework/Graphics/Effects/GlowEffect.cs
+++ b/osu.Framework/Graphics/Effects/GlowEffect.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.Effects
         /// <summary>
         /// The color of the outline. Default is <see cref="Color4.White"/>.
         /// </summary>
-        public SRGBColour Colour = Color4.White;
+        public ColourInfo Colour = Color4.White;
 
         /// <summary>
         /// The blending mode of the glow. Default is <see cref="BlendingMode.Additive"/>.

--- a/osu.Framework/Graphics/Effects/GlowEffect.cs
+++ b/osu.Framework/Graphics/Effects/GlowEffect.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Graphics.Effects
         public ColourInfo Colour = Color4.White;
 
         /// <summary>
-        /// The blending mode of the glow. Default is <see cref="BlendingMode.Additive"/>.
+        /// The blending mode of the glow. Default is additive.
         /// </summary>
         public BlendingMode BlendingMode = BlendingMode.Additive;
 

--- a/osu.Framework/Graphics/Effects/OutlineEffect.cs
+++ b/osu.Framework/Graphics/Effects/OutlineEffect.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Graphics.Effects
         /// <summary>
         /// The color of the outline. Default is <see cref="Color4.Black"/>.
         /// </summary>
-        public SRGBColour Colour = Color4.Black;
+        public ColourInfo Colour = Color4.Black;
 
         /// <summary>
         /// Whether to automatically pad by the blur extent such that no clipping occurs at the sides of the effect. Default is false.

--- a/osu.Framework/Graphics/Effects/OutlineEffect.cs
+++ b/osu.Framework/Graphics/Effects/OutlineEffect.cs
@@ -5,7 +5,6 @@ using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Effects
 {
@@ -15,47 +14,42 @@ namespace osu.Framework.Graphics.Effects
     public class OutlineEffect : IEffect<BufferedContainer>
     {
         /// <summary>
-        /// The color of the outline.
+        /// The strength of the outline. A higher strength means that the blur effect used to draw the outline fades slower.
+        /// Default is 1.
         /// </summary>
-        public ColourInfo OutlineColour { get; set; } = Color4.Black;
+        public float Strength = 1f;
 
         /// <summary>
         /// The sigma value for the blur effect used to draw the outline. This controls over how many pixels the outline gets spread.
+        /// Default is <see cref="Vector2.One"/>.
         /// </summary>
-        public Vector2 BlurSigma { get; set; } = Vector2.One;
+        public Vector2 BlurSigma = Vector2.One;
 
         /// <summary>
-        /// The strength of the outline. A higher strength means that the blur effect used to draw the outline fades slower.
+        /// The color of the outline. Default is <see cref="Color4.Black"/>.
         /// </summary>
-        public float Strength { get; set; } = 1f;
+        public SRGBColour Colour = Color4.Black;
 
         /// <summary>
-        /// True if the effect should be cached. This is an optimization, but can cause issues if the drawable changes the way it looks without changing its size. Turned off by default.
+        /// Whether to automatically pad by the blur extent such that no clipping occurs at the sides of the effect. Default is false.
         /// </summary>
-        public bool CacheDrawnEffect { get; set; }
+        public bool PadExtent;
 
-        public BufferedContainer ApplyTo(Drawable drawable)
+        /// <summary>
+        /// True if the effect should be cached. This is an optimization, but can cause issues if the drawable changes the way it looks without changing its size.
+        /// Turned off by default.
+        /// </summary>
+        public bool CacheDrawnEffect;
+
+        public BufferedContainer ApplyTo(Drawable drawable) => drawable.WithEffect(new BlurEffect
         {
-            return new BufferedContainer
-            {
-                CacheDrawnFrameBuffer = CacheDrawnEffect,
+            Strength = Strength,
+            Sigma = BlurSigma,
+            Colour = Colour,
+            PadExtent = PadExtent,
+            CacheDrawnEffect = CacheDrawnEffect,
 
-                Padding = new MarginPadding
-                {
-                    Horizontal = Blur.KernelSize(BlurSigma.X),
-                    Vertical = Blur.KernelSize(BlurSigma.Y)
-                },
-
-                RelativeSizeAxes = drawable.RelativeSizeAxes,
-                AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
-                Anchor = drawable.Anchor,
-                Origin = drawable.Origin,
-
-                DrawOriginal = true,
-                EffectColour = OutlineColour.MultiplyAlpha(Strength),
-                BlurSigma = BlurSigma,
-                Child = drawable
-            };
-        }
+            DrawOriginal = true,
+        });
     }
 }

--- a/osu.Framework/Graphics/Lines/PathDrawNode.cs
+++ b/osu.Framework/Graphics/Lines/PathDrawNode.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Graphics.Lines
         private Vector2 relativePosition(Vector2 localPos) => Vector2.Divide(localPos, DrawSize);
 
         private Color4 colourAt(Vector2 localPos) => DrawInfo.Colour.HasSingleColour
-            ? DrawInfo.Colour.Colour.Linear
+            ? (Color4)DrawInfo.Colour
             : DrawInfo.Colour.Interpolate(relativePosition(localPos)).Linear;
 
         private void addLineCap(Vector2 origin, float theta, float thetaDiff)

--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -77,7 +77,7 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts <see cref="Drawable.Colour"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> FadeColour<T>(this TransformSequence<T> t, SRGBColour newColour, double duration = 0, Easing easing = Easing.None)
+        public static TransformSequence<T> FadeColour<T>(this TransformSequence<T> t, ColourInfo newColour, double duration = 0, Easing easing = Easing.None)
             where T : Drawable =>
             t.Append(o => o.FadeColour(newColour, duration, easing));
 
@@ -85,7 +85,7 @@ namespace osu.Framework.Graphics
         /// Instantaneously flashes <see cref="Drawable.Colour"/>, then smoothly changes it back over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> FlashColour<T>(this TransformSequence<T> t, SRGBColour flashColour, double duration, Easing easing = Easing.None)
+        public static TransformSequence<T> FlashColour<T>(this TransformSequence<T> t, ColourInfo flashColour, double duration, Easing easing = Easing.None)
             where T : Drawable =>
             t.Append(o => o.FlashColour(flashColour, duration, easing));
 

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Graphics
         /// <param name="duration">The transform duration.</param>
         /// <param name="easing">The transform easing to be used for tweening.</param>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<TThis> TransformTo<TThis, TValue>(this TThis t, string propertyOrFieldName, TValue newValue, double duration, Easing easing)
+        public static TransformSequence<TThis> TransformTo<TThis, TValue>(this TThis t, string propertyOrFieldName, TValue newValue, double duration = 0, Easing easing = Easing.None)
             where TThis : ITransformable =>
             t.TransformTo(t.MakeTransform(propertyOrFieldName, newValue, duration, easing));
 
@@ -58,7 +58,7 @@ namespace osu.Framework.Graphics
         /// <param name="duration">The transform duration.</param>
         /// <param name="easing">The transform easing to be used for tweening.</param>
         /// <returns>The resulting <see cref="Transform{TValue, T}"/>.</returns>
-        public static Transform<TValue, TThis> MakeTransform<TThis, TValue>(this TThis t, string propertyOrFieldName, TValue newValue, double duration, Easing easing)
+        public static Transform<TValue, TThis> MakeTransform<TThis, TValue>(this TThis t, string propertyOrFieldName, TValue newValue, double duration = 0, Easing easing = Easing.None)
             where TThis : ITransformable =>
             t.PopulateTransform(new TransformCustom<TValue, TThis>(propertyOrFieldName), newValue, duration, easing);
 
@@ -74,7 +74,7 @@ namespace osu.Framework.Graphics
         /// <param name="duration">The transform duration.</param>
         /// <param name="easing">The transform easing to be used for tweening.</param>
         /// <returns>The populated <paramref name="transform"/>.</returns>
-        public static Transform<TValue, TThis> PopulateTransform<TValue, TThis>(this TThis t, Transform<TValue, TThis> transform, TValue newValue, double duration, Easing easing)
+        public static Transform<TValue, TThis> PopulateTransform<TValue, TThis>(this TThis t, Transform<TValue, TThis> transform, TValue newValue, double duration = 0, Easing easing = Easing.None)
             where TThis : ITransformable
         {
             if (duration < 0)

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -162,16 +162,16 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts <see cref="Drawable.Colour"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> FadeColour<T>(this T drawable, SRGBColour newColour, double duration = 0, Easing easing = Easing.None) where T : Drawable =>
+        public static TransformSequence<T> FadeColour<T>(this T drawable, ColourInfo newColour, double duration = 0, Easing easing = Easing.None) where T : Drawable =>
             drawable.TransformTo(nameof(drawable.Colour), newColour, duration, easing);
 
         /// <summary>
         /// Instantaneously flashes <see cref="Drawable.Colour"/>, then smoothly changes it back over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> FlashColour<T>(this T drawable, SRGBColour flashColour, double duration, Easing easing = Easing.None) where T : Drawable
+        public static TransformSequence<T> FlashColour<T>(this T drawable, ColourInfo flashColour, double duration, Easing easing = Easing.None) where T : Drawable
         {
-            SRGBColour endValue = (drawable.Transforms.LastOrDefault(t => t.TargetMember == nameof(drawable.Colour)) as Transform<SRGBColour>)?.EndValue ?? drawable.Colour;
+            ColourInfo endValue = (drawable.Transforms.LastOrDefault(t => t.TargetMember == nameof(drawable.Colour)) as Transform<ColourInfo>)?.EndValue ?? drawable.Colour;
             return drawable.FadeColour(flashColour).FadeColour(endValue, duration, easing);
         }
 

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         // Gets colour at the localPos position in the unit square of our Colour gradient box.
         private Color4 colourAt(Vector2 localPos) => DrawInfo.Colour.HasSingleColour
-            ? DrawInfo.Colour.Colour.Linear
+            ? (Color4)DrawInfo.Colour
             : DrawInfo.Colour.Interpolate(localPos).Linear;
 
         private static readonly Vector2 origin = new Vector2(0.5f, 0.5f);

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -271,7 +271,7 @@ namespace osu.Framework.Graphics.Visualisation
             }
 
             previewBox.Alpha = Math.Max(0.2f, Target.Alpha);
-            previewBox.ColourInfo = Target.ColourInfo;
+            previewBox.Colour = Target.Colour;
 
             int childCount = (Target as CompositeDrawable)?.InternalChildren.Count ?? 0;
 

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.MathUtils
                 TopRight = ValueAt(time, (Color4)startColour.TopRight, (Color4)endColour.TopRight, startTime, endTime, easing),
                 BottomRight = ValueAt(time, (Color4)startColour.BottomRight, (Color4)endColour.BottomRight, startTime, endTime, easing),
             };
-        } 
+        }
 
         public static SRGBColour ValueAt(double time, SRGBColour startColour, SRGBColour endColour, double startTime, double endTime, Easing easing = Easing.None) =>
             ValueAt(time, (Color4)startColour, (Color4)endColour, startTime, endTime, easing);

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -32,6 +32,20 @@ namespace osu.Framework.MathUtils
             return Lerp(start, final, 1 - Math.Pow(@base, exponent));
         }
 
+        public static ColourInfo ValueAt(double time, ColourInfo startColour, ColourInfo endColour, double startTime, double endTime, Easing easing = Easing.None)
+        {
+            if (startColour.HasSingleColour && endColour.HasSingleColour)
+                return ValueAt(time, (Color4)startColour, (Color4)endColour, startTime, endTime, easing);
+
+            return new ColourInfo
+            {
+                TopLeft = ValueAt(time, (Color4)startColour.TopLeft, (Color4)endColour.TopLeft, startTime, endTime, easing),
+                BottomLeft = ValueAt(time, (Color4)startColour.BottomLeft, (Color4)endColour.BottomLeft, startTime, endTime, easing),
+                TopRight = ValueAt(time, (Color4)startColour.TopRight, (Color4)endColour.TopRight, startTime, endTime, easing),
+                BottomRight = ValueAt(time, (Color4)startColour.BottomRight, (Color4)endColour.BottomRight, startTime, endTime, easing),
+            };
+        } 
+
         public static SRGBColour ValueAt(double time, SRGBColour startColour, SRGBColour endColour, double startTime, double endTime, Easing easing = Easing.None) =>
             ValueAt(time, (Color4)startColour, (Color4)endColour, startTime, endTime, easing);
 

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -122,6 +122,7 @@
     <Compile Include="Graphics\Containers\CompositeDrawable.cs" />
     <Compile Include="Graphics\Containers\DelayedLoadWrapper.cs" />
     <Compile Include="Graphics\Containers\IFillFlowContainer.cs" />
+    <Compile Include="Graphics\Effects\GlowEffect.cs" />
     <Compile Include="Graphics\Effects\OutlineEffect.cs" />
     <Compile Include="Graphics\Containers\IBufferedContainer.cs" />
     <Compile Include="Graphics\Cursor\CursorEffectContainer.cs" />


### PR DESCRIPTION
This PR adds the following functionality to `BufferedContainer`:
- Effects can now be drawn in front of the original (only relevant if `DrawOriginal` is true).
- Effects can now have a custom blending mode (useful for additive glow).

Further, `BlurEffect` has been made more versatile and a new `GlowEffect` has been added. It looks like this on text (in contrast to `OutlineEffect`):
![](http://i.imgur.com/aLEaZss.png)