### PR TITLE
Move common TestBrowser components to Testing

### DIFF
--- a/osu.Framework.Testing/Drawables/TestCaseButton.cs
+++ b/osu.Framework.Testing/Drawables/TestCaseButton.cs
@@ -7,11 +7,10 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
-using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
 
-namespace osu.Framework.VisualTests.Drawables
+namespace osu.Framework.Testing.Drawables
 {
     internal class TestCaseButton : ClickableContainer
     {

--- a/osu.Framework.Testing/DynamicClassCompiler.cs
+++ b/osu.Framework.Testing/DynamicClassCompiler.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using Microsoft.CodeDom.Providers.DotNetCompilerPlatform;
 using osu.Framework.Logging;
 
-namespace osu.Framework.VisualTests
+namespace osu.Framework.Testing
 {
     public class DynamicClassCompiler
     {

--- a/osu.Framework.Testing/TestBrowser.cs
+++ b/osu.Framework.Testing/TestBrowser.cs
@@ -15,12 +15,11 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
-using osu.Framework.Testing;
-using osu.Framework.VisualTests.Drawables;
+using osu.Framework.Testing.Drawables;
 using OpenTK;
 using OpenTK.Graphics;
 
-namespace osu.Framework.VisualTests
+namespace osu.Framework.Testing
 {
     public class TestBrowser : Screen
     {

--- a/osu.Framework.Testing/TestBrowserConfig.cs
+++ b/osu.Framework.Testing/TestBrowserConfig.cs
@@ -4,7 +4,7 @@
 using osu.Framework.Configuration;
 using osu.Framework.Platform;
 
-namespace osu.Framework.VisualTests
+namespace osu.Framework.Testing
 {
     internal class TestBrowserConfig : ConfigManager<TestBrowserSetting>
     {

--- a/osu.Framework.Testing/TestBrowserTestRunner.cs
+++ b/osu.Framework.Testing/TestBrowserTestRunner.cs
@@ -8,7 +8,7 @@ using osu.Framework.Configuration;
 using osu.Framework.Platform;
 using osu.Framework.Screens;
 
-namespace osu.Framework.VisualTests
+namespace osu.Framework.Testing
 {
     public class TestBrowserTestRunner : Screen
     {

--- a/osu.Framework.Testing/osu.Framework.Testing.csproj
+++ b/osu.Framework.Testing/osu.Framework.Testing.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(SolutionDir)\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.2\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.2\build\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
@@ -36,6 +36,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.2\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.7.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
@@ -53,8 +57,13 @@
     <Compile Include="Drawables\StepButtons\SingleStepButton.cs" />
     <Compile Include="Drawables\StepButtons\StepButton.cs" />
     <Compile Include="Drawables\StepButtons\ToggleStepButton.cs" />
+    <Compile Include="Drawables\TestCaseButton.cs" />
+    <Compile Include="DynamicClassCompiler.cs" />
     <Compile Include="GridTestCase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestBrowser.cs" />
+    <Compile Include="TestBrowserConfig.cs" />
+    <Compile Include="TestBrowserTestRunner.cs" />
     <Compile Include="TestCase.cs" />
     <Compile Include="Tests\TestTestCase.cs" />
     <Compile Include="TestCaseTestRunner.cs" />
@@ -80,4 +89,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Net.Compilers.2.2.0\build\Microsoft.Net.Compilers.props'))" />
+  </Target>
 </Project>

--- a/osu.Framework.Testing/packages.config
+++ b/osu.Framework.Testing/packages.config
@@ -4,6 +4,8 @@ Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 -->
 <packages>
+  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall" version="1.0.3.2" targetFramework="net45" />
+  <package id="Microsoft.Net.Compilers" version="2.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="NUnit" version="3.7.1" targetFramework="net45" />
   <package id="ppy.OpenTK" version="3.0" targetFramework="net45" />
 </packages>

--- a/osu.Framework.VisualTestBrowser/AutomatedVisualTestGame.cs
+++ b/osu.Framework.VisualTestBrowser/AutomatedVisualTestGame.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using osu.Framework.Testing;
+
 namespace osu.Framework.VisualTests
 {
     public class AutomatedVisualTestGame : Game

--- a/osu.Framework.VisualTestBrowser/VisualTestGame.cs
+++ b/osu.Framework.VisualTestBrowser/VisualTestGame.cs
@@ -5,6 +5,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Platform;
+using osu.Framework.Testing;
 
 namespace osu.Framework.VisualTests
 {

--- a/osu.Framework.VisualTestBrowser/osu.Framework.VisualTestBrowser.csproj
+++ b/osu.Framework.VisualTestBrowser/osu.Framework.VisualTestBrowser.csproj
@@ -42,10 +42,6 @@
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall.1.0.3.2\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="OpenTK, Version=3.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\ppy.OpenTK.3.0\lib\net45\OpenTK.dll</HintPath>
       <Private>True</Private>
@@ -57,13 +53,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutomatedVisualTestGame.cs" />
-    <Compile Include="Drawables\TestCaseButton.cs" />
-    <Compile Include="DynamicClassCompiler.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestBrowser.cs" />
-    <Compile Include="TestBrowserConfig.cs" />
-    <Compile Include="TestBrowserTestRunner.cs" />
     <Compile Include="VisualTestGame.cs" />
     <None Include="..\osu-framework.licenseheader">
       <Link>osu-framework.licenseheader</Link>

--- a/osu.Framework.VisualTestBrowser/packages.config
+++ b/osu.Framework.VisualTestBrowser/packages.config
@@ -4,7 +4,5 @@ Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 -->
 <packages>
-  <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.NoInstall" version="1.0.3.2" targetFramework="net45" />
-  <package id="Microsoft.Net.Compilers" version="2.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="ppy.OpenTK" version="3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This is done to avoid referencing VisualTestBrowser from framework consumers.