### PR TITLE
Apply FillModes after computing the absolute size to account for RelativeChildSize

### DIFF
--- a/osu.Framework.Desktop.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Desktop.Tests/Platform/HeadlessGameHostTest.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Desktop.Tests.Platform
                         Thread.Sleep(1);
                 };
 
-                Assert.IsTrue(waitAction.BeginInvoke(null, null).AsyncWaitHandle.WaitOne(1000),
+                Assert.IsTrue(waitAction.BeginInvoke(null, null).AsyncWaitHandle.WaitOne(10000),
                     @"Message was not received in a timely fashion");
             }
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -661,6 +661,11 @@ namespace osu.Framework.Graphics
             {
                 Vector2 conversion = relativeToAbsoluteFactor;
 
+                if ((relativeAxes & Axes.X) > 0)
+                    v.X *= conversion.X;
+                if ((relativeAxes & Axes.Y) > 0)
+                    v.Y *= conversion.Y;
+
                 // FillMode only makes sense if both axes are relatively sized as the general rule
                 // for n-dimensional aspect preservation is to simply take the minimum or the maximum
                 // scale among all active axes. For single axes the minimum / maximum is just the
@@ -668,16 +673,11 @@ namespace osu.Framework.Graphics
                 if (relativeAxes == Axes.Both && fillMode != FillMode.Stretch)
                 {
                     if (fillMode == FillMode.Fill)
-                        conversion = new Vector2(Math.Max(conversion.X, conversion.Y * fillAspectRatio));
+                        v = new Vector2(Math.Max(v.X, v.Y * fillAspectRatio));
                     else if (fillMode == FillMode.Fit)
-                        conversion = new Vector2(Math.Min(conversion.X, conversion.Y * fillAspectRatio));
-                    conversion.Y /= fillAspectRatio;
+                        v = new Vector2(Math.Min(v.X, v.Y * fillAspectRatio));
+                    v.Y /= fillAspectRatio;
                 }
-
-                if ((relativeAxes & Axes.X) > 0)
-                    v.X *= conversion.X;
-                if ((relativeAxes & Axes.Y) > 0)
-                    v.Y *= conversion.Y;
             }
             return v;
         }


### PR DESCRIPTION
RelativeChildSize caused issues with fillmodes because they used relativeToAbsoluteFactor without taking into account the final absolute size in each dimension, thus yielded incorrect conversions. For example:
```
Assume square 50x50 parent, RelativeChildSize = Vector2(1)
Size = Vector2(1)
FillMode.Fit
---
Conversion = ComponentMin(relativeToAbsoluteFactor) = Min(50, 50) = Vector2(50)
FinalSize = Size * conversion = Vector2(1) * Vector2(50) = Vector2(50)
```
vs
```
Assume square 50x50 parent, RelativeChildSize = Vector2(2, 1)
Size = Vector2(2, 1)
FillMode.Fit
---
Conversion = ComponentMin(relativeToAbsoluteFactor) = Min(25, 50) = Vector2(25)
FinalSize = Size * Conversion = Vector2(2, 1) * Vector2(25, 25) = Vector2(50, 25)  // Even though Size == RelativeChildSize
```

So now we first compute the absolute size in both dimensions, i.e. `Size * Conversion` before computing the fill mode to avoid this.