### PR TITLE
Implemented macOS file drag and drop

### DIFF
--- a/osu.Framework.Desktop/Host.cs
+++ b/osu.Framework.Desktop/Host.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Desktop.Platform;
 using osu.Framework.Desktop.Platform.Linux;
+using osu.Framework.Desktop.Platform.MacOS;
 using osu.Framework.Desktop.Platform.Windows;
 
 namespace osu.Framework.Desktop
@@ -11,6 +12,9 @@ namespace osu.Framework.Desktop
     {
         public static DesktopGameHost GetSuitableHost(string gameName, bool bindIPC = false)
         {
+            if (RuntimeInfo.IsMacOsx)
+                return new MacOSGameHost(gameName, bindIPC);
+            
             if (RuntimeInfo.IsUnix)
                 return new LinuxGameHost(gameName, bindIPC);
 

--- a/osu.Framework.Desktop/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework.Desktop/Platform/MacOS/MacOSClipboard.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Windows.Forms;
+
+namespace osu.Framework.Desktop.Platform.MacOS
+{
+    public class MacOSClipboard : Framework.Platform.Clipboard
+    {
+        public override string GetText()
+        {
+            return Clipboard.GetText(TextDataFormat.UnicodeText);
+        }
+
+        public override void SetText(string selectedText)
+        {
+            //Clipboard.SetText(selectedText);
+
+            //This works within osu but will hang any application you try to paste to afterwards until osu is closed.
+            //Likely requires the use of X libraries directly to fix
+        }
+    }
+}

--- a/osu.Framework.Desktop/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework.Desktop/Platform/MacOS/MacOSGameHost.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Platform;
+
+namespace osu.Framework.Desktop.Platform.MacOS
+{
+    public class MacOSGameHost : DesktopGameHost
+    {
+        internal MacOSGameHost(string gameName, bool bindIPC = false)
+            : base(gameName, bindIPC)
+        {
+            Window = new MacOSGameWindow();
+            Window.WindowStateChanged += (sender, e) =>
+            {
+                if (Window.WindowState != OpenTK.WindowState.Minimized)
+                    OnActivated();
+                else
+                    OnDeactivated();
+            };
+            Dependencies.Cache(Storage = new MacOSStorage(gameName));
+        }
+
+        public override Clipboard GetClipboard()
+        {
+            return new MacOSClipboard();
+        }
+    }
+}

--- a/osu.Framework.Desktop/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework.Desktop/Platform/MacOS/MacOSGameWindow.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows.Forms;
+using System.Collections.Generic;
+
+using osu.Framework.Desktop.Platform.MacOS.Native;
+
+namespace osu.Framework.Desktop.Platform.MacOS
+{
+    internal class MacOSGameWindow : DesktopGameWindow
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private delegate IntPtr DraggingEnteredDelegate(IntPtr self, IntPtr cmd, IntPtr sender);
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private delegate bool PerformDragOperationDelegate(IntPtr self, IntPtr cmd, IntPtr sender);
+
+        private DraggingEnteredDelegate DraggingEnteredHandler;
+        private PerformDragOperationDelegate PerformDragOperationHandler;
+
+        private static IntPtr NSFilenamesPboardType;
+
+        protected override void OnLoad(EventArgs e)
+        {
+            PerformDragOperationHandler = PerformDragOperation;
+            DraggingEnteredHandler = DraggingEntered;
+
+            var fieldImplementation = typeof(OpenTK.NativeWindow).GetRuntimeFields().Single(x => x.Name == "implementation");
+            var typeCocoaNativeWindow = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "CocoaNativeWindow");
+            var nativeWindow = fieldImplementation.GetValue(this);
+            var fieldWindowClass = typeCocoaNativeWindow.GetRuntimeFields().Single(x => x.Name == "windowClass");
+            NSFilenamesPboardType = Cocoa.GetStringConstant(Cocoa.AppKitLibrary, "NSFilenamesPboardType");
+
+            var windowClass = (IntPtr)fieldWindowClass.GetValue(nativeWindow);
+            Class.RegisterMethod(windowClass, DraggingEnteredHandler, "draggingEntered:", "@@:@");
+            Class.RegisterMethod(windowClass, PerformDragOperationHandler, "performDragOperation:", "b@:@");
+
+            Cocoa.SendIntPtr(this.WindowInfo.Handle,
+                             Selector.Get("registerForDraggedTypes:"),
+                             Cocoa.SendIntPtr(
+                                 Class.Get("NSArray"),
+                                 Selector.Get("arrayWithObject:"),
+                                 NSFilenamesPboardType));
+            base.OnLoad(e);
+        }
+
+        private IntPtr DraggingEntered(IntPtr self, IntPtr cmd, IntPtr sender)
+        {
+            int mask = Cocoa.SendInt(sender, Selector.Get("draggingSourceOperationMask"));
+            int NSDragOperation_Generic = 4;
+            int NSDragOperation_None = 0;
+            if ((mask & NSDragOperation_Generic) == NSDragOperation_Generic)
+            {
+                return new IntPtr(NSDragOperation_Generic);
+            }
+
+            return new IntPtr(NSDragOperation_None);
+        }
+
+        private bool PerformDragOperation(IntPtr self, IntPtr cmd, IntPtr sender)
+        {
+            IntPtr pboard = Cocoa.SendIntPtr(sender, Selector.Get("draggingPasteboard"));
+
+            IntPtr files = Cocoa.SendIntPtr(pboard, Selector.Get("propertyListForType:"), NSFilenamesPboardType);
+
+            var filenames = new List<String>();
+            int count = Cocoa.SendInt(files, Selector.Get("count"));
+            for (int i = 0; i < count; ++i)
+            {
+                IntPtr obj = Cocoa.SendIntPtr(files, Selector.Get("objectAtIndex:"), new IntPtr(i));
+                IntPtr str = Cocoa.SendIntPtr(obj, Selector.Get("cStringUsingEncoding:"), new IntPtr(1));
+                filenames.Add(Marshal.PtrToStringAuto(str));
+            }
+            OnFileDrop(filenames.ToArray());
+            return true;
+        }
+
+        void OnFileDrop(string[] filenames)
+        {
+            var data = new DataObject(DataFormats.FileDrop, filenames);
+            var args = new DragEventArgs(data, 0, 0, 0, DragDropEffects.Copy, DragDropEffects.Copy);
+            this.OnDragDrop(args);
+        }
+    }
+}

--- a/osu.Framework.Desktop/Platform/MacOS/MacOSStorage.cs
+++ b/osu.Framework.Desktop/Platform/MacOS/MacOSStorage.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.IO;
+
+namespace osu.Framework.Desktop.Platform.MacOS
+{
+    public class MacOSStorage : DesktopStorage
+    {
+        public MacOSStorage(string baseName)
+            : base(baseName)
+        {
+        }
+
+        protected override string LocateBasePath()
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            string xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+            string[] paths =
+            {
+                xdg ?? Path.Combine(home, ".local", "share"),
+                Path.Combine(home)
+            };
+
+            foreach (string path in paths)
+            {
+                if (Directory.Exists(path))
+                    return path;
+            }
+
+            return paths[0];
+        }
+    }
+}

--- a/osu.Framework.Desktop/Platform/MacOS/Native/Class.cs
+++ b/osu.Framework.Desktop/Platform/MacOS/Native/Class.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace osu.Framework.Desktop.Platform.MacOS.Native
+{
+    internal class Class
+    {
+        static Type typeClass;
+        static MethodInfo methodClassGet;
+        static MethodInfo methodRegisterMethod;
+
+        static Class()
+        {
+            typeClass = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Class");
+            methodClassGet = typeClass.GetMethod("Get");
+            methodRegisterMethod = typeClass.GetMethod("RegisterMethod");
+        }
+
+        public static IntPtr Get(string name)
+        {
+            return (IntPtr)methodClassGet.Invoke(null, new object[] { name });
+        }
+
+        public static void RegisterMethod(IntPtr handle, Delegate d, string selector, string typeString)
+        {
+            methodRegisterMethod.Invoke(null, new object[] { handle, d, selector, typeString });
+        }
+    }
+}

--- a/osu.Framework.Desktop/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework.Desktop/Platform/MacOS/Native/Cocoa.cs
@@ -1,0 +1,71 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace osu.Framework.Desktop.Platform.MacOS.Native
+{
+    internal class Cocoa
+    {
+        static Type typeCocoa;
+        static MethodInfo methodCocoaSendIntPtr1;
+        static MethodInfo methodCocoaSendIntPtr2;
+        static MethodInfo methodCocoaSendInt;
+        static MethodInfo methodCocoaFromNSString;
+        static MethodInfo methodCocoaToNSString;
+        static MethodInfo methodCocoaGetStringConstant;
+        static FieldInfo fieldAppKitLibrary;
+        static FieldInfo fieldFoundationLibrary;
+
+        public static IntPtr AppKitLibrary;
+        public static IntPtr FoundationLibrary;
+
+        static Cocoa()
+        {
+            typeCocoa = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Cocoa");
+            methodCocoaSendIntPtr1 = typeCocoa.GetMethod("SendIntPtr", new Type[] { typeof(IntPtr), typeof(IntPtr) });
+            methodCocoaSendIntPtr2 = typeCocoa.GetMethod("SendIntPtr", new Type[] { typeof(IntPtr), typeof(IntPtr), typeof(IntPtr) });
+            methodCocoaSendInt = typeCocoa.GetMethod("SendInt");
+            methodCocoaFromNSString = typeCocoa.GetMethod("FromNSString");
+            methodCocoaToNSString = typeCocoa.GetMethod("ToNSString");
+            methodCocoaGetStringConstant = typeCocoa.GetMethod("GetStringConstant");
+            fieldAppKitLibrary = typeCocoa.GetField("AppKitLibrary");
+            fieldFoundationLibrary = typeCocoa.GetField("FoundationLibrary");
+
+            AppKitLibrary = (IntPtr)fieldAppKitLibrary.GetValue(null);
+            FoundationLibrary = (IntPtr)fieldFoundationLibrary.GetValue(null);
+        }
+
+        public static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector)
+        {
+            return (IntPtr)methodCocoaSendIntPtr1.Invoke(null, new object[] { receiver, selector });
+        }
+
+        public static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr intPtr1)
+        {
+            return (IntPtr)methodCocoaSendIntPtr2.Invoke(null, new object[] { receiver, selector, intPtr1 });
+        }
+
+        public static int SendInt(IntPtr receiver, IntPtr selector)
+        {
+            return (int)methodCocoaSendInt.Invoke(null, new object[] { receiver, selector });
+        }
+
+        public static string FromNSString(IntPtr handle)
+        {
+            return (string)methodCocoaFromNSString.Invoke(null, new object[] { handle });
+        }
+
+        public static IntPtr ToNSString(string str)
+        {
+            return (IntPtr)methodCocoaToNSString.Invoke(null, new object[] { str });
+        }
+
+        public static IntPtr GetStringConstant(IntPtr handle, string symbol)
+        {
+            return (IntPtr)methodCocoaGetStringConstant.Invoke(null, new object[] { handle, symbol });
+        }
+    }
+}

--- a/osu.Framework.Desktop/Platform/MacOS/Native/Selector.cs
+++ b/osu.Framework.Desktop/Platform/MacOS/Native/Selector.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace osu.Framework.Desktop.Platform.MacOS.Native
+{
+    internal class Selector
+    {
+        static Type typeSelector;
+        static MethodInfo methodSelectorGet;
+
+        static Selector()
+        {
+            typeSelector = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Selector");
+            methodSelectorGet = typeSelector.GetMethod("Get");
+        }
+
+        public static IntPtr Get(string name)
+        {
+            return (IntPtr)methodSelectorGet.Invoke(null, new object[] { name });
+        }
+    }
+}

--- a/osu.Framework.Desktop/osu.Framework.Desktop.csproj
+++ b/osu.Framework.Desktop/osu.Framework.Desktop.csproj
@@ -88,6 +88,13 @@
     <Compile Include="Platform\HeadlessGameHost.cs" />
     <Compile Include="Platform\TcpIpcProvider.cs" />
     <Compile Include="Platform\Linux\LinuxClipboard.cs" />
+    <Compile Include="Platform\MacOS\MacOSGameHost.cs" />
+    <Compile Include="Platform\MacOS\MacOSClipboard.cs" />
+    <Compile Include="Platform\MacOS\MacOSStorage.cs" />
+    <Compile Include="Platform\MacOS\MacOSGameWindow.cs" />
+    <Compile Include="Platform\MacOS\Native\Cocoa.cs" />
+    <Compile Include="Platform\MacOS\Native\Class.cs" />
+    <Compile Include="Platform\MacOS\Native\Selector.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj">
@@ -189,6 +196,10 @@
     <Content Include="x86\SQLite.Interop.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Platform\MacOS\" />
+    <Folder Include="Platform\MacOS\Native\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.


### PR DESCRIPTION
Added support for dragging osz files into the osu!lazer window from Finder, part of which includes copying the `Linux` namespace into a separate `MacOS` namespace.

The native calls are implemented using reflection by hooking into the internal interop classes provided by OpenTK.

I noticed that OpenTK 3.0.5 officially supports drag and drop, so if the projects get updated to peppy's latest fork, this can be replaced with the `FileDrop` event.

TODO: Implement macOS clipboard support.