### PR TITLE
Default frame limiter to a refresh rate of 60 Hz

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -442,8 +442,10 @@ namespace osu.Framework.Platform
             frameSyncMode = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
             frameSyncMode.ValueChanged += newMode =>
             {
-
                 float refreshRate = DisplayDevice.Default.RefreshRate;
+                // For invalid refresh rates let's assume 60 Hz as it is most common.
+                if (refreshRate <= 0)
+                    refreshRate = 60;
 
                 float drawLimiter = refreshRate;
                 float updateLimiter = drawLimiter * 2;


### PR DESCRIPTION
In some cases OpenTK provides the framework with an invalid refresh rate (e.g. 0 Hz). In such cases the frame limiter was previously broken; it did nothing. This commit instead defaults the frame limiter to using a refresh rate of 60 Hz (and multiples thereof) as it is most likely the user has a 60 Hz display. If the user has a higher refresh rate, then the 8x or unlimited frame limiters should still provide sufficient functionality for good use.