### PR TITLE
Add method to search upwards for first parent InputManager

### DIFF
--- a/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using osu.Framework.Input;
 using OpenTK.Input;
-using osu.Framework.Allocation;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -26,21 +25,15 @@ namespace osu.Framework.Graphics.Containers
             base.OnFocusLost(state);
         }
 
-        [BackgroundDependencyLoader]
-        private void load(UserInputManager inputManager)
-        {
-            InputManager = inputManager;
-        }
-
         protected override void PopIn()
         {
-            Schedule(() => InputManager.TriggerFocusContention());
+            Schedule(() => GetContainingInputManager().TriggerFocusContention());
         }
 
         protected override void PopOut()
         {
             if (HasFocus)
-                InputManager.ChangeFocus(null);
+                GetContainingInputManager().ChangeFocus(null);
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/TabbableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContainer.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Input;
 using OpenTK.Input;
-using osu.Framework.Allocation;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -28,21 +27,13 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public Container<Drawable> TabbableContentContainer { private get; set; }
 
-        private InputManager inputManager;
-
-        [BackgroundDependencyLoader]
-        private void load(UserInputManager inputManager)
-        {
-            this.inputManager = inputManager;
-        }
-
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {
             if (TabbableContentContainer == null || args.Key != Key.Tab)
                 return false;
 
             var nextTab = nextTabStop(TabbableContentContainer, state.Keyboard.ShiftPressed);
-            if (nextTab != null) inputManager.ChangeFocus(nextTab);
+            if (nextTab != null) GetContainingInputManager().ChangeFocus(nextTab);
             return true;
         }
 

--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using System.Collections.Generic;
@@ -14,12 +13,12 @@ namespace osu.Framework.Graphics.Cursor
         where TSelf : CursorEffectContainer<TSelf, TTarget>
         where TTarget : class, IDrawable
     {
-        private UserInputManager inputManager;
+        private InputManager inputManager;
 
-        [BackgroundDependencyLoader]
-        private void load(UserInputManager input)
+        protected override void LoadComplete()
         {
-            inputManager = input;
+            base.LoadComplete();
+            inputManager = GetContainingInputManager();
         }
 
         private readonly HashSet<IDrawable> childDrawables = new HashSet<IDrawable>();

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -3,7 +3,6 @@
 
 using OpenTK;
 using OpenTK.Graphics;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
@@ -25,7 +24,7 @@ namespace osu.Framework.Graphics.Cursor
 
         private ITooltip currentTooltip;
 
-        private UserInputManager inputManager;
+        private InputManager inputManager;
 
         /// <summary>
         /// Duration the cursor has to stay in a circular region of <see cref="AppearRadius"/>
@@ -82,10 +81,10 @@ namespace osu.Framework.Graphics.Cursor
             }
         }
 
-        [BackgroundDependencyLoader]
-        private void load(UserInputManager input)
+        protected override void LoadComplete()
         {
-            inputManager = input;
+            base.LoadComplete();
+            inputManager = GetContainingInputManager();
         }
 
         private Vector2 computeTooltipPosition()

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1173,6 +1173,24 @@ namespace osu.Framework.Graphics
 
         #region Parenting (scene graph operations, including ProxyDrawable)
 
+        /// <summary>
+        /// Retrieve the first parent in the tree which derives from <see cref="InputManager"/>.
+        /// As this is performing an upward tree traversal, avoid calling every frame.
+        /// </summary>
+        /// <returns>The first parent <see cref="InputManager"/>.</returns>
+        protected InputManager GetContainingInputManager()
+        {
+            Drawable search = Parent;
+            while (search != null)
+            {
+                var test = search as InputManager;
+                if (test != null) return test;
+
+                search = search.Parent;
+            }
+            return null;
+        }
+
         private CompositeDrawable parent;
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -5,7 +5,6 @@ using System;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.UserInterface
@@ -52,14 +51,6 @@ namespace osu.Framework.Graphics.UserInterface
             AnimateClose();
         }
 
-        private InputManager inputManager;
-
-        [BackgroundDependencyLoader]
-        private void load(UserInputManager inputManager)
-        {
-            this.inputManager = inputManager;
-        }
-
         private MenuState state;
 
         public MenuState State
@@ -74,13 +65,13 @@ namespace osu.Framework.Graphics.UserInterface
                     case MenuState.Closed:
                         AnimateClose();
                         if (HasFocus)
-                            inputManager.ChangeFocus(null);
+                            GetContainingInputManager().ChangeFocus(null);
                         break;
                     case MenuState.Opened:
                         AnimateOpen();
 
                         //schedule required as we may not be present currently.
-                        Schedule(() => inputManager.ChangeFocus(this));
+                        Schedule(() => GetContainingInputManager().ChangeFocus(this));
                         break;
                 }
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -43,8 +43,6 @@ namespace osu.Framework.Graphics.UserInterface
 
         private AudioManager audio;
 
-        private InputManager inputManager;
-
         /// <summary>
         /// Should this TextBox accept arrow keys for navigation?
         /// </summary>
@@ -112,10 +110,9 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         [BackgroundDependencyLoader]
-        private void load(GameHost host, AudioManager audio, UserInputManager inputManager)
+        private void load(GameHost host, AudioManager audio)
         {
             this.audio = audio;
-            this.inputManager = inputManager;
 
             textInput = host.GetTextInput();
             clipboard = host.GetClipboard();
@@ -565,7 +562,7 @@ namespace osu.Framework.Graphics.UserInterface
                     if (HasFocus)
                     {
                         if (ReleaseFocusOnCommit)
-                            inputManager.ChangeFocus(null);
+                            GetContainingInputManager().ChangeFocus(null);
 
                         Background.Colour = ReleaseFocusOnCommit ? BackgroundUnfocused : BackgroundFocused;
                         Background.ClearTransforms();
@@ -688,7 +685,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 selectionEnd = getCharacterClosestTo(state.Mouse.Position);
                 if (selectionLength > 0)
-                    inputManager.ChangeFocus(this);
+                    GetContainingInputManager().ChangeFocus(this);
 
                 cursorAndLayout.Invalidate();
             }


### PR DESCRIPTION
Previous DI logic was causing issues where PassThroughInputManagers were present in the tree, due to fetching an InputManager too global.

While we may modify DI to better support this scenario, this is a better solution for the time being.