### PR TITLE
Revert Precision changes but add scale check to IsPresent.

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1067,7 +1067,7 @@ namespace osu.Framework.Graphics
         /// Determines whether this Drawable is present based on its <see cref="Alpha"/> value.
         /// Can be forced always on with <see cref="AlwaysPresent"/>.
         /// </summary>
-        public virtual bool IsPresent => AlwaysPresent || Alpha > visibility_cutoff;
+        public virtual bool IsPresent => (AlwaysPresent || Alpha > visibility_cutoff) && Scale.X > Precision.FLOAT_EPSILON && Scale.Y > Precision.FLOAT_EPSILON;
 
         private bool alwaysPresent;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1067,7 +1067,7 @@ namespace osu.Framework.Graphics
         /// Determines whether this Drawable is present based on its <see cref="Alpha"/> value.
         /// Can be forced always on with <see cref="AlwaysPresent"/>.
         /// </summary>
-        public virtual bool IsPresent => (AlwaysPresent || Alpha > visibility_cutoff) && Scale.X > Precision.FLOAT_EPSILON && Scale.Y > Precision.FLOAT_EPSILON;
+        public virtual bool IsPresent => AlwaysPresent || Alpha > visibility_cutoff && Scale.X > Precision.FLOAT_EPSILON && Scale.Y > Precision.FLOAT_EPSILON;
 
         private bool alwaysPresent;
 

--- a/osu.Framework/MathUtils/Precision.cs
+++ b/osu.Framework/MathUtils/Precision.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.MathUtils
 {
     public static class Precision
     {
-        public const float FLOAT_EPSILON = 1e-4f;
+        public const float FLOAT_EPSILON = 1e-3f;
         public const double DOUBLE_EPSILON = 1e-7;
 
         public static bool DefinitelyBigger(float value1, float value2, float acceptableDifference = FLOAT_EPSILON)


### PR DESCRIPTION
Apparently my last changes to precision caused asserts to be fired in ScrollContainer. So I'm reverting them for now but also added an IsPresent check because we'll experience undesired pixel visibility with effectively 0 scale on medium-sized sprites.