### PR TITLE
Expose PressedActions for querying currently actuated actions

### DIFF
--- a/osu.Framework/Input/Bindings/KeyBindingInputManager.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingInputManager.cs
@@ -29,10 +29,9 @@ namespace osu.Framework.Input.Bindings
         }
 
         private readonly List<KeyBinding> pressedBindings = new List<KeyBinding>();
-        public IReadOnlyList<KeyBinding> PressedBindings => pressedBindings.AsReadOnly();
 
         private readonly List<T> pressedActions = new List<T>();
-        public IReadOnlyList<T> PressedActions => pressedActions.AsReadOnly();
+        public IEnumerable<T> PressedActions => pressedActions;
 
         private bool isModifier(Key k) => k < Key.F1;
 

--- a/osu.Framework/Input/Bindings/KeyBindingInputManager.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingInputManager.cs
@@ -29,7 +29,10 @@ namespace osu.Framework.Input.Bindings
         }
 
         private readonly List<KeyBinding> pressedBindings = new List<KeyBinding>();
+        public IReadOnlyList<KeyBinding> PressedBindings => pressedBindings.AsReadOnly();
+
         private readonly List<T> pressedActions = new List<T>();
+        public IReadOnlyList<T> PressedActions => pressedActions.AsReadOnly();
 
         private bool isModifier(Key k) => k < Key.F1;
 


### PR DESCRIPTION
This change is to allow elements to query whether a specific action is pressed, without needing to explicitly implement `IKeyBindingHandler<T>`.