### PR TITLE
Dispose draw tree on GameHost.Dispose

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -547,6 +547,8 @@ namespace osu.Framework.Platform
         {
             Dispose(true);
             GC.SuppressFinalize(this);
+
+            Root?.Dispose();
         }
 
         #endregion


### PR DESCRIPTION
Previously we were relying on the finalizer for disposal, which is too slow for things like nUnit