### PR TITLE
Reverse handling order of KeyBindings (handle raw events first)

### DIFF
--- a/osu.Framework/Input/Bindings/KeyBindingInputManager.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingInputManager.cs
@@ -45,10 +45,10 @@ namespace osu.Framework.Input.Bindings
         protected virtual IEnumerable<Drawable> KeyBindingInputQueue => InputQueue;
 
         protected override bool PropagateMouseDown(IEnumerable<Drawable> drawables, InputState state, MouseDownEventArgs args) =>
-            handleNewDown(state, KeyCombination.FromMouseButton(args.Button)) || base.PropagateMouseDown(drawables, state, args);
+            base.PropagateMouseDown(drawables, state, args) || handleNewDown(state, KeyCombination.FromMouseButton(args.Button));
 
         protected override bool PropagateMouseUp(IEnumerable<Drawable> drawables, InputState state, MouseUpEventArgs args) =>
-            handleNewUp(state, KeyCombination.FromMouseButton(args.Button)) || base.PropagateMouseUp(drawables, state, args);
+            base.PropagateMouseUp(drawables, state, args) || handleNewUp(state, KeyCombination.FromMouseButton(args.Button));
 
         protected override bool PropagateKeyDown(IEnumerable<Drawable> drawables, InputState state, KeyDownEventArgs args)
         {
@@ -60,11 +60,11 @@ namespace osu.Framework.Input.Bindings
                 return base.PropagateKeyDown(drawables, state, args);
             }
 
-            return handleNewDown(state, KeyCombination.FromKey(args.Key)) || base.PropagateKeyDown(drawables, state, args);
+            return base.PropagateKeyDown(drawables, state, args) || handleNewDown(state, KeyCombination.FromKey(args.Key));
         }
 
         protected override bool PropagateKeyUp(IEnumerable<Drawable> drawables, InputState state, KeyUpEventArgs args) =>
-            handleNewUp(state, KeyCombination.FromKey(args.Key)) || base.PropagateKeyUp(drawables, state, args);
+            base.PropagateKeyUp(drawables, state, args) || handleNewUp(state, KeyCombination.FromKey(args.Key));
 
         private bool handleNewDown(InputState state, InputKey newKey)
         {


### PR DESCRIPTION
This seems like a better default and solves a lot of issues that were coming up (like global bindings overriding local scrolling in ScrollContainers).