### PR TITLE
Enforce Root is at least 1px size for any children that scale relative to its size

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -236,6 +236,9 @@ namespace osu.Framework.Platform
                 Root.Size = Window != null ? new Vector2(Window.ClientSize.Width, Window.ClientSize.Height) :
                     new Vector2(config.Get<int>(FrameworkSetting.Width), config.Get<int>(FrameworkSetting.Height));
 
+            // Ensure we maintain a valid size for any children immediately scaling by the window size
+            Root.Size = Vector2.ComponentMax(Vector2.One, Root.Size);
+
             Root.UpdateSubTree();
             using (var buffer = DrawRoots.Get(UsageType.Write))
                 buffer.Object = Root.GenerateDrawNodeSubtree(buffer.Index, Root.ScreenSpaceDrawQuad.AABBFloat);


### PR DESCRIPTION
e.g. osu! uses a RatioAdjust container which scales relative to the Root size, and this may result in bad/irrecoverable states.

This should fix the "black screen" issue we've been experiencing erratically.