### PR TITLE
Add support for creating a horizontally-tiling MenuBar

### DIFF
--- a/osu.Framework.Desktop.Tests/Visual/TestCaseMenuBar.cs
+++ b/osu.Framework.Desktop.Tests/Visual/TestCaseMenuBar.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Desktop.Tests.Visual
+{
+    internal class TestCaseMenuBar : TestCase
+    {
+        public TestCaseMenuBar()
+        {
+            MenuItem second;
+            Add(new MenuBar
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Items = new[]
+                {
+                    new MenuItem("First")
+                    {
+                        Items = new[]
+                        {
+                            new MenuItem("First #1"),
+                            new MenuItem("First #2"),
+                            new MenuItem("First #3"),
+                            new MenuItem("First #4"),
+                            new MenuItem("First #5"),
+                        }
+                    },
+                    second = new MenuItem("Second")
+                    {
+                        Items = new[]
+                        {
+                            new MenuItem("Second #1"),
+                            new MenuItem("Second #2"),
+                            new MenuItem("Second #3"),
+                            new MenuItem("Second #4"),
+                            new MenuItem("Second #5"),
+                        }
+                    }
+                }
+            });
+
+            AddStep("Change text", () =>
+            {
+                second.Text.Value = "Third";
+                second.Items.ForEach(i => i.Text.Value = i.Text.Value.Replace("Second", "Third"));
+            });
+        }
+    }
+}

--- a/osu.Framework.Desktop.Tests/osu.Framework.Desktop.Tests.csproj
+++ b/osu.Framework.Desktop.Tests/osu.Framework.Desktop.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Visual\TestCaseKeyBindings.cs" />
     <Compile Include="Visual\TestCaseLocalisation.cs" />
     <Compile Include="Visual\TestCaseMasking.cs" />
+    <Compile Include="Visual\TestCaseMenuBar.cs" />
     <Compile Include="Visual\TestCaseNestedHover.cs" />
     <Compile Include="Visual\TestCaseContainerState.cs" />
     <Compile Include="Visual\TestCasePadding.cs" />

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
@@ -39,8 +40,7 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 itemsContainer.Clear();
 
-                foreach (var item in value)
-                    Add(item);
+                value?.ForEach(Add);
 
                 menuWidth.Invalidate();
             }

--- a/osu.Framework/Graphics/UserInterface/MenuBar.cs
+++ b/osu.Framework/Graphics/UserInterface/MenuBar.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Graphics.UserInterface
         public IReadOnlyList<MenuItem> Items
         {
             get { return ItemsContainer.Select(i => i.Item).ToList(); }
-            set { value.ForEach(Add); }
+            set { value?.ForEach(Add); }
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/MenuBar.cs
+++ b/osu.Framework/Graphics/UserInterface/MenuBar.cs
@@ -1,0 +1,190 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
+
+namespace osu.Framework.Graphics.UserInterface
+{
+    /// <summary>
+    /// A horizontally-tiling bar of <see cref="MenuItem"/> that expand into separate <see cref="Menu"/>s.
+    /// </summary>
+    public class MenuBar : CompositeDrawable
+    {
+        /// <summary>
+        /// The <see cref="FlowContainer{DrawableMenuBarItem}"/> that handles positioning for the <see cref="DrawableMenuBarItem"/>s.
+        /// </summary>
+        protected readonly FlowContainer<DrawableMenuBarItem> ItemsContainer;
+
+        /// <summary>
+        /// Constructs a new <see cref="MenuBar"/>.
+        /// </summary>
+        public MenuBar()
+        {
+            AutoSizeAxes = Axes.Both;
+
+            AddInternal(ItemsContainer = new FillFlowContainer<DrawableMenuBarItem>
+            {
+                AutoSizeAxes = Axes.Both,
+                Direction = FillDirection.Horizontal
+            });
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="MenuItem"/>s contained by this <see cref="MenuBar"/>.
+        /// </summary>
+        public IReadOnlyList<MenuItem> Items
+        {
+            get { return ItemsContainer.Select(i => i.Item).ToList(); }
+            set { value.ForEach(Add); }
+        }
+
+        /// <summary>
+        /// Adds a <see cref="MenuItem"/> to this <see cref="MenuBar"/>.
+        /// </summary>
+        /// <param name="item">The <see cref="MenuItem"/> to add.</param>
+        public void Add(MenuItem item) => ItemsContainer.Add(CreateDrawableMenuBarItem(item));
+
+        /// <summary>
+        /// Removes a <see cref="MenuItem"/> from this <see cref="MenuBar"/>.
+        /// </summary>
+        /// <param name="item">The <see cref="MenuItem"/> to remove.</param>
+        /// <returns>Whether <paramref name="item"/> was successfully removed.</returns>
+        public bool Remove(MenuItem item) => ItemsContainer.RemoveAll(i => i.Item == item) > 0;
+
+        /// <summary>
+        /// Clears all <see cref="MenuItem"/>s from this <see cref="MenuBar"/>.
+        /// </summary>
+        public void Clear() => ItemsContainer.Clear();
+
+        protected override bool OnMouseMove(InputState state)
+        {
+            // Find the previously-opened item
+            var previousItem = ItemsContainer.FirstOrDefault(i => i.State == MenuState.Opened);
+            if (previousItem == null)
+                return false;
+
+            // Find the newly-hovered item
+            var newItem = ItemsContainer.FirstOrDefault(i => i.IsHovered);
+            if (newItem == null)
+                return false;
+
+            // If they're the same item, there's nothing to do
+            if (previousItem == newItem)
+                return false;
+
+            // Move the opened state to the newly-hovered item
+            previousItem.Close();
+            newItem.Open();
+            return true;
+        }
+
+        /// <summary>
+        /// Creates the drawable visualisation for a <see cref="MenuItem"/>.
+        /// </summary>
+        /// <param name="item">The <see cref="MenuItem"/> that is to be visualised.</param>
+        /// <returns>The <see cref="DrawableMenuBarItem"/>.</returns>
+        protected virtual DrawableMenuBarItem CreateDrawableMenuBarItem(MenuItem item) => new DrawableMenuBarItem(item);
+
+        /// <summary>
+        /// A <see cref="CompositeDrawable"/> that visualises a <see cref="MenuItem"/>.
+        /// </summary>
+        protected class DrawableMenuBarItem : CompositeDrawable
+        {
+            /// <summary>
+            /// The <see cref="Menu"/> that is expanded when this <see cref="DrawableMenuBarItem"/> is clicked.
+            /// </summary>
+            protected readonly Menu Menu;
+
+            /// <summary>
+            /// The <see cref="SpriteText"/> that visualises the <see cref="MenuItem.Text"/>.
+            /// </summary>
+            protected readonly SpriteText Text;
+
+            /// <summary>
+            /// The <see cref="MenuItem"/> that this <see cref="DrawableMenuBarItem"/> visualises.
+            /// </summary>
+            public readonly MenuItem Item;
+
+            /// <summary>
+            /// Constructs a new <see cref="DrawableMenuBarItem"/>.
+            /// </summary>
+            /// <param name="item">The <see cref="MenuItem"/> which this <see cref="DrawableMenuBarItem"/> will visualise.</param>
+            public DrawableMenuBarItem(MenuItem item)
+            {
+                Item = item;
+
+                AutoSizeAxes = Axes.Both;
+
+                AddRangeInternal(new Drawable[]
+                {
+                    Text = CreateText(),
+                    Menu = CreateMenu()
+                });
+
+                Text.Text = item.Text;
+
+                Menu.BypassAutoSizeAxes = Axes.Both;
+                Menu.Items = item.Items;
+
+                item.Text.ValueChanged += newText => Text.Text = newText;
+            }
+
+            /// <summary>
+            /// The current state of the <see cref="Menu"/>.
+            /// </summary>
+            public MenuState State => Menu.State;
+
+            /// <summary>
+            /// Opens the <see cref="Menu"/>.
+            /// </summary>
+            public void Open()
+            {
+                Menu.Open();
+            }
+
+            /// <summary>
+            /// Closes the <see cref="Menu"/>.
+            /// </summary>
+            public void Close()
+            {
+                Menu.Close();
+            }
+
+            protected override bool OnClick(InputState state)
+            {
+                switch (Menu.State)
+                {
+                    case MenuState.Closed:
+                        Open();
+                        break;
+                    case MenuState.Opened:
+                        Close();
+                        break;
+                }
+
+                return true;
+            }
+
+            /// <summary>
+            /// Creates the <see cref="SpriteText"/> that visualises the <see cref="MenuItem.Text"/>.
+            /// </summary>
+            /// <returns></returns>
+            protected virtual SpriteText CreateText() => new SpriteText
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre
+            };
+
+            /// <summary>
+            /// Creates the <see cref="Menu"/> that is expanded when this <see cref="DrawableMenuBarItem"/> is clicked.
+            /// </summary>
+            /// <returns></returns>
+            protected virtual Menu CreateMenu() => new Menu { Anchor = Anchor.BottomLeft };
+        }
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/MenuItem.cs
+++ b/osu.Framework/Graphics/UserInterface/MenuItem.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// A list of items which are to be displayed in a sub-menu originating from this <see cref="MenuItem"/>.
         /// </summary>
-        public IReadOnlyList<MenuItem> Items;
+        public IReadOnlyList<MenuItem> Items = new MenuItem[0];
 
         /// <summary>
         /// Creates a new <see cref="MenuItem"/>.

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -162,6 +162,7 @@
     <Compile Include="Graphics\UserInterface\BasicDropdown.cs" />
     <Compile Include="Graphics\UserInterface\Checkbox.cs" />
     <Compile Include="Graphics\UserInterface\IHasCurrentValue.cs" />
+    <Compile Include="Graphics\UserInterface\MenuBar.cs" />
     <Compile Include="Graphics\UserInterface\MenuItem.cs" />
     <Compile Include="Graphics\UserInterface\Menu.cs" />
     <Compile Include="Graphics\Shapes\EquilateralTriangle.cs" />


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/1007

Follows the example built in the PR above to create a bar that contains a collection of menus.