### PR TITLE
Do not use 'this' object for locking

### DIFF
--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Graphics.Textures
 
         private readonly bool manualMipmaps;
         private readonly All filteringMode;
-        private readonly object locker = new object();
+        private readonly object textureRetrievalLock = new object();
 
         public TextureAtlas(int width, int height, bool manualMipmaps = false, All filteringMode = All.Linear)
         {
@@ -95,7 +95,7 @@ namespace osu.Framework.Graphics.Textures
 
         internal Texture Add(int width, int height)
         {
-            lock (locker)
+            lock (textureRetrievalLock)
             {
                 if (atlasTexture == null)
                     Reset();

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -30,6 +30,7 @@ namespace osu.Framework.Graphics.Textures
 
         private readonly bool manualMipmaps;
         private readonly All filteringMode;
+        private readonly object locker = new object();
 
         public TextureAtlas(int width, int height, bool manualMipmaps = false, All filteringMode = All.Linear)
         {
@@ -94,7 +95,7 @@ namespace osu.Framework.Graphics.Textures
 
         internal Texture Add(int width, int height)
         {
-            lock (this)
+            lock (locker)
             {
                 if (atlasTexture == null)
                     Reset();

--- a/osu.Framework/Input/Handlers/InputHandler.cs
+++ b/osu.Framework/Input/Handlers/InputHandler.cs
@@ -19,12 +19,14 @@ namespace osu.Framework.Input.Handlers
 
         protected ConcurrentQueue<InputState> PendingStates = new ConcurrentQueue<InputState>();
 
+        private readonly object locker = new object();
+
         /// <summary>
         /// Retrieve a list of all pending states since the last call to this method.
         /// </summary>
         public virtual List<InputState> GetPendingStates()
         {
-            lock (this)
+            lock (locker)
             {
                 List<InputState> pending = new List<InputState>();
 

--- a/osu.Framework/Input/Handlers/InputHandler.cs
+++ b/osu.Framework/Input/Handlers/InputHandler.cs
@@ -19,14 +19,14 @@ namespace osu.Framework.Input.Handlers
 
         protected ConcurrentQueue<InputState> PendingStates = new ConcurrentQueue<InputState>();
 
-        private readonly object locker = new object();
+        private readonly object pendingStatesRetrievalLock = new object();
 
         /// <summary>
         /// Retrieve a list of all pending states since the last call to this method.
         /// </summary>
         public virtual List<InputState> GetPendingStates()
         {
-            lock (locker)
+            lock (pendingStatesRetrievalLock)
             {
                 List<InputState> pending = new List<InputState>();
 


### PR DESCRIPTION
Locking on 'this' is unsafe when the class is not private: an object can be locked on in any part of the program after creating its instance.