### PR TITLE
Make DrawableMenuItems IStateful

### DIFF
--- a/SampleGame/SampleGame.csproj
+++ b/SampleGame/SampleGame.csproj
@@ -83,7 +83,7 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="OpenTK, Version=3.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
-      <HintPath>..\osu.Framework\bin\Debug\OpenTK.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\ppy.OpenTK.3.0\lib\net45\OpenTK.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/SampleGame/SampleGame.csproj
+++ b/SampleGame/SampleGame.csproj
@@ -83,7 +83,7 @@
   <ItemGroup>
     <Reference Include="mscorlib" />
     <Reference Include="OpenTK, Version=3.0.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\ppy.OpenTK.3.0\lib\net45\OpenTK.dll</HintPath>
+      <HintPath>..\osu.Framework\bin\Debug\OpenTK.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/osu.Framework.Desktop.Tests/Visual/TestCaseNestedMenus.cs
+++ b/osu.Framework.Desktop.Tests/Visual/TestCaseNestedMenus.cs
@@ -374,6 +374,36 @@ namespace osu.Framework.Desktop.Tests.Visual
                 });
             }
         }
+
+        [Test]
+        public void TestSelectedState()
+        {
+            AddStep("Click item", () => clickItem(0, 2));
+            AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
+
+            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[1]));
+            AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
+            AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
+            AddAssert("Check selected index", () => menus.GetSubStructure(1).GetSelectedIndex() == 1);
+
+            IReadOnlyList<Drawable> items = null;
+            AddStep("Get items", () => items = menus.GetSubStructure(2).GetMenuItems().ToList());
+
+            AddStep("Change selection", () => menus.GetSubStructure(1).SetSelectedState(0, MenuItemState.Selected));
+            AddAssert("Check selected index", () => menus.GetSubStructure(1).GetSelectedIndex() == 0);
+            AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
+            AddAssert("Check different items", () => !menus.GetSubStructure(2).GetMenuItems().SequenceEqual(items));
+
+            AddStep("Get items", () => items = menus.GetSubStructure(2).GetMenuItems().ToList());
+
+            AddStep("Change selection", () => menus.GetSubStructure(1).SetSelectedState(2, MenuItemState.Selected));
+            AddAssert("Check selected index", () => menus.GetSubStructure(1).GetSelectedIndex() == 2);
+            AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
+            AddAssert("Check different items", () => !menus.GetSubStructure(2).GetMenuItems().SequenceEqual(items));
+
+            AddStep("Close menus", () => menus.GetSubMenu(0).Close());
+            AddAssert("Check selected index", () => menus.GetSubStructure(1).GetSelectedIndex() == -1);
+        }
         #endregion
 
         private void clickItem(int menuIndex, int itemIndex)

--- a/osu.Framework.Desktop.Tests/Visual/TestCaseNestedMenus.cs
+++ b/osu.Framework.Desktop.Tests/Visual/TestCaseNestedMenus.cs
@@ -225,7 +225,7 @@ namespace osu.Framework.Desktop.Tests.Visual
             AddStep("Click item", () => clickItem(0, 2));
             AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[0]));
             AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
-            AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
+            AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
 
             IReadOnlyList<MenuItem> currentItems = null;
             AddStep("Hover item", () =>
@@ -234,8 +234,8 @@ namespace osu.Framework.Desktop.Tests.Visual
                 inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[1]);
             });
 
-            AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
-            AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
+            AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
+            AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
 
             AddAssert("Check new items", () => !menus.GetSubMenu(2).Items.SequenceEqual(currentItems));
             AddAssert("Check closed", () =>
@@ -488,7 +488,7 @@ namespace osu.Framework.Desktop.Tests.Visual
             public void SetSelectedState(int index, MenuItemState state)
             {
                 var item = GetMenuItems()[index];
-                item.GetType().GetProperty("State").SetValue(item, state);
+                item.GetType().GetProperty("State")?.SetValue(item, state);
             }
 
             /// <summary>

--- a/osu.Framework.Desktop.Tests/Visual/TestCaseNestedMenus.cs
+++ b/osu.Framework.Desktop.Tests/Visual/TestCaseNestedMenus.cs
@@ -106,8 +106,8 @@ namespace osu.Framework.Desktop.Tests.Visual
         public void TestHoverState()
         {
             AddAssert("Check submenu closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetMenuItem(0)));
-            AddAssert("Check item hovered", () => menus.GetMenuItem(0).IsHovered);
+            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetMenuItems()[0]));
+            AddAssert("Check item hovered", () => menus.GetMenuItems()[0].IsHovered);
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace osu.Framework.Desktop.Tests.Visual
         [Test]
         public void TestRequireClickToOpen()
         {
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItem(0)));
+            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItems()[0]));
             AddAssert("Check closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
             AddAssert("Check closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
             AddStep("Click item", () => inputManager.Click(MouseButton.Left));
@@ -166,10 +166,10 @@ namespace osu.Framework.Desktop.Tests.Visual
         public void TestHoverOpen()
         {
             AddStep("Click item", () => clickItem(0, 1));
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItem(0)));
+            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[0]));
             AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
             AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(2).GetMenuItem(0)));
+            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(2).GetMenuItems()[0]));
             AddAssert("Check closed", () => menus.GetSubMenu(3)?.State != MenuState.Open);
             AddAssert("Check open", () => menus.GetSubMenu(3).State == MenuState.Open);
         }
@@ -193,7 +193,7 @@ namespace osu.Framework.Desktop.Tests.Visual
             });
 
             AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItem(1)));
+            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItems()[1]));
             AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
 
             AddAssert("Check new items", () => !menus.GetSubMenu(1).Items.SequenceEqual(currentItems));
@@ -223,7 +223,7 @@ namespace osu.Framework.Desktop.Tests.Visual
         public void TestDelayedHoverChange()
         {
             AddStep("Click item", () => clickItem(0, 2));
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItem(0)));
+            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[0]));
             AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
             AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
 
@@ -231,7 +231,7 @@ namespace osu.Framework.Desktop.Tests.Visual
             AddStep("Hover item", () =>
             {
                 currentItems = menus.GetSubMenu(2).Items;
-                inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItem(1));
+                inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[1]);
             });
 
             AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
@@ -270,7 +270,7 @@ namespace osu.Framework.Desktop.Tests.Visual
             for (int i = 3; i >= 1; i--)
             {
                 int menuIndex = i;
-                AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItem(0)));
+                AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItems()[0]));
                 AddAssert("Check submenu open", () => menus.GetSubMenu(menuIndex + 1).State == MenuState.Open);
                 AddStep("Click item", () => inputManager.Click(MouseButton.Left));
                 AddAssert("Check all open", () =>
@@ -357,7 +357,7 @@ namespace osu.Framework.Desktop.Tests.Visual
                 }
 
                 if (hoverPrevious && i > 0)
-                    AddStep("Hover previous", () => inputManager.MoveMouseTo(menus.GetSubStructure(i2 - 1).GetMenuItem(i2 > 1 ? 0 : 1)));
+                    AddStep("Hover previous", () => inputManager.MoveMouseTo(menus.GetSubStructure(i2 - 1).GetMenuItems()[i2 > 1 ? 0 : 1]));
 
                 AddStep("Remove hover", () => inputManager.MoveMouseTo(Vector2.Zero));
                 AddStep("Click outside", () => inputManager.Click(MouseButton.Left));
@@ -378,7 +378,7 @@ namespace osu.Framework.Desktop.Tests.Visual
 
         private void clickItem(int menuIndex, int itemIndex)
         {
-            inputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItem(itemIndex));
+            inputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItems()[itemIndex]);
             inputManager.Click(MouseButton.Left);
         }
 
@@ -440,6 +440,9 @@ namespace osu.Framework.Desktop.Tests.Visual
             public override int Priority => 0;
         }
 
+        /// <summary>
+        /// Helper class used to retrieve various internal properties/items from a <see cref="Menu"/>.
+        /// </summary>
         private class MenuStructure
         {
             private readonly Menu menu;
@@ -449,17 +452,49 @@ namespace osu.Framework.Desktop.Tests.Visual
                 this.menu = menu;
             }
 
-            public Drawable GetMenuItem(int index)
+            /// <summary>
+            /// Retrieves the <see cref="Menu.DrawableMenuItem"/>s of the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.
+            /// </summary>
+            public IReadOnlyList<Drawable> GetMenuItems()
             {
                 var contents = (CompositeDrawable)menu.InternalChildren[0];
                 var contentContainer = (CompositeDrawable)contents.InternalChildren[1];
-                var itemsContainer = (CompositeDrawable)((CompositeDrawable)contentContainer.InternalChildren[0]).InternalChildren[0];
-
-                return itemsContainer.InternalChildren[index];
+                return ((CompositeDrawable)((CompositeDrawable)contentContainer.InternalChildren[0]).InternalChildren[0]).InternalChildren;
             }
 
-            public MenuStructure GetSubStructure(int index) => new MenuStructure(GetSubMenu(index));
+            /// <summary>
+            /// Finds the <see cref="Menu.DrawableMenuItem"/> index in the <see cref="Menu"/> represented by this <see cref="MenuStructure"/> that
+            /// has <see cref="Menu.DrawableMenuItem.State"/> set to <see cref="MenuItemState.Selected"/>.
+            /// </summary>
+            public int GetSelectedIndex()
+            {
+                var items = GetMenuItems();
 
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var state = (MenuItemState)(items[i]?.GetType().GetProperty("State")?.GetValue(items[i]) ?? MenuItemState.NotSelected);
+                    if (state == MenuItemState.Selected)
+                        return i;
+                }
+
+                return -1;
+            }
+
+            /// <summary>
+            /// Sets the <see cref="Menu.DrawableMenuItem"/> <see cref="Menu.DrawableMenuItem.State"/> at the specified index to a specified state.
+            /// </summary>
+            /// <param name="index">The index of the <see cref="Menu.DrawableMenuItem"/> to set the state of.</param>
+            /// <param name="state">The state to be set.</param>
+            public void SetSelectedState(int index, MenuItemState state)
+            {
+                var item = GetMenuItems()[index];
+                item.GetType().GetProperty("State").SetValue(item, state);
+            }
+
+            /// <summary>
+            /// Retrieves the sub-<see cref="Menu"/> at an index-offset from the current <see cref="Menu"/>.
+            /// </summary>
+            /// <param name="index">The sub-<see cref="Menu"/> index. An index of 0 is the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.</param>
             public Menu GetSubMenu(int index)
             {
                 var currentMenu = menu;
@@ -474,6 +509,12 @@ namespace osu.Framework.Desktop.Tests.Visual
 
                 return currentMenu;
             }
+
+            /// <summary>
+            /// Generates a new <see cref="MenuStructure"/> for the a sub-<see cref="Menu"/>.
+            /// </summary>
+            /// <param name="index">The sub-<see cref="Menu"/> index to generate the <see cref="MenuStructure"/> for. An index of 0 is the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.</param>
+            public MenuStructure GetSubStructure(int index) => new MenuStructure(GetSubMenu(index));
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -407,6 +407,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Direction == Direction.Horizontal ? Height : item.Y);
 
             currentlySelected = item;
+
             if (item.Item.Items.Count > 0)
                 subMenu.Open();
             else
@@ -418,6 +419,9 @@ namespace osu.Framework.Graphics.UserInterface
             switch (state)
             {
                 case MenuItemState.Selected:
+                    if (currentlySelected != item)
+                        currentlySelected.State = MenuItemState.NotSelected;
+
                     openSubmenuFor(item);
                     break;
             }

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -662,6 +662,8 @@ namespace osu.Framework.Graphics.UserInterface
 
                     UpdateForegroundColour();
                     UpdateBackgroundColour();
+
+                    StateChanged?.Invoke();
                 }
             }
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -761,7 +761,7 @@ namespace osu.Framework.Graphics.UserInterface
 
     public enum MenuItemState
     {
-        Selected,
-        NotSelected
+        NotSelected,
+        Selected
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -222,9 +222,6 @@ namespace osu.Framework.Graphics.UserInterface
                     return;
                 state = value;
 
-                if (!IsLoaded)
-                    return;
-
                 updateState();
                 StateChanged?.Invoke(State);
             }
@@ -232,6 +229,9 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void updateState()
         {
+            if (!IsLoaded)
+                return;
+
             subMenu?.Close();
 
             switch (State)

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -238,23 +238,11 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 case MenuState.Closed:
                     AnimateClose();
-
-                    if (HasFocus)
-                        GetContainingInputManager().ChangeFocus(null);
-
                     break;
                 case MenuState.Open:
                     AnimateOpen();
 
-                    if (AlwaysOpen)
-                        break;
-
-                    //schedule required as we may not be present currently.
-                    Schedule(() =>
-                    {
-                        if (State == MenuState.Open)
-                            GetContainingInputManager().ChangeFocus(this);
-                    });
+                    GetContainingInputManager().TriggerFocusContention();
                     break;
             }
 
@@ -419,7 +407,10 @@ namespace osu.Framework.Graphics.UserInterface
                 Direction == Direction.Horizontal ? Height : item.Y);
 
             currentlySelected = item;
-            subMenu.Open();
+            if (item.Item.Items.Count > 0)
+                subMenu.Open();
+            else
+                subMenu.Close();
         }
 
         private void itemStateChanged(DrawableMenuItem item, MenuItemState state)
@@ -466,6 +457,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
+        public override bool RequestsFocus => State == MenuState.Open;
         public override bool AcceptsFocus => true;
         protected override bool OnClick(InputState state) => true;
         protected override bool OnHover(InputState state) => true;

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -226,6 +226,7 @@ namespace osu.Framework.Graphics.UserInterface
                     return;
 
                 updateState();
+                StateChanged?.Invoke(State);
             }
         }
 
@@ -258,7 +259,6 @@ namespace osu.Framework.Graphics.UserInterface
             }
 
             sizeCache.Invalidate();
-            StateChanged?.Invoke(State);
         }
 
         /// <summary>
@@ -296,7 +296,7 @@ namespace osu.Framework.Graphics.UserInterface
         public void Clear()
         {
             ItemsContainer.Clear();
-            sizeCache.Invalidate();
+            updateState();
         }
 
         /// <summary>
@@ -412,8 +412,6 @@ namespace osu.Framework.Graphics.UserInterface
                 subMenu.parentMenu = this;
                 subMenu.StateChanged += subMenuStateChanged;
             }
-            else
-                subMenu.Close();
 
             subMenu.Items = item.Item.Items;
             subMenu.Position = new Vector2(
@@ -663,7 +661,7 @@ namespace osu.Framework.Graphics.UserInterface
                     UpdateForegroundColour();
                     UpdateBackgroundColour();
 
-                    StateChanged?.Invoke();
+                    StateChanged?.Invoke(state);
                 }
             }
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -516,7 +516,7 @@ namespace osu.Framework.Graphics.UserInterface
             /// <summary>
             /// The background of this <see cref="DrawableMenuItem"/>.
             /// </summary>
-            protected readonly Box Background;
+            protected readonly Drawable Background;
 
             /// <summary>
             /// The foreground of this <see cref="DrawableMenuItem"/>. This contains the content of this <see cref="DrawableMenuItem"/>.
@@ -527,9 +527,9 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 Item = item;
 
-                InternalChildren = new Drawable[]
+                InternalChildren = new[]
                 {
-                    Background = new Box { RelativeSizeAxes = Axes.Both },
+                    Background = CreateBackground(),
                     Foreground = new Container { Child = Content = CreateContent() },
                 };
 
@@ -683,6 +683,11 @@ namespace osu.Framework.Graphics.UserInterface
 
                 return true;
             }
+
+            /// <summary>
+            /// Creates the background of this <see cref="DrawableMenuItem"/>.
+            /// </summary>
+            protected virtual Drawable CreateBackground() => new Box { RelativeSizeAxes = Axes.Both };
 
             /// <summary>
             /// Creates the content which will be displayed in this <see cref="DrawableMenuItem"/>.

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -19,6 +19,9 @@ namespace osu.Framework.Graphics.UserInterface
 {
     public class Menu : CompositeDrawable, IStateful<MenuState>
     {
+        /// <summary>
+        /// Invoked when this <see cref="Menu"/>'s <see cref="State"/> changes.
+        /// </summary>
         public event Action<MenuState> StateChanged;
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -496,12 +496,12 @@ namespace osu.Framework.Graphics.UserInterface
             /// Invoked when this <see cref="DrawableMenuItem"/> is clicked. This occurs regardless of whether or not <see cref="MenuItem.Action"/> was
             /// invoked or not, or whether <see cref="Item"/> contains any sub-<see cref="MenuItem"/>s.
             /// </summary>
-            public Action<DrawableMenuItem> Clicked;
+            internal Action<DrawableMenuItem> Clicked;
 
             /// <summary>
             /// Invoked when this <see cref="DrawableMenuItem"/> is hovered. This runs one update frame behind the actual hover event.
             /// </summary>
-            public Action<DrawableMenuItem> Hovered;
+            internal Action<DrawableMenuItem> Hovered;
 
             /// <summary>
             /// The <see cref="MenuItem"/> which this <see cref="DrawableMenuItem"/> represents.


### PR DESCRIPTION
`DrawableMenuItem`s now expose a `State`. Changes to this property from within a derived `DrawableMenuItem` will propagate these changes to the menu containing the `DrawableMenuItem`.

Furthermore, the `DrawableMenuItem`'s `State` is updated appropriately when the `State` of the menu containing it changes.

Test case TBD, in next PR, because I'm not implementing it without https://github.com/ppy/osu-framework/pull/1019 .