### PR TITLE
Ignore negative mouse coordinates when polling

### DIFF
--- a/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
+++ b/osu.Framework.Desktop/Input/Handlers/Mouse/OpenTKMouseHandler.cs
@@ -77,6 +77,11 @@ namespace osu.Framework.Desktop.Input.Handlers.Mouse
             if (!mouseInWindow)
                 return;
 
+            if (e.Mouse.X < 0 || e.Mouse.Y < 0)
+                // todo: investigate further why we are getting negative values from OpenTK events
+                // on windows when crossing centre screen boundaries (width/2 or height/2).
+                return;
+
             handleState(new OpenTKEventMouseState(e.Mouse, host.IsActive, null));
         }
 


### PR DESCRIPTION
This fixes a bug where OpenTK is returning negative data when the mouse crosses a screen center (width or height div 2) on Windows 10 under certain circumstances.

Whenever my mouse passes over `screen_width.x/2` or `screen_width.y/2` in a negative direction (towards zero) the mouse coordinate in that direction will become negative of what it should be for one single event. Reproducible in Parallels 13, but I've heard from other users not using a VM that can reproduce the same issue.