### PR TITLE
Do not process input when window isn't focused.

### DIFF
--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -19,6 +19,10 @@ namespace osu.Framework.Threading
             StatisticsCounterType.KeyEvents,
         };
 
-        public void RunUpdate() => ProcessFrame();
+        public void RunUpdate()
+        {
+            if (!IsActive) return; // do not process input if not active
+            ProcessFrame();
+        }
     }
 }


### PR DESCRIPTION
This hack fixes ppy/osu#1282, but it should be done in OpenTK #578.