### PR TITLE
Allow GetUsablePathFor to create directories when they don't exist

### DIFF
--- a/osu.Framework/Platform/DesktopStorage.cs
+++ b/osu.Framework/Platform/DesktopStorage.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Platform
 
         public override Stream GetStream(string path, FileAccess access = FileAccess.Read, FileMode mode = FileMode.OpenOrCreate)
         {
-            path = GetUsablePathFor(path);
+            path = GetUsablePathFor(path, access != FileAccess.Read);
 
             if (string.IsNullOrEmpty(path))
                 throw new ArgumentNullException(nameof(path));
@@ -59,24 +59,21 @@ namespace osu.Framework.Platform
             switch (access)
             {
                 case FileAccess.Read:
-                    if (!File.Exists(path))
-                        return null;
+                    if (!File.Exists(path)) return null;
                     return File.Open(path, FileMode.Open, access, FileShare.Read);
                 default:
-                    Directory.CreateDirectory(Path.GetDirectoryName(path));
                     return File.Open(path, mode, access);
             }
         }
 
         public override SQLiteConnection GetDatabase(string name)
         {
-            Directory.CreateDirectory(BasePath);
             ISQLitePlatform platform;
             if (RuntimeInfo.IsWindows)
                 platform = new SQLitePlatformWin32(Architecture.NativeIncludePath);
             else
                 platform = new SQLitePlatformGeneric();
-            return new SQLiteConnection(platform, GetUsablePathFor($@"{name}.db"));
+            return new SQLiteConnection(platform, GetUsablePathFor($@"{name}.db", true));
         }
 
         public override void DeleteDatabase(string name) => Delete($@"{name}.db");

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -38,8 +38,14 @@ namespace osu.Framework.Platform
         /// Get a Storage-usable path for the provided path.
         /// </summary>
         /// <param name="path">An incomplete path, usually provided as user input.</param>
+        /// <param name="createIfNotExisting">Create the path if it doesn't already exist.</param>
         /// <returns></returns>
-        protected string GetUsablePathFor(string path) => Path.Combine(BasePath, BaseName, SubDirectory, path);
+        protected string GetUsablePathFor(string path, bool createIfNotExisting = false)
+        {
+            var resolvedPath = Path.Combine(BasePath, BaseName, SubDirectory, path);
+            if (createIfNotExisting) Directory.CreateDirectory(Path.GetDirectoryName(resolvedPath));
+            return resolvedPath;
+        }
 
         /// <summary>
         /// Check whether a file exists at the specified path.


### PR DESCRIPTION
Fixes database initialisation potentially not having a containing folder ready for it.