### PR TITLE
Fix weird auto/relative sizing in Menu

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,7 @@
         },
         "type": "mono",
         "request": "launch",
-        "program": "${workspaceRoot}/osu.Framework.VisualTestBrowser/bin/Debug/osu.Framework.VisualTests.exe",
+        "program": "${workspaceRoot}/osu.Framework.Tests/bin/Debug/osu.Framework.Tests.exe",
         "cwd": "${workspaceRoot}",
         "preLaunchTask": "Build (Debug)",
         "runtimeExecutable": null,

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -232,10 +232,17 @@ namespace osu.Framework.Graphics.UserInterface
             /// </summary>
             public bool AnyPresent => Children.Any(c => c.IsPresent);
 
+            protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new DrawableDropdownMenuItem(item);
+
             #region DrawableDropdownMenuItem
             // must be public due to mono bug(?) https://github.com/ppy/osu/issues/1204
             public class DrawableDropdownMenuItem : DrawableMenuItem
             {
+                public DrawableDropdownMenuItem(MenuItem item)
+                    : base(item)
+                {
+                }
+
                 private bool selected;
                 public bool IsSelected
                 {
@@ -273,11 +280,6 @@ namespace osu.Framework.Graphics.UserInterface
                         foregroundColourSelected = value;
                         UpdateForegroundColour();
                     }
-                }
-
-                public DrawableDropdownMenuItem(MenuItem item)
-                    : base(item)
-                {
                 }
 
                 protected virtual void OnSelectChange()

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -252,11 +252,11 @@ namespace osu.Framework.Graphics.UserInterface
         public virtual void Add(MenuItem item)
         {
             var drawableItem = CreateDrawableMenuItem(item);
-            drawableItem.AutoSizeAxes = ItemsContainer.AutoSizeAxes;
-            drawableItem.RelativeSizeAxes = ItemsContainer.RelativeSizeAxes;
             drawableItem.Clicked = menuItemClicked;
             drawableItem.Hovered = menuItemHovered;
             drawableItem.StateChanged += s => itemStateChanged(drawableItem, s);
+
+            drawableItem.SetFlowDirection(Direction);
 
             ItemsContainer.Add(drawableItem);
         }
@@ -580,7 +580,11 @@ namespace osu.Framework.Graphics.UserInterface
                 InternalChildren = new[]
                 {
                     Background = CreateBackground(),
-                    Foreground = new Container { Child = Content = CreateContent() },
+                    Foreground = new Container
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Child = Content = CreateContent()
+                    },
                 };
 
                 var textContent = Content as IHasText;
@@ -589,6 +593,17 @@ namespace osu.Framework.Graphics.UserInterface
                     textContent.Text = item.Text;
                     Item.Text.ValueChanged += newText => textContent.Text = newText;
                 }
+            }
+
+            /// <summary>
+            /// Sets various properties of this <see cref="DrawableMenuItem"/> that depend on the direction in which
+            /// <see cref="DrawableMenuItem"/>s flow inside the containing <see cref="Menu"/> (e.g. sizing axes).
+            /// </summary>
+            /// <param name="direction">The direction in which <see cref="DrawableMenuItem"/>s will be flowed.</param>
+            public virtual void SetFlowDirection(Direction direction)
+            {
+                RelativeSizeAxes = direction == Direction.Horizontal ? Axes.Y : Axes.X;
+                AutoSizeAxes = direction == Direction.Horizontal ? Axes.X : Axes.Y;
             }
 
             private Color4 backgroundColour = Color4.DarkSlateGray;
@@ -644,26 +659,6 @@ namespace osu.Framework.Graphics.UserInterface
                 {
                     foregroundColourHover = value;
                     UpdateForegroundColour();
-                }
-            }
-
-            public override Axes RelativeSizeAxes
-            {
-                get { return base.RelativeSizeAxes; }
-                set
-                {
-                    base.RelativeSizeAxes = value;
-                    Foreground.RelativeSizeAxes = value;
-                }
-            }
-
-            public new Axes AutoSizeAxes
-            {
-                get { return base.AutoSizeAxes; }
-                set
-                {
-                    base.AutoSizeAxes = value;
-                    Foreground.AutoSizeAxes = value;
                 }
             }
 


### PR DESCRIPTION
This was ugly and couldn't be overridden easily when this sizing functionality is not desired (e.g. EditorMenuBar).

Also fixes:
* Framework Dropdowns not using their DropdownMenuItems.
* VSCode launch config.

(Both of these are minor changes ¯\_(ツ)_/¯