### PR TITLE
Fix up FlowContainer conditional not properly accounting for fit fill…

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseFillModes.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillModes.cs
@@ -157,5 +157,53 @@ namespace osu.Framework.Tests.Visual
 
             protected override bool OnDragStart(InputState state) => true;
         }
+
+        #region Test Cases
+
+        private const float container_width = 60;
+        private Box fitBox;
+
+        /// <summary>
+        /// Tests that using <see cref="FillMode.Fit"/> inside a <see cref="FlowContainer{T}"/> that is autosizing in one axis doesn't result in autosize feedback loops.
+        /// Various sizes of the box are tested to ensure that non-one sizes also don't lead to feedback loops.
+        /// </summary>
+        /// <param name="value">The relative size of the box that is fitting.</param>
+        [TestCase(0.5f)]
+        [TestCase(1f)]
+        [TestCase(1.5f)]
+        public void TestFitInsideFlow(float value)
+        {
+            Clear();
+            Add(new FillFlowContainer
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Y,
+                Width = container_width,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    fitBox = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        FillMode = FillMode.Fit
+                    },
+                    // A box which forces the minimum dimension of the autosize flow container to be the horizontal dimension
+                    new Box { Size = new Vector2(container_width, container_width * 2) }
+                }
+            });
+
+            AddStep("Set size", () => fitBox.Size = new Vector2(value));
+
+            var expectedSize = new Vector2(container_width * value, container_width * value);
+
+            AddAssert("Check size before invalidate (1/2)", () => fitBox.DrawSize == expectedSize);
+            AddAssert("Check size before invalidate (2/2)", () => fitBox.DrawSize == expectedSize);
+            AddStep("Invalidate", () => fitBox.Invalidate());
+            AddAssert("Check size after invalidate (1/2)", () => fitBox.DrawSize == expectedSize);
+            AddAssert("Check size after invalidate (2/2)", () => fitBox.DrawSize == expectedSize);
+        }
+
+        #endregion
     }
 }

--- a/osu.Framework.Tests/Visual/TestCaseFillModes.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillModes.cs
@@ -165,16 +165,16 @@ namespace osu.Framework.Tests.Visual
 
         /// <summary>
         /// Tests that using <see cref="FillMode.Fit"/> inside a <see cref="FlowContainer{T}"/> that is autosizing in one axis doesn't result in autosize feedback loops.
-        /// Various sizes of the box are tested to ensure that non-one sizes also don't lead to feedback loops.
+        /// Various sizes of the box are tested to ensure that non-one sizes also don't lead to erroneous sizes.
         /// </summary>
         /// <param name="value">The relative size of the box that is fitting.</param>
+        [TestCase(0f)]
         [TestCase(0.5f)]
         [TestCase(1f)]
-        [TestCase(1.5f)]
         public void TestFitInsideFlow(float value)
         {
-            Clear();
-            Add(new FillFlowContainer
+            ClearInternal();
+            AddInternal(new FillFlowContainer
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Graphics.Containers
                 // in the vertical direction. Now, we can add relatively sized children with FillMode.Fit to make sure their
                 // aspect ratio is preserved while still allowing them to flow vertically. This special case can not result
                 // in an autosize-related feedback loop, and we can thus simply allow it.
-                if ((d.RelativeSizeAxes & AutoSizeAxes) != 0 && (d.FillMode != FillMode.Fit || d.RelativeSizeAxes != Axes.Both || d.Size.X >= RelativeChildSize.X || d.Size.Y >= RelativeChildSize.Y || AutoSizeAxes == Axes.Both))
+                if ((d.RelativeSizeAxes & AutoSizeAxes) != 0 && (d.FillMode != FillMode.Fit || d.RelativeSizeAxes != Axes.Both || d.Size.X > RelativeChildSize.X || d.Size.Y > RelativeChildSize.Y || AutoSizeAxes == Axes.Both))
                     throw new InvalidOperationException(
                         "Drawables inside a flow container may not have a relative size axis that the flow container is auto sizing for." +
                         $"The flow container is set to autosize in {AutoSizeAxes} axes and the child is set to relative size in {d.RelativeSizeAxes} axes.");


### PR DESCRIPTION
Fixes Drawings crashing because this is being used in the case of `GroupTeam` which is auto-sized in the y-axis but the flag is fillmode-fit inside it.