### PR TITLE
Limit the rate at which seeks are performed at bass' end

### DIFF
--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -198,7 +198,7 @@ namespace osu.Framework.Audio.Track
 
             action = () =>
             {
-                // we only want to run the most fresh seek event, else we may fall behind (seeks can be realtively expensive).
+                // we only want to run the most fresh seek event, else we may fall behind (seeks can be relatively expensive).
                 if (action != seekAction) return;
 
                 double clamped = MathHelper.Clamp(seek, 0, Length);


### PR DESCRIPTION
Previously seeks triggered by a drag operation could lag behind.