### PR TITLE
Fix occasional blackscreens on startup

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -262,25 +262,26 @@ namespace osu.Framework.Platform
             if (Root == null)
                 return;
 
-            using (drawMonitor.BeginCollecting(PerformanceCollectionType.GLReset))
-            {
-                GLWrapper.Reset(Root.DrawSize);
-                GLWrapper.ClearColour(Color4.Black);
-            }
-
             while (!exitInitiated)
             {
                 using (var buffer = DrawRoots.Get(UsageType.Read))
                 {
-                    if (buffer?.Object != null && buffer.FrameId != lastDrawFrameId)
+                    if (buffer?.Object == null || buffer.FrameId == lastDrawFrameId)
                     {
-                        buffer.Object.Draw(null);
-                        lastDrawFrameId = buffer.FrameId;
-                        break;
+                        Thread.Sleep(1);
+                        continue;
                     }
-                }
 
-                Thread.Sleep(1);
+                    using (drawMonitor.BeginCollecting(PerformanceCollectionType.GLReset))
+                    {
+                        GLWrapper.Reset(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height));
+                        GLWrapper.ClearColour(Color4.Black);
+                    }
+
+                    buffer.Object.Draw(null);
+                    lastDrawFrameId = buffer.FrameId;
+                    break;
+                }
             }
 
             GLWrapper.FlushCurrentBatch();


### PR DESCRIPTION
I've tested this over 2000 startups and haven't been able to replicate the blackscreen bug once.

Does two things:
1. Moves GLWrapper calls to just before the draw nodes are drawn.
2. Changes the GLWrapper.Reset call to not reference DrawSize.

I believe #2 is what actually provides the fix, but #1 also makes sense otherwise the screen could be cleared too early if updates are running behind draws.