### PR TITLE
Allow children to be loaded in containers which are still in a Loading state

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -372,7 +372,7 @@ namespace osu.Framework.Graphics.Containers
             Debug.Assert(internalChildren.Contains(child), "Can only check and react to the life of our own children.");
 
             // Can not have alive children if we are not loaded.
-            if (LoadState < LoadState.Ready)
+            if (LoadState < LoadState.Loading)
                 return false;
 
             bool changed = false;


### PR DESCRIPTION
Conside the case where a Container has an autosize content with a drawable inside it. The drawable won't be considered for autosize until after the first UpdateSubTree without this change, as UpdateChildrenLife's (when called in load()) checkChildLife will return early.

Therefore, querying DrawSize in LoadComplete() will fail without this change, where it is expected to work.