### PR TITLE
Ensure base invalidation happens before DrawSize is consumed

### DIFF
--- a/osu.Framework/Graphics/Containers/CircularContainer.cs
+++ b/osu.Framework/Graphics/Containers/CircularContainer.cs
@@ -12,10 +12,12 @@ namespace osu.Framework.Graphics.Containers
     {
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
+            bool result = base.Invalidate(invalidation, source, shallPropagate);
+
             if ((invalidation & Invalidation.DrawSize) > 0)
                 CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) / 2f;
 
-            return base.Invalidate(invalidation, source, shallPropagate);
+            return result;
         }
     }
 }


### PR DESCRIPTION
Previously a stale value of DrawSize may have been used, causing unexpected results.