### PR TITLE
Draw size preserving fill container

### DIFF
--- a/osu.Framework.Tests/VisualTestGame.cs
+++ b/osu.Framework.Tests/VisualTestGame.cs
@@ -15,10 +15,13 @@ namespace osu.Framework.Tests
         [BackgroundDependencyLoader]
         private void load()
         {
-            Children = new Drawable[]
+            Child = new DrawSizePreservingFillContainer
             {
-                new TestBrowser(),
-                new CursorContainer(),
+                Children = new Drawable[]
+                {
+                    new TestBrowser(),
+                    new CursorContainer(),
+                },
             };
         }
 

--- a/osu.Framework.Tests/VisualTestGame.cs
+++ b/osu.Framework.Tests/VisualTestGame.cs
@@ -10,7 +10,7 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.Tests
 {
-    internal class VisualTestGame : Game
+    internal class VisualTestGame : TestGame
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Framework.Tests/VisualTestGame.cs
+++ b/osu.Framework.Tests/VisualTestGame.cs
@@ -4,12 +4,13 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 
 namespace osu.Framework.Tests
 {
-    internal class VisualTestGame : TestGame
+    internal class VisualTestGame : Game
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
+++ b/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
@@ -1,0 +1,91 @@
+// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using OpenTK;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// A <see cref="Container"/> filling its parent while preserving a given target
+    /// <see cref="Drawable.DrawSize"/> according to a <see cref="DrawSizePreservationStrategy"/>.
+    /// This is useful, for example, to automatically scale the user interface according to
+    /// the window resolution, or to provide automatic HiDPI display support.
+    /// </summary>
+    public class DrawSizePreservingFillContainer : Container
+    {
+        /// <summary>
+        /// The target <see cref="DrawSize"/> to be enforced according to <see cref="Strategy"/>.
+        /// </summary>
+        public Vector2 TargetDrawSize = new Vector2(1024, 768);
+
+        /// <summary>
+        /// The strategy to be used for enforcing <see cref="TargetDrawSize"/>. The default strategy
+        /// is Minimum, which preserves the aspect ratio of all children while ensuring one of the
+        /// two axes matches <see cref="TargetDrawSize"/> while the other is always larger.
+        /// </summary>
+        public DrawSizePreservationStrategy Strategy;
+
+        public DrawSizePreservingFillContainer()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            Vector2 drawSizeRatio = Vector2.Divide(Parent.DrawSize, TargetDrawSize);
+
+            switch (Strategy)
+            {
+                case DrawSizePreservationStrategy.Minimum:
+                    Scale = new Vector2(Math.Min(drawSizeRatio.X, drawSizeRatio.Y));
+                    break;
+
+                case DrawSizePreservationStrategy.Maximum:
+                    Scale = new Vector2(Math.Min(drawSizeRatio.X, drawSizeRatio.Y));
+                    break;
+
+                case DrawSizePreservationStrategy.Average:
+                    Scale = new Vector2(0.5f * (drawSizeRatio.X + drawSizeRatio.Y));
+                    break;
+
+                case DrawSizePreservationStrategy.Separate:
+                    Scale = drawSizeRatio;
+                    break;
+            }
+
+
+            Size = Vector2.Divide(Vector2.One, Scale);
+        }
+    }
+
+    /// <summary>
+    /// Strategies used by <see cref="DrawSizePreservingFillContainer"/> to enforce its
+    /// <see cref="DrawSizePreservingFillContainer.TargetDrawSize"/>.
+    /// </summary>
+    public enum DrawSizePreservationStrategy
+    {
+        /// <summary>
+        /// Preserves the aspect ratio of all children while ensuring one of the
+        /// two axes matches <see cref="TargetDrawSize"/> while the other is always larger.
+        /// </summary>
+        Minimum,
+        /// <summary>
+        /// Preserves the aspect ratio of all children while ensuring one of the
+        /// two axes matches <see cref="TargetDrawSize"/> while the other is always smaller.
+        /// </summary>
+        Maximum,
+        /// <summary>
+        /// Preserves the aspect ratio of all children while one axis is always larger and
+        /// the other always smaller than <see cref="TargetDrawSize"/>, achieving a good compromise.
+        /// </summary>
+        Average,
+        /// <summary>
+        /// Ensures <see cref="TargetDrawSize"/> is perfectly matched, while aspect ratio of children
+        /// is disregarded.
+        /// </summary>
+        Separate,
+    }
+}

--- a/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
+++ b/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
@@ -86,7 +86,7 @@ namespace osu.Framework.Graphics.Containers
         Average,
         /// <summary>
         /// Ensures <see cref="DrawSizePreservingFillContainer.TargetDrawSize"/> is perfectly
-        /// matched, while aspect ratio of children is disregarded.
+        /// matched while aspect ratio of children is disregarded.
         /// </summary>
         Separate,
     }

--- a/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
+++ b/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.Containers
     public class DrawSizePreservingFillContainer : Container
     {
         /// <summary>
-        /// The target <see cref="DrawSize"/> to be enforced according to <see cref="Strategy"/>.
+        /// The target <see cref="Drawable.DrawSize"/> to be enforced according to <see cref="Strategy"/>.
         /// </summary>
         public Vector2 TargetDrawSize = new Vector2(1024, 768);
 
@@ -68,22 +68,25 @@ namespace osu.Framework.Graphics.Containers
     {
         /// <summary>
         /// Preserves the aspect ratio of all children while ensuring one of the
-        /// two axes matches <see cref="TargetDrawSize"/> while the other is always larger.
+        /// two axes matches <see cref="DrawSizePreservingFillContainer.TargetDrawSize"/>
+        /// while the other is always larger.
         /// </summary>
         Minimum,
         /// <summary>
         /// Preserves the aspect ratio of all children while ensuring one of the
-        /// two axes matches <see cref="TargetDrawSize"/> while the other is always smaller.
+        /// two axes matches <see cref="DrawSizePreservingFillContainer.TargetDrawSize"/>
+        /// while the other is always smaller.
         /// </summary>
         Maximum,
         /// <summary>
         /// Preserves the aspect ratio of all children while one axis is always larger and
-        /// the other always smaller than <see cref="TargetDrawSize"/>, achieving a good compromise.
+        /// the other always smaller than <see cref="DrawSizePreservingFillContainer.TargetDrawSize"/>,
+        /// achieving a good compromise.
         /// </summary>
         Average,
         /// <summary>
-        /// Ensures <see cref="TargetDrawSize"/> is perfectly matched, while aspect ratio of children
-        /// is disregarded.
+        /// Ensures <see cref="DrawSizePreservingFillContainer.TargetDrawSize"/> is perfectly
+        /// matched, while aspect ratio of children is disregarded.
         /// </summary>
         Separate,
     }

--- a/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
+++ b/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Containers
                     break;
 
                 case DrawSizePreservationStrategy.Maximum:
-                    Scale = new Vector2(Math.Min(drawSizeRatio.X, drawSizeRatio.Y));
+                    Scale = new Vector2(Math.Max(drawSizeRatio.X, drawSizeRatio.Y));
                     break;
 
                 case DrawSizePreservationStrategy.Average:
@@ -55,7 +55,6 @@ namespace osu.Framework.Graphics.Containers
                     Scale = drawSizeRatio;
                     break;
             }
-
 
             Size = Vector2.Divide(Vector2.One, Scale);
         }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -217,6 +217,7 @@
     <Compile Include="Graphics\Containers\OverlayContainer.cs" />
     <Compile Include="Graphics\Containers\ScrollContainer.cs" />
     <Compile Include="Graphics\Containers\CompositeDrawNode.cs" />
+    <Compile Include="Graphics\Containers\DrawSizePreservingFillContainer.cs" />
     <Compile Include="Graphics\Cursor\CursorContainer.cs" />
     <Compile Include="Graphics\IDrawable.cs" />
     <Compile Include="Graphics\Lines\Path.cs" />


### PR DESCRIPTION
Introduces `DrawSizePreservingFillContainer` as a generalization of `RatioAdjust` from https://github.com/ppy/osu . Once this is merged in, https://github.com/ppy/osu/pull/1359 removes `RatioAdjust` and replaces it with this.

Further, this PR uses `DrawSizePreservingFillContainer` within `VisualTestGame` to make the tests usable on HiDPI screens. 