### PR TITLE
Allow waveform to handle null data

### DIFF
--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -27,11 +27,13 @@ namespace osu.Framework.Audio.Track
         private readonly Task readTask;
 
         /// <summary>
-        /// Constructs a new <see cref="Waveform"/>.
+        /// Constructs a new <see cref="Waveform"/> from provided audio data.
         /// </summary>
-        /// <param name="data">The sample data stream.</param>
-        public Waveform(Stream data)
+        /// <param name="data">The sample data stream. If null, an empty waveform is constructed.</param>
+        public Waveform(Stream data = null)
         {
+            if (data == null) return;
+
             readTask = Task.Run(() =>
             {
                 var procs = new DataStreamFileProcedures(data);
@@ -71,13 +73,6 @@ namespace osu.Framework.Audio.Track
 
                 channels = info.Channels;
             }, cancelSource.Token);
-        }
-
-        /// <summary>
-        /// Constructs an empty <see cref="Waveform"/>.
-        /// </summary>
-        public Waveform()
-        {
         }
 
         /// <summary>


### PR DESCRIPTION
Removes the empty parameter ctor and exposes an optional default.