### PR TITLE
Don't dispose underlying Waveform in WaveformGraph

### DIFF
--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -68,7 +68,6 @@ namespace osu.Framework.Graphics.Audio
                 if (waveform == value)
                     return;
 
-                waveform?.Dispose();
                 waveform = value;
 
                 cancelGeneration();
@@ -137,9 +136,7 @@ namespace osu.Framework.Graphics.Audio
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
-
             cancelGeneration();
-            Waveform?.Dispose();
         }
 
         private class WaveformDrawNodeSharedData


### PR DESCRIPTION
In some cases, Waveforms are shared between multiple WaveformGraphs. This logic was causing the waveform data to be disposed while references were still held.