### PR TITLE
Revert loading children while the parent is in a loading state

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -372,7 +372,7 @@ namespace osu.Framework.Graphics.Containers
             Debug.Assert(internalChildren.Contains(child), "Can only check and react to the life of our own children.");
 
             // Can not have alive children if we are not loaded.
-            if (LoadState < LoadState.Loading)
+            if (LoadState < LoadState.Ready)
                 return false;
 
             bool changed = false;


### PR DESCRIPTION
This reverts commit 3717de89726ad643b321627da911f55394a74d34.

Let's not do this like this. Causes lots of problems game-wide.