### PR TITLE
Improved macOS target

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -192,6 +192,8 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IPC/@EntryIndexedValue">IPC</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LTRB/@EntryIndexedValue">LTRB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MD/@EntryIndexedValue">MD5</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NS/@EntryIndexedValue">NS</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=OS/@EntryIndexedValue">OS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RNG/@EntryIndexedValue">RNG</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SHA/@EntryIndexedValue">SHA</s:String>
   <s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=RGB/@EntryIndexedValue">RGB</s:String>

--- a/osu.Framework/Host.cs
+++ b/osu.Framework/Host.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Platform;
 using osu.Framework.Platform.Linux;
+using osu.Framework.Platform.MacOS;
 using osu.Framework.Platform.Windows;
 
 namespace osu.Framework
@@ -11,6 +12,9 @@ namespace osu.Framework
     {
         public static DesktopGameHost GetSuitableHost(string gameName, bool bindIPC = false)
         {
+            if (RuntimeInfo.IsMacOsx)
+                return new MacOSGameHost(gameName, bindIPC);
+            
             if (RuntimeInfo.IsUnix)
                 return new LinuxGameHost(gameName, bindIPC);
 

--- a/osu.Framework/Host.cs
+++ b/osu.Framework/Host.cs
@@ -14,7 +14,7 @@ namespace osu.Framework
         {
             if (RuntimeInfo.IsMacOsx)
                 return new MacOSGameHost(gameName, bindIPC);
-            
+
             if (RuntimeInfo.IsUnix)
                 return new LinuxGameHost(gameName, bindIPC);
 

--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -32,6 +32,9 @@ namespace osu.Framework.Input
                     || state.IsKeyDown(OpenTK.Input.Key.LWin)
                     || state.IsKeyDown(OpenTK.Input.Key.RWin))
                     return;
+                // arbitrary choice here, but it caters for any non-printable keys on an A1243 Apple Keyboard
+                if (e.KeyChar > 63000)
+                    return;
             }
             pending += e.KeyChar;
         }

--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -22,14 +22,17 @@ namespace osu.Framework.Input
             // Drop any keypresses if the control, alt, or windows/command key are being held.
             // This is a workaround for an issue on macOS where OpenTK will fire KeyPress events even
             // if modifier keys are held.  This can be reverted when it is fixed on OpenTK's side.
-            var state = OpenTK.Input.Keyboard.GetState();
-            if (state.IsKeyDown(OpenTK.Input.Key.LControl)
-                || state.IsKeyDown(OpenTK.Input.Key.RControl)
-                || state.IsKeyDown(OpenTK.Input.Key.LAlt)
-                || state.IsKeyDown(OpenTK.Input.Key.RAlt)
-                || state.IsKeyDown(OpenTK.Input.Key.LWin)
-                || state.IsKeyDown(OpenTK.Input.Key.RWin))
-                return;
+            if (RuntimeInfo.IsMacOsx)
+            {
+                var state = OpenTK.Input.Keyboard.GetState();
+                if (state.IsKeyDown(OpenTK.Input.Key.LControl)
+                    || state.IsKeyDown(OpenTK.Input.Key.RControl)
+                    || state.IsKeyDown(OpenTK.Input.Key.LAlt)
+                    || state.IsKeyDown(OpenTK.Input.Key.RAlt)
+                    || state.IsKeyDown(OpenTK.Input.Key.LWin)
+                    || state.IsKeyDown(OpenTK.Input.Key.RWin))
+                    return;
+            }
             pending += e.KeyChar;
         }
 

--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -19,6 +19,17 @@ namespace osu.Framework.Input
 
         private void window_KeyPress(object sender, OpenTK.KeyPressEventArgs e)
         {
+            // Drop any keypresses if the control, alt, or windows/command key are being held.
+            // This is a workaround for an issue on macOS where OpenTK will fire KeyPress events even
+            // if modifier keys are held.  This can be reverted when it is fixed on OpenTK's side.
+            var state = OpenTK.Input.Keyboard.GetState();
+            if (state.IsKeyDown(OpenTK.Input.Key.LControl)
+                || state.IsKeyDown(OpenTK.Input.Key.RControl)
+                || state.IsKeyDown(OpenTK.Input.Key.LAlt)
+                || state.IsKeyDown(OpenTK.Input.Key.RAlt)
+                || state.IsKeyDown(OpenTK.Input.Key.LWin)
+                || state.IsKeyDown(OpenTK.Input.Key.RWin))
+                return;
             pending += e.KeyChar;
         }
 

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -21,20 +21,6 @@ namespace osu.Framework.Platform
         private readonly TcpIpcProvider ipcProvider;
         private readonly Task ipcTask;
 
-        public override Storage Storage
-        {
-            get
-            {
-                return base.Storage;
-            }
-
-            protected set
-            {
-                base.Storage = value;
-                Logger.Storage = value.GetStorageForDirectory("logs");
-            }
-        }
-
         protected DesktopGameHost(string gameName = @"", bool bindIPCPort = false)
             : base(gameName)
         {
@@ -61,6 +47,8 @@ namespace osu.Framework.Platform
                     ipcTask = Task.Factory.StartNew(ipcProvider.StartAsync, TaskCreationOptions.LongRunning);
                 }
             }
+
+            Logger.Storage = Storage.GetStorageForDirectory("logs");
         }
 
         /// <summary>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Platform
 
         protected abstract Storage GetStorage(string baseName);
 
-        public virtual Storage Storage { get; protected set; }
+        public Storage Storage { get; protected set; }
 
         /// <summary>
         /// If capslock is enabled on the system, false if not overwritten by a subclass

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -78,6 +78,8 @@ namespace osu.Framework.Platform
 
         public virtual Clipboard GetClipboard() => null;
 
+        public virtual Storage GetStorage(string baseName) => null;
+
         public virtual Storage Storage { get; protected set; }
 
         /// <summary>
@@ -150,6 +152,8 @@ namespace osu.Framework.Platform
             AppDomain.CurrentDomain.UnhandledException += exceptionHandler;
 
             Dependencies.Cache(this);
+            Dependencies.Cache(Storage = GetStorage(gameName));
+
             Name = gameName;
             Logger.GameIdentifier = gameName;
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Platform
 
         public virtual Clipboard GetClipboard() => null;
 
-        public virtual Storage GetStorage(string baseName) => null;
+        protected abstract Storage GetStorage(string baseName);
 
         public virtual Storage Storage { get; protected set; }
 

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -16,13 +16,14 @@ namespace osu.Framework.Platform
 
         protected override IFrameBasedClock SceneGraphClock => customClock ?? base.SceneGraphClock;
 
+        protected override Storage GetStorage(string baseName) => new DesktopStorage($"headless-{baseName}");
+
         public HeadlessGameHost(string gameName = @"", bool bindIPC = false, bool realtime = true)
             : base(gameName, bindIPC)
         {
             if (!realtime) customClock = new FramedClock(new FastClock(1000.0 / 30));
 
             UpdateThread.Scheduler.Update();
-            Dependencies.Cache(Storage = new DesktopStorage($"headless-{gameName}"));
         }
 
         protected override void UpdateInitialize()

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -19,9 +19,6 @@ namespace osu.Framework.Platform.Linux
             Dependencies.Cache(Storage = new LinuxStorage(gameName));
         }
 
-        public override Clipboard GetClipboard()
-        {
-            return new LinuxClipboard();
-        }
+        public override Clipboard GetClipboard() => new LinuxClipboard();
     }
 }

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -16,8 +16,9 @@ namespace osu.Framework.Platform.Linux
                 else
                     OnDeactivated();
             };
-            Dependencies.Cache(Storage = new LinuxStorage(gameName));
         }
+
+        public override Storage GetStorage(string baseName) => new LinuxStorage(baseName);
 
         public override Clipboard GetClipboard() => new LinuxClipboard();
     }

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Platform.Linux
             };
         }
 
-        public override Storage GetStorage(string baseName) => new LinuxStorage(baseName);
+        protected override Storage GetStorage(string baseName) => new LinuxStorage(baseName);
 
         public override Clipboard GetClipboard() => new LinuxClipboard();
     }

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -8,14 +8,14 @@ namespace osu.Framework.Platform.MacOS
 {
     public class MacOSClipboard : Clipboard
     {
-        internal NSPasteboard generalPasteboard = NSPasteboard.GeneralPasteboard();
+        internal NSPasteboard GeneralPasteboard = NSPasteboard.GeneralPasteboard();
 
         public override string GetText()
         {
             NSArray classArray = NSArray.ArrayWithObject(Class.Get("NSString"));
-            if (generalPasteboard.CanReadObjectForClasses(classArray, null))
+            if (GeneralPasteboard.CanReadObjectForClasses(classArray, null))
             {
-                var result = generalPasteboard.ReadObjectsForClasses(classArray, null);
+                var result = GeneralPasteboard.ReadObjectsForClasses(classArray, null);
                 var objects = result?.ToArray() ?? new IntPtr[0];
                 if (objects.Length > 0 && objects[0] != IntPtr.Zero)
                     return Cocoa.FromNSString(objects[0]);
@@ -25,8 +25,8 @@ namespace osu.Framework.Platform.MacOS
 
         public override void SetText(string selectedText)
         {
-            generalPasteboard.ClearContents();
-            generalPasteboard.WriteObjects(NSArray.ArrayWithObject(Cocoa.ToNSString(selectedText)));
+            GeneralPasteboard.ClearContents();
+            GeneralPasteboard.WriteObjects(NSArray.ArrayWithObject(Cocoa.ToNSString(selectedText)));
         }
     }
 }

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Platform.MacOS
                 if (objects.Length > 0 && objects[0] != IntPtr.Zero)
                     return Cocoa.FromNSString(objects[0]);
             }
-            return "";
+            return string.Empty;
         }
 
         public override void SetText(string selectedText)

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Windows.Forms;
+
+namespace osu.Framework.Platform.MacOS
+{
+    public class MacOSClipboard : Clipboard
+    {
+        public override string GetText()
+        {
+            return System.Windows.Forms.Clipboard.GetText(TextDataFormat.UnicodeText);
+        }
+
+        public override void SetText(string selectedText)
+        {
+            //Clipboard.SetText(selectedText);
+
+            //This works within osu but will hang any application you try to paste to afterwards until osu is closed.
+            //Likely requires the use of X libraries directly to fix
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Platform.MacOS
+{
+    public class MacOSGameHost : DesktopGameHost
+    {
+        internal MacOSGameHost(string gameName, bool bindIPC = false)
+            : base(gameName, bindIPC)
+        {
+            Window = new DesktopGameWindow();
+            Window.WindowStateChanged += (sender, e) =>
+            {
+                if (Window.WindowState != OpenTK.WindowState.Minimized)
+                    OnActivated();
+                else
+                    OnDeactivated();
+            };
+            Dependencies.Cache(Storage = new MacOSStorage(gameName));
+        }
+
+        public override Clipboard GetClipboard()
+        {
+            return new MacOSClipboard();
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Platform.MacOS
         internal MacOSGameHost(string gameName, bool bindIPC = false)
             : base(gameName, bindIPC)
         {
-            Window = new DesktopGameWindow();
+            Window = new MacOSGameWindow();
             Window.WindowStateChanged += (sender, e) =>
             {
                 if (Window.WindowState != OpenTK.WindowState.Minimized)
@@ -19,9 +19,6 @@ namespace osu.Framework.Platform.MacOS
             Dependencies.Cache(Storage = new MacOSStorage(gameName));
         }
 
-        public override Clipboard GetClipboard()
-        {
-            return new MacOSClipboard();
-        }
+        public override Clipboard GetClipboard() => new MacOSClipboard();
     }
 }

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -16,8 +16,9 @@ namespace osu.Framework.Platform.MacOS
                 else
                     OnDeactivated();
             };
-            Dependencies.Cache(Storage = new MacOSStorage(gameName));
         }
+
+        public override Storage GetStorage(string baseName) => new MacOSStorage(baseName);
 
         public override Clipboard GetClipboard() => new MacOSClipboard();
     }

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Platform.MacOS
             };
         }
 
-        public override Storage GetStorage(string baseName) => new MacOSStorage(baseName);
+        protected override Storage GetStorage(string baseName) => new MacOSStorage(baseName);
 
         public override Clipboard GetClipboard() => new MacOSClipboard();
     }

--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -14,27 +14,27 @@ namespace osu.Framework.Platform.MacOS
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate void FlagsChangedDelegate(IntPtr self, IntPtr cmd, IntPtr notification);
 
-        private FlagsChangedDelegate FlagsChangedHandler;
+        private FlagsChangedDelegate flagsChangedHandler;
 
-        private IntPtr selModifierFlags = Selector.Get("modifierFlags");
-        private IntPtr selKeyCode = Selector.Get("keyCode");
+        private readonly IntPtr selModifierFlags = Selector.Get("modifierFlags");
+        private readonly IntPtr selKeyCode = Selector.Get("keyCode");
         private MethodInfo methodKeyDown;
         private MethodInfo methodKeyUp;
 
-        private int modifierFlagLeftControl = 1 << 0;
-        private int modifierFlagLeftShift = 1 << 1;
-        private int modifierFlagRightShift = 1 << 2;
-        private int modifierFlagLeftCommand = 1 << 3;
-        private int modifierFlagRightCommand = 1 << 4;
-        private int modifierFlagLeftAlt = 1 << 5;
-        private int modifierFlagRightAlt = 1 << 6;
-        private int modifierFlagRightControl = 1 << 13;
+        private const int modifier_flag_left_control = 1 << 0;
+        private const int modifier_flag_left_shift = 1 << 1;
+        private const int modifier_flag_right_shift = 1 << 2;
+        private const int modifier_flag_left_command = 1 << 3;
+        private const int modifier_flag_right_command = 1 << 4;
+        private const int modifier_flag_left_alt = 1 << 5;
+        private const int modifier_flag_right_alt = 1 << 6;
+        private const int modifier_flag_right_control = 1 << 13;
 
         private object nativeWindow;
 
         protected override void OnLoad(EventArgs e)
         {
-            FlagsChangedHandler = flagsChanged;
+            flagsChangedHandler = flagsChanged;
 
             var fieldImplementation = typeof(OpenTK.NativeWindow).GetRuntimeFields().Single(x => x.Name == "implementation");
             var typeCocoaNativeWindow = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "CocoaNativeWindow");
@@ -43,7 +43,7 @@ namespace osu.Framework.Platform.MacOS
             nativeWindow = fieldImplementation.GetValue(this);
             var windowClass = (IntPtr)fieldWindowClass.GetValue(nativeWindow);
 
-            Class.RegisterMethod(windowClass, FlagsChangedHandler, "flagsChanged:", "v@:@");
+            Class.RegisterMethod(windowClass, flagsChangedHandler, "flagsChanged:", "v@:@");
 
             methodKeyDown = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyDown");
             methodKeyUp = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyUp");
@@ -56,49 +56,49 @@ namespace osu.Framework.Platform.MacOS
             var modifierFlags = Cocoa.SendInt(sender, selModifierFlags);
             var keyCode = Cocoa.SendInt(sender, selKeyCode);
 
-            bool keyDown = false;
+            bool keyDown;
             OpenTK.Input.Key key;
 
             switch ((MacOSKeyCodes)keyCode)
             {
                 case MacOSKeyCodes.LShift:
                     key = OpenTK.Input.Key.LShift;
-                    keyDown = (modifierFlags & modifierFlagLeftShift) > 0;
+                    keyDown = (modifierFlags & modifier_flag_left_shift) > 0;
                     break;
 
                 case MacOSKeyCodes.RShift:
                     key = OpenTK.Input.Key.RShift;
-                    keyDown = (modifierFlags & modifierFlagRightShift) > 0;
+                    keyDown = (modifierFlags & modifier_flag_right_shift) > 0;
                     break;
 
                 case MacOSKeyCodes.LControl:
                     key = OpenTK.Input.Key.LControl;
-                    keyDown = (modifierFlags & modifierFlagLeftControl) > 0;
+                    keyDown = (modifierFlags & modifier_flag_left_control) > 0;
                     break;
 
                 case MacOSKeyCodes.RControl:
                     key = OpenTK.Input.Key.RControl;
-                    keyDown = (modifierFlags & modifierFlagRightControl) > 0;
+                    keyDown = (modifierFlags & modifier_flag_right_control) > 0;
                     break;
 
                 case MacOSKeyCodes.LAlt:
                     key = OpenTK.Input.Key.LAlt;
-                    keyDown = (modifierFlags & modifierFlagLeftAlt) > 0;
+                    keyDown = (modifierFlags & modifier_flag_left_alt) > 0;
                     break;
 
                 case MacOSKeyCodes.RAlt:
                     key = OpenTK.Input.Key.RAlt;
-                    keyDown = (modifierFlags & modifierFlagRightAlt) > 0;
+                    keyDown = (modifierFlags & modifier_flag_right_alt) > 0;
                     break;
 
                 case MacOSKeyCodes.LCommand:
                     key = OpenTK.Input.Key.LWin;
-                    keyDown = (modifierFlags & modifierFlagLeftCommand) > 0;
+                    keyDown = (modifierFlags & modifier_flag_left_command) > 0;
                     break;
 
                 case MacOSKeyCodes.RCommand:
                     key = OpenTK.Input.Key.RWin;
-                    keyDown = (modifierFlags & modifierFlagRightCommand) > 0;
+                    keyDown = (modifierFlags & modifier_flag_right_command) > 0;
                     break;
 
                 default:

--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Platform.MacOS
                     key = OpenTK.Input.Key.RControl;
                     keyDown = (modifierFlags & modifierFlagRightControl) > 0;
                     break;
-                
+
                 case MacOSKeyCodes.LAlt:
                     key = OpenTK.Input.Key.LAlt;
                     keyDown = (modifierFlags & modifierFlagLeftAlt) > 0;

--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Reflection;
+using osu.Framework.Platform.MacOS.Native;
+
+namespace osu.Framework.Platform.MacOS
+{
+    internal class MacOSGameWindow : DesktopGameWindow
+    {
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private delegate void FlagsChangedDelegate(IntPtr self, IntPtr cmd, IntPtr notification);
+
+        private FlagsChangedDelegate FlagsChangedHandler;
+
+        private IntPtr selModifierFlags = Selector.Get("modifierFlags");
+        private IntPtr selKeyCode = Selector.Get("keyCode");
+        private MethodInfo methodKeyDown;
+        private MethodInfo methodKeyUp;
+
+        private int modifierFlagLeftControl = 1 << 0;
+        private int modifierFlagLeftShift = 1 << 1;
+        private int modifierFlagRightShift = 1 << 2;
+        private int modifierFlagLeftCommand = 1 << 3;
+        private int modifierFlagRightCommand = 1 << 4;
+        private int modifierFlagLeftAlt = 1 << 5;
+        private int modifierFlagRightAlt = 1 << 6;
+        private int modifierFlagRightControl = 1 << 13;
+
+        private object nativeWindow;
+
+        protected override void OnLoad(EventArgs e)
+        {
+            FlagsChangedHandler = flagsChanged;
+
+            var fieldImplementation = typeof(OpenTK.NativeWindow).GetRuntimeFields().Single(x => x.Name == "implementation");
+            var typeCocoaNativeWindow = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "CocoaNativeWindow");
+            var fieldWindowClass = typeCocoaNativeWindow.GetRuntimeFields().Single(x => x.Name == "windowClass");
+
+            nativeWindow = fieldImplementation.GetValue(this);
+            var windowClass = (IntPtr)fieldWindowClass.GetValue(nativeWindow);
+
+            Class.RegisterMethod(windowClass, FlagsChangedHandler, "flagsChanged:", "v@:@");
+
+            methodKeyDown = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyDown");
+            methodKeyUp = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyUp");
+
+            base.OnLoad(e);
+        }
+
+        private void flagsChanged(IntPtr self, IntPtr cmd, IntPtr sender)
+        {
+            var modifierFlags = Cocoa.SendInt(sender, selModifierFlags);
+            var keyCode = Cocoa.SendInt(sender, selKeyCode);
+
+            bool keyDown = false;
+            OpenTK.Input.Key key;
+
+            switch ((MacOSKeyCodes)keyCode)
+            {
+                case MacOSKeyCodes.LShift:
+                    key = OpenTK.Input.Key.LShift;
+                    keyDown = (modifierFlags & modifierFlagLeftShift) > 0;
+                    break;
+
+                case MacOSKeyCodes.RShift:
+                    key = OpenTK.Input.Key.RShift;
+                    keyDown = (modifierFlags & modifierFlagRightShift) > 0;
+                    break;
+
+                case MacOSKeyCodes.LControl:
+                    key = OpenTK.Input.Key.LControl;
+                    keyDown = (modifierFlags & modifierFlagLeftControl) > 0;
+                    break;
+
+                case MacOSKeyCodes.RControl:
+                    key = OpenTK.Input.Key.RControl;
+                    keyDown = (modifierFlags & modifierFlagRightControl) > 0;
+                    break;
+                
+                case MacOSKeyCodes.LAlt:
+                    key = OpenTK.Input.Key.LAlt;
+                    keyDown = (modifierFlags & modifierFlagLeftAlt) > 0;
+                    break;
+
+                case MacOSKeyCodes.RAlt:
+                    key = OpenTK.Input.Key.RAlt;
+                    keyDown = (modifierFlags & modifierFlagRightAlt) > 0;
+                    break;
+
+                case MacOSKeyCodes.LCommand:
+                    key = OpenTK.Input.Key.LWin;
+                    keyDown = (modifierFlags & modifierFlagLeftCommand) > 0;
+                    break;
+
+                case MacOSKeyCodes.RCommand:
+                    key = OpenTK.Input.Key.RWin;
+                    keyDown = (modifierFlags & modifierFlagRightCommand) > 0;
+                    break;
+
+                default:
+                    return;
+            }
+
+            if (keyDown)
+                methodKeyDown.Invoke(nativeWindow, new object[] { key, false });
+            else
+                methodKeyUp.Invoke(nativeWindow, new object[] { key });
+        }
+    }
+
+    internal enum MacOSKeyCodes
+    {
+        LShift = 56,
+        RShift = 60,
+        LControl = 59,
+        RControl = 62,
+        LAlt = 58,
+        RAlt = 61,
+        LCommand = 55,
+        RCommand = 54,
+        CapsLock = 57,
+        Function = 63
+    }
+}

--- a/osu.Framework/Platform/MacOS/MacOSStorage.cs
+++ b/osu.Framework/Platform/MacOS/MacOSStorage.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.IO;
+
+namespace osu.Framework.Platform.MacOS
+{
+    public class MacOSStorage : DesktopStorage
+    {
+        public MacOSStorage(string baseName)
+            : base(baseName)
+        {
+        }
+
+        protected override string LocateBasePath()
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            string xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
+            string[] paths =
+            {
+                xdg ?? Path.Combine(home, ".local", "share"),
+                Path.Combine(home)
+            };
+
+            foreach (string path in paths)
+            {
+                if (Directory.Exists(path))
+                    return path;
+            }
+
+            return paths[0];
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/Class.cs
+++ b/osu.Framework/Platform/MacOS/Native/Class.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    internal static class Class
+    {
+        static Type typeClass;
+        static MethodInfo methodClassGet;
+        static MethodInfo methodRegisterMethod;
+
+        static Class()
+        {
+            typeClass = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Class");
+            methodClassGet = typeClass.GetMethod("Get");
+            methodRegisterMethod = typeClass.GetMethod("RegisterMethod");
+        }
+
+        public static IntPtr Get(string name)
+        {
+            return (IntPtr)methodClassGet.Invoke(null, new object[] { name });
+        }
+
+        public static void RegisterMethod(IntPtr handle, Delegate d, string selector, string typeString)
+        {
+            methodRegisterMethod.Invoke(null, new object[] { handle, d, selector, typeString });
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/Class.cs
+++ b/osu.Framework/Platform/MacOS/Native/Class.cs
@@ -9,25 +9,18 @@ namespace osu.Framework.Platform.MacOS.Native
 {
     internal static class Class
     {
-        static Type typeClass;
-        static MethodInfo methodClassGet;
-        static MethodInfo methodRegisterMethod;
-
-        static Class()
-        {
-            typeClass = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Class");
-            methodClassGet = typeClass.GetMethod("Get");
-            methodRegisterMethod = typeClass.GetMethod("RegisterMethod");
-        }
+        private static readonly Type type_class = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Class");
+        private static readonly MethodInfo method_class_get = type_class.GetMethod("Get");
+        private static readonly MethodInfo method_register_method = type_class.GetMethod("RegisterMethod");
 
         public static IntPtr Get(string name)
         {
-            return (IntPtr)methodClassGet.Invoke(null, new object[] { name });
+            return (IntPtr)method_class_get.Invoke(null, new object[] { name });
         }
 
         public static void RegisterMethod(IntPtr handle, Delegate d, string selector, string typeString)
         {
-            methodRegisterMethod.Invoke(null, new object[] { handle, d, selector, typeString });
+            method_register_method.Invoke(null, new object[] { handle, d, selector, typeString });
         }
     }
 }

--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -10,79 +10,74 @@ namespace osu.Framework.Platform.MacOS.Native
 {
     internal static class Cocoa
     {
-        internal const string LibObjC = "/usr/lib/libobjc.dylib";
+        internal const string LIB_OBJ_C = "/usr/lib/libobjc.dylib";
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, int arg);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, int arg);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr ptr1);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr ptr1);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static int SendInt(IntPtr receiver, IntPtr selector);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern int SendInt(IntPtr receiver, IntPtr selector);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static int SendInt(IntPtr receiver, IntPtr selector, IntPtr ptr1);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern int SendInt(IntPtr receiver, IntPtr selector, IntPtr ptr1);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static int SendInt(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern int SendInt(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static bool SendBool(IntPtr receiver, IntPtr selector);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern bool SendBool(IntPtr receiver, IntPtr selector);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static bool SendBool(IntPtr receiver, IntPtr selector, IntPtr ptr1);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern bool SendBool(IntPtr receiver, IntPtr selector, IntPtr ptr1);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static bool SendBool(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern bool SendBool(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static void SendVoid(IntPtr receiver, IntPtr selector);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern void SendVoid(IntPtr receiver, IntPtr selector);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static void SendVoid(IntPtr receiver, IntPtr selector, IntPtr ptr1);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern void SendVoid(IntPtr receiver, IntPtr selector, IntPtr ptr1);
 
-        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
-        public extern static void SendVoid(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern void SendVoid(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
 
-        private static Type typeCocoa;
-        private static MethodInfo methodCocoaFromNSString;
-        private static MethodInfo methodCocoaToNSString;
-        private static MethodInfo methodCocoaGetStringConstant;
+        private static readonly Type type_cocoa = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Cocoa");
+        private static readonly MethodInfo method_cocoa_from_ns_string = type_cocoa.GetMethod("FromNSString");
+        private static readonly MethodInfo method_cocoa_to_ns_string = type_cocoa.GetMethod("ToNSString");
+        private static readonly MethodInfo method_cocoa_get_string_constant = type_cocoa.GetMethod("GetStringConstant");
 
         public static IntPtr AppKitLibrary;
         public static IntPtr FoundationLibrary;
 
         static Cocoa()
         {
-            typeCocoa = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Cocoa");
-            methodCocoaFromNSString = typeCocoa.GetMethod("FromNSString");
-            methodCocoaToNSString = typeCocoa.GetMethod("ToNSString");
-            methodCocoaGetStringConstant = typeCocoa.GetMethod("GetStringConstant");
-
-            AppKitLibrary = (IntPtr)typeCocoa.GetField("AppKitLibrary").GetValue(null);
-            FoundationLibrary = (IntPtr)typeCocoa.GetField("FoundationLibrary").GetValue(null);
+            AppKitLibrary = (IntPtr)type_cocoa.GetField("AppKitLibrary").GetValue(null);
+            FoundationLibrary = (IntPtr)type_cocoa.GetField("FoundationLibrary").GetValue(null);
         }
 
         public static string FromNSString(IntPtr handle)
         {
-            return (string)methodCocoaFromNSString.Invoke(null, new object[] { handle });
+            return (string)method_cocoa_from_ns_string.Invoke(null, new object[] { handle });
         }
 
         public static IntPtr ToNSString(string str)
         {
-            return (IntPtr)methodCocoaToNSString.Invoke(null, new object[] { str });
+            return (IntPtr)method_cocoa_to_ns_string.Invoke(null, new object[] { str });
         }
 
         public static IntPtr GetStringConstant(IntPtr handle, string symbol)
         {
-            return (IntPtr)methodCocoaGetStringConstant.Invoke(null, new object[] { handle, symbol });
+            return (IntPtr)method_cocoa_get_string_constant.Invoke(null, new object[] { handle, symbol });
         }
     }
 }

--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    internal static class Cocoa
+    {
+        internal const string LibObjC = "/usr/lib/libobjc.dylib";
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, int arg);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr ptr1);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static int SendInt(IntPtr receiver, IntPtr selector);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static int SendInt(IntPtr receiver, IntPtr selector, IntPtr ptr1);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static int SendInt(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static bool SendBool(IntPtr receiver, IntPtr selector);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static bool SendBool(IntPtr receiver, IntPtr selector, IntPtr ptr1);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static bool SendBool(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static void SendVoid(IntPtr receiver, IntPtr selector);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static void SendVoid(IntPtr receiver, IntPtr selector, IntPtr ptr1);
+
+        [DllImport(LibObjC, EntryPoint = "objc_msgSend")]
+        public extern static void SendVoid(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
+
+        private static Type typeCocoa;
+        private static MethodInfo methodCocoaFromNSString;
+        private static MethodInfo methodCocoaToNSString;
+        private static MethodInfo methodCocoaGetStringConstant;
+
+        public static IntPtr AppKitLibrary;
+        public static IntPtr FoundationLibrary;
+
+        static Cocoa()
+        {
+            typeCocoa = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Cocoa");
+            methodCocoaFromNSString = typeCocoa.GetMethod("FromNSString");
+            methodCocoaToNSString = typeCocoa.GetMethod("ToNSString");
+            methodCocoaGetStringConstant = typeCocoa.GetMethod("GetStringConstant");
+
+            AppKitLibrary = (IntPtr)typeCocoa.GetField("AppKitLibrary").GetValue(null);
+            FoundationLibrary = (IntPtr)typeCocoa.GetField("FoundationLibrary").GetValue(null);
+        }
+
+        public static string FromNSString(IntPtr handle)
+        {
+            return (string)methodCocoaFromNSString.Invoke(null, new object[] { handle });
+        }
+
+        public static IntPtr ToNSString(string str)
+        {
+            return (IntPtr)methodCocoaToNSString.Invoke(null, new object[] { str });
+        }
+
+        public static IntPtr GetStringConstant(IntPtr handle, string symbol)
+        {
+            return (IntPtr)methodCocoaGetStringConstant.Invoke(null, new object[] { handle, symbol });
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/NSArray.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSArray.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    internal struct NSArray
+    {
+        internal IntPtr Handle { get; private set; }
+
+        private static IntPtr classPointer = Class.Get("NSArray");
+        private static IntPtr mutableClassPointer = Class.Get("NSMutableArray");
+        private static IntPtr selArrayWithObject = Selector.Get("arrayWithObject:");
+        private static IntPtr selArray = Selector.Get("array");
+        private static IntPtr selAddObject = Selector.Get("addObject:");
+        private static IntPtr selCount = Selector.Get("count");
+        private static IntPtr selObjectAtIndex = Selector.Get("objectAtIndex:");
+
+        internal NSArray(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        internal static NSArray ArrayWithObject(IntPtr obj) => new NSArray(Cocoa.SendIntPtr(classPointer, selArrayWithObject, obj));
+
+        internal static NSArray ArrayWithObjects(IntPtr[] objs)
+        {
+            var mutableArray = Cocoa.SendIntPtr(mutableClassPointer, selArray);
+            foreach (IntPtr obj in objs)
+                Cocoa.SendVoid(mutableArray, selAddObject, obj);
+            return new NSArray(mutableArray);
+        }
+
+        internal int Count() => Cocoa.SendInt(Handle, selCount);
+
+        internal IntPtr ObjectAtIndex(int index) => Cocoa.SendIntPtr(Handle, selObjectAtIndex, index);
+
+        internal IntPtr[] ToArray()
+        {
+            IntPtr[] result = new IntPtr[Count()];
+            for (int i = 0; i < result.Length; i++)
+                result[i] = ObjectAtIndex(i);
+            return result;
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/NSArray.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSArray.cs
@@ -9,32 +9,32 @@ namespace osu.Framework.Platform.MacOS.Native
     {
         internal IntPtr Handle { get; private set; }
 
-        private static IntPtr classPointer = Class.Get("NSArray");
-        private static IntPtr mutableClassPointer = Class.Get("NSMutableArray");
-        private static IntPtr selArrayWithObject = Selector.Get("arrayWithObject:");
-        private static IntPtr selArray = Selector.Get("array");
-        private static IntPtr selAddObject = Selector.Get("addObject:");
-        private static IntPtr selCount = Selector.Get("count");
-        private static IntPtr selObjectAtIndex = Selector.Get("objectAtIndex:");
+        private static readonly IntPtr class_pointer = Class.Get("NSArray");
+        private static readonly IntPtr mutable_class_pointer = Class.Get("NSMutableArray");
+        private static readonly IntPtr sel_array_with_object = Selector.Get("arrayWithObject:");
+        private static readonly IntPtr sel_array = Selector.Get("array");
+        private static readonly IntPtr sel_add_object = Selector.Get("addObject:");
+        private static readonly IntPtr sel_count = Selector.Get("count");
+        private static readonly IntPtr sel_object_at_index = Selector.Get("objectAtIndex:");
 
         internal NSArray(IntPtr handle)
         {
             Handle = handle;
         }
 
-        internal static NSArray ArrayWithObject(IntPtr obj) => new NSArray(Cocoa.SendIntPtr(classPointer, selArrayWithObject, obj));
+        internal static NSArray ArrayWithObject(IntPtr obj) => new NSArray(Cocoa.SendIntPtr(class_pointer, sel_array_with_object, obj));
 
         internal static NSArray ArrayWithObjects(IntPtr[] objs)
         {
-            var mutableArray = Cocoa.SendIntPtr(mutableClassPointer, selArray);
+            var mutableArray = Cocoa.SendIntPtr(mutable_class_pointer, sel_array);
             foreach (IntPtr obj in objs)
-                Cocoa.SendVoid(mutableArray, selAddObject, obj);
+                Cocoa.SendVoid(mutableArray, sel_add_object, obj);
             return new NSArray(mutableArray);
         }
 
-        internal int Count() => Cocoa.SendInt(Handle, selCount);
+        internal int Count() => Cocoa.SendInt(Handle, sel_count);
 
-        internal IntPtr ObjectAtIndex(int index) => Cocoa.SendIntPtr(Handle, selObjectAtIndex, index);
+        internal IntPtr ObjectAtIndex(int index) => Cocoa.SendIntPtr(Handle, sel_object_at_index, index);
 
         internal IntPtr[] ToArray()
         {

--- a/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    internal struct NSDictionary
+    {
+        internal IntPtr Handle { get; private set; }
+
+        private static IntPtr classPointer = Class.Get("NSDictionary");
+
+        internal NSDictionary(IntPtr handle)
+        {
+            Handle = handle;
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/NSPasteboard.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSPasteboard.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    internal struct NSPasteboard
+    {
+        internal IntPtr Handle { get; private set; }
+
+        private static IntPtr classPointer = Class.Get("NSPasteboard");
+        private static IntPtr selGeneralPasteboard = Selector.Get("generalPasteboard");
+        private static IntPtr selClearContents = Selector.Get("clearContents");
+        private static IntPtr selCanReadObjectForClasses = Selector.Get("canReadObjectForClasses:options:");
+        private static IntPtr selReadObjectsForClasses = Selector.Get("readObjectsForClasses:options:");
+        private static IntPtr selWriteObjects = Selector.Get("writeObjects:");
+
+        internal NSPasteboard(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        internal static NSPasteboard GeneralPasteboard() => new NSPasteboard(Cocoa.SendIntPtr(classPointer, selGeneralPasteboard));
+
+        internal int ClearContents() => Cocoa.SendInt(Handle, selClearContents);
+
+        internal bool CanReadObjectForClasses(NSArray classArray, NSDictionary? optionDict) => Cocoa.SendBool(Handle, selCanReadObjectForClasses, classArray.Handle, optionDict?.Handle ?? IntPtr.Zero);
+
+        internal NSArray? ReadObjectsForClasses(NSArray classArray, NSDictionary? optionDict)
+        {
+            var result = Cocoa.SendIntPtr(Handle, selReadObjectsForClasses, classArray.Handle, optionDict?.Handle ?? IntPtr.Zero);
+            return result == IntPtr.Zero ? (NSArray?)null : new NSArray(result);
+        }
+
+        internal bool WriteObjects(NSArray objects) => Cocoa.SendBool(Handle, selWriteObjects, objects.Handle);
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/NSPasteboard.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSPasteboard.cs
@@ -9,30 +9,30 @@ namespace osu.Framework.Platform.MacOS.Native
     {
         internal IntPtr Handle { get; private set; }
 
-        private static IntPtr classPointer = Class.Get("NSPasteboard");
-        private static IntPtr selGeneralPasteboard = Selector.Get("generalPasteboard");
-        private static IntPtr selClearContents = Selector.Get("clearContents");
-        private static IntPtr selCanReadObjectForClasses = Selector.Get("canReadObjectForClasses:options:");
-        private static IntPtr selReadObjectsForClasses = Selector.Get("readObjectsForClasses:options:");
-        private static IntPtr selWriteObjects = Selector.Get("writeObjects:");
+        private static readonly IntPtr class_pointer = Class.Get("NSPasteboard");
+        private static readonly IntPtr sel_general_pasteboard = Selector.Get("generalPasteboard");
+        private static readonly IntPtr sel_clear_contents = Selector.Get("clearContents");
+        private static readonly IntPtr sel_can_read_object_for_classes = Selector.Get("canReadObjectForClasses:options:");
+        private static readonly IntPtr sel_read_objects_for_classes = Selector.Get("readObjectsForClasses:options:");
+        private static readonly IntPtr sel_write_objects = Selector.Get("writeObjects:");
 
         internal NSPasteboard(IntPtr handle)
         {
             Handle = handle;
         }
 
-        internal static NSPasteboard GeneralPasteboard() => new NSPasteboard(Cocoa.SendIntPtr(classPointer, selGeneralPasteboard));
+        internal static NSPasteboard GeneralPasteboard() => new NSPasteboard(Cocoa.SendIntPtr(class_pointer, sel_general_pasteboard));
 
-        internal int ClearContents() => Cocoa.SendInt(Handle, selClearContents);
+        internal int ClearContents() => Cocoa.SendInt(Handle, sel_clear_contents);
 
-        internal bool CanReadObjectForClasses(NSArray classArray, NSDictionary? optionDict) => Cocoa.SendBool(Handle, selCanReadObjectForClasses, classArray.Handle, optionDict?.Handle ?? IntPtr.Zero);
+        internal bool CanReadObjectForClasses(NSArray classArray, NSDictionary? optionDict) => Cocoa.SendBool(Handle, sel_can_read_object_for_classes, classArray.Handle, optionDict?.Handle ?? IntPtr.Zero);
 
         internal NSArray? ReadObjectsForClasses(NSArray classArray, NSDictionary? optionDict)
         {
-            var result = Cocoa.SendIntPtr(Handle, selReadObjectsForClasses, classArray.Handle, optionDict?.Handle ?? IntPtr.Zero);
+            var result = Cocoa.SendIntPtr(Handle, sel_read_objects_for_classes, classArray.Handle, optionDict?.Handle ?? IntPtr.Zero);
             return result == IntPtr.Zero ? (NSArray?)null : new NSArray(result);
         }
 
-        internal bool WriteObjects(NSArray objects) => Cocoa.SendBool(Handle, selWriteObjects, objects.Handle);
+        internal bool WriteObjects(NSArray objects) => Cocoa.SendBool(Handle, sel_write_objects, objects.Handle);
     }
 }

--- a/osu.Framework/Platform/MacOS/Native/Selector.cs
+++ b/osu.Framework/Platform/MacOS/Native/Selector.cs
@@ -9,18 +9,12 @@ namespace osu.Framework.Platform.MacOS.Native
 {
     internal static class Selector
     {
-        static Type typeSelector;
-        static MethodInfo methodSelectorGet;
-
-        static Selector()
-        {
-            typeSelector = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Selector");
-            methodSelectorGet = typeSelector.GetMethod("Get");
-        }
+        private static readonly Type type_selector = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Selector");
+        private static readonly MethodInfo method_selector_get = type_selector.GetMethod("Get");
 
         public static IntPtr Get(string name)
         {
-            return (IntPtr)methodSelectorGet.Invoke(null, new object[] { name });
+            return (IntPtr)method_selector_get.Invoke(null, new object[] { name });
         }
     }
 }

--- a/osu.Framework/Platform/MacOS/Native/Selector.cs
+++ b/osu.Framework/Platform/MacOS/Native/Selector.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    internal static class Selector
+    {
+        static Type typeSelector;
+        static MethodInfo methodSelectorGet;
+
+        static Selector()
+        {
+            typeSelector = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Selector");
+            methodSelectorGet = typeSelector.GetMethod("Get");
+        }
+
+        public static IntPtr Get(string name)
+        {
+            return (IntPtr)methodSelectorGet.Invoke(null, new object[] { name });
+        }
+    }
+}

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Platform.Windows
 
         public override Clipboard GetClipboard() => new WindowsClipboard();
 
-        public override Storage GetStorage(string baseName) => new WindowsStorage(baseName);
+        protected override Storage GetStorage(string baseName) => new WindowsStorage(baseName);
 
         public override bool CapsLockEnabled => Console.CapsLock;
 

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -12,6 +12,8 @@ namespace osu.Framework.Platform.Windows
 
         public override Clipboard GetClipboard() => new WindowsClipboard();
 
+        public override Storage GetStorage(string baseName) => new WindowsStorage(baseName);
+
         public override bool CapsLockEnabled => Console.CapsLock;
 
         internal WindowsGameHost(string gameName, bool bindIPC = false)
@@ -30,8 +32,6 @@ namespace osu.Framework.Platform.Windows
                 else
                     OnDeactivated();
             };
-
-            Dependencies.Cache(Storage = new WindowsStorage(gameName));
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -429,6 +429,13 @@
     <Compile Include="Platform\MacOS\MacOSClipboard.cs" />
     <Compile Include="Platform\MacOS\MacOSGameHost.cs" />
     <Compile Include="Platform\MacOS\MacOSStorage.cs" />
+    <Compile Include="Platform\MacOS\MacOSGameWindow.cs" />
+    <Compile Include="Platform\MacOS\Native\Class.cs" />
+    <Compile Include="Platform\MacOS\Native\Cocoa.cs" />
+    <Compile Include="Platform\MacOS\Native\Selector.cs" />
+    <Compile Include="Platform\MacOS\Native\NSPasteboard.cs" />
+    <Compile Include="Platform\MacOS\Native\NSArray.cs" />
+    <Compile Include="Platform\MacOS\Native\NSDictionary.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\osu-framework.licenseheader">
@@ -539,6 +546,9 @@
     <EmbeddedResource Include="Resources\Shaders\sh_TextureRounded.fs" />
     <EmbeddedResource Include="Resources\Fonts\OpenSans_1.png" />
     <EmbeddedResource Include="Resources\Fonts\OpenSans_0.png" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Platform\MacOS\Native\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -426,6 +426,9 @@
     <Compile Include="Graphics\Containers\TextFlowContainer.cs" />
     <Compile Include="Graphics\UserInterface\CircularProgress.cs" />
     <Compile Include="Threading\AudioThread.cs" />
+    <Compile Include="Platform\MacOS\MacOSClipboard.cs" />
+    <Compile Include="Platform\MacOS\MacOSGameHost.cs" />
+    <Compile Include="Platform\MacOS\MacOSStorage.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\osu-framework.licenseheader">


### PR DESCRIPTION
* Added macOS framework classes (host, window, etc.)
* Added native classes (combination of interop and reflection on the OpenTK classes)
* Added a workaround for an OpenTK bug where modifier keys (command, control, etc.) do not receive their own keydown/keyup events on macOS
* Added a workaround for an OpenTK bug where printable keys fire a keypress event on macOS even if a modifier key is held (this is not the case on Windows).  Note that the workaround does not drop the actual event.
* Added an implementation of macOS clipboard using the general pasteboard

This includes some of the initial changes of #945 but not the actual drag+drop functionality.  I will make a separate PR for that later based on this branch.

OpenTK issue: https://github.com/opentk/opentk/issues/669
