### PR TITLE
Fix isolation of individual TestCase runs

### DIFF
--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -224,6 +224,14 @@ namespace osu.Framework.Logging
         private static readonly List<string> filters = new List<string>();
         private static readonly Dictionary<LoggingTarget, Logger> static_loggers = new Dictionary<LoggingTarget, Logger>();
         private static readonly ThreadedScheduler background_scheduler = new ThreadedScheduler(@"Logger");
+
+        /// <summary>
+        /// Pause execution until all logger writes have completed and file handles have been closed.
+        /// </summary>
+        public static void WaitForCompletion()
+        {
+            background_scheduler.Dispose();
+        }
     }
 
     public class LogEntry

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -558,8 +558,8 @@ namespace osu.Framework.Platform
             stopAllThreads();
             Root?.Dispose();
 
-            config.Dispose();
-            debugConfig.Dispose();
+            config?.Dispose();
+            debugConfig?.Dispose();
         }
 
         ~GameHost()

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -557,6 +557,9 @@ namespace osu.Framework.Platform
             isDisposed = true;
             stopAllThreads();
             Root?.Dispose();
+
+            config.Dispose();
+            debugConfig.Dispose();
         }
 
         ~GameHost()

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -560,6 +560,8 @@ namespace osu.Framework.Platform
 
             config?.Dispose();
             debugConfig?.Dispose();
+
+            Logger.WaitForCompletion();
         }
 
         ~GameHost()

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -49,8 +49,17 @@ namespace osu.Framework.Testing
         [TearDown]
         public virtual void RunTest()
         {
-            using (var host = new HeadlessGameHost())
+            string name = $"test-{Guid.NewGuid()}";
+
+            Storage storage;
+            using (var host = new HeadlessGameHost(name, realtime: false))
+            {
+                storage = host.Storage;
                 host.Run(new TestCaseTestRunner(this));
+            }
+
+            // clean up after each run
+            storage.DeleteDirectory(string.Empty);
         }
 
         /// <summary>

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -49,10 +49,8 @@ namespace osu.Framework.Testing
         [TearDown]
         public virtual void RunTest()
         {
-            string name = $"test-{Guid.NewGuid()}";
-
             Storage storage;
-            using (var host = new HeadlessGameHost(name, realtime: false))
+            using (var host = new HeadlessGameHost($"test-{Guid.NewGuid()}", realtime: false))
             {
                 storage = host.Storage;
                 host.Run(new TestCaseTestRunner(this));

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -325,10 +325,11 @@ namespace osu.Framework.Threading
     public class ThreadedScheduler : Scheduler
     {
         private bool isDisposed;
+        private readonly Thread workerThread;
 
         public ThreadedScheduler(string threadName = null, int runInterval = 50)
         {
-            var workerThread = new Thread(() =>
+            workerThread = new Thread(() =>
             {
                 while (!isDisposed)
                 {
@@ -347,6 +348,9 @@ namespace osu.Framework.Threading
         protected override void Dispose(bool disposing)
         {
             isDisposed = true;
+
+            workerThread.Join();
+
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
This also enabled faster-than-realtime testcase runs, which seems to have been overlooked at the framework level. Shaves a minute off CI runs.