### PR TITLE
Fix TextureAnimation nullref on null texture

### DIFF
--- a/osu.Framework/Graphics/Animations/TextureAnimation.cs
+++ b/osu.Framework/Graphics/Animations/TextureAnimation.cs
@@ -27,7 +27,8 @@ namespace osu.Framework.Graphics.Animations
         protected override void OnFrameAdded(Texture content, double displayDuration)
         {
             base.OnFrameAdded(content, displayDuration);
-            maxTextureSize = Vector2.ComponentMax(new Vector2(content.DisplayWidth, content.DisplayHeight), maxTextureSize);
+
+            maxTextureSize = Vector2.ComponentMax(new Vector2(content?.DisplayWidth ?? 0, content?.DisplayHeight ?? 0), maxTextureSize);
         }
 
         protected override void DisplayFrame(Texture content)


### PR DESCRIPTION
Given that Sprite.Texture accepts a null value, I want to allow TextureAnimation to accept nulls. This is also consistent with TextureAnimation.updateTextureHolderSize(), which checks if the texture is null.