### PR TITLE
Make WebRequest use HttpClient and proper async/await

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -48,6 +48,22 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test]
+        public void TestBadStatusCode()
+        {
+            var request = new WebRequest("https://httpbin.org/hidden-basic-auth/user/passwd");
+
+            bool hasThrown = false;
+            request.Finished += (webRequest, exception) => hasThrown = exception != null;
+
+            Assert.DoesNotThrowAsync(request.PerformAsync);
+
+            Assert.AreEqual(string.Empty, request.ResponseString);
+            Assert.IsFalse(request.Aborted);
+            Assert.IsTrue(request.Completed);
+            Assert.IsFalse(hasThrown);
+        }
+
+        [Test]
         public void TestAbortGet()
         {
             var request = new WebRequest($"https://{valid_get_url}") { Method = HttpMethod.GET };

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -101,7 +101,8 @@ namespace osu.Framework.Tests.IO
         {
             var request = new JsonWebRequest<HttpBinResponse>("https://httpbin.org/post") { Method = HttpMethod.POST };
 
-            request.AddRaw(JsonConvert.SerializeObject(new TestObject()));
+            var testObject = new TestObject();
+            request.AddRaw(JsonConvert.SerializeObject(testObject));
 
             Assert.DoesNotThrowAsync(request.PerformAsync);
 
@@ -112,8 +113,9 @@ namespace osu.Framework.Tests.IO
 
             Assert.IsTrue(responseObject.Headers.ContentLength > 0);
             Assert.IsTrue(responseObject.Json != null);
+            Assert.AreEqual(testObject.TestString, responseObject.Json.TestString);
 
-            Assert.IsTrue(!responseObject.Headers.ContentType.StartsWith("multipart/form-data; boundary="));
+            Assert.IsTrue(responseObject.Headers.ContentType == null);
         }
 
         [Serializable]
@@ -129,7 +131,7 @@ namespace osu.Framework.Tests.IO
             public HttpBinHeaders Headers;
 
             [JsonProperty("json")]
-            public string Json;
+            public TestObject Json;
 
             [Serializable]
             public class HttpBinHeaders

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -118,7 +118,6 @@ namespace osu.Framework.Tests.IO
             Assert.IsTrue(responseObject.Headers.ContentType == null);
         }
 
-        [Serializable]
         private class HttpBinResponse
         {
             [JsonProperty("data")]
@@ -133,7 +132,6 @@ namespace osu.Framework.Tests.IO
             [JsonProperty("json")]
             public TestObject Json;
 
-            [Serializable]
             public class HttpBinHeaders
             {
                 [JsonProperty("Content-Length")]

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using Newtonsoft.Json;
@@ -121,27 +120,27 @@ namespace osu.Framework.Tests.IO
         private class HttpBinResponse
         {
             [JsonProperty("data")]
-            public string Data;
+            public string Data { get; set; }
 
             [JsonProperty("form")]
-            public IDictionary<string, string> Form;
+            public IDictionary<string, string> Form { get; set; }
 
             [JsonProperty("headers")]
-            public HttpBinHeaders Headers;
+            public HttpBinHeaders Headers { get; set; }
 
             [JsonProperty("json")]
-            public TestObject Json;
+            public TestObject Json { get; set; }
 
             public class HttpBinHeaders
             {
                 [JsonProperty("Content-Length")]
-                public int ContentLength;
+                public int ContentLength { get; set; }
 
                 [JsonProperty("Content-Type")]
-                public string ContentType;
+                public string ContentType { get; set; }
 
                 [JsonProperty("User-Agent")]
-                public string UserAgent;
+                public string UserAgent { get; set; }
             }
         }
 

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Tests.IO
 
         [TestCase("http")]
         [TestCase("https")]
-        public void TestValidGet(string protocol)
+        public void TestValidGetAsync(string protocol)
         {
             var request = new WebRequest($"{protocol}://{valid_get_url}") { Method = HttpMethod.GET };
 
@@ -26,6 +26,22 @@ namespace osu.Framework.Tests.IO
             request.Finished += (webRequest, exception) => hasThrown = exception != null;
 
             Assert.DoesNotThrowAsync(request.PerformAsync);
+            Assert.AreNotEqual(0, request.ResponseData.Length);
+            Assert.IsFalse(request.Aborted);
+            Assert.IsTrue(request.Completed);
+            Assert.IsFalse(hasThrown);
+        }
+
+        [TestCase("http")]
+        [TestCase("https")]
+        public void TestValidGet(string protocol)
+        {
+            var request = new WebRequest($"{protocol}://{valid_get_url}") { Method = HttpMethod.GET };
+
+            bool hasThrown = false;
+            request.Finished += (webRequest, exception) => hasThrown = exception != null;
+
+            Assert.DoesNotThrow(request.Perform);
             Assert.AreNotEqual(0, request.ResponseData.Length);
             Assert.IsFalse(request.Aborted);
             Assert.IsTrue(request.Completed);

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Newtonsoft.Json;
@@ -133,6 +134,7 @@ namespace osu.Framework.Tests.IO
             Assert.IsTrue(responseObject.Headers.ContentType == null);
         }
 
+        [Serializable]
         private class HttpBinResponse
         {
             [JsonProperty("data")]
@@ -147,6 +149,7 @@ namespace osu.Framework.Tests.IO
             [JsonProperty("json")]
             public TestObject Json { get; set; }
 
+            [Serializable]
             public class HttpBinHeaders
             {
                 [JsonProperty("Content-Length")]
@@ -160,6 +163,7 @@ namespace osu.Framework.Tests.IO
             }
         }
 
+        [Serializable]
         public class TestObject
         {
             public string TestString = "readable";

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.IO.Network;
+
+namespace osu.Framework.Tests.IO
+{
+    [TestFixture]
+    public class TestWebRequest
+    {
+        private const string valid_get_url = "a.ppy.sh/2";
+        private const string invalid_get_url = "a.ppy.shhhhh";
+
+        [TestCase("http")]
+        [TestCase("https")]
+        public void TestValidGet(string protocol)
+        {
+            var request = new WebRequest($"{protocol}://{valid_get_url}") { Method = HttpMethod.GET };
+
+            bool hasThrown = false;
+            request.Finished += (webRequest, exception) => hasThrown = exception != null;
+
+            Assert.DoesNotThrowAsync(request.PerformAsync);
+            Assert.AreNotEqual(0, request.ResponseData.Length);
+            Assert.IsFalse(request.Aborted);
+            Assert.IsTrue(request.Completed);
+            Assert.IsFalse(hasThrown);
+        }
+
+        [TestCase("http")]
+        [TestCase("https")]
+        public void TestInvalidGet(string protocol)
+        {
+            var request = new WebRequest($"{protocol}://{invalid_get_url}") { Method = HttpMethod.GET };
+
+            bool hasThrown = false;
+            request.Finished += (webRequest, exception) => hasThrown = exception != null;
+
+            Assert.DoesNotThrowAsync(request.PerformAsync);
+            Assert.AreEqual(null, request.ResponseData);
+            Assert.IsTrue(request.Aborted);
+            Assert.IsFalse(request.Completed);
+            Assert.IsTrue(hasThrown);
+        }
+    }
+}

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Threading;
 using NUnit.Framework;
 using osu.Framework.IO.Network;
 
@@ -42,6 +43,25 @@ namespace osu.Framework.Tests.IO
             Assert.IsTrue(request.Aborted);
             Assert.IsFalse(request.Completed);
             Assert.IsTrue(hasThrown);
+        }
+
+        [Test]
+        public void TestAbortGet()
+        {
+            var request = new WebRequest($"https://{valid_get_url}") { Method = HttpMethod.GET };
+
+            bool hasThrown = false;
+            request.Finished += (webRequest, exception) => hasThrown = exception != null;
+
+            request.PerformAsync();
+            request.Abort();
+
+            Thread.Sleep(100);
+
+            Assert.AreEqual(null, request.ResponseData);
+            Assert.IsTrue(request.Aborted);
+            Assert.IsFalse(request.Completed);
+            Assert.IsFalse(hasThrown);
         }
     }
 }

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -47,23 +47,24 @@ namespace osu.Framework.Tests.IO
         [TestCase("https", false)]
         [TestCase("http", true)]
         [TestCase("https", true)]
-        public void TestInvalidGet(string protocol, bool async)
+        public void TestInvalidGetExceptions(string protocol, bool async)
         {
             var request = new WebRequest($"{protocol}://{invalid_get_url}") { Method = HttpMethod.GET };
 
-            bool hasThrown = false;
-            request.Finished += (webRequest, exception) => hasThrown = exception != null;
+            Exception finishedException = null;
+            request.Finished += (webRequest, exception) => finishedException = exception;
 
             if (async)
-                Assert.DoesNotThrowAsync(request.PerformAsync);
+                Assert.ThrowsAsync<AggregateException>(request.PerformAsync);
             else
-                Assert.DoesNotThrow(request.Perform);
+                Assert.Throws<AggregateException>(request.Perform);
 
             Assert.IsTrue(request.ResponseString == null);
 
             Assert.IsTrue(request.Aborted);
             Assert.IsFalse(request.Completed);
-            Assert.IsTrue(hasThrown);
+
+            Assert.IsNotNull(finishedException);
         }
 
         [TestCase(false)]

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -1,7 +1,10 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
+using System.Collections.Generic;
 using System.Threading;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using osu.Framework.IO.Network;
 
@@ -62,6 +65,89 @@ namespace osu.Framework.Tests.IO
             Assert.IsTrue(request.Aborted);
             Assert.IsFalse(request.Completed);
             Assert.IsFalse(hasThrown);
+        }
+
+        [Test]
+        public void TestPostWithJsonResponse()
+        {
+            var request = new JsonWebRequest<HttpBinResponse>("https://httpbin.org/post") { Method = HttpMethod.POST };
+
+            request.AddParameter("testkey1", "testval1");
+            request.AddParameter("testkey2", "testval2");
+
+            Assert.DoesNotThrowAsync(request.PerformAsync);
+
+            var responseObject = request.ResponseObject;
+
+            Assert.IsFalse(request.Aborted);
+            Assert.IsTrue(request.Completed);
+
+            Assert.IsTrue(responseObject.Form != null);
+            Assert.IsTrue(responseObject.Form.Count == 2);
+
+            Assert.IsTrue(responseObject.Headers.ContentLength > 0);
+
+            Assert.IsTrue(responseObject.Form.ContainsKey("testkey1"));
+            Assert.IsTrue(responseObject.Form["testkey1"] == "testval1");
+
+            Assert.IsTrue(responseObject.Form.ContainsKey("testkey2"));
+            Assert.IsTrue(responseObject.Form["testkey2"] == "testval2");
+
+            Assert.IsTrue(responseObject.Headers.ContentType.StartsWith("multipart/form-data; boundary="));
+        }
+
+        [Test]
+        public void TestPostWithJsonRequest()
+        {
+            var request = new JsonWebRequest<HttpBinResponse>("https://httpbin.org/post") { Method = HttpMethod.POST };
+
+            request.AddRaw(JsonConvert.SerializeObject(new TestObject()));
+
+            Assert.DoesNotThrowAsync(request.PerformAsync);
+
+            var responseObject = request.ResponseObject;
+
+            Assert.IsFalse(request.Aborted);
+            Assert.IsTrue(request.Completed);
+
+            Assert.IsTrue(responseObject.Headers.ContentLength > 0);
+            Assert.IsTrue(responseObject.Json != null);
+
+            Assert.IsTrue(!responseObject.Headers.ContentType.StartsWith("multipart/form-data; boundary="));
+        }
+
+        [Serializable]
+        private class HttpBinResponse
+        {
+            [JsonProperty("data")]
+            public string Data;
+
+            [JsonProperty("form")]
+            public IDictionary<string, string> Form;
+
+            [JsonProperty("headers")]
+            public HttpBinHeaders Headers;
+
+            [JsonProperty("json")]
+            public string Json;
+
+            [Serializable]
+            public class HttpBinHeaders
+            {
+                [JsonProperty("Content-Length")]
+                public int ContentLength;
+
+                [JsonProperty("Content-Type")]
+                public string ContentType;
+
+                [JsonProperty("User-Agent")]
+                public string UserAgent;
+            }
+        }
+
+        public class TestObject
+        {
+            public string TestString = "readable";
         }
     }
 }

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutomatedVisualTestGame.cs" />
+    <Compile Include="IO\TestWebRequest.cs" />
     <Compile Include="Lists\TestSortedList.cs" />
     <Compile Include="MathUtils\TestInterpolation.cs" />
     <Compile Include="Platform\HeadlessGameHostTest.cs" />

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -36,6 +36,9 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+      <HintPath>$(SolutionDir)\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>$(SolutionDir)\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>

--- a/osu.Framework/IO/Network/FileWebRequest.cs
+++ b/osu.Framework/IO/Network/FileWebRequest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using System.Net;
 using osu.Framework.IO.File;
 
 namespace osu.Framework.IO.Network
@@ -15,19 +14,14 @@ namespace osu.Framework.IO.Network
     {
         public string Filename;
 
+        protected override string Accept => "application/octet-stream";
+
         protected override Stream CreateOutputStream()
         {
             string path = Path.GetDirectoryName(Filename);
             if (!string.IsNullOrEmpty(path)) Directory.CreateDirectory(path);
 
             return new FileStream(Filename, FileMode.Create, FileAccess.Write, FileShare.Write, 32768);
-        }
-
-        protected override HttpWebRequest CreateWebRequest(string requestString = null)
-        {
-            var req = base.CreateWebRequest(requestString);
-            req.Accept = "application/octet-stream";
-            return req;
         }
 
         public FileWebRequest(string filename, string url)

--- a/osu.Framework/IO/Network/JsonWebRequest.cs
+++ b/osu.Framework/IO/Network/JsonWebRequest.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Net;
 using Newtonsoft.Json;
 
 namespace osu.Framework.IO.Network
@@ -13,17 +12,12 @@ namespace osu.Framework.IO.Network
     /// <typeparam name="T">the response format.</typeparam>
     public class JsonWebRequest<T> : WebRequest
     {
+        protected override string Accept => "application/json";
+
         public JsonWebRequest(string url = null, params object[] args)
             : base(url, args)
         {
             base.Finished += finished;
-        }
-
-        protected override HttpWebRequest CreateWebRequest(string requestString = null)
-        {
-            var req = base.CreateWebRequest(requestString);
-            req.Accept = @"application/json";
-            return req;
         }
 
         private void finished(WebRequest request, Exception e)

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -244,7 +244,10 @@ namespace osu.Framework.IO.Network
                         default:
                             throw new InvalidOperationException($"HTTP method {Method} is currently not supported");
                         case HttpMethod.GET:
-                            Debug.Assert(Files.Count == 0);
+                            if (Parameters.Count > 0)
+                                throw new InvalidOperationException($"Cannot use {nameof(AddParameter)} in a GET request. Please set the {nameof(Method)} to POST.");
+                            if (Files.Count > 0)
+                                throw new InvalidOperationException($"Cannot use {nameof(AddFile)} in a GET request. Please set the {nameof(Method)} to POST.");
 
                             StringBuilder requestParameters = new StringBuilder();
                             foreach (var p in Parameters)

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -269,16 +269,14 @@ namespace osu.Framework.IO.Network
                             foreach (var p in Files)
                                 formData.Add(new ByteArrayContent(p.Value), p.Key, p.Key);
 
-                            using (var requestStream = new LengthTrackingStream(formData.ReadAsStreamAsync().Result))
+                            requestStream = new LengthTrackingStream(formData.ReadAsStreamAsync().Result);
+                            requestStream.BytesRead.ValueChanged += v =>
                             {
-                                requestStream.BytesRead.ValueChanged += v =>
-                                {
-                                    reportForwardProgress();
-                                    UploadProgress?.Invoke(this, v, contentLength);
-                                };
+                                reportForwardProgress();
+                                UploadProgress?.Invoke(this, v, contentLength);
+                            };
 
-                                request = new HttpRequestMessage(System.Net.Http.HttpMethod.Post, Url) { Content = new StreamContent(requestStream) };
-                            }
+                            request = new HttpRequestMessage(System.Net.Http.HttpMethod.Post, Url) { Content = new StreamContent(requestStream) };
                             break;
                     }
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -228,16 +228,16 @@ namespace osu.Framework.IO.Network
         /// </summary>
         public Task PerformAsync()
         {
+            if (!canPerform)
+                throw new InvalidOperationException("Can not perform a web request multiple times.");
+            canPerform = false;
+
+            Aborted = false;
+            abortRequest();
+            cancellationToken = new CancellationTokenSource();
+
             return Task.Factory.StartNew(() =>
             {
-                if (!canPerform)
-                    throw new InvalidOperationException("Can not perform a web request multiple times.");
-                canPerform = false;
-
-                Aborted = false;
-                abortRequest();
-                cancellationToken = new CancellationTokenSource();
-
                 PrePerform();
 
                 try
@@ -317,7 +317,7 @@ namespace osu.Framework.IO.Network
                 {
                     Complete(e);
                 }
-            }, TaskCreationOptions.LongRunning);
+            }, cancellationToken.Token, TaskCreationOptions.LongRunning, TaskScheduler.Current);
         }
 
         /// <summary>

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -219,6 +219,7 @@ namespace osu.Framework.IO.Network
         private bool canPerform = true;
 
         private CancellationTokenSource cancellationToken;
+        private LengthTrackingStream requestStream;
         private HttpResponseMessage response;
         private int contentLength;
 
@@ -514,6 +515,8 @@ namespace osu.Framework.IO.Network
             isDisposed = true;
 
             abortRequest();
+
+            requestStream?.Dispose();
 
             if (!(ResponseStream is MemoryStream))
                 ResponseStream?.Dispose();

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -136,15 +136,7 @@ namespace osu.Framework.IO.Network
 
         static WebRequest()
         {
-            var handler = new HttpClientHandler
-            {
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-//                SslProtocols = SslProtocols.Tls,
-//                CheckCertificateRevocationList = false,
-//                MaxConnectionsPerServer = 12
-            };
-
-            client = new HttpClient(handler);
+            client = new HttpClient(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate });
             client.DefaultRequestHeaders.UserAgent.ParseAdd("osu!");
             client.DefaultRequestHeaders.ExpectContinue = true;
             client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -373,6 +373,8 @@ namespace osu.Framework.IO.Network
 
             if (e == null)
                 logger.Add($@"Request to {Url} successfully completed!");
+            else if (response == null)
+                logger.Add($"Request to {Url} failed with {e.Message} (FAILED).");
             else
             {
                 bool allowRetry = true;

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -241,6 +241,8 @@ namespace osu.Framework.IO.Network
 
                     switch (Method)
                     {
+                        default:
+                            throw new InvalidOperationException($"HTTP method {Method} is currently not supported");
                         case HttpMethod.GET:
                             Debug.Assert(Files.Count == 0);
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -356,6 +356,8 @@ namespace osu.Framework.IO.Network
 
                     while (true)
                     {
+                        cancellationToken.Token.ThrowIfCancellationRequested();
+
                         int read = responseStream.Read(buffer, 0, buffer_size);
 
                         reportForwardProgress();

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -262,12 +262,12 @@ namespace osu.Framework.IO.Network
                             const string boundary = @"-----------------------------28947758029299";
 
                             var formData = new MultipartFormDataContent(boundary);
-                            contentLength = formData.ReadAsByteArrayAsync().Result.Length;
 
                             formData.Add(new FormUrlEncodedContent(Parameters));
 
                             foreach (var p in Files)
                                 formData.Add(new ByteArrayContent(p.Value), p.Key, p.Key);
+                            contentLength = formData.ReadAsByteArrayAsync().Result.Length;
 
                             requestStream = new LengthTrackingStream(formData.ReadAsStreamAsync().Result);
                             requestStream.BytesRead.ValueChanged += v =>

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -248,8 +248,6 @@ namespace osu.Framework.IO.Network
                         default:
                             throw new InvalidOperationException($"HTTP method {Method} is currently not supported");
                         case HttpMethod.GET:
-                            if (Parameters.Count > 0)
-                                throw new InvalidOperationException($"Cannot use {nameof(AddParameter)} in a GET request. Please set the {nameof(Method)} to POST.");
                             if (Files.Count > 0)
                                 throw new InvalidOperationException($"Cannot use {nameof(AddFile)} in a GET request. Please set the {nameof(Method)} to POST.");
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Security.Authentication;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -114,6 +113,7 @@ namespace osu.Framework.IO.Network
         /// <summary>
         /// The request headers.
         /// </summary>
+        // ReSharper disable once CollectionNeverUpdated.Global
         public Dictionary<string, string> Headers = new Dictionary<string, string>();
 
         public const int DEFAULT_TIMEOUT = 10000;
@@ -139,9 +139,9 @@ namespace osu.Framework.IO.Network
             var handler = new HttpClientHandler
             {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-                SslProtocols = SslProtocols.Tls,
-                CheckCertificateRevocationList = false,
-                MaxConnectionsPerServer = 12
+//                SslProtocols = SslProtocols.Tls,
+//                CheckCertificateRevocationList = false,
+//                MaxConnectionsPerServer = 12
             };
 
             client = new HttpClient(handler);

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -382,10 +382,10 @@ namespace osu.Framework.IO.Network
             if (Aborted)
                 return;
 
-            if (e == null)
-                logger.Add($@"Request to {Url} successfully completed!");
-            else if (response == null)
+            if (e != null)
                 logger.Add($"Request to {Url} failed with {e.Message} (FAILED).");
+            else if (response.IsSuccessStatusCode)
+                logger.Add($@"Request to {Url} successfully completed!");
             else
             {
                 bool allowRetry = true;

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -111,6 +111,11 @@ namespace osu.Framework.IO.Network
         /// </summary>
         public Dictionary<string, byte[]> Files = new Dictionary<string, byte[]>();
 
+        /// <summary>
+        /// The request headers.
+        /// </summary>
+        public Dictionary<string, string> Headers = new Dictionary<string, string>();
+
         public const int DEFAULT_TIMEOUT = 10000;
 
         public HttpMethod Method;
@@ -279,6 +284,9 @@ namespace osu.Framework.IO.Network
 
                     if (!string.IsNullOrEmpty(Accept))
                         request?.Headers.Accept.TryParseAdd(Accept);
+
+                    foreach (var kvp in Headers)
+                        request?.Headers.Add(kvp.Key, kvp.Value);
 
                     response = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken.Token).Result;
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -6,12 +6,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
-using System.Net.Sockets;
-using System.Reflection;
-using System.Security.Cryptography.X509Certificates;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Authentication;
 using System.Text;
 using System.Threading;
-using osu.Framework.Extensions;
+using System.Threading.Tasks;
+using osu.Framework.Configuration;
 using osu.Framework.Logging;
 
 namespace osu.Framework.IO.Network
@@ -110,11 +111,6 @@ namespace osu.Framework.IO.Network
         /// </summary>
         public Dictionary<string, byte[]> Files = new Dictionary<string, byte[]>();
 
-        /// <summary>
-        /// Headers.
-        /// </summary>
-        public Dictionary<string, string> Headers = new Dictionary<string, string>();
-
         public const int DEFAULT_TIMEOUT = 10000;
 
         public HttpMethod Method;
@@ -124,20 +120,29 @@ namespace osu.Framework.IO.Network
         /// </summary>
         public int Timeout = DEFAULT_TIMEOUT;
 
+        /// <summary>
+        /// The type of content expected by this web request.
+        /// </summary>
+        protected virtual string Accept => string.Empty;
+
         private static readonly Logger logger;
 
-        /// <summary>
-        /// The remote IP address used for this connection.
-        /// </summary>
-        private string address;
+        private static readonly HttpClient client;
 
         static WebRequest()
         {
-            //set some sane defaults for ServicePoints
-            ServicePointManager.Expect100Continue = false;
-            ServicePointManager.DefaultConnectionLimit = 12;
-            ServicePointManager.CheckCertificateRevocationList = false;
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls;
+            var handler = new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                SslProtocols = SslProtocols.Tls,
+                CheckCertificateRevocationList = false,
+                MaxConnectionsPerServer = 12
+            };
+
+            client = new HttpClient(handler);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("osu!");
+            client.DefaultRequestHeaders.ExpectContinue = true;
+            client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
 
             logger = Logger.GetLogger(LoggingTarget.Network, true);
         }
@@ -153,91 +158,10 @@ namespace osu.Framework.IO.Network
             Dispose(false);
         }
 
-        private HttpWebRequest request;
-        private HttpWebResponse response;
-
-        private Stream internalResponseStream;
-
-        private static readonly AddressFamily? preferred_network = AddressFamily.InterNetwork;
-
-        /// <summary>
-        /// Does a manual DNS lookup and forcefully uses IPv4 by shoving IP addresses where the host normally is.
-        /// Unreliable for HTTPS+Cloudflare? Only use when necessary.
-        /// </summary>
-        public static bool UseExplicitIPv4Requests;
-
-        private static bool? useFallbackPath;
-        private bool didGetIPv6IP;
-
-        protected virtual HttpWebRequest CreateWebRequest(string requestString = null)
-        {
-            HttpWebRequest req;
-
-            string requestUrl = string.IsNullOrEmpty(requestString) ? Url : $@"{Url}?{requestString}";
-
-            if (useFallbackPath != true && !UseExplicitIPv4Requests)
-            {
-                req = (HttpWebRequest)System.Net.WebRequest.Create(requestUrl);
-                req.ServicePoint.BindIPEndPointDelegate += bindEndPoint;
-            }
-            else
-            {
-                string baseHost = requestUrl.Split('/', ':')[3];
-
-                var addresses = Dns.GetHostAddresses(baseHost);
-
-                address = null;
-
-                foreach (var ip in addresses)
-                {
-                    bool preferred = ip.AddressFamily == preferred_network;
-
-                    if (!preferred && address != null)
-                        continue;
-
-                    switch (ip.AddressFamily)
-                    {
-                        case AddressFamily.InterNetwork:
-                            address = $@"{ip}";
-                            break;
-                        case AddressFamily.InterNetworkV6:
-                            address = $@"[{ip}]";
-                            break;
-                    }
-
-                    if (preferred)
-                        //always use first preferred network address for now.
-                        break;
-                }
-
-                req = System.Net.WebRequest.Create(requestUrl.Replace(baseHost, $"{address}:443")) as HttpWebRequest;
-            }
-
-            if (req == null)
-                throw new InvalidOperationException(@"request could not be created");
-
-            req.UserAgent = @"osu!";
-            req.KeepAlive = useFallbackPath != true;
-            req.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-            req.Host = requestUrl.Split('/')[2];
-            req.ReadWriteTimeout = System.Threading.Timeout.Infinite;
-            req.Timeout = System.Threading.Timeout.Infinite;
-
-            return req;
-        }
-
-        private IPEndPoint bindEndPoint(ServicePoint servicePoint, IPEndPoint remoteEndPoint, int retries)
-        {
-            didGetIPv6IP |= remoteEndPoint.AddressFamily == AddressFamily.InterNetworkV6;
-            return null;
-        }
-
         private int responseBytesRead;
 
         private const int buffer_size = 32768;
         private byte[] buffer;
-
-        private MemoryStream requestBody;
 
         private MemoryStream rawContent;
 
@@ -285,126 +209,100 @@ namespace osu.Framework.IO.Network
             }
         }
 
-        public WebHeaderCollection ResponseHeaders => response?.Headers;
+        public HttpResponseHeaders ResponseHeaders => response.Headers;
 
         private bool canPerform = true;
 
+        private CancellationTokenSource cancellationToken;
+        private HttpResponseMessage response;
+        private int contentLength;
+
         /// <summary>
-        /// Start the request asynchronously.
+        /// Performs the request asynchronously.
         /// </summary>
-        public void Perform()
+        public Task PerformAsync()
         {
-            if (!canPerform)
-                throw new InvalidOperationException("Can not perform a web request multiple times.");
-
-            canPerform = false;
-
-            ThreadPool.QueueUserWorkItem(_ => perform());
-
-            int workerThreads, completionPortThreads;
-            ThreadPool.GetAvailableThreads(out workerThreads, out completionPortThreads);
-            if (workerThreads == 0)
-                logger.Add(@"WARNING: ThreadPool is saturated!", LogLevel.Error);
-        }
-
-        private void perform()
-        {
-            Aborted = false;
-            abortRequest();
-
-            PrePerform();
-
-            try
+            return Task.Factory.StartNew(() =>
             {
-                reportForwardProgress();
-                ThreadPool.QueueUserWorkItem(checkTimeoutLoop);
+                if (!canPerform)
+                    throw new InvalidOperationException("Can not perform a web request multiple times.");
+                canPerform = false;
 
-                requestBody = new MemoryStream();
+                Aborted = false;
+                abortRequest();
+                cancellationToken = new CancellationTokenSource();
 
-                switch (Method)
+                PrePerform();
+
+                try
                 {
-                    case HttpMethod.GET:
-                        Debug.Assert(Files.Count == 0);
+                    reportForwardProgress();
+                    ThreadPool.QueueUserWorkItem(checkTimeoutLoop);
 
-                        StringBuilder requestParameters = new StringBuilder();
-                        foreach (var p in Parameters)
-                            requestParameters.Append($@"{p.Key}={p.Value}&");
+                    HttpRequestMessage request = null;
 
-                        request = CreateWebRequest(requestParameters.ToString().TrimEnd('&'));
-                        request.Method = @"GET";
-                        break;
-                    case HttpMethod.POST:
-                        request = CreateWebRequest();
-                        request.Method = @"POST";
+                    switch (Method)
+                    {
+                        case HttpMethod.GET:
+                            Debug.Assert(Files.Count == 0);
 
-                        if (Parameters.Count + Files.Count == 0)
-                        {
-                            rawContent?.WriteTo(requestBody);
-                            request.ContentType = ContentType;
-                            requestBody.Flush();
+                            StringBuilder requestParameters = new StringBuilder();
+                            foreach (var p in Parameters)
+                                requestParameters.Append($@"{p.Key}={p.Value}&");
+                            string requestString = requestParameters.ToString().TrimEnd('&');
+
+                            request = new HttpRequestMessage(System.Net.Http.HttpMethod.Get, string.IsNullOrEmpty(requestString) ? Url : $"{Url}?{requestString}");
                             break;
-                        }
+                        case HttpMethod.POST:
+                            const string boundary = @"-----------------------------28947758029299";
 
-                        const string boundary = @"-----------------------------28947758029299";
+                            var formData = new MultipartFormDataContent(boundary);
+                            contentLength = formData.ReadAsByteArrayAsync().Result.Length;
 
-                        request.ContentType = $@"multipart/form-data; boundary={boundary}";
+                            formData.Add(new FormUrlEncodedContent(Parameters));
 
-                        foreach (KeyValuePair<string, string> p in Parameters)
-                        {
-                            requestBody.WriteLineExplicit($@"--{boundary}");
-                            requestBody.WriteLineExplicit($@"Content-Disposition: form-data; name=""{p.Key}""");
-                            requestBody.WriteLineExplicit();
-                            requestBody.WriteLineExplicit(p.Value);
-                        }
+                            foreach (var p in Files)
+                                formData.Add(new ByteArrayContent(p.Value), p.Key, p.Key);
 
-                        foreach (KeyValuePair<string, byte[]> p in Files)
-                        {
-                            requestBody.WriteLineExplicit($@"--{boundary}");
+                            using (var requestStream = new LengthTrackingStream(formData.ReadAsStreamAsync().Result))
+                            {
+                                requestStream.BytesRead.ValueChanged += v =>
+                                {
+                                    reportForwardProgress();
+                                    UploadProgress?.Invoke(this, v, contentLength);
+                                };
 
-                            requestBody.WriteLineExplicit($@"Content-Disposition: form-data; name=""{p.Key}""; filename=""{p.Key}""");
-                            requestBody.WriteLineExplicit(@"Content-Type: application/octet-stream");
-                            requestBody.WriteLineExplicit();
-                            requestBody.Write(p.Value, 0, p.Value.Length);
-                            requestBody.WriteLineExplicit();
-                        }
+                                request = new HttpRequestMessage(System.Net.Http.HttpMethod.Post, Url) { Content = new StreamContent(requestStream) };
+                            }
+                            break;
+                    }
 
-                        requestBody.WriteLineExplicit($@"--{boundary}--");
-                        requestBody.Flush();
-                        break;
+                    if (!string.IsNullOrEmpty(Accept))
+                        request?.Headers.Accept.TryParseAdd(Accept);
+
+                    response = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken.Token).Result;
+
+                    ResponseStream = CreateOutputStream();
+
+                    switch (Method)
+                    {
+                        case HttpMethod.GET:
+                            //GETs are easy
+                            beginResponse();
+                            break;
+                        case HttpMethod.POST:
+                            reportForwardProgress();
+                            UploadProgress?.Invoke(this, 0, contentLength);
+
+                            beginResponse();
+                            break;
+                    }
                 }
-
-                request.UserAgent = @"osu!";
-                request.KeepAlive = useFallbackPath != true;
-                request.Host = Url.Split('/')[2];
-                request.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
-                request.ReadWriteTimeout = System.Threading.Timeout.Infinite;
-                request.Timeout = Timeout; //todo: make sure this works correctly for long-lasting transfers.
-
-                foreach (KeyValuePair<string, string> h in Headers)
-                    request.Headers.Add(h.Key, h.Value);
-
-                ResponseStream = CreateOutputStream();
-
-                switch (Method)
+                catch (Exception e)
                 {
-                    case HttpMethod.GET:
-                        //GETs are easy
-                        beginResponse();
-                        break;
-                    case HttpMethod.POST:
-                        request.ContentLength = requestBody.Length;
-
-                        UploadProgress?.Invoke(this, 0, request.ContentLength);
-                        reportForwardProgress();
-
-                        beginRequestOutput();
-                        break;
+                    Complete(e);
                 }
-            }
-            catch (Exception e)
-            {
-                Complete(e);
-            }
+            }, TaskCreationOptions.LongRunning);
         }
 
         /// <summary>
@@ -414,73 +312,35 @@ namespace osu.Framework.IO.Network
         {
         }
 
-        private void beginRequestOutput()
-        {
-            try
-            {
-                using (Stream requestStream = request.GetRequestStream())
-                {
-                    reportForwardProgress();
-                    requestBody.Position = 0;
-                    byte[] buff = new byte[buffer_size];
-                    int read;
-                    int totalRead = 0;
-                    while ((read = requestBody.Read(buff, 0, buffer_size)) > 0)
-                    {
-                        reportForwardProgress();
-                        requestStream.Write(buff, 0, read);
-                        requestStream.Flush();
-
-                        totalRead += read;
-                        UploadProgress?.Invoke(this, totalRead, request.ContentLength);
-                    }
-                }
-
-                beginResponse();
-            }
-            catch (Exception e)
-            {
-                Complete(e);
-            }
-        }
-
         private void beginResponse()
         {
             try
             {
-                response = request.GetResponse() as HttpWebResponse;
-                Trace.Assert(response != null);
-
-                Started?.Invoke(this);
-
-                internalResponseStream = response.GetResponseStream();
-                Trace.Assert(internalResponseStream != null);
-
-#if !DEBUG
-                checkCertificate();
-#endif
-
-                buffer = new byte[buffer_size];
-
-                reportForwardProgress();
-
-                while (true)
+                using (var responseStream = response.Content.ReadAsStreamAsync().Result)
                 {
-                    int read = internalResponseStream.Read(buffer, 0, buffer_size);
-
                     reportForwardProgress();
+                    Started?.Invoke(this);
 
-                    if (read > 0)
+                    buffer = new byte[buffer_size];
+
+                    while (true)
                     {
-                        ResponseStream.Write(buffer, 0, read);
-                        responseBytesRead += read;
-                        DownloadProgress?.Invoke(this, responseBytesRead, response.ContentLength);
-                    }
-                    else
-                    {
-                        ResponseStream.Seek(0, SeekOrigin.Begin);
-                        Complete();
-                        break;
+                        int read = responseStream.Read(buffer, 0, buffer_size);
+
+                        reportForwardProgress();
+
+                        if (read > 0)
+                        {
+                            ResponseStream.Write(buffer, 0, read);
+                            responseBytesRead += read;
+                            DownloadProgress?.Invoke(this, responseBytesRead, response.Content.Headers.ContentLength ?? responseBytesRead);
+                        }
+                        else
+                        {
+                            ResponseStream.Seek(0, SeekOrigin.Begin);
+                            Complete();
+                            break;
+                        }
                     }
                 }
             }
@@ -490,101 +350,51 @@ namespace osu.Framework.IO.Network
             }
         }
 
-        [Obfuscation(Feature = @"virtualization", Exclude = false)]
-        private void checkCertificate()
-        {
-            if (request.ServicePoint.Certificate == null && request.RequestUri.Host != request.Address.Host && request.Address.Host.EndsWith(@".ppy.sh", StringComparison.Ordinal))
-                //osu!direct downloads happen over http at the moment. we should probably move them across to https.
-                return;
-
-            //if it's null at this point we don't mind throwing an exception.
-            Trace.Assert(request.ServicePoint.Certificate != null);
-
-            //this is enough for now to assume we have a valid certificate.
-            if (new X509Certificate2(request.ServicePoint.Certificate).Subject.Contains(@"CN=*.ppy.sh"))
-                return;
-
-            //else we should just destroy the response and no.
-            response?.Close();
-            response = null;
-            throw new WebException(@"SSL failures");
-        }
-
-        public virtual void BlockingPerform()
-        {
-            Exception exc = null;
-            bool completed = false;
-
-            Finished += delegate(WebRequest r, Exception e)
-            {
-                exc = e;
-                completed = true;
-            };
-
-            perform();
-
-            while (!completed && !Aborted)
-                Thread.Sleep(10);
-
-            if (exc != null)
-                throw exc;
-        }
 
         protected virtual void Complete(Exception e = null)
         {
             if (Aborted)
                 return;
 
-            WebException we = e as WebException;
-            if (we != null)
+            switch (e)
             {
-                bool allowRetry = true;
+                default:
+                    bool allowRetry = true;
 
-                HttpStatusCode? statusCode = (we.Response as HttpWebResponse)?.StatusCode ?? HttpStatusCode.RequestTimeout;
+                    switch (response.StatusCode)
+                    {
+                        case HttpStatusCode.RequestTimeout:
+                            if (hasExceededTimeout)
+                            {
+                                logger.Add($@"Timeout exceeded ({timeSinceLastAction} > {DEFAULT_TIMEOUT})");
+                                e = new WebException($"Timeout to {Url} after {timeSinceLastAction / 1000} seconds idle (read {responseBytesRead} bytes).", WebExceptionStatus.Timeout);
+                            }
+                            break;
+                        case HttpStatusCode.NotFound:
+                        case HttpStatusCode.MethodNotAllowed:
+                        case HttpStatusCode.Forbidden:
+                            allowRetry = false;
+                            break;
+                        case HttpStatusCode.Unauthorized:
+                            allowRetry = false;
+                            break;
+                    }
 
-                switch (statusCode)
-                {
-                    case HttpStatusCode.RequestTimeout:
-                        if (hasExceededTimeout)
-                        {
-                            logger.Add($@"Timeout exceeded ({timeSinceLastAction} > {DEFAULT_TIMEOUT})");
-                            e = new WebException($"Timeout to {Url} ({address}) after {timeSinceLastAction / 1000} seconds idle (read {responseBytesRead} bytes).", WebExceptionStatus.Timeout);
-                        }
-                        break;
-                    case HttpStatusCode.NotFound:
-                    case HttpStatusCode.MethodNotAllowed:
-                    case HttpStatusCode.Forbidden:
-                        allowRetry = false;
-                        break;
-                    case HttpStatusCode.Unauthorized:
-                        allowRetry = false;
-                        break;
-                }
+                    if (allowRetry && retriesRemaining-- > 0 && responseBytesRead == 0)
+                    {
+                        logger.Add($@"Request to {Url} failed with {response.StatusCode} (retrying {default_retry_count - retriesRemaining}/{default_retry_count}).");
 
-                if (allowRetry && retriesRemaining-- > 0 && responseBytesRead == 0)
-                {
-                    logger.Add($@"Request to {Url} ({address}) failed with {statusCode} (retrying {default_retry_count - retriesRemaining}/{default_retry_count}).");
+                        //do a retry
+                        PerformAsync();
+                        return;
+                    }
 
-                    //do a retry
-                    perform();
-                    return;
-                }
-                if (useFallbackPath == null && allowRetry && didGetIPv6IP)
-                {
-                    useFallbackPath = true;
-                    logger.Add(@"---------------------- USING FALLBACK PATH! ---------------------");
-                }
-
-                logger.Add($@"Request to {Url} ({address}) failed with {statusCode} (FAILED).");
+                    logger.Add($@"Request to {Url} failed with {response.StatusCode} (FAILED).");
+                    break;
+                case null:
+                    logger.Add($@"Request to {Url} successfully completed!");
+                    break;
             }
-            else if (e == null)
-            {
-                if (useFallbackPath == null)
-                    useFallbackPath = false;
-                logger.Add($@"Request to {Url} ({address}) successfully completed!");
-            }
-
-            response?.Close();
 
             Finished?.Invoke(this, e);
 
@@ -599,15 +409,9 @@ namespace osu.Framework.IO.Network
 
         private void abortRequest()
         {
-            try
-            {
-                request?.Abort();
-                response?.Close();
-            }
-            catch
-            {
-                //This *can* throw random exceptions internally from inside ServicePointManager.
-            }
+            cancellationToken?.Cancel();
+            cancellationToken?.Dispose();
+            cancellationToken = null;
         }
 
         /// <summary>
@@ -623,14 +427,6 @@ namespace osu.Framework.IO.Network
 
             if (!KeepEventsBound)
                 unbindEvents();
-        }
-
-        /// <summary>
-        /// Add a header to this request.
-        /// </summary>
-        public void AddHeader(string key, string val)
-        {
-            Headers.Add(key, val);
         }
 
         /// <summary>
@@ -676,16 +472,6 @@ namespace osu.Framework.IO.Network
             DownloadProgress = null;
             Finished = null;
             Started = null;
-
-            try
-            {
-                if (request?.ServicePoint.BindIPEndPointDelegate != null)
-                    // ReSharper disable once DelegateSubtraction
-                    request.ServicePoint.BindIPEndPointDelegate -= bindEndPoint;
-            }
-            catch
-            {
-            }
         }
 
         #region Timeout Handling
@@ -721,11 +507,11 @@ namespace osu.Framework.IO.Network
             if (isDisposed) return;
             isDisposed = true;
 
+            abortRequest();
+
             if (!(ResponseStream is MemoryStream))
                 ResponseStream?.Dispose();
 
-            internalResponseStream?.Dispose();
-            response?.Close();
             unbindEvents();
         }
 
@@ -752,5 +538,60 @@ namespace osu.Framework.IO.Network
         private int retriesRemaining = default_retry_count;
 
         #endregion
+
+        private class LengthTrackingStream : Stream
+        {
+            public readonly BindableLong BytesRead = new BindableLong();
+
+            private readonly Stream baseStream;
+
+            public LengthTrackingStream(Stream baseStream)
+            {
+                this.baseStream = baseStream;
+            }
+
+            public override void Flush()
+            {
+                baseStream.Flush();
+            }
+
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                int read = baseStream.Read(buffer, offset, count);
+                BytesRead.Value += read;
+                return read;
+            }
+
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                return baseStream.Seek(offset, origin);
+            }
+
+            public override void SetLength(long value)
+            {
+                baseStream.SetLength(value);
+            }
+
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                baseStream.Write(buffer, offset, count);
+            }
+
+            public override bool CanRead => baseStream.CanRead;
+            public override bool CanSeek => baseStream.CanSeek;
+            public override bool CanWrite => baseStream.CanWrite;
+            public override long Length => baseStream.Length;
+            public override long Position
+            {
+                get => baseStream.Position;
+                set => baseStream.Position = value;
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                baseStream.Dispose();
+            }
+        }
     }
 }

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -332,6 +332,11 @@ namespace osu.Framework.IO.Network
         }
 
         /// <summary>
+        /// Performs the request synchronously.
+        /// </summary>
+        public void Perform() => PerformAsync().Wait();
+
+        /// <summary>
         /// Task to run direct before performing the request.
         /// </summary>
         protected virtual void PrePerform()

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -327,6 +327,7 @@ namespace osu.Framework.IO.Network
                 catch (Exception e)
                 {
                     Complete(e);
+                    throw;
                 }
             }, cancellationToken.Token, TaskCreationOptions.LongRunning, TaskScheduler.Current);
         }

--- a/osu.Framework/IO/Stores/OnlineStore.cs
+++ b/osu.Framework/IO/Stores/OnlineStore.cs
@@ -4,7 +4,7 @@
 using System;
 using System.IO;
 using System.Threading.Tasks;
-using osu.Framework.IO.Network;
+using WebRequest = osu.Framework.IO.Network.WebRequest;
 
 namespace osu.Framework.IO.Stores
 {
@@ -12,22 +12,19 @@ namespace osu.Framework.IO.Stores
     {
         public async Task<byte[]> GetAsync(string url)
         {
-            return await Task.Factory.StartNew(delegate
-            {
-                if (!url.StartsWith(@"https://", StringComparison.Ordinal))
-                    return null;
+            if (!url.StartsWith(@"https://", StringComparison.Ordinal))
+                return null;
 
-                try
-                {
-                    WebRequest req = new WebRequest($@"{url}");
-                    req.BlockingPerform();
-                    return req.ResponseData;
-                }
-                catch
-                {
-                    return null;
-                }
-            }, TaskCreationOptions.LongRunning).ConfigureAwait(false);
+            try
+            {
+                WebRequest req = new WebRequest($@"{url}");
+                await req.PerformAsync();
+                return req.ResponseData;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         public byte[] Get(string url)

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -84,6 +84,21 @@
     <Reference Include="SQLiteNetExtensions">
       <HintPath>$(SolutionDir)\packages\SQLiteNetExtensions.1.3.0\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\SQLiteNetExtensions.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net.Http, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Net.Http.4.3.3\lib\net46\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -84,21 +84,9 @@
     <Reference Include="SQLiteNetExtensions">
       <HintPath>$(SolutionDir)\packages\SQLiteNetExtensions.1.3.0\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\SQLiteNetExtensions.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=4.1.1.2, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Net.Http.4.3.3\lib\net46\System.Net.Http.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/osu.Framework/packages.config
+++ b/osu.Framework/packages.config
@@ -15,4 +15,9 @@ Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-frame
   <package id="SQLite.Net.Core-PCL" version="3.1.1" targetFramework="net45" />
   <package id="SQLite.Net-PCL" version="3.1.1" targetFramework="net45" />
   <package id="SQLiteNetExtensions" version="1.3.0" targetFramework="net45" />
+  <package id="System.Net.Http" version="4.3.3" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
 </packages>

--- a/osu.Framework/packages.config
+++ b/osu.Framework/packages.config
@@ -15,9 +15,4 @@ Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-frame
   <package id="SQLite.Net.Core-PCL" version="3.1.1" targetFramework="net45" />
   <package id="SQLite.Net-PCL" version="3.1.1" targetFramework="net45" />
   <package id="SQLiteNetExtensions" version="1.3.0" targetFramework="net45" />
-  <package id="System.Net.Http" version="4.3.3" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net461" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Optional:
- [x] https://github.com/ppy/osu-framework/pull/1090

Found [this](https://github.com/dotnet/corefx/issues/11885#issuecomment-248915149) comment during my quest to fix the WebRequest issue on .NET Core. Furthermore [this](https://github.com/dotnet/corefx/issues/7037) thread basically states that:
1. Anything to do with WebRequest is deprecated.
2. `HttpClient` handles the proxy stuff much better.

As far as I can see, `HttpClient` is the only way forward for .NET Core compatibility.

This branch serves two main purposes:
1. Making `WebRequest` use `HttpClient` for requests.
2. Utilising async/await methods to make the code neater.

The following is _not_ implemented:
1. Certificate validation. This needs to be re-implemented at an osu.Game level - it cannot enforce `*ppy.sh` certificates.
2. IPv4 fallback. I don't know if this is needed and will need further testing to make sure .NET (and core) doesn't just handle this for us.
3. Enforcing maximum 12 connections. This isn't available in the .NET Framework HttpClient (`MaxConnectionsPerServer`) and has been commented out. This is available in System.Net.Http/4.3.3.

The following has _not_ been tested:
1. `POST` file requests. Implementation looks 1:1 as far as I can see though.

