### PR TITLE
Stop TriggerChange from propagating out to bound bindables

### DIFF
--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -132,24 +132,24 @@ namespace osu.Framework.Configuration
 
         /// <summary>
         /// Raise <see cref="ValueChanged"/> and <see cref="DisabledChanged"/> once, without any changes actually occurring.
-        /// Useful for trigering bound events with initial state data.
+        /// This does not propagate to any outward bound bindables.
         /// </summary>
         public void TriggerChange()
         {
-            TriggerValueChange();
-            TriggerDisabledChange();
+            TriggerValueChange(false);
+            TriggerDisabledChange(false);
         }
 
-        protected void TriggerValueChange()
+        protected void TriggerValueChange(bool propagateToBindings = true)
         {
             ValueChanged?.Invoke(value);
-            bindings?.ForEachAlive(b => b.Value = value);
+            if (propagateToBindings) bindings?.ForEachAlive(b => b.Value = value);
         }
 
-        protected void TriggerDisabledChange()
+        protected void TriggerDisabledChange(bool propagateToBindings = true)
         {
             DisabledChanged?.Invoke(disabled);
-            bindings?.ForEachAlive(b => b.Disabled = disabled);
+            if (propagateToBindings) bindings?.ForEachAlive(b => b.Disabled = disabled);
         }
 
         /// <summary>


### PR DESCRIPTION
It should only be used to trigger the local events, not any other Bindable's events. While this is not a serious issue as the ForEach would be essentially a no-op (the values are synchronised at point of binding), this change makes it more clear what is going on.