### PR TITLE
Allow VisibilityContainer to always animate at LoadComplete

### DIFF
--- a/osu.Framework/Graphics/Containers/VisibilityContainer.cs
+++ b/osu.Framework/Graphics/Containers/VisibilityContainer.cs
@@ -10,15 +10,23 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public abstract class VisibilityContainer : Container, IStateful<Visibility>
     {
+        /// <summary>
+        /// Whether we should be in a hidden state when first displayed.
+        /// Override this and set to true to *always* perform a <see cref="PopIn"/> animation even when the state is non-hidden at
+        /// first display.
+        /// </summary>
+        protected virtual bool StartHidden => state == Visibility.Hidden;
+
         protected override void LoadComplete()
         {
-            if (state == Visibility.Hidden)
+            if (StartHidden)
             {
                 // do this without triggering the StateChanged event, since hidden is a default.
                 PopOut();
                 FinishTransforms(true);
             }
-            else
+
+            if (state != Visibility.Hidden)
                 updateState();
 
             base.LoadComplete();


### PR DESCRIPTION
Until now, setting the state on VisibilityContainer before LoadComplete would result in the container being displayed in the set state (without transition).

This allows the consumer to be in control of whether the PopIn animation is played on first display or not.

Fixes https://github.com/ppy/osu/issues/1419.