### PR TITLE
Fix CircularContainer using DrawSize too early

### DIFF
--- a/osu.Framework/Graphics/Containers/CircularContainer.cs
+++ b/osu.Framework/Graphics/Containers/CircularContainer.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using osu.Framework.Caching;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -10,14 +11,27 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public class CircularContainer : Container
     {
+        private Cached cornerRadius = new Cached();
+
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
             bool result = base.Invalidate(invalidation, source, shallPropagate);
 
             if ((invalidation & (Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit)) > 0)
-                CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) / 2f;
+                cornerRadius.Invalidate();
 
             return result;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (!cornerRadius.IsValid)
+            {
+                CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) / 2f;
+                cornerRadius.Validate();
+            }
         }
     }
 }


### PR DESCRIPTION
Could be potentially caching an incorrect value.

Fixes https://github.com/ppy/osu/issues/1416