### PR TITLE
Remove unused SQLite.Net library

### DIFF
--- a/osu.Framework/Platform/DesktopStorage.cs
+++ b/osu.Framework/Platform/DesktopStorage.cs
@@ -4,10 +4,6 @@
 using System;
 using System.Diagnostics;
 using System.IO;
-using SQLite.Net;
-using SQLite.Net.Interop;
-using SQLite.Net.Platform.Generic;
-using SQLite.Net.Platform.Win32;
 using osu.Framework.IO.File;
 
 namespace osu.Framework.Platform
@@ -63,16 +59,6 @@ namespace osu.Framework.Platform
         public override string GetDatabaseConnectionString(string name)
         {
             return string.Concat("Data Source=", GetUsablePathFor($@"{name}.db", true));
-        }
-
-        public override SQLiteConnection GetDatabase(string name)
-        {
-            ISQLitePlatform platform;
-            if (RuntimeInfo.IsWindows)
-                platform = new SQLitePlatformWin32(Architecture.NativeIncludePath);
-            else
-                platform = new SQLitePlatformGeneric();
-            return new SQLiteConnection(platform, GetUsablePathFor($@"{name}.db", true));
         }
 
         public override void DeleteDatabase(string name) => Delete($@"{name}.db");

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using osu.Framework.IO.File;
-using SQLite.Net;
 
 namespace osu.Framework.Platform
 {
@@ -107,13 +106,6 @@ namespace osu.Framework.Platform
         /// <param name="name">The name of the database.</param>
         /// <returns>An SQLite connection string.</returns>
         public abstract string GetDatabaseConnectionString(string name);
-
-        /// <summary>
-        /// Retrieve an SQLite database from within this storage.
-        /// </summary>
-        /// <param name="name">The name of the database.</param>
-        /// <returns>An SQLite connection.</returns>
-        public abstract SQLiteConnection GetDatabase(string name);
 
         /// <summary>
         /// Delete an SQLite database from within this storage.

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -66,18 +66,6 @@
       <HintPath>$(SolutionDir)\packages\OpenTK.3.0.0-git00009\lib\net20\OpenTK.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="SQLite.Net, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\SQLite.Net.Core-PCL.3.1.1\lib\portable-win8+net45+wp8+wpa81+MonoAndroid1+MonoTouch1\SQLite.Net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SQLite.Net.Platform.Generic, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\SQLite.Net-PCL.3.1.1\lib\net40\SQLite.Net.Platform.Generic.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="SQLite.Net.Platform.Win32, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>$(SolutionDir)\packages\SQLite.Net-PCL.3.1.1\lib\net4\SQLite.Net.Platform.Win32.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.AppContext, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>$(SolutionDir)\packages\System.AppContext.4.3.0\lib\net46\System.AppContext.dll</HintPath>
@@ -96,9 +84,6 @@
       <HintPath>$(SolutionDir)\packages\System.Diagnostics.StackTrace.4.3.0\lib\net46\System.Diagnostics.StackTrace.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
-    <Reference Include="SQLiteNetExtensions">
-      <HintPath>$(SolutionDir)\packages\SQLiteNetExtensions.1.3.0\lib\portable-net45+netcore45+wpa81+wp8+MonoAndroid1+MonoTouch1\SQLiteNetExtensions.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Security" />
@@ -614,20 +599,4 @@
     <Folder Include="Platform\MacOS\Native\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <Import Project="$(SolutionDir)\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.0.1\build\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets" Condition="Exists('$(SolutionDir)\packages\SQLitePCLRaw.lib.e_sqlite3.v110_xp.1.0.1\build\SQLitePCLRaw.lib.e_sqlite3.v110_xp.targets')" />
-  <Import Project="$(SolutionDir)\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.0.1\build\SQLitePCLRaw.lib.e_sqlite3.osx.targets" Condition="Exists('$(SolutionDir)\packages\SQLitePCLRaw.lib.e_sqlite3.osx.1.0.1\build\SQLitePCLRaw.lib.e_sqlite3.osx.targets')" />
-  <Import Project="$(SolutionDir)\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.0.1\build\SQLitePCLRaw.lib.e_sqlite3.linux.targets" Condition="Exists('$(SolutionDir)\packages\SQLitePCLRaw.lib.e_sqlite3.linux.1.0.1\build\SQLitePCLRaw.lib.e_sqlite3.linux.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\packages\Microsoft.Net.Compilers.2.3.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\packages\Microsoft.Net.Compilers.2.3.2\build\Microsoft.Net.Compilers.props'))" />
-  </Target>
 </Project>

--- a/osu.Framework/packages.config
+++ b/osu.Framework/packages.config
@@ -14,9 +14,6 @@ Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-frame
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="NUnit" version="3.8.1" targetFramework="net461" />
   <package id="OpenTK" version="3.0.0-git00009" targetFramework="net461" />
-  <package id="SQLite.Net.Core-PCL" version="3.1.1" targetFramework="net45" />
-  <package id="SQLite.Net-PCL" version="3.1.1" targetFramework="net45" />
-  <package id="SQLiteNetExtensions" version="1.3.0" targetFramework="net45" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net461" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
Gonna say that for my own sanity, this is a prerequisite to https://github.com/ppy/osu-framework/pull/1106.

1. We are no longer using SQLite.Net, and as of the latest discussions, we're moving all database-related code to the osu! project. We can figure this out later, but this is how it is right now.
2. The SQLite targets are also targeted by osu.Game and osu.Desktop.