### PR TITLE
Catch any exceptions thrown by macOS reflection during initialisation

### DIFF
--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -34,20 +34,27 @@ namespace osu.Framework.Platform.MacOS
 
         protected override void OnLoad(EventArgs e)
         {
-            flagsChangedHandler = flagsChanged;
+            try
+            {
+                flagsChangedHandler = flagsChanged;
 
-            var fieldImplementation = typeof(OpenTK.NativeWindow).GetRuntimeFields().Single(x => x.Name == "implementation");
-            var typeCocoaNativeWindow = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "CocoaNativeWindow");
-            var fieldWindowClass = typeCocoaNativeWindow.GetRuntimeFields().Single(x => x.Name == "windowClass");
+                var fieldImplementation = typeof(OpenTK.NativeWindow).GetRuntimeFields().Single(x => x.Name == "implementation");
+                var typeCocoaNativeWindow = typeof(OpenTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "CocoaNativeWindow");
+                var fieldWindowClass = typeCocoaNativeWindow.GetRuntimeFields().Single(x => x.Name == "windowClass");
 
-            nativeWindow = fieldImplementation.GetValue(this);
-            var windowClass = (IntPtr)fieldWindowClass.GetValue(nativeWindow);
+                nativeWindow = fieldImplementation.GetValue(this);
+                var windowClass = (IntPtr)fieldWindowClass.GetValue(nativeWindow);
 
-            Class.RegisterMethod(windowClass, flagsChangedHandler, "flagsChanged:", "v@:@");
+                Class.RegisterMethod(windowClass, flagsChangedHandler, "flagsChanged:", "v@:@");
 
-            methodKeyDown = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyDown");
-            methodKeyUp = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyUp");
-
+                methodKeyDown = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyDown");
+                methodKeyUp = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyUp");
+            }
+            catch
+            {
+                // This reflection may fail if we're using the SDL backend, so we'll just ignore it.
+                // The result will be that modifier keys and possibly the clipboard may not work correctly.
+            }
             base.OnLoad(e);
         }
 

--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Reflection;
+using osu.Framework.Logging;
 using osu.Framework.Platform.MacOS.Native;
 
 namespace osu.Framework.Platform.MacOS
@@ -52,9 +53,10 @@ namespace osu.Framework.Platform.MacOS
             }
             catch
             {
-                // This reflection may fail if we're using the SDL backend, so we'll just ignore it.
-                // The result will be that modifier keys and possibly the clipboard may not work correctly.
+                Logger.Log("Window initialisation couldn't complete, likely due to the SDL backend being enabled.", LoggingTarget.Runtime, LogLevel.Important);
+                Logger.Log("Execution will continue but keyboard functionality may be limited.", LoggingTarget.Runtime, LogLevel.Important);
             }
+
             base.OnLoad(e);
         }
 


### PR DESCRIPTION
As noted in #1138, apps will hard crash if running on macOS with the SDL backend.  This change will prevent the crash, but special handling for modifier keys will no longer be initialised.

It's possible that the reflection workarounds may be unnecessary with SDL anyway.  Need more info from @Zylviij regarding this.