### PR TITLE
Improve performance of DrawVisualiser

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -104,7 +104,14 @@ namespace osu.Framework.Graphics.Containers
 
         #region Children management
 
+        /// <summary>
+        /// Invoked when a child has entered <see cref="AliveInternalChildren"/>.
+        /// </summary>
         internal event Action<Drawable> ChildBecameAlive;
+
+        /// <summary>
+        /// Invoked when a child has left <see cref="AliveInternalChildren"/>.
+        /// </summary>
         internal event Action<Drawable> ChildDied;
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -104,6 +104,9 @@ namespace osu.Framework.Graphics.Containers
 
         #region Children management
 
+        internal event Action<Drawable> ChildBecameAlive;
+        internal event Action<Drawable> ChildDied;
+
         /// <summary>
         /// Gets or sets the only child in <see cref="InternalChildren"/>.
         /// </summary>
@@ -222,7 +225,10 @@ namespace osu.Framework.Graphics.Containers
 
             internalChildren.RemoveAt(index);
             if (drawable.IsAlive)
+            {
                 aliveInternalChildren.Remove(drawable);
+                ChildDied?.Invoke(drawable);
+            }
 
             if (drawable.LoadState >= LoadState.Ready)
             {
@@ -250,6 +256,9 @@ namespace osu.Framework.Graphics.Containers
         {
             foreach (Drawable t in internalChildren)
             {
+                if (t.IsAlive)
+                    ChildDied?.Invoke(t);
+
                 t.IsAlive = false;
 
                 if (disposeChildren)
@@ -387,6 +396,7 @@ namespace osu.Framework.Graphics.Containers
                     if (child.LoadState >= LoadState.Ready)
                     {
                         aliveInternalChildren.Add(child);
+                        ChildBecameAlive?.Invoke(child);
                         child.IsAlive = true;
                         changed = true;
                     }
@@ -397,6 +407,7 @@ namespace osu.Framework.Graphics.Containers
                 if (child.IsAlive)
                 {
                     aliveInternalChildren.Remove(child);
+                    ChildDied?.Invoke(child);
                     child.IsAlive = false;
                     changed = true;
                 }

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Graphics.Visualisation
                         // Rehighlight the last highlight
                         if (lastHighlight != null)
                         {
-                            VisualisedDrawable visualised = findVisualised(lastHighlight, targetDrawable);
+                            VisualisedDrawable visualised = targetDrawable.FindVisualisedDrawable(lastHighlight);
                             if (visualised != null)
                             {
                                 propertyDisplay.State = Visibility.Visible;
@@ -81,21 +81,6 @@ namespace osu.Framework.Graphics.Visualisation
         {
             base.LoadComplete();
             inputManager = GetContainingInputManager();
-        }
-
-        private VisualisedDrawable findVisualised(Drawable d, VisualisedDrawable root)
-        {
-            foreach (VisualisedDrawable child in root.Flow.InternalChildren.OfType<VisualisedDrawable>())
-            {
-                if (child.Target == d)
-                    return child;
-
-                VisualisedDrawable found = findVisualised(d, child);
-                if (found != null)
-                    return found;
-            }
-
-            return null;
         }
 
         protected override bool BlockPassThroughMouse => false;

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -4,9 +4,7 @@
 using System.Linq;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
-using osu.Framework.Threading;
 
 namespace osu.Framework.Graphics.Visualisation
 {

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -12,7 +12,6 @@ using OpenTK.Input;
 using osu.Framework.Graphics.Shapes;
 using System.Collections.Generic;
 using osu.Framework.Extensions.IEnumerableExtensions;
-using System.Linq;
 
 namespace osu.Framework.Graphics.Visualisation
 {
@@ -57,7 +56,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         private const int line_height = 12;
 
-        private FillFlowContainer<VisualisedDrawable> flow;
+        private readonly FillFlowContainer<VisualisedDrawable> flow;
         private readonly TreeContainer tree;
 
         public VisualisedDrawable(Drawable d, TreeContainer tree)
@@ -141,8 +140,7 @@ namespace osu.Framework.Graphics.Visualisation
             previewBox.Size = new Vector2(line_height, line_height);
 
             var compositeTarget = Target as CompositeDrawable;
-            if (compositeTarget != null)
-                compositeTarget.AliveInternalChildren.ForEach(c => addChild(c));
+            compositeTarget?.AliveInternalChildren.ForEach(addChild);
 
             updateSpecifics();
         }
@@ -185,7 +183,7 @@ namespace osu.Framework.Graphics.Visualisation
             // Make sure to never add the DrawVisualiser (recursive scenario)
             if (drawable is DrawVisualiser) return;
 
-            /// Don't add individual characters of SpriteText
+            // Don't add individual characters of SpriteText
             if (Target is SpriteText) return;
 
             VisualisedDrawable vis;

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -12,6 +12,7 @@ using OpenTK.Input;
 using osu.Framework.Graphics.Shapes;
 using System.Collections.Generic;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using System.Linq;
 
 namespace osu.Framework.Graphics.Visualisation
 {
@@ -56,7 +57,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         private const int line_height = 12;
 
-        public FillFlowContainer<VisualisedDrawable> Flow;
+        private FillFlowContainer<VisualisedDrawable> flow;
         private readonly TreeContainer tree;
 
         public VisualisedDrawable(Drawable d, TreeContainer tree)
@@ -127,7 +128,7 @@ namespace osu.Framework.Graphics.Visualisation
                         text = new SpriteText()
                     }
                 },
-                Flow = new FillFlowContainer<VisualisedDrawable>
+                flow = new FillFlowContainer<VisualisedDrawable>
                 {
                     Direction = FillDirection.Vertical,
                     RelativeSizeAxes = Axes.X,
@@ -197,14 +198,29 @@ namespace osu.Framework.Graphics.Visualisation
                 };
             }
 
-            Flow.Add(vis);
+            flow.Add(vis);
         }
 
         private void removeChild(Drawable drawable)
         {
             if (!visCache.ContainsKey(drawable))
                 return;
-            Flow.Remove(visCache[drawable]);
+            flow.Remove(visCache[drawable]);
+        }
+
+        public VisualisedDrawable FindVisualisedDrawable(Drawable drawable)
+        {
+            if (drawable == Target)
+                return this;
+
+            foreach (var child in flow)
+            {
+                var vis = child.FindVisualisedDrawable(drawable);
+                if (vis != null)
+                    return vis;
+            }
+
+            return null;
         }
 
         protected override void Dispose(bool isDisposing)
@@ -254,7 +270,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         public void Expand()
         {
-            Flow.FadeIn();
+            flow.FadeIn();
             updateSpecifics();
 
             isExpanded = true;
@@ -262,7 +278,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         public void Collapse()
         {
-            Flow.FadeOut();
+            flow.FadeOut();
             updateSpecifics();
 
             isExpanded = false;


### PR DESCRIPTION
Previously it would iterate over every container and perform a FirstOrDefault on it to figure out whether a VisualisedDrawable existed/should be updated. With many drawables, this was super expensive, tending towards O(n^2) in worst case, plus other O(n) loops over visualised drawables.

I noticed this as a hot line when profiling:
<img width="682" alt="screen shot 2017-11-10 at 7 23 49 pm" src="https://user-images.githubusercontent.com/1329837/32656347-cc3f000e-c654-11e7-90a6-ba77afb2e727.png">

This changes makes DrawVisualiser instead respond to additions/removal from AliveInternalChildren, and caches the VisualisedDrawables, removing the need for expiry/reconstruction and more O(n) searching.

Along with this, these changes also seem to fix the flickering present due to the expiries inside VisualisedDrawable, such as in the case of TestCaseBlending.