### PR TITLE
Fix TabbableContainer ignoring children of CompositeDrawables

### DIFF
--- a/osu.Framework/Graphics/Containers/TabbableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContainer.cs
@@ -39,39 +39,43 @@ namespace osu.Framework.Graphics.Containers
 
         private Drawable nextTabStop(Container<Drawable> target, bool reverse)
         {
-            Stack<IContainerEnumerable<Drawable>> stack = new Stack<IContainerEnumerable<Drawable>>();
+            Stack<Drawable> stack = new Stack<Drawable>();
             stack.Push(target); // Extra push for circular tabbing
             stack.Push(target);
 
             bool started = false;
             while (stack.Count > 0)
             {
-                var container = stack.Pop();
+                var drawable = stack.Pop();
 
                 if (!started)
-                    started = ReferenceEquals(container, this);
-                else if (container is ITabbableContainer)
-                    return container as Drawable;
+                    started = ReferenceEquals(drawable, this);
+                else if (drawable is ITabbableContainer)
+                    return drawable as Drawable;
 
-                var filtered = container.Children.OfType<IContainerEnumerable<Drawable>>().ToList();
-                int bound = reverse ? filtered.Count : 0;
-                if (!started)
+                var composite = drawable as CompositeDrawable;
+                if (composite != null)
                 {
-                    // Find self, to know starting point
-                    int index = filtered.IndexOf(this);
-                    if (index != -1)
-                        bound = reverse ? index + 1 : index;
-                }
+                    var newChildren = composite.InternalChildren.ToList();
+                    int bound = reverse ? newChildren.Count : 0;
+                    if (!started)
+                    {
+                        // Find self, to know starting point
+                        int index = newChildren.IndexOf(this);
+                        if (index != -1)
+                            bound = reverse ? index + 1 : index;
+                    }
 
-                if (reverse)
-                {
-                    for (int i = 0; i < bound; i++)
-                        stack.Push(filtered[i]);
-                }
-                else
-                {
-                    for (int i = filtered.Count - 1; i >= bound; i--)
-                        stack.Push(filtered[i]);
+                    if (reverse)
+                    {
+                        for (int i = 0; i < bound; i++)
+                            stack.Push(newChildren[i]);
+                    }
+                    else
+                    {
+                        for (int i = newChildren.Count - 1; i >= bound; i--)
+                            stack.Push(newChildren[i]);
+                    }
                 }
             }
 

--- a/osu.Framework/Graphics/Containers/TabbableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContainer.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Graphics.Containers
                 if (!started)
                     started = ReferenceEquals(drawable, this);
                 else if (drawable is ITabbableContainer)
-                    return drawable as Drawable;
+                    return drawable;
 
                 var composite = drawable as CompositeDrawable;
                 if (composite != null)


### PR DESCRIPTION
What it sounds like. If you had a hierarchy like this:
```
Container
|-> CompositeDrawable
     |-> TextBox (TabbableContentContainer set to Container)
|-> CompositeDrawable
     |-> TextBox (TabbableContentContainer set to Container)
```
Then tabbing between the TextBoxes would not work, because they are both children of a CompositeDrawable. This is fixed by checking through all children of all CompositeDrawables, instead of only of Containers when figuring out which control to transfer focus to when tabbing.