### PR TITLE
Add note about HandleInput to Tooltip docs

### DIFF
--- a/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
@@ -4,7 +4,8 @@
 namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
-    /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a custom tooltip if it is the child of a <see cref="TooltipContainer"/>
+    /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a custom tooltip if it is the child of a <see cref="TooltipContainer"/>.
+    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasCustomTooltip"/> has <see cref="Drawable.HandleInput"/> set to true.
     /// </summary>
     public interface IHasCustomTooltip : IHasTooltip
     {

--- a/osu.Framework/Graphics/Cursor/IHasTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasTooltip.cs
@@ -6,6 +6,7 @@ namespace osu.Framework.Graphics.Cursor
     /// <summary>
     /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a tooltip if it is the child of a <see cref="TooltipContainer"/>. The tooltip used is
     /// dependent on the implementation of the <see cref="TooltipContainer.CreateTooltip"/> method of the <see cref="TooltipContainer"/> containing this <see cref="Drawable"/>.
+    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasTooltip"/> has <see cref="Drawable.HandleInput"/> set to true.
     /// </summary>
     public interface IHasTooltip : IDrawable
     {

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -15,7 +15,7 @@ using System.Linq;
 namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
-    /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces.
+    /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces. Keep in mind that only children with <see cref="Drawable.HandleInput"/> set to true will be checked for their tooltips.
     /// </summary>
     public class TooltipContainer : CursorEffectContainer<TooltipContainer, IHasTooltip>
     {


### PR DESCRIPTION
Adds a line about the need for HandleInput to be set to true in the xml docs of TooltipContainer, IHasTooltip and IHasCustomTooltip.