### PR TITLE
Expose a way to stop clock updates

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -320,7 +320,7 @@ namespace osu.Framework.Graphics
             if (isDisposed)
                 throw new ObjectDisposedException(ToString(), "Disposed Drawables may never be in the scene graph.");
 
-            if (ShouldUpdateCustomClock)
+            if (ShouldProcessClock)
                 customClock?.ProcessFrame();
 
             if (loadState < LoadState.Ready)
@@ -1156,7 +1156,7 @@ namespace osu.Framework.Graphics
         /// Whether <see cref="IFrameBasedClock.ProcessFrame"/> should be automatically invoked on this <see cref="Drawable"/>'s <see cref="Clock"/>
         /// in <see cref="UpdateSubTree"/>. This should only be used in scenarios where <see cref="UpdateSubTree"/> is overridden to perform the functionality itself.
         /// </summary>
-        protected virtual bool ShouldUpdateCustomClock => Parent != null; //we don't want to update our clock if we are at the top of the stack. it's handled elsewhere for us.
+        protected virtual bool ShouldProcessClock => Parent != null; //we don't want to update our clock if we are at the top of the stack. it's handled elsewhere for us.
 
         /// <summary>
         /// The time at which this drawable becomes valid (and is considered for drawing).

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -320,7 +320,7 @@ namespace osu.Framework.Graphics
             if (isDisposed)
                 throw new ObjectDisposedException(ToString(), "Disposed Drawables may never be in the scene graph.");
 
-            if (Parent != null) //we don't want to update our clock if we are at the top of the stack. it's handled elsewhere for us.
+            if (ShouldUpdateCustomClock)
                 customClock?.ProcessFrame();
 
             if (loadState < LoadState.Ready)
@@ -1151,6 +1151,12 @@ namespace osu.Framework.Graphics
             this.clock = customClock ?? clock;
             scheduler?.UpdateClock(this.clock);
         }
+
+        /// <summary>
+        /// Whether <see cref="IFrameBasedClock.ProcessFrame"/> should be automatically invoked on this <see cref="Drawable"/>'s <see cref="Clock"/>
+        /// in <see cref="UpdateSubTree"/>. This should only be used in scenarios where <see cref="UpdateSubTree"/> is overridden to perform the functionality itself.
+        /// </summary>
+        protected virtual bool ShouldUpdateCustomClock => Parent != null; //we don't want to update our clock if we are at the top of the stack. it's handled elsewhere for us.
 
         /// <summary>
         /// The time at which this drawable becomes valid (and is considered for drawing).


### PR DESCRIPTION
This is useful in scenarios where the clock time is read from somewhere else and updated within a derived UpdateSubTree, such as replay playback. In such scenarios, we don't want to call ProcessFrame() on the clock twice as doing so would affect FPS count and AverageFrameTime.