### PR TITLE
Don't show log overlay by default

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Configuration
 
         protected override void InitialiseDefaults()
         {
-            Set(FrameworkSetting.ShowLogOverlay, true);
+            Set(FrameworkSetting.ShowLogOverlay, false);
 
             Set(FrameworkSetting.Width, 1366, 640);
             Set(FrameworkSetting.Height, 768, 480);


### PR DESCRIPTION
I think most users would want this to be off as a default behaviour.