### PR TITLE
Easing improvements

### DIFF
--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -149,7 +149,7 @@ namespace osu.Framework.MathUtils
 
             if (duration == 0 || current == 0)
                 return val1;
-            
+
             float t = (float)ApplyEasing(easing, current / duration);
 
             return new RectangleF(
@@ -197,8 +197,6 @@ namespace osu.Framework.MathUtils
                     return time * time * time * time * time;
                 case Easing.OutQuint:
                     return --time * time * time * time * time + 1;
-                case Easing.OutPow10:
-                    return --time * Math.Pow(time, 10) + 1;
                 case Easing.InOutQuint:
                     if (time < .5) return time * time * time * time * time * 16;
                     return --time * time * time * time * time * 16 + 1;
@@ -286,6 +284,9 @@ namespace osu.Framework.MathUtils
                 case Easing.InOutBounce:
                     if (time < .5) return .5 - .5 * ApplyEasing(Easing.OutBounce, 1 - time * 2);
                     return ApplyEasing(Easing.OutBounce, (time - .5) * 2) * .5 + .5;
+
+                case Easing.OutPow10:
+                    return --time * Math.Pow(time, 10) + 1;
             }
         }
     }

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -161,9 +161,16 @@ namespace osu.Framework.MathUtils
 
         public static double ApplyEasing(Easing easing, double time)
         {
+            const double elastic_const = 2 * Math.PI / .3;
+            const double elastic_const2 = .3 / 4;
+
+            const double back_const = 1.70158;
+            const double back_const2 = back_const * 1.525;
+
+            const double bounce_const = 1 / 2.75;
+
             switch (easing)
             {
-                case Easing.None:
                 default:
                     return time;
 
@@ -225,62 +232,43 @@ namespace osu.Framework.MathUtils
                     return .5 * Math.Sqrt(1 - (time -= 2) * time) + .5;
 
                 case Easing.InElastic:
-                    const double ELASTIC_CONST = 2 * Math.PI / .3;
-                    const double ELASTIC_CONST2 = .3 / 4;
-                    return -Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - ELASTIC_CONST2 - time) * ELASTIC_CONST);
+                    return -Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - elastic_const2 - time) * elastic_const);
                 case Easing.OutElastic:
-                    return Math.Pow(2, -10 * time) * Math.Sin((time - ELASTIC_CONST2) * ELASTIC_CONST) + 1;
+                    return Math.Pow(2, -10 * time) * Math.Sin((time - elastic_const2) * elastic_const) + 1;
                 case Easing.OutElasticHalf:
-                    return Math.Pow(2, -10 * time) * Math.Sin((.5 * time - ELASTIC_CONST2) * ELASTIC_CONST) + 1;
+                    return Math.Pow(2, -10 * time) * Math.Sin((.5 * time - elastic_const2) * elastic_const) + 1;
                 case Easing.OutElasticQuarter:
-                    return Math.Pow(2, -10 * time) * Math.Sin((.25 * time - ELASTIC_CONST2) * ELASTIC_CONST) + 1;
+                    return Math.Pow(2, -10 * time) * Math.Sin((.25 * time - elastic_const2) * elastic_const) + 1;
                 case Easing.InOutElastic:
                     if ((time *= 2) < 1)
-                    {
-                        return -.5 * Math.Pow(2, -10 + 10 * time) * Math.Sin(((1 - ELASTIC_CONST2 * 1.5) - time) * ELASTIC_CONST / 1.5);
-                    }
-                    return .5 * Math.Pow(2, -10 * --time) * Math.Sin((time - ELASTIC_CONST2 * 1.5) * ELASTIC_CONST / 1.5) + 1;
+                        return -.5 * Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - elastic_const2 * 1.5 - time) * elastic_const / 1.5);
+                    return .5 * Math.Pow(2, -10 * --time) * Math.Sin((time - elastic_const2 * 1.5) * elastic_const / 1.5) + 1;
 
                 case Easing.InBack:
-                    const double BACK_CONST = 1.70158;
-                    return time * time * ((BACK_CONST + 1) * time - BACK_CONST);
+                    return time * time * ((back_const + 1) * time - back_const);
                 case Easing.OutBack:
-                    return --time * time * ((BACK_CONST + 1) * time + BACK_CONST) + 1;
+                    return --time * time * ((back_const + 1) * time + back_const) + 1;
                 case Easing.InOutBack:
-                    const double BACK_CONST2 = BACK_CONST * 1.525;
-                    if ((time *= 2) < 1) return .5 * time * time * ((BACK_CONST2 + 1) * time - BACK_CONST2);
-                    return .5 * ((time -= 2) * time * ((BACK_CONST2 + 1) * time + BACK_CONST2) + 2);
+                    if ((time *= 2) < 1) return .5 * time * time * ((back_const2 + 1) * time - back_const2);
+                    return .5 * ((time -= 2) * time * ((back_const2 + 1) * time + back_const2) + 2);
 
                 case Easing.InBounce:
-                    const double BOUNCE_CONST = 1 / 2.75;
                     time = 1 - time;
-                    if (time < BOUNCE_CONST)
-                    {
-                        return 1 - (7.5625 * time * time);
-                    }
-                    if (time < 2 * BOUNCE_CONST)
-                    {
-                        return 1 - (7.5625 * (time -= 1.5 * BOUNCE_CONST) * time + .75);
-                    }
-                    if (time < 2.5 * BOUNCE_CONST)
-                    {
-                        return 1 - (7.5625 * (time -= 2.25 * BOUNCE_CONST) * time + .9375);
-                    }
-                    return 1 - (7.5625 * (time -= 2.625 * BOUNCE_CONST) * time + .984375);
+                    if (time < bounce_const)
+                        return 1 - 7.5625 * time * time;
+                    if (time < 2 * bounce_const)
+                        return 1 - (7.5625 * (time -= 1.5 * bounce_const) * time + .75);
+                    if (time < 2.5 * bounce_const)
+                        return 1 - (7.5625 * (time -= 2.25 * bounce_const) * time + .9375);
+                    return 1 - (7.5625 * (time -= 2.625 * bounce_const) * time + .984375);
                 case Easing.OutBounce:
-                    if (time < BOUNCE_CONST)
-                    {
-                        return (7.5625 * time * time);
-                    }
-                    if (time < 2 * BOUNCE_CONST)
-                    {
-                        return (7.5625 * (time -= 1.5 * BOUNCE_CONST) * time + .75);
-                    }
-                    if (time < 2.5 * BOUNCE_CONST)
-                    {
-                        return (7.5625 * (time -= 2.25 * BOUNCE_CONST) * time + .9375);
-                    }
-                    return (7.5625 * (time -= 2.625 * BOUNCE_CONST) * time + .984375);
+                    if (time < bounce_const)
+                        return 7.5625 * time * time;
+                    if (time < 2 * bounce_const)
+                        return 7.5625 * (time -= 1.5 * bounce_const) * time + .75;
+                    if (time < 2.5 * bounce_const)
+                        return 7.5625 * (time -= 2.25 * bounce_const) * time + .9375;
+                    return 7.5625 * (time -= 2.625 * bounce_const) * time + .984375;
                 case Easing.InOutBounce:
                     if (time < .5) return .5 - .5 * ApplyEasing(Easing.OutBounce, 1 - time * 2);
                     return ApplyEasing(Easing.OutBounce, (time - .5) * 2) * .5 + .5;

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -74,11 +74,13 @@ namespace osu.Framework.MathUtils
             if (duration == 0 || current == 0)
                 return startColour;
 
+            float t = Math.Max(0, Math.Min(1, (float)ApplyEasing(easing, current / duration)));
+
             return new Color4(
-                (float)Math.Max(0, Math.Min(1, ApplyEasing(easing, current, startColour.R, endColour.R - startColour.R, duration))),
-                (float)Math.Max(0, Math.Min(1, ApplyEasing(easing, current, startColour.G, endColour.G - startColour.G, duration))),
-                (float)Math.Max(0, Math.Min(1, ApplyEasing(easing, current, startColour.B, endColour.B - startColour.B, duration))),
-                (float)Math.Max(0, Math.Min(1, ApplyEasing(easing, current, startColour.A, endColour.A - startColour.A, duration))));
+                startColour.R + t * (endColour.R - startColour.R),
+                startColour.G + t * (endColour.G - startColour.G),
+                startColour.B + t * (endColour.B - startColour.B),
+                startColour.A + t * (endColour.A - startColour.A));
         }
 
         public static byte ValueAt(double time, byte val1, byte val2, double startTime, double endTime, Easing easing = Easing.None) =>
@@ -124,7 +126,8 @@ namespace osu.Framework.MathUtils
             if (duration == 0)
                 return val2;
 
-            return ApplyEasing(easing, current, val1, val2 - val1, duration);
+            double t = ApplyEasing(easing, current / duration);
+            return val1 + t * (val2 - val1);
         }
 
         public static Vector2 ValueAt(double time, Vector2 val1, Vector2 val2, double startTime, double endTime, Easing easing = Easing.None)
@@ -135,9 +138,8 @@ namespace osu.Framework.MathUtils
             if (duration == 0 || current == 0)
                 return val1;
 
-            return new Vector2(
-                (float)ApplyEasing(easing, current, val1.X, val2.X - val1.X, duration),
-                (float)ApplyEasing(easing, current, val1.Y, val2.Y - val1.Y, duration));
+            float t = (float)ApplyEasing(easing, current / duration);
+            return val1 + t * (val2 - val1);
         }
 
         public static RectangleF ValueAt(double time, RectangleF val1, RectangleF val2, double startTime, double endTime, Easing easing = Easing.None)
@@ -147,187 +149,143 @@ namespace osu.Framework.MathUtils
 
             if (duration == 0 || current == 0)
                 return val1;
+            
+            float t = (float)ApplyEasing(easing, current / duration);
 
             return new RectangleF(
-                (float)ApplyEasing(easing, current, val1.X, val2.X - val1.X, duration),
-                (float)ApplyEasing(easing, current, val1.Y, val2.Y - val1.Y, duration),
-                (float)ApplyEasing(easing, current, val1.Width, val2.Width - val1.Width, duration),
-                (float)ApplyEasing(easing, current, val1.Height, val2.Height - val1.Height, duration));
+                val1.X + t * (val2.X - val1.X),
+                val1.Y + t * (val2.Y - val1.Y),
+                val1.Width + t * (val2.Width - val1.Width),
+                val1.Height + t * (val2.X - val1.Height));
         }
 
-        public static double ApplyEasing(Easing easing, double time, double initial, double change, double duration)
+        public static double ApplyEasing(Easing easing, double time)
         {
-            if (change == 0 || time == 0 || duration == 0) return initial;
-            if (time == duration) return initial + change;
-
             switch (easing)
             {
+                case Easing.None:
                 default:
-                    return change * (time / duration) + initial;
+                    return time;
+
                 case Easing.In:
                 case Easing.InQuad:
-                    return change * (time /= duration) * time + initial;
+                    return time * time;
                 case Easing.Out:
                 case Easing.OutQuad:
-                    return -change * (time /= duration) * (time - 2) + initial;
+                    return time * (2 - time);
                 case Easing.InOutQuad:
-                    if ((time /= duration / 2) < 1) return change / 2 * time * time + initial;
-                    return -change / 2 * (--time * (time - 2) - 1) + initial;
+                    if (time < .5) return time * time * 2;
+                    return --time * time * -2 + 1;
+
                 case Easing.InCubic:
-                    return change * (time /= duration) * time * time + initial;
+                    return time * time * time;
                 case Easing.OutCubic:
-                    return change * ((time = time / duration - 1) * time * time + 1) + initial;
+                    return --time * time * time + 1;
                 case Easing.InOutCubic:
-                    if ((time /= duration / 2) < 1) return change / 2 * time * time * time + initial;
-                    return change / 2 * ((time -= 2) * time * time + 2) + initial;
+                    if (time < .5) return time * time * time * 4;
+                    return --time * time * time * 4 + 1;
+
                 case Easing.InQuart:
-                    return change * (time /= duration) * time * time * time + initial;
+                    return time * time * time * time;
                 case Easing.OutQuart:
-                    return -change * ((time = time / duration - 1) * time * time * time - 1) + initial;
+                    return 1 - --time * time * time * time;
                 case Easing.InOutQuart:
-                    if ((time /= duration / 2) < 1) return change / 2 * time * time * time * time + initial;
-                    return -change / 2 * ((time -= 2) * time * time * time - 2) + initial;
+                    if (time < .5) return time * time * time * time * 8;
+                    return --time * time * time * time * -8 + 1;
+
                 case Easing.InQuint:
-                    return change * (time /= duration) * time * time * time * time + initial;
+                    return time * time * time * time * time;
                 case Easing.OutQuint:
-                    return change * ((time = time / duration - 1) * time * time * time * time + 1) + initial;
+                    return --time * time * time * time * time + 1;
                 case Easing.OutPow10:
-                    return change * ((time = time / duration - 1) * Math.Pow(time, 10) + 1) + initial;
+                    return --time * Math.Pow(time, 10) + 1;
                 case Easing.InOutQuint:
-                    if ((time /= duration / 2) < 1) return change / 2 * time * time * time * time * time + initial;
-                    return change / 2 * ((time -= 2) * time * time * time * time + 2) + initial;
+                    if (time < .5) return time * time * time * time * time * 16;
+                    return --time * time * time * time * time * 16 + 1;
+
                 case Easing.InSine:
-                    return -change * Math.Cos(time / duration * (MathHelper.Pi / 2)) + change + initial;
+                    return 1 - Math.Cos(time * Math.PI * .5);
                 case Easing.OutSine:
-                    return change * Math.Sin(time / duration * (MathHelper.Pi / 2)) + initial;
+                    return Math.Sin(time * Math.PI * .5);
                 case Easing.InOutSine:
-                    return -change / 2 * (Math.Cos(MathHelper.Pi * time / duration) - 1) + initial;
+                    return .5 - .5 * Math.Cos(Math.PI * time);
+
                 case Easing.InExpo:
-                    return change * Math.Pow(2, 10 * (time / duration - 1)) + initial;
+                    return Math.Pow(2, 10 * (time - 1));
                 case Easing.OutExpo:
-                    return time == duration ? initial + change : change * (-Math.Pow(2, -10 * time / duration) + 1) + initial;
+                    return -Math.Pow(2, -10 * time) + 1;
                 case Easing.InOutExpo:
-                    if ((time /= duration / 2) < 1) return change / 2 * Math.Pow(2, 10 * (time - 1)) + initial;
-                    return change / 2 * (-Math.Pow(2, -10 * --time) + 2) + initial;
+                    if (time < .5) return .5 * Math.Pow(2, 20 * time - 10);
+                    return 1 - .5 * Math.Pow(2, -20 * time + 10);
+
                 case Easing.InCirc:
-                    return -change * (Math.Sqrt(1 - (time /= duration) * time) - 1) + initial;
+                    return 1 - Math.Sqrt(1 - time * time);
                 case Easing.OutCirc:
-                    return change * Math.Sqrt(1 - (time = time / duration - 1) * time) + initial;
+                    return Math.Sqrt(1 - --time * time);
                 case Easing.InOutCirc:
-                    if ((time /= duration / 2) < 1) return -change / 2 * (Math.Sqrt(1 - time * time) - 1) + initial;
-                    return change / 2 * (Math.Sqrt(1 - (time -= 2) * time) + 1) + initial;
+                    if ((time *= 2) < 1) return .5 - .5 * Math.Sqrt(1 - time * time);
+                    return .5 * Math.Sqrt(1 - (time -= 2) * time) + .5;
+
                 case Easing.InElastic:
-                    {
-                        if ((time /= duration) == 1) return initial + change;
-
-                        var p = duration * .3;
-                        var a = change;
-                        double s;
-                        if (a < Math.Abs(change))
-                        {
-                            a = change;
-                            s = p / 4;
-                        }
-                        else
-                            s = p / (2 * MathHelper.Pi) * Math.Asin(change / a);
-                        return -(a * Math.Pow(2, 10 * (time -= 1)) * Math.Sin((time * duration - s) * (2 * MathHelper.Pi) / p)) + initial;
-                    }
+                    const double ELASTIC_CONST = 2 * Math.PI / .3;
+                    const double ELASTIC_CONST2 = .3 / 4;
+                    return -Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - ELASTIC_CONST2 - time) * ELASTIC_CONST);
                 case Easing.OutElastic:
-                    {
-                        if ((time /= duration) == 1) return initial + change;
-
-                        var p = duration * .3;
-                        var a = change;
-                        double s;
-                        if (a < Math.Abs(change))
-                        {
-                            a = change;
-                            s = p / 4;
-                        }
-                        else s = p / (2 * MathHelper.Pi) * Math.Asin(change / a);
-                        return a * Math.Pow(2, -10 * time) * Math.Sin((time * duration - s) * (2 * MathHelper.Pi) / p) + change + initial;
-                    }
+                    return Math.Pow(2, -10 * time) * Math.Sin((time - ELASTIC_CONST2) * ELASTIC_CONST) + 1;
                 case Easing.OutElasticHalf:
-                    {
-                        if ((time /= duration) == 1) return initial + change;
-
-                        var p = duration * .3;
-                        var a = change;
-                        double s;
-                        if (a < Math.Abs(change))
-                        {
-                            a = change;
-                            s = p / 4;
-                        }
-                        else s = p / (2 * MathHelper.Pi) * Math.Asin(change / a);
-                        return a * Math.Pow(2, -10 * time) * Math.Sin((0.5f * time * duration - s) * (2 * MathHelper.Pi) / p) + change + initial;
-                    }
+                    return Math.Pow(2, -10 * time) * Math.Sin((.5 * time - ELASTIC_CONST2) * ELASTIC_CONST) + 1;
                 case Easing.OutElasticQuarter:
-                    {
-                        if ((time /= duration) == 1) return initial + change;
-
-                        var p = duration * .3;
-                        var a = change;
-                        double s;
-                        if (a < Math.Abs(change))
-                        {
-                            a = change;
-                            s = p / 4;
-                        }
-                        else s = p / (2 * MathHelper.Pi) * Math.Asin(change / a);
-                        return a * Math.Pow(2, -10 * time) * Math.Sin((0.25f * time * duration - s) * (2 * MathHelper.Pi) / p) + change + initial;
-                    }
+                    return Math.Pow(2, -10 * time) * Math.Sin((.25 * time - ELASTIC_CONST2) * ELASTIC_CONST) + 1;
                 case Easing.InOutElastic:
+                    if ((time *= 2) < 1)
                     {
-                        if ((time /= duration / 2) == 2) return initial + change;
+                        return -.5 * Math.Pow(2, -10 + 10 * time) * Math.Sin(((1 - ELASTIC_CONST2 * 1.5) - time) * ELASTIC_CONST / 1.5);
+                    }
+                    return .5 * Math.Pow(2, -10 * --time) * Math.Sin((time - ELASTIC_CONST2 * 1.5) * ELASTIC_CONST / 1.5) + 1;
 
-                        var p = duration * (.3 * 1.5);
-                        var a = change;
-                        double s;
-                        if (a < Math.Abs(change))
-                        {
-                            a = change;
-                            s = p / 4;
-                        }
-                        else s = p / (2 * MathHelper.Pi) * Math.Asin(change / a);
-                        if (time < 1) return -.5 * (a * Math.Pow(2, 10 * (time -= 1)) * Math.Sin((time * duration - s) * (2 * MathHelper.Pi) / p)) + initial;
-                        return a * Math.Pow(2, -10 * (time -= 1)) * Math.Sin((time * duration - s) * (2 * MathHelper.Pi) / p) * .5 + change + initial;
-                    }
                 case Easing.InBack:
-                    {
-                        const double s = 1.70158;
-                        return change * (time /= duration) * time * ((s + 1) * time - s) + initial;
-                    }
+                    const double BACK_CONST = 1.70158;
+                    return time * time * ((BACK_CONST + 1) * time - BACK_CONST);
                 case Easing.OutBack:
-                    {
-                        const double s = 1.70158;
-                        return change * ((time = time / duration - 1) * time * ((s + 1) * time + s) + 1) + initial;
-                    }
+                    return --time * time * ((BACK_CONST + 1) * time + BACK_CONST) + 1;
                 case Easing.InOutBack:
-                    {
-                        double s = 1.70158;
-                        if ((time /= duration / 2) < 1) return change / 2 * (time * time * (((s *= 1.525) + 1) * time - s)) + initial;
-                        return change / 2 * ((time -= 2) * time * (((s *= 1.525) + 1) * time + s) + 2) + initial;
-                    }
+                    const double BACK_CONST2 = BACK_CONST * 1.525;
+                    if ((time *= 2) < 1) return .5 * time * time * ((BACK_CONST2 + 1) * time - BACK_CONST2);
+                    return .5 * ((time -= 2) * time * ((BACK_CONST2 + 1) * time + BACK_CONST2) + 2);
+
                 case Easing.InBounce:
-                    return change - ApplyEasing(Easing.OutBounce, duration - time, 0, change, duration) + initial;
+                    const double BOUNCE_CONST = 1 / 2.75;
+                    time = 1 - time;
+                    if (time < BOUNCE_CONST)
+                    {
+                        return 1 - (7.5625 * time * time);
+                    }
+                    if (time < 2 * BOUNCE_CONST)
+                    {
+                        return 1 - (7.5625 * (time -= 1.5 * BOUNCE_CONST) * time + .75);
+                    }
+                    if (time < 2.5 * BOUNCE_CONST)
+                    {
+                        return 1 - (7.5625 * (time -= 2.25 * BOUNCE_CONST) * time + .9375);
+                    }
+                    return 1 - (7.5625 * (time -= 2.625 * BOUNCE_CONST) * time + .984375);
                 case Easing.OutBounce:
-                    if ((time /= duration) < 1 / 2.75)
+                    if (time < BOUNCE_CONST)
                     {
-                        return change * (7.5625 * time * time) + initial;
+                        return (7.5625 * time * time);
                     }
-                    if (time < 2 / 2.75)
+                    if (time < 2 * BOUNCE_CONST)
                     {
-                        return change * (7.5625 * (time -= 1.5 / 2.75) * time + .75) + initial;
+                        return (7.5625 * (time -= 1.5 * BOUNCE_CONST) * time + .75);
                     }
-                    if (time < 2.5 / 2.75)
+                    if (time < 2.5 * BOUNCE_CONST)
                     {
-                        return change * (7.5625 * (time -= 2.25 / 2.75) * time + .9375) + initial;
+                        return (7.5625 * (time -= 2.25 * BOUNCE_CONST) * time + .9375);
                     }
-                    return change * (7.5625 * (time -= 2.625 / 2.75) * time + .984375) + initial;
+                    return (7.5625 * (time -= 2.625 * BOUNCE_CONST) * time + .984375);
                 case Easing.InOutBounce:
-                    if (time < duration / 2) return ApplyEasing(Easing.InBounce, time * 2, 0, change, duration) * .5 + initial;
-                    return ApplyEasing(Easing.OutBounce, time * 2 - duration, 0, change, duration) * .5 + change * .5 + initial;
+                    if (time < .5) return .5 - .5 * ApplyEasing(Easing.OutBounce, 1 - time * 2);
+                    return ApplyEasing(Easing.OutBounce, (time - .5) * 2) * .5 + .5;
             }
         }
     }


### PR DESCRIPTION
Improved the easing functions by repeating less code, and by optimizing the algorithms.

The `ApplyEasing` method now only accepts one parameter next to `easing` type: `time`.
`time ` is the precalculated `time / duration`, it should be normalized in the 0 - 1 range. The return value of `ApplyEasing` is the amount to `Lerp` the `start` and `end` values with.
By removing these parameters a lot of useless value copies can be avoided.

Some of the algorithm changes were based on:
https://joshondesign.com/2013/03/01/improvedEasingEquations
https://gist.github.com/gre/1650294