### PR TITLE
Move distinct state creation to InputeState

### DIFF
--- a/osu.Framework/Input/InputState.cs
+++ b/osu.Framework/Input/InputState.cs
@@ -2,6 +2,9 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using OpenTK.Input;
 
 namespace osu.Framework.Input
 {
@@ -19,6 +22,74 @@ namespace osu.Framework.Input
             clone.Last = Last;
 
             return clone;
+        }
+
+        /// <summary>
+        /// In order to provide a reliable event system to drawables, we want to ensure that we reprocess input queues (via the
+        /// main loop in <see cref="InputManager"/> after each and every button or key change. This allows
+        /// correct behaviour in a case where the input queues change based on triggered by a button or key.
+        /// </summary>
+        /// <param name="currentState">The current InputState from which distinct states will be computed.</param>
+        /// <returns>Processed states such that at most one attribute change occurs between any two consecutive states.</returns>
+        public virtual IEnumerable<InputState> CreateDistinctStates(InputState currentState)
+        {
+            IKeyboardState lastKeyboard = currentState.Keyboard;
+            IMouseState lastMouse = currentState.Mouse;
+
+            InputState state;
+
+            if (Mouse != null)
+            {
+                // first we want to create a copy of ourselves without any button changes
+                // this is done only for mouse handlers, as they have positional data we want to handle in a separate pass.
+                var iWithoutButtons = Mouse.Clone();
+
+                for (MouseButton b = 0; b < MouseButton.LastButton; b++)
+                    iWithoutButtons.SetPressed(b, lastMouse?.IsPressed(b) ?? false);
+
+                //we start by adding this state to the processed list...
+                state = Clone();
+                state.Mouse = iWithoutButtons;
+                yield return state;
+
+                lastMouse = iWithoutButtons;
+
+                //and then iterate over each button/key change, adding intermediate states along the way.
+                for (MouseButton b = 0; b < MouseButton.LastButton; b++)
+                {
+                    if (Mouse.IsPressed(b) != (lastMouse?.IsPressed(b) ?? false))
+                    {
+                        var intermediateState = lastMouse?.Clone() ?? new MouseState();
+
+                        //add our single local change
+                        intermediateState.SetPressed(b, Mouse.IsPressed(b));
+
+                        lastMouse = intermediateState;
+
+                        state = Clone();
+                        state.Mouse = intermediateState;
+                        yield return state;
+                    }
+                }
+            }
+
+            if (Keyboard != null)
+            {
+                if (lastKeyboard != null)
+                    foreach (var releasedKey in lastKeyboard.Keys.Except(Keyboard.Keys))
+                    {
+                        state = Clone();
+                        state.Keyboard = lastKeyboard = new KeyboardState { Keys = lastKeyboard.Keys.Where(d => d != releasedKey).ToArray() };
+                        yield return state;
+                    }
+
+                foreach (var pressedKey in Keyboard.Keys.Except(lastKeyboard?.Keys ?? new Key[] { }))
+                {
+                    state = Clone();
+                    state.Keyboard = lastKeyboard = new KeyboardState { Keys = lastKeyboard?.Keys.Union(new[] { pressedKey }) ?? new [] { pressedKey } };
+                    yield return state;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Seems like a better place to leave this. Derived InputStates shouls also create distinct states for what they add to the base implementation.

Also contains a fix for derived implementations types being lost in distinct state creation (uses Clone instead of new InputState). This caused a regression in osu!.