### PR TITLE
Propagate WebRequest exceptions outwards from Perform methods

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Tests.IO
             var request = new JsonWebRequest<HttpBinGetResponse>(url) { Method = HttpMethod.GET };
 
             bool hasThrown = false;
-            request.Finished += exception => hasThrown = exception != null;
+            request.Failed += exception => hasThrown = exception != null;
 
             if (async)
                 Assert.DoesNotThrowAsync(request.PerformAsync);
@@ -58,7 +58,7 @@ namespace osu.Framework.Tests.IO
             var request = new WebRequest($"{protocol}://{invalid_get_url}") { Method = HttpMethod.GET };
 
             Exception finishedException = null;
-            request.Finished += exception => finishedException = exception;
+            request.Failed += exception => finishedException = exception;
 
             if (async)
                 Assert.ThrowsAsync<HttpRequestException>(request.PerformAsync);
@@ -79,12 +79,12 @@ namespace osu.Framework.Tests.IO
             var request = new WebRequest("https://httpbin.org/hidden-basic-auth/user/passwd");
 
             bool hasThrown = false;
-            request.Finished += exception => hasThrown = exception != null;
+            request.Failed += exception => hasThrown = exception != null;
 
             if (async)
-                Assert.DoesNotThrowAsync(request.PerformAsync);
+                Assert.ThrowsAsync<WebException>(request.PerformAsync);
             else
-                Assert.DoesNotThrow(request.Perform);
+                Assert.Throws<WebException>(request.Perform);
 
             Assert.IsTrue(request.Completed);
             Assert.IsTrue(request.Aborted);
@@ -105,7 +105,7 @@ namespace osu.Framework.Tests.IO
             var request = new JsonWebRequest<HttpBinGetResponse>("https://httpbin.org/get") { Method = HttpMethod.GET };
 
             bool hasThrown = false;
-            request.Finished += exception => hasThrown = exception != null;
+            request.Failed += exception => hasThrown = exception != null;
             request.Started += () => request.Abort();
 
             if (async)
@@ -130,7 +130,7 @@ namespace osu.Framework.Tests.IO
             var request = new JsonWebRequest<HttpBinGetResponse>("https://httpbin.org/get") { Method = HttpMethod.GET };
 
             bool hasThrown = false;
-            request.Finished += exception => hasThrown = exception != null;
+            request.Failed += exception => hasThrown = exception != null;
 
 #pragma warning disable 4014
             request.PerformAsync();
@@ -156,7 +156,7 @@ namespace osu.Framework.Tests.IO
             var request = new JsonWebRequest<HttpBinGetResponse>("https://httpbin.org/get") { Method = HttpMethod.GET };
 
             bool hasThrown = false;
-            request.Finished += exception => hasThrown = exception != null;
+            request.Failed += exception => hasThrown = exception != null;
 
 #pragma warning disable 4014
             request.PerformAsync();
@@ -192,7 +192,7 @@ namespace osu.Framework.Tests.IO
             };
 
             Exception thrownException = null;
-            request.Finished += e => thrownException = e;
+            request.Failed += e => thrownException = e;
             request.CompleteInvoked = () => request.Delay = 0;
 
             Assert.DoesNotThrow(request.Perform);
@@ -217,9 +217,9 @@ namespace osu.Framework.Tests.IO
             };
 
             Exception thrownException = null;
-            request.Finished += e => thrownException = e;
+            request.Failed += e => thrownException = e;
 
-            Assert.DoesNotThrow(request.Perform);
+            Assert.Throws<WebException>(request.Perform);
 
             Assert.IsTrue(request.Completed);
             Assert.IsTrue(request.Aborted);
@@ -239,7 +239,7 @@ namespace osu.Framework.Tests.IO
             var request = new JsonWebRequest<HttpBinGetResponse>("https://httpbin.org/get") { Method = HttpMethod.GET };
 
             request.Started += () => { };
-            request.Finished += e => { };
+            request.Failed += e => { };
             request.DownloadProgress += (l1, l2) => { };
             request.UploadProgress += (l1, l2) => { };
 
@@ -263,9 +263,8 @@ namespace osu.Framework.Tests.IO
             WebRequest request;
             using (request = new JsonWebRequest<HttpBinGetResponse>("https://httpbin.org/get") { Method = HttpMethod.GET })
             {
-
                 request.Started += () => { };
-                request.Finished += e => { };
+                request.Failed += e => { };
                 request.DownloadProgress += (l1, l2) => { };
                 request.UploadProgress += (l1, l2) => { };
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -26,10 +26,14 @@ namespace osu.Framework.IO.Network
         public event Action Started;
 
         /// <summary>
-        /// Invoked when the <see cref="WebRequest"/> has finished.
-        /// An unsuccessful completion is indicated by the presence of an exception.
+        /// Invoked when the <see cref="WebRequest"/> has finished successfully.
         /// </summary>
-        public event Action<Exception> Finished;
+        public event Action Finished;
+
+        /// <summary>
+        /// Invoked when the <see cref="WebRequest"/> has failed.
+        /// </summary>
+        public event Action<Exception> Failed;
 
         /// <summary>
         /// Invoked when the download progress has changed.
@@ -460,10 +464,16 @@ namespace osu.Framework.IO.Network
             }
             catch (Exception se) { e = e == null ? se : new AggregateException(e, se); }
 
-            Finished?.Invoke(e);
-
-            if (e != null)
+            if (e == null)
+            {
+                Finished?.Invoke();
+            }
+            else
+            {
+                Failed?.Invoke(e);
                 Aborted = true;
+            }
+
             Completed = true;
         }
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -344,8 +344,11 @@ namespace osu.Framework.IO.Network
                 }
                 catch (Exception e)
                 {
+                    if (Completed)
+                        // we may be coming from one of the exception blocks handled above (as Complete will rethrow all exceptions).
+                        throw;
+
                     Complete(e);
-                    throw;
                 }
             }
         }
@@ -464,6 +467,8 @@ namespace osu.Framework.IO.Network
             }
             catch (Exception se) { e = e == null ? se : new AggregateException(e, se); }
 
+            Completed = true;
+
             if (e == null)
             {
                 Finished?.Invoke();
@@ -472,9 +477,8 @@ namespace osu.Framework.IO.Network
             {
                 Failed?.Invoke(e);
                 Aborted = true;
+                throw e;
             }
-
-            Completed = true;
         }
 
         /// <summary>


### PR DESCRIPTION
Should resolve https://github.com/ppy/osu/issues/1539, along with any other usages which rely on try-catch around `Perform()` or `await PerformAsync()`.

This is a regression from original WebRequest behaviour.

WebRequests also only fire `Finished` on non-erroneous completion. A new event `Failed` exists to handle failures now.