### PR TITLE
Move TestCase descriptions to attributes

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseAnimation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseAnimation.cs
@@ -15,10 +15,9 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
+    [Description("frame-based animations")]
     internal class TestCaseAnimation : TestCase
     {
-        public override string Description => "Various frame-based animations";
-
         public TestCaseAnimation()
         {
             DrawableAnimation drawableAnimation;

--- a/osu.Framework.Tests/Visual/TestCaseBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBufferedContainer.cs
@@ -11,8 +11,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseBufferedContainer : TestCaseMasking
     {
-        public override string Description => @"Buffered containers containing almost all visual effects.";
-
         private readonly BufferedContainer buffer;
 
         public TestCaseBufferedContainer()

--- a/osu.Framework.Tests/Visual/TestCaseCheckboxes.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCheckboxes.cs
@@ -13,8 +13,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseCheckboxes : TestCase
     {
-        public override string Description => @"Checkboxes with clickable labels";
-
         public TestCaseCheckboxes()
         {
             Children = new Drawable[]

--- a/osu.Framework.Tests/Visual/TestCaseCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCircularProgress.cs
@@ -15,8 +15,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseCircularProgress : TestCase
     {
-        public override string Description => @"Circular progress bar";
-
         private readonly CircularProgress clock;
 
         private int rotateMode;

--- a/osu.Framework.Tests/Visual/TestCaseColourGradient.cs
+++ b/osu.Framework.Tests/Visual/TestCaseColourGradient.cs
@@ -81,8 +81,6 @@ namespace osu.Framework.Tests.Visual
             }
         }
 
-        public override string Description => @"Various cases of colour gradients.";
-
         private readonly Box[] boxes = new Box[4];
 
         protected override void Update()

--- a/osu.Framework.Tests/Visual/TestCaseContainerState.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContainerState.cs
@@ -12,10 +12,9 @@ using osu.Framework.Testing;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
+    [Description("ensure valid container state in various scenarios")]
     public class TestCaseContainerState : TestCase
     {
-        public override string Description => "Ensuring a container's state is consistent in various scenarios.";
-
         private readonly Container container;
 
         public TestCaseContainerState()

--- a/osu.Framework.Tests/Visual/TestCaseContextMenu.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContextMenu.cs
@@ -16,8 +16,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseContextMenu : TestCase
     {
-        public override string Description => @"Menu visible on right click";
-
         private const int start_time = 0;
         private const int duration = 1000;
 

--- a/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
@@ -12,9 +12,9 @@ using osu.Framework.Testing;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseDspfContainer : TestCase
+    internal class TestCaseDrawSizePreservingFillContainer : TestCase
     {
-        public TestCaseDspfContainer()
+        public TestCaseDrawSizePreservingFillContainer()
         {
             DrawSizePreservingFillContainer fillContainer;
             Child = new Container
@@ -57,7 +57,5 @@ namespace osu.Framework.Tests.Visual
             AddSliderStep("Width", 50, 650, 500, v => Child.Width = v);
             AddSliderStep("Height", 50, 650, 500, v => Child.Height = v);
         }
-
-        public override string Description => @"DrawSize-preserving fill container.";
     }
 }

--- a/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
@@ -103,8 +103,6 @@ namespace osu.Framework.Tests.Visual
             Colour = Color4.White,
         };
 
-        public override string Description => @"Various cases of drawable paths.";
-
         private class UserDrawnPath : Path
         {
             public override bool HandleInput => true;

--- a/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
@@ -16,8 +16,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseDropdownBox : TestCase
     {
-        public override string Description => @"Drop-down boxes";
-
         private const int items_to_add = 10;
 
         public TestCaseDropdownBox()

--- a/osu.Framework.Tests/Visual/TestCaseDynamicDepth.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDynamicDepth.cs
@@ -13,10 +13,9 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
+    [Description("changing depth of child dynamically")]
     public class TestCaseDynamicDepth : TestCase
     {
-        public override string Description => @"Dynamically change depth of a child.";
-
         private void addDepthSteps(DepthBox box, Container container)
         {
             AddStep($@"bring forward {box.Name}", () => container.ChangeChildDepth(box, box.Depth - 1));

--- a/osu.Framework.Tests/Visual/TestCaseEffects.cs
+++ b/osu.Framework.Tests/Visual/TestCaseEffects.cs
@@ -15,10 +15,9 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
+    [Description("implementing the IEffect interface")]
     internal class TestCaseEffects : TestCase
     {
-        public override string Description => "Tests classes implement the IEffect interface.";
-
         public TestCaseEffects()
         {
             var effect = new EdgeEffect

--- a/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
@@ -20,10 +20,8 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseFlow : TestCase
+    internal class TestCaseFillFlowContainer : TestCase
     {
-        public override string Description => "Test lots of different settings for Flow Containers";
-
         private FillDirectionDropdown selectionDropdown;
 
         private Anchor childAnchor = Anchor.TopLeft;
@@ -36,7 +34,7 @@ namespace osu.Framework.Tests.Visual
         private ScheduledDelegate scheduledAdder;
         private bool doNotAddChildren;
 
-        public TestCaseFlow()
+        public TestCaseFillFlowContainer()
         {
             reset();
         }

--- a/osu.Framework.Tests/Visual/TestCaseFillModes.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillModes.cs
@@ -16,6 +16,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
+    [System.ComponentModel.Description("sprite stretching")]
     internal class TestCaseFillModes : GridTestCase
     {
         public TestCaseFillModes() : base(3, 3)
@@ -75,8 +76,6 @@ namespace osu.Framework.Tests.Visual
                 }
             }
         }
-
-        public override string Description => @"Test sprite display and fill modes";
 
         private Texture texture;
 

--- a/osu.Framework.Tests/Visual/TestCaseHollowEdgeEffect.cs
+++ b/osu.Framework.Tests/Visual/TestCaseHollowEdgeEffect.cs
@@ -85,7 +85,5 @@ namespace osu.Framework.Tests.Visual
                 });
             }
         }
-
-        public override string Description => @"Hollow Container with EdgeEffect";
     }
 }

--- a/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
@@ -16,6 +16,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
+    [System.ComponentModel.Description("live path optimiastion")]
     internal class TestCaseInputResampler : GridTestCase
     {
         public TestCaseInputResampler() : base(3, 3)
@@ -120,8 +121,6 @@ namespace osu.Framework.Tests.Visual
             TextSize = 14,
             Colour = Color4.White,
         };
-
-        public override string Description => @"Live optimizing paths to relevant nodes.";
 
         private class SmoothedPath : Path
         {

--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -18,8 +18,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     public class TestCaseKeyBindings : GridTestCase
     {
-        public override string Description => @"Keybindings";
-
         public TestCaseKeyBindings()
             : base(2, 2)
         {

--- a/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
@@ -20,8 +20,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseLocalisation : TestCase
     {
-        public override string Description => "Localisation engine";
-
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly LocalisationEngine engine; //keep a reference to avoid GC of the engine
 

--- a/osu.Framework.Tests/Visual/TestCaseMasking.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMasking.cs
@@ -17,8 +17,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseMasking : TestCase
     {
-        public override string Description => @"Various scenarios which potentially challenge masking calculations.";
-
         protected Container TestContainer;
 
         public TestCaseMasking()

--- a/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
+++ b/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
@@ -15,8 +15,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseNestedHover : TestCase
     {
-        public override string Description => @"Hovering multiple nested elements";
-
         public TestCaseNestedHover()
         {
             HoverBox box1;

--- a/osu.Framework.Tests/Visual/TestCasePadding.cs
+++ b/osu.Framework.Tests/Visual/TestCasePadding.cs
@@ -175,8 +175,6 @@ namespace osu.Framework.Tests.Visual
             });
         }
 
-        public override string Description => @"Add fixed padding via a PaddingContainer";
-
         private class PaddedBox : Container
         {
             private readonly SpriteText t1;

--- a/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
+++ b/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
@@ -11,10 +11,9 @@ using OpenTK;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
+    [System.ComponentModel.Description("ensure validity of drawables when receiving certain values")]
     internal class TestCasePropertyBoundaries : TestCase
     {
-        public override string Description => "Testing the validity of drawables after being passed certain values.";
-
         [BackgroundDependencyLoader]
         private void load()
         {

--- a/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
+++ b/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
@@ -17,8 +17,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseRigidBody : TestCase
     {
-        public override string Description => @"Rigid body simulation scenarios.";
-
         private readonly TestRigidBodySimulation sim;
 
         private float restitutionBacking;

--- a/osu.Framework.Tests/Visual/TestCaseScreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScreen.cs
@@ -19,8 +19,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseScreen : TestCase
     {
-        public override string Description => @"Test stackable game screens";
-
         public TestCaseScreen()
         {
             Add(new TestScreen());

--- a/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
@@ -18,8 +18,6 @@ namespace osu.Framework.Tests.Visual
     {
         private readonly ScheduledDelegate boxCreator;
 
-        public override string Description => @"A flow container in a scroll container";
-
         private ScrollContainer scroll;
         private FillFlowContainer flow;
 

--- a/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
@@ -16,8 +16,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseSearchContainer : TestCase
     {
-        public override string Description => "Tests the SearchContainer";
-
         public TestCaseSearchContainer()
         {
             SearchContainer<HeaderContainer> search;

--- a/osu.Framework.Tests/Visual/TestCaseSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSizing.cs
@@ -14,10 +14,9 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
+    [Description("potentially challenging size calculations")]
     internal class TestCaseSizing : TestCase
     {
-        public override string Description => @"Various scenarios which potentially challenge size calculations.";
-
         private readonly Container testContainer;
 
         public TestCaseSizing()

--- a/osu.Framework.Tests/Visual/TestCaseSliderbar.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSliderbar.cs
@@ -14,8 +14,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     public class TestCaseSliderbar : TestCase
     {
-        public override string Description => @"Sliderbar tests.";
-
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly BindableDouble sliderBarValue; //keep a reference to avoid GC of the bindable
         private readonly SpriteText sliderbarText;

--- a/osu.Framework.Tests/Visual/TestCaseSmoothedEdges.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSmoothedEdges.cs
@@ -46,8 +46,6 @@ namespace osu.Framework.Tests.Visual
             }
         }
 
-        public override string Description => @"Boxes with automatically smoothed edges (no anti-aliasing).";
-
         private readonly Box[] boxes = new Box[4];
 
         protected override void Update()

--- a/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
@@ -12,8 +12,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseSpriteText : TestCase
     {
-        public override string Description => @"Test all sizes of text rendering";
-
         public TestCaseSpriteText()
         {
             FillFlowContainer flow;

--- a/osu.Framework.Tests/Visual/TestCaseTabControl.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTabControl.cs
@@ -20,8 +20,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseTabControl : TestCase
     {
-        public override string Description => @"Tab control";
-
         public TestCaseTabControl()
         {
             List<KeyValuePair<string, TestEnum>> items = new List<KeyValuePair<string, TestEnum>>();

--- a/osu.Framework.Tests/Visual/TestCaseTextBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextBox.cs
@@ -13,8 +13,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseTextBox : TestCase
     {
-        public override string Description => @"Text entry evolved";
-
         public TestCaseTextBox()
         {
             FillFlowContainer textBoxes = new FillFlowContainer

--- a/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
@@ -14,10 +14,9 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
+    [Description("word-wrap and paragraphs")]
     internal class TestCaseTextFlow : TestCase
     {
-        public override string Description => @"Test word-wrapping and paragraphs";
-
         public TestCaseTextFlow()
         {
             FillFlowContainer flow;

--- a/osu.Framework.Tests/Visual/TestCaseTooltip.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTooltip.cs
@@ -17,8 +17,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseTooltip : TestCase
     {
-        public override string Description => "Tooltip that shows when hovering a drawable";
-
         private readonly Container testContainer;
 
         public TestCaseTooltip()

--- a/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
@@ -16,8 +16,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseTransformSequence : GridTestCase
     {
-        public override string Description => @"Sequences (potentially looping) of transforms";
-
         private readonly Container[] boxes;
 
         public TestCaseTransformSequence()

--- a/osu.Framework.Tests/Visual/TestCaseTriangles.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTriangles.cs
@@ -15,8 +15,6 @@ namespace osu.Framework.Tests.Visual
     [TestFixture]
     internal class TestCaseTriangles : TestCase
     {
-        public override string Description => @"Various scenarios which potentially challenge triangles.";
-
         private readonly Container testContainer;
 
         public TestCaseTriangles()

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -75,12 +75,12 @@
     <Compile Include="Visual\TestCaseCountingText.cs" />
     <Compile Include="Visual\TestCaseDelayedLoad.cs" />
     <Compile Include="Visual\TestCaseDrawablePath.cs" />
-    <Compile Include="Visual\TestCaseDspfContainer.cs" />
+    <Compile Include="Visual\TestCaseDrawSizePreservingFillContainer.cs" />
     <Compile Include="Visual\TestCaseDropdownBox.cs" />
     <Compile Include="Visual\TestCaseDynamicDepth.cs" />
     <Compile Include="Visual\TestCaseEffects.cs" />
     <Compile Include="Visual\TestCaseFillModes.cs" />
-    <Compile Include="Visual\TestCaseFlow.cs" />
+    <Compile Include="Visual\TestCaseFillFlowContainer.cs" />
     <Compile Include="Visual\TestCaseGridContainer.cs" />
     <Compile Include="Visual\TestCaseHollowEdgeEffect.cs" />
     <Compile Include="Visual\TestCaseInputResampler.cs" />

--- a/osu.Framework/Testing/Drawables/TestCaseButton.cs
+++ b/osu.Framework/Testing/Drawables/TestCaseButton.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using System.ComponentModel;
+using System.Reflection;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
-using OpenTK;
 using OpenTK.Graphics;
 
 namespace osu.Framework.Testing.Drawables
@@ -15,7 +15,7 @@ namespace osu.Framework.Testing.Drawables
     internal class TestCaseButton : ClickableContainer
     {
         private readonly Box box;
-        private readonly Container text;
+        private readonly TextFlowContainer text;
 
         public readonly Type TestType;
 
@@ -46,9 +46,7 @@ namespace osu.Framework.Testing.Drawables
 
             CornerRadius = 5;
             RelativeSizeAxes = Axes.X;
-            Size = new Vector2(1, 60);
-
-            TestCase tempTestCase = (TestCase)Activator.CreateInstance(test);
+            AutoSizeAxes = Axes.Y;
 
             AddRange(new Drawable[]
             {
@@ -58,35 +56,27 @@ namespace osu.Framework.Testing.Drawables
                     Colour = new Color4(140, 140, 140, 255),
                     Alpha = 0.7f
                 },
-                text = new Container
+                text = new TextFlowContainer
                 {
-                    RelativeSizeAxes = Axes.Both,
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding
                     {
                         Left = 4,
                         Right = 4,
                         Bottom = 2,
                     },
-                    Children = new[]
-                    {
-                        new SpriteText
-                        {
-                            Anchor = Anchor.TopCentre,
-                            Origin = Anchor.TopCentre,
-                            Text = tempTestCase.Name,
-                        },
-                        new SpriteText
-                        {
-                            Anchor = Anchor.BottomLeft,
-                            Origin = Anchor.BottomLeft,
-                            Text = tempTestCase.Description,
-                            TextSize = 15,
-                            AutoSizeAxes = Axes.Y,
-                            RelativeSizeAxes = Axes.X,
-                        }
-                    }
                 }
             });
+
+            text.AddText(test.Name.Replace("TestCase", ""));
+
+            var description = test.GetCustomAttribute<DescriptionAttribute>()?.Description;
+            if (description != null)
+            {
+                text.NewLine();
+                text.AddText(description, t => t.TextSize = 15);
+            }
         }
 
         protected override bool OnHover(InputState state)

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -21,8 +21,6 @@ namespace osu.Framework.Testing
     [TestFixture]
     public abstract class TestCase : Container, IDynamicallyCompile
     {
-        public virtual string Description => @"The base class for a test case";
-
         public readonly FillFlowContainer<Drawable> StepsContainer;
         private readonly Container content;
 


### PR DESCRIPTION
Removes the necessity to construct a TestCase to get its description. Removes descriptions where they weren't adding anything to the titles.

Also tidies up naming of some TestCases and button layout.

Closes #1185.