### PR TITLE
Fixed Description attributes in Framework Tests

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseAnimation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseAnimation.cs
@@ -15,7 +15,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    [Description("frame-based animations")]
+    [System.ComponentModel.Description("frame-based animations")]
     internal class TestCaseAnimation : TestCase
     {
         public TestCaseAnimation()

--- a/osu.Framework.Tests/Visual/TestCaseContainerState.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContainerState.cs
@@ -12,7 +12,7 @@ using osu.Framework.Testing;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    [Description("ensure valid container state in various scenarios")]
+    [System.ComponentModel.Description("ensure valid container state in various scenarios")]
     public class TestCaseContainerState : TestCase
     {
         private readonly Container container;

--- a/osu.Framework.Tests/Visual/TestCaseDynamicDepth.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDynamicDepth.cs
@@ -13,7 +13,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    [Description("changing depth of child dynamically")]
+    [System.ComponentModel.Description("changing depth of child dynamically")]
     public class TestCaseDynamicDepth : TestCase
     {
         private void addDepthSteps(DepthBox box, Container container)

--- a/osu.Framework.Tests/Visual/TestCaseEffects.cs
+++ b/osu.Framework.Tests/Visual/TestCaseEffects.cs
@@ -15,7 +15,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    [Description("implementing the IEffect interface")]
+    [System.ComponentModel.Description("implementing the IEffect interface")]
     internal class TestCaseEffects : TestCase
     {
         public TestCaseEffects()

--- a/osu.Framework.Tests/Visual/TestCaseSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSizing.cs
@@ -14,7 +14,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    [Description("potentially challenging size calculations")]
+    [System.ComponentModel.Description("potentially challenging size calculations")]
     internal class TestCaseSizing : TestCase
     {
         private readonly Container testContainer;

--- a/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
@@ -14,7 +14,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    [Description("word-wrap and paragraphs")]
+    [System.ComponentModel.Description("word-wrap and paragraphs")]
     internal class TestCaseTextFlow : TestCase
     {
         public TestCaseTextFlow()


### PR DESCRIPTION
the `using NUnit.Framework` directives at the beginning of those TestCase files made them originally use the wrong Description attribute. They are now all fully qualified so the attributes work.

Framework change that originally introduced this problem: #1186 