### PR TITLE
Fix calling Reset on a TrackVirtual starting the track unexpectedly

### DIFF
--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -21,7 +21,14 @@ namespace osu.Framework.Audio.Track
             double current = CurrentTime;
 
             seekOffset = seek;
-            lock (clock) clock.Restart();
+
+            lock (clock)
+            {
+                if (IsRunning)
+                    clock.Restart();
+                else
+                    clock.Reset();
+            }
 
             if (Length > 0 && seekOffset > Length)
                 seekOffset = Length;


### PR DESCRIPTION
Not sure how this wasn't an issue until now...
