### PR TITLE
Changed the float validation inside DrawInfo.ApplyTransform for performance gain

### DIFF
--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -35,12 +35,6 @@ namespace osu.Framework.Graphics
         /// <param name="origin">The center of rotation and scale.</param>
         public void ApplyTransform(Vector2 translation, Vector2 scale, float rotation, Vector2 shear, Vector2 origin)
         {
-            checkComponentValid(translation, nameof(translation));
-            checkComponentValid(scale, nameof(scale));
-            checkComponentValid(rotation, nameof(rotation));
-            checkComponentValid(shear, nameof(shear));
-            checkComponentValid(origin, nameof(origin));
-
             if (translation != Vector2.Zero)
             {
                 MatrixExtensions.TranslateFromLeft(ref Matrix, translation);
@@ -79,27 +73,6 @@ namespace osu.Framework.Graphics
             //target.MatrixInverse = target.Matrix;
             //MatrixExtensions.FastInvert(ref target.MatrixInverse);
         }
-
-        private void checkComponentValid(float component, string name)
-        {
-            if (isInvalidFloat(component))
-                throw new ArgumentException($"Invalid value ({component}) provided for component {name}.");
-        }
-
-        private void checkComponentValid(Vector2 component, string name)
-        {
-            if (isInvalidFloat(component.X))
-                throw new ArgumentException($"Invalid value ({component}) provided for component {name}.X.");
-            if (isInvalidFloat(component.Y))
-                throw new ArgumentException($"Invalid value ({component}) provided for component {name}.Y.");
-        }
-
-        // Takes the bits from value, interprets them as an int and then shifts them so that we get the exponent (bit 2 to 8) back.
-        // Returns as byte because it's a smaller data type and enough for the exponent
-        private unsafe byte singleToExponentAsByte(float value) => (byte)(*(int*)&value >> 23);
-
-        // If exponent is 255, float is either ±Infinity or NaN (by definition)
-        private bool isInvalidFloat(float toCheck) => singleToExponentAsByte(toCheck) == byte.MaxValue;
 
         public bool Equals(DrawInfo other)
         {

--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -96,7 +96,7 @@ namespace osu.Framework.Graphics
 
         // Takes the bits from value, interprets them as an int and then shifts them so that we get the exponent (bit 2 to 8) back.
         // Returns as byte because it's a smaller data type and enough for the exponent
-        private unsafe byte singleToExponentAsByte(float value) => (byte)((*(int*)(&value)) >> 23);
+        private unsafe byte singleToExponentAsByte(float value) => (byte)(*(int*)&value >> 23);
 
         // If exponent is 255, float is either ±Infinity or NaN (by definition)
         private bool isInvalidFloat(float toCheck) => singleToExponentAsByte(toCheck) == byte.MaxValue;

--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -82,17 +82,24 @@ namespace osu.Framework.Graphics
 
         private void checkComponentValid(float component, string name)
         {
-            if (float.IsNaN(component) || float.IsInfinity(component))
+            if (isInvalidFloat(component))
                 throw new ArgumentException($"Invalid value ({component}) provided for component {name}.");
         }
 
         private void checkComponentValid(Vector2 component, string name)
         {
-            if (float.IsNaN(component.X) || float.IsInfinity(component.X))
+            if (isInvalidFloat(component.X))
                 throw new ArgumentException($"Invalid value ({component}) provided for component {name}.X.");
-            if (float.IsNaN(component.Y) || float.IsInfinity(component.Y))
+            if (isInvalidFloat(component.Y))
                 throw new ArgumentException($"Invalid value ({component}) provided for component {name}.Y.");
         }
+
+        // Takes the bits from value, interprets them as an int and then shifts them so that we get the exponent (bit 2 to 8) back.
+        // Returns as byte because it's a smaller data type and enough for the exponent
+        private unsafe byte singleToExponentAsByte(float value) => (byte)((*(int*)(&value)) >> 23);
+
+        // If exponent is 255, float is either ±Infinity or NaN (by definition)
+        private bool isInvalidFloat(float toCheck) => singleToExponentAsByte(toCheck) == byte.MaxValue;
 
         public bool Equals(DrawInfo other)
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -998,6 +998,8 @@ namespace osu.Framework.Graphics
 
             set
             {
+                if (!isFinite(value)) throw new ArgumentException($@"{nameof(RelativeAnchorPosition)} must be finite, but is {value}");
+
                 customRelativeAnchorPosition = value;
                 Anchor = Anchor.Custom;
             }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1323,7 +1323,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <param name="toCheck">The <see cref="Vector2"/> to check.</param>
         /// <returns>false if X or Y are Infinity or NaN, true otherwise. </returns>
-        private bool isFinite(Vector2 toCheck) => isFinite(toCheck.X) || isFinite(toCheck.Y);
+        private bool isFinite(Vector2 toCheck) => isFinite(toCheck.X) && isFinite(toCheck.Y);
 
         private DrawInfo computeDrawInfo()
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1315,7 +1315,7 @@ namespace osu.Framework.Graphics
         /// <param name="toCheck"></param>
         /// <remarks>Is equivalent to (<see cref="float.IsNaN(float)"/> || <see cref="float.IsInfinity(float)"/>), but with less overhead.</remarks>
         /// <returns>Whether the float is valid in our conditions.</returns>
-        private bool isFinite(float toCheck) => !(singleToExponentAsByte(toCheck) == byte.MaxValue);
+        private bool isFinite(float toCheck) => singleToExponentAsByte(toCheck) != byte.MaxValue;
 
         /// <summary>
         /// Returns whether the two coordinates of a vector are not infinite or NaN.


### PR DESCRIPTION
Saw #1153 and tried to reduce CPU usage of the function. In my (isolated) tests with a huge load of tested floats, this resulted in around 12-15% performance increase and in in-game tests (granted I'm not too used to performance profiling, but the numbers should still be correct) CPU time for checkComponentValid was actually reduced by 15-20%.

Explanation for why I did what I did:
The old implementation checks for `float.IsNaN(value) || float.IsInfinity(value)`. So for this to be true, the `value` has to be `float.NaN`, `float.PositiveInfinity` or `float.NegativeInfinity`.

Looking into the specifications, if the exponent of a float value is 255 (its max value), the float has to be any one of these three values ([source](https://en.wikipedia.org/wiki/Single-precision_floating-point_format#Exponent_encoding), last row). So in this new implementation I'm checking whether the exponent is 255 and if it is, the float is invalid by the old standards.

As to what the code does:
Everything except the `singleToExponentAsByte` method should be self-explanatory.

`*(int*)(&value)` takes `value`'s pointer, casts it to an int pointer and dereferences the pointer so we get an int back. This int has the same binary contents as `value`.

This is done so that we can shift the exponent bits (bits 2 - 8) to the 8 least significant bits (`>> 23`), which allows us to cast this int to a byte (so a smaller data type is passed around) which contains the exponent of `value`.