### PR TITLE
Reduce default sample concurrency to two

### DIFF
--- a/osu.Framework/Audio/Sample/Sample.cs
+++ b/osu.Framework/Audio/Sample/Sample.cs
@@ -5,5 +5,17 @@ namespace osu.Framework.Audio.Sample
 {
     public abstract class Sample : AudioComponent
     {
+        public const int DEFAULT_CONCURRENCY = 2;
+
+        protected int PlaybackConcurrency;
+
+        /// <summary>
+        /// Construct a new sample.
+        /// </summary>
+        /// <param name="playbackConcurrency">How many instances of this sample should be allowed to playback concurrently before stopping the longest playing.</param>
+        protected Sample(int playbackConcurrency = DEFAULT_CONCURRENCY)
+        {
+            PlaybackConcurrency = playbackConcurrency;
+        }
     }
 }

--- a/osu.Framework/Audio/Sample/Sample.cs
+++ b/osu.Framework/Audio/Sample/Sample.cs
@@ -7,7 +7,7 @@ namespace osu.Framework.Audio.Sample
     {
         public const int DEFAULT_CONCURRENCY = 2;
 
-        protected int PlaybackConcurrency;
+        protected readonly int PlaybackConcurrency;
 
         /// <summary>
         /// Construct a new sample.

--- a/osu.Framework/Audio/Sample/SampleBass.cs
+++ b/osu.Framework/Audio/Sample/SampleBass.cs
@@ -13,12 +13,13 @@ namespace osu.Framework.Audio.Sample
 
         public override bool IsLoaded => sampleId != 0;
 
-        public SampleBass(byte[] data, ConcurrentQueue<Action> customPendingActions = null)
+        public SampleBass(byte[] data, ConcurrentQueue<Action> customPendingActions = null, int concurrency = DEFAULT_CONCURRENCY)
+            : base(concurrency)
         {
             if (customPendingActions != null)
                 PendingActions = customPendingActions;
 
-            PendingActions.Enqueue(() => { sampleId = Bass.SampleLoad(data, 0, data.Length, 8, BassFlags.Default | BassFlags.SampleOverrideLongestPlaying); });
+            PendingActions.Enqueue(() => { sampleId = Bass.SampleLoad(data, 0, data.Length, PlaybackConcurrency, BassFlags.Default | BassFlags.SampleOverrideLongestPlaying); });
         }
 
         protected override void Dispose(bool disposing)

--- a/osu.Framework/Audio/Sample/SampleManager.cs
+++ b/osu.Framework/Audio/Sample/SampleManager.cs
@@ -15,6 +15,11 @@ namespace osu.Framework.Audio.Sample
 
         private readonly ConcurrentDictionary<string, Sample> sampleCache = new ConcurrentDictionary<string, Sample>();
 
+        /// <summary>
+        /// How many instances of a single sample should be allowed to playback concurrently before stopping the longest playing.
+        /// </summary>
+        public int PlaybackConcurrency { get; set; } = Sample.DEFAULT_CONCURRENCY;
+
         public SampleManager(IResourceStore<byte[]> store)
         {
             this.store = store;
@@ -30,7 +35,7 @@ namespace osu.Framework.Audio.Sample
                 {
                     byte[] data = store.Get(name);
                     if (data != null)
-                        sample = sampleCache[name] = new SampleBass(data, PendingActions);
+                        sample = sampleCache[name] = new SampleBass(data, PendingActions, PlaybackConcurrency);
                 }
 
                 if (sample != null)


### PR DESCRIPTION
8 was way too high for most use-cases. Also makes this configurable at a SampleManager level if this default is not appropriate for certain use-cases. Can be expanded to per-Get when necessary.