### PR TITLE
Fixes the reoccurring "blackscreen on minimize" bug

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
@@ -56,6 +56,8 @@ namespace osu.Framework.Tests.Visual
 
             AddSliderStep("Width", 50, 650, 500, v => Child.Width = v);
             AddSliderStep("Height", 50, 650, 500, v => Child.Height = v);
+
+            AddStep("Override Size to 1x1", () => Child.Size = Vector2.One);
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
+++ b/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
@@ -14,6 +14,10 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public class DrawSizePreservingFillContainer : Container
     {
+        private readonly Container content;
+
+        protected override Container<Drawable> Content => content;
+
         /// <summary>
         /// The target <see cref="Drawable.DrawSize"/> to be enforced according to <see cref="Strategy"/>.
         /// </summary>
@@ -28,6 +32,11 @@ namespace osu.Framework.Graphics.Containers
 
         public DrawSizePreservingFillContainer()
         {
+            AddInternal(content = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+            });
+
             RelativeSizeAxes = Axes.Both;
         }
 
@@ -40,23 +49,23 @@ namespace osu.Framework.Graphics.Containers
             switch (Strategy)
             {
                 case DrawSizePreservationStrategy.Minimum:
-                    Scale = new Vector2(Math.Min(drawSizeRatio.X, drawSizeRatio.Y));
+                    content.Scale = new Vector2(Math.Min(drawSizeRatio.X, drawSizeRatio.Y));
                     break;
 
                 case DrawSizePreservationStrategy.Maximum:
-                    Scale = new Vector2(Math.Max(drawSizeRatio.X, drawSizeRatio.Y));
+                    content.Scale = new Vector2(Math.Max(drawSizeRatio.X, drawSizeRatio.Y));
                     break;
 
                 case DrawSizePreservationStrategy.Average:
-                    Scale = new Vector2(0.5f * (drawSizeRatio.X + drawSizeRatio.Y));
+                    content.Scale = new Vector2(0.5f * (drawSizeRatio.X + drawSizeRatio.Y));
                     break;
 
                 case DrawSizePreservationStrategy.Separate:
-                    Scale = drawSizeRatio;
+                    content.Scale = drawSizeRatio;
                     break;
             }
 
-            Size = Vector2.Divide(Vector2.One, Scale);
+            content.Size = Vector2.Divide(Vector2.One, content.Scale);
         }
     }
 


### PR DESCRIPTION
Fixes ppy/osu#1512

First commit is an addition to `TestCaseDrawSizePreservingFillContainer` where you can manually override the `DrawSizePreservingFillContainer`'s `Parent.Size` to 1x1, after which you can re-adjust it via the sliders again. What you should see is that the content of the `DrawSizePreservingFillContainer` stays black (in the old version), and with the draw visualiser you can see that the `DrawSizePreservingFillContainer`'s Scale is very small which leads to it's `IsPresent` field being false, which in turn leads to it not getting any more `Update()` calls which then again leads to it (and its children) not displaying ever again.

I (well, Tom94 had the good idea, mine was more a hackaround) fix this in the second commit by overriding `DrawSizePreservingFillContainer.Content` with an empty Container, to which all new Children are added. The re-scaling is then applied to that Container instead of being applied to the `DrawSizePreservingFillContainer` itself, which leads to the `DrawSizePreservingFillContainer` still updating the Container, even if very small scale values -> `!Container.IsPresent` should occur.