### PR TITLE
Add a better method to retrieve platform-specific information

### DIFF
--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
 
 namespace osu.Framework
@@ -28,38 +26,13 @@ namespace osu.Framework
         static RuntimeInfo()
         {
             IsMono = Type.GetType("Mono.Runtime") != null;
-            int p = (int)Environment.OSVersion.Platform;
-            IsUnix = p == 4 || p == 6 || p == 128;
-            IsWindows = Path.DirectorySeparatorChar == '\\';
+            IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            IsMacOsx = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            IsUnix = IsMacOsx || IsUnix;
 
             Is32Bit = IntPtr.Size == 4;
             Is64Bit = IntPtr.Size == 8;
-
-            if (IsUnix)
-            {
-                Process uname = Process.Start(new ProcessStartInfo
-                {
-                    FileName = "uname",
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true
-                });
-
-                if (uname != null)
-                {
-                    string output = uname.StandardOutput.ReadToEnd();
-                    uname.WaitForExit();
-
-                    output = output.ToUpper().Replace("\n", "").Trim();
-
-                    IsMacOsx = output == "DARWIN";
-                    IsLinux = output == "LINUX";
-                }
-            }
-            else
-            {
-                IsMacOsx = false;
-                IsLinux = false;
-            }
 
             if (IsWindows)
             {

--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -26,9 +26,12 @@ namespace osu.Framework
         static RuntimeInfo()
         {
             IsMono = Type.GetType("Mono.Runtime") != null;
-            IsLinux = RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
-            IsMacOsx = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-            IsWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                IsWindows = true;
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                IsMacOsx = true;
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                IsLinux = true;
             IsUnix = IsMacOsx || IsUnix;
 
             Is32Bit = IntPtr.Size == 4;

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -87,6 +87,9 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <HintPath>$(SolutionDir)\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.IO.Compression, Version=4.1.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
       <HintPath>$(SolutionDir)\packages\System.IO.Compression.4.3.0\lib\net46\System.IO.Compression.dll</HintPath>

--- a/osu.Framework/packages.config
+++ b/osu.Framework/packages.config
@@ -37,6 +37,7 @@ Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-frame
   <package id="System.Runtime" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net461" />
   <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net461" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net461" />


### PR DESCRIPTION
✓ Cross platform (.NET Core compatible)
✓ No uname issues with debugging
✓ No more relying on magic constants defined by mono (6 is a recent addition for osx)