### PR TITLE
Allow TextFlowContainer to AutoSize on the X axis

### DIFF
--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -142,7 +142,7 @@ namespace osu.Framework.Graphics.Containers
                 float rowWidth = rowBeginOffset + current.X + (1 - spacingFactor(c).X) * size.X;
 
                 //We've exceeded our allowed width, move to a new row
-                if (direction != FillDirection.Horizontal && (Precision.DefinitelyBigger(rowWidth, max.X) || direction == FillDirection.Vertical || forceNewRow(c)))
+                if (direction != FillDirection.Horizontal && (Precision.DefinitelyBigger(rowWidth, max.X) || direction == FillDirection.Vertical || ForceNewRow(c)))
                 {
                     current.X = 0;
                     current.Y += rowHeight;
@@ -235,7 +235,7 @@ namespace osu.Framework.Graphics.Containers
             return result;
         }
 
-        protected virtual bool forceNewRow(Drawable child) => false;
+        protected virtual bool ForceNewRow(Drawable child) => false;
     }
 
     /// <summary>

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -142,7 +142,7 @@ namespace osu.Framework.Graphics.Containers
                 float rowWidth = rowBeginOffset + current.X + (1 - spacingFactor(c).X) * size.X;
 
                 //We've exceeded our allowed width, move to a new row
-                if (direction != FillDirection.Horizontal && (Precision.DefinitelyBigger(rowWidth, max.X) || direction == FillDirection.Vertical))
+                if (direction != FillDirection.Horizontal && (Precision.DefinitelyBigger(rowWidth, max.X) || direction == FillDirection.Vertical || forceNewRow(c)))
                 {
                     current.X = 0;
                     current.Y += rowHeight;
@@ -234,6 +234,8 @@ namespace osu.Framework.Graphics.Containers
 
             return result;
         }
+
+        protected virtual bool forceNewRow(Drawable child) => false;
     }
 
     /// <summary>

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -235,6 +235,11 @@ namespace osu.Framework.Graphics.Containers
             return result;
         }
 
+        /// <summary>
+        /// Returns true if the given child should be placed on a new row, false otherwise. This will be called automatically for each child in this FillFlowContainers FlowingChildren-List.
+        /// </summary>
+        /// <param name="child">The child to check.</param>
+        /// <returns>True if the given child should be placed on a new row, false otherwise.</returns>
         protected virtual bool ForceNewRow(Drawable child) => false;
     }
 

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -328,13 +328,14 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        protected override bool forceNewRow(Drawable child) => child is NewLineContainer;
+
         internal class NewLineContainer : Container
         {
             public readonly bool IndicatesNewParagraph;
 
             public NewLineContainer(bool newParagraph)
             {
-                RelativeSizeAxes = Axes.X;
                 IndicatesNewParagraph = newParagraph;
             }
         }

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -328,6 +328,11 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        /// <summary>
+        /// Returns true if the given child should be placed on a new row, false otherwise.
+        /// </summary>
+        /// <param name="child">The child to check.</param>
+        /// <returns>True if the given child should be placed on a new row, false otherwise.</returns>
         protected override bool forceNewRow(Drawable child) => child is NewLineContainer;
 
         internal class NewLineContainer : Container

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -333,7 +333,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="child">The child to check.</param>
         /// <returns>True if the given child should be placed on a new row, false otherwise.</returns>
-        protected override bool forceNewRow(Drawable child) => child is NewLineContainer;
+        protected override bool ForceNewRow(Drawable child) => child is NewLineContainer;
 
         internal class NewLineContainer : Container
         {

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -328,11 +328,6 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        /// <summary>
-        /// Returns true if the given child should be placed on a new row, false otherwise.
-        /// </summary>
-        /// <param name="child">The child to check.</param>
-        /// <returns>True if the given child should be placed on a new row, false otherwise.</returns>
         protected override bool ForceNewRow(Drawable child) => child is NewLineContainer;
 
         internal class NewLineContainer : Container


### PR DESCRIPTION
Does what it says in the title. Previously setting a TextFlowContainer to AutoSize on X would crash as soon as it internally added a NewLineContainer due to the NewLineContainer being implemented via relative-sizing on the X axis, creating an exception in the FlowContainers internal validation.

This somewhat hackily allows subclasses of FillFlowContainer more control over the layout the FillFlowContainer creates, which TextFlowContainer can use to sidestep the whole issue.

Unsure if this is the right way forward, but it was a simple thing to do and gets the job done without getting in the way of anything else, not that I can think of, at least.

Please destroy.