### PR TITLE
Use replace instead of magic substring when assigning a TestCase's name

### DIFF
--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -59,6 +59,11 @@ namespace osu.Framework.Testing
         }
 
         /// <summary>
+        /// Most derived usages of this start with TestCase. This will be removed for display purposes.
+        /// </summary>
+        private const string prefix = "TestCase";
+
+        /// <summary>
         /// Tests any steps and assertions in the constructor of this <see cref="TestCase"/>.
         /// This test must run before any other tests, as it relies on <see cref="StepsContainer"/> not being cleared and not having any elements.
         /// </summary>
@@ -67,7 +72,10 @@ namespace osu.Framework.Testing
 
         protected TestCase()
         {
-            Name = GetType().ReadableName().Substring(8); // Skip the "TestCase prefix
+            Name = GetType().ReadableName();
+
+            // Skip the "TestCase" prefix
+            if (Name.StartsWith(prefix)) Name = Name.Replace(prefix, string.Empty);
 
             RelativeSizeAxes = Axes.Both;
             Masking = true;


### PR DESCRIPTION
Also only replace if the class name starts with TestCase, to avoid cases like OsuTestCase being potentially mangled.