### PR TITLE
Remove Screen.OnKeyDown override

### DIFF
--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -114,20 +114,6 @@ namespace osu.Framework.Screens
                 OnEntering(null);
         }
 
-        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
-        {
-            if (args.Repeat || !IsCurrentScreen) return false;
-
-            switch (args.Key)
-            {
-                case Key.Escape:
-                    Exit();
-                    return true;
-            }
-
-            return base.OnKeyDown(state, args);
-        }
-
         /// <summary>
         /// Changes to a new Screen.
         /// </summary>

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -5,8 +5,6 @@ using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Input;
-using OpenTK.Input;
 
 namespace osu.Framework.Screens
 {


### PR DESCRIPTION
The Screens OnKeyDown-Method was overridden to automatically exit the
screen on hitting escape. This is hardly always wanted or necessary and
being unaware of this feature can trivially cause bugs. This
functionality is best left to be implemented by the user via their
own Screen subclasses.

Please note that the osu project itself will need to make compensatory changes if it relies on this behaviour. I assume it currently does so for things like the options or similar.