### PR TITLE
Fix tracks no longer getting processed when they complete playback

### DIFF
--- a/osu.Framework/Audio/AudioCollectionManager.cs
+++ b/osu.Framework/Audio/AudioCollectionManager.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Audio
             {
                 var item = Items[i];
 
-                if (item.HasCompleted)
+                if (!item.IsAlive)
                 {
                     Items.RemoveAt(i--);
                     continue;

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -48,9 +48,14 @@ namespace osu.Framework.Audio
         }
 
         /// <summary>
-        /// The component has completed its task and is potentially no longer needed.
+        /// This component has completed playback and is now in a stopped state.
         /// </summary>
-        public virtual bool HasCompleted => IsDisposed;
+        public virtual bool HasCompleted => !IsAlive;
+
+        /// <summary>
+        /// This component has completed all processing and is ready to be removed from its parent.
+        /// </summary>
+        public virtual bool IsAlive => !IsDisposed;
 
         public virtual bool IsLoaded => true;
 

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -53,6 +53,6 @@ namespace osu.Framework.Audio.Sample
 
         public virtual bool Played => WasStarted && !Playing;
 
-        public override bool HasCompleted => base.HasCompleted || Played;
+        public override bool IsAlive => base.IsAlive && !Played;
     }
 }


### PR DESCRIPTION
Tracks have more manual lifetime management and should not be removed from their parent until disposed.