### PR TITLE
Netstandard tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,63 +2,75 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
-    "command": "msbuild",
-    "type": "shell",
-    "suppressTaskName": true,
-    "args": [
-        "/property:GenerateFullPaths=true",
-        "/property:DebugType=portable",
-        "/verbosity:minimal",
-        "/m" //parallel compiling support.
-    ],
-    "tasks": [{
-            "taskName": "Build (Debug)",
+    "tasks": [
+        {
+            "label": "Build (Debug)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "/p:GenerateFullPaths=true",
+                "/p:DebugType=portable",
+                "/m",
+                "/v:m"
+            ],
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         },
         {
-            "taskName": "Build (Release)",
+            "label": "Build (Release)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "-c:Release",
+                "/p:DebugType=portable",
+                "/p:GenerateFullPaths=true",
+                "/m",
+                "/v:m"
+            ],
             "group": "build",
-            "args": [
-                "/property:Configuration=Release"
-            ],
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         },
         {
-            "taskName": "Clean (Debug)",
+            "label": "Clean (Debug)",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
-                "/target:Clean"
+                "build",
+                "/p:DebugType=portable",
+                "/p:GenerateFullPaths=true",
+                "/m",
+                "/t:Clean",
+                "/v:m"
             ],
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         },
         {
-            "taskName": "Clean (Release)",
+            "label": "Clean (Release)",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
-                "/target:Clean",
-                "/property:Configuration=Release"
+                "build",
+                "-c:Release",
+                "/p:GenerateFullPaths=true",
+                "/p:DebugType=portable",
+                "/m",
+                "/t:Clean",
+                "/v:m"
             ],
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         },
         {
-            "taskName": "Clean All",
+            "label": "Clean All",
             "dependsOn": [
                 "Clean (Debug)",
                 "Clean (Release)"
             ],
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,75 +2,63 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "Build (Debug)",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "build",
-                "/p:GenerateFullPaths=true",
-                "/p:DebugType=portable",
-                "/m",
-                "/v:m"
-            ],
+    "command": "msbuild",
+    "type": "shell",
+    "suppressTaskName": true,
+    "args": [
+        "/property:GenerateFullPaths=true",
+        "/property:DebugType=portable",
+        "/verbosity:minimal",
+        "/m" //parallel compiling support.
+    ],
+    "tasks": [{
+            "taskName": "Build (Debug)",
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
-            "problemMatcher": "$msCompile"
+            "problemMatcher": [
+                "$msCompile"
+            ]
         },
         {
-            "label": "Build (Release)",
-            "type": "shell",
-            "command": "dotnet",
-            "args": [
-                "build",
-                "-c:Release",
-                "/p:DebugType=portable",
-                "/p:GenerateFullPaths=true",
-                "/m",
-                "/v:m"
-            ],
+            "taskName": "Build (Release)",
             "group": "build",
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "Clean (Debug)",
-            "type": "shell",
-            "command": "dotnet",
             "args": [
-                "build",
-                "/p:DebugType=portable",
-                "/p:GenerateFullPaths=true",
-                "/m",
-                "/t:Clean",
-                "/v:m"
+                "/property:Configuration=Release"
             ],
-            "problemMatcher": "$msCompile"
+            "problemMatcher": [
+                "$msCompile"
+            ]
         },
         {
-            "label": "Clean (Release)",
-            "type": "shell",
-            "command": "dotnet",
+            "taskName": "Clean (Debug)",
             "args": [
-                "build",
-                "-c:Release",
-                "/p:GenerateFullPaths=true",
-                "/p:DebugType=portable",
-                "/m",
-                "/t:Clean",
-                "/v:m"
+                "/target:Clean"
             ],
-            "problemMatcher": "$msCompile"
+            "problemMatcher": [
+                "$msCompile"
+            ]
         },
         {
-            "label": "Clean All",
+            "taskName": "Clean (Release)",
+            "args": [
+                "/target:Clean",
+                "/property:Configuration=Release"
+            ],
+            "problemMatcher": [
+                "$msCompile"
+            ]
+        },
+        {
+            "taskName": "Clean All",
             "dependsOn": [
                 "Clean (Debug)",
                 "Clean (Release)"
             ],
-            "problemMatcher": "$msCompile"
+            "problemMatcher": [
+                "$msCompile"
+            ]
         }
     ]
 }


### PR DESCRIPTION
Since last request, `/p:Configuration=Release` to `-c:Release`, fixed stupid spelling mistake.