### PR TITLE
Make KeyBindingInputManagers into Containers

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Tests.Visual
             RightMouse
         }
 
-        private class TestInputManager : KeyBindingInputManager<TestAction>
+        private class TestInputManager : KeyBindingContainer<TestAction>
         {
             public TestInputManager(SimultaneousBindingMode concurrencyMode = SimultaneousBindingMode.None) : base(concurrencyMode)
             {
@@ -121,7 +121,6 @@ namespace osu.Framework.Tests.Visual
                 {
                     alphaTarget += 0.2f;
                     Background.FadeTo(alphaTarget, 100, Easing.OutQuint);
-                    return true;
                 }
 
                 return false;
@@ -133,7 +132,6 @@ namespace osu.Framework.Tests.Visual
                 {
                     alphaTarget -= 0.2f;
                     Background.FadeTo(alphaTarget, 100, Easing.OutQuint);
-                    return true;
                 }
 
                 return false;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -81,7 +81,7 @@ namespace osu.Framework.Graphics.UserInterface
                     Colour = BackgroundUnfocused,
                     RelativeSizeAxes = Axes.Both,
                 },
-                TextContainer = new KeyBindingContainer(this)
+                TextContainer = new TextBoxPlatformBindingHandler(this)
                 {
                     AutoSizeAxes = Axes.X,
                     RelativeSizeAxes = Axes.Y,
@@ -871,11 +871,11 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        private class KeyBindingContainer : Container, IKeyBindingHandler<PlatformAction>
+        private class TextBoxPlatformBindingHandler : Container, IKeyBindingHandler<PlatformAction>
         {
             private readonly TextBox textBox;
 
-            public KeyBindingContainer(TextBox textBox)
+            public TextBoxPlatformBindingHandler(TextBox textBox)
             {
                 this.textBox = textBox;
             }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -73,40 +73,33 @@ namespace osu.Framework.Graphics.UserInterface
         {
             Masking = true;
             CornerRadius = 3;
-            // TextBoxes currently require their own top-level PlatformInputManager, as InputManagers
-            // will not propagate events through other InputManagers.
-            // Once this restriction has been addressed, we can utilise a single instance of PlatformInputManager
-            // at the Game level, and TextBoxes need only implement IKeyBindingHandler<PlatformAction>.
-            Child = new PlatformInputManager
+
+            Children = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
+                Background = new Box
                 {
-                    Background = new Box
+                    Colour = BackgroundUnfocused,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                TextContainer = new KeyBindingContainer(this)
+                {
+                    AutoSizeAxes = Axes.X,
+                    RelativeSizeAxes = Axes.Y,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Position = new Vector2(LeftRightPadding, 0),
+                    Children = new[]
                     {
-                        Colour = BackgroundUnfocused,
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    TextContainer = new KeyBindingContainer(this)
-                    {
-                        AutoSizeAxes = Axes.X,
-                        RelativeSizeAxes = Axes.Y,
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Position = new Vector2(LeftRightPadding, 0),
-                        Children = new[]
+                        Placeholder = CreatePlaceholder(),
+                        Caret = new DrawableCaret(),
+                        TextFlow = new FillFlowContainer
                         {
-                            Placeholder = CreatePlaceholder(),
-                            Caret = new DrawableCaret(),
-                            TextFlow = new FillFlowContainer
-                            {
-                                Direction = FillDirection.Horizontal,
-                                AutoSizeAxes = Axes.X,
-                                RelativeSizeAxes = Axes.Y,
-                            },
+                            Direction = FillDirection.Horizontal,
+                            AutoSizeAxes = Axes.X,
+                            RelativeSizeAxes = Axes.Y,
                         },
                     },
-                }
+                },
             };
 
             Current.ValueChanged += newValue => { Text = newValue; };

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -203,7 +203,7 @@ namespace osu.Framework.Input.Bindings
 
         public void TriggerReleased(T released) => PropagateReleased(KeyBindingInputQueue, released);
 
-        public void TriggerPressed(T pressed) => PropagateReleased(KeyBindingInputQueue, pressed);
+        public void TriggerPressed(T pressed) => PropagatePressed(KeyBindingInputQueue, pressed);
     }
 
     /// <summary>

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -58,15 +58,13 @@ namespace osu.Framework.Input.Bindings
 
         protected override bool OnWheel(InputState state)
         {
+            InputKey key = state.Mouse.WheelDelta > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
+
             // we need to create a local cloned state to ensure the underlying code in handleNewReleased thinks we are in a sane state,
             // even though we are pressing and releasing an InputKey in a single frame.
+            // the important part of this cloned state is the value of Wheel reset to zero.
             var clonedState = state.Clone();
-            var clonedMouseState = (MouseState)clonedState.Mouse;
-
-            clonedMouseState.Wheel = 0;
-            clonedMouseState.LastState = null;
-
-            InputKey key = state.Mouse.WheelDelta > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
+            clonedState.Mouse = new MouseState { Buttons = clonedState.Mouse.Buttons };
 
             return handleNewPressed(state, key, false) | handleNewReleased(clonedState, key);
         }
@@ -206,7 +204,6 @@ namespace osu.Framework.Input.Bindings
         public void TriggerReleased(T released) => PropagateReleased(KeyBindingInputQueue, released);
 
         public void TriggerPressed(T pressed) => PropagateReleased(KeyBindingInputQueue, pressed);
-
     }
 
     /// <summary>
@@ -236,12 +233,14 @@ namespace osu.Framework.Input.Bindings
         /// One action can be in a pressed state at once. If a new matching binding is encountered, any existing binding is first released.
         /// </summary>
         None,
+
         /// <summary>
         /// Unique actions are allowed to be pressed at the same time. There may therefore be more than one action in an actuated state at once.
         /// If one action has multiple bindings, only the first will trigger an <see cref="IKeyBindingHandler{T}.OnPressed"/>.
         /// The last binding to be released will trigger an <see cref="IKeyBindingHandler{T}.OnReleased(T)"/>.
         /// </summary>
         Unique,
+
         /// <summary>
         /// Unique actions are allowed to be pressed at the same time, as well as multiple times from different bindings. There may therefore be
         /// more than one action in an pressed state at once, as well as multiple consecutive <see cref="IKeyBindingHandler{T}.OnPressed"/> events

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Framework.Input
+{
+    public class FrameworkActionContainer : KeyBindingContainer<FrameworkAction>
+    {
+        public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
+        {
+            new KeyBinding(new[] { InputKey.Control, InputKey.F1 }, FrameworkAction.ToggleDrawVisualiser),
+            new KeyBinding(new[] { InputKey.Control, InputKey.F11 }, FrameworkAction.CycleFrameStatistics),
+            new KeyBinding(new[] { InputKey.Control, InputKey.F10 }, FrameworkAction.ToggleLogOverlay),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.Enter }, FrameworkAction.ToggleFullscreen),
+        };
+
+        protected override IEnumerable<Drawable> KeyBindingInputQueue => new[] { Child }.Concat(base.KeyBindingInputQueue);
+    }
+}

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Generic;
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Bindings;
@@ -16,5 +19,13 @@ namespace osu.Framework.Input
         };
 
         protected override IEnumerable<Drawable> KeyBindingInputQueue => new[] { Child }.Concat(base.KeyBindingInputQueue);
+    }
+
+    public enum FrameworkAction
+    {
+        CycleFrameStatistics,
+        ToggleDrawVisualiser,
+        ToggleLogOverlay,
+        ToggleFullscreen
     }
 }

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -10,7 +10,15 @@ namespace osu.Framework.Input
 {
     public class MouseState : IMouseState
     {
-        public IReadOnlyList<MouseButton> Buttons => buttons;
+        public IReadOnlyList<MouseButton> Buttons
+        {
+            get { return buttons; }
+            set
+            {
+                buttons.Clear();
+                buttons.AddRange(value);
+            }
+        }
 
         private List<MouseButton> buttons { get; set; } = new List<MouseButton>();
 

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Platform;
 
 namespace osu.Framework.Input
 {
@@ -12,9 +14,17 @@ namespace osu.Framework.Input
     /// can be created to handle events that should trigger specifically on a focused drawable.
     /// Will send repeat events by default.
     /// </summary>
-    public class PlatformInputManager : KeyBindingInputManager<PlatformAction>
+    public class PlatformActionContainer : KeyBindingContainer<PlatformAction>
     {
-        public override IEnumerable<KeyBinding> DefaultKeyBindings => Host.PlatformKeyBindings;
+        private GameHost host;
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            this.host = host;
+        }
+
+        public override IEnumerable<KeyBinding> DefaultKeyBindings => host.PlatformKeyBindings;
 
         protected override bool SendRepeats => true;
     }

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -2,24 +2,13 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Collections.Generic;
-using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
 
 namespace osu.Framework.Input
 {
-    public class UserInputManager : KeyBindingInputManager<FrameworkAction>
+    public class UserInputManager : PassThroughInputManager
     {
         protected override IEnumerable<InputHandler> InputHandlers => Host.AvailableInputHandlers;
-
-        public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
-        {
-            new KeyBinding(new[] { InputKey.Control, InputKey.F1 }, FrameworkAction.ToggleDrawVisualiser),
-            new KeyBinding(new[] { InputKey.Control, InputKey.F11 }, FrameworkAction.CycleFrameStatistics),
-            new KeyBinding(new[] { InputKey.Control, InputKey.F10 }, FrameworkAction.ToggleLogOverlay),
-            new KeyBinding(new[] { InputKey.Alt, InputKey.Enter }, FrameworkAction.ToggleFullscreen),
-        };
 
         protected override bool HandleHoverEvents => Host.Window?.CursorInWindow ?? true;
 
@@ -27,8 +16,6 @@ namespace osu.Framework.Input
         {
             UseParentState = false;
         }
-
-        protected override IEnumerable<Drawable> KeyBindingInputQueue => new[] { Child }.Concat(base.KeyBindingInputQueue);
     }
 
     public enum FrameworkAction

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -17,12 +17,4 @@ namespace osu.Framework.Input
             UseParentState = false;
         }
     }
-
-    public enum FrameworkAction
-    {
-        CycleFrameStatistics,
-        ToggleDrawVisualiser,
-        ToggleLogOverlay,
-        ToggleFullscreen
-    }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -408,9 +408,9 @@ namespace osu.Framework.Platform
         {
             var root = new UserInputManager
             {
-                Child = new FrameworkActionContainer
+                Child = new PlatformActionContainer
                 {
-                    Child = new PlatformActionContainer
+                    Child = new FrameworkActionContainer
                     {
                         Child = game
                     }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -406,7 +406,16 @@ namespace osu.Framework.Platform
 
         private void bootstrapSceneGraph(Game game)
         {
-            var root = new UserInputManager { Child = game };
+            var root = new UserInputManager
+            {
+                Child = new FrameworkActionContainer
+                {
+                    Child = new PlatformActionContainer
+                    {
+                        Child = game
+                    }
+                }
+            };
 
             Dependencies.Cache(root);
             Dependencies.Cache(game);
@@ -582,7 +591,7 @@ namespace osu.Framework.Platform
         #endregion
 
         /// <summary>
-        /// Defines the platform-specific key bindings that will be used by <see cref="osu.Framework.Input.PlatformInputManager"/>.
+        /// Defines the platform-specific key bindings that will be used by <see cref="PlatformActionContainer"/>.
         /// Should be overridden per-platform to provide native key bindings.
         /// </summary>
         public virtual IEnumerable<KeyBinding> PlatformKeyBindings => new[]
@@ -599,7 +608,7 @@ namespace osu.Framework.Platform
             new KeyBinding(new KeyCombination(new[] { InputKey.Shift, InputKey.Right }), new PlatformAction(PlatformActionType.CharNext, PlatformActionMethod.Select)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Left }), new PlatformAction(PlatformActionType.WordPrevious, PlatformActionMethod.Move)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Right }), new PlatformAction(PlatformActionType.WordNext, PlatformActionMethod.Move)),
-            new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.BackSpace}), new PlatformAction(PlatformActionType.WordPrevious, PlatformActionMethod.Delete)),
+            new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.BackSpace }), new PlatformAction(PlatformActionType.WordPrevious, PlatformActionMethod.Delete)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Delete }), new PlatformAction(PlatformActionType.WordNext, PlatformActionMethod.Delete)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Shift, InputKey.Left }), new PlatformAction(PlatformActionType.WordPrevious, PlatformActionMethod.Select)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Shift, InputKey.Right }), new PlatformAction(PlatformActionType.WordNext, PlatformActionMethod.Select)),

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -239,9 +239,10 @@
     <Compile Include="Input\CustomInputManager.cs" />
     <Compile Include="Input\Bindings\IKeyBindingHandler.cs" />
     <Compile Include="Input\Bindings\KeyBinding.cs" />
-    <Compile Include="Input\Bindings\KeyBindingInputManager.cs" />
+    <Compile Include="Input\Bindings\KeyBindingContainer.cs" />
     <Compile Include="Input\Bindings\KeyCombination.cs" />
     <Compile Include="Graphics\Visualisation\PropertyDisplay.cs" />
+    <Compile Include="Input\FrameworkActionContainer.cs" />
     <Compile Include="Input\GameWindowTextInput.cs" />
     <Compile Include="Input\Handlers\IHasCursorSensitivity.cs" />
     <Compile Include="Input\Handlers\Keyboard\OpenTKKeyboardHandler.cs" />
@@ -305,7 +306,7 @@
     <Compile Include="Input\IKeyboardState.cs" />
     <Compile Include="Input\IMouseState.cs" />
     <Compile Include="Input\ITextInputSource.cs" />
-    <Compile Include="Input\PlatformInputManager.cs" />
+    <Compile Include="Input\PlatformActionContainer.cs" />
     <Compile Include="IO\File\FileSafety.cs" />
     <Compile Include="IO\Network\FileWebRequest.cs" />
     <Compile Include="IO\Network\HttpMethod.cs" />


### PR DESCRIPTION
It turns out the overhead and complexity is a lot lower this way.

This resolves the inability to nest `KeyBinding` handlers inside each other and better handles cross-`Container` and cross-`InputManager` scenarios.

This removes the workaround in `TextBox` which involved every `TextBox` having their own `InputManager`.