### PR TITLE
Add the ability to ignore a tooltip and get the below tooltip

### DIFF
--- a/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
+++ b/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Linq;
 using OpenTK;
 using OpenTK.Input;
 using osu.Framework.Graphics.Containers;
@@ -63,17 +64,7 @@ namespace osu.Framework.Graphics.Cursor
             switch (args.Button)
             {
                 case MouseButton.Right:
-                    menuTarget = null;
-
-                    var targets = FindTargets();
-                    foreach (var target in targets) 
-                    {
-                        if (target != null) 
-                        {
-                            menuTarget = target;
-                            break;
-                        }
-                    }
+                    menuTarget = FindTargets().FirstOrDefault();
 
                     if (menuTarget == null)
                     {

--- a/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
+++ b/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
@@ -63,7 +63,17 @@ namespace osu.Framework.Graphics.Cursor
             switch (args.Button)
             {
                 case MouseButton.Right:
-                    menuTarget = FindTarget();
+                    menuTarget = null;
+
+                    var targets = FindTargets();
+                    foreach (var target in targets) 
+                    {
+                        if (target != null) 
+                        {
+                            menuTarget = target;
+                            break;
+                        }
+                    }
 
                     if (menuTarget == null)
                     {

--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -87,23 +87,6 @@ namespace osu.Framework.Graphics.Cursor
             }
         }
 
-        protected TTarget FindTarget()
-        {
-            findTargetChildren();
-
-            // If we found any valid effect targets, pick the _last_ one as it
-            // represents the front-most drawn one.
-            TTarget result = targetChildren.LastOrDefault();
-
-            // Clean up
-            childDrawables.Clear();
-            nestedTtcChildDrawables.Clear();
-            newChildDrawables.Clear();
-            targetChildren.Clear();
-
-            return result;
-        }
-
         protected List<TTarget> FindTargets()
         {
             findTargetChildren();

--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -103,5 +103,20 @@ namespace osu.Framework.Graphics.Cursor
 
             return result;
         }
+
+        protected List<TTarget> FindTargets()
+        {
+            findTargetChildren();
+
+            List<TTarget> result = new List<TTarget>(targetChildren);
+
+            // Clean up
+            childDrawables.Clear();
+            nestedTtcChildDrawables.Clear();
+            newChildDrawables.Clear();
+            targetChildren.Clear();
+
+            return result;
+        }
     }
 }

--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -109,6 +109,7 @@ namespace osu.Framework.Graphics.Cursor
             findTargetChildren();
 
             List<TTarget> result = new List<TTarget>(targetChildren);
+            result.Reverse();
 
             // Clean up
             childDrawables.Clear();

--- a/osu.Framework/Graphics/Cursor/IHasTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasTooltip.cs
@@ -14,10 +14,5 @@ namespace osu.Framework.Graphics.Cursor
         /// Tooltip that shows when hovering the drawable.
         /// </summary>
         string TooltipText { get; }
-
-        /// <summary>
-        /// Whether or not the tooltip should be ignored and the tooltip below is fetched.
-        /// </summary>
-        bool IgnoreTooltip { get; }
     }
 }

--- a/osu.Framework/Graphics/Cursor/IHasTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasTooltip.cs
@@ -14,5 +14,10 @@ namespace osu.Framework.Graphics.Cursor
         /// Tooltip that shows when hovering the drawable.
         /// </summary>
         string TooltipText { get; }
+
+        /// <summary>
+        /// Whether or not the tooltip should be ignored and the tooltip below is fetched.
+        /// </summary>
+        bool IgnoreTooltip { get; }
     }
 }

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -196,10 +196,15 @@ namespace osu.Framework.Graphics.Cursor
 
             if (relevantPositions.All(t => Vector2Extensions.DistanceSquared(t.Position, first) < appearRadiusSq))
             {
-                // Only return the target if it has a valid tooltip
-                IHasTooltip target = FindTarget();
-                if (hasValidTooltip(target))
-                    return target;
+
+                var targets = base.FindTargets();
+
+                // Go through each item until we find a tooltip
+                foreach (var target in targets) {
+                    if (hasValidTooltip(target)) {
+                        return target;
+                    }
+                }
             }
 
             return null;

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -196,12 +196,13 @@ namespace osu.Framework.Graphics.Cursor
 
             if (relevantPositions.All(t => Vector2Extensions.DistanceSquared(t.Position, first) < appearRadiusSq))
             {
-
                 var targets = base.FindTargets();
+                // The top items are at the end of the list
+                targets.Reverse();
 
                 // Go through each item until we find a tooltip
                 foreach (var target in targets) {
-                    if (hasValidTooltip(target)) {
+                    if (hasValidTooltip(target) && !target.IgnoreTooltip) {
                         return target;
                     }
                 }

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -197,14 +197,18 @@ namespace osu.Framework.Graphics.Cursor
             if (relevantPositions.All(t => Vector2Extensions.DistanceSquared(t.Position, first) < appearRadiusSq))
             {
                 var targets = base.FindTargets();
-                // The top items are at the end of the list
-                targets.Reverse();
 
-                // Go through each item until we find a tooltip
-                foreach (var target in targets) {
-                    if (hasValidTooltip(target) && !target.IgnoreTooltip) {
-                        return target;
+                foreach (var target in targets)
+                {
+                    if (target.TooltipText == null)
+                    {
+                        continue;
                     }
+                    if (target.TooltipText == string.Empty)
+                    {
+                        break;
+                    }
+                    return target;
                 }
             }
 

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -195,22 +195,7 @@ namespace osu.Framework.Graphics.Cursor
             float appearRadiusSq = AppearRadius * AppearRadius;
 
             if (relevantPositions.All(t => Vector2Extensions.DistanceSquared(t.Position, first) < appearRadiusSq))
-            {
-                var targets = base.FindTargets();
-
-                foreach (var target in targets)
-                {
-                    if (target.TooltipText == null)
-                    {
-                        continue;
-                    }
-                    if (target.TooltipText == string.Empty)
-                    {
-                        break;
-                    }
-                    return target;
-                }
-            }
+                return FindTargets().FirstOrDefault(t => t != null);
 
             return null;
         }


### PR DESCRIPTION
This allows for a "pass-through" style for tooltips, where something can be on top of something else, but the tooltip is still retrieved from the bottom item.

I thought it was better to use an extra property rather than ignoring `null` tooltips in case it is intentional for a tooltip to be set to `null`.