### PR TITLE
Prevent ChildID from being changed by ChangeInternalChildDepth

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -344,8 +344,9 @@ namespace osu.Framework.Graphics.Containers
 
 
             internalChildren.RemoveAt(IndexOfInternal(child));
-            if (child.IsAlive)
-                aliveInternalChildren.Remove(child);
+            var aliveIndex = aliveInternalChildren.IndexOf(child);
+            if (aliveIndex >= 0) // remove if found
+                aliveInternalChildren.RemoveAt(aliveIndex);
 
             var chId = child.ChildID;
             child.ChildID = 0; // ensure Depth-change does not throw an exception
@@ -353,7 +354,7 @@ namespace osu.Framework.Graphics.Containers
             child.ChildID = chId;
 
             internalChildren.Add(child);
-            if (child.IsAlive)
+            if (aliveIndex >= 0) // re-add if it used to be in aliveInternalChildren
                 aliveInternalChildren.Add(child);
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -339,11 +339,11 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="newDepth">The new depth value to be set.</param>
         protected internal void ChangeInternalChildDepth(Drawable child, float newDepth)
         {
-            if (!ContainsInternal(child))
+            var index = IndexOfInternal(child);
+            if (index < 0)
                 throw new InvalidOperationException($"Can not change depth of drawable which is not contained within this {nameof(CompositeDrawable)}.");
 
-
-            internalChildren.RemoveAt(IndexOfInternal(child));
+            internalChildren.RemoveAt(index);
             var aliveIndex = aliveInternalChildren.IndexOf(child);
             if (aliveIndex >= 0) // remove if found
                 aliveInternalChildren.RemoveAt(aliveIndex);

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -342,9 +342,19 @@ namespace osu.Framework.Graphics.Containers
             if (!ContainsInternal(child))
                 throw new InvalidOperationException($"Can not change depth of drawable which is not contained within this {nameof(CompositeDrawable)}.");
 
-            RemoveInternal(child);
+
+            internalChildren.RemoveAt(IndexOfInternal(child));
+            if (child.IsAlive)
+                aliveInternalChildren.Remove(child);
+
+            var chId = child.ChildID;
+            child.ChildID = 0; // ensure Depth-change does not throw an exception
             child.Depth = newDepth;
-            AddInternal(child);
+            child.ChildID = chId;
+
+            internalChildren.Add(child);
+            if (child.IsAlive)
+                aliveInternalChildren.Add(child);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -278,12 +278,10 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="newDepth">The new depth value to be set.</param>
         public void ChangeChildDepth(T child, float newDepth)
         {
-            if (!Contains(child))
-                throw new InvalidOperationException("Can not change depth of drawable which is not contained within this container.");
-
-            Remove(child);
-            child.Depth = newDepth;
-            Add(child);
+            if (Content != this)
+                Content.ChangeChildDepth(child, newDepth);
+            else
+                ChangeInternalChildDepth(child, newDepth);
         }
 
         /// <summary>


### PR DESCRIPTION
The implementation of ChangeInternalChildDepth via AddInternal and
RemoveInternal would influence the ChildID, causing z-ordering to be
incorrect if the Depth was changed to a non-unique value inside the
CompositeDrawable.

Specifically, the following code will have bad z-ordering without this patch:
```C#
container.Add(drawable1);
container.Add(drawable2);
container.ChangeInternalChildDepth(drawable1, 10f);
container.ChangeInternalChildDepth(drawable1, 0f);
```

Despite ``drawable1`` being added first and having the same ``Depth``-Value as ``drawable2``, ``drawable1`` will be drawn on top of ``drawable2``.
This patch remedies this situation and ensures that ``drawable1`` after this code will be drawn behind ``drawable2`` as would be expected.