### PR TITLE
Dropdown depth

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Tests.Visual
 
         public TestCaseDropdownBox()
         {
-            StyledDropdown styledDropdown, styledDropdownMenu2, styledDropdownMenu3;
+            StyledDropdown styledDropdown, styledDropdownMenu2;
 
             var testItems = new string[10];
             int i = 0;
@@ -41,7 +41,7 @@ namespace osu.Framework.Tests.Visual
                 Items = testItems.Select(item => new KeyValuePair<string, string>(item, item)),
             });
 
-            Add(styledDropdownMenu3 = new StyledDropdown
+            Add(new StyledDropdown
             {
                 Width = 150,
                 Position = new Vector2(170, 90),

--- a/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Tests.Visual
 
         public TestCaseDropdownBox()
         {
-            StyledDropdown styledDropdown, styledDropdownMenu2;
+            StyledDropdown styledDropdown, styledDropdownMenu2, styledDropdownMenu3;
 
             var testItems = new string[10];
             int i = 0;
@@ -38,6 +38,13 @@ namespace osu.Framework.Tests.Visual
             {
                 Width = 150,
                 Position = new Vector2(400, 70),
+                Items = testItems.Select(item => new KeyValuePair<string, string>(item, item)),
+            });
+
+            Add(styledDropdownMenu3 = new StyledDropdown
+            {
+                Width = 150,
+                Position = new Vector2(170, 90),
                 Items = testItems.Select(item => new KeyValuePair<string, string>(item, item)),
             });
 

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -113,6 +113,8 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
+        private float depthCache;
+
         protected Dropdown()
         {
             AutoSizeAxes = Axes.Y;
@@ -123,11 +125,25 @@ namespace osu.Framework.Graphics.UserInterface
                 Header = CreateHeader(),
                 Menu = CreateMenu()
             };
+            Menu.StateChanged += onMenuStateChanged;
 
             Menu.RelativeSizeAxes = Axes.X;
 
             Header.Action = Menu.Toggle;
             Current.ValueChanged += selectionChanged;
+        }
+
+        private void onMenuStateChanged(MenuState state)
+        {
+            if (state == MenuState.Open)
+            {
+                depthCache = Depth;
+                Parent.ChangeInternalChildDepth(this, float.MinValue);
+            }
+            else
+            {
+                Parent.ChangeInternalChildDepth(this, depthCache);
+            }
         }
 
         protected override void LoadComplete()


### PR DESCRIPTION
This ensures that opened dropdowns are drawn on top of anything else inside their container, but only for the duration of them being opened.
This renders things like [ReverseChildIDFillFlowContainer](https://github.com/ppy/osu/blob/349dbfe263495b3479f8a13331446aafcc8a3b38/osu.Game/Graphics/Containers/ReverseChildIDFillFlowContainer.cs) unnecessary insofar ``FillFlowContainer``s with dropdowns in them are concerned.

Depends on #1239