### PR TITLE
Update tasks.json format

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,13 +2,11 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
-    "tasks": [
-        {
+    "tasks": [{
             "label": "Build (Debug)",
             "type": "shell",
-            "command": "dotnet",
+            "command": "msbuild",
             "args": [
-                "build",
                 "/p:GenerateFullPaths=true",
                 "/p:DebugType=portable",
                 "/m",
@@ -23,10 +21,9 @@
         {
             "label": "Build (Release)",
             "type": "shell",
-            "command": "dotnet",
+            "command": "msbuild",
             "args": [
-                "build",
-                "-c:Release",
+                "/p:Configuration=Release",
                 "/p:DebugType=portable",
                 "/p:GenerateFullPaths=true",
                 "/m",
@@ -38,9 +35,8 @@
         {
             "label": "Clean (Debug)",
             "type": "shell",
-            "command": "dotnet",
+            "command": "msbuild",
             "args": [
-                "build",
                 "/p:DebugType=portable",
                 "/p:GenerateFullPaths=true",
                 "/m",
@@ -52,10 +48,9 @@
         {
             "label": "Clean (Release)",
             "type": "shell",
-            "command": "dotnet",
+            "command": "msbuild",
             "args": [
-                "build",
-                "-c:Release",
+                "/p:Configuration=Release",
                 "/p:GenerateFullPaths=true",
                 "/p:DebugType=portable",
                 "/m",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,63 +2,75 @@
     // See https://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format
     "version": "2.0.0",
-    "command": "msbuild",
-    "type": "shell",
-    "suppressTaskName": true,
-    "args": [
-        "/property:GenerateFullPaths=true",
-        "/property:DebugType=portable",
-        "/verbosity:minimal",
-        "/m" //parallel compiling support.
-    ],
-    "tasks": [{
-            "taskName": "Build (Debug)",
+    "tasks": [
+        {
+            "label": "Build (Debug)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "/p:GenerateFullPaths=true",
+                "/p:DebugType=portable",
+                "/m",
+                "/v:m"
+            ],
             "group": {
                 "kind": "build",
                 "isDefault": true
             },
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         },
         {
-            "taskName": "Build (Release)",
+            "label": "Build (Release)",
+            "type": "shell",
+            "command": "dotnet",
+            "args": [
+                "build",
+                "-c:Release",
+                "/p:DebugType=portable",
+                "/p:GenerateFullPaths=true",
+                "/m",
+                "/v:m"
+            ],
             "group": "build",
-            "args": [
-                "/property:Configuration=Release"
-            ],
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         },
         {
-            "taskName": "Clean (Debug)",
+            "label": "Clean (Debug)",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
-                "/target:Clean"
+                "build",
+                "/p:DebugType=portable",
+                "/p:GenerateFullPaths=true",
+                "/m",
+                "/t:Clean",
+                "/v:m"
             ],
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         },
         {
-            "taskName": "Clean (Release)",
+            "label": "Clean (Release)",
+            "type": "shell",
+            "command": "dotnet",
             "args": [
-                "/target:Clean",
-                "/property:Configuration=Release"
+                "build",
+                "-c:Release",
+                "/p:GenerateFullPaths=true",
+                "/p:DebugType=portable",
+                "/m",
+                "/t:Clean",
+                "/v:m"
             ],
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         },
         {
-            "taskName": "Clean All",
+            "label": "Clean All",
             "dependsOn": [
                 "Clean (Debug)",
                 "Clean (Release)"
             ],
-            "problemMatcher": [
-                "$msCompile"
-            ]
+            "problemMatcher": "$msCompile"
         }
     ]
 }


### PR DESCRIPTION
Follows what's already in ppy/netstandard, however uses msbuild instead of dotnet, since dotnet doesn't support targetting net461 on mono.