### PR TITLE
Use DelayedLoadWrapped instead of LoadComponentAsync for loading TestCases

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -48,6 +48,9 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Loads a future child or grand-child of this <see cref="CompositeDrawable"/> asyncronously. <see cref="Drawable.Dependencies"/>
         /// and <see cref="Drawable.Clock"/> are inherited from this <see cref="CompositeDrawable"/>.
+        ///
+        /// Note that this will always use the dependencies and clock from this instance. If you must load to a nested container level,
+        /// consider using <see cref="DelayedLoadWrapper"/>
         /// </summary>
         /// <typeparam name="TLoadable">The type of the future future child or grand-child to be loaded.</typeparam>
         /// <param name="component">The type of the future future child or grand-child to be loaded.</param>

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -295,11 +295,15 @@ namespace osu.Framework.Testing
 
                 dropdown.Current.Value = testType.Assembly;
 
-                CurrentTest = (TestCase)Activator.CreateInstance(testType);
+                var newTest = (TestCase)Activator.CreateInstance(testType);
+
+                CurrentTest = newTest;
 
                 updateButtons();
 
-                LoadComponentAsync(CurrentTest, loaded =>
+                testContentContainer.Add(new DelayedLoadWrapper(CurrentTest, 0));
+
+                newTest.OnLoadComplete = d =>
                 {
                     if (lastTest?.Parent != null)
                     {
@@ -307,9 +311,11 @@ namespace osu.Framework.Testing
                         lastTest.Clear();
                     }
 
-                    if (CurrentTest != loaded) return;
-
-                    testContentContainer.Add(loaded);
+                    if (CurrentTest != newTest)
+                    {
+                        testContentContainer.Remove(newTest);
+                        return;
+                    }
 
                     updateButtons();
 
@@ -327,11 +333,11 @@ namespace osu.Framework.Testing
                     backgroundCompiler.Checkpoint(CurrentTest);
 
                     if (!interactive)
-                        loaded.RunAllSteps(onCompletion);
+                        newTest.RunAllSteps(onCompletion);
                     else
                         CurrentTest.RunFirstStep();
                     updateButtons();
-                });
+                };
             }
         }
 


### PR DESCRIPTION
Previously the wrong clock and dependncies were used – the TestBrowser's rather than their load target, which contains a custom clock implementation.