### PR TITLE
Simplify BackgroundDependencyLoader exceptions

### DIFF
--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using osu.Framework.Extensions.ExceptionExtensions;
 
 namespace osu.Framework.Allocation
 {
@@ -83,7 +84,15 @@ namespace osu.Framework.Allocation
                 return new Action<object>(instance =>
                 {
                     var p = parameters.Select(pa => pa()).ToArray();
-                    initializer.Invoke(instance, p);
+
+                    try
+                    {
+                        initializer.Invoke(instance, p);
+                    }
+                    catch (TargetInvocationException e)
+                    {
+                        new RecursiveLoadException(e.GetLastInvocation(), initializer).Rethrow();
+                    }
                 });
             }).ToList();
 

--- a/osu.Framework/Allocation/RecursiveLoadException.cs
+++ b/osu.Framework/Allocation/RecursiveLoadException.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Allocation
         public override string ToString()
         {
             var builder = new StringBuilder();
-            builder.Append(InnerException?.ToString() ?? string.Empty);
+            builder.AppendLine(InnerException?.ToString() ?? string.Empty);
             builder.AppendLine(traceBuilder.ToString());
 
             return builder.ToString();

--- a/osu.Framework/Allocation/RecursiveLoadException.cs
+++ b/osu.Framework/Allocation/RecursiveLoadException.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Allocation
         public override string ToString()
         {
             var builder = new StringBuilder();
-            builder.Append(nameof(RecursiveLoadException));
+            builder.Append(InnerException?.ToString() ?? string.Empty);
             builder.AppendLine(traceBuilder.ToString());
 
             return builder.ToString();

--- a/osu.Framework/Allocation/RecursiveLoadException.cs
+++ b/osu.Framework/Allocation/RecursiveLoadException.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Allocation
                 foreach (var o in lines)
                 {
                     traceBuilder.AppendLine(o);
-                    if (o.Contains($"{loaderLocation}"))
+                    if (o.Contains(loaderLocation))
                         break;
                 }
             }

--- a/osu.Framework/Allocation/RecursiveLoadException.cs
+++ b/osu.Framework/Allocation/RecursiveLoadException.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Allocation
+{
+    /// <summary>
+    /// The exception that is re-thrown by <see cref="DependencyContainer"/> when a loader invocation fails.
+    /// This exception type builds a readablestacktrace message since loader invocations tend to be long recursive reflection calls.
+    /// </summary>
+    public class RecursiveLoadException : Exception
+    {
+        /// <summary>
+        /// Types that are ignored for the custom stack traces. The initializers for these typically invoke
+        /// initializers in user code where the problem actually lies.
+        /// </summary>
+        private static readonly Type[] blacklist =
+        {
+            typeof(Container),
+            typeof(Container<>),
+            typeof(CompositeDrawable)
+        };
+
+        private readonly StringBuilder traceBuilder;
+
+        public RecursiveLoadException(Exception inner, MethodInfo loaderMethod)
+            : base(string.Empty, (inner as RecursiveLoadException)?.InnerException ?? inner)
+        {
+            traceBuilder = inner is RecursiveLoadException recursiveException ? recursiveException.traceBuilder : new StringBuilder();
+
+            if (!blacklist.Contains(loaderMethod.DeclaringType))
+                traceBuilder.AppendLine($" at {loaderMethod.DeclaringType?.ReadableName() ?? string.Empty}.{loaderMethod.Name} ()");
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.Append(nameof(RecursiveLoadException));
+            builder.AppendLine(traceBuilder.ToString());
+
+            return builder.ToString();
+        }
+    }
+}

--- a/osu.Framework/Allocation/RecursiveLoadException.cs
+++ b/osu.Framework/Allocation/RecursiveLoadException.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Allocation
             traceBuilder = inner is RecursiveLoadException recursiveException ? recursiveException.traceBuilder : new StringBuilder();
 
             if (!blacklist.Contains(loaderMethod.DeclaringType))
-                traceBuilder.AppendLine($"  at {loaderMethod.DeclaringType?.ReadableName() ?? string.Empty}.{loaderMethod.Name} ()");
+                traceBuilder.AppendLine($"  at {loaderMethod.DeclaringType}.{loaderMethod.Name} ()");
         }
 
         public override string ToString()

--- a/osu.Framework/Allocation/RecursiveLoadException.cs
+++ b/osu.Framework/Allocation/RecursiveLoadException.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Allocation

--- a/osu.Framework/Allocation/RecursiveLoadException.cs
+++ b/osu.Framework/Allocation/RecursiveLoadException.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Allocation
             traceBuilder = inner is RecursiveLoadException recursiveException ? recursiveException.traceBuilder : new StringBuilder();
 
             if (!blacklist.Contains(loaderMethod.DeclaringType))
-                traceBuilder.AppendLine($" at {loaderMethod.DeclaringType?.ReadableName() ?? string.Empty}.{loaderMethod.Name} ()");
+                traceBuilder.AppendLine($"  at {loaderMethod.DeclaringType?.ReadableName() ?? string.Empty}.{loaderMethod.Name} ()");
         }
 
         public override string ToString()

--- a/osu.Framework/Extensions/ExceptionExtensions/ExceptionExtensions.cs
+++ b/osu.Framework/Extensions/ExceptionExtensions/ExceptionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using System.Reflection;
 using System.Runtime.ExceptionServices;
 
 namespace osu.Framework.Extensions.ExceptionExtensions
@@ -47,6 +48,19 @@ namespace osu.Framework.Extensions.ExceptionExtensions
             }
 
             return aggregateException;
+        }
+
+        /// <summary>
+        /// Retrieves the last exception from a recursive <see cref="TargetInvocationException"/>.
+        /// </summary>
+        /// <param name="exception">The exception to retrieve the exception from.</param>
+        /// <returns>The exception at the point of invocation.</returns>
+        public static Exception GetLastInvocation(this TargetInvocationException exception)
+        {
+            var inner = exception.InnerException;
+            while (inner is TargetInvocationException)
+                inner = inner.InnerException;
+            return inner;
         }
     }
 }

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -195,19 +195,18 @@ namespace osu.Framework.Extensions
             => value.GetType().GetField(value.ToString())
                     .GetCustomAttribute<DescriptionAttribute>()?.Description ?? value.ToString();
 
-        public static void ThrowIfFaulted(this Task task)
+        public static void ThrowIfFaulted(this Task task, Type expectedBaseType = null)
         {
-            if (task.IsFaulted)
-            {
-                Exception e = task.Exception;
+            if (!task.IsFaulted) return;
 
-                Debug.Assert(e != null);
+            Exception e = task.Exception;
 
-                while (e.InnerException != null)
-                    e = e.InnerException;
+            Debug.Assert(e != null);
 
-                ExceptionDispatchInfo.Capture(e).Throw();
-            }
+            while (e.InnerException != null && e.GetType() != expectedBaseType)
+                e = e.InnerException;
+
+            ExceptionDispatchInfo.Capture(e).Throw();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -145,7 +145,7 @@ namespace osu.Framework.Graphics
             return loadTask = Task.Factory.StartNew(() => Load(target.Clock, target.Dependencies), TaskCreationOptions.LongRunning)
                                   .ContinueWith(task => game.Schedule(() =>
                                   {
-                                      task.ThrowIfFaulted();
+                                      task.ThrowIfFaulted(typeof(RecursiveLoadException));
                                       onLoaded?.Invoke();
                                       loadTask = null;
                                   }));

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -141,6 +141,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Allocation\IReadOnlyDependencyContainer.cs" />
+    <Compile Include="Allocation\RecursiveLoadException.cs" />
     <Compile Include="Audio\AudioComponent.cs" />
     <Compile Include="Audio\IBassAudio.cs" />
     <Compile Include="Audio\IHasPitchAdjust.cs" />


### PR DESCRIPTION
Because [this](https://ci.appveyor.com/project/peppy/osu/build/master-5904) is unreadable.

From:
```
[ERROR] FATAL UNHANDLED EXCEPTION: System.Exception: Try find me!
  at osu.Game.Rulesets.UI.Playfield.load () [0x00001] in /Users/smoogipoo/Repos/Temp/temp-osu/osu.Game/Rulesets/UI/Playfield.cs:64 
  at (wrapper managed-to-native) System.Reflection.MonoMethod:InternalInvoke (System.Reflection.MonoMethod,object,object[],System.Exception&)
  at System.Reflection.MonoMethod.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) [0x00032] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/corlib/System.Reflection/MonoMethod.cs:305 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/runtime/exceptionservices/exceptionservicescommon.cs:152 
  at osu.Framework.Extensions.ExtensionMethods.ThrowIfFaulted (System.Threading.Tasks.Task task) [0x00033] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Extensions/ExtensionMethods.cs:209 
  at osu.Framework.Graphics.Drawable+<>c__DisplayClass15_1.<LoadAsync>b__2 () [0x00001] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Drawable.cs:148 
  at osu.Framework.Threading.ScheduledDelegate.RunTask () [0x0000e] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Threading/Scheduler.cs:293 
  at osu.Framework.Threading.Scheduler.Update () [0x0023c] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Threading/Scheduler.cs:148 
  at osu.Framework.Graphics.Drawable.UpdateSubTree () [0x000a1] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Drawable.cs:348 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00001] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:467 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Platform.GameHost.UpdateFrame () [0x000b2] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Platform/GameHost.cs:250 
  at osu.Framework.Threading.GameThread.ProcessFrame () [0x00040] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Threading/GameThread.cs:115 
  at osu.Framework.Threading.GameThread.runWork () [0x0002d] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Threading/GameThread.cs:104 
  at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00014] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/thread.cs:68 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:957 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:904 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:893 
  at System.Threading.ThreadHelper.ThreadStart () [0x00008] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/thread.cs:105 
```

To:
```
[ERROR] FATAL UNHANDLED EXCEPTION: System.Exception: Try find me!
  at osu.Game.Rulesets.UI.Playfield.load () [0x00001] in /Users/smoogipoo/Repos/Temp/temp-osu/osu.Game/Rulesets/UI/Playfield.cs:64 
  at osu.Game.Rulesets.UI.RulesetContainer`1[osu.Game.Rulesets.Osu.Objects.OsuHitObject].load ()
  at osu.Game.Screens.Play.Player.load ()
```