### PR TITLE
Simplify UpdateSubTree exception output

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -462,6 +462,8 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected virtual bool RequiresChildrenUpdate => !IsMaskedAway || !childrenSizeDependencies.IsValid;
 
+        internal int CurrentUpdateIndex { get; private set; } = -1;
+
         public override bool UpdateSubTree()
         {
             if (!base.UpdateSubTree()) return false;
@@ -477,12 +479,14 @@ namespace osu.Framework.Graphics.Containers
 
             // We iterate by index to gain performance
             // ReSharper disable once ForCanBeConvertedToForeach
-            for (int i = 0; i < aliveInternalChildren.Count; ++i)
+            for (CurrentUpdateIndex = 0; CurrentUpdateIndex < aliveInternalChildren.Count; ++CurrentUpdateIndex)
             {
-                Drawable c = aliveInternalChildren[i];
+                Drawable c = aliveInternalChildren[CurrentUpdateIndex];
                 Debug.Assert(c.LoadState >= LoadState.Ready);
                 c.UpdateSubTree();
             }
+
+            CurrentUpdateIndex = -1;
 
             if (schedulerAfterChildren != null)
             {

--- a/osu.Framework/Graphics/UpdateSubTreeException.cs
+++ b/osu.Framework/Graphics/UpdateSubTreeException.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Graphics
+{
+    public class UpdateSubTreeException : Exception
+    {
+        /// <summary>
+        /// Types that are ignored for the custom stack traces.
+        /// </summary>
+        private static readonly Type[] blacklist =
+        {
+            typeof(Container),
+            typeof(Container<>),
+            typeof(CompositeDrawable)
+        };
+
+        public UpdateSubTreeException(Exception originalException, CompositeDrawable root)
+            : base(originalException.Message)
+        {
+            var originType = originalException.TargetSite.DeclaringType;
+
+            var recursiveTypes = new List<Type>();
+
+            Drawable current = root;
+            while (current != null)
+            {
+                var currentType = current.GetType();
+                if (currentType == originType || !blacklist.Contains(currentType))
+                    recursiveTypes.Add(current.GetType());
+
+                var composite = current as CompositeDrawable;
+                if (composite == null || composite.CurrentUpdateIndex == -1)
+                    break;
+                current = composite.AliveInternalChildren[composite.CurrentUpdateIndex];
+            }
+
+            var traceBuilder = new StringBuilder();
+
+            var lines = originalException.StackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var o in lines)
+            {
+                traceBuilder.AppendLine(o);
+                if (o.Contains(nameof(Drawable.UpdateSubTree)))
+                    break;
+            }
+
+            // Skip the first type, since that's going to be handled by the foreach above
+            for (int i = recursiveTypes.Count - 2; i >= 0; i--)
+                traceBuilder.AppendLine($"  at {recursiveTypes[i]}.{nameof(Drawable.UpdateSubTree)} ()");
+            stackTrace = traceBuilder.ToString();
+        }
+
+        private readonly string stackTrace;
+        public override string StackTrace => stackTrace;
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine(Message);
+            builder.AppendLine(stackTrace);
+
+            return builder.ToString();
+        }
+    }
+}

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -15,6 +15,7 @@ using OpenTK.Graphics.ES30;
 using OpenTK.Input;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
+using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -247,7 +248,15 @@ namespace osu.Framework.Platform
             // Ensure we maintain a valid size for any children immediately scaling by the window size
             Root.Size = Vector2.ComponentMax(Vector2.One, Root.Size);
 
-            Root.UpdateSubTree();
+            try
+            {
+                Root.UpdateSubTree();
+            }
+            catch (Exception e)
+            {
+                new UpdateSubTreeException(e, Root).Rethrow();
+            }
+
             using (var buffer = DrawRoots.Get(UsageType.Write))
                 buffer.Object = Root.GenerateDrawNodeSubtree(buffer.Index, Root.ScreenSpaceDrawQuad.AABBFloat);
         }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -224,6 +224,7 @@
     <Compile Include="Graphics\TransformableExtensions.cs" />
     <Compile Include="Graphics\Transforms\TransformSequence.cs" />
     <Compile Include="Graphics\Transforms\TransformCustom.cs" />
+    <Compile Include="Graphics\UpdateSubTreeException.cs" />
     <Compile Include="Graphics\UserInterface\BasicCheckbox.cs" />
     <Compile Include="Graphics\UserInterface\BasicDropdown.cs" />
     <Compile Include="Graphics\UserInterface\Checkbox.cs" />


### PR DESCRIPTION
Because the relevant exceptions [in here](https://ci.appveyor.com/project/peppy/osu/build/master-5904) are unreadable.

From:
```
[ERROR] FATAL UNHANDLED EXCEPTION: System.Exception: Find me!
  at osu.Game.Rulesets.Osu.Objects.Drawables.Pieces.CirclePiece.OnPressed (osu.Game.Rulesets.Osu.OsuAction action) [0x00001] in /Users/smoogipoo/Repos/Temp/temp-osu/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/CirclePiece.cs:54 
  at osu.Framework.Input.Bindings.KeyBindingContainer`1+<>c__DisplayClass19_1[T].<PropagatePressed>b__1 (osu.Framework.Input.Bindings.IKeyBindingHandler`1[T] d) [0x00000] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:156 
  at System.Linq.Enumerable.TryGetFirst[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate, System.Boolean& found) [0x0003f] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/First.cs:107 
  at System.Linq.Enumerable.FirstOrDefault[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/First.cs:46 
  at osu.Framework.Input.Bindings.KeyBindingContainer`1[T].PropagatePressed (System.Collections.Generic.IEnumerable`1[T] drawables, T pressed) [0x000bb] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:156 
  at osu.Framework.Input.Bindings.KeyBindingContainer`1[T].handleNewPressed (osu.Framework.Input.InputState state, osu.Framework.Input.Bindings.InputKey newKey, System.Boolean repeat) [0x000c8] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:129 
  at osu.Framework.Input.Bindings.KeyBindingContainer`1[T].OnMouseDown (osu.Framework.Input.InputState state, osu.Framework.Input.MouseDownEventArgs args) [0x00000] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:88 
  at osu.Framework.Graphics.Drawable.TriggerOnMouseDown (osu.Framework.Input.InputState screenSpaceState, osu.Framework.Input.MouseDownEventArgs args) [0x00000] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Drawable.cs:1662 
  at osu.Framework.Input.InputManager+<>c__DisplayClass51_0.<PropagateMouseDown>b__0 (osu.Framework.Graphics.Drawable target) [0x00000] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:552 
  at System.Linq.Enumerable.TryGetFirst[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate, System.Boolean& found) [0x0003f] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/First.cs:107 
  at System.Linq.Enumerable.FirstOrDefault[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/First.cs:46 
  at osu.Framework.Input.InputManager.PropagateMouseDown (System.Collections.Generic.IEnumerable`1[T] drawables, osu.Framework.Input.InputState state, osu.Framework.Input.MouseDownEventArgs args) [0x00015] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:552 
  at osu.Framework.Input.InputManager.handleMouseDown (osu.Framework.Input.InputState state, OpenTK.Input.MouseButton button) [0x0001f] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:510 
  at osu.Framework.Input.InputManager.updateMouseEvents (osu.Framework.Input.InputState state) [0x0009f] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:446 
  at osu.Framework.Input.InputManager.HandleNewState (osu.Framework.Input.InputState state) [0x00144] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:274 
  at osu.Game.Rulesets.UI.RulesetInputManager`1[T].HandleNewState (osu.Framework.Input.InputState state) [0x00001] in /Users/smoogipoo/Repos/Temp/temp-osu/osu.Game/Rulesets/UI/RulesetInputManager.cs:47 
  at osu.Framework.Input.InputManager.Update () [0x00045] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:217 
  at osu.Game.Rulesets.UI.RulesetInputManager`1[T].Update () [0x000da] in /Users/smoogipoo/Repos/Temp/temp-osu/osu.Game/Rulesets/UI/RulesetInputManager.cs:177 
  at osu.Framework.Graphics.Drawable.UpdateSubTree () [0x000b9] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Drawable.cs:352 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00001] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:467 
  at osu.Game.Rulesets.UI.RulesetInputManager`1[T].UpdateSubTree () [0x00013] in /Users/smoogipoo/Repos/Temp/temp-osu/osu.Game/Rulesets/UI/RulesetInputManager.cs:139 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree () [0x00061] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:484 
  at osu.Framework.Platform.GameHost.UpdateFrame () [0x000b2] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Platform/GameHost.cs:250 
  at osu.Framework.Threading.GameThread.ProcessFrame () [0x00040] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Threading/GameThread.cs:115 
  at osu.Framework.Threading.GameThread.runWork () [0x0002d] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Threading/GameThread.cs:104 
  at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00014] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/thread.cs:68 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:957 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:904 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/executioncontext.cs:893 
  at System.Threading.ThreadHelper.ThreadStart () [0x00008] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/mcs/class/referencesource/mscorlib/system/threading/thread.cs:105 
```

To:
```
ERROR] FATAL UNHANDLED EXCEPTION: System.Exception: Try find me!
  at osu.Game.Rulesets.Osu.Objects.Drawables.Pieces.CirclePiece.OnPressed (osu.Game.Rulesets.Osu.OsuAction action) [0x00001] in /Users/smoogipoo/Repos/Temp/temp-osu/osu.Game.Rulesets.Osu/Objects/Drawables/Pieces/CirclePiece.cs:54 
  at osu.Framework.Input.Bindings.KeyBindingContainer`1+<>c__DisplayClass19_1[T].<PropagatePressed>b__1 (osu.Framework.Input.Bindings.IKeyBindingHandler`1[T] d) [0x00000] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:156 
  at System.Linq.Enumerable.TryGetFirst[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate, System.Boolean& found) [0x0003f] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/First.cs:107 
  at System.Linq.Enumerable.FirstOrDefault[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/First.cs:46 
  at osu.Framework.Input.Bindings.KeyBindingContainer`1[T].PropagatePressed (System.Collections.Generic.IEnumerable`1[T] drawables, T pressed) [0x000bb] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:156 
  at osu.Framework.Input.Bindings.KeyBindingContainer`1[T].handleNewPressed (osu.Framework.Input.InputState state, osu.Framework.Input.Bindings.InputKey newKey, System.Boolean repeat) [0x000c8] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:129 
  at osu.Framework.Input.Bindings.KeyBindingContainer`1[T].OnMouseDown (osu.Framework.Input.InputState state, osu.Framework.Input.MouseDownEventArgs args) [0x00000] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/Bindings/KeyBindingContainer.cs:88 
  at osu.Framework.Graphics.Drawable.TriggerOnMouseDown (osu.Framework.Input.InputState screenSpaceState, osu.Framework.Input.MouseDownEventArgs args) [0x00000] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Drawable.cs:1662 
  at osu.Framework.Input.InputManager+<>c__DisplayClass51_0.<PropagateMouseDown>b__0 (osu.Framework.Graphics.Drawable target) [0x00000] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:552 
  at System.Linq.Enumerable.TryGetFirst[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate, System.Boolean& found) [0x0003f] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/First.cs:107 
  at System.Linq.Enumerable.FirstOrDefault[TSource] (System.Collections.Generic.IEnumerable`1[T] source, System.Func`2[T,TResult] predicate) [0x00000] in /Users/builder/data/lanes/4992/mono-mac-sdk/external/bockbuild/builds/mono-x64/external/corefx/src/System.Linq/src/System/Linq/First.cs:46 
  at osu.Framework.Input.InputManager.PropagateMouseDown (System.Collections.Generic.IEnumerable`1[T] drawables, osu.Framework.Input.InputState state, osu.Framework.Input.MouseDownEventArgs args) [0x00015] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:552 
  at osu.Framework.Input.InputManager.handleMouseDown (osu.Framework.Input.InputState state, OpenTK.Input.MouseButton button) [0x0001f] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:510 
  at osu.Framework.Input.InputManager.updateMouseEvents (osu.Framework.Input.InputState state) [0x0009f] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:446 
  at osu.Framework.Input.InputManager.HandleNewState (osu.Framework.Input.InputState state) [0x00144] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:274 
  at osu.Game.Rulesets.UI.RulesetInputManager`1[T].HandleNewState (osu.Framework.Input.InputState state) [0x00001] in /Users/smoogipoo/Repos/Temp/temp-osu/osu.Game/Rulesets/UI/RulesetInputManager.cs:47 
  at osu.Framework.Input.InputManager.Update () [0x00045] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Input/InputManager.cs:217 
  at osu.Game.Rulesets.UI.RulesetInputManager`1[T].Update () [0x000da] in /Users/smoogipoo/Repos/Temp/temp-osu/osu.Game/Rulesets/UI/RulesetInputManager.cs:177 
  at osu.Framework.Graphics.Drawable.UpdateSubTree () [0x000b9] in /Users/smoogipoo/Repos/Temp/temp-osu/osu-framework/osu.Framework/Graphics/Drawable.cs:352 
  at osu.Game.Rulesets.Osu.UI.OsuRulesetContainer.UpdateSubTree ()
  at osu.Game.Screens.Play.PauseContainer.UpdateSubTree ()
  at osu.Framework.Screens.Screen+ContentContainer.UpdateSubTree ()
  at osu.Game.Screens.Play.Player.UpdateSubTree ()
  at osu.Game.Tests.Visual.ScreenTestCase+TestOsuScreen.UpdateSubTree ()
  at osu.Game.Tests.Visual.TestCaseAllPlayers.UpdateSubTree ()
  at osu.Framework.Graphics.Containers.DelayedLoadWrapper.UpdateSubTree ()
  at osu.Framework.Screens.Screen+ContentContainer.UpdateSubTree ()
  at osu.Framework.Testing.TestBrowser.UpdateSubTree ()
  at osu.Game.Graphics.Cursor.OsuTooltipContainer.UpdateSubTree ()
  at osu.Game.Input.Bindings.GlobalKeyBindingInputManager.UpdateSubTree ()
  at osu.Framework.Graphics.Containers.DrawSizePreservingFillContainer.UpdateSubTree ()
  at osu.Desktop.OsuTestBrowser.UpdateSubTree ()
  at osu.Framework.Input.FrameworkActionContainer.UpdateSubTree ()
  at osu.Framework.Input.PlatformActionContainer.UpdateSubTree ()
  at osu.Framework.Input.UserInputManager.UpdateSubTree ()
```