### PR TITLE
Check for multiple OS platform matches and throw an exception.

### DIFF
--- a/osu.Framework/Host.cs
+++ b/osu.Framework/Host.cs
@@ -5,6 +5,7 @@ using osu.Framework.Platform;
 using osu.Framework.Platform.Linux;
 using osu.Framework.Platform.MacOS;
 using osu.Framework.Platform.Windows;
+using System;
 
 namespace osu.Framework
 {
@@ -12,13 +13,17 @@ namespace osu.Framework
     {
         public static DesktopGameHost GetSuitableHost(string gameName, bool bindIPC = false)
         {
-            if (RuntimeInfo.IsMacOsx)
-                return new MacOSGameHost(gameName, bindIPC);
-
-            if (RuntimeInfo.IsUnix)
-                return new LinuxGameHost(gameName, bindIPC);
-
-            return new WindowsGameHost(gameName, bindIPC);
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.MacOsx:
+                    return new MacOSGameHost(gameName, bindIPC);
+                case RuntimeInfo.Platform.Linux:
+                    return new LinuxGameHost(gameName, bindIPC);
+                case RuntimeInfo.Platform.Windows:
+                    return new WindowsGameHost(gameName, bindIPC);
+                default:
+                    throw new InvalidOperationException($"Could not find a suitable host for the selected operating system ({Enum.GetName(typeof(RuntimeInfo.Platform), RuntimeInfo.OS)}).");
+            }
         }
     }
 }

--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Input
             // Drop any keypresses if the control, alt, or windows/command key are being held.
             // This is a workaround for an issue on macOS where OpenTK will fire KeyPress events even
             // if modifier keys are held.  This can be reverted when it is fixed on OpenTK's side.
-            if (RuntimeInfo.IsMacOsx)
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.MacOsx)
             {
                 var state = OpenTK.Input.Keyboard.GetState();
                 if (state.IsKeyDown(OpenTK.Input.Key.LControl)

--- a/osu.Framework/Platform/Architecture.cs
+++ b/osu.Framework/Platform/Architecture.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Platform
 
         internal static void SetIncludePath()
         {
-            if (RuntimeInfo.IsWindows)
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
                 SetDllDirectory(NativeIncludePath);
         }
     }

--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -17,27 +17,27 @@ namespace osu.Framework
         public static bool Is32Bit { get; }
         public static bool Is64Bit { get; }
         public static bool IsMono { get; }
-        public static bool IsWindows { get; }
-        public static bool IsUnix { get; }
-        public static bool IsLinux { get; }
-        public static bool IsMacOsx { get; }
+        public static Platform OS { get; }
+        public static bool IsUnix => OS == Platform.Linux || OS == Platform.MacOsx;
         public static bool IsWine { get; }
 
         static RuntimeInfo()
         {
             IsMono = Type.GetType("Mono.Runtime") != null;
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                IsWindows = true;
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                IsMacOsx = true;
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                IsLinux = true;
-            IsUnix = IsMacOsx || IsLinux;
+                OS = Platform.Windows;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                OS = OS == 0 ? Platform.MacOsx : throw new InvalidOperationException($"Tried to set OS Platform to {nameof(Platform.MacOsx)}, but is already {Enum.GetName(typeof(Platform), OS)}");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                OS = OS == 0 ? Platform.Linux : throw new InvalidOperationException($"Tried to set OS Platform to {nameof(Platform.Linux)}, but is already {Enum.GetName(typeof(Platform), OS)}");
+
+            if (OS == 0)
+                throw new PlatformNotSupportedException("Operating system could not be detected correctly.");
 
             Is32Bit = IntPtr.Size == 4;
             Is64Bit = IntPtr.Size == 8;
 
-            if (IsWindows)
+            if (OS == Platform.Windows)
             {
                 IntPtr hModule = GetModuleHandle(@"ntdll.dll");
                 if (hModule == IntPtr.Zero)
@@ -48,6 +48,13 @@ namespace osu.Framework
                     IsWine = fptr != IntPtr.Zero;
                 }
             }
+        }
+
+        public enum Platform
+        {
+            Windows = 1,
+            Linux = 2,
+            MacOsx = 3,
         }
     }
 }


### PR DESCRIPTION
Also replaced the multiple bool values by an enum.
I left the `IsUnix` property in even though it's not used currently (or should `Host.cs` be changed so that the `LinuxGameHost` is used as a fallback if `IsUnix` is true? Atm it's exactly the same as checking for `OS == Linux`).

This closes #1224 .