### PR TITLE
Explicit flow order

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTabControl.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTabControl.cs
@@ -60,9 +60,9 @@ namespace osu.Framework.Tests.Visual
 
             AddStep("RemoveItem", () =>
             {
-                if (pinnedAndAutoSort.Any())
+                if (pinnedAndAutoSort.Items.Any())
                 {
-                    pinnedAndAutoSort.RemoveItem(pinnedAndAutoSort.Items.Last());
+                    pinnedAndAutoSort.RemoveItem(pinnedAndAutoSort.Items.First());
                 }
             });
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -225,7 +225,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="drawable">The <see cref="Drawable"/> to be removed.</param>
         /// <returns>False if <paramref name="drawable"/> was not a child of this <see cref="CompositeDrawable"/> and true otherwise.</returns>
-        protected internal bool RemoveInternal(Drawable drawable)
+        protected internal virtual bool RemoveInternal(Drawable drawable)
         {
             if (drawable == null)
                 throw new ArgumentNullException(nameof(drawable));
@@ -260,7 +260,7 @@ namespace osu.Framework.Graphics.Containers
         /// Whether removed children should also get disposed.
         /// Disposal will be recursive.
         /// </param>
-        protected internal void ClearInternal(bool disposeChildren = true)
+        protected internal virtual void ClearInternal(bool disposeChildren = true)
         {
             foreach (Drawable t in internalChildren)
             {

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -77,16 +77,25 @@ namespace osu.Framework.Graphics.Containers
         protected internal override void AddInternal(Drawable drawable)
         {
             layoutChildren.Add(drawable, 0f);
+            // we have to ensure that the layout gets invalidated since Adding or Removing a child will affect the layout. The base class will not invalidate
+            // if we are set to AutoSizeAxes.None, but even in that situation, the layout can and often does change when children are added/removed.
+            InvalidateLayout();
             base.AddInternal(drawable);
         }
         protected internal override bool RemoveInternal(Drawable drawable)
         {
             layoutChildren.Remove(drawable);
+            // we have to ensure that the layout gets invalidated since Adding or Removing a child will affect the layout. The base class will not invalidate
+            // if we are set to AutoSizeAxes.None, but even in that situation, the layout can and often does change when children are added/removed.
+            InvalidateLayout();
             return base.RemoveInternal(drawable);
         }
         protected internal override void ClearInternal(bool disposeChildren = true)
         {
             layoutChildren.Clear();
+            // we have to ensure that the layout gets invalidated since Adding or Removing a child will affect the layout. The base class will not invalidate
+            // if we are set to AutoSizeAxes.None, but even in that situation, the layout can and often does change when children are added/removed.
+            InvalidateLayout();
             base.ClearInternal(disposeChildren);
         }
 
@@ -101,6 +110,7 @@ namespace osu.Framework.Graphics.Containers
             if (!layoutChildren.ContainsKey(drawable))
                 throw new InvalidOperationException($"Cannot change layout position of drawable which is not contained within this {nameof(FlowContainer<T>)}.");
             layoutChildren[drawable] = newPosition;
+            InvalidateLayout();
         }
 
         protected override bool UpdateChildrenLife()

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -72,7 +72,7 @@ namespace osu.Framework.Graphics.Containers
             return base.Invalidate(invalidation, source, shallPropagate);
         }
 
-        private Dictionary<Drawable, float> layoutChildren = new Dictionary<Drawable, float>();
+        private readonly Dictionary<Drawable, float> layoutChildren = new Dictionary<Drawable, float>();
 
         protected internal override void AddInternal(Drawable drawable)
         {

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -3,7 +3,6 @@
 
 using OpenTK;
 using osu.Framework.Caching;
-using osu.Framework.Lists;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -99,6 +99,8 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="newPosition">The new position in the layout the drawable should have.</param>
         public void SetLayoutPosition(Drawable drawable, float newPosition)
         {
+            if (!layoutChildren.ContainsKey(drawable))
+                throw new InvalidOperationException($"Cannot change layout position of drawable which is not contained within this {nameof(FlowContainer<T>)}.");
             layoutChildren[drawable] = newPosition;
         }
 

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -253,17 +253,11 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void performTabSort(TabItem<T> tab)
         {
-            if (IsLoaded)
-                TabContainer.Remove(tab);
-
-            tab.Depth = getTabDepth(tab);
+            TabContainer.SetLayoutPosition(tab, getTabDepth(tab));
 
             // IsPresent of TabItems is based on Y position.
             // We reset it here to allow tabs to get a correct initial position.
             tab.Y = 0;
-
-            if (IsLoaded)
-                TabContainer.Add(tab);
         }
 
         private float getTabDepth(TabItem<T> tab) => tab.Pinned ? float.MinValue : --depthCounter;
@@ -271,10 +265,6 @@ namespace osu.Framework.Graphics.UserInterface
         public class TabFillFlowContainer<U> : FillFlowContainer<U> where U : TabItem
         {
             public Action<U, bool> TabVisibilityChanged;
-
-            protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
-
-            protected override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
 
             protected override IEnumerable<Vector2> ComputeLayoutPositions()
             {

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -24,9 +24,9 @@ namespace osu.Framework.Graphics.UserInterface
         public Bindable<T> Current { get; } = new Bindable<T>();
 
         /// <summary>
-        /// A list of items currently in the tab control in the other they are dispalyed.
+        /// A list of items currently in the tab control in the order they are dispalyed.
         /// </summary>
-        public IEnumerable<T> Items => TabContainer.Children.Select(tab => tab.Value);
+        public IEnumerable<T> Items => TabContainer.TabItems.Select(t => t.Value).Concat(Dropdown.Items.Select(kvp => kvp.Value)).Distinct();
 
         /// <summary>
         /// When true, tabs selected from the overflow dropdown will be moved to the front of the list (after pinned items).
@@ -55,7 +55,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected abstract TabItem<T> CreateTabItem(T value);
 
         /// <summary>
-        /// Incremented each time a tab needs to be inserted at the start of the list.
+        /// Decremented each time a tab needs to be inserted at the start of the list.
         /// </summary>
         private int depthCounter;
 
@@ -219,9 +219,6 @@ namespace osu.Framework.Graphics.UserInterface
                 Dropdown?.RemoveDropdownItem(tab.Value);
 
             TabContainer.Remove(tab);
-
-            if (TabContainer.Count > 0)
-                performTabSort(TabContainer.Last());
         }
 
         /// <summary>
@@ -264,7 +261,15 @@ namespace osu.Framework.Graphics.UserInterface
 
         public class TabFillFlowContainer<U> : FillFlowContainer<U> where U : TabItem
         {
+            /// <summary>
+            /// Gets called whenever the visibility of a tab in this container changes. Gets invoked with the <see cref="TabItem"/> whose visibility changed and the new visibility state (true = visible, false = hidden).
+            /// </summary>
             public Action<U, bool> TabVisibilityChanged;
+
+            /// <summary>
+            /// The list of tabs currently displayed by this container.
+            /// </summary>
+            public IEnumerable<U> TabItems => FlowingChildren.OfType<U>();
 
             protected override IEnumerable<Vector2> ComputeLayoutPositions()
             {

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -190,8 +190,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             tab.PinnedChanged += t =>
             {
-                // Todo: This schedule is a temporary fix for https://github.com/ppy/osu-framework/issues/821
-                Schedule(() => performTabSort(t));
+                performTabSort(t);
             };
 
             tab.ActivationRequested += SelectTab;

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -188,10 +188,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <param name="addToDropdown">Whether the tab should be added to the Dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
         protected virtual void AddTabItem(TabItem<T> tab, bool addToDropdown = true)
         {
-            tab.PinnedChanged += t =>
-            {
-                performTabSort(t);
-            };
+            tab.PinnedChanged += performTabSort;
 
             tab.ActivationRequested += SelectTab;
 


### PR DESCRIPTION
This adds a separate order value that gets tracked alongside each child added to a ``FlowContainer`` effectively ensuring that the z-ordering of children has no influence over their position in a layout produced by a ``FlowContainer``.

This change required fixing up ``TabControl`` which relied on the old behaviour and adjusted z-ordering of children in order to change their positions in a layout.
While reworking ``TabControl`` I also noticed that the ``Items`` property returned the list of values not in the displayed order, but in reversed display order, which I changed, since it conflicted with what the documentation said about the ``Items`` property.