### PR TITLE
Throw exceptions when implicitly casing Bindables to their counterparts

### DIFF
--- a/osu.Framework/Configuration/BindableBool.cs
+++ b/osu.Framework/Configuration/BindableBool.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Configuration
         {
         }
 
-        public static implicit operator bool(BindableBool value) => value != null && value.Value;
+        public static implicit operator bool(BindableBool value) => value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableBool)} to a bool is likely a mistake");
 
         public override string ToString() => Value.ToString();
 

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Configuration
         /// </summary>
         public bool HasDefinedRange => !MinValue.Equals(DefaultMinValue) || !MaxValue.Equals(DefaultMaxValue);
 
-        public static implicit operator T(BindableNumber<T> value) => value?.Value ?? default(T);
+        public static implicit operator T(BindableNumber<T> value) => value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableNumber<T>)} to a {nameof(T)} is likely a mistake");
 
         public bool IsInteger
         {


### PR DESCRIPTION
Avoid misleading scenarios like:

![image](https://user-images.githubusercontent.com/191335/34051227-157017dc-e201-11e7-81c8-4da59e634a7e.png)

![image](https://user-images.githubusercontent.com/191335/34051209-088fa3c0-e201-11e7-936e-65604680416f.png)
