### PR TITLE
Avoid unnecessarily aborting WebRequests if they are already completed or aborted

### DIFF
--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -494,6 +494,8 @@ namespace osu.Framework.IO.Network
         /// </summary>
         public void Abort()
         {
+            if (Aborted || Completed) return;
+
             Aborted = true;
             Completed = true;
 


### PR DESCRIPTION
This was causing countless unnecessary ObjectDisposedExceptions which impacts performance.