### PR TITLE
Update netstandard with the latest ppy/master

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
@@ -56,6 +56,8 @@ namespace osu.Framework.Tests.Visual
 
             AddSliderStep("Width", 50, 650, 500, v => Child.Width = v);
             AddSliderStep("Height", 50, 650, 500, v => Child.Height = v);
+
+            AddStep("Override Size to 1x1", () => Child.Size = Vector2.One);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
@@ -105,8 +105,6 @@ namespace osu.Framework.Tests.Visual
 
         private class UserDrawnPath : Path
         {
-            public override bool HandleInput => true;
-
             private Vector2 oldPos;
 
             protected override bool OnDragStart(InputState state)

--- a/osu.Framework.Tests/Visual/TestCaseGridContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseGridContainer.cs
@@ -42,27 +42,27 @@ namespace osu.Framework.Tests.Visual
             AddStep("1-cell (auto)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][] { new[] { new FillBox() } };
+                grid.Content = new[] { new Drawable[] { new FillBox() } };
             });
 
             AddStep("1-cell (absolute)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][] { new[] { new FillBox() } };
+                grid.Content = new[] { new Drawable[] { new FillBox() } };
                 grid.RowDimensions = grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.Absolute, 100) };
             });
 
             AddStep("1-cell (relative)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][] { new[] { new FillBox() } };
+                grid.Content = new [] { new Drawable[] { new FillBox() } };
                 grid.RowDimensions = grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.Relative, 0.5f) };
             });
 
             AddStep("1-cell (mixed)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][] { new[] { new FillBox() } };
+                grid.Content = new [] { new Drawable[] { new FillBox() } };
                 grid.RowDimensions = new[] { new Dimension(GridSizeMode.Absolute, 100) };
                 grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.Relative, 0.5f) };
             });
@@ -70,20 +70,20 @@ namespace osu.Framework.Tests.Visual
             AddStep("1-cell (mixed) 2", () =>
             {
                 reset();
-                grid.Content = new Drawable[][] { new[] { new FillBox() } };
-                grid.RowDimensions = new[] { new Dimension(GridSizeMode.Relative, 0.5f) };
+                grid.Content = new [] { new Drawable[] { new FillBox() } };
+                grid.RowDimensions = new [] { new Dimension(GridSizeMode.Relative, 0.5f) };
             });
 
             AddStep("3-cell row (auto)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][] { new[] { new FillBox(), new FillBox(), new FillBox() } };
+                grid.Content = new [] { new Drawable[] { new FillBox(), new FillBox(), new FillBox() } };
             });
 
             AddStep("3-cell row (absolute)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][] { new[] { new FillBox(), new FillBox(), new FillBox() } };
+                grid.Content = new [] { new Drawable[] { new FillBox(), new FillBox(), new FillBox() } };
                 grid.RowDimensions = grid.ColumnDimensions = new[]
                 {
                     new Dimension(GridSizeMode.Absolute, 50),
@@ -95,7 +95,7 @@ namespace osu.Framework.Tests.Visual
             AddStep("3-cell row (relative)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][] { new[] { new FillBox(), new FillBox(), new FillBox() } };
+                grid.Content = new [] { new Drawable[] { new FillBox(), new FillBox(), new FillBox() } };
                 grid.RowDimensions = grid.ColumnDimensions = new[]
                 {
                     new Dimension(GridSizeMode.Relative, 0.1f),
@@ -107,7 +107,7 @@ namespace osu.Framework.Tests.Visual
             AddStep("3-cell row (mixed)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][] { new[] { new FillBox(), new FillBox(), new FillBox() } };
+                grid.Content = new [] { new Drawable[] { new FillBox(), new FillBox(), new FillBox() } };
                 grid.RowDimensions = grid.ColumnDimensions = new[]
                 {
                     new Dimension(GridSizeMode.Absolute, 50),
@@ -118,22 +118,22 @@ namespace osu.Framework.Tests.Visual
             AddStep("3-cell column (auto)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox() },
-                    new[] { new FillBox() },
-                    new[] { new FillBox() }
+                    new Drawable[] { new FillBox() },
+                    new Drawable[] { new FillBox() },
+                    new Drawable[] { new FillBox() }
                 };
             });
 
             AddStep("3-cell column (absolute)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox() },
-                    new[] { new FillBox() },
-                    new[] { new FillBox() }
+                    new Drawable[] { new FillBox() },
+                    new Drawable[] { new FillBox() },
+                    new Drawable[] { new FillBox() }
                 };
 
                 grid.RowDimensions = grid.ColumnDimensions = new[]
@@ -147,11 +147,11 @@ namespace osu.Framework.Tests.Visual
             AddStep("3-cell column (relative)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox() },
-                    new[] { new FillBox() },
-                    new[] { new FillBox() }
+                    new Drawable[] { new FillBox() },
+                    new Drawable[] { new FillBox() },
+                    new Drawable[] { new FillBox() }
                 };
 
                 grid.RowDimensions = grid.ColumnDimensions = new[]
@@ -165,11 +165,11 @@ namespace osu.Framework.Tests.Visual
             AddStep("3-cell column (mixed)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox() },
-                    new[] { new FillBox() },
-                    new[] { new FillBox() }
+                    new Drawable[] { new FillBox() },
+                    new Drawable[] { new FillBox() },
+                    new Drawable[] { new FillBox() }
                 };
 
                 grid.RowDimensions = grid.ColumnDimensions = new[]
@@ -182,22 +182,22 @@ namespace osu.Framework.Tests.Visual
             AddStep("3x3-cell (auto)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() }
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
                 };
             });
 
             AddStep("3x3-cell (absolute)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() }
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
                 };
 
                 grid.RowDimensions = grid.ColumnDimensions = new[]
@@ -211,11 +211,11 @@ namespace osu.Framework.Tests.Visual
             AddStep("3x3-cell (relative)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() }
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
                 };
 
                 grid.RowDimensions = grid.ColumnDimensions = new[]
@@ -229,11 +229,11 @@ namespace osu.Framework.Tests.Visual
             AddStep("3x3-cell (mixed)", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() }
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
                 };
 
                 grid.RowDimensions = grid.ColumnDimensions = new[]
@@ -246,11 +246,11 @@ namespace osu.Framework.Tests.Visual
             AddStep("Larger sides", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() },
-                    new[] { new FillBox(), new FillBox(), new FillBox() }
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
+                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
                 };
 
                 grid.ColumnDimensions = grid.RowDimensions = new[]
@@ -264,22 +264,22 @@ namespace osu.Framework.Tests.Visual
             AddStep("Separated", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox(), null, new FillBox() },
+                    new Drawable[] { new FillBox(), null, new FillBox() },
                     null,
-                    new[] { new FillBox(), null, new FillBox() }
+                    new Drawable[] { new FillBox(), null, new FillBox() }
                 };
             });
 
             AddStep("Separated 2", () =>
             {
                 reset();
-                grid.Content = new Drawable[][]
+                grid.Content = new[]
                 {
-                    new[] { new FillBox(), null, new FillBox(), null },
+                    new Drawable[] { new FillBox(), null, new FillBox(), null },
                     null,
-                    new[] { new FillBox(), null, new FillBox(), null },
+                    new Drawable[] { new FillBox(), null, new FillBox(), null },
                     null
                 };
             });
@@ -304,10 +304,10 @@ namespace osu.Framework.Tests.Visual
                                     new GridContainer
                                     {
                                         RelativeSizeAxes = Axes.Both,
-                                        Content = new Drawable[][]
+                                        Content = new[]
                                         {
-                                            new[] { new FillBox(), new FillBox() },
-                                            new[] { new FillBox(), new FillBox() }
+                                            new Drawable[] { new FillBox(), new FillBox() },
+                                            new Drawable[] { new FillBox(), new FillBox() }
                                         }
                                     }
                                 }

--- a/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
@@ -183,8 +183,6 @@ namespace osu.Framework.Tests.Visual
 
         private class UserDrawnPath : SmoothedPath
         {
-            public override bool HandleInput => true;
-
             public SpriteText DrawText;
 
             protected virtual void AddUserVertex(Vector2 v) => AddRawVertex(v);

--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Tests.Visual
             RightMouse
         }
 
-        private class TestInputManager : KeyBindingInputManager<TestAction>
+        private class TestInputManager : KeyBindingContainer<TestAction>
         {
             public TestInputManager(SimultaneousBindingMode concurrencyMode = SimultaneousBindingMode.None) : base(concurrencyMode)
             {
@@ -121,7 +121,6 @@ namespace osu.Framework.Tests.Visual
                 {
                     alphaTarget += 0.2f;
                     Background.FadeTo(alphaTarget, 100, Easing.OutQuint);
-                    return true;
                 }
 
                 return false;
@@ -133,7 +132,6 @@ namespace osu.Framework.Tests.Visual
                 {
                     alphaTarget -= 0.2f;
                     Background.FadeTo(alphaTarget, 100, Easing.OutQuint);
-                    return true;
                 }
 
                 return false;

--- a/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
@@ -64,15 +64,15 @@ namespace osu.Framework.Tests.Visual
                                             AutoSizeAxes = Axes.Both,
                                             Children = new []
                                             {
-                                                new KeywordText
+                                                new SpriteText
                                                 {
                                                     Text = "multi",
                                                 },
-                                                new KeywordText
+                                                new SpriteText
                                                 {
                                                     Text = "piece",
                                                 },
-                                                new KeywordText
+                                                new SpriteText
                                                 {
                                                     Text = "container",
                                                 },
@@ -160,11 +160,6 @@ namespace osu.Framework.Tests.Visual
             }
         }
 
-        private class KeywordText : SpriteText, IHasFilterTerms
-        {
-            public IEnumerable<string> FilterTerms => new[] { Text };
-        }
-
         private class FilterableFlowContainer : FillFlowContainer, IFilterable
         {
             public IEnumerable<string> FilterTerms => Children.OfType<IHasFilterTerms>().SelectMany(d => d.FilterTerms);
@@ -183,8 +178,6 @@ namespace osu.Framework.Tests.Visual
 
         private class SearchableText : SpriteText, IFilterable
         {
-            public IEnumerable<string> FilterTerms => new[] { Text };
-
             public bool MatchingFilter
             {
                 set

--- a/osu.Framework.Tests/Visual/TestCaseTriangles.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTriangles.cs
@@ -172,7 +172,6 @@ namespace osu.Framework.Tests.Visual
     internal class DraggableTriangle : Triangle
     {
         public bool AllowDrag = true;
-        public override bool HandleInput => true;
 
         protected override bool OnDrag(InputState state)
         {

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -7,6 +7,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using osu.Framework.Extensions.ExceptionExtensions;
 
 namespace osu.Framework.Allocation
 {
@@ -83,7 +84,15 @@ namespace osu.Framework.Allocation
                 return new Action<object>(instance =>
                 {
                     var p = parameters.Select(pa => pa()).ToArray();
-                    initializer.Invoke(instance, p);
+
+                    try
+                    {
+                        initializer.Invoke(instance, p);
+                    }
+                    catch (TargetInvocationException e)
+                    {
+                        new RecursiveLoadException(e.GetLastInvocation(), initializer).Rethrow();
+                    }
                 });
             }).ToList();
 

--- a/osu.Framework/Allocation/RecursiveLoadException.cs
+++ b/osu.Framework/Allocation/RecursiveLoadException.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Allocation
+{
+    /// <summary>
+    /// The exception that is re-thrown by <see cref="DependencyContainer"/> when a loader invocation fails.
+    /// This exception type builds a readablestacktrace message since loader invocations tend to be long recursive reflection calls.
+    /// </summary>
+    public class RecursiveLoadException : Exception
+    {
+        /// <summary>
+        /// Types that are ignored for the custom stack traces. The initializers for these typically invoke
+        /// initializers in user code where the problem actually lies.
+        /// </summary>
+        private static readonly Type[] blacklist =
+        {
+            typeof(Container),
+            typeof(Container<>),
+            typeof(CompositeDrawable)
+        };
+
+        private readonly StringBuilder traceBuilder;
+        private readonly Exception original;
+
+        public RecursiveLoadException(Exception original, MethodInfo loaderMethod)
+        {
+            var recursive = original as RecursiveLoadException;
+
+            this.original = recursive?.original ?? original;
+            traceBuilder = recursive?.traceBuilder ?? new StringBuilder();
+
+            // Find the location of the load method
+            var loaderLocation = $"{loaderMethod.DeclaringType}.{loaderMethod.Name}";
+
+            if (recursive == null)
+            {
+                var lines = original.StackTrace.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+                // Write all lines from the original exception until the loader method is hit
+                foreach (var o in lines)
+                {
+                    traceBuilder.AppendLine(o);
+                    if (o.Contains(loaderLocation))
+                        break;
+                }
+            }
+            else if (!blacklist.Contains(loaderMethod.DeclaringType))
+                traceBuilder.AppendLine($"  at {loaderLocation} ()");
+
+            stackTrace = traceBuilder.ToString();
+        }
+
+        private readonly string stackTrace;
+        public override string StackTrace => stackTrace;
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine($"{original.GetType()}: {original.Message}");
+            builder.AppendLine(stackTrace);
+
+            return builder.ToString();
+        }
+    }
+}

--- a/osu.Framework/Audio/AudioCollectionManager.cs
+++ b/osu.Framework/Audio/AudioCollectionManager.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Audio
             {
                 var item = Items[i];
 
-                if (item.HasCompleted)
+                if (!item.IsAlive)
                 {
                     Items.RemoveAt(i--);
                     continue;

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -47,7 +47,15 @@ namespace osu.Framework.Audio
                 UpdateState();
         }
 
-        public virtual bool HasCompleted => IsDisposed;
+        /// <summary>
+        /// This component has completed playback and is now in a stopped state.
+        /// </summary>
+        public virtual bool HasCompleted => !IsAlive;
+
+        /// <summary>
+        /// This component has completed all processing and is ready to be removed from its parent.
+        /// </summary>
+        public virtual bool IsAlive => !IsDisposed;
 
         public virtual bool IsLoaded => true;
 

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -53,6 +53,6 @@ namespace osu.Framework.Audio.Sample
 
         public virtual bool Played => WasStarted && !Playing;
 
-        public override bool HasCompleted => base.HasCompleted || Played;
+        public override bool IsAlive => base.IsAlive && !Played;
     }
 }

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -15,6 +15,9 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         public virtual bool IsDummyDevice => true;
 
+        /// <summary>
+        /// States if this track should repeat.
+        /// </summary>
         public bool Looping { get; set; }
 
         /// <summary>
@@ -38,6 +41,16 @@ namespace osu.Framework.Audio.Track
 
             Stop();
             Seek(0);
+        }
+
+        /// <summary>
+        /// Restarts this track from the beginning while retaining adjustments.
+        /// </summary>
+        public virtual void Restart()
+        {
+            Stop();
+            Seek(0);
+            Start();
         }
 
         public virtual void ResetSpeedAdjustments()
@@ -90,6 +103,8 @@ namespace osu.Framework.Audio.Track
 
         public bool IsReversed => Rate < 0;
 
+        public override bool HasCompleted => IsLoaded && !IsRunning && CurrentTime >= Length;
+
         /// <summary>
         /// Current amplitude of stereo channels where 1 is full volume and 0 is silent.
         /// LeftChannel and RightChannel represent the maximum current amplitude of all of the left and right channels respectively.
@@ -102,10 +117,7 @@ namespace osu.Framework.Audio.Track
             FrameStatistics.Increment(StatisticsCounterType.Tracks);
 
             if (Looping && HasCompleted)
-            {
-                Reset();
-                Start();
-            }
+                Restart();
 
             base.UpdateState();
         }

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -233,8 +233,6 @@ namespace osu.Framework.Audio.Track
 
         public override int? Bitrate => bitrate;
 
-        public override bool HasCompleted => base.HasCompleted || IsLoaded && !IsRunning && CurrentTime >= Length;
-
         public double PitchAdjust
         {
             get { return Frequency.Value; }

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -62,14 +62,6 @@ namespace osu.Framework.Audio.Track
             }
         }
 
-        public override bool HasCompleted
-        {
-            get
-            {
-                lock (clock) return base.HasCompleted || IsLoaded && !IsRunning && CurrentTime >= Length;
-            }
-        }
-
         public override double CurrentTime
         {
             get

--- a/osu.Framework/Configuration/BindableBool.cs
+++ b/osu.Framework/Configuration/BindableBool.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Configuration
         {
         }
 
-        public static implicit operator bool(BindableBool value) => value != null && value.Value;
+        public static implicit operator bool(BindableBool value) => value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableBool)} to a bool is likely a mistake");
 
         public override string ToString() => Value.ToString();
 

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Configuration
         /// </summary>
         public bool HasDefinedRange => !MinValue.Equals(DefaultMinValue) || !MaxValue.Equals(DefaultMaxValue);
 
-        public static implicit operator T(BindableNumber<T> value) => value?.Value ?? default(T);
+        public static implicit operator T(BindableNumber<T> value) => value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableNumber<T>)} to a {nameof(T)} is likely a mistake");
 
         public bool IsInteger
         {

--- a/osu.Framework/Extensions/ExceptionExtensions/ExceptionExtensions.cs
+++ b/osu.Framework/Extensions/ExceptionExtensions/ExceptionExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using System.Reflection;
 using System.Runtime.ExceptionServices;
 
 namespace osu.Framework.Extensions.ExceptionExtensions
@@ -47,6 +48,19 @@ namespace osu.Framework.Extensions.ExceptionExtensions
             }
 
             return aggregateException;
+        }
+
+        /// <summary>
+        /// Retrieves the last exception from a recursive <see cref="TargetInvocationException"/>.
+        /// </summary>
+        /// <param name="exception">The exception to retrieve the exception from.</param>
+        /// <returns>The exception at the point of invocation.</returns>
+        public static Exception GetLastInvocation(this TargetInvocationException exception)
+        {
+            var inner = exception.InnerException;
+            while (inner is TargetInvocationException)
+                inner = inner.InnerException;
+            return inner;
         }
     }
 }

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -195,20 +195,18 @@ namespace osu.Framework.Extensions
             => value.GetType().GetField(value.ToString())
                     .GetCustomAttribute<DescriptionAttribute>()?.Description ?? value.ToString();
 
-        public static void ThrowIfFaulted(this Task task)
+        public static void ThrowIfFaulted(this Task task, Type expectedBaseType = null)
         {
-            if (task.IsFaulted)
-            {
-                Exception e = task.Exception;
+            if (!task.IsFaulted) return;
 
-                Debug.Assert(e != null);
+            Exception e = task.Exception;
 
-                // ReSharper disable once PossibleNullReferenceException
-                while (e.InnerException != null)
-                    e = e.InnerException;
+            Debug.Assert(e != null);
 
-                ExceptionDispatchInfo.Capture(e).Throw();
-            }
+            while (e.InnerException != null && e.GetType() != expectedBaseType)
+                e = e.InnerException;
+
+            ExceptionDispatchInfo.Capture(e).Throw();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -48,6 +48,9 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Loads a future child or grand-child of this <see cref="CompositeDrawable"/> asyncronously. <see cref="Drawable.Dependencies"/>
         /// and <see cref="Drawable.Clock"/> are inherited from this <see cref="CompositeDrawable"/>.
+        ///
+        /// Note that this will always use the dependencies and clock from this instance. If you must load to a nested container level,
+        /// consider using <see cref="DelayedLoadWrapper"/>
         /// </summary>
         /// <typeparam name="TLoadable">The type of the future future child or grand-child to be loaded.</typeparam>
         /// <param name="component">The type of the future future child or grand-child to be loaded.</param>
@@ -259,6 +262,8 @@ namespace osu.Framework.Graphics.Containers
         /// </param>
         protected internal void ClearInternal(bool disposeChildren = true)
         {
+            if (internalChildren.Count == 0) return;
+
             foreach (Drawable t in internalChildren)
             {
                 if (t.IsAlive)
@@ -339,12 +344,23 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="newDepth">The new depth value to be set.</param>
         protected internal void ChangeInternalChildDepth(Drawable child, float newDepth)
         {
-            if (!ContainsInternal(child))
+            var index = IndexOfInternal(child);
+            if (index < 0)
                 throw new InvalidOperationException($"Can not change depth of drawable which is not contained within this {nameof(CompositeDrawable)}.");
 
-            RemoveInternal(child);
+            internalChildren.RemoveAt(index);
+            var aliveIndex = aliveInternalChildren.IndexOf(child);
+            if (aliveIndex >= 0) // remove if found
+                aliveInternalChildren.RemoveAt(aliveIndex);
+
+            var chId = child.ChildID;
+            child.ChildID = 0; // ensure Depth-change does not throw an exception
             child.Depth = newDepth;
-            AddInternal(child);
+            child.ChildID = chId;
+
+            internalChildren.Add(child);
+            if (aliveIndex >= 0) // re-add if it used to be in aliveInternalChildren
+                aliveInternalChildren.Add(child);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -278,12 +278,10 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="newDepth">The new depth value to be set.</param>
         public void ChangeChildDepth(T child, float newDepth)
         {
-            if (!Contains(child))
-                throw new InvalidOperationException("Can not change depth of drawable which is not contained within this container.");
-
-            Remove(child);
-            child.Depth = newDepth;
-            Add(child);
+            if (Content != this)
+                Content.ChangeChildDepth(child, newDepth);
+            else
+                ChangeInternalChildDepth(child, newDepth);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
+++ b/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
@@ -14,6 +14,10 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public class DrawSizePreservingFillContainer : Container
     {
+        private readonly Container content;
+
+        protected override Container<Drawable> Content => content;
+
         /// <summary>
         /// The target <see cref="Drawable.DrawSize"/> to be enforced according to <see cref="Strategy"/>.
         /// </summary>
@@ -28,6 +32,11 @@ namespace osu.Framework.Graphics.Containers
 
         public DrawSizePreservingFillContainer()
         {
+            AddInternal(content = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+            });
+
             RelativeSizeAxes = Axes.Both;
         }
 
@@ -40,23 +49,23 @@ namespace osu.Framework.Graphics.Containers
             switch (Strategy)
             {
                 case DrawSizePreservationStrategy.Minimum:
-                    Scale = new Vector2(Math.Min(drawSizeRatio.X, drawSizeRatio.Y));
+                    content.Scale = new Vector2(Math.Min(drawSizeRatio.X, drawSizeRatio.Y));
                     break;
 
                 case DrawSizePreservationStrategy.Maximum:
-                    Scale = new Vector2(Math.Max(drawSizeRatio.X, drawSizeRatio.Y));
+                    content.Scale = new Vector2(Math.Max(drawSizeRatio.X, drawSizeRatio.Y));
                     break;
 
                 case DrawSizePreservationStrategy.Average:
-                    Scale = new Vector2(0.5f * (drawSizeRatio.X + drawSizeRatio.Y));
+                    content.Scale = new Vector2(0.5f * (drawSizeRatio.X + drawSizeRatio.Y));
                     break;
 
                 case DrawSizePreservationStrategy.Separate:
-                    Scale = drawSizeRatio;
+                    content.Scale = drawSizeRatio;
                     break;
             }
 
-            Size = Vector2.Divide(Vector2.One, Scale);
+            content.Size = Vector2.Divide(Vector2.One, content.Scale);
         }
     }
 

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -142,7 +142,7 @@ namespace osu.Framework.Graphics.Containers
                 float rowWidth = rowBeginOffset + current.X + (1 - spacingFactor(c).X) * size.X;
 
                 //We've exceeded our allowed width, move to a new row
-                if (direction != FillDirection.Horizontal && (Precision.DefinitelyBigger(rowWidth, max.X) || direction == FillDirection.Vertical))
+                if (direction != FillDirection.Horizontal && (Precision.DefinitelyBigger(rowWidth, max.X) || direction == FillDirection.Vertical || ForceNewRow(c)))
                 {
                     current.X = 0;
                     current.Y += rowHeight;
@@ -234,6 +234,13 @@ namespace osu.Framework.Graphics.Containers
 
             return result;
         }
+
+        /// <summary>
+        /// Returns true if the given child should be placed on a new row, false otherwise. This will be called automatically for each child in this FillFlowContainers FlowingChildren-List.
+        /// </summary>
+        /// <param name="child">The child to check.</param>
+        /// <returns>True if the given child should be placed on a new row, false otherwise.</returns>
+        protected virtual bool ForceNewRow(Drawable child) => false;
     }
 
     /// <summary>

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -287,7 +287,7 @@ namespace osu.Framework.Graphics.Containers
             float scrollOffset = -childDelta[ScrollDim];
             float clampedScrollOffset = Clamp(target + scrollOffset) - Clamp(target);
 
-            Trace.Assert(Precision.AlmostBigger(Math.Abs(scrollOffset), clampedScrollOffset * Math.Sign(scrollOffset)));
+            Debug.Assert(Precision.AlmostBigger(Math.Abs(scrollOffset), clampedScrollOffset * Math.Sign(scrollOffset)));
 
             // If we are dragging past the extent of the scrollable area, half the offset
             // such that the user can feel it.

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -328,13 +328,14 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        protected override bool ForceNewRow(Drawable child) => child is NewLineContainer;
+
         internal class NewLineContainer : Container
         {
             public readonly bool IndicatesNewParagraph;
 
             public NewLineContainer(bool newParagraph)
             {
-                RelativeSizeAxes = Axes.X;
                 IndicatesNewParagraph = newParagraph;
             }
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -19,8 +19,10 @@ using osu.Framework.Statistics;
 using osu.Framework.Threading;
 using osu.Framework.Timing;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Development;
@@ -44,6 +46,11 @@ namespace osu.Framework.Graphics
     public abstract class Drawable : Transformable, IDisposable, IDrawable
     {
         #region Construction and disposal
+
+        protected Drawable()
+        {
+            handleInput = HandleInputCache.Get(this);
+        }
 
         ~Drawable()
         {
@@ -139,7 +146,7 @@ namespace osu.Framework.Graphics
             return loadTask = Task.Factory.StartNew(() => Load(target.Clock, target.Dependencies), TaskCreationOptions.LongRunning)
                                   .ContinueWith(task => game.Schedule(() =>
                                   {
-                                      task.ThrowIfFaulted();
+                                      task.ThrowIfFaulted(typeof(RecursiveLoadException));
                                       onLoaded?.Invoke();
                                       loadTask = null;
                                   }));
@@ -217,8 +224,8 @@ namespace osu.Framework.Graphics
             MainThread = Thread.CurrentThread;
             scheduler?.SetCurrentThread(MainThread);
 
-            Invalidate();
             loadState = LoadState.Loaded;
+            Invalidate();
             LoadComplete();
             OnLoadComplete?.Invoke(this);
             return true;
@@ -1449,7 +1456,7 @@ namespace osu.Framework.Graphics
         /// <returns>If the invalidate was actually necessary.</returns>
         public virtual bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
-            if (invalidation == Invalidation.None)
+            if (invalidation == Invalidation.None || !IsLoaded)
                 return false;
 
             if (shallPropagate && Parent != null && source != Parent)
@@ -1832,10 +1839,63 @@ namespace osu.Framework.Graphics
         /// is propagated up the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnMouseMove(InputState state) => false;
 
+        private readonly bool handleInput;
         /// <summary>
-        /// This drawable only receives input events if HandleInput is true.
+        /// Whether this <see cref="Drawable"/> handles input.
+        /// This value is true by default if any "On-" input methods are overridden.
         /// </summary>
-        public virtual bool HandleInput => false;
+        public virtual bool HandleInput => handleInput;
+
+        /// <summary>
+        /// Nested class which is used for caching <see cref="HandleInput"/> values obtained via reflection.
+        /// </summary>
+        private static class HandleInputCache
+        {
+            private static readonly ConcurrentDictionary<Type, bool> cached_values = new ConcurrentDictionary<Type, bool>();
+
+            private static string[] inputMethods => new[]
+            {
+                nameof(OnHover),
+                nameof(OnHoverLost),
+                nameof(OnMouseDown),
+                nameof(OnMouseUp),
+                nameof(OnClick),
+                nameof(OnDoubleClick),
+                nameof(OnDragStart),
+                nameof(OnDrag),
+                nameof(OnDragEnd),
+                nameof(OnWheel),
+                nameof(OnFocus),
+                nameof(OnFocusLost),
+                nameof(OnKeyDown),
+                nameof(OnKeyUp),
+                nameof(OnMouseMove),
+            };
+
+            public static bool Get(Drawable drawable)
+            {
+                var type = drawable.GetType();
+                if (cached_values.TryGetValue(type, out var value))
+                    return value;
+
+                foreach (var inputMethod in inputMethods)
+                {
+                    // check for any input method overrides which are at a higher level than drawable.
+                    var method = type.GetMethod(inputMethod, BindingFlags.Instance | BindingFlags.NonPublic);
+
+                    Debug.Assert(method != null);
+
+                    if (method.DeclaringType != typeof(Drawable))
+                    {
+                        cached_values.TryAdd(type, true);
+                        return true;
+                    }
+                }
+
+                cached_values.TryAdd(type, false);
+                return false;
+            }
+        }
 
         /// <summary>
         /// Check whether we have active focus.

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -12,7 +12,12 @@ namespace osu.Framework.Graphics.Shaders
     public class Shader : IDisposable
     {
         internal StringBuilder Log = new StringBuilder();
-        internal bool Loaded;
+
+        /// <summary>
+        /// Whether this shader has been loaded and compiled.
+        /// </summary>
+        public bool Loaded { get; private set; }
+
         internal bool IsBound;
 
         private readonly string name;
@@ -29,6 +34,8 @@ namespace osu.Framework.Graphics.Shaders
         {
             this.name = name;
             this.parts = parts;
+
+            GLWrapper.EnqueueShaderCompile(this);
         }
 
         #region Disposal
@@ -129,7 +136,7 @@ namespace osu.Framework.Graphics.Shaders
             }
         }
 
-        private void ensureLoaded()
+        internal void EnsureLoaded()
         {
             if (!Loaded)
                 Compile();
@@ -140,7 +147,7 @@ namespace osu.Framework.Graphics.Shaders
             if (IsBound)
                 return;
 
-            ensureLoaded();
+            EnsureLoaded();
 
             GLWrapper.UseProgram(this);
 
@@ -170,7 +177,7 @@ namespace osu.Framework.Graphics.Shaders
         /// <returns>Returns a base uniform.</returns>
         public Uniform<T> GetUniform<T>(string name)
         {
-            ensureLoaded();
+            EnsureLoaded();
             if (!uniforms.ContainsKey(name))
                 throw new ArgumentException($"Uniform {name} does not exist in shader {this.name}.", nameof(name));
             return new Uniform<T>(uniforms[name]);
@@ -188,7 +195,7 @@ namespace osu.Framework.Graphics.Shaders
 
             foreach (Shader shader in all_shaders)
             {
-                shader.ensureLoaded();
+                shader.EnsureLoaded();
                 if (shader.uniforms.ContainsKey(name))
                     shader.uniforms[name].Value = value;
             }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -20,8 +20,10 @@ namespace osu.Framework.Graphics.Sprites
     /// <summary>
     /// A container for simple text rendering purposes. If more complex text rendering is required, use <see cref="TextFlowContainer"/> instead.
     /// </summary>
-    public class SpriteText : FillFlowContainer, IHasCurrentValue<string>, IHasLineBaseHeight, IHasText
+    public class SpriteText : FillFlowContainer, IHasCurrentValue<string>, IHasLineBaseHeight, IHasText, IHasFilterTerms
     {
+        public IEnumerable<string> FilterTerms => new[] { Text };
+
         private static readonly char[] default_fixed_width_exceptions = { '.', ':', ',' };
 
         /// <summary>

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Graphics.Transforms
                     nameof(Interpolation.ValueAt),
                     typeof(InterpolationFunc<TValue>)
                         .GetMethod(nameof(InterpolationFunc<TValue>.Invoke))
-                        .GetParameters().Select(p => p.ParameterType).ToArray()
+                        ?.GetParameters().Select(p => p.ParameterType).ToArray()
                 )?.CreateDelegate(typeof(InterpolationFunc<TValue>));
         }
 

--- a/osu.Framework/Graphics/UserInterface/BasicCheckbox.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicCheckbox.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using osu.Framework.Extensions.Color4Extensions;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -11,9 +12,10 @@ namespace osu.Framework.Graphics.UserInterface
 {
     public class BasicCheckbox : Checkbox
     {
-        public Color4 CheckedColor { get; set; } = Color4.Cyan;
-        public Color4 UncheckedColor { get; set; } = Color4.White;
-        public int FadeDuration { get; set; }
+        public Color4 CheckedColor { get; set; } = Color4.White;
+        public Color4 UncheckedColor { get; set; } = Color4.White.Opacity(0.2f);
+
+        public int FadeDuration { get; set; } = 50;
 
         public string LabelText
         {
@@ -57,14 +59,22 @@ namespace osu.Framework.Graphics.UserInterface
                         },
                         Depth = float.MinValue
                     },
-                    box = new Box
+                    new Container
                     {
+                        BorderColour= Color4.White,
+                        BorderThickness = 3,
+                        Masking = true,
                         Size = new Vector2(20, 20),
+                        Child = box = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both
+                        }
                     }
                 }
             };
 
             Current.ValueChanged += c => box.FadeColour(c ? CheckedColor : UncheckedColor, FadeDuration);
+            Current.TriggerChange();
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
@@ -26,6 +26,9 @@ namespace osu.Framework.Graphics.UserInterface
 
         public BasicSliderBar()
         {
+            CornerRadius = 4;
+            Masking = true;
+
             Children = new Drawable[]
             {
                 Box = new Box

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -73,40 +73,33 @@ namespace osu.Framework.Graphics.UserInterface
         {
             Masking = true;
             CornerRadius = 3;
-            // TextBoxes currently require their own top-level PlatformInputManager, as InputManagers
-            // will not propagate events through other InputManagers.
-            // Once this restriction has been addressed, we can utilise a single instance of PlatformInputManager
-            // at the Game level, and TextBoxes need only implement IKeyBindingHandler<PlatformAction>.
-            Child = new PlatformInputManager
+
+            Children = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
+                Background = new Box
                 {
-                    Background = new Box
+                    Colour = BackgroundUnfocused,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                TextContainer = new TextBoxPlatformBindingHandler(this)
+                {
+                    AutoSizeAxes = Axes.X,
+                    RelativeSizeAxes = Axes.Y,
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    Position = new Vector2(LeftRightPadding, 0),
+                    Children = new[]
                     {
-                        Colour = BackgroundUnfocused,
-                        RelativeSizeAxes = Axes.Both,
-                    },
-                    TextContainer = new KeyBindingContainer(this)
-                    {
-                        AutoSizeAxes = Axes.X,
-                        RelativeSizeAxes = Axes.Y,
-                        Anchor = Anchor.CentreLeft,
-                        Origin = Anchor.CentreLeft,
-                        Position = new Vector2(LeftRightPadding, 0),
-                        Children = new[]
+                        Placeholder = CreatePlaceholder(),
+                        Caret = new DrawableCaret(),
+                        TextFlow = new FillFlowContainer
                         {
-                            Placeholder = CreatePlaceholder(),
-                            Caret = new DrawableCaret(),
-                            TextFlow = new FillFlowContainer
-                            {
-                                Direction = FillDirection.Horizontal,
-                                AutoSizeAxes = Axes.X,
-                                RelativeSizeAxes = Axes.Y,
-                            },
+                            Direction = FillDirection.Horizontal,
+                            AutoSizeAxes = Axes.X,
+                            RelativeSizeAxes = Axes.Y,
                         },
                     },
-                }
+                },
             };
 
             Current.ValueChanged += newValue => { Text = newValue; };
@@ -878,11 +871,11 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        private class KeyBindingContainer : Container, IKeyBindingHandler<PlatformAction>
+        private class TextBoxPlatformBindingHandler : Container, IKeyBindingHandler<PlatformAction>
         {
             private readonly TextBox textBox;
 
-            public KeyBindingContainer(TextBox textBox)
+            public TextBoxPlatformBindingHandler(TextBox textBox)
             {
                 this.textBox = textBox;
             }

--- a/osu.Framework/Host.cs
+++ b/osu.Framework/Host.cs
@@ -5,6 +5,7 @@ using osu.Framework.Platform;
 using osu.Framework.Platform.Linux;
 using osu.Framework.Platform.MacOS;
 using osu.Framework.Platform.Windows;
+using System;
 
 namespace osu.Framework
 {
@@ -12,13 +13,17 @@ namespace osu.Framework
     {
         public static DesktopGameHost GetSuitableHost(string gameName, bool bindIPC = false)
         {
-            if (RuntimeInfo.IsMacOsx)
-                return new MacOSGameHost(gameName, bindIPC);
-
-            if (RuntimeInfo.IsUnix)
-                return new LinuxGameHost(gameName, bindIPC);
-
-            return new WindowsGameHost(gameName, bindIPC);
+            switch (RuntimeInfo.OS)
+            {
+                case RuntimeInfo.Platform.MacOsx:
+                    return new MacOSGameHost(gameName, bindIPC);
+                case RuntimeInfo.Platform.Linux:
+                    return new LinuxGameHost(gameName, bindIPC);
+                case RuntimeInfo.Platform.Windows:
+                    return new WindowsGameHost(gameName, bindIPC);
+                default:
+                    throw new InvalidOperationException($"Could not find a suitable host for the selected operating system ({Enum.GetName(typeof(RuntimeInfo.Platform), RuntimeInfo.OS)}).");
+            }
         }
     }
 }

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -494,6 +494,8 @@ namespace osu.Framework.IO.Network
         /// </summary>
         public void Abort()
         {
+            if (Aborted || Completed) return;
+
             Aborted = true;
             Completed = true;
 

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
 
 namespace osu.Framework.Input.Bindings
@@ -14,7 +15,7 @@ namespace osu.Framework.Input.Bindings
     /// Maps input actions to custom action data of type <see cref="T"/>. Use in conjunction with <see cref="Drawable"/>s implementing <see cref="IKeyBindingHandler{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of the custom action.</typeparam>
-    public abstract class KeyBindingInputManager<T> : KeyBindingInputManager
+    public abstract class KeyBindingContainer<T> : KeyBindingContainer
         where T : struct
     {
         private readonly SimultaneousBindingMode simultaneousMode;
@@ -23,8 +24,10 @@ namespace osu.Framework.Input.Bindings
         /// Create a new instance.
         /// </summary>
         /// <param name="simultaneousMode">Specify how to deal with multiple matches of <see cref="KeyCombination"/>s and <see cref="T"/>s.</param>
-        protected KeyBindingInputManager(SimultaneousBindingMode simultaneousMode = SimultaneousBindingMode.None)
+        protected KeyBindingContainer(SimultaneousBindingMode simultaneousMode = SimultaneousBindingMode.None)
         {
+            RelativeSizeAxes = Axes.Both;
+
             this.simultaneousMode = simultaneousMode;
         }
 
@@ -43,7 +46,9 @@ namespace osu.Framework.Input.Bindings
         /// The input queue to be used for processing key bindings. Based on the non-positional <see cref="InputManager.InputQueue"/>.
         /// Can be overridden to change priorities.
         /// </summary>
-        protected virtual IEnumerable<Drawable> KeyBindingInputQueue => InputQueue;
+        protected virtual IEnumerable<Drawable> KeyBindingInputQueue => localQueue;
+
+        private readonly List<Drawable> localQueue = new List<Drawable>();
 
         /// <summary>
         /// Override to enable or disable sending of repeated actions (disabled by default).
@@ -51,44 +56,53 @@ namespace osu.Framework.Input.Bindings
         /// </summary>
         protected virtual bool SendRepeats => false;
 
-        protected override bool PropagateWheel(IEnumerable<Drawable> drawables, InputState state)
+        protected override bool OnWheel(InputState state)
         {
-            if (base.PropagateWheel(drawables, state)) return true;
+            InputKey key = state.Mouse.WheelDelta > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
 
             // we need to create a local cloned state to ensure the underlying code in handleNewReleased thinks we are in a sane state,
             // even though we are pressing and releasing an InputKey in a single frame.
+            // the important part of this cloned state is the value of Wheel reset to zero.
             var clonedState = state.Clone();
-            var clonedMouseState = (MouseState)clonedState.Mouse;
-
-            clonedMouseState.Wheel = 0;
-            clonedMouseState.LastState = null;
-
-            InputKey key = state.Mouse.WheelDelta > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
+            clonedState.Mouse = new MouseState { Buttons = clonedState.Mouse.Buttons };
 
             return handleNewPressed(state, key, false) | handleNewReleased(clonedState, key);
         }
 
-        protected override bool PropagateMouseDown(IEnumerable<Drawable> drawables, InputState state, MouseDownEventArgs args) =>
-            base.PropagateMouseDown(drawables, state, args) || handleNewPressed(state, KeyCombination.FromMouseButton(args.Button), false);
+        internal override bool BuildKeyboardInputQueue(List<Drawable> queue)
+        {
+            localQueue.Clear();
 
-        protected override bool PropagateMouseUp(IEnumerable<Drawable> drawables, InputState state, MouseUpEventArgs args) =>
-            base.PropagateMouseUp(drawables, state, args) || handleNewReleased(state, KeyCombination.FromMouseButton(args.Button));
+            var addedSelf = base.BuildKeyboardInputQueue(localQueue);
 
-        protected override bool PropagateKeyDown(IEnumerable<Drawable> drawables, InputState state, KeyDownEventArgs args)
+            queue.AddRange(localQueue);
+
+            if (addedSelf)
+                localQueue.Remove(this);
+
+            localQueue.Reverse();
+
+            return true;
+        }
+
+        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => handleNewPressed(state, KeyCombination.FromMouseButton(args.Button), false);
+
+        protected override bool OnMouseUp(InputState state, MouseUpEventArgs args) => handleNewReleased(state, KeyCombination.FromMouseButton(args.Button));
+
+        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {
             if (args.Repeat && !SendRepeats)
             {
                 if (pressedBindings.Count > 0)
                     return true;
 
-                return base.PropagateKeyDown(drawables, state, args);
+                return false;
             }
 
-            return base.PropagateKeyDown(drawables, state, args) || handleNewPressed(state, KeyCombination.FromKey(args.Key), args.Repeat);
+            return handleNewPressed(state, KeyCombination.FromKey(args.Key), args.Repeat);
         }
 
-        protected override bool PropagateKeyUp(IEnumerable<Drawable> drawables, InputState state, KeyUpEventArgs args) =>
-            base.PropagateKeyUp(drawables, state, args) || handleNewReleased(state, KeyCombination.FromKey(args.Key));
+        protected override bool OnKeyUp(InputState state, KeyUpEventArgs args) => handleNewReleased(state, KeyCombination.FromKey(args.Key));
 
         private bool handleNewPressed(InputState state, InputKey newKey, bool repeat)
         {
@@ -188,12 +202,16 @@ namespace osu.Framework.Input.Bindings
 
             return handled != null;
         }
+
+        public void TriggerReleased(T released) => PropagateReleased(KeyBindingInputQueue, released);
+
+        public void TriggerPressed(T pressed) => PropagatePressed(KeyBindingInputQueue, pressed);
     }
 
     /// <summary>
     /// Maps input actions to custom action data.
     /// </summary>
-    public abstract class KeyBindingInputManager : PassThroughInputManager
+    public abstract class KeyBindingContainer : Container
     {
         protected IEnumerable<KeyBinding> KeyBindings;
 
@@ -217,12 +235,14 @@ namespace osu.Framework.Input.Bindings
         /// One action can be in a pressed state at once. If a new matching binding is encountered, any existing binding is first released.
         /// </summary>
         None,
+
         /// <summary>
         /// Unique actions are allowed to be pressed at the same time. There may therefore be more than one action in an actuated state at once.
         /// If one action has multiple bindings, only the first will trigger an <see cref="IKeyBindingHandler{T}.OnPressed"/>.
         /// The last binding to be released will trigger an <see cref="IKeyBindingHandler{T}.OnReleased(T)"/>.
         /// </summary>
         Unique,
+
         /// <summary>
         /// Unique actions are allowed to be pressed at the same time, as well as multiple times from different bindings. There may therefore be
         /// more than one action in an pressed state at once, as well as multiple consecutive <see cref="IKeyBindingHandler{T}.OnPressed"/> events

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Framework.Input
+{
+    public class FrameworkActionContainer : KeyBindingContainer<FrameworkAction>
+    {
+        public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
+        {
+            new KeyBinding(new[] { InputKey.Control, InputKey.F1 }, FrameworkAction.ToggleDrawVisualiser),
+            new KeyBinding(new[] { InputKey.Control, InputKey.F11 }, FrameworkAction.CycleFrameStatistics),
+            new KeyBinding(new[] { InputKey.Control, InputKey.F10 }, FrameworkAction.ToggleLogOverlay),
+            new KeyBinding(new[] { InputKey.Alt, InputKey.Enter }, FrameworkAction.ToggleFullscreen),
+        };
+
+        protected override IEnumerable<Drawable> KeyBindingInputQueue => new[] { Child }.Concat(base.KeyBindingInputQueue);
+    }
+
+    public enum FrameworkAction
+    {
+        CycleFrameStatistics,
+        ToggleDrawVisualiser,
+        ToggleLogOverlay,
+        ToggleFullscreen
+    }
+}

--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Input
             // Drop any keypresses if the control, alt, or windows/command key are being held.
             // This is a workaround for an issue on macOS where OpenTK will fire KeyPress events even
             // if modifier keys are held.  This can be reverted when it is fixed on OpenTK's side.
-            if (RuntimeInfo.IsMacOsx)
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.MacOsx)
             {
                 var state = OpenTK.Input.Keyboard.GetState();
                 if (state.IsKeyDown(OpenTK.Input.Key.LControl)

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -316,6 +316,8 @@ namespace osu.Framework.Input
             positionalInputQueue.Reverse();
         }
 
+        protected virtual bool HandleHoverEvents => true;
+
         private void updateHoverEvents(InputState state)
         {
             Drawable lastHoverHandledDrawable = hoverHandledDrawable;
@@ -326,7 +328,7 @@ namespace osu.Framework.Input
             hoveredDrawables.Clear();
 
             // New drawables shouldn't be hovered if the cursor isn't in the window
-            if (Host.Window?.CursorInWindow ?? true)
+            if (HandleHoverEvents)
             {
                 // First, we need to construct hoveredDrawables for the current frame
                 foreach (Drawable d in positionalInputQueue)

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -10,7 +10,15 @@ namespace osu.Framework.Input
 {
     public class MouseState : IMouseState
     {
-        public IReadOnlyList<MouseButton> Buttons => buttons;
+        public IReadOnlyList<MouseButton> Buttons
+        {
+            get { return buttons; }
+            set
+            {
+                buttons.Clear();
+                buttons.AddRange(value);
+            }
+        }
 
         private List<MouseButton> buttons { get; set; } = new List<MouseButton>();
 

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Platform;
 
 namespace osu.Framework.Input
 {
@@ -12,9 +14,17 @@ namespace osu.Framework.Input
     /// can be created to handle events that should trigger specifically on a focused drawable.
     /// Will send repeat events by default.
     /// </summary>
-    public class PlatformInputManager : KeyBindingInputManager<PlatformAction>
+    public class PlatformActionContainer : KeyBindingContainer<PlatformAction>
     {
-        public override IEnumerable<KeyBinding> DefaultKeyBindings => Host.PlatformKeyBindings;
+        private GameHost host;
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            this.host = host;
+        }
+
+        public override IEnumerable<KeyBinding> DefaultKeyBindings => host.PlatformKeyBindings;
 
         protected override bool SendRepeats => true;
     }

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -2,38 +2,19 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Collections.Generic;
-using System.Linq;
-using osu.Framework.Graphics;
-using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
 
 namespace osu.Framework.Input
 {
-    public class UserInputManager : KeyBindingInputManager<FrameworkAction>
+    public class UserInputManager : PassThroughInputManager
     {
         protected override IEnumerable<InputHandler> InputHandlers => Host.AvailableInputHandlers;
 
-        public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
-        {
-            new KeyBinding(new[] { InputKey.Control, InputKey.F1 }, FrameworkAction.ToggleDrawVisualiser),
-            new KeyBinding(new[] { InputKey.Control, InputKey.F11 }, FrameworkAction.CycleFrameStatistics),
-            new KeyBinding(new[] { InputKey.Control, InputKey.F10 }, FrameworkAction.ToggleLogOverlay),
-            new KeyBinding(new[] { InputKey.Alt, InputKey.Enter }, FrameworkAction.ToggleFullscreen),
-        };
+        protected override bool HandleHoverEvents => Host.Window?.CursorInWindow ?? true;
 
         public UserInputManager()
         {
             UseParentState = false;
         }
-
-        protected override IEnumerable<Drawable> KeyBindingInputQueue => new[] { Child }.Concat(base.KeyBindingInputQueue);
-    }
-
-    public enum FrameworkAction
-    {
-        CycleFrameStatistics,
-        ToggleDrawVisualiser,
-        ToggleLogOverlay,
-        ToggleFullscreen
     }
 }

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -280,7 +280,10 @@ namespace osu.Framework.Logging
         /// </summary>
         /// <param name="message">The message to log. Can include newline (\n) characters to split into multiple lines.</param>
         /// <param name="level">The verbosity level.</param>
-        public void Add(string message = @"", LogLevel level = LogLevel.Verbose)
+        public void Add(string message = @"", LogLevel level = LogLevel.Verbose) =>
+            add(message, level, OutputToListeners);
+
+        private void add(string message = @"", LogLevel level = LogLevel.Verbose, bool outputToListeners = true)
         {
             if (!Enabled || level < Level)
                 return;
@@ -288,10 +291,10 @@ namespace osu.Framework.Logging
             ensureHeader();
 
 #if DEBUG
-            var debugLine = $"[{Target?.ToString().ToLower() ?? Name}:{level.ToString().ToLower()}] {message}";
-
-            if (OutputToListeners)
+            if (outputToListeners)
             {
+                var debugLine = $"[{Target?.ToString().ToLower() ?? Name}:{level.ToString().ToLower()}] {message}";
+
                 // fire to all debug listeners (like visual studio's output window)
                 System.Diagnostics.Debug.Print(debugLine);
 
@@ -318,15 +321,14 @@ namespace osu.Framework.Logging
                 lines[i] = $@"{DateTime.UtcNow.ToString(NumberFormatInfo.InvariantInfo)}: {s.Trim()}";
             }
 
-            LogEntry entry = new LogEntry
-            {
-                Level = level,
-                Target = Target,
-                LoggerName = Name,
-                Message = message
-            };
-
-            NewEntry?.Invoke(entry);
+            if (outputToListeners)
+                NewEntry?.Invoke(new LogEntry
+                {
+                    Level = level,
+                    Target = Target,
+                    LoggerName = Name,
+                    Message = message
+                });
 
             if (Target == LoggingTarget.Information)
                 // don't want to log this to a file
@@ -383,11 +385,11 @@ namespace osu.Framework.Logging
             if (headerAdded) return;
             headerAdded = true;
 
-            Add(@"----------------------------------------------------------");
-            Add($@"{Target} Log for {UserIdentifier}");
-            Add($@"{GameIdentifier} version {VersionIdentifier}");
-            Add($@"Running on {Environment.OSVersion}, {Environment.ProcessorCount} cores");
-            Add(@"----------------------------------------------------------");
+            add("----------------------------------------------------------", outputToListeners: false);
+            add($"{Target} Log for {UserIdentifier}", outputToListeners: false);
+            add($"{GameIdentifier} version {VersionIdentifier}", outputToListeners: false);
+            add($"Running on {Environment.OSVersion}, {Environment.ProcessorCount} cores", outputToListeners: false);
+            add("----------------------------------------------------------", outputToListeners: false);
         }
 
         private static readonly List<string> filters = new List<string>();

--- a/osu.Framework/Platform/Architecture.cs
+++ b/osu.Framework/Platform/Architecture.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Platform
 
         internal static void SetIncludePath()
         {
-            if (RuntimeInfo.IsWindows)
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Windows)
                 SetDllDirectory(NativeIncludePath);
         }
     }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -406,7 +406,16 @@ namespace osu.Framework.Platform
 
         private void bootstrapSceneGraph(Game game)
         {
-            var root = new UserInputManager { Child = game };
+            var root = new UserInputManager
+            {
+                Child = new PlatformActionContainer
+                {
+                    Child = new FrameworkActionContainer
+                    {
+                        Child = game
+                    }
+                }
+            };
 
             Dependencies.Cache(root);
             Dependencies.Cache(game);
@@ -582,7 +591,7 @@ namespace osu.Framework.Platform
         #endregion
 
         /// <summary>
-        /// Defines the platform-specific key bindings that will be used by <see cref="osu.Framework.Input.PlatformInputManager"/>.
+        /// Defines the platform-specific key bindings that will be used by <see cref="PlatformActionContainer"/>.
         /// Should be overridden per-platform to provide native key bindings.
         /// </summary>
         public virtual IEnumerable<KeyBinding> PlatformKeyBindings => new[]
@@ -599,7 +608,7 @@ namespace osu.Framework.Platform
             new KeyBinding(new KeyCombination(new[] { InputKey.Shift, InputKey.Right }), new PlatformAction(PlatformActionType.CharNext, PlatformActionMethod.Select)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Left }), new PlatformAction(PlatformActionType.WordPrevious, PlatformActionMethod.Move)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Right }), new PlatformAction(PlatformActionType.WordNext, PlatformActionMethod.Move)),
-            new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.BackSpace}), new PlatformAction(PlatformActionType.WordPrevious, PlatformActionMethod.Delete)),
+            new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.BackSpace }), new PlatformAction(PlatformActionType.WordPrevious, PlatformActionMethod.Delete)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Delete }), new PlatformAction(PlatformActionType.WordNext, PlatformActionMethod.Delete)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Shift, InputKey.Left }), new PlatformAction(PlatformActionType.WordPrevious, PlatformActionMethod.Select)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Shift, InputKey.Right }), new PlatformAction(PlatformActionType.WordNext, PlatformActionMethod.Select)),

--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Runtime.InteropServices;
 
 namespace osu.Framework
@@ -19,49 +17,27 @@ namespace osu.Framework
         public static bool Is32Bit { get; }
         public static bool Is64Bit { get; }
         public static bool IsMono { get; }
-        public static bool IsWindows { get; }
-        public static bool IsUnix { get; }
-        public static bool IsLinux { get; }
-        public static bool IsMacOsx { get; }
+        public static Platform OS { get; }
+        public static bool IsUnix => OS == Platform.Linux || OS == Platform.MacOsx;
         public static bool IsWine { get; }
 
         static RuntimeInfo()
         {
             IsMono = Type.GetType("Mono.Runtime") != null;
-            int p = (int)Environment.OSVersion.Platform;
-            IsUnix = p == 4 || p == 6 || p == 128;
-            IsWindows = Path.DirectorySeparatorChar == '\\';
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                OS = Platform.Windows;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                OS = OS == 0 ? Platform.MacOsx : throw new InvalidOperationException($"Tried to set OS Platform to {nameof(Platform.MacOsx)}, but is already {Enum.GetName(typeof(Platform), OS)}");
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                OS = OS == 0 ? Platform.Linux : throw new InvalidOperationException($"Tried to set OS Platform to {nameof(Platform.Linux)}, but is already {Enum.GetName(typeof(Platform), OS)}");
+
+            if (OS == 0)
+                throw new PlatformNotSupportedException("Operating system could not be detected correctly.");
 
             Is32Bit = IntPtr.Size == 4;
             Is64Bit = IntPtr.Size == 8;
 
-            if (IsUnix)
-            {
-                Process uname = Process.Start(new ProcessStartInfo
-                {
-                    FileName = "uname",
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true
-                });
-
-                if (uname != null)
-                {
-                    string output = uname.StandardOutput.ReadToEnd();
-                    uname.WaitForExit();
-
-                    output = output.ToUpper().Replace("\n", "").Trim();
-
-                    IsMacOsx = output == "DARWIN";
-                    IsLinux = output == "LINUX";
-                }
-            }
-            else
-            {
-                IsMacOsx = false;
-                IsLinux = false;
-            }
-
-            if (IsWindows)
+            if (OS == Platform.Windows)
             {
                 IntPtr hModule = GetModuleHandle(@"ntdll.dll");
                 if (hModule == IntPtr.Zero)
@@ -72,6 +48,13 @@ namespace osu.Framework
                     IsWine = fptr != IntPtr.Zero;
                 }
             }
+        }
+
+        public enum Platform
+        {
+            Windows = 1,
+            Linux = 2,
+            MacOsx = 3,
         }
     }
 }

--- a/osu.Framework/Testing/Drawables/Steps/AssertButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/AssertButton.cs
@@ -22,12 +22,21 @@ namespace osu.Framework.Testing.Drawables.Steps
         private void checkAssert()
         {
             if (Assertion())
-            {
                 Success();
-                BackgroundColour = Color4.YellowGreen;
-            }
             else
                 throw new TracedException($"{Text} {ExtendedDescription}", CallStack);
+        }
+
+        protected override void Success()
+        {
+            base.Success();
+            BackgroundColour = Color4.YellowGreen;
+        }
+
+        protected override void Failure()
+        {
+            base.Failure();
+            BackgroundColour = Color4.Red;
         }
 
         public override string ToString() => "Assert: " + base.ToString();

--- a/osu.Framework/Testing/Drawables/Steps/StepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepButton.cs
@@ -1,34 +1,108 @@
 // Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
 using OpenTK.Graphics;
 
 namespace osu.Framework.Testing.Drawables.Steps
 {
-    public abstract class StepButton : Button
+    public abstract class StepButton : CompositeDrawable
     {
         public virtual int RequiredRepetitions => 1;
 
+        protected Box Light;
+        protected Box Background;
+        protected SpriteText SpriteText;
+
+        public Action Action { get; protected set; }
+
+        public string Text
+        {
+            get { return SpriteText.Text; }
+            set { SpriteText.Text = value; }
+        }
+
+        public Color4 BackgroundColour
+        {
+            get { return Light.Colour; }
+            set { Light.FadeColour(value); }
+        }
+
+        private readonly Color4 idleColour = new Color4(0.15f, 0.15f, 0.15f, 1);
+        private readonly Color4 runningColour = new Color4(0.5f, 0.5f, 0.5f, 1);
+
         protected StepButton()
         {
-            Height = 25;
+            InternalChildren = new Drawable[]
+            {
+                Background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = idleColour,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+                Light = new Box
+                {
+                    RelativeSizeAxes = Axes.Y,
+                    Width = 5,
+                },
+                SpriteText = new SpriteText
+                {
+                    Anchor = Anchor.CentreLeft,
+                    Origin = Anchor.CentreLeft,
+                    TextSize = 14,
+                    X = 5,
+                    Padding = new MarginPadding(5),
+                }
+            };
+
+            Height = 20;
             RelativeSizeAxes = Axes.X;
 
             BackgroundColour = Color4.BlueViolet;
 
+            BorderThickness = 1.5f;
+            BorderColour = new Color4(0.15f, 0.15f, 0.15f, 1);
+
             CornerRadius = 2;
             Masking = true;
-
-            SpriteText.Anchor = Anchor.CentreLeft;
-            SpriteText.Origin = Anchor.CentreLeft;
-            SpriteText.Padding = new MarginPadding(5);
         }
 
-        protected void Success()
+        protected override bool OnClick(InputState state)
         {
-            Background.Alpha = 0.4f;
+            Background.ClearTransforms();
+            Background.FadeColour(runningColour, 40, Easing.OutQuint);
+
+            try
+            {
+                Action?.Invoke();
+            }
+            catch (Exception)
+            {
+                Failure();
+
+                // if our state is null, we were triggered programmatically and want to handle the exception in the outer scope.
+                if (state == null)
+                    throw;
+            }
+
+            return true;
+        }
+
+        protected virtual void Failure()
+        {
+            Background.DelayUntilTransformsFinished().FadeColour(new Color4(0.3f, 0.15f, 0.15f, 1), 1000, Easing.OutQuint);
+        }
+
+        protected virtual void Success()
+        {
+            Background.DelayUntilTransformsFinished().FadeColour(idleColour, 1000, Easing.OutQuint);
             SpriteText.Alpha = 0.8f;
         }
 

--- a/osu.Framework/Testing/Drawables/TestCaseButton.cs
+++ b/osu.Framework/Testing/Drawables/TestCaseButton.cs
@@ -9,11 +9,26 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using OpenTK.Graphics;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace osu.Framework.Testing.Drawables
 {
-    internal class TestCaseButton : ClickableContainer
+    internal class TestCaseButton : ClickableContainer, IFilterable
     {
+        public IEnumerable<string> FilterTerms => text.Children.OfType<IHasFilterTerms>().SelectMany(c => c.FilterTerms);
+
+        public bool MatchingFilter
+        {
+            set
+            {
+                if (value)
+                    Show();
+                else
+                    Hide();
+            }
+        }
+
         private readonly Box box;
         private readonly TextFlowContainer text;
 


### PR DESCRIPTION
I can't actually run the net461 compiled version with mono - something else broke in the latest mono that causes:
```
System.TypeInitializationException: The type initializer for 'osu.Framework.RuntimeInfo' threw an exception. ---> System.EntryPointNotFoundException: GetModuleHandle
  at (wrapper managed-to-native) osu.Framework.RuntimeInfo.GetModuleHandle(string)
  at osu.Framework.RuntimeInfo..cctor () [0x000fc] in <24cbbc9c93b34e6899894ac483bb00e8>:0
   --- End of inner exception stack trace ---
  at osu.Framework.Host.GetSuitableHost (System.String gameName, System.Boolean bindIPC) [0x00001] in <24cbbc9c93b34e6899894ac483bb00e8>:0
  at osu.Framework.Tests.Program.Main (System.String[] args) [0x00016] in <3c032dc4d47f44238ed36feae0c4c374>:0
```

With the new csproj sdks. /sigh