### PR TITLE
Add blocking Wait method for audio tracks

### DIFF
--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using osu.Framework.Configuration;
 
 namespace osu.Framework.Audio
@@ -13,6 +14,17 @@ namespace osu.Framework.Audio
         private readonly HashSet<BindableDouble> volumeAdjustments = new HashSet<BindableDouble>();
         private readonly HashSet<BindableDouble> balanceAdjustments = new HashSet<BindableDouble>();
         private readonly HashSet<BindableDouble> frequencyAdjustments = new HashSet<BindableDouble>();
+
+        protected bool ShouldSetEvent;
+        protected readonly AutoResetEvent AutoResetEvent;
+
+        protected void SetEventIfNeeded()
+        {
+            if (ShouldSetEvent)
+                PendingActions.Enqueue(() => AutoResetEvent.Set());
+        }
+        public void Wait() => AutoResetEvent.WaitOne();
+
 
         /// <summary>
         /// Global volume of this component.
@@ -56,6 +68,9 @@ namespace osu.Framework.Audio
             Volume.ValueChanged += InvalidateState;
             Balance.ValueChanged += InvalidateState;
             Frequency.ValueChanged += InvalidateState;
+
+            ShouldSetEvent = true;
+            AutoResetEvent = new AutoResetEvent(false);
         }
 
         internal void InvalidateState(double newValue = 0)

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -48,9 +48,12 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         public virtual void Restart()
         {
+            ShouldSetEvent = false;
             Stop();
             Seek(0);
             Start();
+            ShouldSetEvent = true;
+            SetEventIfNeeded();
         }
 
         public virtual void ResetSpeedAdjustments()

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -48,6 +48,7 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         public virtual void Restart()
         {
+            WaitingAvailable = true;
             ShouldSetEvent = false;
             Stop();
             Seek(0);

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -143,6 +143,7 @@ namespace osu.Framework.Audio.Track
 
         public override void Stop()
         {
+            WaitingAvailable = true;
             base.Stop();
 
             PendingActions.Enqueue(() =>
@@ -165,6 +166,7 @@ namespace osu.Framework.Audio.Track
 
         public override void Start()
         {
+            WaitingAvailable = true;
             base.Start();
             PendingActions.Enqueue(() =>
             {

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -152,6 +152,7 @@ namespace osu.Framework.Audio.Track
 
                 isPlayed = false;
             });
+            SetEventIfNeeded();
         }
 
         private int direction;
@@ -172,6 +173,7 @@ namespace osu.Framework.Audio.Track
                 else
                     isRunning = false;
             });
+            SetEventIfNeeded();
         }
 
         private Action seekAction;


### PR DESCRIPTION
I guess this should improve situation described in #1230 for a bit.

Please take into consideration that:
1. I did not touch audio samples because, as far as I understand, [this workaround](https://github.com/ppy/osu/pull/1658) was applied only to tracks.
2. I understand that `track.Restart().Wait();` is much more better, but these `Start`/`Stop`/`Restart` methods are from `IAdjustableClock` interface. According to it's name, it is not audio specific and I guess I can't just change described method signatures to something like `AsyncAudioTask Start();`.
3. Updated game code can be [here](https://github.com/UselessToucan/osu/commit/8916b83987f19739947571ccb35abb96d9748971).