### PR TITLE
Don't access Children when changing TextSize

### DIFF
--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -147,8 +147,7 @@ namespace osu.Framework.Graphics.Sprites
 
                 textSize = value;
 
-                foreach (Drawable d in Children)
-                    d.Scale = new Vector2(textSize);
+                layout.Invalidate();
             }
         }
 


### PR DESCRIPTION
In cases where a derived class overrided `Content` this would cause failures. As changing TextSize is a relatively rare thing, there's no reason for this "optimisation" anyways.