### PR TITLE
Clean up the TestBrowser assembly dropdown

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseAnimation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseAnimation.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
     [System.ComponentModel.Description("frame-based animations")]
-    internal class TestCaseAnimation : TestCase
+    public class TestCaseAnimation : TestCase
     {
         public TestCaseAnimation()
         {

--- a/osu.Framework.Tests/Visual/TestCaseBlending.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBlending.cs
@@ -16,7 +16,7 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    internal class TestCaseBlending : TestCase
+    public class TestCaseBlending : TestCase
     {
         private readonly Dropdown<BlendingMode> colourModeDropdown;
         private readonly Dropdown<BlendingEquation> colourEquation;

--- a/osu.Framework.Tests/Visual/TestCaseBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBufferedContainer.cs
@@ -9,7 +9,7 @@ using OpenTK;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseBufferedContainer : TestCaseMasking
+    public class TestCaseBufferedContainer : TestCaseMasking
     {
         private readonly BufferedContainer buffer;
 

--- a/osu.Framework.Tests/Visual/TestCaseCheckboxes.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCheckboxes.cs
@@ -11,7 +11,7 @@ using OpenTK;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseCheckboxes : TestCase
+    public class TestCaseCheckboxes : TestCase
     {
         public TestCaseCheckboxes()
         {

--- a/osu.Framework.Tests/Visual/TestCaseCircularContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCircularContainer.cs
@@ -10,7 +10,7 @@ using osu.Framework.Testing;
 namespace osu.Framework.Tests.Visual
 {
     [System.ComponentModel.Description(@"Checking for bugged corner radius")]
-    internal class TestCaseCircularContainer : TestCase
+    public class TestCaseCircularContainer : TestCase
     {
         private SingleUpdateCircularContainer container;
 

--- a/osu.Framework.Tests/Visual/TestCaseCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCircularProgress.cs
@@ -13,7 +13,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseCircularProgress : TestCase
+    public class TestCaseCircularProgress : TestCase
     {
         private readonly CircularProgress clock;
 

--- a/osu.Framework.Tests/Visual/TestCaseContextMenu.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContextMenu.cs
@@ -14,7 +14,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseContextMenu : TestCase
+    public class TestCaseContextMenu : TestCase
     {
         private const int start_time = 0;
         private const int duration = 1000;

--- a/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
@@ -14,7 +14,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseDelayedLoad : TestCase
+    public class TestCaseDelayedLoad : TestCase
     {
         private const int panel_count = 2048;
 

--- a/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
@@ -12,7 +12,7 @@ using osu.Framework.Testing;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseDrawSizePreservingFillContainer : TestCase
+    public class TestCaseDrawSizePreservingFillContainer : TestCase
     {
         public TestCaseDrawSizePreservingFillContainer()
         {

--- a/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
@@ -14,7 +14,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseDropdownBox : TestCase
+    public class TestCaseDropdownBox : TestCase
     {
         private const int items_to_add = 10;
 

--- a/osu.Framework.Tests/Visual/TestCaseEffects.cs
+++ b/osu.Framework.Tests/Visual/TestCaseEffects.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
     [System.ComponentModel.Description("implementing the IEffect interface")]
-    internal class TestCaseEffects : TestCase
+    public class TestCaseEffects : TestCase
     {
         public TestCaseEffects()
         {

--- a/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
@@ -20,7 +20,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseFillFlowContainer : TestCase
+    public class TestCaseFillFlowContainer : TestCase
     {
         private FillDirectionDropdown selectionDropdown;
 

--- a/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
@@ -18,7 +18,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseLocalisation : TestCase
+    public class TestCaseLocalisation : TestCase
     {
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly LocalisationEngine engine; //keep a reference to avoid GC of the engine

--- a/osu.Framework.Tests/Visual/TestCaseMasking.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMasking.cs
@@ -15,7 +15,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseMasking : TestCase
+    public class TestCaseMasking : TestCase
     {
         protected Container TestContainer;
 

--- a/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
+++ b/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
@@ -13,7 +13,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseNestedHover : TestCase
+    public class TestCaseNestedHover : TestCase
     {
         public TestCaseNestedHover()
         {

--- a/osu.Framework.Tests/Visual/TestCaseNestedMenus.cs
+++ b/osu.Framework.Tests/Visual/TestCaseNestedMenus.cs
@@ -19,7 +19,7 @@ using MouseState = osu.Framework.Input.MouseState;
 
 namespace osu.Framework.Tests.Visual
 {
-    internal class TestCaseNestedMenus : TestCase
+    public class TestCaseNestedMenus : TestCase
     {
         private const int max_depth = 5;
         private const int max_count = 5;

--- a/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
+++ b/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
     [System.ComponentModel.Description("ensure validity of drawables when receiving certain values")]
-    internal class TestCasePropertyBoundaries : TestCase
+    public class TestCasePropertyBoundaries : TestCase
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
+++ b/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
@@ -15,7 +15,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseRigidBody : TestCase
+    public class TestCaseRigidBody : TestCase
     {
         private readonly TestRigidBodySimulation sim;
 

--- a/osu.Framework.Tests/Visual/TestCaseScreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScreen.cs
@@ -17,7 +17,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseScreen : TestCase
+    public class TestCaseScreen : TestCase
     {
         public TestCaseScreen()
         {

--- a/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
@@ -14,7 +14,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseScrollableFlow : TestCase
+    public class TestCaseScrollableFlow : TestCase
     {
         private readonly ScheduledDelegate boxCreator;
 

--- a/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
@@ -14,7 +14,7 @@ using OpenTK;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseSearchContainer : TestCase
+    public class TestCaseSearchContainer : TestCase
     {
         public TestCaseSearchContainer()
         {

--- a/osu.Framework.Tests/Visual/TestCaseSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSizing.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
     [System.ComponentModel.Description("potentially challenging size calculations")]
-    internal class TestCaseSizing : TestCase
+    public class TestCaseSizing : TestCase
     {
         private readonly Container testContainer;
 

--- a/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
@@ -10,7 +10,7 @@ using osu.Framework.Testing;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseSpriteText : TestCase
+    public class TestCaseSpriteText : TestCase
     {
         public TestCaseSpriteText()
         {

--- a/osu.Framework.Tests/Visual/TestCaseTabControl.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTabControl.cs
@@ -18,7 +18,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseTabControl : TestCase
+    public class TestCaseTabControl : TestCase
     {
         public TestCaseTabControl()
         {

--- a/osu.Framework.Tests/Visual/TestCaseTextBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextBox.cs
@@ -11,7 +11,7 @@ using OpenTK;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseTextBox : TestCase
+    public class TestCaseTextBox : TestCase
     {
         public TestCaseTextBox()
         {

--- a/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
     [System.ComponentModel.Description("word-wrap and paragraphs")]
-    internal class TestCaseTextFlow : TestCase
+    public class TestCaseTextFlow : TestCase
     {
         public TestCaseTextFlow()
         {

--- a/osu.Framework.Tests/Visual/TestCaseTooltip.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTooltip.cs
@@ -15,7 +15,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseTooltip : TestCase
+    public class TestCaseTooltip : TestCase
     {
         private readonly Container testContainer;
 

--- a/osu.Framework.Tests/Visual/TestCaseTriangles.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTriangles.cs
@@ -13,7 +13,7 @@ using OpenTK.Graphics;
 namespace osu.Framework.Tests.Visual
 {
     [TestFixture]
-    internal class TestCaseTriangles : TestCase
+    public class TestCaseTriangles : TestCase
     {
         private readonly Container testContainer;
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -65,7 +65,7 @@ namespace osu.Framework.Testing
             //we want to build the lists here because we're interested in the assembly we were *created* on.
             foreach (Assembly asm in assemblies.ToList())
             {
-                var tests = asm.GetLoadableTypes().Where(t => t.IsSubclassOf(typeof(TestCase)) && !t.IsAbstract).ToList();
+                var tests = asm.GetLoadableTypes().Where(t => t.IsSubclassOf(typeof(TestCase)) && !t.IsAbstract && t.IsPublic).ToList();
 
                 if (!tests.Any())
                 {

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -63,12 +63,15 @@ namespace osu.Framework.Testing
             assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(n => n.FullName.StartsWith("osu") || assemblyNamespace != null && n.FullName.StartsWith(assemblyNamespace)).ToList();
 
             //we want to build the lists here because we're interested in the assembly we were *created* on.
-            foreach (Assembly asm in assemblies)
+            foreach (Assembly asm in assemblies.ToList())
             {
                 var tests = asm.GetLoadableTypes().Where(t => t.IsSubclassOf(typeof(TestCase)) && !t.IsAbstract).ToList();
 
                 if (!tests.Any())
+                {
+                    assemblies.Remove(asm);
                     continue;
+                }
 
                 foreach (Type type in tests)
                     TestTypes.Add(type);


### PR DESCRIPTION
Don't show assemblies with no tests.