### PR TITLE
Improve key blocking behaviour of OverlayContainer

### DIFF
--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Collections.Generic;
 using osu.Framework.Input;
 
 namespace osu.Framework.Graphics.Containers
@@ -30,9 +31,17 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnWheel(InputState state) => BlockPassThroughMouse;
 
-        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args) => BlockPassThroughKeyboard;
+        internal override bool BuildKeyboardInputQueue(List<Drawable> queue)
+        {
+            if (CanReceiveInput && BlockPassThroughKeyboard)
+            {
+                // when blocking keyboard input behind us, we still want to make sure the global handlers receive events
+                // but we don't want other drawables behind us handling them.
+                queue.RemoveAll(d => !(d is IHandleGlobalInput));
+            }
 
-        protected override bool OnKeyUp(InputState state, KeyUpEventArgs args) => BlockPassThroughKeyboard;
+            return base.BuildKeyboardInputQueue(queue);
+        }
     }
 
     public enum Visibility

--- a/osu.Framework/Input/IHandleGlobalInput.cs
+++ b/osu.Framework/Input/IHandleGlobalInput.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) 2007-2017 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Input
+{
+    /// <summary>
+    /// Denotes that this class handles input globally.
+    /// </summary>
+    public interface IHandleGlobalInput
+    {
+    }
+}

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Input
     /// can be created to handle events that should trigger specifically on a focused drawable.
     /// Will send repeat events by default.
     /// </summary>
-    public class PlatformActionContainer : KeyBindingContainer<PlatformAction>
+    public class PlatformActionContainer : KeyBindingContainer<PlatformAction>, IHandleGlobalInput
     {
         private GameHost host;
 

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -252,6 +252,7 @@
     <Compile Include="Input\Handlers\Mouse\OpenTKMouseState.cs" />
     <Compile Include="Input\Handlers\Mouse\OpenTKPollMouseState.cs" />
     <Compile Include="Input\Handlers\Mouse\OpenTKRawMouseHandler.cs" />
+    <Compile Include="Input\IHandleGlobalInput.cs" />
     <Compile Include="Input\KeyUpEventArgs.cs" />
     <Compile Include="Allocation\TimedExpiryCache.cs" />
     <Compile Include="Input\IRequireHighFrequencyMousePosition.cs" />


### PR DESCRIPTION
Global handlers can now continue to receive input even when it is being blocked by OverlayContainers.

Helps in fixing https://github.com/ppy/osu/issues/1668 and https://github.com/ppy/osu/issues/1615.