### PR TITLE
Immediately unbind all bindings to OnLoadComplete after load is complete

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -226,7 +226,9 @@ namespace osu.Framework.Graphics
             loadState = LoadState.Loaded;
             Invalidate();
             LoadComplete();
+
             OnLoadComplete?.Invoke(this);
+            OnLoadComplete = null;
             return true;
         }
 


### PR DESCRIPTION
Was causing a memory leak in TestBrowser.