### PR TITLE
Log exception content as Important rather than error

### DIFF
--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -125,12 +125,12 @@ namespace osu.Framework.Logging
 
         private static void error(Exception e, string description, LoggingTarget? target, string name, bool recursive)
         {
-            log($@"ERROR: {description}", target, name, LogLevel.Error);
-            log(e.ToString(), target, name, LogLevel.Error);
+            log($@"{description}", target, name, LogLevel.Error);
+            log(e.ToString(), target, name, LogLevel.Important);
 
             if (recursive)
                 for (Exception inner = e.InnerException; inner != null; inner = inner.InnerException)
-                    log(inner.ToString(), target, name, LogLevel.Error);
+                    log(inner.ToString(), target, name, LogLevel.Important);
         }
 
         /// <summary>

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -148,7 +148,7 @@ namespace osu.Framework.Testing
             }
             catch (Exception e)
             {
-                Logging.Logger.Log($"Error on running first step: {e}");
+                Logging.Logger.Error(e, "Error on running first step");
             }
         }
 


### PR DESCRIPTION
This allows discerning between description and raw exception outputs when displaying to the end user.

Does not affect underlying logging to file.