### PR TITLE
Recreate changes for explicit flow order from #1261

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTabControl.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTabControl.cs
@@ -58,9 +58,9 @@ namespace osu.Framework.Tests.Visual
 
             AddStep("RemoveItem", () =>
             {
-                if (pinnedAndAutoSort.Any())
+                if (pinnedAndAutoSort.Items.Any())
                 {
-                    pinnedAndAutoSort.RemoveItem(pinnedAndAutoSort.Items.Last());
+                    pinnedAndAutoSort.RemoveItem(pinnedAndAutoSort.Items.First());
                 }
             });
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -137,7 +137,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private class ChildComparer : IComparer<Drawable>
+        protected class ChildComparer : IComparer<Drawable>
         {
             private readonly CompositeDrawable owner;
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -225,7 +225,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="drawable">The <see cref="Drawable"/> to be removed.</param>
         /// <returns>False if <paramref name="drawable"/> was not a child of this <see cref="CompositeDrawable"/> and true otherwise.</returns>
-        protected internal bool RemoveInternal(Drawable drawable)
+        protected internal virtual bool RemoveInternal(Drawable drawable)
         {
             if (drawable == null)
                 throw new ArgumentNullException(nameof(drawable));
@@ -260,7 +260,7 @@ namespace osu.Framework.Graphics.Containers
         /// Whether removed children should also get disposed.
         /// Disposal will be recursive.
         /// </param>
-        protected internal void ClearInternal(bool disposeChildren = true)
+        protected internal virtual void ClearInternal(bool disposeChildren = true)
         {
             if (internalChildren.Count == 0) return;
 

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -83,6 +83,7 @@ namespace osu.Framework.Graphics.Containers
             InvalidateLayout();
             base.AddInternal(drawable);
         }
+
         protected internal override bool RemoveInternal(Drawable drawable)
         {
             layoutChildren.Remove(drawable);
@@ -91,6 +92,7 @@ namespace osu.Framework.Graphics.Containers
             InvalidateLayout();
             return base.RemoveInternal(drawable);
         }
+
         protected internal override void ClearInternal(bool disposeChildren = true)
         {
             layoutChildren.Clear();
@@ -119,7 +121,7 @@ namespace osu.Framework.Graphics.Containers
         /// For example, the drawable with the lowest position value will be the left-most drawable in a horizontal <see cref="FillFlowContainer{T}"/> and the drawable with the highest position value will be the right-most drawable in a horizontal <see cref="FillFlowContainer{T}"/>.
         /// </summary>
         /// <param name="drawable">The drawable whose position should be retrieved, must be a child of this container.</param>
-        /// <returns>The position of the drawable in the layout. A higher position value means the drawable will be processed later (that is, the drawables with the lowest position appear first, and the drawable with the highest position appear last).</returns>
+        /// <returns>The position of the drawable in the layout.</returns>
         public float GetLayoutPosition(Drawable drawable)
         {
             if (!layoutChildren.ContainsKey(drawable))

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -18,6 +18,14 @@ namespace osu.Framework.Graphics.Containers
     {
         internal event Action OnLayout;
 
+        private readonly ChildComparer childComparer;
+
+        protected FlowContainer()
+        {
+            childComparer = new ChildComparer(this);
+        }
+
+
         /// <summary>
         /// The easing that should be used when children are moved to their position in the layout.
         /// </summary>
@@ -153,7 +161,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Gets the children that appear in the flow of this FlowContainer in the order in which they are processed within the flowing layout.
         /// </summary>
-        public virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent).OrderBy(d => layoutChildren[d]).ThenBy(d => d.ChildID);
+        public virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent).OrderBy(d => layoutChildren[d]).ThenBy(d => d, childComparer);
 
         protected abstract IEnumerable<Vector2> ComputeLayoutPositions();
 

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -73,6 +73,47 @@ namespace osu.Framework.Graphics.Containers
             return base.Invalidate(invalidation, source, shallPropagate);
         }
 
+        private readonly Dictionary<Drawable, float> layoutChildren = new Dictionary<Drawable, float>();
+
+        protected internal override void AddInternal(Drawable drawable)
+        {
+            layoutChildren.Add(drawable, 0f);
+            // we have to ensure that the layout gets invalidated since Adding or Removing a child will affect the layout. The base class will not invalidate
+            // if we are set to AutoSizeAxes.None, but even in that situation, the layout can and often does change when children are added/removed.
+            InvalidateLayout();
+            base.AddInternal(drawable);
+        }
+        protected internal override bool RemoveInternal(Drawable drawable)
+        {
+            layoutChildren.Remove(drawable);
+            // we have to ensure that the layout gets invalidated since Adding or Removing a child will affect the layout. The base class will not invalidate
+            // if we are set to AutoSizeAxes.None, but even in that situation, the layout can and often does change when children are added/removed.
+            InvalidateLayout();
+            return base.RemoveInternal(drawable);
+        }
+        protected internal override void ClearInternal(bool disposeChildren = true)
+        {
+            layoutChildren.Clear();
+            // we have to ensure that the layout gets invalidated since Adding or Removing a child will affect the layout. The base class will not invalidate
+            // if we are set to AutoSizeAxes.None, but even in that situation, the layout can and often does change when children are added/removed.
+            InvalidateLayout();
+            base.ClearInternal(disposeChildren);
+        }
+
+        /// <summary>
+        /// Changes the position of the drawable in the layout. A higher position value means the drawable will be processed later (that is, the drawables with the lowest position appear first, and the drawable with the highest position appear last).
+        /// For example, the drawable with the lowest position value will be the left-most drawable in a horizontal <see cref="FillFlowContainer{T}"/> and the drawable with the highest position value will be the right-most drawable in a horizontal <see cref="FillFlowContainer{T}"/>.
+        /// </summary>
+        /// <param name="drawable">The drawable whose position should be changed, must be a child of this container.</param>
+        /// <param name="newPosition">The new position in the layout the drawable should have.</param>
+        public void SetLayoutPosition(Drawable drawable, float newPosition)
+        {
+            if (!layoutChildren.ContainsKey(drawable))
+                throw new InvalidOperationException($"Cannot change layout position of drawable which is not contained within this {nameof(FlowContainer<T>)}.");
+            layoutChildren[drawable] = newPosition;
+            InvalidateLayout();
+        }
+
         protected override bool UpdateChildrenLife()
         {
             bool changed = base.UpdateChildrenLife();
@@ -93,7 +134,7 @@ namespace osu.Framework.Graphics.Containers
             base.InvalidateFromChild(invalidation);
         }
 
-        protected virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent);
+        protected virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent).OrderBy(d => layoutChildren[d]).ThenBy(d => d.ChildID);
 
         protected abstract IEnumerable<Vector2> ComputeLayoutPositions();
 

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -114,6 +114,20 @@ namespace osu.Framework.Graphics.Containers
             InvalidateLayout();
         }
 
+        /// <summary>
+        /// Gets the position of the drawable in the layout. A higher position value means the drawable will be processed later (that is, the drawables with the lowest position appear first, and the drawable with the highest position appear last).
+        /// For example, the drawable with the lowest position value will be the left-most drawable in a horizontal <see cref="FillFlowContainer{T}"/> and the drawable with the highest position value will be the right-most drawable in a horizontal <see cref="FillFlowContainer{T}"/>.
+        /// </summary>
+        /// <param name="drawable">The drawable whose position should be retrieved, must be a child of this container.</param>
+        /// <returns>The position of the drawable in the layout. A higher position value means the drawable will be processed later (that is, the drawables with the lowest position appear first, and the drawable with the highest position appear last).</returns>
+        public float GetLayoutPosition(Drawable drawable)
+        {
+            if (!layoutChildren.ContainsKey(drawable))
+                throw new InvalidOperationException($"Cannot get layout position of drawable which is not contained within this {nameof(FlowContainer<T>)}.");
+
+            return layoutChildren[drawable];
+        }
+
         protected override bool UpdateChildrenLife()
         {
             bool changed = base.UpdateChildrenLife();
@@ -134,7 +148,10 @@ namespace osu.Framework.Graphics.Containers
             base.InvalidateFromChild(invalidation);
         }
 
-        protected virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent).OrderBy(d => layoutChildren[d]).ThenBy(d => d.ChildID);
+        /// <summary>
+        /// Gets the children that appear in the flow of this FlowContainer in the order in which they are processed within the flowing layout.
+        /// </summary>
+        public virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent).OrderBy(d => layoutChildren[d]).ThenBy(d => d.ChildID);
 
         protected abstract IEnumerable<Vector2> ComputeLayoutPositions();
 

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -24,9 +24,9 @@ namespace osu.Framework.Graphics.UserInterface
         public Bindable<T> Current { get; } = new Bindable<T>();
 
         /// <summary>
-        /// A list of items currently in the tab control in the other they are dispalyed.
+        /// A list of items currently in the tab control in the order they are dispalyed.
         /// </summary>
-        public IEnumerable<T> Items => TabContainer.Children.Select(tab => tab.Value);
+        public IEnumerable<T> Items => TabContainer.TabItems.Select(t => t.Value).Concat(Dropdown.Items.Select(kvp => kvp.Value)).Distinct();
 
         /// <summary>
         /// When true, tabs selected from the overflow dropdown will be moved to the front of the list (after pinned items).
@@ -55,7 +55,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected abstract TabItem<T> CreateTabItem(T value);
 
         /// <summary>
-        /// Incremented each time a tab needs to be inserted at the start of the list.
+        /// Decremented each time a tab needs to be inserted at the start of the list.
         /// </summary>
         private int depthCounter;
 
@@ -188,11 +188,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <param name="addToDropdown">Whether the tab should be added to the Dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
         protected virtual void AddTabItem(TabItem<T> tab, bool addToDropdown = true)
         {
-            tab.PinnedChanged += t =>
-            {
-                // Todo: This schedule is a temporary fix for https://github.com/ppy/osu-framework/issues/821
-                Schedule(() => performTabSort(t));
-            };
+            tab.PinnedChanged += performTabSort;
 
             tab.ActivationRequested += SelectTab;
 
@@ -220,9 +216,6 @@ namespace osu.Framework.Graphics.UserInterface
                 Dropdown?.RemoveDropdownItem(tab.Value);
 
             TabContainer.Remove(tab);
-
-            if (TabContainer.Count > 0)
-                performTabSort(TabContainer.Last());
         }
 
         /// <summary>
@@ -254,28 +247,26 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void performTabSort(TabItem<T> tab)
         {
-            if (IsLoaded)
-                TabContainer.Remove(tab);
-
-            tab.Depth = getTabDepth(tab);
+            TabContainer.SetLayoutPosition(tab, getTabDepth(tab));
 
             // IsPresent of TabItems is based on Y position.
             // We reset it here to allow tabs to get a correct initial position.
             tab.Y = 0;
-
-            if (IsLoaded)
-                TabContainer.Add(tab);
         }
 
         private float getTabDepth(TabItem<T> tab) => tab.Pinned ? float.MinValue : --depthCounter;
 
         public class TabFillFlowContainer<U> : FillFlowContainer<U> where U : TabItem
         {
+            /// <summary>
+            /// Gets called whenever the visibility of a tab in this container changes. Gets invoked with the <see cref="TabItem"/> whose visibility changed and the new visibility state (true = visible, false = hidden).
+            /// </summary>
             public Action<U, bool> TabVisibilityChanged;
 
-            protected override int Compare(Drawable x, Drawable y) => CompareReverseChildID(x, y);
-
-            protected override IEnumerable<Drawable> FlowingChildren => base.FlowingChildren.Reverse();
+            /// <summary>
+            /// The list of tabs currently displayed by this container.
+            /// </summary>
+            public IEnumerable<U> TabItems => FlowingChildren.OfType<U>();
 
             protected override IEnumerable<Vector2> ComputeLayoutPositions()
             {


### PR DESCRIPTION
This adds a separate order value that gets tracked alongside each child added to a FlowContainer effectively ensuring that the z-ordering of children has no influence over their position in a layout produced by a FlowContainer.

This change required fixing up TabControl which relied on the old behaviour and adjusted z-ordering of children in order to change their positions in a layout.
While reworking TabControl I also noticed that the Items property returned the list of values not in the displayed order, but in reversed display order, which I changed, since it conflicted with what the documentation said about the Items property.

Recreates #1261 due to demand in #1303