### PR TITLE
Expose a new method that is invoked after UpdateChildrenLife

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -477,6 +477,8 @@ namespace osu.Framework.Graphics.Containers
             // for children, as they should never affect our present status.
             if (!IsPresent || !RequiresChildrenUpdate) return false;
 
+            UpdateAfterChildrenLife();
+
             // We iterate by index to gain performance
             // ReSharper disable once ForCanBeConvertedToForeach
             for (int i = 0; i < aliveInternalChildren.Count; ++i)
@@ -497,6 +499,15 @@ namespace osu.Framework.Graphics.Containers
             updateChildrenSizeDependencies();
             UpdateAfterAutoSize();
             return true;
+        }
+
+        /// <summary>
+        /// Invoked after <see cref="UpdateChildrenLife"/> and <see cref="Drawable.IsPresent"/> state checks have taken place,
+        /// but before <see cref="Drawable.UpdateSubTree"/> is invoked for all <see cref="InternalChildren"/>.
+        /// This occurs after <see cref="Drawable.Update"/> has been invoked on this <see cref="CompositeDrawable"/>
+        /// </summary>
+        protected virtual void UpdateAfterChildrenLife()
+        {
         }
 
         /// <summary>


### PR DESCRIPTION
For when you want to compute values using the alive states of children, but `Update` is too early (called before `UpdateChildrenLife`) and `UpdateAfterChildren` is too late (called after childrens' `UpdateSubTree`)