### PR TITLE
Store handleability of input separate for keyboard and mouse

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
@@ -69,6 +69,8 @@ namespace osu.Framework.Tests.Visual
         private class FillFlowContainerNoInput : FillFlowContainer<Container>
         {
             public override bool HandleInput => false;
+            public override bool HandleKeyboardInput => false;
+            public override bool HandleMouseInput => false;
         }
     }
 

--- a/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
@@ -68,7 +68,6 @@ namespace osu.Framework.Tests.Visual
 
         private class FillFlowContainerNoInput : FillFlowContainer<Container>
         {
-            public override bool HandleInput => false;
             public override bool HandleKeyboardInput => false;
             public override bool HandleMouseInput => false;
         }

--- a/osu.Framework.Tests/Visual/TestCaseTooltip.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTooltip.cs
@@ -194,7 +194,8 @@ namespace osu.Framework.Tests.Visual
         {
             public string TooltipText { get; set; }
 
-            public override bool HandleInput => true;
+            public override bool HandleKeyboardInput => true;
+            public override bool HandleMouseInput => true;
         }
 
         private class RectangleCursorContainer : CursorContainer

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -840,7 +840,8 @@ namespace osu.Framework.Graphics.Containers
 
         // Required to pass through input to children by default.
         // TODO: Evaluate effects of this on performance and address.
-        public override bool HandleInput => true;
+        public override bool HandleKeyboardInput => true;
+        public override bool HandleMouseInput => true;
 
         public override bool Contains(Vector2 screenSpacePos)
         {
@@ -867,7 +868,7 @@ namespace osu.Framework.Graphics.Containers
 
         internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
         {
-            if (!base.BuildMouseInputQueue(screenSpaceMousePos, queue) && (!CanReceiveInput || Masking))
+            if (!base.BuildMouseInputQueue(screenSpaceMousePos, queue) && (!CanReceiveMouseInput || Masking))
                 return false;
 
             // We iterate by index to gain performance

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Graphics.Containers
 
         internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
         {
-            if (CanReceiveInput && BlockPassThroughMouse && ReceiveMouseInputAt(screenSpaceMousePos))
+            if (CanReceiveMouseInput && BlockPassThroughMouse && ReceiveMouseInputAt(screenSpaceMousePos))
             {
                 // when blocking mouse input behind us, we still want to make sure the global handlers receive events
                 // but we don't want other drawables behind us handling them.

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Graphics.Containers
 
         internal override bool BuildKeyboardInputQueue(List<Drawable> queue)
         {
-            if (CanReceiveInput && BlockPassThroughKeyboard)
+            if (CanReceiveKeyboardInput && BlockPassThroughKeyboard)
             {
                 // when blocking keyboard input behind us, we still want to make sure the global handlers receive events
                 // but we don't want other drawables behind us handling them.

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -119,6 +119,8 @@ namespace osu.Framework.Graphics.Containers
         }
 
         public override bool HandleInput => false;
+        public override bool HandleKeyboardInput => false;
+        public override bool HandleMouseInput => false;
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -118,7 +118,6 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        public override bool HandleInput => false;
         public override bool HandleKeyboardInput => false;
         public override bool HandleMouseInput => false;
 

--- a/osu.Framework/Graphics/Containers/VisibilityContainer.cs
+++ b/osu.Framework/Graphics/Containers/VisibilityContainer.cs
@@ -68,6 +68,8 @@ namespace osu.Framework.Graphics.Containers
         public override void Show() => State = Visibility.Visible;
 
         public override bool HandleInput => State == Visibility.Visible;
+        public override bool HandleKeyboardInput => HandleInput;
+        public override bool HandleMouseInput => HandleInput;
 
         public event Action<Visibility> StateChanged;
 

--- a/osu.Framework/Graphics/Containers/VisibilityContainer.cs
+++ b/osu.Framework/Graphics/Containers/VisibilityContainer.cs
@@ -67,9 +67,8 @@ namespace osu.Framework.Graphics.Containers
 
         public override void Show() => State = Visibility.Visible;
 
-        public override bool HandleInput => State == Visibility.Visible;
-        public override bool HandleKeyboardInput => HandleInput;
-        public override bool HandleMouseInput => HandleInput;
+        public override bool HandleKeyboardInput => State == Visibility.Visible;
+        public override bool HandleMouseInput => State == Visibility.Visible;
 
         public event Action<Visibility> StateChanged;
 

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -17,6 +17,8 @@ namespace osu.Framework.Graphics.Cursor
 
         //OverlayContainer tried to be smart about this, but we don't want none of that.
         public override bool HandleInput => IsPresent;
+        public override bool HandleKeyboardInput => HandleInput;
+        public override bool HandleMouseInput => HandleInput;
 
         public CursorContainer()
         {

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -16,9 +16,8 @@ namespace osu.Framework.Graphics.Cursor
         protected override bool BlockPassThroughMouse => false;
 
         //OverlayContainer tried to be smart about this, but we don't want none of that.
-        public override bool HandleInput => IsPresent;
-        public override bool HandleKeyboardInput => HandleInput;
-        public override bool HandleMouseInput => HandleInput;
+        public override bool HandleKeyboardInput => IsPresent;
+        public override bool HandleMouseInput => IsPresent;
 
         public CursorContainer()
         {

--- a/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
@@ -5,7 +5,7 @@ namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
     /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a custom tooltip if it is the child of a <see cref="TooltipContainer"/>.
-    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasCustomTooltip"/> has <see cref="Drawable.HandleInput"/> set to true.
+    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasCustomTooltip"/> has <see cref="Drawable.HandleMouseInput"/> set to true.
     /// </summary>
     public interface IHasCustomTooltip : IHasTooltip
     {

--- a/osu.Framework/Graphics/Cursor/IHasTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasTooltip.cs
@@ -6,7 +6,7 @@ namespace osu.Framework.Graphics.Cursor
     /// <summary>
     /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a tooltip if it is the child of a <see cref="TooltipContainer"/>. The tooltip used is
     /// dependent on the implementation of the <see cref="TooltipContainer.CreateTooltip"/> method of the <see cref="TooltipContainer"/> containing this <see cref="Drawable"/>.
-    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasTooltip"/> has <see cref="Drawable.HandleInput"/> set to true.
+    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasTooltip"/> has <see cref="Drawable.HandleMouseInput"/> set to true.
     /// </summary>
     public interface IHasTooltip : IDrawable
     {

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -259,7 +259,6 @@ namespace osu.Framework.Graphics.Cursor
                 }
             }
 
-            public override bool HandleInput => false;
             public override bool HandleKeyboardInput => false;
             public override bool HandleMouseInput => false;
 

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -260,6 +260,8 @@ namespace osu.Framework.Graphics.Cursor
             }
 
             public override bool HandleInput => false;
+            public override bool HandleKeyboardInput => false;
+            public override bool HandleMouseInput => false;
 
             private const float text_size = 16;
 

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -15,7 +15,7 @@ using System.Linq;
 namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
-    /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces. Keep in mind that only children with <see cref="Drawable.HandleInput"/> set to true will be checked for their tooltips.
+    /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces. Keep in mind that only children with <see cref="Drawable.HandleMouseInput"/> set to true will be checked for their tooltips.
     /// </summary>
     public class TooltipContainer : CursorEffectContainer<TooltipContainer, IHasTooltip>
     {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -50,7 +50,6 @@ namespace osu.Framework.Graphics
         {
             handleKeyboardInput = HandleInputCache.HandleKeyboardInput(this);
             handleMouseInput = HandleInputCache.HandleMouseInput(this);
-            handleInput = HandleInputCache.HandleInput(this);
         }
 
         ~Drawable()
@@ -1841,27 +1840,22 @@ namespace osu.Framework.Graphics
         /// is propagated up the scene graph to the next eligible Drawable.</returns>
         protected virtual bool OnMouseMove(InputState state) => false;
 
-        private readonly bool handleInput, handleKeyboardInput, handleMouseInput;
-        /// <summary>
-        /// Whether this <see cref="Drawable"/> handles input.
-        /// This value is true by default if any "On-" input methods are overridden.
-        /// </summary>
-        public virtual bool HandleInput => handleInput;
+        private readonly bool handleKeyboardInput, handleMouseInput;
 
         /// <summary>
         /// Whether this <see cref="Drawable"/> handles keyboard input.
-        /// This value is true by default if any keyboard specific "On-" input methods are overridden.
+        /// This value is true by default if any keyboard related "On-" input methods are overridden.
         /// </summary>
         public virtual bool HandleKeyboardInput => handleKeyboardInput;
 
         /// <summary>
         /// Whether this <see cref="Drawable"/> handles mouse input.
-        /// This value is true by default if any mouse specific "On-" input methods are overridden.
+        /// This value is true by default if any mouse related "On-" input methods are overridden.
         /// </summary>
         public virtual bool HandleMouseInput => handleMouseInput;
 
         /// <summary>
-        /// Nested class which is used for caching <see cref="HandleInput"/>, <see cref="HandleKeyboardInput"/>, <see cref="HandleMouseInput"/> values obtained via reflection.
+        /// Nested class which is used for caching <see cref="HandleKeyboardInput"/>, <see cref="HandleMouseInput"/> values obtained via reflection.
         /// </summary>
         private static class HandleInputCache
         {
@@ -1890,8 +1884,6 @@ namespace osu.Framework.Graphics
                 nameof(OnKeyDown),
                 nameof(OnKeyUp)
             };
-
-            public static bool HandleInput(Drawable drawable) => HandleKeyboardInput(drawable) || HandleMouseInput(drawable);
 
             public static bool HandleKeyboardInput(Drawable drawable) => get(drawable, keyboard_cached_values, keyboard_input_methods);
 
@@ -1964,9 +1956,14 @@ namespace osu.Framework.Graphics
         public virtual bool Contains(Vector2 screenSpacePos) => DrawRectangle.Contains(ToLocalSpace(screenSpacePos));
 
         /// <summary>
-        /// Whether this Drawable can receive input, taking into account all optimizations and masking.
+        /// Whether this Drawable can keyboard receive input, taking into account all optimizations and masking.
         /// </summary>
-        public bool CanReceiveInput => HandleInput && IsPresent && !IsMaskedAway;
+        public bool CanReceiveKeyboardInput => HandleKeyboardInput && IsPresent && !IsMaskedAway;
+
+        /// <summary>
+        /// Whether this Drawable can mouse receive input, taking into account all optimizations and masking.
+        /// </summary>
+        public bool CanReceiveMouseInput => HandleMouseInput && IsPresent && !IsMaskedAway;
 
         /// <summary>
         /// Creates a new InputState with mouse coodinates converted to the coordinate space of our parent.
@@ -1991,7 +1988,7 @@ namespace osu.Framework.Graphics
         /// <returns>Whether we have added ourself to the queue.</returns>
         internal virtual bool BuildKeyboardInputQueue(List<Drawable> queue)
         {
-            if (!CanReceiveInput || !HandleKeyboardInput)
+            if (!CanReceiveKeyboardInput)
                 return false;
 
             queue.Add(this);
@@ -2008,7 +2005,7 @@ namespace osu.Framework.Graphics
         /// <returns>Whether we have added ourself to the queue.</returns>
         internal virtual bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
         {
-            if (!CanReceiveInput || !HandleMouseInput || !ReceiveMouseInputAt(screenSpaceMousePos))
+            if (!CanReceiveMouseInput || !ReceiveMouseInputAt(screenSpaceMousePos))
                 return false;
 
             queue.Add(this);

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1991,7 +1991,7 @@ namespace osu.Framework.Graphics
         /// <returns>Whether we have added ourself to the queue.</returns>
         internal virtual bool BuildKeyboardInputQueue(List<Drawable> queue)
         {
-            if (!CanReceiveInput)
+            if (!CanReceiveInput || !HandleKeyboardInput)
                 return false;
 
             queue.Add(this);
@@ -2008,7 +2008,7 @@ namespace osu.Framework.Graphics
         /// <returns>Whether we have added ourself to the queue.</returns>
         internal virtual bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
         {
-            if (!CanReceiveInput || !ReceiveMouseInputAt(screenSpaceMousePos))
+            if (!CanReceiveInput || !HandleMouseInput || !ReceiveMouseInputAt(screenSpaceMousePos))
                 return false;
 
             queue.Add(this);

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -483,7 +483,6 @@ namespace osu.Framework.Graphics.Performance
                 Sprite.Texture = atlas.Add(WIDTH, HEIGHT);
             }
 
-            public override bool HandleInput => false;
             public override bool HandleKeyboardInput => false;
             public override bool HandleMouseInput => false;
         }

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -484,6 +484,8 @@ namespace osu.Framework.Graphics.Performance
             }
 
             public override bool HandleInput => false;
+            public override bool HandleKeyboardInput => false;
+            public override bool HandleMouseInput => false;
         }
 
         private class CounterBar : Container

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -121,7 +121,6 @@ namespace osu.Framework.Graphics.Sprites
 
         private FontStore store;
 
-        public override bool HandleInput => false;
         public override bool HandleKeyboardInput => false;
         public override bool HandleMouseInput => false;
 

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -122,6 +122,8 @@ namespace osu.Framework.Graphics.Sprites
         private FontStore store;
 
         public override bool HandleInput => false;
+        public override bool HandleKeyboardInput => false;
+        public override bool HandleMouseInput => false;
 
         /// <summary>
         /// Creates a new sprite text. <see cref="Container{T}.AutoSizeAxes"/> is set to <see cref="Axes.Both"/> by default.

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -146,6 +146,8 @@ namespace osu.Framework.Graphics.Visualisation
         private const float font_size = 14;
 
         public override bool HandleInput => false;
+        public override bool HandleKeyboardInput => false;
+        public override bool HandleMouseInput => false;
 
         public DrawableLogEntry(LogEntry entry)
         {

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -145,7 +145,6 @@ namespace osu.Framework.Graphics.Visualisation
 
         private const float font_size = 14;
 
-        public override bool HandleInput => false;
         public override bool HandleKeyboardInput => false;
         public override bool HandleMouseInput => false;
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -572,7 +572,7 @@ namespace osu.Framework.Input
 
             // click pass, triggering an OnClick on all drawables up to the first which returns true.
             // an extra IsHovered check is performed because we are using an outdated queue (for valid reasons which we need to document).
-            clickedDrawable = intersectingQueue.FirstOrDefault(t => t.CanReceiveInput && t.ReceiveMouseInputAt(state.Mouse.Position) && t.TriggerOnClick(state));
+            clickedDrawable = intersectingQueue.FirstOrDefault(t => t.CanReceiveMouseInput && t.ReceiveMouseInputAt(state.Mouse.Position) && t.TriggerOnClick(state));
 
             if (clickedDrawable != null)
             {

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Input
 
         internal override bool BuildKeyboardInputQueue(List<Drawable> queue)
         {
-            if (!CanReceiveInput) return false;
+            if (!CanReceiveKeyboardInput) return false;
 
             if (UseParentState)
                 queue.Add(this);
@@ -25,7 +25,7 @@ namespace osu.Framework.Input
 
         internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
         {
-            if (!CanReceiveInput) return false;
+            if (!CanReceiveMouseInput) return false;
 
             if (UseParentState)
                 queue.Add(this);

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -63,6 +63,8 @@ namespace osu.Framework.Screens
         // children inside childScreenContainer.
         // this means the root screen always received input.
         public override bool HandleInput => IsCurrentScreen || !hasExited && ParentScreen == null;
+        public override bool HandleKeyboardInput => HandleInput;
+        public override bool HandleMouseInput => HandleInput;
 
         /// <summary>
         /// Called when this Screen is being entered. Only happens once, ever.
@@ -236,6 +238,8 @@ namespace osu.Framework.Screens
         protected class ContentContainer : Container
         {
             public override bool HandleInput => LifetimeEnd == double.MaxValue;
+            public override bool HandleKeyboardInput => HandleInput;
+            public override bool HandleMouseInput => HandleInput;
             public override bool RemoveWhenNotAlive => false;
 
             public ContentContainer()

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -62,9 +62,8 @@ namespace osu.Framework.Screens
         // in the case we don't have a parent screen, we still want to handle input as we are also responsible for
         // children inside childScreenContainer.
         // this means the root screen always received input.
-        public override bool HandleInput => IsCurrentScreen || !hasExited && ParentScreen == null;
-        public override bool HandleKeyboardInput => HandleInput;
-        public override bool HandleMouseInput => HandleInput;
+        public override bool HandleKeyboardInput => IsCurrentScreen || !hasExited && ParentScreen == null;
+        public override bool HandleMouseInput => IsCurrentScreen || !hasExited && ParentScreen == null;
 
         /// <summary>
         /// Called when this Screen is being entered. Only happens once, ever.
@@ -237,9 +236,8 @@ namespace osu.Framework.Screens
 
         protected class ContentContainer : Container
         {
-            public override bool HandleInput => LifetimeEnd == double.MaxValue;
-            public override bool HandleKeyboardInput => HandleInput;
-            public override bool HandleMouseInput => HandleInput;
+            public override bool HandleKeyboardInput => LifetimeEnd == double.MaxValue;
+            public override bool HandleMouseInput => LifetimeEnd == double.MaxValue;
             public override bool RemoveWhenNotAlive => false;
 
             public ContentContainer()


### PR DESCRIPTION
At the moment both keyboard and mouse input queues are built using `CanReceiveInput`(which depends on `HandleInput` property).
Since `HandleInput` does not distinguish keyboard and mouse events this causes one small problem. Keyboard queue can contain drawables which handles only mouse events and mouse queue can contain drawables which handles only keyboard events which is not correct.

I guess that not having unnecessary drawables in input queues is good in terms of performance.

On the other hand, I did increase the number of properties. :(
I hope this is acceptable since we do not override `HandleInput` often.
All overrides in osu! solution:
![handleinput_overrides](https://user-images.githubusercontent.com/22450664/34654275-97b5839c-f40a-11e7-92a7-7830e745954c.jpg)

[osu! game](https://github.com/UselessToucan/osu/tree/RefactorInputQueues) branch which I can PR if required.
