### PR TITLE
Fixed possible nullref in tests

### DIFF
--- a/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected override void PopIn()
         {
-            Schedule(() => GetContainingInputManager().TriggerFocusContention(this));
+            Schedule(() => GetContainingInputManager()?.TriggerFocusContention(this));
         }
 
         protected override void PopOut()

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -259,7 +259,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         protected override bool OnMouseMove(InputState state)
         {
-            overlay.Target = targetSearching ? findTarget(state) : inputManager.HoveredDrawables.OfType<VisualisedDrawable>().FirstOrDefault()?.Target;
+            overlay.Target = targetSearching ? findTarget(state) : inputManager?.HoveredDrawables.OfType<VisualisedDrawable>().FirstOrDefault()?.Target;
             return base.OnMouseMove(state);
         }
     }


### PR DESCRIPTION
Closes ppy/osu#1781 .

As mentioned there, this is only a quick fix for a different potential issue:
Since the `GetContainingInputManager` call relies on parent accessors, it can return null if `this` is removed from the object tree before the call happens (even though you would usually expect a result).

Not sure if it's necessary (since most of the time it won't be a problem), but we could also return some kind of dummy object that replaces all calls with no-ops instead of null-checking.