### PR TITLE
Fix precision not working for BindableInt/BindableLong

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseBindableNumbers.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBindableNumbers.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseBindableNumbers : TestCase
+    {
+        private readonly BindableInt bindableInt = new BindableInt();
+        private readonly BindableLong bindableLong = new BindableLong();
+        private readonly BindableDouble bindableDouble = new BindableDouble();
+        private readonly BindableFloat bindableFloat = new BindableFloat();
+
+        public TestCaseBindableNumbers()
+        {
+            AddStep("Reset", () =>
+            {
+                setValue(0);
+                setPrecision(1);
+            });
+
+            AddStep("Value = 10", () => setValue(10));
+            AddAssert("Check = 10", () => checkExact(10));
+
+            AddStep("Precision = 3", () => setPrecision(3));
+            AddStep("Value = 4", () => setValue(3));
+            AddAssert("Check = 3", () => checkExact(3));
+            AddStep("Value = 5", () => setValue(5));
+            AddAssert("Check = 6", () => checkExact(6));
+            AddStep("Value = 59", () => setValue(59));
+            AddAssert("Check 60", () => checkExact(60));
+
+            AddStep("Precision = 10", () => setPrecision(10));
+            AddStep("Value = 6", () => setValue(6));
+            AddAssert("Check = 10", () => checkExact(10));
+
+            AddSliderStep("Value", -1000.0, 1000.0, 0.0, setValue);
+            AddSliderStep("Precision", 1, 10, 1, setPrecision);
+
+            Child = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Content = new[]
+                {
+                    new Drawable[]
+                    {
+                        new BindableDisplayContainer<int>(bindableInt),
+                        new BindableDisplayContainer<long>(bindableLong),
+                    },
+                    new Drawable[]
+                    {
+                        new BindableDisplayContainer<float>(bindableFloat),
+                        new BindableDisplayContainer<double>(bindableDouble),
+                    }
+                }
+            };
+        }
+
+        private bool checkExact(decimal value)
+            => bindableInt.Value == value && bindableLong.Value == value
+            && bindableFloat.Value.ToString(CultureInfo.InvariantCulture) == value.ToString(CultureInfo.InvariantCulture)
+            && bindableDouble.Value.ToString(CultureInfo.InvariantCulture) == value.ToString(CultureInfo.InvariantCulture);
+
+        private void setValue<T>(T value)
+        {
+            bindableInt.Value = Convert.ToInt32(value);
+            bindableLong.Value = Convert.ToInt64(value);
+            bindableDouble.Value = Convert.ToDouble(value);
+            bindableFloat.Value = Convert.ToSingle(value);
+        }
+
+        private void setPrecision<T>(T precision)
+        {
+            bindableInt.Precision = Convert.ToInt32(precision);
+            bindableLong.Precision = Convert.ToInt64(precision);
+            bindableDouble.Precision = Convert.ToDouble(precision);
+            bindableFloat.Precision = Convert.ToSingle(precision);
+        }
+
+        private class BindableDisplayContainer<T> : CompositeDrawable
+            where T : struct
+        {
+            public BindableDisplayContainer(BindableNumber<T> bindable)
+            {
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                SpriteText valueText;
+                InternalChild = new FillFlowContainer
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        new SpriteText { Text = $"{typeof(T).Name} value:" },
+                        valueText = new SpriteText { Text = bindable.Value.ToString() }
+                    }
+                };
+
+                bindable.ValueChanged += v => valueText.Text = v.ToString();
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/TestCaseBindableNumbers.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBindableNumbers.cs
@@ -31,6 +31,7 @@ namespace osu.Framework.Tests.Visual
             testPrecision10();
             testMinMaxWithoutPrecision();
             testMinMaxWithPrecision();
+            testInvalidPrecision();
 
             AddSliderStep("Min value", -100, 100, -100, setMin);
             AddSliderStep("Max value", -100, 100, 100, setMax);
@@ -118,6 +119,38 @@ namespace osu.Framework.Tests.Visual
             AddAssert("Check = 25", () => checkExact(25));
         }
 
+        /// <summary>
+        /// Tests that invalid precisions cause exceptions.
+        /// </summary>
+        private void testInvalidPrecision()
+        {
+            AddAssert("Precision = 0 throws", () =>
+            {
+                try
+                {
+                    setPrecision(0);
+                    return false;
+                }
+                catch (Exception)
+                {
+                    return true;
+                }
+            });
+
+            AddAssert("Precision = -1 throws", () =>
+            {
+                try
+                {
+                    setPrecision(-1);
+                    return false;
+                }
+                catch (Exception)
+                {
+                    return true;
+                }
+            });
+        }
+
         private bool checkExact(decimal value)
             => bindableInt.Value == value && bindableLong.Value == value
             && bindableFloat.Value.ToString(CultureInfo.InvariantCulture) == value.ToString(CultureInfo.InvariantCulture)
@@ -156,7 +189,7 @@ namespace osu.Framework.Tests.Visual
         }
 
         private class BindableDisplayContainer<T> : CompositeDrawable
-            where T : struct
+            where T : struct, IComparable
         {
             public BindableDisplayContainer(BindableNumber<T> bindable)
             {

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="VisualTestGame.cs" />
     <Compile Include="Visual\FrameworkTestCase.cs" />
     <Compile Include="Visual\TestCaseAnimation.cs" />
+    <Compile Include="Visual\TestCaseBindableNumbers.cs" />
     <Compile Include="Visual\TestCaseBlending.cs" />
     <Compile Include="Visual\TestCaseBufferedContainer.cs" />
     <Compile Include="Visual\TestCaseCheckboxes.cs" />

--- a/osu.Framework/Configuration/BindableDouble.cs
+++ b/osu.Framework/Configuration/BindableDouble.cs
@@ -3,27 +3,12 @@
 
 using System;
 using System.Globalization;
-using OpenTK;
 
 namespace osu.Framework.Configuration
 {
     public class BindableDouble : BindableNumber<double>
     {
         public override bool IsDefault => Math.Abs(Value - Default) < Precision;
-
-        public override double Value
-        {
-            get { return base.Value; }
-            set
-            {
-                double boundValue = MathHelper.Clamp(value, MinValue, MaxValue);
-
-                if (Precision > double.Epsilon)
-                    boundValue = Math.Round(boundValue / Precision) * Precision;
-
-                base.Value = boundValue;
-            }
-        }
 
         protected override double DefaultMinValue => double.MinValue;
         protected override double DefaultMaxValue => double.MaxValue;

--- a/osu.Framework/Configuration/BindableDouble.cs
+++ b/osu.Framework/Configuration/BindableDouble.cs
@@ -34,26 +34,6 @@ namespace osu.Framework.Configuration
         {
         }
 
-        /// <summary>
-        /// Binds outselves to another bindable such that they receive bi-directional updates.
-        /// We will take on any value limitations of the bindable we bind width.
-        /// </summary>
-        /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
-        public override void BindTo(Bindable<double> them)
-        {
-            if (them is BindableDouble other)
-            {
-                Precision = Math.Max(Precision, other.Precision);
-                MinValue = Math.Max(MinValue, other.MinValue);
-                MaxValue = Math.Min(MaxValue, other.MaxValue);
-                if (MinValue > MaxValue)
-                    throw new ArgumentOutOfRangeException(
-                        $"Can not weld bindable doubles with non-overlapping min/max-ranges. The ranges were [{MinValue} - {MaxValue}] and [{other.MinValue} - {other.MaxValue}].", nameof(them));
-            }
-
-            base.BindTo(them);
-        }
-
         public override string ToString() => Value.ToString("0.0###", NumberFormatInfo.InvariantInfo);
 
         /// <summary>

--- a/osu.Framework/Configuration/BindableDouble.cs
+++ b/osu.Framework/Configuration/BindableDouble.cs
@@ -27,8 +27,7 @@ namespace osu.Framework.Configuration
         /// <param name="input">The input which is to be parsed.</param>
         public override void Parse(object input)
         {
-            string str = input as string;
-            if (str == null)
+            if (!(input is string str))
                 throw new InvalidCastException($@"Input type {input.GetType()} could not be cast to a string for parsing");
 
             var parsed = double.Parse(str, NumberFormatInfo.InvariantInfo);

--- a/osu.Framework/Configuration/BindableFloat.cs
+++ b/osu.Framework/Configuration/BindableFloat.cs
@@ -34,26 +34,6 @@ namespace osu.Framework.Configuration
         {
         }
 
-        /// <summary>
-        /// Binds outselves to another bindable such that they receive bi-directional updates.
-        /// We will take on any value limitations of the bindable we bind width.
-        /// </summary>
-        /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
-        public override void BindTo(Bindable<float> them)
-        {
-            if (them is BindableFloat other)
-            {
-                Precision = Math.Max(Precision, other.Precision);
-                MinValue = Math.Max(MinValue, other.MinValue);
-                MaxValue = Math.Min(MaxValue, other.MaxValue);
-                if (MinValue > MaxValue)
-                    throw new ArgumentOutOfRangeException(
-                        $"Can not weld bindable singles with non-overlapping min/max-ranges. The ranges were [{MinValue} - {MaxValue}] and [{other.MinValue} - {other.MaxValue}].", nameof(them));
-            }
-
-            base.BindTo(them);
-        }
-
         public override string ToString() => Value.ToString("0.0###", NumberFormatInfo.InvariantInfo);
 
         /// <summary>

--- a/osu.Framework/Configuration/BindableFloat.cs
+++ b/osu.Framework/Configuration/BindableFloat.cs
@@ -27,8 +27,7 @@ namespace osu.Framework.Configuration
         /// <param name="input">The input which is to be parsed.</param>
         public override void Parse(object input)
         {
-            string str = input as string;
-            if (str == null)
+            if (!(input is string str))
                 throw new InvalidCastException($@"Input type {input.GetType()} could not be cast to a string for parsing");
 
             var parsed = float.Parse(str, NumberFormatInfo.InvariantInfo);

--- a/osu.Framework/Configuration/BindableFloat.cs
+++ b/osu.Framework/Configuration/BindableFloat.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using OpenTK;
 using System;
 using System.Globalization;
 
@@ -10,20 +9,6 @@ namespace osu.Framework.Configuration
     public class BindableFloat : BindableNumber<float>
     {
         public override bool IsDefault => Math.Abs(Value - Default) < Precision;
-
-        public override float Value
-        {
-            get { return base.Value; }
-            set
-            {
-                float boundValue = MathHelper.Clamp(value, MinValue, MaxValue);
-
-                if (Precision > float.Epsilon)
-                    boundValue = (float)Math.Round(boundValue / Precision) * Precision;
-
-                base.Value = boundValue;
-            }
-        }
 
         protected override float DefaultMinValue => float.MinValue;
         protected override float DefaultMaxValue => float.MaxValue;

--- a/osu.Framework/Configuration/BindableInt.cs
+++ b/osu.Framework/Configuration/BindableInt.cs
@@ -19,8 +19,7 @@ namespace osu.Framework.Configuration
 
         public override void Parse(object s)
         {
-            string str = s as string;
-            if (str == null)
+            if (!(s is string str))
                 throw new InvalidCastException($@"Input type {s.GetType()} could not be cast to a string for parsing");
 
             var parsed = int.Parse(str, NumberFormatInfo.InvariantInfo);

--- a/osu.Framework/Configuration/BindableInt.cs
+++ b/osu.Framework/Configuration/BindableInt.cs
@@ -12,7 +12,11 @@ namespace osu.Framework.Configuration
         public override int Value
         {
             get { return base.Value; }
-            set { base.Value = MathHelper.Clamp(value, MinValue, MaxValue); }
+            set
+            {
+                double doubleValue = MathHelper.Clamp(value, MinValue, MaxValue);
+                base.Value = (int)Math.Round(doubleValue / Precision) * Precision;
+            }
         }
 
         protected override int DefaultMinValue => int.MinValue;

--- a/osu.Framework/Configuration/BindableInt.cs
+++ b/osu.Framework/Configuration/BindableInt.cs
@@ -28,21 +28,6 @@ namespace osu.Framework.Configuration
         {
         }
 
-        public override void BindTo(Bindable<int> them)
-        {
-            if (them is BindableInt other)
-            {
-                Precision = Math.Max(Precision, other.Precision);
-                MinValue = Math.Max(MinValue, other.MinValue);
-                MaxValue = Math.Min(MaxValue, other.MaxValue);
-                if (MinValue > MaxValue)
-                    throw new ArgumentOutOfRangeException(
-                        $"Can not weld bindable ints with non-overlapping min/max-ranges. The ranges were [{MinValue} - {MaxValue}] and [{other.MinValue} - {other.MaxValue}].", nameof(them));
-            }
-
-            base.BindTo(them);
-        }
-
         public override void Parse(object s)
         {
             string str = s as string;

--- a/osu.Framework/Configuration/BindableInt.cs
+++ b/osu.Framework/Configuration/BindableInt.cs
@@ -3,22 +3,11 @@
 
 using System;
 using System.Globalization;
-using OpenTK;
 
 namespace osu.Framework.Configuration
 {
     public class BindableInt : BindableNumber<int>
     {
-        public override int Value
-        {
-            get { return base.Value; }
-            set
-            {
-                double doubleValue = MathHelper.Clamp(value, MinValue, MaxValue);
-                base.Value = (int)Math.Round(doubleValue / Precision) * Precision;
-            }
-        }
-
         protected override int DefaultMinValue => int.MinValue;
         protected override int DefaultMaxValue => int.MaxValue;
         protected override int DefaultPrecision => 1;

--- a/osu.Framework/Configuration/BindableInt.cs
+++ b/osu.Framework/Configuration/BindableInt.cs
@@ -30,14 +30,14 @@ namespace osu.Framework.Configuration
 
         public override void BindTo(Bindable<int> them)
         {
-            var i = them as BindableInt;
-            if (i != null)
+            if (them is BindableInt other)
             {
-                MinValue = Math.Max(MinValue, i.MinValue);
-                MaxValue = Math.Min(MaxValue, i.MaxValue);
+                Precision = Math.Max(Precision, other.Precision);
+                MinValue = Math.Max(MinValue, other.MinValue);
+                MaxValue = Math.Min(MaxValue, other.MaxValue);
                 if (MinValue > MaxValue)
                     throw new ArgumentOutOfRangeException(
-                        $"Can not weld bindable ints with non-overlapping min/max-ranges. The ranges were [{MinValue} - {MaxValue}] and [{i.MinValue} - {i.MaxValue}].", nameof(them));
+                        $"Can not weld bindable ints with non-overlapping min/max-ranges. The ranges were [{MinValue} - {MaxValue}] and [{other.MinValue} - {other.MaxValue}].", nameof(them));
             }
 
             base.BindTo(them);

--- a/osu.Framework/Configuration/BindableLong.cs
+++ b/osu.Framework/Configuration/BindableLong.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using OpenTK;
 
 namespace osu.Framework.Configuration
 {
@@ -11,7 +12,11 @@ namespace osu.Framework.Configuration
         public override long Value
         {
             get { return base.Value; }
-            set { base.Value = Math.Max(MinValue, Math.Min(MaxValue, value)); }
+            set
+            {
+                double doubleValue = MathHelper.Clamp(value, MinValue, MaxValue);
+                base.Value = (long)Math.Round(doubleValue / Precision) * Precision;
+            }
         }
 
         protected override long DefaultMinValue => long.MinValue;

--- a/osu.Framework/Configuration/BindableLong.cs
+++ b/osu.Framework/Configuration/BindableLong.cs
@@ -19,8 +19,7 @@ namespace osu.Framework.Configuration
 
         public override void Parse(object s)
         {
-            string str = s as string;
-            if (str == null)
+            if (!(s is string str))
                 throw new InvalidCastException($@"Input type {s.GetType()} could not be cast to a string for parsing");
 
             var parsed = long.Parse(str, NumberFormatInfo.InvariantInfo);

--- a/osu.Framework/Configuration/BindableLong.cs
+++ b/osu.Framework/Configuration/BindableLong.cs
@@ -30,14 +30,14 @@ namespace osu.Framework.Configuration
 
         public override void BindTo(Bindable<long> them)
         {
-            var i = them as BindableLong;
-            if (i != null)
+            if (them is BindableLong other)
             {
-                MinValue = Math.Max(MinValue, i.MinValue);
-                MaxValue = Math.Min(MaxValue, i.MaxValue);
+                Precision = Math.Max(Precision, other.Precision);
+                MinValue = Math.Max(MinValue, other.MinValue);
+                MaxValue = Math.Min(MaxValue, other.MaxValue);
                 if (MinValue > MaxValue)
                     throw new ArgumentOutOfRangeException(
-                        $"Can not weld bindable longs with non-overlapping min/max-ranges. The ranges were [{MinValue} - {MaxValue}] and [{i.MinValue} - {i.MaxValue}].", nameof(them));
+                        $"Can not weld bindable longs with non-overlapping min/max-ranges. The ranges were [{MinValue} - {MaxValue}] and [{other.MinValue} - {other.MaxValue}].", nameof(them));
             }
 
             base.BindTo(them);

--- a/osu.Framework/Configuration/BindableLong.cs
+++ b/osu.Framework/Configuration/BindableLong.cs
@@ -3,22 +3,11 @@
 
 using System;
 using System.Globalization;
-using OpenTK;
 
 namespace osu.Framework.Configuration
 {
     public class BindableLong : BindableNumber<long>
     {
-        public override long Value
-        {
-            get { return base.Value; }
-            set
-            {
-                double doubleValue = MathHelper.Clamp(value, MinValue, MaxValue);
-                base.Value = (long)Math.Round(doubleValue / Precision) * Precision;
-            }
-        }
-
         protected override long DefaultMinValue => long.MinValue;
         protected override long DefaultMaxValue => long.MaxValue;
         protected override long DefaultPrecision => 1;

--- a/osu.Framework/Configuration/BindableLong.cs
+++ b/osu.Framework/Configuration/BindableLong.cs
@@ -28,21 +28,6 @@ namespace osu.Framework.Configuration
         {
         }
 
-        public override void BindTo(Bindable<long> them)
-        {
-            if (them is BindableLong other)
-            {
-                Precision = Math.Max(Precision, other.Precision);
-                MinValue = Math.Max(MinValue, other.MinValue);
-                MaxValue = Math.Min(MaxValue, other.MaxValue);
-                if (MinValue > MaxValue)
-                    throw new ArgumentOutOfRangeException(
-                        $"Can not weld bindable longs with non-overlapping min/max-ranges. The ranges were [{MinValue} - {MaxValue}] and [{other.MinValue} - {other.MaxValue}].", nameof(them));
-            }
-
-            base.BindTo(them);
-        }
-
         public override void Parse(object s)
         {
             string str = s as string;

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -8,7 +8,7 @@ using OpenTK;
 namespace osu.Framework.Configuration
 {
     public abstract class BindableNumber<T> : Bindable<T>
-        where T : struct, IComparable
+        where T : struct, IComparable, IConvertible
     {
         static BindableNumber()
         {
@@ -59,7 +59,7 @@ namespace osu.Framework.Configuration
                 if (precision.Equals(value))
                     return;
 
-                if (value.CompareTo(Convert.ChangeType(0, typeof(T))) <= 0)
+                if (Convert.ToDouble(value) <= 0)
                     throw new ArgumentOutOfRangeException(nameof(Precision), "Must be greater than 0.");
 
                 precision = value;
@@ -68,6 +68,21 @@ namespace osu.Framework.Configuration
             }
         }
 
+        public override T Value
+        {
+            get { return base.Value; }
+            set
+            {
+                double doubleValue = Convert.ToDouble(clamp(value, MinValue, MaxValue));
+
+                if (Precision.CompareTo(DefaultPrecision) > 0)
+                    doubleValue = Math.Round(doubleValue / Convert.ToDouble(Precision)) * Convert.ToDouble(Precision);
+
+                // ReSharper disable once PossibleNullReferenceException
+                // https://youtrack.jetbrains.com/issue/RIDER-12652
+                base.Value = (T)Convert.ChangeType(doubleValue, typeof(T));
+            }
+        }
 
         /// <summary>
         /// The minimum value of this bindable. <see cref="Bindable{T}.Value"/> will never go below this value.

--- a/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
@@ -1,13 +1,15 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    public class BasicSliderBar<T> : SliderBar<T> where T : struct
+    public class BasicSliderBar<T> : SliderBar<T>
+        where T : struct, IComparable
     {
         public Color4 Color
         {

--- a/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Shapes;
 namespace osu.Framework.Graphics.UserInterface
 {
     public class BasicSliderBar<T> : SliderBar<T>
-        where T : struct, IComparable
+        where T : struct, IComparable, IConvertible
     {
         public Color4 Color
         {

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -12,7 +12,7 @@ using System.Diagnostics;
 namespace osu.Framework.Graphics.UserInterface
 {
     public abstract class SliderBar<T> : Container, IHasCurrentValue<T>
-        where T : struct
+        where T : struct, IComparable
     {
         /// <summary>
         /// Range padding reduces the range of movement a slider bar is allowed to have

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -12,7 +12,7 @@ using System.Diagnostics;
 namespace osu.Framework.Graphics.UserInterface
 {
     public abstract class SliderBar<T> : Container, IHasCurrentValue<T>
-        where T : struct, IComparable
+        where T : struct, IComparable, IConvertible
     {
         /// <summary>
         /// Range padding reduces the range of movement a slider bar is allowed to have

--- a/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
@@ -14,7 +14,7 @@ using osu.Framework.Extensions.Color4Extensions;
 namespace osu.Framework.Testing.Drawables.Steps
 {
     public class StepSlider<T> : SliderBar<T>
-        where T : struct, IComparable
+        where T : struct, IComparable, IConvertible
     {
         private readonly Box selection;
         private readonly Box background;

--- a/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
@@ -14,7 +14,7 @@ using osu.Framework.Extensions.Color4Extensions;
 namespace osu.Framework.Testing.Drawables.Steps
 {
     public class StepSlider<T> : SliderBar<T>
-        where T : struct
+        where T : struct, IComparable
     {
         private readonly Box selection;
         private readonly Box background;

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -255,7 +255,7 @@ namespace osu.Framework.Testing
         }
 
         protected void AddSliderStep<T>(string description, T min, T max, T start, Action<T> valueChanged)
-            where T : struct, IComparable
+            where T : struct, IComparable, IConvertible
         {
             StepsContainer.Add(new StepSlider<T>(description, min, max, start)
             {

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -255,7 +255,7 @@ namespace osu.Framework.Testing
         }
 
         protected void AddSliderStep<T>(string description, T min, T max, T start, Action<T> valueChanged)
-            where T : struct
+            where T : struct, IComparable
         {
             StepsContainer.Add(new StepSlider<T>(description, min, max, start)
             {


### PR DESCRIPTION
* Fixes Precision not working for BindableInt/BindableLong.
* Cleans up/consolidates a lot of code that was shared between all numeric BindableNumber implementations.
* Adds testcase.