### PR TITLE
Fix GridContainer not performing layout/loading children before Update

### DIFF
--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using osu.Framework.Allocation;
 using OpenTK;
 using osu.Framework.Caching;
 
@@ -64,6 +65,13 @@ namespace osu.Framework.Graphics.Containers
 
                 cellLayout.Invalidate();
             }
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            layoutContent();
+            layoutCells();
         }
 
         protected override void Update()


### PR DESCRIPTION
There are three scenarios where this is desired:

1. Fully async-loading a grid structure.
    * `GridContainer` will currently load itself, but because its children aren't added until the `layoutContent` which is called during `Update`, its children won't be loaded until the first `Update`, at which point they'll load synchronously.
2. If an object is added to a GridContainer and that object constructs a child inside its load() method, an outsider cannot indirectly reference that child expecting it to be constructed.
    * E.g.
```
GridContainer
    -> Contains a playfield

load()
    -> playfield.Add(myHitObject) // Will fail because the hitobject list is constructed in playfield's load, which hasn't been called yet due to its wrapping GridContainer
``` 