### PR TITLE
Don't layout cells in GridContainer's BDL

### DIFF
--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -71,7 +71,6 @@ namespace osu.Framework.Graphics.Containers
         private void load()
         {
             layoutContent();
-            layoutCells();
         }
 
         protected override void Update()


### PR DESCRIPTION
This is a pretty useless computation to be done at this point in time for a few reasons:

1. It is wrong in terms of getting correct sizing since we don't have a parent at this point.
2. The cell layout is invalidated upon LoadComplete (and hence re-computed in Update) anyway.