### PR TITLE
Add IHandleGlobalInput to TooltipContainer

### DIFF
--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Graphics.Cursor
     /// <summary>
     /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces. Keep in mind that only children with <see cref="Drawable.HandleInput"/> set to true will be checked for their tooltips.
     /// </summary>
-    public class TooltipContainer : CursorEffectContainer<TooltipContainer, IHasTooltip>
+    public class TooltipContainer : CursorEffectContainer<TooltipContainer, IHasTooltip>, IHandleGlobalInput
     {
         private readonly CursorContainer cursorContainer;
         private readonly ITooltip defaultTooltip;


### PR DESCRIPTION
This fixes tooltips not working inside `OverlayContainer`.