### PR TITLE
Fix DllResourceStore not being able to handle hyphens in file path

### DIFF
--- a/osu.Framework/IO/Stores/DllResourceStore.cs
+++ b/osu.Framework/IO/Stores/DllResourceStore.cs
@@ -32,7 +32,11 @@ namespace osu.Framework.IO.Stores
 
         public Stream GetStream(string name)
         {
-            return assembly?.GetManifestResourceStream($@"{space}.{name.Replace('/', '.')}");
+            var split = name.Split('/');
+            for (int i = 0; i < split.Length - 1; i++)
+                split[i] = split[i].Replace('-', '_');
+
+            return assembly?.GetManifestResourceStream($@"{space}.{string.Join(".", split)}");
         }
     }
 }


### PR DESCRIPTION
Note that everything _but the last_ string here has its hyphens replaced by underscores. This is intentional because only the directory paths in the manifest replace the hyphens. The actual file names don't.