### PR TITLE
Clean up tests

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseAnimation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseAnimation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;

--- a/osu.Framework.Tests/Visual/TestCaseAnimation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseAnimation.cs
@@ -14,7 +14,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     [System.ComponentModel.Description("frame-based animations")]
     public class TestCaseAnimation : TestCase
     {

--- a/osu.Framework.Tests/Visual/TestCaseBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBufferedContainer.cs
@@ -8,7 +8,6 @@ using OpenTK;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseBufferedContainer : TestCaseMasking
     {
         private readonly BufferedContainer buffer;

--- a/osu.Framework.Tests/Visual/TestCaseBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBufferedContainer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using OpenTK;

--- a/osu.Framework.Tests/Visual/TestCaseCheckboxes.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCheckboxes.cs
@@ -10,7 +10,6 @@ using OpenTK;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseCheckboxes : TestCase
     {
         public TestCaseCheckboxes()

--- a/osu.Framework.Tests/Visual/TestCaseCheckboxes.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCheckboxes.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;

--- a/osu.Framework.Tests/Visual/TestCaseCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCircularProgress.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Textures;

--- a/osu.Framework.Tests/Visual/TestCaseCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCircularProgress.cs
@@ -12,7 +12,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseCircularProgress : TestCase
     {
         private readonly CircularProgress clock;

--- a/osu.Framework.Tests/Visual/TestCaseColourGradient.cs
+++ b/osu.Framework.Tests/Visual/TestCaseColourGradient.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseColourGradient.cs
+++ b/osu.Framework.Tests/Visual/TestCaseColourGradient.cs
@@ -12,8 +12,7 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
-    internal class TestCaseColourGradient : GridTestCase
+    public class TestCaseColourGradient : GridTestCase
     {
         public TestCaseColourGradient() : base(2, 2)
         {

--- a/osu.Framework.Tests/Visual/TestCaseContainerState.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContainerState.cs
@@ -11,7 +11,6 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     [System.ComponentModel.Description("ensure valid container state in various scenarios")]
     public class TestCaseContainerState : TestCase
     {

--- a/osu.Framework.Tests/Visual/TestCaseContextMenu.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContextMenu.cs
@@ -13,7 +13,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseContextMenu : TestCase
     {
         private const int start_time = 0;

--- a/osu.Framework.Tests/Visual/TestCaseContextMenu.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContextMenu.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;

--- a/osu.Framework.Tests/Visual/TestCaseCoordinateSpaces.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCoordinateSpaces.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Globalization;
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseCoordinateSpaces.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCoordinateSpaces.cs
@@ -13,7 +13,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseCoordinateSpaces : TestCase
     {
         public TestCaseCoordinateSpaces()

--- a/osu.Framework.Tests/Visual/TestCaseCoordinateSpaces.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCoordinateSpaces.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Globalization;
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
@@ -13,7 +13,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseDelayedLoad : TestCase
     {
         private const int panel_count = 2048;

--- a/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawSizePreservingFillContainer.cs
@@ -11,7 +11,6 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseDrawSizePreservingFillContainer : TestCase
     {
         public TestCaseDrawSizePreservingFillContainer()

--- a/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
@@ -15,8 +15,7 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
-    internal class TestCaseDrawablePath : GridTestCase
+    public class TestCaseDrawablePath : GridTestCase
     {
         public TestCaseDrawablePath() : base(2, 2)
         {

--- a/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Collections.Generic;
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.OpenGL.Textures;

--- a/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Collections.Generic;
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.OpenGL.Textures;

--- a/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;

--- a/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDropdownBox.cs
@@ -13,7 +13,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseDropdownBox : TestCase
     {
         private const int items_to_add = 10;

--- a/osu.Framework.Tests/Visual/TestCaseDynamicDepth.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDynamicDepth.cs
@@ -12,7 +12,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     [System.ComponentModel.Description("changing depth of child dynamically")]
     public class TestCaseDynamicDepth : TestCase
     {

--- a/osu.Framework.Tests/Visual/TestCaseDynamicDepth.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDynamicDepth.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseEffects.cs
+++ b/osu.Framework.Tests/Visual/TestCaseEffects.cs
@@ -14,7 +14,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     [System.ComponentModel.Description("implementing the IEffect interface")]
     public class TestCaseEffects : TestCase
     {

--- a/osu.Framework.Tests/Visual/TestCaseEffects.cs
+++ b/osu.Framework.Tests/Visual/TestCaseEffects.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
@@ -19,7 +19,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseFillFlowContainer : TestCase
     {
         private FillDirectionDropdown selectionDropdown;

--- a/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseFillModes.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillModes.cs
@@ -15,9 +15,8 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     [System.ComponentModel.Description("sprite stretching")]
-    internal class TestCaseFillModes : GridTestCase
+    public class TestCaseFillModes : GridTestCase
     {
         public TestCaseFillModes() : base(3, 3)
         {

--- a/osu.Framework.Tests/Visual/TestCaseHollowEdgeEffect.cs
+++ b/osu.Framework.Tests/Visual/TestCaseHollowEdgeEffect.cs
@@ -12,7 +12,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseHollowEdgeEffect : GridTestCase
     {
         public TestCaseHollowEdgeEffect() : base(2, 2)

--- a/osu.Framework.Tests/Visual/TestCaseHollowEdgeEffect.cs
+++ b/osu.Framework.Tests/Visual/TestCaseHollowEdgeEffect.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseHollowEdgeEffect.cs
+++ b/osu.Framework.Tests/Visual/TestCaseHollowEdgeEffect.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
@@ -15,9 +15,8 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     [System.ComponentModel.Description("live path optimiastion")]
-    internal class TestCaseInputResampler : GridTestCase
+    public class TestCaseInputResampler : GridTestCase
     {
         public TestCaseInputResampler() : base(3, 3)
         {

--- a/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.OpenGL.Textures;

--- a/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.OpenGL.Textures;

--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -15,7 +15,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseKeyBindings : GridTestCase
     {
         public TestCaseKeyBindings()

--- a/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Globalization;
 using System.IO;
-using NUnit.Framework;
+
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
@@ -17,7 +17,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseLocalisation : TestCase
     {
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable

--- a/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLocalisation.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Globalization;
 using System.IO;
-
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/TestCaseMasking.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMasking.cs
@@ -14,7 +14,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseMasking : TestCase
     {
         protected Container TestContainer;

--- a/osu.Framework.Tests/Visual/TestCaseMasking.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMasking.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseMasking.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMasking.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
+++ b/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
@@ -12,7 +12,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseNestedHover : TestCase
     {
         public TestCaseNestedHover()

--- a/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
+++ b/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
+++ b/osu.Framework.Tests/Visual/TestCaseNestedHover.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCasePadding.cs
+++ b/osu.Framework.Tests/Visual/TestCasePadding.cs
@@ -13,8 +13,7 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
-    internal class TestCasePadding : GridTestCase
+    public class TestCasePadding : GridTestCase
     {
         public TestCasePadding() : base(2, 2)
         {

--- a/osu.Framework.Tests/Visual/TestCasePadding.cs
+++ b/osu.Framework.Tests/Visual/TestCasePadding.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCasePadding.cs
+++ b/osu.Framework.Tests/Visual/TestCasePadding.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
+++ b/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
+++ b/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
@@ -10,7 +10,6 @@ using OpenTK;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     [System.ComponentModel.Description("ensure validity of drawables when receiving certain values")]
     public class TestCasePropertyBoundaries : TestCase
     {

--- a/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
+++ b/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
+++ b/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;

--- a/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
+++ b/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
@@ -14,7 +14,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseRigidBody : TestCase
     {
         private readonly TestRigidBodySimulation sim;

--- a/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
+++ b/osu.Framework.Tests/Visual/TestCaseRigidBody.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;

--- a/osu.Framework.Tests/Visual/TestCaseScreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScreen.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseScreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScreen.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using NUnit.Framework;
+
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseScreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScreen.cs
@@ -16,7 +16,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseScreen : TestCase
     {
         public TestCaseScreen()

--- a/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScrollableFlow.cs
@@ -13,7 +13,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseScrollableFlow : TestCase
     {
         private readonly ScheduledDelegate boxCreator;

--- a/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
@@ -13,7 +13,6 @@ using OpenTK;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseSearchContainer : TestCase
     {
         public TestCaseSearchContainer()

--- a/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSearchContainer.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework.Tests/Visual/TestCaseSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSizing.cs
@@ -13,7 +13,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     [System.ComponentModel.Description("potentially challenging size calculations")]
     public class TestCaseSizing : TestCase
     {

--- a/osu.Framework.Tests/Visual/TestCaseSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSizing.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSizing.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseSliderbar.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSliderbar.cs
@@ -11,7 +11,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseSliderbar : TestCase
     {
         // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable

--- a/osu.Framework.Tests/Visual/TestCaseSliderbar.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSliderbar.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Configuration;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;

--- a/osu.Framework.Tests/Visual/TestCaseSliderbar.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSliderbar.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Configuration;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;

--- a/osu.Framework.Tests/Visual/TestCaseSmoothedEdges.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSmoothedEdges.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework.Tests/Visual/TestCaseSmoothedEdges.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSmoothedEdges.cs
@@ -11,8 +11,7 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
-    internal class TestCaseSmoothedEdges : GridTestCase
+    public class TestCaseSmoothedEdges : GridTestCase
     {
         public TestCaseSmoothedEdges() : base(2, 2)
         {

--- a/osu.Framework.Tests/Visual/TestCaseSmoothedEdges.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSmoothedEdges.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
@@ -9,7 +9,6 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseSpriteText : TestCase
     {
         public TestCaseSpriteText()

--- a/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSpriteText.cs
@@ -1,7 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;

--- a/osu.Framework.Tests/Visual/TestCaseTabControl.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTabControl.cs
@@ -17,7 +17,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseTabControl : TestCase
     {
         public TestCaseTabControl()

--- a/osu.Framework.Tests/Visual/TestCaseTabControl.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTabControl.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/TestCaseTextBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextBox.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;

--- a/osu.Framework.Tests/Visual/TestCaseTextBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextBox.cs
@@ -10,7 +10,6 @@ using OpenTK;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseTextBox : TestCase
     {
         public TestCaseTextBox()

--- a/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
@@ -13,7 +13,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     [System.ComponentModel.Description("word-wrap and paragraphs")]
     public class TestCaseTextFlow : TestCase
     {

--- a/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;

--- a/osu.Framework.Tests/Visual/TestCaseTooltip.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTooltip.cs
@@ -14,7 +14,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseTooltip : TestCase
     {
         private readonly Container testContainer;

--- a/osu.Framework.Tests/Visual/TestCaseTooltip.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTooltip.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;

--- a/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
@@ -13,8 +13,7 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
-    internal class TestCaseTransformSequence : GridTestCase
+    public class TestCaseTransformSequence : GridTestCase
     {
         private readonly Container[] boxes;
 

--- a/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
+
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseTriangles.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTriangles.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;

--- a/osu.Framework.Tests/Visual/TestCaseTriangles.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTriangles.cs
@@ -12,7 +12,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    [TestFixture]
     public class TestCaseTriangles : TestCase
     {
         private readonly Container testContainer;

--- a/osu.Framework.Tests/Visual/TestCaseWaveform.cs
+++ b/osu.Framework.Tests/Visual/TestCaseWaveform.cs
@@ -15,7 +15,7 @@ using System;
 
 namespace osu.Framework.Tests.Visual
 {
-    internal class TestCaseWaveform : FrameworkTestCase
+    public class TestCaseWaveform : FrameworkTestCase
     {
         private readonly List<WaveformGraph> waveforms = new List<WaveformGraph>();
 


### PR DESCRIPTION
The `TestFixture` attribute is not required since the base class `TestCase` already has it.