### PR TITLE
Make CursorContainer not an OverlayContainer

### DIFF
--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -9,15 +9,9 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Graphics.Cursor
 {
-    public class CursorContainer : OverlayContainer, IRequireHighFrequencyMousePosition
+    public class CursorContainer : VisibilityContainer, IRequireHighFrequencyMousePosition
     {
         public Drawable ActiveCursor { get; protected set; }
-
-        protected override bool BlockPassThroughMouse => false;
-
-        //OverlayContainer tried to be smart about this, but we don't want none of that.
-        public override bool HandleKeyboardInput => IsPresent;
-        public override bool HandleMouseInput => IsPresent;
 
         public CursorContainer()
         {


### PR DESCRIPTION
Doesn't seem to have any effects (testcase, visualtests, and gameplay). There's no reason why this should be an overlaycontainer imo, since it never requires input to not be passed to children.