### PR TITLE
Fix AutoSizeDuration not being cleared correctly in some cases

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1305,16 +1305,10 @@ namespace osu.Framework.Graphics.Containers
 
             Vector2 b = computeAutoSize() + Padding.Total;
 
-            if (AutoSizeDuration > 0)
-                autoSizeResizeTo(new Vector2(
-                    (AutoSizeAxes & Axes.X) > 0 ? b.X : base.Width,
-                    (AutoSizeAxes & Axes.Y) > 0 ? b.Y : base.Height
-                ), AutoSizeDuration, AutoSizeEasing);
-            else
-            {
-                if ((AutoSizeAxes & Axes.X) > 0) base.Width = b.X;
-                if ((AutoSizeAxes & Axes.Y) > 0) base.Height = b.Y;
-            }
+            autoSizeResizeTo(new Vector2(
+                (AutoSizeAxes & Axes.X) > 0 ? b.X : base.Width,
+                (AutoSizeAxes & Axes.Y) > 0 ? b.Y : base.Height
+            ), AutoSizeDuration, AutoSizeEasing);
 
             //note that this is called before autoSize becomes valid. may be something to consider down the line.
             //might work better to add an OnRefresh event in Cached<> and invoke there.


### PR DESCRIPTION
In a case where AutoSizeDuration is changed from non-zero to zero at runtime, it si possible a previous transform is still running when a subsequent autosize is performed. The previous transform would overwrite the new size and provide an incorrect final size.