### PR TITLE
Cache both the base and the declaring types in DependencyContainer

### DIFF
--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -127,11 +127,8 @@ namespace osu.Framework.Allocation
         /// <summary>
         /// Caches an instance of a type. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
-        public T Cache<T>(T instance = null, bool overwrite = false) where T : class
+        public T Cache<T>(T instance = null) where T : class
         {
-            if (!overwrite && cache.ContainsKey(typeof(T)))
-                throw new InvalidOperationException($@"Type {typeof(T).FullName} is already cached");
-
             if (instance == null)
                 instance = this.Get<T>();
 

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -20,7 +20,6 @@ namespace osu.Framework.Allocation
 
         private readonly ConcurrentDictionary<Type, ObjectActivator> activators = new ConcurrentDictionary<Type, ObjectActivator>();
         private readonly ConcurrentDictionary<Type, object> cache = new ConcurrentDictionary<Type, object>();
-        private readonly HashSet<Type> cacheable = new HashSet<Type>();
 
         private readonly IReadOnlyDependencyContainer parentContainer;
 
@@ -134,7 +133,6 @@ namespace osu.Framework.Allocation
                 throw new InvalidOperationException($@"Type {typeof(T).FullName} is already cached");
             if (instance == null)
                 instance = this.Get<T>();
-            cacheable.Add(typeof(T));
             cache[typeof(T)] = instance;
             return instance;
         }

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -131,9 +131,16 @@ namespace osu.Framework.Allocation
         {
             if (!overwrite && cache.ContainsKey(typeof(T)))
                 throw new InvalidOperationException($@"Type {typeof(T).FullName} is already cached");
+
             if (instance == null)
                 instance = this.Get<T>();
-            cache[typeof(T)] = instance;
+
+            var baseType = typeof(T);
+            var declaringType = instance.GetType();
+
+            cache[baseType] = instance;
+            cache[declaringType] = instance;
+
             return instance;
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -164,7 +164,7 @@ namespace osu.Framework.Graphics
 
         /// <summary>
         /// Contains all dependencies that can be injected into this Drawable using <see cref="BackgroundDependencyLoader"/>.
-        /// Add or override dependencies by calling <see cref="DependencyContainer.Cache{T}(T, bool)"/>.
+        /// Add or override dependencies by calling <see cref="DependencyContainer.Cache{T}(T)"/>.
         /// </summary>
         public IReadOnlyDependencyContainer Dependencies { get; private set; }
 


### PR DESCRIPTION
For example

```
virtual IMyInterface ReturnDerivedType() => new DerivedType();

dependencies.Cache(ReturnDerivedType());
```

Would previously cache one type:
1. An `IMyInterface` type.

Would now cache two types:
1. An `IMyInterface` type.
2. A `DerivedType` type.

One such use-case is configuration, where eventually we'll want Rulesets to create a config manager (e.g. `ManiaConfigManager`), that can only be exposed as a `IRulesetConfigManager`. In this scenario we'd still like the ability to inject a `ManiaConfigManager` into a mania playfield.