### PR TITLE
Allow BDL caching by specific type

### DIFF
--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -20,7 +20,6 @@ namespace osu.Framework.Allocation
 
         private readonly ConcurrentDictionary<Type, ObjectActivator> activators = new ConcurrentDictionary<Type, ObjectActivator>();
         private readonly ConcurrentDictionary<Type, object> cache = new ConcurrentDictionary<Type, object>();
-        private readonly HashSet<Type> cacheable = new HashSet<Type>();
 
         private readonly IReadOnlyDependencyContainer parentContainer;
 
@@ -134,7 +133,6 @@ namespace osu.Framework.Allocation
                 throw new InvalidOperationException($@"Type {typeof(T).FullName} is already cached");
             if (instance == null)
                 instance = this.Get<T>();
-            cacheable.Add(typeof(T));
             cache[typeof(T)] = instance;
             return instance;
         }

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -127,6 +127,7 @@ namespace osu.Framework.Allocation
         /// <summary>
         /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
+        /// <param name="instance">The instance to cache.</param>
         public void Cache<T>(T instance)
             where T : class
         {
@@ -136,8 +137,9 @@ namespace osu.Framework.Allocation
         }
 
         /// <summary>
-        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
+        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
+        /// <param name="instance">The instance to cache. Must be or derive from <typeparamref name="T"/>.</param>
         public void CacheAs<T>(object instance)
             where T : class
         {

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -125,14 +125,26 @@ namespace osu.Framework.Allocation
         }
 
         /// <summary>
-        /// Caches an instance of a type. This instance will be returned each time you <see cref="Get(Type)"/>.
+        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
-        public T Cache<T>(T instance = null) where T : class
+        public void Cache<T>(T instance)
+            where T : class
         {
-            if (instance == null)
-                instance = this.Get<T>();
+            if (instance == null)　throw new ArgumentNullException(nameof(instance));
+
+            cache[instance.GetType()] = instance;
+        }
+
+        /// <summary>
+        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
+        /// </summary>
+        public void CacheAs<T>(object instance)
+            where T : class
+        {
+            if (instance == null)　throw new ArgumentNullException(nameof(instance));
+            if (!(instance is T))　throw new InvalidCastException($"{instance} must be {typeof(T)}.");
+
             cache[typeof(T)] = instance;
-            return instance;
         }
 
         /// <summary>

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -127,10 +127,8 @@ namespace osu.Framework.Allocation
         /// <summary>
         /// Caches an instance of a type. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
-        public T Cache<T>(T instance = null, bool overwrite = false) where T : class
+        public T Cache<T>(T instance = null) where T : class
         {
-            if (!overwrite && cache.ContainsKey(typeof(T)))
-                throw new InvalidOperationException($@"Type {typeof(T).FullName} is already cached");
             if (instance == null)
                 instance = this.Get<T>();
             cache[typeof(T)] = instance;

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -115,12 +115,8 @@ namespace osu.Framework
             samples.AddStore(new NamespacedResourceStore<byte[]>(Resources, @"Samples"));
             samples.AddStore(new OnlineStore());
 
-            Audio = dependencies.Cache(new AudioManager(
-                tracks,
-                samples)
-            {
-                EventScheduler = Scheduler
-            });
+            Audio = new AudioManager(tracks, samples) { EventScheduler = Scheduler };
+            dependencies.Cache(Audio);
 
             Host.RegisterThread(Audio.Thread);
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -164,7 +164,7 @@ namespace osu.Framework.Graphics
 
         /// <summary>
         /// Contains all dependencies that can be injected into this Drawable using <see cref="BackgroundDependencyLoader"/>.
-        /// Add or override dependencies by calling <see cref="DependencyContainer.Cache{T}(T, bool)"/>.
+        /// Add or override dependencies by calling <see cref="DependencyContainer.Cache{T}(T)"/>.
         /// </summary>
         public IReadOnlyDependencyContainer Dependencies { get; private set; }
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -155,8 +155,8 @@ namespace osu.Framework.Platform
 
             FileSafety.DeleteCleanupDirectory();
 
-            Dependencies.Cache(this);
-            Dependencies.Cache(Storage = GetStorage(gameName));
+            Dependencies.CacheAs<GameHost>(this);
+            Dependencies.CacheAs<Storage>(Storage = GetStorage(gameName));
 
             Name = gameName;
             Logger.GameIdentifier = gameName;
@@ -418,7 +418,7 @@ namespace osu.Framework.Platform
             };
 
             Dependencies.Cache(root);
-            Dependencies.Cache(game);
+            Dependencies.CacheAs<Game>(game);
 
             game.SetHost(this);
 


### PR DESCRIPTION
Alternative to https://github.com/ppy/osu-framework/pull/1336 . Since we can't seem to come to an agreement as to which type we should cache. One of these has to happen, and I believe this is the cleaner of the solutions.

With these changes:
* `Cache` - Always caches the most derived type.
* `CacheAs<T>` - Allows caching as a base type (e.g. `Storage`).
* There is no more overwrite parameter - we've previously discussed that this isn't useful anymore since we have local dependencies.
* `Cache` no longer returns the object back.