### PR TITLE
Add a way to disable masking checks for input

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1958,12 +1958,17 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Whether this Drawable can keyboard receive input, taking into account all optimizations and masking.
         /// </summary>
-        public bool CanReceiveKeyboardInput => HandleKeyboardInput && IsPresent && !IsMaskedAway;
+        public bool CanReceiveKeyboardInput => HandleKeyboardInput && IsPresent && (!MaskingAffectsInput || !IsMaskedAway);
 
         /// <summary>
         /// Whether this Drawable can mouse receive input, taking into account all optimizations and masking.
         /// </summary>
-        public bool CanReceiveMouseInput => HandleMouseInput && IsPresent && !IsMaskedAway;
+        public bool CanReceiveMouseInput => HandleMouseInput && IsPresent && (!MaskingAffectsInput || !IsMaskedAway);
+
+        /// <summary>
+        /// Whether masking checks affect if this <see cref="Drawable"/> receives mouse and keyboard input.
+        /// </summary>
+        public virtual bool MaskingAffectsInput => true;
 
         /// <summary>
         /// Creates a new InputState with mouse coodinates converted to the coordinate space of our parent.


### PR DESCRIPTION
IsMaskedAway is computed on the draw thread. In general it's kind of unsafe to use IsMaskedAway checks on the update thread for input, but I recognize that it may help in certain scenarios.

Ideally we'll want IsMaskedAway to be computed on the Update thread, but this is a big change and I've regressed a lot with my other attempts.

The case for this is replay skipping, where multiple input updates are done within a single Update frame (thus also a single Draw frame).

Closes ppy/osu#1626