### PR TITLE
Bindable parsing fixes

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBoolTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBoolTest.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Configuration;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableBoolTest
+    {
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestSet(bool value)
+        {
+            var bindable = new BindableBool { Value = value };
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        [TestCase("True", true)]
+        [TestCase("true", true)]
+        [TestCase("False", false)]
+        [TestCase("false", false)]
+        [TestCase("1", true)]
+        [TestCase("0", false)]
+        public void TestParsingString(string value, bool expected)
+        {
+            var bindable = new BindableBool();
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestParsingBoolean(bool value)
+        {
+            var bindable = new BindableBool();
+            bindable.Parse(value);
+
+            Assert.AreEqual(value, bindable.Value);
+        }
+    }
+}

--- a/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Configuration;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableDoubleTest
+    {
+        [TestCase(0)]
+        [TestCase(-0)]
+        [TestCase(1)]
+        [TestCase(-105.123)]
+        [TestCase(105.123)]
+        [TestCase(double.MinValue)]
+        [TestCase(double.MaxValue)]
+        public void TestSet(double value)
+        {
+            var bindable = new BindableDouble { Value = value };
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        [TestCase("0", 0f)]
+        [TestCase("1", 1f)]
+        [TestCase("-0", 0f)]
+        [TestCase("-105.123", -105.123)]
+        [TestCase("105.123", 105.123)]
+        public void TestParsingString(string value, double expected)
+        {
+            var bindable = new BindableDouble();
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase("0", -10, 10, 0)]
+        [TestCase("1", -10, 10, 1)]
+        [TestCase("-0", -10, 10, 0)]
+        [TestCase("-105.123", -10, 10, -10)]
+        [TestCase("105.123", -10, 10, 10)]
+        public void TestParsingStringWithRange(string value, double minValue, double maxValue, double expected)
+        {
+            var bindable = new BindableDouble { MinValue = minValue, MaxValue = maxValue };
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase(0)]
+        [TestCase(-0)]
+        [TestCase(1)]
+        [TestCase(-105.123)]
+        [TestCase(105.123)]
+        [TestCase(double.MinValue)]
+        [TestCase(double.MaxValue)]
+        public void TestParsingDouble(double value)
+        {
+            var bindable = new BindableDouble();
+            bindable.Parse(value);
+
+            Assert.AreEqual(value, bindable.Value);
+        }
+    }
+}

--- a/osu.Framework.Tests/Bindables/BindableEnumTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableEnumTest.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Configuration;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableEnumTest
+    {
+        [TestCase(TestEnum.Value1)]
+        [TestCase(TestEnum.Value2)]
+        [TestCase(TestEnum.Value1 - 1)]
+        [TestCase(TestEnum.Value2 + 1)]
+        public void TestSet(TestEnum value)
+        {
+            var bindable = new Bindable<TestEnum> { Value = value };
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        [TestCase("Value1", TestEnum.Value1)]
+        [TestCase("Value2", TestEnum.Value2)]
+        [TestCase("-1", TestEnum.Value1 - 1)]
+        [TestCase("2", TestEnum.Value2 + 1)]
+        public void TestParsingString(string value, TestEnum expected)
+        {
+            var bindable = new Bindable<TestEnum>();
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase(TestEnum.Value1)]
+        [TestCase(TestEnum.Value2)]
+        [TestCase(TestEnum.Value1 - 1)]
+        [TestCase(TestEnum.Value2 + 1)]
+        public void TestParsingEnum(TestEnum value)
+        {
+            var bindable = new Bindable<TestEnum>();
+            bindable.Parse(value);
+
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        public enum TestEnum
+        {
+            Value1 = 0,
+            Value2 = 1
+        }
+    }
+}

--- a/osu.Framework.Tests/Bindables/BindableFloatTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableFloatTest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Configuration;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableFloatTest
+    {
+        [TestCase(0)]
+        [TestCase(-0)]
+        [TestCase(1)]
+        [TestCase(-105.123f)]
+        [TestCase(105.123f)]
+        [TestCase(float.MinValue)]
+        [TestCase(float.MaxValue)]
+        public void TestSet(float value)
+        {
+            var bindable = new BindableFloat { Value = value };
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        [TestCase("0", 0f)]
+        [TestCase("1", 1f)]
+        [TestCase("-0", 0f)]
+        [TestCase("-105.123", -105.123f)]
+        [TestCase("105.123", 105.123f)]
+        public void TestParsingString(string value, float expected)
+        {
+            var bindable = new BindableFloat();
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase("0", -10, 10, 0)]
+        [TestCase("1", -10, 10, 1)]
+        [TestCase("-0", -10, 10, 0)]
+        [TestCase("-105.123", -10, 10, -10)]
+        [TestCase("105.123", -10, 10, 10)]
+        public void TestParsingStringWithRange(string value, float minValue, float maxValue, float expected)
+        {
+            var bindable = new BindableFloat { MinValue = minValue, MaxValue = maxValue };
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase(0)]
+        [TestCase(-0)]
+        [TestCase(1)]
+        [TestCase(-105.123f)]
+        [TestCase(105.123f)]
+        [TestCase(float.MinValue)]
+        [TestCase(float.MaxValue)]
+        public void TestParsingFloat(float value)
+        {
+            var bindable = new BindableFloat();
+            bindable.Parse(value);
+
+            Assert.AreEqual(value, bindable.Value);
+        }
+    }
+}

--- a/osu.Framework.Tests/Bindables/BindableIntTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableIntTest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Configuration;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableIntTest
+    {
+        [TestCase(0)]
+        [TestCase(-0)]
+        [TestCase(1)]
+        [TestCase(-105)]
+        [TestCase(105)]
+        [TestCase(int.MinValue)]
+        [TestCase(int.MaxValue)]
+        public void TestSet(int value)
+        {
+            var bindable = new BindableInt { Value = value };
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        [TestCase("0", 0)]
+        [TestCase("1", 1)]
+        [TestCase("-0", 0)]
+        [TestCase("-105", -105)]
+        [TestCase("105", 105)]
+        public void TestParsingString(string value, int expected)
+        {
+            var bindable = new BindableInt();
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase("0", -10, 10, 0)]
+        [TestCase("1", -10, 10, 1)]
+        [TestCase("-0", -10, 10, 0)]
+        [TestCase("-105", -10, 10, -10)]
+        [TestCase("105", -10, 10, 10)]
+        public void TestParsingStringWithRange(string value, int minValue, int maxValue, int expected)
+        {
+            var bindable = new BindableInt { MinValue = minValue, MaxValue = maxValue };
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase(0)]
+        [TestCase(-0)]
+        [TestCase(1)]
+        [TestCase(-105)]
+        [TestCase(105)]
+        [TestCase(int.MinValue)]
+        [TestCase(int.MaxValue)]
+        public void TestParsingInt(int value)
+        {
+            var bindable = new BindableInt();
+            bindable.Parse(value);
+
+            Assert.AreEqual(value, bindable.Value);
+        }
+    }
+}

--- a/osu.Framework.Tests/Bindables/BindableLongTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableLongTest.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Configuration;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableLongTest
+    {
+        [TestCase(0)]
+        [TestCase(-0)]
+        [TestCase(1)]
+        [TestCase(-105)]
+        [TestCase(105)]
+        [TestCase(long.MinValue)]
+        [TestCase(long.MaxValue - 1)] // This will overflow a double - this is probably an issue
+        public void TestSet(long value)
+        {
+            var bindable = new BindableLong { Value = value };
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        [TestCase("0", 0)]
+        [TestCase("1", 1)]
+        [TestCase("-0", 0)]
+        [TestCase("-105", -105)]
+        [TestCase("105", 105)]
+        public void TestParsingString(string value, long expected)
+        {
+            var bindable = new BindableLong();
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase("0", -10, 10, 0)]
+        [TestCase("1", -10, 10, 1)]
+        [TestCase("-0", -10, 10, 0)]
+        [TestCase("-105", -10, 10, -10)]
+        [TestCase("105", -10, 10, 10)]
+        public void TestParsingStringWithRange(string value, long minValue, long maxValue, long expected)
+        {
+            var bindable = new BindableLong { MinValue = minValue, MaxValue = maxValue };
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+
+        [TestCase(0)]
+        [TestCase(-0)]
+        [TestCase(1)]
+        [TestCase(-105)]
+        [TestCase(105)]
+        [TestCase(long.MinValue)]
+        [TestCase(long.MaxValue)]
+        public void TestParsingLong(long value)
+        {
+            var bindable = new BindableLong();
+            bindable.Parse(value);
+
+            Assert.AreEqual(value, bindable.Value);
+        }
+    }
+}

--- a/osu.Framework.Tests/Bindables/BindableLongTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableLongTest.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Tests.Bindables
         [TestCase(-105)]
         [TestCase(105)]
         [TestCase(long.MinValue)]
-        [TestCase(long.MaxValue - 1)] // This will overflow a double - this is probably an issue
+        [TestCase(long.MaxValue)]
         public void TestSet(long value)
         {
             var bindable = new BindableLong { Value = value };

--- a/osu.Framework.Tests/Bindables/BindableLongTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableLongTest.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using NUnit.Framework;
 using osu.Framework.Configuration;

--- a/osu.Framework.Tests/Bindables/BindableStringTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableStringTest.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Configuration;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableStringTest
+    {
+        [TestCase("")]
+        [TestCase(null)]
+        [TestCase("this is a string")]
+        public void TestSet(string value)
+        {
+            var bindable = new Bindable<string> { Value = value };
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        [TestCase("")]
+        [TestCase("null")]
+        [TestCase("this is a string")]
+        public void TestParsingString(string value)
+        {
+            var bindable = new Bindable<string>();
+            bindable.Parse(value);
+
+            Assert.AreEqual(value, bindable.Value);
+        }
+    }
+}

--- a/osu.Framework.Tests/Bindables/BindableStringTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableStringTest.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using NUnit.Framework;
 using osu.Framework.Configuration;

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -54,6 +54,13 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AutomatedVisualTestGame.cs" />
+    <Compile Include="Bindables\BindableBoolTest.cs" />
+    <Compile Include="Bindables\BindableDoubleTest.cs" />
+    <Compile Include="Bindables\BindableEnumTest.cs" />
+    <Compile Include="Bindables\BindableFloatTest.cs" />
+    <Compile Include="Bindables\BindableIntTest.cs" />
+    <Compile Include="Bindables\BindableLongTest.cs" />
+    <Compile Include="Bindables\BindableStringTest.cs" />
     <Compile Include="IO\TestSortedListSerialization.cs" />
     <Compile Include="IO\TestWebRequest.cs" />
     <Compile Include="Lists\TestArrayExtensions.cs" />

--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using osu.Framework.Lists;
 
 namespace osu.Framework.Configuration
@@ -130,7 +131,7 @@ namespace osu.Framework.Configuration
                 case string s:
                     Value = typeof(T).IsEnum
                         ? (T)Enum.Parse(typeof(T), s)
-                        : (T)Convert.ChangeType(s, typeof(T));
+                        : (T)Convert.ChangeType(s, typeof(T), NumberFormatInfo.InvariantInfo);
                     break;
                 default:
                     throw new ArgumentException($@"Could not parse provided {input.GetType()} ({input}) to {typeof(T)}.");

--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -131,7 +131,7 @@ namespace osu.Framework.Configuration
                 case string s:
                     Value = typeof(T).IsEnum
                         ? (T)Enum.Parse(typeof(T), s)
-                        : (T)Convert.ChangeType(s, typeof(T), NumberFormatInfo.InvariantInfo);
+                        : (T)Convert.ChangeType(s, typeof(T), CultureInfo.InvariantCulture);
                     break;
                 default:
                     throw new ArgumentException($@"Could not parse provided {input.GetType()} ({input}) to {typeof(T)}.");

--- a/osu.Framework/Configuration/BindableBool.cs
+++ b/osu.Framework/Configuration/BindableBool.cs
@@ -16,13 +16,14 @@ namespace osu.Framework.Configuration
 
         public override string ToString() => Value.ToString();
 
-        public override void Parse(object s)
+        public override void Parse(object input)
         {
-            string str = s as string;
-            if (str == null)
-                throw new InvalidCastException($@"Input type {s.GetType()} could not be cast to a string for parsing");
-
-            Value = str == @"1" || str.Equals(@"true", StringComparison.OrdinalIgnoreCase);
+            if (input.Equals("1"))
+                Value = true;
+            else if (input.Equals("0"))
+                Value = false;
+            else
+                base.Parse(input);
         }
 
         public void Toggle() => Value = !Value;

--- a/osu.Framework/Configuration/BindableDouble.cs
+++ b/osu.Framework/Configuration/BindableDouble.cs
@@ -20,21 +20,5 @@ namespace osu.Framework.Configuration
         }
 
         public override string ToString() => Value.ToString("0.0###", NumberFormatInfo.InvariantInfo);
-
-        /// <summary>
-        /// Parse an input into this instance.
-        /// </summary>
-        /// <param name="input">The input which is to be parsed.</param>
-        public override void Parse(object input)
-        {
-            if (!(input is string str))
-                throw new InvalidCastException($@"Input type {input.GetType()} could not be cast to a string for parsing");
-
-            var parsed = double.Parse(str, NumberFormatInfo.InvariantInfo);
-            if (parsed < MinValue || parsed > MaxValue)
-                throw new ArgumentOutOfRangeException($"Parsed number ({parsed}) is outside the valid range ({MinValue} - {MaxValue})");
-
-            Value = parsed;
-        }
     }
 }

--- a/osu.Framework/Configuration/BindableFloat.cs
+++ b/osu.Framework/Configuration/BindableFloat.cs
@@ -20,21 +20,5 @@ namespace osu.Framework.Configuration
         }
 
         public override string ToString() => Value.ToString("0.0###", NumberFormatInfo.InvariantInfo);
-
-        /// <summary>
-        /// Parse an input into this instance.
-        /// </summary>
-        /// <param name="input">The input which is to be parsed.</param>
-        public override void Parse(object input)
-        {
-            if (!(input is string str))
-                throw new InvalidCastException($@"Input type {input.GetType()} could not be cast to a string for parsing");
-
-            var parsed = float.Parse(str, NumberFormatInfo.InvariantInfo);
-            if (parsed < MinValue || parsed > MaxValue)
-                throw new ArgumentOutOfRangeException($"Parsed number ({parsed}) is outside the valid range ({MinValue} - {MaxValue})");
-
-            Value = parsed;
-        }
     }
 }

--- a/osu.Framework/Configuration/BindableInt.cs
+++ b/osu.Framework/Configuration/BindableInt.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
 using System.Globalization;
 
 namespace osu.Framework.Configuration
@@ -15,18 +14,6 @@ namespace osu.Framework.Configuration
         public BindableInt(int value = 0)
             : base(value)
         {
-        }
-
-        public override void Parse(object s)
-        {
-            if (!(s is string str))
-                throw new InvalidCastException($@"Input type {s.GetType()} could not be cast to a string for parsing");
-
-            var parsed = int.Parse(str, NumberFormatInfo.InvariantInfo);
-            if (parsed < MinValue || parsed > MaxValue)
-                throw new ArgumentOutOfRangeException($"Parsed number ({parsed}) is outside the valid range ({MinValue} - {MaxValue})");
-
-            Value = parsed;
         }
 
         public override string ToString() => Value.ToString(NumberFormatInfo.InvariantInfo);

--- a/osu.Framework/Configuration/BindableLong.cs
+++ b/osu.Framework/Configuration/BindableLong.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
 using System.Globalization;
 
 namespace osu.Framework.Configuration
@@ -15,18 +14,6 @@ namespace osu.Framework.Configuration
         public BindableLong(long value = 0)
             : base(value)
         {
-        }
-
-        public override void Parse(object s)
-        {
-            if (!(s is string str))
-                throw new InvalidCastException($@"Input type {s.GetType()} could not be cast to a string for parsing");
-
-            var parsed = long.Parse(str, NumberFormatInfo.InvariantInfo);
-            if (parsed < MinValue || parsed > MaxValue)
-                throw new ArgumentOutOfRangeException($"Parsed number ({parsed}) is outside the valid range ({MinValue} - {MaxValue})");
-
-            Value = parsed;
         }
 
         public override string ToString() => Value.ToString(NumberFormatInfo.InvariantInfo);

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -84,7 +84,7 @@ namespace osu.Framework.Configuration
                     base.Value = (T)Convert.ChangeType(doubleValue, typeof(T), CultureInfo.InvariantCulture);
                 }
                 else
-                    base.Value = value;
+                    base.Value = clamp(value, MinValue, MaxValue);
             }
         }
 

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using OpenTK;
 
 namespace osu.Framework.Configuration
@@ -73,14 +74,17 @@ namespace osu.Framework.Configuration
             get { return base.Value; }
             set
             {
-                double doubleValue = Convert.ToDouble(clamp(value, MinValue, MaxValue));
-
                 if (Precision.CompareTo(DefaultPrecision) > 0)
+                {
+                    double doubleValue = Convert.ToDouble(clamp(value, MinValue, MaxValue));
                     doubleValue = Math.Round(doubleValue / Convert.ToDouble(Precision)) * Convert.ToDouble(Precision);
 
-                // ReSharper disable once PossibleNullReferenceException
-                // https://youtrack.jetbrains.com/issue/RIDER-12652
-                base.Value = (T)Convert.ChangeType(doubleValue, typeof(T));
+                    // ReSharper disable once PossibleNullReferenceException
+                    // https://youtrack.jetbrains.com/issue/RIDER-12652
+                    base.Value = (T)Convert.ChangeType(doubleValue, typeof(T), CultureInfo.InvariantCulture);
+                }
+                else
+                    base.Value = value;
             }
         }
 


### PR DESCRIPTION
* Removes custom `Parse` methods from derivers of `BindableNumber`.
  * This is handled by the base `Bindable<T>.Parse`.
  * Only "big" difference is that value-in-range checks are missing, which I don't think are a critical component anyway.
* Adds testcases.