### PR TITLE
Stop ConfigManager from setting a default when calling GetOriginalBindable

### DIFF
--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -129,19 +129,14 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        public U Get<U>(T lookup)
-        {
-            return GetOriginalBindable<U>(lookup).Value;
-        }
+        public U Get<U>(T lookup) => GetOriginalBindable<U>(lookup).Value;
 
         protected Bindable<U> GetOriginalBindable<U>(T lookup)
         {
-            IBindable obj;
-
-            if (ConfigStore.TryGetValue(lookup, out obj))
+            if (ConfigStore.TryGetValue(lookup, out IBindable obj))
                 return obj as Bindable<U>;
 
-            return set(lookup, default(U));
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION
This behaviour wasn't even correct as `default(U)` would not match the expected type for cases like `BindableDouble`.