### PR TITLE
Use AlmostEquals for CircularContainer test cases

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseCircularContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCircularContainer.cs
@@ -5,6 +5,7 @@ using osu.Framework.Graphics;
 using OpenTK;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.MathUtils;
 using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual
@@ -17,11 +18,11 @@ namespace osu.Framework.Tests.Visual
         public TestCaseCircularContainer()
         {
             AddStep("128x128 box", () => addContainer(new Vector2(128)));
-            AddAssert("Expect CornerRadius = 64", () => container.CornerRadius == 64);
+            AddAssert("Expect CornerRadius = 64", () => Precision.AlmostEquals(container.CornerRadius, 64));
             AddStep("128x64 box", () => addContainer(new Vector2(128, 64)));
-            AddAssert("Expect CornerRadius = 32", () => container.CornerRadius == 32);
+            AddAssert("Expect CornerRadius = 32", () => Precision.AlmostEquals(container.CornerRadius, 32));
             AddStep("64x128 box", () => addContainer(new Vector2(64, 128)));
-            AddAssert("Expect CornerRadius = 32", () => container.CornerRadius == 32);
+            AddAssert("Expect CornerRadius = 32", () => Precision.AlmostEquals(container.CornerRadius, 32));
         }
 
         private void addContainer(Vector2 size)


### PR DESCRIPTION
Failing under some environments