### PR TITLE
Fix up recent IsMaskedAway regressions

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -323,6 +323,8 @@ namespace osu.Framework.Graphics.Containers
             attachedFormats.Add(format);
         }
 
+        protected override RectangleF ComputeChildMaskingBounds(RectangleF maskingBounds) => ScreenSpaceDrawQuad.AABBFloat; // Make sure children never get masked away
+
         protected override void Update()
         {
             // Invalidate drawn frame buffer every frame.

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -340,8 +340,6 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate && childrenUpdateVersion != updateVersion;
 
-        protected override RectangleF ComputeChildMaskingRectangle() => ScreenSpaceDrawQuad.AABBFloat; // Make sure no children get masked away
-
         public override DrawInfo DrawInfo
         {
             get

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -547,10 +547,6 @@ namespace osu.Framework.Graphics.Containers
             if (!base.Invalidate(invalidation, source, shallPropagate))
                 return false;
 
-            // Either ScreenSize OR ScreenPosition OR Colour
-            if ((invalidation & (Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
-                childMaskingRectangleBacking.Invalidate();
-
             if (!shallPropagate) return true;
 
             // This way of looping turns out to be slightly faster than a foreach
@@ -641,7 +637,8 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="j">The running index into the target List.</param>
         /// <param name="parentComposite">The <see cref="CompositeDrawable"/> whose children's DrawNodes to add.</param>
         /// <param name="target">The target list to fill with DrawNodes.</param>
-        private static void addFromComposite(int treeIndex, ref int j, CompositeDrawable parentComposite, List<DrawNode> target)
+        /// <param name="maskingBounds">The masking bounds. Children lying outside of them should be ignored.</param>
+        private static void addFromComposite(int treeIndex, ref int j, CompositeDrawable parentComposite, List<DrawNode> target, RectangleF maskingBounds)
         {
             SortedList<Drawable> current = parentComposite.aliveInternalChildren;
             // ReSharper disable once ForCanBeConvertedToForeach
@@ -665,16 +662,22 @@ namespace osu.Framework.Graphics.Containers
                 CompositeDrawable composite = drawable as CompositeDrawable;
                 if (composite?.CanBeFlattened == true)
                 {
+                    // The masking check is overly expensive (requires creation of ScreenSpaceDrawQuad)
+                    // when only few children exist.
+                    composite.IsMaskedAway = composite.AliveInternalChildren.Count >= amount_children_required_for_masking_check &&
+                                             !maskingBounds.IntersectsWith(drawable.ScreenSpaceDrawQuad.AABBFloat);
+
                     if (!composite.IsMaskedAway)
-                        addFromComposite(treeIndex, ref j, composite, target);
+                        addFromComposite(treeIndex, ref j, composite, target, maskingBounds);
 
                     continue;
                 }
 
+                drawable.IsMaskedAway = !maskingBounds.IntersectsWith(drawable.ScreenSpaceDrawQuad.AABBFloat);
                 if (drawable.IsMaskedAway)
                     continue;
 
-                DrawNode next = drawable.GenerateDrawNodeSubtree(treeIndex);
+                DrawNode next = drawable.GenerateDrawNodeSubtree(treeIndex, maskingBounds);
                 if (next == null)
                     continue;
 
@@ -687,15 +690,23 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        internal sealed override DrawNode GenerateDrawNodeSubtree(int treeIndex)
+        internal sealed override DrawNode GenerateDrawNodeSubtree(int treeIndex, RectangleF bounds)
         {
             // No need for a draw node at all if there are no children and we are not glowing.
             if (aliveInternalChildren.Count == 0 && CanBeFlattened)
                 return null;
 
-            CompositeDrawNode cNode = base.GenerateDrawNodeSubtree(treeIndex) as CompositeDrawNode;
+            CompositeDrawNode cNode = base.GenerateDrawNodeSubtree(treeIndex, bounds) as CompositeDrawNode;
             if (cNode == null)
                 return null;
+
+            RectangleF childBounds = bounds;
+            // If we are going to render a buffered container we need to make sure no children get masked away,
+            // even if they are off-screen.
+            if (this is IBufferedContainer)
+                childBounds = ScreenSpaceDrawQuad.AABBFloat;
+            else if (Masking)
+                childBounds.Intersect(ScreenSpaceDrawQuad.AABBFloat);
 
             if (cNode.Children == null)
                 cNode.Children = new List<DrawNode>(aliveInternalChildren.Count);
@@ -703,7 +714,7 @@ namespace osu.Framework.Graphics.Containers
             List<DrawNode> target = cNode.Children;
 
             int j = 0;
-            addFromComposite(treeIndex, ref j, this, target);
+            addFromComposite(treeIndex, ref j, this, target, childBounds);
 
             if (j < target.Count)
                 target.RemoveRange(j, target.Count - j);
@@ -871,40 +882,6 @@ namespace osu.Framework.Graphics.Containers
         #endregion
 
         #region Masking and related effects (e.g. round corners)
-
-        internal override bool ComputeIsMaskedAway(RectangleF maskingBounds)
-        {
-            if (!CanBeFlattened)
-                return base.ComputeIsMaskedAway(maskingBounds);
-
-            // This masking check is overly expensive (requires creation of ScreenSpaceDrawQuad) when only few children exist
-            return AliveInternalChildren.Count >= amount_children_required_for_masking_check && base.ComputeIsMaskedAway(maskingBounds);
-        }
-
-        private Cached<RectangleF> childMaskingRectangleBacking;
-
-        /// <summary>
-        /// The screen-space <see cref="RectangleF"/> which child <see cref="Drawable"/>s perform masking checks against.
-        /// </summary>
-        internal RectangleF ChildMaskingRectangle =>
-            childMaskingRectangleBacking.IsValid
-                ? childMaskingRectangleBacking.Value
-                : (childMaskingRectangleBacking.Value = ComputeChildMaskingRectangle());
-
-        /// <summary>
-        /// Compute the screen-space <see cref="RectangleF"/> for child <see cref="Drawable"/>s to perform masking checks against.
-        /// </summary>
-        protected virtual RectangleF ComputeChildMaskingRectangle()
-        {
-            if (Parent == null)
-                return ScreenSpaceDrawQuad.AABBFloat;
-
-            var localRectangle = Parent.ChildMaskingRectangle;
-            if (Masking)
-                localRectangle.Intersect(ScreenSpaceDrawQuad.AABBFloat);
-
-            return localRectangle;
-        }
 
         private bool masking;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1319,23 +1319,12 @@ namespace osu.Framework.Graphics
 
         #region Caching & invalidation (for things too expensive to compute every frame)
 
-        private Cached<bool> isMaskedAwayBacking;
-
         /// <summary>
-        /// Whether this <see cref="Drawable"/> is currently masked away.
-        /// This is measured conservatively based on the AABB of this <see cref="Drawable"/>
-        /// and may be false even if it is visually fully masked away.
+        /// Was this Drawable masked away completely during the last frame?
+        /// This is measured conservatively, i.e. it is only true when the Drawable was
+        /// actually masked away, but it may be false, even if the Drawable was masked away.
         /// </summary>
-        internal bool IsMaskedAway =>
-            isMaskedAwayBacking.IsValid
-                ? isMaskedAwayBacking.Value
-                : (isMaskedAwayBacking.Value = Parent != null && ComputeIsMaskedAway(Parent.ChildMaskingRectangle));
-
-        /// <summary>
-        /// Computes whether this <see cref="Drawable"/> is currently masked away, based on the <see cref="Parent"/>'s <see cref="CompositeDrawable.ChildMaskingRectangle"/>.
-        /// </summary>
-        /// <param name="maskingRectangle">The current masking rectangle.</param>
-        internal virtual bool ComputeIsMaskedAway(RectangleF maskingRectangle) => !maskingRectangle.IntersectsWith(ScreenSpaceDrawQuad.AABBFloat);
+        internal bool IsMaskedAway;
 
         private Cached<Quad> screenSpaceDrawQuadBacking;
 
@@ -1485,7 +1474,6 @@ namespace osu.Framework.Graphics
                 alreadyInvalidated &= !screenSpaceDrawQuadBacking.Invalidate();
                 alreadyInvalidated &= !drawInfoBacking.Invalidate();
                 alreadyInvalidated &= !drawSizeBacking.Invalidate();
-                alreadyInvalidated &= !isMaskedAwayBacking.Invalidate();
             }
 
             if (!alreadyInvalidated || (invalidation & Invalidation.DrawNode) > 0)
@@ -1519,7 +1507,7 @@ namespace osu.Framework.Graphics
         /// Generates the DrawNode for ourselves.
         /// </summary>
         /// <returns>A complete and updated DrawNode, or null if the DrawNode would be invisible.</returns>
-        internal virtual DrawNode GenerateDrawNodeSubtree(int treeIndex)
+        internal virtual DrawNode GenerateDrawNodeSubtree(int treeIndex, RectangleF bounds)
         {
             DrawNode node = drawNodes[treeIndex];
             if (node == null)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1338,7 +1338,7 @@ namespace osu.Framework.Graphics
         /// This is measured conservatively, i.e. it is only true when the Drawable was
         /// actually masked away, but it may be false, even if the Drawable was masked away.
         /// </summary>
-        internal bool IsMaskedAway;
+        internal bool IsMaskedAway { get; private set; }
 
         private Cached<Quad> screenSpaceDrawQuadBacking;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -358,6 +358,20 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
+        /// Updates all masking calculations for this <see cref="Drawable"/>.
+        /// This occurs post-<see cref="UpdateSubTree"/> to ensure that all <see cref="Drawable"/> updates have taken place.
+        /// </summary>
+        /// <param name="maskingBounds">The <see cref="RectangleF"/> that defines the masking bounds.</param>
+        public virtual void UpdateSubTreeMasking(RectangleF maskingBounds) => IsMaskedAway = ComputeIsMaskedAway(maskingBounds);
+
+        /// <summary>
+        /// Computes whether this <see cref="Drawable"/> is masked away.
+        /// </summary>
+        /// <param name="maskingBounds">The <see cref="RectangleF"/> that defines the masking bounds.</param>
+        /// <returns>Whether this <see cref="Drawable"/> is currently masked away.</returns>
+        protected virtual bool ComputeIsMaskedAway(RectangleF maskingBounds) => !maskingBounds.IntersectsWith(ScreenSpaceDrawQuad.AABBFloat);
+
+        /// <summary>
         /// Performs a once-per-frame update specific to this Drawable. A more elegant alternative to
         /// <see cref="OnUpdate"/> when deriving from <see cref="Drawable"/>. Note, that this
         /// method is always called before Drawables further down the scene graph are updated.
@@ -1507,7 +1521,7 @@ namespace osu.Framework.Graphics
         /// Generates the DrawNode for ourselves.
         /// </summary>
         /// <returns>A complete and updated DrawNode, or null if the DrawNode would be invisible.</returns>
-        internal virtual DrawNode GenerateDrawNodeSubtree(int treeIndex, RectangleF bounds)
+        internal virtual DrawNode GenerateDrawNodeSubtree(int treeIndex)
         {
             DrawNode node = drawNodes[treeIndex];
             if (node == null)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -248,8 +248,10 @@ namespace osu.Framework.Platform
             Root.Size = Vector2.ComponentMax(Vector2.One, Root.Size);
 
             Root.UpdateSubTree();
+            Root.UpdateSubTreeMasking(Root.ScreenSpaceDrawQuad.AABBFloat);
+
             using (var buffer = DrawRoots.Get(UsageType.Write))
-                buffer.Object = Root.GenerateDrawNodeSubtree(buffer.Index, Root.ScreenSpaceDrawQuad.AABBFloat);
+                buffer.Object = Root.GenerateDrawNodeSubtree(buffer.Index);
         }
 
         protected virtual void DrawInitialize()

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -249,7 +249,7 @@ namespace osu.Framework.Platform
 
             Root.UpdateSubTree();
             using (var buffer = DrawRoots.Get(UsageType.Write))
-                buffer.Object = Root.GenerateDrawNodeSubtree(buffer.Index);
+                buffer.Object = Root.GenerateDrawNodeSubtree(buffer.Index, Root.ScreenSpaceDrawQuad.AABBFloat);
         }
 
         protected virtual void DrawInitialize()


### PR DESCRIPTION
@Tom94 Thoughts?

Basically, we cannot compute `IsMaskedAway` as soon as it is used due to it requiring that autosize calculations have taken place. It is dangerous for autosize computations to occur through a call to `IsMaskedAway` since it's possible that `UpdateSubTree` hasn't been called on the relevant drawables, and lifetimes/other stuff has possibly not been updated by that point.

To be able to use this in `RulesetInputManager`, we cannot have the computation occur in `GenerateDrawNodeSubtree`, as that constructs/modifies `DrawNode`s. Due to this, I chose to have the computation occur as a post-`UpdateSubTree` method, with the following usage in `RulesetInputManager`:

<img width="871" alt="screen shot 2018-02-01 at 3 11 27 pm" src="https://user-images.githubusercontent.com/1329837/35663752-391229c4-0762-11e8-8bf5-b928d63471f6.png">
