### PR TITLE
Fix wrong IsMaskedAway value when proxies are involved

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseIsMaskedAway.cs
+++ b/osu.Framework.Tests/Visual/TestCaseIsMaskedAway.cs
@@ -1,0 +1,341 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using OpenTK;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseIsMaskedAway : TestCase
+    {
+        /// <summary>
+        /// Tests that a box which is within the bounds of a parent is never masked away, regardless of whether the parent is masking or not.
+        /// </summary>
+        /// <param name="masking">Whether the box's parent is masking.</param>
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestBoxInBounds(bool masking)
+        {
+            Box box;
+            Child = new Container
+            {
+                Size = new Vector2(200),
+                Masking = masking,
+                Child = box = new Box()
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => !box.IsMaskedAway);
+        }
+
+        /// <summary>
+        /// Tests that a box which is outside the bounds of a parent is never masked away if the parent is not masking.
+        /// </summary>
+        [Test]
+        public void TestBoxOutOfBoundsNoMasking()
+        {
+            Box box;
+            Child = new Container
+            {
+                Size = new Vector2(200),
+                Child = box = new Box { Position = new Vector2(-1) }
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => !box.IsMaskedAway);
+        }
+
+        /// <summary>
+        /// Tests that a box which is slightly outside the bounds of a masking parent is never masked away, regardless of its anchor/origin.
+        /// Ensures that all screen-space calculations are current by the time <see cref="Drawable.IsMaskedAway"/> is calculated.
+        /// </summary>
+        /// <param name="anchor">The box's anchor in the masking parent.</param>
+        [TestCase(Anchor.TopLeft)]
+        [TestCase(Anchor.TopRight)]
+        [TestCase(Anchor.BottomLeft)]
+        [TestCase(Anchor.BottomRight)]
+        public void TestBoxSlightlyOutOfBoundsMasking(Anchor anchor)
+        {
+            Box box;
+            Child = new Container
+            {
+                Size = new Vector2(200),
+                Masking = true,
+                Child = box = new Box
+                {
+                    Anchor = anchor,
+                    Origin = anchor,
+                    Size = new Vector2(10),
+                    Position = new Vector2((anchor & Anchor.x0) > 0 ? -5 : 5, (anchor & Anchor.y0) > 0 ? -5 : 5),
+                }
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => !box.IsMaskedAway);
+        }
+
+        /// <summary>
+        /// Tests that a box which is fully outside the bounds of a masking parent is always masked away, regardless of its anchor/origin.
+        /// Ensures that all screen-space calculations are current by the time <see cref="Drawable.IsMaskedAway"/> is calculated.
+        /// </summary>
+        /// <param name="anchor">The box's anchor in the masking parent.</param>
+        [TestCase(Anchor.TopLeft)]
+        [TestCase(Anchor.TopRight)]
+        [TestCase(Anchor.BottomLeft)]
+        [TestCase(Anchor.BottomRight)]
+        public void TestBoxFullyOutOfBoundsMasking(Anchor anchor)
+        {
+            Box box;
+            Child = new Container
+            {
+                Size = new Vector2(200),
+                Masking = true,
+                Child = box = new Box
+                {
+                    Anchor = anchor,
+                    Origin = anchor,
+                    Size = new Vector2(10),
+                    Position = new Vector2((anchor & Anchor.x0) > 0 ? -20 : 20, (anchor & Anchor.y0) > 0 ? -20 : 20),
+                }
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => box.IsMaskedAway);
+        }
+
+        /// <summary>
+        /// Tests that a box is never masked away when it and its proxy are within the bounds of their parents, regardless of whether their parents
+        /// are masking or not.
+        /// </summary>
+        /// <param name="boxMasking">Whether the box's parent is masking.</param>
+        /// <param name="proxyMasking">Whether the proxy's parent is masking.</param>
+        [TestCase(false, false)]
+        [TestCase(true, true)]
+        public void TestBoxInBoundsWithProxyInBounds(bool boxMasking, bool proxyMasking)
+        {
+            var box = new Box();
+
+            ProxyDrawable proxy;
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Masking = boxMasking,
+                    Child = box
+                },
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Masking = proxyMasking,
+                    Child = proxy = box.CreateProxy()
+                },
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => !box.IsMaskedAway);
+            AddAssert("Check proxy IsMaskedAway", () => !proxy.IsMaskedAway);
+        }
+
+        /// <summary>
+        /// Tests that a box is never masked away when its proxy is within the bounds of its parent, even if the box is outside the bounds of its parent.
+        /// </summary>
+        /// <param name="masking">Whether the box's parent is masking. This does not affect the proxy's parent.</param>
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestBoxOutOfBoundsWithProxyInBounds(bool masking)
+        {
+            var box = new Box { Position = new Vector2(-1) };
+
+            ProxyDrawable proxy;
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Masking = masking,
+                    Child = box
+                },
+                proxy = box.CreateProxy()
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => !box.IsMaskedAway);
+            AddAssert("Check proxy IsMaskedAway", () => !proxy.IsMaskedAway);
+        }
+
+        /// <summary>
+        /// Tests that a box is only masked away when its proxy is masked away.
+        /// </summary>
+        /// <param name="boxMasking">Whether the box's parent is masking.</param>
+        /// <param name="proxyMasking">Whether the proxy's parent is masking.</param>
+        /// <param name="shouldBeMaskedAway">Whether the box should be masked away.</param>
+        [TestCase(false, false, false)]
+        [TestCase(false, true, true)]
+        [TestCase(true, false, false)]
+        [TestCase(true, true, true)]
+        public void TestBoxInBoundsWithProxyOutOfBounds(bool boxMasking, bool proxyMasking, bool shouldBeMaskedAway)
+        {
+            var box = new Box();
+
+            ProxyDrawable proxy;
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Masking = boxMasking,
+                    Child = box
+                },
+                new Container
+                {
+                    Position = new Vector2(10),
+                    Size = new Vector2(200),
+                    Masking = proxyMasking,
+                    Child = proxy = box.CreateProxy()
+                },
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => box.IsMaskedAway == shouldBeMaskedAway);
+            AddAssert("Check proxy IsMaskedAway", () => !proxy.IsMaskedAway);
+        }
+
+        /// <summary>
+        /// Tests that whether the box is out of bounds of its parent is not a consideration for masking, only whether its proxy is out of bounds of its parent.
+        /// </summary>
+        /// <param name="boxMasking">Whether the box's parent is masking.</param>
+        /// <param name="proxyMasking">Whether the proxy's parent is masking.</param>
+        /// <param name="shouldBeMaskedAway">Whether the box should be masked away</param>
+        [TestCase(false, false, false)]
+        [TestCase(false, true, true)]
+        [TestCase(true, false, false)]
+        [TestCase(true, true, true)]
+        public void TestBoxOutOfBoundsWithProxyOutOfBounds(bool boxMasking, bool proxyMasking, bool shouldBeMaskedAway)
+        {
+            var box = new Box { Position = new Vector2(-1) };
+
+            ProxyDrawable proxy;
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Masking = boxMasking,
+                    Child = box
+                },
+                new Container
+                {
+                    Position = new Vector2(10),
+                    Size = new Vector2(200),
+                    Masking = proxyMasking,
+                    Child = proxy = box.CreateProxy()
+                },
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => box.IsMaskedAway == shouldBeMaskedAway);
+            AddAssert("Check proxy IsMaskedAway", () => !proxy.IsMaskedAway);
+        }
+
+        /// <summary>
+        /// Tests that the box doesn't get masked away unless its most-proxied-proxy is masked away.
+        /// In this case, the most-proxied-proxy is never going to be masked away, because it is within the bounds of its parent.
+        /// </summary>
+        /// <param name="boxMasking">Whether the box's parent is masking.</param>
+        /// <param name="proxy1Masking">Whether the parent of box's proxy is masking.</param>
+        /// <param name="proxy2Masking">Whether the parent of the proxy's proxy is masking.</param>
+        [TestCase(false, false, false)]
+        [TestCase(true, false, false)]
+        [TestCase(true, true, false)]
+        [TestCase(true, true, true)]
+        [TestCase(false, true, true)]
+        public void TestBoxInBoundsWithProxy1OutOfBoundsWithProxy2InBounds(bool boxMasking, bool proxy1Masking, bool proxy2Masking)
+        {
+            var box = new Box();
+            var proxy1 = box.CreateProxy();
+            var proxy2 = proxy1.CreateProxy();
+
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Masking = boxMasking,
+                    Child = box
+                },
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Position = new Vector2(10),
+                    Masking = proxy1Masking,
+                    Child = proxy1
+                },
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Masking = proxy2Masking,
+                    Child = proxy2
+                }
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => !box.IsMaskedAway);
+            AddAssert("Check proxy1 IsMaskedAway", () => !proxy1.IsMaskedAway);
+            AddAssert("Check proxy2 IsMaskedAway", () => !proxy2.IsMaskedAway);
+        }
+
+        /// <summary>
+        /// Tests that whether the box is out of bounds of its parent is not a consideration for masking, only whether its most-proxied-proxy is out of bounds of its parent,
+        /// and the most-proxied-proxy's parent is masking.
+        /// </summary>
+        /// <param name="boxMasking">Whether the box's parent is masking.</param>
+        /// <param name="proxy1Masking">Whether the parent of box's proxy is masking.</param>
+        /// <param name="proxy2Masking">Whether the parent of the proxy's proxy is masking.</param>
+        /// <param name="shouldBeMaskedAway">Whether the box should be masked away.</param>
+        [TestCase(false, false, false, false)]
+        [TestCase(true, false, false, false)]
+        [TestCase(true, true, false, false)]
+        [TestCase(true, true, true, true)]
+        [TestCase(false, true, true, true)]
+        [TestCase(false, false, true, true)]
+        public void TestBoxInBoundsWithProxy1OutOfBoundsWithProxy2OutOfBounds(bool boxMasking, bool proxy1Masking, bool proxy2Masking, bool shouldBeMaskedAway)
+        {
+            var box = new Box();
+            var proxy1 = box.CreateProxy();
+            var proxy2 = proxy1.CreateProxy();
+
+            Children = new Drawable[]
+            {
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Masking = boxMasking,
+                    Child = box
+                },
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Masking = proxy1Masking,
+                    Child = proxy1
+                },
+                new Container
+                {
+                    Size = new Vector2(200),
+                    Position = new Vector2(10),
+                    Masking = proxy2Masking,
+                    Child = proxy2
+                }
+            };
+
+            AddWaitStep(1, "Wait for UpdateSubTree");
+            AddAssert("Check box IsMaskedAway", () => box.IsMaskedAway == shouldBeMaskedAway);
+            AddAssert("Check proxy1 IsMaskedAway", () => !proxy1.IsMaskedAway);
+            AddAssert("Check proxy2 IsMaskedAway", () => !proxy2.IsMaskedAway);
+        }
+    }
+}

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Visual\TestCaseGridContainer.cs" />
     <Compile Include="Visual\TestCaseHollowEdgeEffect.cs" />
     <Compile Include="Visual\TestCaseInputResampler.cs" />
+    <Compile Include="Visual\TestCaseIsMaskedAway.cs" />
     <Compile Include="Visual\TestCaseKeyBindings.cs" />
     <Compile Include="Visual\TestCaseLayoutTransformRewinding.cs" />
     <Compile Include="Visual\TestCaseLocalisation.cs" />

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -507,6 +507,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="source">The parent that triggered this update on this <see cref="Drawable"/>.</param>
         /// <param name="maskingBounds">The <see cref="RectangleF"/> that defines the masking bounds.</param>
+        /// <returns>Whether masking calculations have taken place.</returns>
         public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
         {
             if (!base.UpdateSubTreeMasking(source, maskingBounds))

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -505,23 +505,27 @@ namespace osu.Framework.Graphics.Containers
         /// Updates all masking calculations for this <see cref="CompositeDrawable"/> and its <see cref="AliveInternalChildren"/>.
         /// This occurs post-<see cref="UpdateSubTree"/> to ensure that all <see cref="Drawable"/> updates have taken place.
         /// </summary>
+        /// <param name="source">The parent that triggered this update on this <see cref="Drawable"/>.</param>
         /// <param name="maskingBounds">The <see cref="RectangleF"/> that defines the masking bounds.</param>
-        public override void UpdateSubTreeMasking(RectangleF maskingBounds)
+        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
         {
-            base.UpdateSubTreeMasking(maskingBounds);
+            if (!base.UpdateSubTreeMasking(source, maskingBounds))
+                return false;
 
             if (IsMaskedAway)
-                return;
+                return true;
 
             if (aliveInternalChildren.Count == 0)
-                return;
+                return true;
 
             var childMaskingBounds = ComputeChildMaskingBounds(maskingBounds);
 
             // We iterate by index to gain performance
             // ReSharper disable once ForCanBeConvertedToForeach
             for (int i = 0; i < aliveInternalChildren.Count; i++)
-                aliveInternalChildren[i].UpdateSubTreeMasking(childMaskingBounds);
+                aliveInternalChildren[i].UpdateSubTreeMasking(this, childMaskingBounds);
+
+            return true;
         }
 
         protected override bool ComputeIsMaskedAway(RectangleF maskingBounds)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -361,8 +361,17 @@ namespace osu.Framework.Graphics
         /// Updates all masking calculations for this <see cref="Drawable"/>.
         /// This occurs post-<see cref="UpdateSubTree"/> to ensure that all <see cref="Drawable"/> updates have taken place.
         /// </summary>
+        /// <param name="source">The parent that triggered this update on this <see cref="Drawable"/>.</param>
         /// <param name="maskingBounds">The <see cref="RectangleF"/> that defines the masking bounds.</param>
-        public virtual void UpdateSubTreeMasking(RectangleF maskingBounds) => IsMaskedAway = ComputeIsMaskedAway(maskingBounds);
+        /// <returns>Whether masking calculations have been updated.</returns>
+        public virtual bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
+        {
+            if (HasProxy && source != proxy)
+                return false;
+
+            IsMaskedAway = ComputeIsMaskedAway(maskingBounds);
+            return true;
+        }
 
         /// <summary>
         /// Computes whether this <see cref="Drawable"/> is masked away.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -363,7 +363,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <param name="source">The parent that triggered this update on this <see cref="Drawable"/>.</param>
         /// <param name="maskingBounds">The <see cref="RectangleF"/> that defines the masking bounds.</param>
-        /// <returns>Whether masking calculations have been updated.</returns>
+        /// <returns>Whether masking calculations have taken place.</returns>
         public virtual bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
         {
             if (HasProxy && source != proxy)

--- a/osu.Framework/Graphics/ProxyDrawable.cs
+++ b/osu.Framework/Graphics/ProxyDrawable.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using osu.Framework.Graphics.Primitives;
+
 namespace osu.Framework.Graphics
 {
     public class ProxyDrawable : Drawable
@@ -19,5 +21,7 @@ namespace osu.Framework.Graphics
         // We do not want to receive updates. That is the business
         // of the original drawable.
         public override bool IsPresent => false;
+
+        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => Original.UpdateSubTreeMasking(this, maskingBounds);
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -248,7 +248,7 @@ namespace osu.Framework.Platform
             Root.Size = Vector2.ComponentMax(Vector2.One, Root.Size);
 
             Root.UpdateSubTree();
-            Root.UpdateSubTreeMasking(Root.ScreenSpaceDrawQuad.AABBFloat);
+            Root.UpdateSubTreeMasking(Root, Root.ScreenSpaceDrawQuad.AABBFloat);
 
             using (var buffer = DrawRoots.Get(UsageType.Write))
                 buffer.Object = Root.GenerateDrawNodeSubtree(buffer.Index);


### PR DESCRIPTION
We were using the incorrect masking bounds for the drawable. This is causing taiko hitobjects to get masked away when they're moved to an upper (non-masking) layer, intended to avoid the hitobjects getting masked away.

Also adds a whole slew of automated testcases for IsMaskedAway.