### PR TITLE
Fix tests being removed from TestBrowser while they're being updated

### DIFF
--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -353,7 +353,7 @@ namespace osu.Framework.Testing
 
                 testContentContainer.Add(new DelayedLoadWrapper(CurrentTest, 0));
 
-                newTest.OnLoadComplete = d =>
+                newTest.OnLoadComplete = d => Schedule(() =>
                 {
                     if (lastTest?.Parent != null)
                     {
@@ -384,7 +384,7 @@ namespace osu.Framework.Testing
                     backgroundCompiler.Checkpoint(CurrentTest);
                     runTests(onCompletion);
                     updateButtons();
-                };
+                });
             }
         }
 


### PR DESCRIPTION
Resolves ppy/osu#1781.

Alternative to #1319, fixes the underlying cause - OnLoadComplete is called from a child which is currently being updated, and this will trigger GetContainingInputManager to be null since the child now has a null parent.