### PR TITLE
Attempting to improve the iOS load/build process

### DIFF
--- a/SampleGame.iOS/SampleGame.iOS.csproj
+++ b/SampleGame.iOS/SampleGame.iOS.csproj
@@ -52,10 +52,11 @@
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchNoSymbolStrip>true</MtouchNoSymbolStrip>
-    <MtouchLink>None</MtouchLink>
+    <MtouchLink>Full</MtouchLink>
     <MtouchArch>x86_64</MtouchArch>
     <MtouchHttpClientHandler>HttpClientHandler</MtouchHttpClientHandler>
     <PlatformTarget>x86</PlatformTarget>
+    <MtouchExtraArgs>--nolinkaway -gcc_flags "-lstdc++ -framework AudioToolbox -framework SystemConfiguration -framework CFNetwork -framework Accelerate -force_load ../Libraries/libbass.a -force_load ../Libraries/libbass_fx.a"</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>true</DebugSymbols>

--- a/osu-framework.iOS.sln
+++ b/osu-framework.iOS.sln
@@ -1,0 +1,43 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleGame.iOS", "SampleGame.iOS\SampleGame.iOS.csproj", "{80B89BDA-D5C8-4987-A03D-037C483ABEF0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework", "osu.Framework\osu.Framework.csproj", "{327A7079-63CF-4D1E-9F14-8E351F50DEAE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+		Debug|iPhoneSimulator = Debug|iPhoneSimulator
+		Release|iPhone = Release|iPhone
+		Release|iPhoneSimulator = Release|iPhoneSimulator
+		Debug|iPhone = Debug|iPhone
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|Any CPU.ActiveCfg = Release|iPhone
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|Any CPU.Build.0 = Release|iPhone
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|iPhone.ActiveCfg = Release|iPhone
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|iPhone.Build.0 = Release|iPhone
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|iPhone.ActiveCfg = Debug|iPhone
+		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|iPhone.Build.0 = Debug|iPhone
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Release|iPhone.Build.0 = Release|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{327A7079-63CF-4D1E-9F14-8E351F50DEAE}.Debug|iPhone.Build.0 = Debug|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/osu-framework.sln
+++ b/osu-framework.sln
@@ -1,41 +1,24 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27004.2002
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework", "osu.Framework\osu.Framework.csproj", "{C76BF5B3-985E-4D39-95FE-97C9C879B83A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework", "osu.Framework\osu.Framework.csproj", "{C76BF5B3-985E-4D39-95FE-97C9C879B83A}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleGame", "SampleGame\SampleGame.csproj", "{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleGame", "SampleGame\SampleGame.csproj", "{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "osu.Framework.Tests", "osu.Framework.Tests\osu.Framework.Tests.csproj", "{79803407-6F50-484F-93F5-641911EABD8A}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SampleGame.iOS", "SampleGame.iOS\SampleGame.iOS.csproj", "{80B89BDA-D5C8-4987-A03D-037C483ABEF0}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "osu.Framework.Tests", "osu.Framework.Tests\osu.Framework.Tests.csproj", "{79803407-6F50-484F-93F5-641911EABD8A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-		Debug|iPhoneSimulator = Debug|iPhoneSimulator
-		Release|iPhone = Release|iPhone
-		Release|iPhoneSimulator = Release|iPhoneSimulator
-		Debug|iPhone = Debug|iPhone
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Release|Any CPU.Build.0 = Release|Any CPU
-
-		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
-		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
-		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Debug|iPhone.ActiveCfg = Debug|Any CPU
-		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Debug|iPhone.Build.0 = Debug|Any CPU
-
-		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
-		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
-		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Release|iPhone.ActiveCfg = Release|Any CPU
-		{C76BF5B3-985E-4D39-95FE-97C9C879B83A}.Release|iPhone.Build.0 = Release|Any CPU
-
 		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -44,19 +27,6 @@ Global
 		{79803407-6F50-484F-93F5-641911EABD8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79803407-6F50-484F-93F5-641911EABD8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79803407-6F50-484F-93F5-641911EABD8A}.Release|Any CPU.Build.0 = Release|Any CPU
-
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|Any CPU.ActiveCfg = Release|iPhone
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|Any CPU.Build.0 = Release|iPhone
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|iPhone.ActiveCfg = Release|iPhone
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|iPhone.Build.0 = Release|iPhone
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|iPhoneSimulator.ActiveCfg = Release|iPhoneSimulator
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Release|iPhoneSimulator.Build.0 = Release|iPhoneSimulator
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|iPhone.ActiveCfg = Debug|iPhone
-		{80B89BDA-D5C8-4987-A03D-037C483ABEF0}.Debug|iPhone.Build.0 = Debug|iPhone
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="References">
-    <Reference Include="System.Runtime.InteropServices.RuntimeInformation"/>
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
   </ItemGroup>
 
   <ItemGroup Label="Package References">


### PR DESCRIPTION
* Splits out iOS build into a separate sln.
* Still requires `nuget restore` to be run from terminal prior to loading in vs for mac... This is potentially an issue we can report to MS.