### PR TITLE
Fix thread race in path segment construction

### DIFF
--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -167,7 +167,7 @@ namespace osu.Framework.Graphics.Lines
 
             n.Shared = pathDrawNodeSharedData;
 
-            n.Segments = segments;
+            n.Segments = segments.ToList();
 
             base.ApplyDrawNode(node);
         }

--- a/osu.Framework/Graphics/Lines/PathDrawNode.cs
+++ b/osu.Framework/Graphics/Lines/PathDrawNode.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Graphics.Lines
     public class PathDrawNode : DrawNode
     {
         public const int MAXRES = 24;
-        public List<Line> Segments = new List<Line>();
+        public List<Line> Segments;
 
         public Vector2 DrawSize;
         public float Width;


### PR DESCRIPTION
Previous PathDrawNode being drawn while segments is being updated on the update thread. :NoGood: