### PR TITLE
Various improvements to textbox input

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTextBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextBox.cs
@@ -65,6 +65,14 @@ namespace osu.Framework.Tests.Visual
                 TabbableContentContainer = textBoxes
             });
 
+            textBoxes.Add(new TextBox
+            {
+                Text = "Readonly textbox",
+                Size = new Vector2(500, 30),
+                ReadOnly = true,
+                TabbableContentContainer = textBoxes
+            });
+
             FillFlowContainer otherTextBoxes = new FillFlowContainer
             {
                 Direction = FillDirection.Vertical,

--- a/osu.Framework/Graphics/Containers/TabbableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContainer.cs
@@ -17,11 +17,20 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     internal interface ITabbableContainer
     {
+        /// <summary>
+        /// Whether this <see cref="ITabbableContainer"/> can be tabbed to.
+        /// </summary>
+        bool CanBeTabbedTo { get; }
     }
 
     public class TabbableContainer<T> : Container<T>, ITabbableContainer
         where T : Drawable
     {
+        /// <summary>
+        /// Whether this <see cref="TabbableContainer{T}"/> can be tabbed to.
+        /// </summary>
+        public virtual bool CanBeTabbedTo => true;
+
         /// <summary>
         /// Allows for tabbing between multiple levels within the TabbableContentContainer.
         /// </summary>
@@ -50,7 +59,7 @@ namespace osu.Framework.Graphics.Containers
 
                 if (!started)
                     started = ReferenceEquals(drawable, this);
-                else if (drawable is ITabbableContainer)
+                else if (drawable is ITabbableContainer tabbable && tabbable.CanBeTabbedTo)
                     return drawable;
 
                 var composite = drawable as CompositeDrawable;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -48,9 +48,9 @@ namespace osu.Framework.Graphics.UserInterface
         private AudioManager audio;
 
         /// <summary>
-        /// Should this TextBox accept arrow keys for navigation?
+        /// Whether this TextBox should accept left and right arrow keys for navigation.
         /// </summary>
-        public bool HandleLeftRightArrows = true;
+        public virtual bool HandleLeftRightArrows => true;
 
         protected virtual Color4 BackgroundCommit => new Color4(249, 90, 255, 200);
         protected virtual Color4 BackgroundFocused => new Color4(100, 100, 100, 255);

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -60,6 +60,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         public bool ReleaseFocusOnCommit = true;
 
+        public override bool CanBeTabbedTo => !ReadOnly;
+
         private ITextInputSource textInput;
         private Clipboard clipboard;
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -590,14 +590,6 @@ namespace osu.Framework.Graphics.UserInterface
 
             switch (args.Key)
             {
-                case Key.Left:
-                case Key.Right:
-                case Key.Delete:
-                case Key.BackSpace:
-                case Key.Home:
-                case Key.End:
-                    return false;
-
                 case Key.Escape:
                     GetContainingInputManager().ChangeFocus(null);
                     return true;
@@ -622,7 +614,7 @@ namespace osu.Framework.Graphics.UserInterface
                     return true;
             }
 
-            return true;
+            return false;
         }
 
         protected override bool OnDrag(InputState state)

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -26,6 +26,8 @@ namespace osu.Framework.Input
 
         public override IEnumerable<KeyBinding> DefaultKeyBindings => host.PlatformKeyBindings;
 
+        protected override bool Prioritised => true;
+
         protected override bool SendRepeats => true;
     }
 


### PR DESCRIPTION
* Fixes TextBoxes blocking all key input.
  * Not entirely sure why this was here, if any case comes up where this breaks we'll analyse it/comment it appropriately.
* Removes unnecessary returns which are already handled in `OnAction`.
* Fixes `PlatformActions` not being handled before keys.
  * Fixes not being able to Cmd+Left/Cmd+Right in the search box in SongSelect.
* Fixes readonly textboxes being able to be tabbed to. Browsers do the same thing.