### PR TITLE
Combine usages/implementations of custom origins and anchors

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseAnchors.cs
+++ b/osu.Framework.Tests/Visual/TestCaseAnchors.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.MathUtils;
+using osu.Framework.Testing;
+using OpenTK;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseAnchors : TestCase
+    {
+        [TestCase(Anchor.TopLeft, 0, 0)]
+        [TestCase(Anchor.TopCentre, 0.5f, 0)]
+        [TestCase(Anchor.TopRight, 1, 0)]
+        [TestCase(Anchor.CentreLeft, 0, 0.5f)]
+        [TestCase(Anchor.Centre, 0.5f, 0.5f)]
+        [TestCase(Anchor.CentreRight, 1, 0.5f)]
+        [TestCase(Anchor.BottomLeft, 0, 1)]
+        [TestCase(Anchor.BottomCentre, 0.5f, 1)]
+        [TestCase(Anchor.BottomRight, 1, 1)]
+        public void TestSimpleAnchors(Anchor anchor, float expectedX, float expectedY)
+        {
+            Box box = null;
+            AddStep($"Construct {anchor}", () =>
+            {
+                Clear();
+                Add(new Container
+                {
+                    Size = Vector2.One,
+                    Child = box = new Box { Anchor = anchor }
+                });
+            });
+
+            AddAssert("At expected position", () => validatePosition(box, new Vector2(expectedX, expectedY)));
+        }
+
+        [TestCase(0, 0)]
+        [TestCase(0.25f, 0)]
+        [TestCase(0.5f, 0)]
+        [TestCase(0.75f, 0)]
+        [TestCase(1, 0)]
+        [TestCase(0, 1)]
+        [TestCase(0, 0.25f)]
+        [TestCase(0, 0.5f)]
+        [TestCase(0, 0.75f)]
+        [TestCase(0, 1)]
+        [TestCase(-0.5f, -0.5f)]
+        [TestCase(1.5f, -0.5f)]
+        [TestCase(-0.5f, 1.5f)]
+        [TestCase(1.5f, 1.5f)]
+        [TestCase(0.5f, 0.5f)]
+        public void TestCustomAnchors(float anchorX, float anchorY)
+        {
+            var anchorPosition = new Vector2(anchorX, anchorY);
+
+            Box box = null;
+            AddStep($"Construct {anchorPosition}", () =>
+            {
+                Clear();
+                Add(new Container
+                {
+                    Size = Vector2.One,
+                    Child = box = new Box { AnchorPosition = anchorPosition }
+                });
+            });
+
+            AddAssert("At expected position", () => validatePosition(box, anchorPosition));
+        }
+
+        private bool validatePosition(Box box, Vector2 expectedPosition) => Precision.AlmostEquals(expectedPosition, box.ToParentSpace(Vector2.Zero));
+    }
+}

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="TestGame.cs" />
     <Compile Include="VisualTestGame.cs" />
     <Compile Include="Visual\FrameworkTestCase.cs" />
+    <Compile Include="Visual\TestCaseAnchors.cs" />
     <Compile Include="Visual\TestCaseAnimation.cs" />
     <Compile Include="Visual\TestCaseBindableNumbers.cs" />
     <Compile Include="Visual\TestCaseBlending.cs" />

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -937,9 +937,6 @@ namespace osu.Framework.Graphics
             }
         }
 
-
-        private Vector2 customOrigin;
-
         /// <summary>
         /// The origin of the local coordinate system of this Drawable
         /// in relative coordinates expressed in the coordinate system with origin at the
@@ -967,6 +964,8 @@ namespace osu.Framework.Graphics
             }
         }
 
+        private Vector2 customOrigin;
+
         /// <summary>
         /// The origin of the local coordinate system of this Drawable
         /// in absolute coordinates expressed in the coordinate system with origin at the
@@ -986,7 +985,6 @@ namespace osu.Framework.Graphics
 
                 return result - new Vector2(margin.Left, margin.Top);
             }
-
             set
             {
                 if (!Validation.IsFinite(value)) throw new ArgumentException($@"{nameof(OriginPosition)} must be finite, but is {value}.");
@@ -996,7 +994,6 @@ namespace osu.Framework.Graphics
             }
         }
 
-
         private Anchor anchor = Anchor.TopLeft;
 
         /// <summary>
@@ -1004,7 +1001,7 @@ namespace osu.Framework.Graphics
         /// in the coordinate system with origin at the top left corner of the
         /// <see cref="Parent"/>'s <see cref="DrawRectangle"/>.
         /// Can either be one of 9 relative positions (0, 0.5, and 1 in x and y)
-        /// or a fixed absolute position via <see cref="RelativeAnchorPosition"/>.
+        /// or a fixed absolute position via <see cref="AnchorPosition"/>.
         /// </summary>
         public Anchor Anchor
         {
@@ -1022,9 +1019,6 @@ namespace osu.Framework.Graphics
             }
         }
 
-
-        private Vector2 customRelativeAnchorPosition;
-
         /// <summary>
         /// Specifies in relative coordinates where <see cref="Origin"/> is attached
         /// to the <see cref="Parent"/> in the coordinate system with origin at the top
@@ -1037,7 +1031,7 @@ namespace osu.Framework.Graphics
             get
             {
                 if (Anchor == Anchor.Custom)
-                    return customRelativeAnchorPosition;
+                    throw new InvalidOperationException(@"Can not obtain relative anchor position for custom anchors.");
 
                 Vector2 result = Vector2.Zero;
                 if ((anchor & Anchor.x1) > 0)
@@ -1052,22 +1046,37 @@ namespace osu.Framework.Graphics
 
                 return result;
             }
-
-            set
-            {
-                if (!Validation.IsFinite(value)) throw new ArgumentException($@"{nameof(RelativeAnchorPosition)} must be finite, but is {value}.");
-
-                customRelativeAnchorPosition = value;
-                Anchor = Anchor.Custom;
-            }
         }
+
+        private Vector2 customAnchor;
 
         /// <summary>
         /// Specifies in absolute coordinates where <see cref="Origin"/> is attached
         /// to the <see cref="Parent"/> in the coordinate system with origin at the top
         /// left corner of the <see cref="Parent"/>'s <see cref="DrawRectangle"/>.
         /// </summary>
-        public Vector2 AnchorPosition => RelativeAnchorPosition * Parent?.ChildSize ?? Vector2.Zero;
+        public Vector2 AnchorPosition
+        {
+            get
+            {
+                Vector2 result;
+                if (Anchor == Anchor.Custom)
+                    result = customAnchor;
+                else if (Anchor == Anchor.TopLeft)
+                    result = Vector2.Zero;
+                else
+                    result = computeAnchorPosition(Parent?.ChildSize ?? Vector2.Zero, Anchor);
+
+                return result;
+            }
+            set
+            {
+                if (!Validation.IsFinite(value)) throw new ArgumentException($@"{nameof(AnchorPosition)} must be finite, but is {value}.");
+
+                customAnchor = value;
+                Anchor = Anchor.Custom;
+            }
+        }
 
         /// <summary>
         /// Helper function to compute an absolute position given an absolute size and


### PR DESCRIPTION
Custom anchors are not used anywhere currently, however I'm about to use them to rewrite `DrawableSlider`.

Custom origins are defined in _absolute_ coordinates.

Previously, custom anchors were defined in _relative_ coordinates. With this change, they will now be defined in _absolute_ coordinates, in-line with custom origins.