### PR TITLE
Fix dynamically compiled test cases disappearing from old assembly

### DIFF
--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -250,14 +250,11 @@ namespace osu.Framework.Testing
             int i = TestTypes.FindIndex(t => t.Name == newType.Name && t.Assembly.GetName().Name == newType.Assembly.GetName().Name);
 
             if (i < 0)
-            {
-                i = TestTypes.Count;
                 TestTypes.Add(newType);
-            }
             else
                 TestTypes[i] = newType;
 
-            LoadTest(i);
+            LoadTest(newType);
         });
 
         protected override void LoadComplete()

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -247,8 +247,16 @@ namespace osu.Framework.Testing
 
             if (newType == null) return;
 
-            int i = TestTypes.FindIndex(t => t.Name == newType.Name);
-            TestTypes[i] = newType;
+            int i = TestTypes.FindIndex(t => t.Name == newType.Name && t.Assembly.GetName().Name == newType.Assembly.GetName().Name);
+
+            if (i < 0)
+            {
+                i = TestTypes.Count;
+                TestTypes.Add(newType);
+            }
+            else
+                TestTypes[i] = newType;
+
             LoadTest(i);
         });
 
@@ -342,6 +350,8 @@ namespace osu.Framework.Testing
                 // if we are a dynamically compiled type (via DynamicClassCompiler) we should update the dropdown accordingly.
                 if (testType.Assembly.FullName.Contains(DynamicClassCompiler.DYNAMIC_ASSEMBLY_NAME))
                     dropdown.AddDropdownItem($"dynamic ({testType.Name})", testType.Assembly);
+                else
+                    TestTypes.RemoveAll(t => t.Assembly.FullName.Contains(DynamicClassCompiler.DYNAMIC_ASSEMBLY_NAME));
 
                 dropdown.Current.Value = testType.Assembly;
 


### PR DESCRIPTION
Closes #1347 .

I kept the behaviour the same, where it deletes the dynamically compiled tests (and the dropdown entry for the dynamic assembly) when switching back to a "statically" compiled test.