### PR TITLE
Add a timeout for thread exiting

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -449,7 +449,7 @@ namespace osu.Framework.Platform
         private void stopAllThreads()
         {
             threads.ForEach(t => t.Exit());
-            threads.Where(t => t.Running).ForEach(t => t.Thread.Join());
+            threads.Where(t => t.Running).ForEach(t => t.Thread.Join(30000));
         }
 
         private void window_KeyDown(object sender, KeyboardKeyEventArgs e)


### PR DESCRIPTION
Under certain conditions, the audio thread is getting stuck during exit due to an underlying bass call. This should hopefully resolve that issue.

On top of this, we *do* always want to have a failsafe timeout for all threads to the game itself eventually gives up and leaves thread cleanup to the OS.