### PR TITLE
Allow resource managers to accept and return null

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -171,7 +171,7 @@ namespace osu.Framework.Audio
         /// Returns the global <see cref="SampleManager"/> if no resource store is passed.
         /// </summary>
         /// <param name="store">The <see cref="T:ResourceStore"/> of which to retrieve the <see cref="SampleManager"/>.</param>
-        public SampleManager GetSampleManager(ResourceStore<byte[]> store = null)
+        public SampleManager GetSampleManager(IResourceStore<byte[]> store = null)
         {
             if (store == null) return globalSampleManager.Value;
 

--- a/osu.Framework/Audio/Sample/SampleManager.cs
+++ b/osu.Framework/Audio/Sample/SampleManager.cs
@@ -27,6 +27,8 @@ namespace osu.Framework.Audio.Sample
 
         public SampleChannel Get(string name)
         {
+            if (string.IsNullOrEmpty(name)) return null;
+
             lock (sampleCache)
             {
                 Sample sample;

--- a/osu.Framework/Audio/Track/TrackManager.cs
+++ b/osu.Framework/Audio/Track/TrackManager.cs
@@ -16,6 +16,8 @@ namespace osu.Framework.Audio.Track
 
         public Track Get(string name)
         {
+            if (string.IsNullOrEmpty(name)) return null;
+
             TrackBass track = new TrackBass(store.GetStream(name));
             AddItem(track);
             return track;

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -58,6 +58,8 @@ namespace osu.Framework.Graphics.Textures
         /// <returns>The texture.</returns>
         public new virtual Texture Get(string name)
         {
+            if (string.IsNullOrEmpty(name)) return null;
+
             var cachedTex = textureCache.GetOrAdd(name, n =>
                 //Laziness ensure we are only ever creating the texture once (and blocking on other access until it is done).
                     new Lazy<TextureGL>(() => getTexture(name)?.TextureGL, LazyThreadSafetyMode.ExecutionAndPublication)).Value;


### PR DESCRIPTION
As we begin to query optional sources, such as user-provided content, it's more frequent that queries may be null or empty. In these cases it seems like handling and returning null is better than throwing exceptions.

Note that nulls are already returned in cases like `TextureStore`; this just allows the query to be null without throwing an exception.