### PR TITLE
Reduce dependence on zero-duration transforms

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -462,8 +462,16 @@ namespace osu.Framework.Graphics.Containers
             updateSize();
             updatePosition();
 
-            Scrollbar?.MoveTo(ScrollDirection, Current * Scrollbar.Size[ScrollDim]);
-            content.MoveTo(ScrollDirection, -Current);
+            if (ScrollDirection == Direction.Horizontal)
+            {
+                Scrollbar.X = Current * Scrollbar.Size.X;
+                content.X = -Current;
+            }
+            else
+            {
+                Scrollbar.Y = Current * Scrollbar.Size.Y;
+                content.Y = -Current;
+            }
         }
 
         protected internal class ScrollbarContainer : Container


### PR DESCRIPTION
They are too expensive to use. We either need to stop using them or make alternative arrangements.

Same changes need to be made on the osu!-side if we decide not to change the way zero-duration transform helpers handle themselves (for instance `ParallaxContainer`).