### PR TITLE
Fix transforms on RemoveCompletedTransforms drawables applying forever

### DIFF
--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -17,6 +17,12 @@ namespace osu.Framework.Graphics.Transforms
         internal bool Applied;
 
         /// <summary>
+        /// Whether this <see cref="Transform"/> has been applied completely to an <see cref="ITransformable"/>.
+        /// Used to track whether we still need to apply for targets which allow rewind.
+        /// </summary>
+        internal bool AppliedToEnd;
+
+        /// <summary>
         /// Whether this <see cref="Transform"/> can be rewound.
         /// </summary>
         public bool Rewindable = true;

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -149,24 +149,27 @@ namespace osu.Framework.Graphics.Transforms
                     }
                 }
 
-                t.Apply(time);
-
-                if (t.EndTime <= time)
+                if (time <= t.EndTime || !t.AppliedToEnd)
                 {
-                    if (RemoveCompletedTransforms || !t.Rewindable)
-                        transformsLazy.RemoveAt(i--);
+                    t.Apply(time);
 
-                    if (t.IsLooping)
+                    if (t.AppliedToEnd = time >= t.EndTime)
                     {
-                        t.StartTime += t.LoopDelay;
-                        t.EndTime += t.LoopDelay;
+                        if (RemoveCompletedTransforms || !t.Rewindable)
+                            transformsLazy.RemoveAt(i--);
 
-                        // this could be added back at a lower index than where we are currently iterating, but
-                        // running the same transform twice isn't a huge deal.
-                        transformsLazy.Add(t);
+                        if (t.IsLooping)
+                        {
+                            t.StartTime += t.LoopDelay;
+                            t.EndTime += t.LoopDelay;
+
+                            // this could be added back at a lower index than where we are currently iterating, but
+                            // running the same transform twice isn't a huge deal.
+                            transformsLazy.Add(t);
+                        }
+                        else if (t.OnComplete != null)
+                            removalActions.Add(t.OnComplete);
                     }
-                    else if (t.OnComplete != null)
-                        removalActions.Add(t.OnComplete);
                 }
             }
 

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -153,7 +153,9 @@ namespace osu.Framework.Graphics.Transforms
                 {
                     t.Apply(time);
 
-                    if (t.AppliedToEnd = time >= t.EndTime)
+                    t.AppliedToEnd = time >= t.EndTime;
+
+                    if (t.AppliedToEnd)
                     {
                         if (RemoveCompletedTransforms || !t.Rewindable)
                             transformsLazy.RemoveAt(i--);


### PR DESCRIPTION
Not only were they applying, but they were running their OnComplete actions every frame forever. Huge performance losses.

Regressed with implementation of rewind support.