### PR TITLE
Fix VisualTests crashing on first startup due to incorrect configuration

### DIFF
--- a/osu.Framework/Testing/TestBrowserConfig.cs
+++ b/osu.Framework/Testing/TestBrowserConfig.cs
@@ -13,6 +13,12 @@ namespace osu.Framework.Testing
         public TestBrowserConfig(Storage storage) : base(storage)
         {
         }
+
+        protected override void InitialiseDefaults()
+        {
+            base.InitialiseDefaults();
+            Set(TestBrowserSetting.LastTest, string.Empty);
+        }
     }
 
     internal enum TestBrowserSetting


### PR DESCRIPTION
Not sure how anyone was using visualtests. It would just crash on a fresh install.