### PR TITLE
Avoid updates / generating draw nodes for valid BufferedContainers

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseCachedBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCachedBufferedContainer.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseCachedBufferedContainer : GridTestCase
+    {
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(BufferedContainer),
+            typeof(BufferedContainerDrawNode),
+        };
+
+        public TestCaseCachedBufferedContainer()
+            : base(4, 2)
+        {
+            string[] labels =
+            {
+                "uncached",
+                "cached",
+                "uncached with rotation",
+                "cached with rotation",
+                "uncached with movement",
+                "cached with movement",
+                "uncached with parent scale",
+                "cached with parent scale",
+            };
+
+            var boxes = new List<ContainingBox>();
+
+            for (int i = 0; i < Rows * Cols; ++i)
+            {
+                ContainingBox box;
+
+                Cell(i).AddRange(new Drawable[]
+                {
+                    new SpriteText
+                    {
+                        Text = labels[i],
+                        TextSize = 20,
+                    },
+                    box = new ContainingBox(i == 6 || i == 7)
+                    {
+                        Child = new CountingBox(i == 2 || i == 3, i == 4 || i == 5)
+                        {
+                            CacheDrawnFrameBuffer = i % 2 == 1
+                        },
+                    }
+                });
+
+                boxes.Add(box);
+            }
+
+            AddWaitStep(5);
+
+            // ensure uncached is always updating children.
+            AddAssert("box 0 count > 0", () => boxes[0].Count > 0);
+            AddAssert("even box counts equal", () =>
+                boxes[0].Count == boxes[2].Count &&
+                boxes[2].Count == boxes[4].Count &&
+                boxes[4].Count == boxes[6].Count);
+
+            // ensure cached is never updating children.
+            AddAssert("box 1 count is 1", () => boxes[1].Count == 1);
+
+            // ensure rotation changes are invalidating cache (for now).
+            AddAssert("box 2 count > 0", () => boxes[2].Count > 0);
+            AddAssert("box 2 count equals box 3 count", () => boxes[2].Count == boxes[3].Count);
+
+            // ensure cached with only translation is never updating children.
+            AddAssert("box 5 count is 1", () => boxes[1].Count == 1);
+
+            // ensure a parent scaling is invalidating cache.
+            AddAssert("box 5 count equals box 6 count", () => boxes[5].Count == boxes[6].Count);
+        }
+
+        private class ContainingBox : Container
+        {
+            private readonly bool scaling;
+
+            public ContainingBox(bool scaling)
+            {
+                this.scaling = scaling;
+                RelativeSizeAxes = Axes.Both;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                if (scaling)
+                    this.ScaleTo(1.2f, 1000).Then().ScaleTo(1, 1000).Loop();
+            }
+        }
+
+        private class CountingBox : BufferedContainer
+        {
+            private readonly bool rotating;
+            private readonly bool moving;
+            private readonly SpriteText count;
+            public new int Count;
+
+            public CountingBox(bool rotating = false, bool moving = false)
+            {
+                this.rotating = rotating;
+                this.moving = moving;
+                RelativeSizeAxes = Axes.Both;
+                Origin = Anchor.Centre;
+                Anchor = Anchor.Centre;
+
+                Scale = new Vector2(0.5f);
+
+                InternalChildren = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.Centre,
+                        Colour = Color4.NavajoWhite,
+                    },
+                    count = new SpriteText
+                    {
+                        Colour = Color4.Black,
+                        Origin = Anchor.Centre,
+                        Anchor = Anchor.Centre,
+                        TextSize = 80
+                    }
+                };
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                if (RequiresChildrenUpdate)
+                {
+                    Count++;
+                    count.Text = Count.ToString();
+                }
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                if (rotating) this.RotateTo(360, 1000).Loop();
+                if (moving) this.MoveTo(new Vector2(100, 0), 2000, Easing.InOutSine).Then().MoveTo(new Vector2(0, 0), 2000, Easing.InOutSine).Loop();
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/TestCaseCachedBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCachedBufferedContainer.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Tests.Visual
         };
 
         public TestCaseCachedBufferedContainer()
-            : base(4, 2)
+            : base(5, 2)
         {
             string[] labels =
             {
@@ -34,6 +34,8 @@ namespace osu.Framework.Tests.Visual
                 "cached with movement",
                 "uncached with parent scale",
                 "cached with parent scale",
+                "uncached with parent scale&fade",
+                "cached with parent scale&fade",
             };
 
             var boxes = new List<ContainingBox>();
@@ -49,11 +51,11 @@ namespace osu.Framework.Tests.Visual
                         Text = labels[i],
                         TextSize = 20,
                     },
-                    box = new ContainingBox(i == 6 || i == 7)
+                    box = new ContainingBox(i >= 6, i >= 8)
                     {
                         Child = new CountingBox(i == 2 || i == 3, i == 4 || i == 5)
                         {
-                            CacheDrawnFrameBuffer = i % 2 == 1
+                            CacheDrawnFrameBuffer = i % 2 == 1,
                         },
                     }
                 });
@@ -82,23 +84,29 @@ namespace osu.Framework.Tests.Visual
 
             // ensure a parent scaling is invalidating cache.
             AddAssert("box 5 count equals box 6 count", () => boxes[5].Count == boxes[6].Count);
+
+            // ensure we don't break on colour invalidations (due to blanket invalidation logic in Drawable.Invalidate).
+            AddAssert("box 7 count equals box 8 count", () => boxes[7].Count == boxes[8].Count);
         }
 
         private class ContainingBox : Container
         {
             private readonly bool scaling;
+            private readonly bool fading;
 
-            public ContainingBox(bool scaling)
+            public ContainingBox(bool scaling, bool fading)
             {
                 this.scaling = scaling;
+                this.fading = fading;
+
                 RelativeSizeAxes = Axes.Both;
             }
 
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                if (scaling)
-                    this.ScaleTo(1.2f, 1000).Then().ScaleTo(1, 1000).Loop();
+                if (scaling) this.ScaleTo(1.2f, 1000).Then().ScaleTo(1, 1000).Loop();
+                if (fading) this.FadeTo(0.5f, 1000).Then().FadeTo(1, 1000).Loop();
             }
         }
 

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Visual\TestCaseBindableNumbers.cs" />
     <Compile Include="Visual\TestCaseBlending.cs" />
     <Compile Include="Visual\TestCaseBufferedContainer.cs" />
+    <Compile Include="Visual\TestCaseCachedBufferedContainer.cs" />
     <Compile Include="Visual\TestCaseCheckboxes.cs" />
     <Compile Include="Visual\TestCaseCircularContainer.cs" />
     <Compile Include="Visual\TestCaseCircularProgress.cs" />

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -334,6 +334,19 @@ namespace osu.Framework.Graphics.Containers
             base.Update();
         }
 
+        private readonly long[] frameBufferVersions = new long[3];
+        private long currentFrameBuffer;
+
+        internal override bool AddChildDrawNodes => frameBufferVersions[currentFrameBuffer] != childrenUpdateVersion;
+
+        internal override DrawNode GenerateDrawNodeSubtree(int treeIndex)
+        {
+            currentFrameBuffer = treeIndex;
+            var node = base.GenerateDrawNodeSubtree(treeIndex);
+            frameBufferVersions[currentFrameBuffer] = childrenUpdateVersion;
+            return node;
+        }
+
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -329,7 +329,8 @@ namespace osu.Framework.Graphics.Containers
             if ((invalidation & Invalidation.DrawNode) > 0)
                     ++updateVersion;
 
-            if ((invalidation & (Invalidation.MiscGeometry | Invalidation.DrawInfo)) > 0)
+            // We actually only care about Invalidation.MiscGeometry | Invalidation.DrawInfo, but must match the blanket invalidation logic in Drawable.Invalidate
+            if ((invalidation & (Invalidation.Colour | Invalidation.RequiredParentSizeToFit | Invalidation.DrawInfo)) > 0)
                 checkScrenSpaceSize = true;
 
             return base.Invalidate(invalidation, source, shallPropagate);

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -216,10 +216,10 @@ namespace osu.Framework.Graphics.Containers
         public void ForceRedraw() => Invalidate(Invalidation.DrawNode);
 
         /// <summary>
-        /// We need 2 frame buffers such that we can accumulate post-processing effects in a
+        /// We need 3 frame buffers such that we can accumulate post-processing effects in a
         /// ping-pong fashion going back and forth (reading from one buffer, writing into the other).
         /// </summary>
-        private readonly FrameBuffer[] frameBuffers = new FrameBuffer[2];
+        private readonly FrameBuffer[] frameBuffers = new FrameBuffer[3];
 
         /// <summary>
         /// In order to signal the draw thread to re-draw the buffered container we version it.

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -337,20 +337,14 @@ namespace osu.Framework.Graphics.Containers
         private readonly long[] frameBufferVersions = new long[3];
         private long currentFrameBuffer;
 
-        internal override bool AddChildDrawNodes => frameBufferVersions[currentFrameBuffer] != childrenUpdateVersion;
+        internal override bool AddChildDrawNodes => frameBufferVersions[currentFrameBuffer] != updateVersion;
 
         internal override DrawNode GenerateDrawNodeSubtree(int treeIndex)
         {
             currentFrameBuffer = treeIndex;
             var node = base.GenerateDrawNodeSubtree(treeIndex);
-            frameBufferVersions[currentFrameBuffer] = childrenUpdateVersion;
+            frameBufferVersions[currentFrameBuffer] = childrenUpdateVersion = updateVersion;
             return node;
-        }
-
-        protected override void UpdateAfterChildren()
-        {
-            base.UpdateAfterChildren();
-            childrenUpdateVersion = updateVersion;
         }
 
         protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate && childrenUpdateVersion != updateVersion;

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -234,6 +234,8 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         private long updateVersion;
 
+        private Vector2 updateVersionScreenSpace;
+
         /// <summary>
         /// We also want to keep track of updates to our children, as we can bypass these updates
         /// when our output is in a cached state.
@@ -273,6 +275,8 @@ namespace osu.Framework.Graphics.Containers
         protected override void ApplyDrawNode(DrawNode node)
         {
             BufferedContainerDrawNode n = (BufferedContainerDrawNode)node;
+
+            updateVersionScreenSpace = new Vector2(ScreenSpaceDrawQuad.Width, ScreenSpaceDrawQuad.Height);
 
             n.ScreenSpaceDrawRectangle = ScreenSpaceDrawQuad.AABBFloat;
             n.Batch = quadBatch;
@@ -330,6 +334,10 @@ namespace osu.Framework.Graphics.Containers
             // Invalidate drawn frame buffer every frame.
             if (!CacheDrawnFrameBuffer)
                 ForceRedraw();
+
+            if (ScreenSpaceDrawQuad.Width != updateVersionScreenSpace.X || ScreenSpaceDrawQuad.Height != updateVersionScreenSpace.Y)
+                ForceRedraw();
+
 
             base.Update();
         }

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -223,7 +223,7 @@ namespace osu.Framework.Graphics.Containers
         /// We need 2 frame buffers such that we can accumulate post-processing effects in a
         /// ping-pong fashion going back and forth (reading from one buffer, writing into the other).
         /// </summary>
-        private readonly FrameBuffer[] frameBuffers = new FrameBuffer[3];
+        private readonly FrameBuffer[] frameBuffers = new FrameBuffer[2];
 
         /// <summary>
         /// In order to signal the draw thread to re-draw the buffered container we version it.

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -174,7 +174,7 @@ namespace osu.Framework.Graphics.Containers
             currentFrameBufferIndex = originalIndex;
 
             Vector2 frameBufferSize = new Vector2((float)Math.Ceiling(ScreenSpaceDrawRectangle.Width), (float)Math.Ceiling(ScreenSpaceDrawRectangle.Height));
-            if (UpdateVersion > DrawVersion.Value || frameBufferSize != FrameBuffers[0].Size)
+            if (UpdateVersion > DrawVersion.Value)
             {
                 DrawVersion.Value = UpdateVersion;
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -730,7 +730,9 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        internal sealed override DrawNode GenerateDrawNodeSubtree(int treeIndex)
+        internal virtual bool AddChildDrawNodes => true;
+
+        internal override DrawNode GenerateDrawNodeSubtree(int treeIndex)
         {
             // No need for a draw node at all if there are no children and we are not glowing.
             if (aliveInternalChildren.Count == 0 && CanBeFlattened)
@@ -740,16 +742,19 @@ namespace osu.Framework.Graphics.Containers
             if (cNode == null)
                 return null;
 
-            if (cNode.Children == null)
-                cNode.Children = new List<DrawNode>(aliveInternalChildren.Count);
+            if (AddChildDrawNodes)
+            {
+                if (cNode.Children == null)
+                    cNode.Children = new List<DrawNode>(aliveInternalChildren.Count);
 
-            List<DrawNode> target = cNode.Children;
+                List<DrawNode> target = cNode.Children;
 
-            int j = 0;
-            addFromComposite(treeIndex, ref j, this, target);
+                int j = 0;
+                addFromComposite(treeIndex, ref j, this, target);
 
-            if (j < target.Count)
-                target.RemoveRange(j, target.Count - j);
+                if (j < target.Count)
+                    target.RemoveRange(j, target.Count - j);
+            }
 
             return cNode;
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -521,12 +521,16 @@ namespace osu.Framework.Graphics.Containers
             if (aliveInternalChildren.Count == 0)
                 return true;
 
-            var childMaskingBounds = ComputeChildMaskingBounds(maskingBounds);
+            if (RequiresChildrenUpdate)
+            {
+                var childMaskingBounds = ComputeChildMaskingBounds(maskingBounds);
 
-            // We iterate by index to gain performance
-            // ReSharper disable once ForCanBeConvertedToForeach
-            for (int i = 0; i < aliveInternalChildren.Count; i++)
-                aliveInternalChildren[i].UpdateSubTreeMasking(this, childMaskingBounds);
+
+                // We iterate by index to gain performance
+                // ReSharper disable once ForCanBeConvertedToForeach
+                for (int i = 0; i < aliveInternalChildren.Count; i++)
+                    aliveInternalChildren[i].UpdateSubTreeMasking(this, childMaskingBounds);
+            }
 
             return true;
         }
@@ -742,11 +746,11 @@ namespace osu.Framework.Graphics.Containers
             if (cNode == null)
                 return null;
 
+            if (cNode.Children == null)
+                cNode.Children = new List<DrawNode>(aliveInternalChildren.Count);
+
             if (AddChildDrawNodes)
             {
-                if (cNode.Children == null)
-                    cNode.Children = new List<DrawNode>(aliveInternalChildren.Count);
-
                 List<DrawNode> target = cNode.Children;
 
                 int j = 0;


### PR DESCRIPTION
Adds extensive testing of caching.