### PR TITLE
Set display colour depth to correct value when switching to fullscreen

### DIFF
--- a/osu.Framework/Platform/DesktopGameWindow.cs
+++ b/osu.Framework/Platform/DesktopGameWindow.cs
@@ -113,7 +113,7 @@ namespace osu.Framework.Platform
             switch (newMode)
             {
                 case Configuration.WindowMode.Fullscreen:
-                    DisplayResolution newResolution = DisplayDevice.Default.SelectResolution(widthFullscreen, heightFullscreen, 0, DisplayDevice.Default.RefreshRate);
+                    DisplayResolution newResolution = DisplayDevice.Default.SelectResolution(widthFullscreen, heightFullscreen, DisplayDevice.Default.BitsPerPixel, DisplayDevice.Default.RefreshRate);
                     DisplayDevice.Default.ChangeResolution(newResolution);
 
                     WindowState = WindowState.Fullscreen;


### PR DESCRIPTION
First time contributing to an open source project, wanted to start small.

fixes ppy/osu#1388 
My reproduction of the bug: https://streamable.com/4wn3l (also tested on my laptop, same result)

When switching to fullscreen mode, the BitsPerPixel were being set to 0, which is an invalid value. When OpenTK detects 0bpp it uses a default value instead, resulting in the 256 colors mode (8bpp) mentioned in the issue above.