### PR TITLE
Overhaul transform logic to fix many failing rewind/seek cases

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -134,36 +134,41 @@ namespace osu.Framework.Tests.Visual
                 Origin = Anchor.Centre;
 
                 RelativeSizeAxes = Axes.Both;
-                FillMode = FillMode.Fit;
 
                 InternalChild = wrapping = new WrappingTimeContainer(startTime)
                 {
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
-                        new Box
+                        new Container
                         {
+                            FillMode = FillMode.Fit,
                             RelativeSizeAxes = Axes.Both,
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                             Size = new Vector2(0.6f),
-                            Colour = Color4.DarkGray,
-                        },
-                        content = new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
-                            Size = new Vector2(0.6f),
-                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = Color4.DarkGray,
+                                },
+                                content = new Container
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Masking = true,
+                                },
+                            }
                         },
                         transforms = new FillFlowContainer<DrawableTransform>
                         {
-                            Anchor = Anchor.BottomCentre,
-                            Origin = Anchor.BottomCentre,
+                            Anchor = Anchor.CentreLeft,
+                            Origin = Anchor.CentreLeft,
                             Spacing = Vector2.One,
-                            RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.8f, 0.18f),
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Width = 0.2f,
                         },
                         new Container
                         {
@@ -202,13 +207,7 @@ namespace osu.Framework.Tests.Visual
                 };
             }
 
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                foreach (var t in ExaminableDrawable.Transforms)
-                    transforms.Add(new DrawableTransform(t));
-            }
+            private int displayedTransformsCount;
 
             protected override void Update()
             {
@@ -223,6 +222,14 @@ namespace osu.Framework.Tests.Visual
 
                 maxTimeText.Colour = time > wrapping.MaxTime ? Color4.Gray : (wrapping.Time.Elapsed > 0 ? Color4.Blue : Color4.Red);
                 minTimeText.Colour = time < wrapping.MinTime ? Color4.Gray : (content.Time.Elapsed > 0 ? Color4.Blue : Color4.Red);
+
+                if (ExaminableDrawable.Transforms.Count != displayedTransformsCount)
+                {
+                    transforms.Clear();
+                    foreach (var t in ExaminableDrawable.Transforms)
+                        transforms.Add(new DrawableTransform(t));
+                    displayedTransformsCount = ExaminableDrawable.Transforms.Count;
+                }
             }
 
             private class DrawableTransform : CompositeDrawable
@@ -232,7 +239,7 @@ namespace osu.Framework.Tests.Visual
                 private readonly Box appliedToEnd;
                 private readonly SpriteText text;
 
-                private const float height = 20;
+                private const float height = 15;
 
                 public DrawableTransform(Transform transform)
                 {
@@ -245,7 +252,7 @@ namespace osu.Framework.Tests.Visual
                     {
                         applied = new Box { Size = new Vector2(height) },
                         appliedToEnd = new Box { X = height + 2, Size = new Vector2(height) },
-                        text = new SpriteText { X = (height + 2) * 2 },
+                        text = new SpriteText { X = (height + 2) * 2, TextSize = height },
                     };
                 }
 

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -72,13 +72,13 @@ namespace osu.Framework.Tests.Visual
             AddStep("Same type in type", () => boxTest(box =>
             {
                 box.ScaleTo(0.5f, interval * 4);
-                box.Delay(interval * 2).ScaleTo(1, interval * 2);
+                box.Delay(interval * 2).ScaleTo(1, interval);
             }));
 
             AddStep("Same type partial overlap", () => boxTest(box =>
             {
-                box.ScaleTo(0.5f, interval * 4);
-                box.Delay(interval * 2).ScaleTo(1, interval);
+                box.ScaleTo(0.5f, interval * 2);
+                box.Delay(interval).ScaleTo(1, interval * 2);
             }));
 
             AddStep("Start in middle of sequence", () => boxTest(box =>

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -28,8 +28,8 @@ namespace osu.Framework.Tests.Visual
 
             AddStep("Basic scale", () => boxTest(box =>
             {
-                box.Scale = new Vector2(0.25f);
-                box.ScaleTo(0.75f, interval * 4);
+                box.Scale = Vector2.One;
+                box.ScaleTo(0, interval * 4);
             }));
 
             AddStep("Scale sequence", () => boxTest(box =>
@@ -60,9 +60,9 @@ namespace osu.Framework.Tests.Visual
                 box.Anchor = Anchor.TopLeft;
                 box.Origin = Anchor.TopLeft;
 
-                box.ScaleTo(0.5f, interval).MoveTo(new Vector2(100), interval)
+                box.ScaleTo(0.5f, interval).MoveTo(new Vector2(0.5f), interval)
                    .Then()
-                   .ScaleTo(0.1f, interval).MoveTo(new Vector2(0, 180), interval)
+                   .ScaleTo(0.1f, interval).MoveTo(new Vector2(0, 0.75f), interval)
                    .Then()
                    .ScaleTo(1f, interval).MoveTo(new Vector2(0, 0), interval)
                    .Then()

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -34,6 +34,7 @@ namespace osu.Framework.Tests.Visual
             AddStep("Move sequence", () => loadTest(3));
             AddStep("Multiple sequence", () => loadTest(4));
             AddStep("Same type in type", () => loadTest(5));
+            AddStep("Start in middle of sequence", () => loadTest(6));
         }
 
         private void loadTest(int testCase)
@@ -142,6 +143,23 @@ namespace osu.Framework.Tests.Visual
                     box.Delay(500).ScaleTo(1, 500);
                     break;
                 }
+                case 6:
+                {
+                    Box box;
+                    Add(new AnimationContainer(750)
+                    {
+                        Size = new Vector2(200),
+                        Child = box = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Scale = new Vector2(1)
+                        }
+                    });
+
+                    box.ScaleTo(0.5f, 1000);
+                    box.Delay(500).ScaleTo(1, 500);
+                    break;
+                }
             }
         }
 
@@ -156,7 +174,7 @@ namespace osu.Framework.Tests.Visual
             private readonly SpriteText currentTimeText;
             private readonly SpriteText maxTimeText;
 
-            public AnimationContainer()
+            public AnimationContainer(int startTime = 0)
             {
                 InternalChildren = new Drawable[]
                 {
@@ -167,7 +185,7 @@ namespace osu.Framework.Tests.Visual
                         Spacing = new Vector2(0, 5),
                         Children = new Drawable[]
                         {
-                            content = new WrappingTimeContainer
+                            content = new WrappingTimeContainer(startTime)
                             {
                                 Anchor = Anchor.TopCentre,
                                 Origin = Anchor.TopCentre,
@@ -212,8 +230,12 @@ namespace osu.Framework.Tests.Visual
             public double MinTime => clock.MinTime;
             public double MaxTime => clock.MaxTime;
 
-            private readonly ReversibleClock clock = new ReversibleClock();
+            private readonly ReversibleClock clock;
 
+            public WrappingTimeContainer(double startTime)
+            {
+                clock = new ReversibleClock(startTime);
+            }
             [BackgroundDependencyLoader]
             private void load()
             {
@@ -248,14 +270,20 @@ namespace osu.Framework.Tests.Visual
 
             private class ReversibleClock : IFrameBasedClock
             {
+                private readonly double startTime;
                 public double MinTime;
                 public double MaxTime = 1000;
 
                 private IFrameBasedClock trackingClock;
 
+                public ReversibleClock(double startTime)
+                {
+                    this.startTime = startTime;
+                }
+
                 public void SetSource(IFrameBasedClock trackingClock)
                 {
-                    this.trackingClock = new FramedOffsetClock(trackingClock) { Offset = -trackingClock.CurrentTime };
+                    this.trackingClock = new FramedOffsetClock(trackingClock) { Offset = -trackingClock.CurrentTime + startTime };
                 }
 
                 public double CurrentTime { get; private set; }

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Linq;
+using System.Text;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Allocation;
@@ -103,7 +103,8 @@ namespace osu.Framework.Tests.Visual
                     RelativeSizeAxes = Axes.Both,
                     RelativePositionAxes = Axes.Both,
                     Scale = new Vector2(0.25f),
-                }
+                },
+                ExaminableDrawable = box,
             });
 
             action(box);
@@ -122,6 +123,10 @@ namespace osu.Framework.Tests.Visual
 
             private readonly Tick seekingTick;
             private readonly WrappingTimeContainer wrapping;
+
+            public Box ExaminableDrawable;
+
+            private readonly TextFlowContainer text;
 
             public AnimationContainer(int startTime = 0)
             {
@@ -151,6 +156,13 @@ namespace osu.Framework.Tests.Visual
                             Origin = Anchor.Centre,
                             Size = new Vector2(0.6f),
                             Masking = true,
+                        },
+                        text = new TextFlowContainer
+                        {
+                            Anchor = Anchor.BottomCentre,
+                            Origin = Anchor.BottomCentre,
+                            RelativeSizeAxes = Axes.Both,
+                            Size = new Vector2(0.8f, 0.18f),
                         },
                         new Container
                         {
@@ -187,6 +199,18 @@ namespace osu.Framework.Tests.Visual
                         }
                     }
                 };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                StringBuilder sb = new StringBuilder();
+
+                foreach (var t in ExaminableDrawable.Transforms)
+                    sb.AppendLine($"{t}");
+
+                text.Text = sb.ToString();
             }
 
             protected override void Update()

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -87,6 +87,10 @@ namespace osu.Framework.Tests.Visual
                 box.Delay(interval * 2).FadeInFromZero(interval);
                 box.ScaleTo(0.9f, interval * 4);
             }, 750));
+
+            AddStep("Loop sequence", () => boxTest(box => { box.RotateTo(0).RotateTo(90, interval).Loop(); }));
+
+            AddStep("Start in middle of loop sequence", () => boxTest(box => { box.RotateTo(0).RotateTo(90, interval).Loop(); }, 750));
         }
 
         private Box box;

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -17,33 +17,29 @@ namespace osu.Framework.Tests.Visual
 {
     public class TestCaseTransformRewinding : TestCase
     {
-        protected override Container<Drawable> Content => content;
-        private readonly FillFlowContainer content;
-
         private const double interval = 250;
+        private const int interval_count = 4;
 
-        private double intervalAt(int sequence) => interval * sequence;
+        private static double intervalAt(int sequence) => interval * sequence;
 
-        public TestCaseTransformRewinding()
+        protected override void LoadComplete()
         {
-            base.Content.Add(content = new FillFlowContainer
-            {
-                RelativeSizeAxes = Axes.Both,
-                Spacing = new Vector2(10, 10)
-            });
+            base.LoadComplete();
 
             AddStep("Basic scale", () => boxTest(box =>
             {
                 box.Scale = new Vector2(0.25f);
-                box.ScaleTo(0.75f, interval);
+                box.ScaleTo(0.75f, interval * 4);
             }));
 
             AddStep("Scale sequence", () => boxTest(box =>
             {
-                box.Scale = new Vector2(0.25f);
+                box.Scale = Vector2.One;
+
                 box.ScaleTo(0.75f, interval).Then()
                    .ScaleTo(0.5f, interval).Then()
-                   .ScaleTo(0.25f, interval);
+                   .ScaleTo(0.25f, interval).Then()
+                   .ScaleTo(0, interval);
             }));
 
             AddStep("Basic movement", () => boxTest(box =>
@@ -52,9 +48,9 @@ namespace osu.Framework.Tests.Visual
                 box.Anchor = Anchor.TopLeft;
                 box.Origin = Anchor.TopLeft;
 
-                box.MoveTo(new Vector2(150, 0), interval).Then()
-                   .MoveTo(new Vector2(150, 150), interval).Then()
-                   .MoveTo(new Vector2(0, 150), interval).Then()
+                box.MoveTo(new Vector2(0.75f, 0), interval).Then()
+                   .MoveTo(new Vector2(0.75f, 0.75f), interval).Then()
+                   .MoveTo(new Vector2(0, 0.75f), interval).Then()
                    .MoveTo(new Vector2(0), interval);
             }));
 
@@ -90,23 +86,22 @@ namespace osu.Framework.Tests.Visual
                 box.Alpha = 0;
                 box.Delay(interval * 2).FadeInFromZero(interval);
                 box.ScaleTo(0.9f, interval * 4);
-            }));
+            }, 750));
         }
 
         private Box box;
 
-        private void boxTest(Action<Box> action)
+        private void boxTest(Action<Box> action, int startTime = 0)
         {
             Clear();
-
-            Add(new AnimationContainer
+            Add(new AnimationContainer(startTime)
             {
-                Size = new Vector2(200),
                 Child = box = new Box
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     RelativeSizeAxes = Axes.Both,
+                    RelativePositionAxes = Axes.Both,
                     Scale = new Vector2(0.25f),
                 }
             });
@@ -119,44 +114,75 @@ namespace osu.Framework.Tests.Visual
             public override bool RemoveCompletedTransforms => false;
 
             protected override Container<Drawable> Content => content;
-            private readonly WrappingTimeContainer content;
+            private readonly Container content;
 
             private readonly SpriteText minTimeText;
             private readonly SpriteText currentTimeText;
             private readonly SpriteText maxTimeText;
 
+            private readonly Tick seekingTick;
+            private readonly WrappingTimeContainer wrapping;
+
             public AnimationContainer(int startTime = 0)
             {
-                InternalChildren = new Drawable[]
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                RelativeSizeAxes = Axes.Both;
+                FillMode = FillMode.Fit;
+
+                InternalChild = wrapping = new WrappingTimeContainer(startTime)
                 {
-                    new FillFlowContainer
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
                     {
-                        RelativeSizeAxes = Axes.Both,
-                        Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(0, 5),
-                        Children = new Drawable[]
+                        new Box
                         {
-                            content = new WrappingTimeContainer(startTime)
+                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(0.6f),
+                            Colour = Color4.DarkGray,
+                        },
+                        content = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(0.6f),
+                            Masking = true,
+                        },
+                        new Container
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            RelativeSizeAxes = Axes.Both,
+                            Size = new Vector2(0.8f, 0.1f),
+                            Children = new Drawable[]
                             {
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
-                                RelativeSizeAxes = Axes.Both,
-                                FillMode = FillMode.Fit,
-                                Masking = true
-                            },
-                            new FillFlowContainer
-                            {
-                                Anchor = Anchor.TopCentre,
-                                Origin = Anchor.TopCentre,
-                                AutoSizeAxes = Axes.Both,
-                                Direction = FillDirection.Horizontal,
-                                Spacing = new Vector2(5, 0),
-                                Children = new[]
+                                minTimeText = new SpriteText
                                 {
-                                    minTimeText = new SpriteText { Colour = Color4.Blue },
-                                    currentTimeText = new SpriteText(),
-                                    maxTimeText = new SpriteText { Colour = Color4.Blue },
-                                }
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.TopLeft,
+                                },
+                                currentTimeText = new SpriteText
+                                {
+                                    RelativePositionAxes = Axes.X,
+                                    Anchor = Anchor.BottomLeft,
+                                    Origin = Anchor.BottomCentre,
+                                    Y = -10,
+                                },
+                                maxTimeText = new SpriteText
+                                {
+                                    Anchor = Anchor.BottomRight,
+                                    Origin = Anchor.TopRight,
+                                },
+                                seekingTick = new Tick(0, false),
+                                new Tick(0),
+                                new Tick(1),
+                                new Tick(2),
+                                new Tick(3),
+                                new Tick(4),
                             }
                         }
                     }
@@ -167,9 +193,43 @@ namespace osu.Framework.Tests.Visual
             {
                 base.Update();
 
-                minTimeText.Text = content.MinTime.ToString("n0");
-                currentTimeText.Text = content.Time.Current.ToString("n0");
-                maxTimeText.Text = content.MaxTime.ToString("n0");
+                double time = wrapping.Time.Current;
+
+                minTimeText.Text = wrapping.MinTime.ToString("n0");
+                currentTimeText.Text = time.ToString("n0");
+                seekingTick.X = currentTimeText.X = (float)(time / (wrapping.MaxTime - wrapping.MinTime));
+                maxTimeText.Text = wrapping.MaxTime.ToString("n0");
+
+                maxTimeText.Colour = time > wrapping.MaxTime ? Color4.Gray : (wrapping.Time.Elapsed > 0 ? Color4.Blue : Color4.Red);
+                minTimeText.Colour = time < wrapping.MinTime ? Color4.Gray : (content.Time.Elapsed > 0 ? Color4.Blue : Color4.Red);
+            }
+
+            private class Tick : Box
+            {
+                private readonly int tick;
+                private readonly bool colouring;
+
+                public Tick(int tick, bool colouring = true)
+                {
+                    this.tick = tick;
+                    this.colouring = colouring;
+                    Anchor = Anchor.BottomLeft;
+                    Origin = Anchor.BottomCentre;
+
+                    Size = new Vector2(1, 10);
+                    Colour = Color4.White;
+
+                    RelativePositionAxes = Axes.X;
+                    X = (float)tick / interval_count;
+                }
+
+                protected override void Update()
+                {
+                    base.Update();
+
+                    if (colouring)
+                        Colour = Time.Current > tick * interval ? Color4.Yellow : Color4.White;
+                }
             }
         }
 
@@ -178,8 +238,8 @@ namespace osu.Framework.Tests.Visual
             // Padding, in milliseconds, at each end of maxima of the clock time
             private const double time_padding = 50;
 
-            public double MinTime => clock.MinTime;
-            public double MaxTime => clock.MaxTime;
+            public double MinTime => clock.MinTime + time_padding;
+            public double MaxTime => clock.MaxTime - time_padding;
 
             private readonly ReversibleClock clock;
 
@@ -200,24 +260,8 @@ namespace osu.Framework.Tests.Visual
             {
                 base.LoadComplete();
 
-                double minTime = double.MaxValue;
-                double maxTime = double.MinValue;
-
-                foreach (var child in Children)
-                {
-                    if (child.Transforms.Count == 0)
-                    {
-                        minTime = Math.Min(minTime, 0);
-                        maxTime = Math.Max(maxTime, 0);
-                        continue;
-                    }
-
-                    minTime = Math.Min(minTime, child.Transforms.Min(t => t.StartTime) - time_padding);
-                    maxTime = Math.Max(maxTime, child.Transforms.Max(t => t.EndTime) + time_padding);
-                }
-
-                clock.MinTime = minTime;
-                clock.MaxTime = maxTime;
+                clock.MinTime = -time_padding;
+                clock.MaxTime = intervalAt(interval_count) + time_padding;
             }
 
             private class ReversibleClock : IFrameBasedClock
@@ -227,6 +271,8 @@ namespace osu.Framework.Tests.Visual
                 public double MaxTime = 1000;
 
                 private IFrameBasedClock trackingClock;
+
+                private bool reversed;
 
                 public ReversibleClock(double startTime)
                 {
@@ -244,7 +290,7 @@ namespace osu.Framework.Tests.Visual
 
                 public bool IsRunning => trackingClock.IsRunning;
 
-                public double ElapsedFrameTime => trackingClock.ElapsedFrameTime;
+                public double ElapsedFrameTime => (reversed ? -1 : 1) * trackingClock.ElapsedFrameTime;
 
                 public double AverageFrameTime => trackingClock.AverageFrameTime;
 
@@ -258,7 +304,7 @@ namespace osu.Framework.Tests.Visual
 
                     // There are two iterations, when iteration % 2 == 0 : not reversed
                     int iteration = (int)(trackingClock.CurrentTime / (MaxTime - MinTime));
-                    bool reversed = iteration % 2 == 1;
+                    reversed = iteration % 2 == 1;
 
                     double iterationTime = trackingClock.CurrentTime % (MaxTime - MinTime);
 

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -135,7 +135,6 @@ namespace osu.Framework.Tests.Visual
                         Child = box = new Box
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Scale = new Vector2(1)
                         }
                     });
 
@@ -152,12 +151,28 @@ namespace osu.Framework.Tests.Visual
                         Child = box = new Box
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Scale = new Vector2(1)
                         }
                     });
 
                     box.ScaleTo(0.5f, 1000);
                     box.Delay(500).ScaleTo(1, 500);
+                    break;
+                }
+                case 7:
+                {
+                    Box box;
+                    Add(new AnimationContainer
+                    {
+                        Size = new Vector2(200),
+                        Child = box = new Box
+                        {
+                            Alpha = 1,
+                            RelativeSizeAxes = Axes.Both,
+                        }
+                    });
+
+                    box.Delay(500).FadeInFromZero(500);
+                    box.ScaleTo(0.9f, 1000);
                     break;
                 }
             }

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -28,154 +28,83 @@ namespace osu.Framework.Tests.Visual
                 Spacing = new Vector2(10, 10)
             });
 
-            AddStep("Basic scale", () => loadTest(0));
-            AddStep("Scale sequence", () => loadTest(1));
-            AddStep("Basic movement", () => loadTest(2));
-            AddStep("Move sequence", () => loadTest(3));
-            AddStep("Multiple sequence", () => loadTest(4));
-            AddStep("Same type in type", () => loadTest(5));
-            AddStep("Start in middle of sequence", () => loadTest(6));
+            AddStep("Basic scale", () => boxTest(box =>
+            {
+                box.Scale = new Vector2(0.25f);
+                box.ScaleTo(0.75f, 300);
+            }));
+
+            AddStep("Scale sequence", () => boxTest(box =>
+            {
+                box.Scale = new Vector2(0.25f);
+                box.ScaleTo(0.75f, 100).Then().ScaleTo(0.5f, 100).Then().ScaleTo(0.25f, 100);
+            }));
+
+            AddStep("Basic movement", () => boxTest(box =>
+            {
+                box.Scale = new Vector2(0.25f);
+                box.Anchor = Anchor.TopLeft;
+                box.Origin = Anchor.TopLeft;
+
+                box.MoveTo(new Vector2(150, 0), 100).Then()
+                   .MoveTo(new Vector2(150, 150), 100).Then()
+                   .MoveTo(new Vector2(0, 150), 100).Then()
+                   .MoveTo(new Vector2(0), 100);
+            }));
+
+            AddStep("Move sequence", () => boxTest(box =>
+            {
+                box.Scale = new Vector2(0.25f);
+                box.Anchor = Anchor.TopLeft;
+                box.Origin = Anchor.TopLeft;
+
+                box.ScaleTo(0.5f, 300).MoveTo(new Vector2(100), 300)
+                   .Then()
+                   .ScaleTo(0.1f, 300).MoveTo(new Vector2(0, 180), 300)
+                   .Then()
+                   .ScaleTo(1f, 300).MoveTo(new Vector2(0, 0), 300)
+                   .Then()
+                   .FadeTo(0, 300);
+            }));
+
+            AddStep("Multiple sequence", () => boxTest(box =>
+            {
+                box.ScaleTo(0.5f, 1000);
+                box.Delay(500).ScaleTo(1, 400);
+            }));
+
+            AddStep("Same type in type", () => boxTest(box =>
+            {
+                box.ScaleTo(0.5f, 1000);
+                box.Delay(500).ScaleTo(1, 500);
+            }));
+
+            AddStep("Start in middle of sequence", () => boxTest(box =>
+            {
+                box.Delay(500).FadeInFromZero(500);
+                box.ScaleTo(0.9f, 1000);
+            }));
         }
 
-        private void loadTest(int testCase)
+        private Box box;
+
+        private void boxTest(Action<Box> action)
         {
             Clear();
 
-            switch (testCase)
+            Add(new AnimationContainer
             {
-                case 0:
-                    {
-                        Box box;
-                        Add(new AnimationContainer
-                        {
-                            Size = new Vector2(200),
-                            Child = box = new Box
-                            {
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                                RelativeSizeAxes = Axes.Both,
-                                Scale = new Vector2(0.25f),
-                            }
-                        });
-
-                        box.ScaleTo(0.75f, 300);
-                        break;
-                    }
-                case 1:
-                    {
-                        Box box;
-                        Add(new AnimationContainer
-                        {
-                            Size = new Vector2(200),
-                            Child = box = new Box
-                            {
-                                Anchor = Anchor.Centre,
-                                Origin = Anchor.Centre,
-                                RelativeSizeAxes = Axes.Both,
-                                Scale = new Vector2(0.25f),
-                            }
-                        });
-
-                        box.ScaleTo(0.75f, 100).Then().ScaleTo(0.5f, 100).Then().ScaleTo(0.25f, 100);
-                        break;
-                    }
-                case 2:
-                    {
-                        Box box;
-                        Add(new AnimationContainer
-                        {
-                            Size = new Vector2(200),
-                            Child = box = new Box { Size = new Vector2(50) }
-                        });
-
-                        box.MoveTo(new Vector2(150, 150), 300);
-                        break;
-                    }
-                case 3:
-                    {
-                        Box box;
-                        Add(new AnimationContainer
-                        {
-                            Size = new Vector2(200),
-                            Child = box = new Box { Size = new Vector2(50) }
-                        });
-
-                        box.MoveTo(new Vector2(150, 0), 100).Then().MoveTo(new Vector2(150, 150), 100).Then().MoveTo(new Vector2(0, 150), 100).Then().MoveTo(new Vector2(0), 100);
-                        break;
-                    }
-                case 4:
-                    {
-                        Box box;
-                        Add(new AnimationContainer
-                        {
-                            Size = new Vector2(200),
-                            Child = box = new Box
-                            {
-                                RelativeSizeAxes = Axes.Both,
-                                Scale = new Vector2(0.25f)
-                            }
-                        });
-
-                        box.ScaleTo(0.5f, 300).MoveTo(new Vector2(100), 300)
-                           .Then()
-                           .ScaleTo(0.1f, 300).MoveTo(new Vector2(0, 180), 300)
-                           .Then()
-                           .ScaleTo(1f, 300).MoveTo(new Vector2(0, 0), 300)
-                           .Then()
-                           .FadeTo(0, 300);
-
-                        break;
-                    }
-                case 5:
+                Size = new Vector2(200),
+                Child = box = new Box
                 {
-                    Box box;
-                    Add(new AnimationContainer
-                    {
-                        Size = new Vector2(200),
-                        Child = box = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                        }
-                    });
-
-                    box.ScaleTo(0.5f, 1000);
-                    box.Delay(500).ScaleTo(1, 500);
-                    break;
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    Scale = new Vector2(0.25f),
                 }
-                case 6:
-                {
-                    Box box;
-                    Add(new AnimationContainer(750)
-                    {
-                        Size = new Vector2(200),
-                        Child = box = new Box
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                        }
-                    });
+            });
 
-                    box.ScaleTo(0.5f, 1000);
-                    box.Delay(500).ScaleTo(1, 500);
-                    break;
-                }
-                case 7:
-                {
-                    Box box;
-                    Add(new AnimationContainer
-                    {
-                        Size = new Vector2(200),
-                        Child = box = new Box
-                        {
-                            Alpha = 1,
-                            RelativeSizeAxes = Axes.Both,
-                        }
-                    });
-
-                    box.Delay(500).FadeInFromZero(500);
-                    box.ScaleTo(0.9f, 1000);
-                    break;
-                }
-            }
+            action(box);
         }
 
         private class AnimationContainer : Container
@@ -217,7 +146,7 @@ namespace osu.Framework.Tests.Visual
                                 Spacing = new Vector2(5, 0),
                                 Children = new[]
                                 {
-                                    minTimeText = new SpriteText { Colour = Color4.Blue},
+                                    minTimeText = new SpriteText { Colour = Color4.Blue },
                                     currentTimeText = new SpriteText(),
                                     maxTimeText = new SpriteText { Colour = Color4.Blue },
                                 }
@@ -251,6 +180,7 @@ namespace osu.Framework.Tests.Visual
             {
                 clock = new ReversibleClock(startTime);
             }
+
             [BackgroundDependencyLoader]
             private void load()
             {

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -33,6 +33,7 @@ namespace osu.Framework.Tests.Visual
             AddStep("Basic movement", () => loadTest(2));
             AddStep("Move sequence", () => loadTest(3));
             AddStep("Multiple sequence", () => loadTest(4));
+            AddStep("Same type in type", () => loadTest(5));
         }
 
         private void loadTest(int testCase)
@@ -124,6 +125,23 @@ namespace osu.Framework.Tests.Visual
 
                         break;
                     }
+                case 5:
+                {
+                    Box box;
+                    Add(new AnimationContainer
+                    {
+                        Size = new Vector2(200),
+                        Child = box = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Scale = new Vector2(1)
+                        }
+                    });
+
+                    box.ScaleTo(0.5f, 1000);
+                    box.Delay(500).ScaleTo(1, 500);
+                    break;
+                }
             }
         }
 
@@ -189,7 +207,7 @@ namespace osu.Framework.Tests.Visual
         private class WrappingTimeContainer : Container
         {
             // Padding, in milliseconds, at each end of maxima of the clock time
-            private const double time_padding = 500;
+            private const double time_padding = 50;
 
             public double MinTime => clock.MinTime;
             public double MaxTime => clock.MaxTime;
@@ -237,7 +255,7 @@ namespace osu.Framework.Tests.Visual
 
                 public void SetSource(IFrameBasedClock trackingClock)
                 {
-                    this.trackingClock = trackingClock;
+                    this.trackingClock = new FramedOffsetClock(trackingClock) { Offset = -trackingClock.CurrentTime };
                 }
 
                 public double CurrentTime { get; private set; }

--- a/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformRewinding.cs
@@ -20,6 +20,10 @@ namespace osu.Framework.Tests.Visual
         protected override Container<Drawable> Content => content;
         private readonly FillFlowContainer content;
 
+        private const double interval = 250;
+
+        private double intervalAt(int sequence) => interval * sequence;
+
         public TestCaseTransformRewinding()
         {
             base.Content.Add(content = new FillFlowContainer
@@ -31,13 +35,15 @@ namespace osu.Framework.Tests.Visual
             AddStep("Basic scale", () => boxTest(box =>
             {
                 box.Scale = new Vector2(0.25f);
-                box.ScaleTo(0.75f, 300);
+                box.ScaleTo(0.75f, interval);
             }));
 
             AddStep("Scale sequence", () => boxTest(box =>
             {
                 box.Scale = new Vector2(0.25f);
-                box.ScaleTo(0.75f, 100).Then().ScaleTo(0.5f, 100).Then().ScaleTo(0.25f, 100);
+                box.ScaleTo(0.75f, interval).Then()
+                   .ScaleTo(0.5f, interval).Then()
+                   .ScaleTo(0.25f, interval);
             }));
 
             AddStep("Basic movement", () => boxTest(box =>
@@ -46,10 +52,10 @@ namespace osu.Framework.Tests.Visual
                 box.Anchor = Anchor.TopLeft;
                 box.Origin = Anchor.TopLeft;
 
-                box.MoveTo(new Vector2(150, 0), 100).Then()
-                   .MoveTo(new Vector2(150, 150), 100).Then()
-                   .MoveTo(new Vector2(0, 150), 100).Then()
-                   .MoveTo(new Vector2(0), 100);
+                box.MoveTo(new Vector2(150, 0), interval).Then()
+                   .MoveTo(new Vector2(150, 150), interval).Then()
+                   .MoveTo(new Vector2(0, 150), interval).Then()
+                   .MoveTo(new Vector2(0), interval);
             }));
 
             AddStep("Move sequence", () => boxTest(box =>
@@ -58,31 +64,32 @@ namespace osu.Framework.Tests.Visual
                 box.Anchor = Anchor.TopLeft;
                 box.Origin = Anchor.TopLeft;
 
-                box.ScaleTo(0.5f, 300).MoveTo(new Vector2(100), 300)
+                box.ScaleTo(0.5f, interval).MoveTo(new Vector2(100), interval)
                    .Then()
-                   .ScaleTo(0.1f, 300).MoveTo(new Vector2(0, 180), 300)
+                   .ScaleTo(0.1f, interval).MoveTo(new Vector2(0, 180), interval)
                    .Then()
-                   .ScaleTo(1f, 300).MoveTo(new Vector2(0, 0), 300)
+                   .ScaleTo(1f, interval).MoveTo(new Vector2(0, 0), interval)
                    .Then()
-                   .FadeTo(0, 300);
-            }));
-
-            AddStep("Multiple sequence", () => boxTest(box =>
-            {
-                box.ScaleTo(0.5f, 1000);
-                box.Delay(500).ScaleTo(1, 400);
+                   .FadeTo(0, interval);
             }));
 
             AddStep("Same type in type", () => boxTest(box =>
             {
-                box.ScaleTo(0.5f, 1000);
-                box.Delay(500).ScaleTo(1, 500);
+                box.ScaleTo(0.5f, interval * 4);
+                box.Delay(interval * 2).ScaleTo(1, interval * 2);
+            }));
+
+            AddStep("Same type partial overlap", () => boxTest(box =>
+            {
+                box.ScaleTo(0.5f, interval * 4);
+                box.Delay(interval * 2).ScaleTo(1, interval);
             }));
 
             AddStep("Start in middle of sequence", () => boxTest(box =>
             {
-                box.Delay(500).FadeInFromZero(500);
-                box.ScaleTo(0.9f, 1000);
+                box.Alpha = 0;
+                box.Delay(interval * 2).FadeInFromZero(interval);
+                box.ScaleTo(0.9f, interval * 4);
             }));
         }
 

--- a/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
@@ -26,9 +26,29 @@ namespace osu.Framework.Tests.Visual
         {
             base.LoadComplete();
 
-            setup();
-            animate();
+            testFinish();
+            testClear();
+        }
 
+        private void testFinish()
+        {
+            AddStep("Animate", delegate
+            {
+                setup();
+                animate();
+            });
+
+            AddStep($"{nameof(FinishTransforms)}", delegate
+            {
+                foreach (var box in boxes)
+                    box.FinishTransforms();
+            });
+
+            AddAssert("finalize triggered", () => finalizeTriggered);
+        }
+
+        private void testClear()
+        {
             AddStep("Animate", delegate
             {
                 setup();
@@ -41,15 +61,13 @@ namespace osu.Framework.Tests.Visual
                     box.ClearTransforms();
             });
 
-            AddStep($"{nameof(FinishTransforms)}", delegate
-            {
-                foreach (var box in boxes)
-                    box.FinishTransforms();
-            });
+            AddAssert("finalize triggered", () => finalizeTriggered);
         }
 
         private void setup()
         {
+            finalizeTriggered = false;
+
             string[] labels =
             {
                 "Spin after 2 seconds",
@@ -94,6 +112,8 @@ namespace osu.Framework.Tests.Visual
             }
         }
 
+        private bool finalizeTriggered;
+
         private void animate()
         {
             boxes[0].Delay(500).Then(500).Then(500).Then(
@@ -118,7 +138,8 @@ namespace osu.Framework.Tests.Visual
             .Then(
                 b => b.Loop(500, 2, d => d.RotateTo(0).RotateTo(360, 1000)).Delay(500).ScaleTo(0.5f, 500)
             )
-            .Then().FadeEdgeEffectTo(Color4.Red, 1000).ScaleTo(2, 500);
+            .Then().FadeEdgeEffectTo(Color4.Red, 1000).ScaleTo(2, 500)
+            .Finally(_ => finalizeTriggered = true);
 
 
             boxes[4].RotateTo(0).ScaleTo(1).RotateTo(360, 500)

--- a/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Tests.Visual
                 b => b.Delay(500).Spin(1000, RotationDirection.CounterClockwise)
             );
 
-            boxes[1].Delay(1000).Loop(5, 1000, b => b.RotateTo(0).RotateTo(340, 1000));
+            boxes[1].Delay(1000).Loop(1000, 10, b => b.RotateTo(0).RotateTo(340, 1000));
 
             boxes[2].RotateTo(0).ScaleTo(1).RotateTo(360, 1000)
             .Then(1000,

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -45,11 +45,11 @@ namespace osu.Framework.Graphics.Transforms
 
         internal bool HasStartValue;
 
-        public Action OnComplete;
+        internal Action OnComplete;
 
-        public Action OnAbort;
+        internal Action OnAbort;
 
-        public void Abort() => OnAbort?.Invoke();
+        internal void Abort() => OnAbort?.Invoke();
 
         public Transform Clone() => (Transform)MemberwiseClone();
 

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -63,9 +63,7 @@ namespace osu.Framework.Graphics.Transforms
                 int compare = x.StartTime.CompareTo(y.StartTime);
                 if (compare != 0) return compare;
 
-                // reverse order as we want to insert *before* matching time transforms.
-                // this is because we want to immediately remove all transforms of the same type at the same time (see Transformable.AddTransform).
-                compare = y.TransformID.CompareTo(x.TransformID);
+                compare = x.TransformID.CompareTo(y.TransformID);
 
                 return compare;
             }

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -49,6 +49,8 @@ namespace osu.Framework.Graphics.Transforms
 
         public Action OnAbort;
 
+        public void Abort() => OnAbort?.Invoke();
+
         public Transform Clone() => (Transform)MemberwiseClone();
 
         public static readonly IComparer<Transform> COMPARER = new TransformTimeComparer();

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -45,11 +45,9 @@ namespace osu.Framework.Graphics.Transforms
 
         internal bool HasStartValue;
 
-        internal Action OnComplete;
+        public Action OnComplete;
 
-        internal Action OnAbort;
-
-        internal void Abort() => OnAbort?.Invoke();
+        public Action OnAbort;
 
         public Transform Clone() => (Transform)MemberwiseClone();
 

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -1,7 +1,6 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using osu.Framework.Extensions.TypeExtensions;
 using System;
 using System.Collections.Generic;
 
@@ -95,6 +94,6 @@ namespace osu.Framework.Graphics.Transforms
 
         protected abstract void ReadIntoStartValue(T d);
 
-        public override string ToString() => $"{typeof(Transform<TValue, T>).ReadableName()} => {Target} {StartTime}:{StartValue}-{EndTime}:{EndValue}";
+        public override string ToString() => $"{Target.GetType().Name}.{TargetMember} {StartTime}-{EndTime}ms {StartValue} -> {EndValue}";
     }
 }

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -331,6 +331,7 @@ namespace osu.Framework.Graphics.Transforms
             {
                 t.IsLooping = true;
                 t.LoopDelay = iterDuration;
+                t.AppliedToEnd = false; // we want to force a reprocess of this transform. it may have been applied-to-end in the Add, but not correctly looped as a result.
             }
 
             onLoopingTransform();

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Graphics.Transforms
             transforms.Add(transform);
 
             transform.OnComplete = null;
-            transform.OnAbort = onTransformAborted;
+            transform.OnAbort = null;
 
             if (transform.IsLooping)
                 onLoopingTransform();
@@ -89,10 +89,14 @@ namespace osu.Framework.Graphics.Transforms
             if (last == null || transform.EndTime > lastEndTime)
             {
                 if (last != null)
+                {
                     last.OnComplete = null;
+                    last.OnAbort = null;
+                }
 
                 last = transform;
                 last.OnComplete = onTransformsComplete;
+                last.OnAbort = onTransformAborted;
                 lastEndTime = last.EndTime;
                 hasCompleted = false;
             }
@@ -173,29 +177,15 @@ namespace osu.Framework.Graphics.Transforms
             return this;
         }
 
-        private void onTransformAborted()
-        {
-            if (transforms.Count == 0)
-                return;
-
-            // No need for OnAbort events to trigger anymore, since
-            // we are already aware of the abortion.
-            foreach (var t in transforms)
-            {
-                t.OnAbort = null;
-                t.TargetTransformable.RemoveTransform(t);
-            }
-
-            transforms.Clear();
-            last = null;
-
-            onAbort?.Invoke();
-        }
-
         private void onTransformsComplete()
         {
             hasCompleted = true;
             onComplete?.Invoke();
+        }
+
+        private void onTransformAborted()
+        {
+            onAbort?.Invoke();
         }
 
         private void subscribeComplete(Action func)

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Graphics.Transforms
             transforms.Add(transform);
 
             transform.OnComplete = null;
-            transform.OnAbort = null;
+            transform.OnAbort = onTransformAborted;
 
             if (transform.IsLooping)
                 onLoopingTransform();
@@ -89,14 +89,10 @@ namespace osu.Framework.Graphics.Transforms
             if (last == null || transform.EndTime > lastEndTime)
             {
                 if (last != null)
-                {
                     last.OnComplete = null;
-                    last.OnAbort = null;
-                }
 
                 last = transform;
                 last.OnComplete = onTransformsComplete;
-                last.OnAbort = onTransformAborted;
                 lastEndTime = last.EndTime;
                 hasCompleted = false;
             }
@@ -177,15 +173,29 @@ namespace osu.Framework.Graphics.Transforms
             return this;
         }
 
+        private void onTransformAborted()
+        {
+            if (transforms.Count == 0)
+                return;
+
+            // No need for OnAbort events to trigger anymore, since
+            // we are already aware of the abortion.
+            foreach (var t in transforms)
+            {
+                t.OnAbort = null;
+                t.TargetTransformable.RemoveTransform(t);
+            }
+
+            transforms.Clear();
+            last = null;
+
+            onAbort?.Invoke();
+        }
+
         private void onTransformsComplete()
         {
             hasCompleted = true;
             onComplete?.Invoke();
-        }
-
-        private void onTransformAborted()
-        {
-            onAbort?.Invoke();
         }
 
         private void subscribeComplete(Action func)

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -235,7 +235,7 @@ namespace osu.Framework.Graphics.Transforms
         /// with <paramref name="pause"/> milliseconds between iterations.
         /// </summary>
         /// <param name="pause">The pause between iterations in milliseconds.</param>
-        /// <param name="numIters">The amount of iterations.</param>
+        /// <param name="numIters">The number of iterations.</param>
         /// <param name="childGenerators">The functions to generate the <see cref="TransformSequence{T}"/>s to be looped.</param>
         /// <returns>This <see cref="TransformSequence{T}"/>.</returns>
         public TransformSequence<T> Loop(double pause, int numIters, params Generator[] childGenerators)
@@ -256,7 +256,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <paramref name="numIters"/> times with <paramref name="pause"/> milliseconds between iterations.
         /// </summary>
         /// <param name="pause">The pause between iterations in milliseconds.</param>
-        /// <param name="numIters">The amount of iterations.</param>
+        /// <param name="numIters">The number of iterations.</param>
         /// <returns>This <see cref="TransformSequence{T}"/>.</returns>
         public TransformSequence<T> Loop(double pause, int numIters)
         {

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -197,16 +197,24 @@ namespace osu.Framework.Graphics.Transforms
 
                         if (t.IsLooping)
                         {
+                            if (tCanRewind)
+                            {
+                                t.IsLooping = false;
+                                t = t.Clone();
+                            }
+
                             t.AppliedToEnd = false;
+                            t.Applied = false;
+                            t.HasStartValue = false;
+
+                            t.IsLooping = true;
+
                             t.StartTime += t.LoopDelay;
                             t.EndTime += t.LoopDelay;
 
-                            if (!tCanRewind)
-                            {
-                                // this could be added back at a lower index than where we are currently iterating, but
-                                // running the same transform twice isn't a huge deal.
-                                transformsLazy.Add(t);
-                            }
+                            // this could be added back at a lower index than where we are currently iterating, but
+                            // running the same transform twice isn't a huge deal.
+                            transformsLazy.Add(t);
                         }
                         else if (t.OnComplete != null)
                             removalActions.Add(t.OnComplete);

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -92,7 +92,7 @@ namespace osu.Framework.Graphics.Transforms
             if (transformsLazy == null)
                 return;
 
-            if (!RemoveCompletedTransforms)
+            if (!RemoveCompletedTransforms) // todo: optimisation -- this only needs to run when rewinding.
             {
                 var appliedToEndReverts = new List<string>();
 

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -112,7 +112,7 @@ namespace osu.Framework.Graphics.Transforms
                     if (time >= t.StartTime)
                     {
                         if (time >= t.EndTime)
-                            break;
+                            continue;
 
                         if (!appliedToEndReverts.Contains(t.TargetMember))
                         {

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -162,7 +162,7 @@ namespace osu.Framework.Graphics.Transforms
                             transformsLazy.RemoveAt(j--);
                             i--;
 
-                            removalActions.Add(u.Abort);
+                            removalActions.Add(u.OnAbort);
                         }
                         else
                             u.AppliedToEnd = true;
@@ -225,7 +225,7 @@ namespace osu.Framework.Graphics.Transforms
             if (transformsLazy == null || !transformsLazy.Remove(toRemove))
                 return;
 
-            toRemove.Abort();
+            toRemove.OnAbort?.Invoke();
         }
 
         /// <summary>
@@ -265,7 +265,7 @@ namespace osu.Framework.Graphics.Transforms
             }
 
             foreach (var t in toAbort)
-                t.Abort();
+                t.OnAbort?.Invoke();
         }
 
         /// <summary>
@@ -417,7 +417,7 @@ namespace osu.Framework.Graphics.Transforms
                 {
                     transformsLazy.RemoveAt(i--);
                     if (t.OnAbort != null)
-                        removalActions.Add(t.Abort);
+                        removalActions.Add(t.OnAbort);
                 }
             }
 

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Graphics.Transforms
         private List<Action> removalActionsLazy;
         private List<Action> removalActions => removalActionsLazy ?? (removalActionsLazy = new List<Action>());
 
-        private double lastTransformAppliedTime;
+        private double lastUpdateTransformsTime;
 
         /// <summary>
         /// Process updates to this class based on loaded <see cref="Transform"/>s. This does not reset <see cref="TransformDelay"/>.
@@ -91,8 +91,8 @@ namespace osu.Framework.Graphics.Transforms
         /// </summary>
         private void updateTransforms(double time)
         {
-            bool rewinding = lastTransformAppliedTime > time;
-            lastTransformAppliedTime = time;
+            bool rewinding = lastUpdateTransformsTime > time;
+            lastUpdateTransformsTime = time;
 
             if (transformsLazy == null)
                 return;

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -134,6 +134,8 @@ namespace osu.Framework.Graphics.Transforms
             {
                 var t = transformsLazy[i];
 
+                var tCanRewind = !RemoveCompletedTransforms && t.Rewindable;
+
                 if (time < t.StartTime)
                     break;
 
@@ -155,7 +157,7 @@ namespace osu.Framework.Graphics.Transforms
                         var u = transformsLazy[j];
                         if (u.TargetMember != t.TargetMember) continue;
 
-                        if (RemoveCompletedTransforms || !t.Rewindable)
+                        if (!tCanRewind)
                         {
                             transformsLazy.RemoveAt(j--);
                             i--;
@@ -175,7 +177,7 @@ namespace osu.Framework.Graphics.Transforms
 
                     if (t.AppliedToEnd)
                     {
-                        if (RemoveCompletedTransforms || !t.Rewindable)
+                        if (!tCanRewind)
                             transformsLazy.RemoveAt(i--);
 
                         if (t.IsLooping)
@@ -184,9 +186,12 @@ namespace osu.Framework.Graphics.Transforms
                             t.StartTime += t.LoopDelay;
                             t.EndTime += t.LoopDelay;
 
-                            // this could be added back at a lower index than where we are currently iterating, but
-                            // running the same transform twice isn't a huge deal.
-                            transformsLazy.Add(t);
+                            if (!tCanRewind)
+                            {
+                                // this could be added back at a lower index than where we are currently iterating, but
+                                // running the same transform twice isn't a huge deal.
+                                transformsLazy.Add(t);
+                            }
                         }
                         else if (t.OnComplete != null)
                             removalActions.Add(t.OnComplete);

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -83,16 +83,21 @@ namespace osu.Framework.Graphics.Transforms
         private List<Action> removalActionsLazy;
         private List<Action> removalActions => removalActionsLazy ?? (removalActionsLazy = new List<Action>());
 
+        private double lastTransformAppliedTime;
+
         /// <summary>
         /// Process updates to this class based on loaded <see cref="Transform"/>s. This does not reset <see cref="TransformDelay"/>.
         /// This is used for performing extra updates on <see cref="Transform"/>s when new <see cref="Transform"/>s are added.
         /// </summary>
         private void updateTransforms(double time)
         {
+            bool rewinding = lastTransformAppliedTime > time;
+            lastTransformAppliedTime = time;
+
             if (transformsLazy == null)
                 return;
 
-            if (!RemoveCompletedTransforms) // todo: optimisation -- this only needs to run when rewinding.
+            if (rewinding && !RemoveCompletedTransforms)
             {
                 var appliedToEndReverts = new List<string>();
 

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -121,9 +121,10 @@ namespace osu.Framework.Graphics.Transforms
                         // we are in the middle of this transform, so we want to mark as not-completely-applied.
                         // note that we should only do this for the last transform of each TargetMemeber to avoid incorrect application order.
                         // the actual application will be in the main loop below now that AppliedToEnd is false.
-                        if (time < t.EndTime && !appliedToEndReverts.Contains(t.TargetMember))
+                        if (!appliedToEndReverts.Contains(t.TargetMember))
                         {
-                            t.AppliedToEnd = false;
+                            if (time < t.EndTime)
+                                t.AppliedToEnd = false;
                             appliedToEndReverts.Add(t.TargetMember);
                         }
                     }


### PR DESCRIPTION
- Fixes jumping forward to the middle of active transforms
- Fixes rewinding in general.
- Fixes rewinding over infinite loops.
- Adds visually understandable tests. Asserts can/should be added in the future.