### PR TITLE
Make DrawQuad/DrawTriangle generic to reduce construction overhead

### DIFF
--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -214,7 +214,7 @@ namespace osu.Framework.Graphics.Audio
                     }
 
                     quadToDraw *= DrawInfo.Matrix;
-                    Texture.DrawQuad<TexturedVertex2D>(quadToDraw, colour, null, Shared.VertexBatch.Add, Vector2.Divide(localInflationAmount, quadToDraw.Size));
+                    Texture.DrawQuad<TexturedVertex2D>(quadToDraw, colour, Shared.VertexBatch.Add, null, Vector2.Divide(localInflationAmount, quadToDraw.Size));
                 }
 
                 Shader.Unbind();

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -214,7 +214,7 @@ namespace osu.Framework.Graphics.Audio
                     }
 
                     quadToDraw *= DrawInfo.Matrix;
-                    Texture.DrawQuad(quadToDraw, colour, null, Shared.VertexBatch.Add, Vector2.Divide(localInflationAmount, quadToDraw.Size));
+                    Texture.DrawQuad<TexturedVertex2D>(quadToDraw, colour, null, Shared.VertexBatch.Add, Vector2.Divide(localInflationAmount, quadToDraw.Size));
                 }
 
                 Shader.Unbind();

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -93,7 +93,7 @@ namespace osu.Framework.Graphics.Containers
             RectangleF textureRect = new RectangleF(0, frameBuffer.Texture.Height, frameBuffer.Texture.Width, -frameBuffer.Texture.Height);
             if (frameBuffer.Texture.Bind())
                 // Color was already applied by base.Draw(); no need to re-apply. Thus we use White here.
-                frameBuffer.Texture.DrawQuad(drawRectangle, textureRect, colourInfo);
+                frameBuffer.Texture.DrawQuad<TexturedVertex2D>(drawRectangle, textureRect, colourInfo);
         }
 
         private void drawChildren(Action<TexturedVertex2D> vertexAction, Vector2 frameBufferSize)

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -93,7 +93,7 @@ namespace osu.Framework.Graphics.Containers
             RectangleF textureRect = new RectangleF(0, frameBuffer.Texture.Height, frameBuffer.Texture.Width, -frameBuffer.Texture.Height);
             if (frameBuffer.Texture.Bind())
                 // Color was already applied by base.Draw(); no need to re-apply. Thus we use White here.
-                frameBuffer.Texture.DrawQuad<TexturedVertex2D>(drawRectangle, textureRect, colourInfo);
+                frameBuffer.Texture.DrawQuad(drawRectangle, textureRect, colourInfo);
         }
 
         private void drawChildren(Action<TexturedVertex2D> vertexAction, Vector2 frameBufferSize)

--- a/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
@@ -162,7 +162,7 @@ namespace osu.Framework.Graphics.Containers
             colour.TopRight.MultiplyAlpha(DrawInfo.Colour.TopRight.Linear.A);
             colour.BottomRight.MultiplyAlpha(DrawInfo.Colour.BottomRight.Linear.A);
 
-            Texture.WhitePixel.DrawQuad(
+            Texture.WhitePixel.DrawQuad<TexturedVertex2D>(
                 ScreenSpaceMaskingQuad.Value,
                 colour, null, null, null,
                 // HACK HACK HACK. We re-use the unused vertex blend range to store the original

--- a/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
@@ -162,9 +162,9 @@ namespace osu.Framework.Graphics.Containers
             colour.TopRight.MultiplyAlpha(DrawInfo.Colour.TopRight.Linear.A);
             colour.BottomRight.MultiplyAlpha(DrawInfo.Colour.BottomRight.Linear.A);
 
-            Texture.WhitePixel.DrawQuad<TexturedVertex2D>(
+            Texture.WhitePixel.DrawQuad(
                 ScreenSpaceMaskingQuad.Value,
-                colour, null, null, null,
+                colour, null, null,
                 // HACK HACK HACK. We re-use the unused vertex blend range to store the original
                 // masking blend range when rendering edge effects. This is needed for smooth inner edges
                 // with a hollow edge effect.

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Graphics.Primitives;
 using OpenTK.Graphics.ES30;
 using OpenTK;
@@ -57,14 +58,24 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <summary>
         /// Blit a triangle to OpenGL display with specified parameters.
         /// </summary>
-        public abstract void DrawTriangle<T>(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null)
+        public abstract void DrawTriangle<T>(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, [NotNull] Action<T> vertexAction, Vector2? inflationPercentage = null)
+            where T : ITexturedVertex2D, IEquatable<T>, new();
+
+        /// <summary>
+        /// Blit a triangle to OpenGL display with specified parameters.
+        /// </summary>
+        public abstract void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null);
+
+        /// <summary>
+        /// Blit a quad to OpenGL display with specified parameters.
+        /// </summary>
+        public abstract void DrawQuad<T>(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, [NotNull] Action<T> vertexAction, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
             where T : ITexturedVertex2D, IEquatable<T>, new();
 
         /// <summary>
         /// Blit a quad to OpenGL display with specified parameters.
         /// </summary>
-        public abstract void DrawQuad<T>(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
-            where T : ITexturedVertex2D, IEquatable<T>, new();
+        public abstract void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null);
 
         /// <summary>
         /// Bind as active texture.

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -64,7 +64,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <summary>
         /// Blit a triangle to OpenGL display with specified parameters.
         /// </summary>
-        public abstract void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null);
+        public abstract void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null);
 
         /// <summary>
         /// Blit a quad to OpenGL display with specified parameters.
@@ -75,7 +75,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <summary>
         /// Blit a quad to OpenGL display with specified parameters.
         /// </summary>
-        public abstract void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null);
+        public abstract void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null);
 
         /// <summary>
         /// Bind as active texture.

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -58,13 +58,13 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// Blit a triangle to OpenGL display with specified parameters.
         /// </summary>
         public abstract void DrawTriangle<T>(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null)
-            where T : ITexturedVertex2D, new();
+            where T : ITexturedVertex2D, IEquatable<T>, new();
 
         /// <summary>
         /// Blit a quad to OpenGL display with specified parameters.
         /// </summary>
         public abstract void DrawQuad<T>(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
-            where T : ITexturedVertex2D, new();
+            where T : ITexturedVertex2D, IEquatable<T>, new();
 
         /// <summary>
         /// Bind as active texture.

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -57,12 +57,14 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <summary>
         /// Blit a triangle to OpenGL display with specified parameters.
         /// </summary>
-        public abstract void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null);
+        public abstract void DrawTriangle<T>(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null)
+            where T : ITexturedVertex2D, new();
 
         /// <summary>
         /// Blit a quad to OpenGL display with specified parameters.
         /// </summary>
-        public abstract void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null);
+        public abstract void DrawQuad<T>(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+            where T : ITexturedVertex2D, new();
 
         /// <summary>
         /// Bind as active texture.

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -207,7 +207,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             FrameStatistics.Add(StatisticsCounterType.Pixels, (long)vertexTriangle.ConservativeArea);
         }
 
-        public override void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null)
+        public override void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null)
         {
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not draw a triangle with a disposed texture.");
@@ -223,8 +223,10 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             SRGBColour topColour = (drawColour.TopLeft + drawColour.TopRight) / 2;
             SRGBColour bottomColour = (drawColour.BottomLeft + drawColour.BottomRight) / 2;
 
+            vertexAction = vertexAction ?? default_triangle_action;
+
             // Left triangle half
-            addVertex(default_triangle_action,
+            addVertex(vertexAction,
                 vertexTriangle.P0,
                 new Vector2(inflatedTexRect.Left, inflatedTexRect.Top),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
@@ -232,7 +234,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 topColour.Linear
             );
 
-            addVertex(default_triangle_action,
+            addVertex(vertexAction,
                 vertexTriangle.P1,
                 new Vector2(inflatedTexRect.Left, inflatedTexRect.Bottom),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
@@ -240,7 +242,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 drawColour.BottomLeft.Linear
             );
 
-            addVertex(default_triangle_action,
+            addVertex(vertexAction,
                 (vertexTriangle.P1 + vertexTriangle.P2) / 2,
                 new Vector2((inflatedTexRect.Left + inflatedTexRect.Right) / 2, inflatedTexRect.Bottom),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
@@ -249,7 +251,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             );
 
             // Right triangle half
-            addVertex(default_triangle_action,
+            addVertex(vertexAction,
                 vertexTriangle.P0,
                 new Vector2(inflatedTexRect.Right, inflatedTexRect.Top),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
@@ -257,7 +259,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 topColour.Linear
             );
 
-            addVertex(default_triangle_action,
+            addVertex(vertexAction,
                 (vertexTriangle.P1 + vertexTriangle.P2) / 2,
                 new Vector2((inflatedTexRect.Left + inflatedTexRect.Right) / 2, inflatedTexRect.Bottom),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
@@ -265,7 +267,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 bottomColour.Linear
             );
 
-            addVertex(default_triangle_action,
+            addVertex(vertexAction,
                 vertexTriangle.P2,
                 new Vector2(inflatedTexRect.Right, inflatedTexRect.Bottom),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
@@ -317,7 +319,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             FrameStatistics.Add(StatisticsCounterType.Pixels, (long)vertexQuad.ConservativeArea);
         }
 
-        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
         {
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not draw a quad with a disposed texture.");
@@ -327,28 +329,30 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             RectangleF inflatedTexRect = texRect.Inflate(inflationAmount);
             Vector2 blendRange = blendRangeOverride ?? inflationAmount;
 
-            addVertex(default_quad_action,
+            vertexAction = vertexAction ?? default_quad_action;
+
+            addVertex(vertexAction,
                 vertexQuad.BottomLeft,
                 new Vector2(inflatedTexRect.Left, inflatedTexRect.Bottom),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 blendRange,
                 drawColour.BottomLeft.Linear);
 
-            addVertex(default_quad_action,
+            addVertex(vertexAction,
                 vertexQuad.BottomRight,
                 new Vector2(inflatedTexRect.Right, inflatedTexRect.Bottom),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 blendRange,
                 drawColour.BottomRight.Linear);
 
-            addVertex(default_quad_action,
+            addVertex(vertexAction,
                 vertexQuad.TopRight,
                 new Vector2(inflatedTexRect.Right, inflatedTexRect.Top),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),
                 blendRange,
                 drawColour.TopRight.Linear);
 
-            addVertex(default_quad_action,
+            addVertex(vertexAction,
                 vertexQuad.TopLeft,
                 new Vector2(inflatedTexRect.Left, inflatedTexRect.Top),
                 new Vector4(texRect.Left, texRect.Top, texRect.Right, texRect.Bottom),

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
@@ -63,14 +63,24 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             return parent.GetTextureRect(boundsInParent(textureRect));
         }
 
-        public override void DrawTriangle<T>(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null)
+        public override void DrawTriangle<T>(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction, Vector2? inflationPercentage = null)
         {
             parent.DrawTriangle(vertexTriangle, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage);
         }
 
-        public override void DrawQuad<T>(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+        public override void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null)
+        {
+            parent.DrawTriangle(vertexTriangle, boundsInParent(textureRect), drawColour, inflationPercentage);
+        }
+
+        public override void DrawQuad<T>(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
         {
             parent.DrawQuad(vertexQuad, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage, blendRangeOverride);
+        }
+
+        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+        {
+            parent.DrawQuad(vertexQuad, boundsInParent(textureRect), drawColour, inflationPercentage, blendRangeOverride);
         }
 
         internal override bool Upload()

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
@@ -6,7 +6,6 @@ using osu.Framework.Graphics.Primitives;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 using OpenTK;
 using osu.Framework.Graphics.Colour;
-using osu.Framework.Graphics.OpenGL.Vertices;
 
 namespace osu.Framework.Graphics.OpenGL.Textures
 {
@@ -64,12 +63,12 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             return parent.GetTextureRect(boundsInParent(textureRect));
         }
 
-        public override void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null)
+        public override void DrawTriangle<T>(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null)
         {
             parent.DrawTriangle(vertexTriangle, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage);
         }
 
-        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+        public override void DrawQuad<T>(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
         {
             parent.DrawQuad(vertexQuad, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage, blendRangeOverride);
         }

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics.Primitives;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 using OpenTK;
 using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.OpenGL.Vertices;
 
 namespace osu.Framework.Graphics.OpenGL.Textures
 {
@@ -68,9 +69,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             parent.DrawTriangle(vertexTriangle, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage);
         }
 
-        public override void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null)
+        public override void DrawTriangle(Triangle vertexTriangle, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null)
         {
-            parent.DrawTriangle(vertexTriangle, boundsInParent(textureRect), drawColour, inflationPercentage);
+            parent.DrawTriangle(vertexTriangle, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage);
         }
 
         public override void DrawQuad<T>(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<T> vertexAction, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
@@ -78,9 +79,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             parent.DrawQuad(vertexQuad, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage, blendRangeOverride);
         }
 
-        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+        public override void DrawQuad(Quad vertexQuad, RectangleF? textureRect, ColourInfo drawColour, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
         {
-            parent.DrawQuad(vertexQuad, boundsInParent(textureRect), drawColour, inflationPercentage, blendRangeOverride);
+            parent.DrawQuad(vertexQuad, boundsInParent(textureRect), drawColour, vertexAction, inflationPercentage, blendRangeOverride);
         }
 
         internal override bool Upload()

--- a/osu.Framework/Graphics/OpenGL/Vertices/ITexturedVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/ITexturedVertex2D.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Runtime.CompilerServices;
 using OpenTK;
 using OpenTK.Graphics;
 
@@ -8,10 +9,10 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
 {
     public interface ITexturedVertex2D : IVertex
     {
-        Vector2 Position { get; set; }
-        Color4 Colour { get; set; }
-        Vector2 TexturePosition { get; set; }
-        Vector4 TextureRect { get; set; }
-        Vector2 BlendRange { get; set; }
+        Vector2 Position { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
+        Color4 Colour { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
+        Vector2 TexturePosition { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
+        Vector4 TextureRect { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
+        Vector2 BlendRange { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Vertices/ITexturedVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/ITexturedVertex2D.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System.Runtime.CompilerServices;
 using OpenTK;
 using OpenTK.Graphics;
 
@@ -9,10 +8,10 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
 {
     public interface ITexturedVertex2D : IVertex
     {
-        Vector2 Position { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
-        Color4 Colour { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
-        Vector2 TexturePosition { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
-        Vector4 TextureRect { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
-        Vector2 BlendRange { [MethodImpl(MethodImplOptions.AggressiveInlining)] set; }
+        Vector2 Position { set; }
+        Color4 Colour { set; }
+        Vector2 TexturePosition { set; }
+        Vector4 TextureRect { set; }
+        Vector2 BlendRange { set; }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Vertices/ITexturedVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/ITexturedVertex2D.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using OpenTK;
 using OpenTK.Graphics;

--- a/osu.Framework/Graphics/OpenGL/Vertices/ITexturedVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/ITexturedVertex2D.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Graphics.OpenGL.Vertices
+{
+    public interface ITexturedVertex2D : IVertex
+    {
+        Vector2 Position { get; set; }
+        Color4 Colour { get; set; }
+        Vector2 TexturePosition { get; set; }
+        Vector4 TextureRect { get; set; }
+        Vector2 BlendRange { get; set; }
+    }
+}

--- a/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex2D.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using OpenTK;
 using OpenTK.Graphics;
@@ -23,43 +24,19 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         [VertexMember(2, VertexAttribPointerType.Float)]
         private Vector2 blendRange;
 
-        public Vector2 Position
-        {
-            get => position;
-            set => position = value;
-        }
-
-        public Color4 Colour
-        {
-            get => colour;
-            set => colour = value;
-        }
-
-        public Vector2 TexturePosition
-        {
-            get => texturePosition;
-            set => texturePosition = value;
-        }
-
-        public Vector4 TextureRect
-        {
-            get => textureRect;
-            set => textureRect = value;
-        }
-
-        public Vector2 BlendRange
-        {
-            get => blendRange;
-            set => blendRange = value;
-        }
+        public Vector2 Position { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => position = value; }
+        public Color4 Colour { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => colour = value; }
+        public Vector2 TexturePosition { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => texturePosition = value; }
+        public Vector4 TextureRect { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => textureRect = value; }
+        public Vector2 BlendRange { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => blendRange = value; }
 
         public bool Equals(TexturedVertex2D other)
         {
-            return Position.Equals(other.Position)
-                   && TexturePosition.Equals(other.TexturePosition)
-                   && Colour.Equals(other.Colour)
-                   && TextureRect.Equals(other.TextureRect)
-                   && BlendRange.Equals(other.BlendRange);
+            return position.Equals(other.position)
+                   && texturePosition.Equals(other.texturePosition)
+                   && colour.Equals(other.colour)
+                   && textureRect.Equals(other.textureRect)
+                   && blendRange.Equals(other.blendRange);
         }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex2D.cs
@@ -10,18 +10,48 @@ using OpenTK.Graphics.ES30;
 namespace osu.Framework.Graphics.OpenGL.Vertices
 {
     [StructLayout(LayoutKind.Sequential)]
-    public struct TexturedVertex2D : IEquatable<TexturedVertex2D>, IVertex
+    public struct TexturedVertex2D : IEquatable<TexturedVertex2D>, ITexturedVertex2D
     {
         [VertexMember(2, VertexAttribPointerType.Float)]
-        public Vector2 Position;
+        private Vector2 position;
         [VertexMember(4, VertexAttribPointerType.Float)]
-        public Color4 Colour;
+        private Color4 colour;
         [VertexMember(2, VertexAttribPointerType.Float)]
-        public Vector2 TexturePosition;
+        private Vector2 texturePosition;
         [VertexMember(4, VertexAttribPointerType.Float)]
-        public Vector4 TextureRect;
+        private Vector4 textureRect;
         [VertexMember(2, VertexAttribPointerType.Float)]
-        public Vector2 BlendRange;
+        private Vector2 blendRange;
+
+        public Vector2 Position
+        {
+            get => position;
+            set => position = value;
+        }
+
+        public Color4 Colour
+        {
+            get => colour;
+            set => colour = value;
+        }
+
+        public Vector2 TexturePosition
+        {
+            get => texturePosition;
+            set => texturePosition = value;
+        }
+
+        public Vector4 TextureRect
+        {
+            get => textureRect;
+            set => textureRect = value;
+        }
+
+        public Vector2 BlendRange
+        {
+            get => blendRange;
+            set => blendRange = value;
+        }
 
         public bool Equals(TexturedVertex2D other)
         {

--- a/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex2D.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using OpenTK;
 using OpenTK.Graphics;
@@ -24,11 +23,11 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         [VertexMember(2, VertexAttribPointerType.Float)]
         private Vector2 blendRange;
 
-        public Vector2 Position { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => position = value; }
-        public Color4 Colour { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => colour = value; }
-        public Vector2 TexturePosition { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => texturePosition = value; }
-        public Vector4 TextureRect { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => textureRect = value; }
-        public Vector2 BlendRange { [MethodImpl(MethodImplOptions.AggressiveInlining)] set => blendRange = value; }
+        public Vector2 Position { set => position = value; }
+        public Color4 Colour { set => colour = value; }
+        public Vector2 TexturePosition { set => texturePosition = value; }
+        public Vector4 TextureRect { set => textureRect = value; }
+        public Vector2 BlendRange { set => blendRange = value; }
 
         public bool Equals(TexturedVertex2D other)
         {

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -38,8 +38,7 @@ namespace osu.Framework.Graphics.Shapes
         {
             protected override void Blit(Action<TexturedVertex2D> vertexAction)
             {
-                Texture.DrawTriangle<TexturedVertex2D>(toTriangle(ScreenSpaceDrawQuad), DrawInfo.Colour, null, null,
-                    new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
+                Texture.DrawTriangle(toTriangle(ScreenSpaceDrawQuad), DrawInfo.Colour, null, new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
             }
         }
     }

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.Shapes
         {
             protected override void Blit(Action<TexturedVertex2D> vertexAction)
             {
-                Texture.DrawTriangle(toTriangle(ScreenSpaceDrawQuad), DrawInfo.Colour, null, null,
+                Texture.DrawTriangle<TexturedVertex2D>(toTriangle(ScreenSpaceDrawQuad), DrawInfo.Colour, null, null,
                     new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
             }
         }

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.Shapes
         {
             protected override void Blit(Action<TexturedVertex2D> vertexAction)
             {
-                Texture.DrawTriangle(toTriangle(ScreenSpaceDrawQuad), DrawInfo.Colour, null, new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
+                Texture.DrawTriangle(toTriangle(ScreenSpaceDrawQuad), DrawInfo.Colour, null, null, new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
             }
         }
     }

--- a/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
@@ -30,8 +30,7 @@ namespace osu.Framework.Graphics.Sprites
 
         protected virtual void Blit(Action<TexturedVertex2D> vertexAction)
         {
-            Texture.DrawQuad(ScreenSpaceDrawQuad, DrawInfo.Colour, null, vertexAction,
-                new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
+            Texture.DrawQuad(ScreenSpaceDrawQuad, DrawInfo.Colour, vertexAction, null, new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
         }
 
         public override void Draw(Action<TexturedVertex2D> vertexAction)

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -184,14 +184,16 @@ namespace osu.Framework.Graphics.Textures
             return TextureGL.GetTextureRect(TextureBounds(textureRect));
         }
 
-        public void DrawTriangle(Triangle vertexTriangle, ColourInfo colour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null)
+        public void DrawTriangle<T>(Triangle vertexTriangle, ColourInfo colour, RectangleF? textureRect = null, Action<T> vertexAction = null, Vector2? inflationPercentage = null)
+            where T : ITexturedVertex2D, IEquatable<T>, new()
         {
             if (TextureGL == null || !TextureGL.Bind()) return;
 
             TextureGL.DrawTriangle(vertexTriangle, TextureBounds(textureRect), colour, vertexAction, inflationPercentage);
         }
 
-        public void DrawQuad(Quad vertexQuad, ColourInfo colour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+        public void DrawQuad<T>(Quad vertexQuad, ColourInfo colour, RectangleF? textureRect = null, Action<T> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+            where T : ITexturedVertex2D, IEquatable<T>, new()
         {
             if (TextureGL == null || !TextureGL.Bind()) return;
 

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -193,11 +193,11 @@ namespace osu.Framework.Graphics.Textures
             TextureGL.DrawTriangle(vertexTriangle, TextureBounds(textureRect), colour, vertexAction, inflationPercentage);
         }
 
-        public void DrawTriangle(Triangle vertexTriangle, ColourInfo colour, RectangleF? textureRect = null, Vector2? inflationPercentage = null)
+        public void DrawTriangle(Triangle vertexTriangle, ColourInfo colour, Action<TexturedVertex2D> vertexAction = null, RectangleF? textureRect = null, Vector2? inflationPercentage = null)
         {
             if (TextureGL == null || !TextureGL.Bind()) return;
 
-            TextureGL.DrawTriangle(vertexTriangle, TextureBounds(textureRect), colour, inflationPercentage);
+            TextureGL.DrawTriangle(vertexTriangle, TextureBounds(textureRect), colour, vertexAction, inflationPercentage);
         }
 
         public void DrawQuad<T>(Quad vertexQuad, ColourInfo colour, [NotNull] Action<T> vertexAction, RectangleF? textureRect = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
@@ -208,11 +208,11 @@ namespace osu.Framework.Graphics.Textures
             TextureGL.DrawQuad(vertexQuad, TextureBounds(textureRect), colour, vertexAction, inflationPercentage, blendRangeOverride);
         }
 
-        public void DrawQuad(Quad vertexQuad, ColourInfo colour, RectangleF? textureRect = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+        public void DrawQuad(Quad vertexQuad, ColourInfo colour, Action<TexturedVertex2D> vertexAction = null, RectangleF? textureRect = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
         {
             if (TextureGL == null || !TextureGL.Bind()) return;
 
-            TextureGL.DrawQuad(vertexQuad, TextureBounds(textureRect), colour, inflationPercentage, blendRangeOverride);
+            TextureGL.DrawQuad(vertexQuad, TextureBounds(textureRect), colour, vertexAction, inflationPercentage, blendRangeOverride);
         }
 
         public override string ToString() => $@"{AssetName} ({Width}, {Height})";

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -5,6 +5,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
+using JetBrains.Annotations;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Primitives;
 using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
@@ -184,7 +185,7 @@ namespace osu.Framework.Graphics.Textures
             return TextureGL.GetTextureRect(TextureBounds(textureRect));
         }
 
-        public void DrawTriangle<T>(Triangle vertexTriangle, ColourInfo colour, RectangleF? textureRect = null, Action<T> vertexAction = null, Vector2? inflationPercentage = null)
+        public void DrawTriangle<T>(Triangle vertexTriangle, ColourInfo colour, [NotNull] Action<T> vertexAction, RectangleF? textureRect = null, Vector2? inflationPercentage = null)
             where T : ITexturedVertex2D, IEquatable<T>, new()
         {
             if (TextureGL == null || !TextureGL.Bind()) return;
@@ -192,12 +193,26 @@ namespace osu.Framework.Graphics.Textures
             TextureGL.DrawTriangle(vertexTriangle, TextureBounds(textureRect), colour, vertexAction, inflationPercentage);
         }
 
-        public void DrawQuad<T>(Quad vertexQuad, ColourInfo colour, RectangleF? textureRect = null, Action<T> vertexAction = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+        public void DrawTriangle(Triangle vertexTriangle, ColourInfo colour, RectangleF? textureRect = null, Vector2? inflationPercentage = null)
+        {
+            if (TextureGL == null || !TextureGL.Bind()) return;
+
+            TextureGL.DrawTriangle(vertexTriangle, TextureBounds(textureRect), colour, inflationPercentage);
+        }
+
+        public void DrawQuad<T>(Quad vertexQuad, ColourInfo colour, [NotNull] Action<T> vertexAction, RectangleF? textureRect = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
             where T : ITexturedVertex2D, IEquatable<T>, new()
         {
             if (TextureGL == null || !TextureGL.Bind()) return;
 
             TextureGL.DrawQuad(vertexQuad, TextureBounds(textureRect), colour, vertexAction, inflationPercentage, blendRangeOverride);
+        }
+
+        public void DrawQuad(Quad vertexQuad, ColourInfo colour, RectangleF? textureRect = null, Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
+        {
+            if (TextureGL == null || !TextureGL.Bind()) return;
+
+            TextureGL.DrawQuad(vertexQuad, TextureBounds(textureRect), colour, inflationPercentage, blendRangeOverride);
         }
 
         public override string ToString() => $@"{AssetName} ({Width}, {Height})";

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -203,6 +203,7 @@
     <Compile Include="Graphics\Cursor\CursorEffectContainer.cs" />
     <Compile Include="Graphics\Cursor\IHasCustomTooltip.cs" />
     <Compile Include="Graphics\Cursor\ITooltip.cs" />
+    <Compile Include="Graphics\OpenGL\Vertices\ITexturedVertex2D.cs" />
     <Compile Include="Graphics\Primitives\RectangleI.cs" />
     <Compile Include="Graphics\Primitives\Vector2I.cs" />
     <Compile Include="Graphics\Shapes\Circle.cs" />


### PR DESCRIPTION
For cases where we're doing, e.g:

```
Texture.DrawQuad(..., v => buffer.Add(new CustomVertex { ... });
```

we can now instead do:

```
Texture.DrawQuad<CustomVertex>(..., v =>
{
    { /* set custom vertex properties here */ }
    buffer.Add(v);
}
```