### PR TITLE
Remove depth comparisons from FlowContainer ordering

### DIFF
--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -18,14 +18,6 @@ namespace osu.Framework.Graphics.Containers
     {
         internal event Action OnLayout;
 
-        private readonly ChildComparer childComparer;
-
-        protected FlowContainer()
-        {
-            childComparer = new ChildComparer(this);
-        }
-
-
         /// <summary>
         /// The easing that should be used when children are moved to their position in the layout.
         /// </summary>
@@ -159,9 +151,9 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Gets the children that appear in the flow of this FlowContainer in the order in which they are processed within the flowing layout.
+        /// Gets the children that appear in the flow of this <see cref="FlowContainer{T}"/> in the order in which they are processed within the flowing layout.
         /// </summary>
-        public virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent).OrderBy(d => layoutChildren[d]).ThenBy(d => d, childComparer);
+        public virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent).OrderBy(d => layoutChildren[d]).ThenBy(d => d.ChildID);
 
         protected abstract IEnumerable<Vector2> ComputeLayoutPositions();
 


### PR DESCRIPTION
I added this back, but this is not intended for @default0 's use cases. My bad.