### PR TITLE
Add method to add arbitrary drawables to TextFlowContainers

### DIFF
--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -157,6 +157,20 @@ namespace osu.Framework.Graphics.Containers
         public IEnumerable<SpriteText> AddText(string text, Action<SpriteText> creationParameters = null) => AddLine(new TextLine(text, creationParameters), true);
 
         /// <summary>
+        /// Add an arbitrary <see cref="SpriteText"/> to this <see cref="TextFlowContainer"/>.
+        /// While default creation parameters are applied automatically, word wrapping is unavailable for contained words.
+        /// This should only be used when a specialised <see cref="SpriteText"/> type is requried.
+        /// </summary>
+        /// <param name="text">The text to add.</param>
+        /// <param name="creationParameters">A callback providing any <see cref="SpriteText" /> instances created for this new text.</param>
+        public void AddText(SpriteText text, Action<SpriteText> creationParameters = null)
+        {
+            base.Add(text);
+            defaultCreationParameters(text);
+            creationParameters?.Invoke(text);
+        }
+
+        /// <summary>
         /// Add a new paragraph to this text flow. The \n character will create a line break. If you need \n to be a new paragraph, not just a line break, use <see cref="AddText(string, Action{SpriteText})"/> instead.
         /// </summary>
         /// <returns>A collection of the <see cref="SpriteText" /> objects for each word created from the given text.</returns>


### PR DESCRIPTION
Sometimes we just want to add a custom `SpriteText` type to a `TextFlow`.

Example usage:

```csharp
infoTextLeft.NewLine();
infoTextLeft.AddText("Last seen ", lightText);
infoTextLeft.AddText(new DrawableDate(user.LastVisit), boldItalic);
infoTextLeft.NewParagraph();
```