### PR TITLE
Add a base component class

### DIFF
--- a/osu.Framework/Graphics/Component.cs
+++ b/osu.Framework/Graphics/Component.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics
+{
+    /// <summary>
+    /// An updateable component that can be inserted into the draw hierarchy.
+    /// This is currently used as a marker for cases where nothing more than load, update, lifetime support and hierarchy presence are required.
+    /// Eventually this will be fleshed out (and the inheritance will be reversed to Drawable : Component).
+    /// </summary>
+    public abstract class Component : Drawable
+    {
+    }
+}

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Graphics\Animations\TextureAnimation.cs" />
     <Compile Include="Graphics\Audio\WaveformGraph.cs" />
     <Compile Include="Graphics\BlendingParameters.cs" />
+    <Compile Include="Graphics\Component.cs" />
     <Compile Include="Graphics\Containers\CompositeDrawable.cs" />
     <Compile Include="Graphics\Containers\CustomizableTextContainer.cs" />
     <Compile Include="Graphics\Containers\IFillFlowContainer.cs" />


### PR DESCRIPTION
This is paving the way to allow for non-drawable components to exist in the hierarchy.

Fully fleshing this out is on the short-term roadmap, but for the time being I would like this class to exist so we can at very least mark non-drawable items as we add them, so they can instantly take advantage of future changes.