### PR TITLE
Fix seekOffset being considered when seeking

### DIFF
--- a/osu.Framework/Timing/StopwatchClock.cs
+++ b/osu.Framework/Timing/StopwatchClock.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Timing
 
         public bool Seek(double position)
         {
-            seekOffset = position - CurrentTime;
+            seekOffset = position - (CurrentTime - seekOffset);
             return true;
         }
 

--- a/osu.Framework/Timing/StopwatchClock.cs
+++ b/osu.Framework/Timing/StopwatchClock.cs
@@ -27,7 +27,12 @@ namespace osu.Framework.Timing
                 Start();
         }
 
-        public double CurrentTime => (stopwatchMilliseconds - rateChangeUsed) * rate + rateChangeAccumulated + seekOffset;
+        public double CurrentTime => stopwatchCurrentTime + seekOffset;
+
+        /// <summary>
+        /// The current time, represented solely by the accumulated <see cref="Stopwatch"/> time.
+        /// </summary>
+        private double stopwatchCurrentTime => (stopwatchMilliseconds - rateChangeUsed) * rate + rateChangeAccumulated;
 
         private double stopwatchMilliseconds => (double)ElapsedTicks / Frequency * 1000;
 
@@ -52,7 +57,8 @@ namespace osu.Framework.Timing
 
         public bool Seek(double position)
         {
-            seekOffset = position - (CurrentTime - seekOffset);
+            // Determine the offset that when added to stopwatchCurrentTime; results in the requested time value
+            seekOffset = position - stopwatchCurrentTime;
             return true;
         }
 


### PR DESCRIPTION
```
StopwatchClock.Seek(50); <- CurrentTime = 50
StopwatchClock.Seek(100); <- CurrentTime = 50
StopwatchClock.Seek(200); <- CurrentTime = 150
```

versus

```
trackBass.Seek(50); <- CurrentTime = 50
trackBass.Seek(100); <- CurrentTime = 100
trackBass.Seek(200); <- CurrentTime = 200
```

This brings the clocks in-line with one another, so that now:

```
StopwatchClock.Seek(50); <- CurrentTime = 50
StopwatchClock.Seek(100); <- CurrentTime = 100
StopwatchClock.Seek(200); <- CurrentTime = 200
```
