### PR TITLE
Move async loading of children to after self

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -71,6 +71,11 @@ namespace osu.Framework.Graphics.Containers
 
             if (shader == null)
                 shader = shaders?.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
+        }
+
+        internal sealed override void Inject()
+        {
+            base.Inject();
 
             // We are in a potentially async context, so let's aggressively load all our children
             // regardless of their alive state. this also gives children a clock so they can be checked

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -205,7 +205,7 @@ namespace osu.Framework.Graphics
                 // get our dependencies from our parent, but allow local overriding of our inherited dependency container
                 Dependencies = CreateLocalDependencies(dependencies);
 
-                Dependencies.Inject(this);
+                Inject();
 
                 LoadAsyncComplete();
 
@@ -214,6 +214,11 @@ namespace osu.Framework.Graphics
                     Logger.Log($@"Drawable [{ToString()}] took {loadDuration:0.00}ms to load and was not async!", LoggingTarget.Performance);
                 loadState = LoadState.Ready;
             }
+        }
+
+        internal virtual void Inject()
+        {
+            Dependencies.Inject(this);
         }
 
         /// <summary>
@@ -758,6 +763,7 @@ namespace osu.Framework.Graphics
                     v.Y /= fillAspectRatio;
                 }
             }
+
             return v;
         }
 
@@ -795,7 +801,9 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Called whenever the <see cref="RelativeSizeAxes"/> of this drawable is changed, or when the <see cref="Container{T}.AutoSizeAxes"/> are changed if this drawable is a <see cref="Container{T}"/>.
         /// </summary>
-        protected virtual void OnSizingChanged() { }
+        protected virtual void OnSizingChanged()
+        {
+        }
 
         #endregion
 
@@ -1195,6 +1203,7 @@ namespace osu.Framework.Graphics
                 Invalidate(Invalidation.Colour);
             }
         }
+
         #endregion
 
         #region Timekeeping
@@ -1284,6 +1293,7 @@ namespace osu.Framework.Graphics
 
                 search = search.Parent;
             }
+
             return null;
         }
 
@@ -1894,7 +1904,8 @@ namespace osu.Framework.Graphics
             private static readonly ConcurrentDictionary<Type, bool> mouse_cached_values = new ConcurrentDictionary<Type, bool>();
             private static readonly ConcurrentDictionary<Type, bool> keyboard_cached_values = new ConcurrentDictionary<Type, bool>();
 
-            private static readonly string[] mouse_input_methods = {
+            private static readonly string[] mouse_input_methods =
+            {
                 nameof(OnHover),
                 nameof(OnHoverLost),
                 nameof(OnMouseDown),
@@ -1910,7 +1921,8 @@ namespace osu.Framework.Graphics
                 nameof(OnMouseMove)
             };
 
-            private static readonly string[] keyboard_input_methods = {
+            private static readonly string[] keyboard_input_methods =
+            {
                 nameof(OnFocus),
                 nameof(OnFocusLost),
                 nameof(OnKeyDown),
@@ -2114,7 +2126,8 @@ namespace osu.Framework.Graphics
             {
                 double min = double.MaxValue;
                 foreach (Transform t in Transforms)
-                    if (t.StartTime < min) min = t.StartTime;
+                    if (t.StartTime < min)
+                        min = t.StartTime;
                 LifetimeStart = min < int.MaxValue ? min : int.MinValue;
             }
         }
@@ -2177,19 +2190,23 @@ namespace osu.Framework.Graphics
         /// is assumed unless indicated by additional flags.
         /// </summary>
         DrawInfo = 1 << 0,
+
         /// <summary>
         /// <see cref="Drawable.DrawSize"/> has changed.
         /// </summary>
         DrawSize = 1 << 1,
+
         /// <summary>
         /// Captures all other geometry changes than <see cref="Drawable.DrawSize"/>, such as
         /// <see cref="Drawable.Rotation"/>, <see cref="Drawable.Shear"/>, and <see cref="Drawable.DrawPosition"/>.
         /// </summary>
         MiscGeometry = 1 << 2,
+
         /// <summary>
         /// Our colour changed.
         /// </summary>
         Colour = 1 << 3,
+
         /// <summary>
         /// <see cref="Drawable.ApplyDrawNode(Graphics.DrawNode)"/> has to be invoked on all old draw nodes.
         /// </summary>
@@ -2199,10 +2216,12 @@ namespace osu.Framework.Graphics
         /// No invalidation.
         /// </summary>
         None = 0,
+
         /// <summary>
         /// <see cref="Drawable.RequiredParentSizeToFit"/> has to be recomputed.
         /// </summary>
         RequiredParentSizeToFit = MiscGeometry | DrawSize,
+
         /// <summary>
         /// All possible things are affected.
         /// </summary>
@@ -2296,17 +2315,20 @@ namespace osu.Framework.Graphics
         /// Not loaded, and no load has been initiated yet.
         /// </summary>
         NotLoaded,
+
         /// <summary>
         /// Currently loading (possibly and usually on a background
         /// thread via <see cref="Drawable.LoadAsync(Game, Drawable, Action)"/>).
         /// </summary>
         Loading,
+
         /// <summary>
         /// Loading is complete, but has not yet been finalized on the update thread
         /// (<see cref="Drawable.LoadComplete"/> has not been called yet, which
         /// always runs on the update thread and requires <see cref="Drawable.IsAlive"/>).
         /// </summary>
         Ready,
+
         /// <summary>
         /// Loading is fully completed and the Drawable is now part of the scene graph.
         /// </summary>
@@ -2322,11 +2344,13 @@ namespace osu.Framework.Graphics
         /// Completely fill the parent with a relative size of 1 at the cost of stretching the aspect ratio (default).
         /// </summary>
         Stretch,
+
         /// <summary>
         /// Always maintains aspect ratio while filling the portion of the parent's size denoted by the relative size.
         /// A relative size of 1 results in completely filling the parent by scaling the smaller axis of the drawable to fill the parent.
         /// </summary>
         Fill,
+
         /// <summary>
         /// Always maintains aspect ratio while fitting into the portion of the parent's size denoted by the relative size.
         /// A relative size of 1 results in fitting exactly into the parent by scaling the larger axis of the drawable to fit into the parent.


### PR DESCRIPTION
Previously, inheriting CompositeDrawable and having a BDL load method would result in the local one being run *after* all your children were run.

PR for regression testing and comment. FWIW this did break a few things in osu!, but most seem to be really awkward (wrong) implementations from the start.