### PR TITLE
Add wrap method to remove duplicate code in effects

### DIFF
--- a/osu.Framework/Graphics/Containers/ContainerExtensions.cs
+++ b/osu.Framework/Graphics/Containers/ContainerExtensions.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+using System;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// Holds extension methods for <see cref="Container{T}"/>.
+    /// </summary>
+    public static class ContainerExtensions
+    {
+        /// <summary>
+        /// Wraps the given <paramref name="drawable"/> with the given <paramref name="container"/>
+        /// such that the <paramref name="container"/> can be used instead of the <paramref name="drawable"/>
+        /// without affecting the layout. The <paramref name="container"/> must not contain any children before wrapping.
+        /// </summary>
+        /// <typeparam name="T">The type of the <paramref name="container"/>.</typeparam>
+        /// <typeparam name="U">The type of the children of <paramref name="container"/>.</typeparam>
+        /// <param name="container">The <paramref name="container"/> that should wrap the given <paramref name="drawable"/>.</param>
+        /// <param name="drawable">The <paramref name="drawable"/> that should be wrapped by the given <paramref name="container"/>.</param>
+        /// <returns>The given <paramref name="container"/>.</returns>
+        public static T Wrap<T, U>(this T container, U drawable)
+            where T : Container<U>
+            where U : Drawable
+        {
+            if (container.Children.Count != 0)
+                throw new InvalidOperationException($"You may not wrap a container that has children.");
+
+            container.RelativeSizeAxes = drawable.RelativeSizeAxes;
+            container.AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes;
+            container.Anchor = drawable.Anchor;
+            container.Origin = drawable.Origin;
+            container.Position = drawable.Position;
+
+            drawable.Position = Vector2.Zero;
+            drawable.Anchor = Anchor.TopLeft;
+            drawable.Origin = Anchor.TopLeft;
+
+            container.Add(drawable);
+
+            return container;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/ContainerExtensions.cs
+++ b/osu.Framework/Graphics/Containers/ContainerExtensions.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.Containers
             where U : Drawable
         {
             if (container.Children.Count != 0)
-                throw new InvalidOperationException($"You may not wrap a container that has children.");
+                throw new InvalidOperationException($"You may not wrap a {nameof(Container<U>)} that has children.");
 
             container.RelativeSizeAxes = drawable.RelativeSizeAxes;
             container.AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes;

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -61,16 +61,8 @@ namespace osu.Framework.Graphics.Effects
 
         public BufferedContainer ApplyTo(Drawable drawable)
         {
-            Vector2 position = drawable.Position;
-            drawable.Position = Vector2.Zero;
-
             return new BufferedContainer
             {
-                RelativeSizeAxes = drawable.RelativeSizeAxes,
-                AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
-                Anchor = drawable.Anchor,
-                Origin = drawable.Origin,
-
                 BlurSigma = Sigma,
                 BlurRotation = Rotation,
                 EffectColour = Colour.MultiplyAlpha(Strength),
@@ -81,15 +73,12 @@ namespace osu.Framework.Graphics.Effects
 
                 CacheDrawnFrameBuffer = CacheDrawnEffect,
 
-                Position = position,
                 Padding = !PadExtent ? new MarginPadding() : new MarginPadding
                 {
                     Horizontal = Blur.KernelSize(Sigma.X),
                     Vertical = Blur.KernelSize(Sigma.Y),
                 },
-
-                Child = drawable
-            };
+            }.Wrap(drawable);
         }
     }
 }

--- a/osu.Framework/Graphics/Effects/EdgeEffect.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffect.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using OpenTK;
 using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Graphics.Effects

--- a/osu.Framework/Graphics/Effects/EdgeEffect.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffect.cs
@@ -23,21 +23,12 @@ namespace osu.Framework.Graphics.Effects
 
         public Container ApplyTo(Drawable drawable)
         {
-            Vector2 position = drawable.Position;
-            drawable.Position = Vector2.Zero;
-
             return new Container
             {
                 Masking = true,
                 EdgeEffect = Parameters,
                 CornerRadius = CornerRadius,
-                Anchor = drawable.Anchor,
-                Origin = drawable.Origin,
-                RelativeSizeAxes = drawable.RelativeSizeAxes,
-                AutoSizeAxes = Axes.Both & ~drawable.RelativeSizeAxes,
-                Position = position,
-                Child = drawable
-            };
+            }.Wrap(drawable);
         }
     }
 }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Graphics\BlendingParameters.cs" />
     <Compile Include="Graphics\Component.cs" />
     <Compile Include="Graphics\Containers\CompositeDrawable.cs" />
+    <Compile Include="Graphics\Containers\ContainerExtensions.cs" />
     <Compile Include="Graphics\Containers\CustomizableTextContainer.cs" />
     <Compile Include="Graphics\Containers\IFillFlowContainer.cs" />
     <Compile Include="Graphics\Containers\DelayedLoadWrapper.cs" />


### PR DESCRIPTION
Adds and exposes a wrap method that removes duplicate code that was shared between `EdgeEffect` and `BlurEffect`.

This also fixes #1167.