### PR TITLE
Add a cached delegate for VertexBatch.Add()

### DIFF
--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -214,7 +214,7 @@ namespace osu.Framework.Graphics.Audio
                     }
 
                     quadToDraw *= DrawInfo.Matrix;
-                    Texture.DrawQuad(quadToDraw, colour, null, Shared.VertexBatch.Add, Vector2.Divide(localInflationAmount, quadToDraw.Size));
+                    Texture.DrawQuad(quadToDraw, colour, null, Shared.VertexBatch.AddAction, Vector2.Divide(localInflationAmount, quadToDraw.Size));
                 }
 
                 Shader.Unbind();

--- a/osu.Framework/Graphics/Batches/VertexBatch.cs
+++ b/osu.Framework/Graphics/Batches/VertexBatch.cs
@@ -39,6 +39,8 @@ namespace osu.Framework.Graphics.Batches
 
             Size = bufferSize;
             this.maxBuffers = maxBuffers;
+
+            AddAction = Add;
         }
 
         #region Disposal
@@ -73,6 +75,10 @@ namespace osu.Framework.Graphics.Batches
 
         protected abstract VertexBuffer<T> CreateVertexBuffer();
 
+        /// <summary>
+        /// Adds a vertex to this <see cref="VertexBatch{T}"/>.
+        /// </summary>
+        /// <param name="v">The vertex to add.</param>
         public void Add(T v)
         {
             GLWrapper.SetActiveBatch(this);
@@ -100,6 +106,12 @@ namespace osu.Framework.Graphics.Batches
                 lastVertex = currentVertex = 0;
             }
         }
+
+        /// <summary>
+        /// Adds a vertex to this <see cref="VertexBatch{T}"/>.
+        /// This is a cached delegate of <see cref="Add"/> that should be used in memory-critical locations such as <see cref="DrawNode"/>s.
+        /// </summary>
+        public readonly Action<T> AddAction;
 
         public int Draw()
         {

--- a/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
@@ -177,12 +177,6 @@ namespace osu.Framework.Graphics.Containers
 
         private const int min_amount_children_to_warrant_batch = 5;
 
-        /// <summary>
-        /// A custom action to perform for every given vertex to render.
-        /// If null, then by default vertices are added to a vertex batch.
-        /// </summary>
-        protected Action<TexturedVertex2D> CustomVertexAction => null;
-
         private bool mayHaveOwnVertexBatch(int amountChildren) => Shared.ForceOwnVertexBatch || amountChildren >= min_amount_children_to_warrant_batch;
 
         private void updateVertexBatch()
@@ -198,16 +192,11 @@ namespace osu.Framework.Graphics.Containers
 
         public override void Draw(Action<TexturedVertex2D> vertexAction)
         {
-            if (CustomVertexAction == null)
-            {
-                updateVertexBatch();
+            updateVertexBatch();
 
-                // Prefer to use own vertex batch instead of the parent-owned one.
-                if (Shared.VertexBatch != null)
-                    vertexAction = Shared.VertexBatch.Add;
-            }
-            else
-                vertexAction = CustomVertexAction;
+            // Prefer to use own vertex batch instead of the parent-owned one.
+            if (Shared.VertexBatch != null)
+                vertexAction = Shared.VertexBatch.Add;
 
             base.Draw(vertexAction);
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
@@ -196,7 +196,7 @@ namespace osu.Framework.Graphics.Containers
 
             // Prefer to use own vertex batch instead of the parent-owned one.
             if (Shared.VertexBatch != null)
-                vertexAction = Shared.VertexBatch.Add;
+                vertexAction = Shared.VertexBatch.AddAction;
 
             base.Draw(vertexAction);
 

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -26,13 +26,13 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         static TextureGLSingle()
         {
             QuadBatch<TexturedVertex2D> quadBatch = new QuadBatch<TexturedVertex2D>(512, 128);
-            default_quad_action = quadBatch.Add;
+            default_quad_action = quadBatch.AddAction;
 
             // We multiply the size param by 3 such that the amount of vertices is a multiple of the amount of vertices
             // per primitive (triangles in this case). Otherwise overflowing the batch will result in wrong
             // grouping of vertices into primitives.
             LinearBatch<TexturedVertex2D> triangleBatch = new LinearBatch<TexturedVertex2D>(512 * 3, 128, PrimitiveType.Triangles);
-            default_triangle_action = triangleBatch.Add;
+            default_triangle_action = triangleBatch.AddAction;
         }
 
         private readonly ConcurrentQueue<TextureUpload> uploadQueue = new ConcurrentQueue<TextureUpload>();


### PR DESCRIPTION
Closes ppy/osu#2274 .

Alternative to ppy/osu#2274, in a way that adds the same change for `CompositeDrawable` and `WaveformGraph`, and any future `DrawNode`s we may implement.

Also removes `CustomVertexAction` because it's never used and it's probably never going to be used.