### PR TITLE
Expose the ability to disable background performance profiling

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -37,6 +37,7 @@ namespace osu.Framework.Configuration
             Set(FrameworkSetting.ActiveInputHandlers, string.Empty);
             Set(FrameworkSetting.CursorSensitivity, 1.0, 0.1, 6, 0.01);
             Set(FrameworkSetting.Locale, string.Empty);
+            Set(FrameworkSetting.PerformanceLogging, false);
         }
 
         public FrameworkConfigManager(Storage storage)
@@ -91,6 +92,8 @@ namespace osu.Framework.Configuration
         Locale,
         ActiveInputHandlers,
         CursorSensitivity,
-        MapAbsoluteInputToWindow
+        MapAbsoluteInputToWindow,
+
+        PerformanceLogging
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -98,6 +98,7 @@ namespace osu.Framework.Platform
         public void RegisterThread(GameThread t)
         {
             threads.Add(t);
+            t.Monitor.EnablePerformanceProfiling = performanceLogging;
         }
 
         public GameThread DrawThread;
@@ -528,6 +529,7 @@ namespace osu.Framework.Platform
         private Bindable<string> enabledInputHandlers;
 
         private Bindable<double> cursorSensitivity;
+        private Bindable<bool> performanceLogging;
 
         private void setupConfig()
         {
@@ -613,6 +615,10 @@ namespace osu.Framework.Platform
             };
 
             cursorSensitivity = config.GetBindable<double>(FrameworkSetting.CursorSensitivity);
+
+            performanceLogging = config.GetBindable<bool>(FrameworkSetting.PerformanceLogging);
+            performanceLogging.ValueChanged += enabled => threads.ForEach(t => t.Monitor.EnablePerformanceProfiling = enabled);
+            performanceLogging.TriggerChange();
         }
 
         private void setVSyncMode()

--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -32,6 +32,8 @@ namespace osu.Framework.Statistics
 
         private readonly CancellationTokenSource cancellationToken;
 
+        public bool Enabled = true;
+
         public BackgroundStackTraceCollector(Thread targetThread, StopwatchClock clock)
         {
             if (Debugger.IsAttached) return;
@@ -46,7 +48,7 @@ namespace osu.Framework.Statistics
             {
                 while (!cancellationToken.IsCancellationRequested)
                 {
-                    if (targetThread.IsAlive && clock.ElapsedMilliseconds - LastConsumptionTime > spikeRecordThreshold / 2 && backgroundMonitorStackTrace == null)
+                    if (Enabled && targetThread.IsAlive && clock.ElapsedMilliseconds - LastConsumptionTime > spikeRecordThreshold / 2 && backgroundMonitorStackTrace == null)
                         backgroundMonitorStackTrace = getStackTrace(targetThread);
 
                     Thread.Sleep(1);
@@ -65,7 +67,7 @@ namespace osu.Framework.Statistics
 
             spikeRecordThreshold = newSpikeThreshold;
 
-            if (elapsedFrameTime < currentThreshold || currentThreshold == 0)
+            if (!Enabled || elapsedFrameTime < currentThreshold || currentThreshold == 0)
                 return;
 
             StringBuilder logMessage = new StringBuilder();

--- a/osu.Framework/Statistics/PerformanceMonitor.cs
+++ b/osu.Framework/Statistics/PerformanceMonitor.cs
@@ -30,6 +30,12 @@ namespace osu.Framework.Statistics
 
         internal bool[] ActiveCounters => (bool[])activeCounters.Clone();
 
+        public bool EnablePerformanceProfiling
+        {
+            get => traceCollector.Enabled;
+            set => traceCollector.Enabled = value;
+        }
+
         private double consumptionTime;
 
         internal ThrottledFrameClock Clock;


### PR DESCRIPTION
This comes with quite a large overhead and as such should not be enabled by default.