### PR TITLE
Explicitly define the dynamic compilation namespace to avoid crosstalk

### DIFF
--- a/osu.Framework/Properties/AssemblyInfo.cs
+++ b/osu.Framework/Properties/AssemblyInfo.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Runtime.CompilerServices;
-using osu.Framework.Testing;
 
 // We publish our internal attributes to other sub-projects of the framework.
 // Note, that we omit visual tests as they are meant to test the framework
 // behavior "in the wild".
 
 [assembly: InternalsVisibleTo("osu.Framework.Tests")]
-[assembly: InternalsVisibleTo(DynamicClassCompiler.DYNAMIC_ASSEMBLY_NAME)]
+[assembly: InternalsVisibleTo("osu.Framework.Tests.Dynamic")]

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -14,12 +14,7 @@ using Microsoft.CodeAnalysis.CSharp;
 
 namespace osu.Framework.Testing
 {
-    public class DynamicClassCompiler
-    {
-        public const string DYNAMIC_ASSEMBLY_NAME = "osu.DynamicTestAssembly";
-    }
-
-    public class DynamicClassCompiler<T> : DynamicClassCompiler
+    public class DynamicClassCompiler<T>
         where T : IDynamicallyCompile
     {
         public Action CompilationStarted;
@@ -143,9 +138,10 @@ namespace osu.Framework.Testing
             CompilationStarted?.Invoke();
 
             string assemblyVersion = $"{++currentVersion}.0.*";
+            string dynamicNamespace = $"{checkpointObject.GetType().Assembly.GetName().Name}.Dynamic";
 
             var compilation = CSharpCompilation.Create(
-                DYNAMIC_ASSEMBLY_NAME,
+                dynamicNamespace,
                 requiredFiles.Select(file => CSharpSyntaxTree.ParseText(File.ReadAllText(file), null, file))
                              // Compile the assembly with a new version so that it replaces the existing one
                              .Append(CSharpSyntaxTree.ParseText($"using System.Reflection; [assembly: AssemblyVersion(\"{assemblyVersion}\")]"))

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -354,13 +354,15 @@ namespace osu.Framework.Testing
 
             var dropdown = toolbar.AssemblyDropdown;
 
-            dropdown.RemoveDropdownItem(dropdown.Items.LastOrDefault(i => i.Value.FullName.Contains(DynamicClassCompiler.DYNAMIC_ASSEMBLY_NAME)).Value);
+            const string dynamic = "dynamic";
+
+            dropdown.RemoveDropdownItem(dropdown.Items.LastOrDefault(i => i.Value.FullName.Contains(dynamic)).Value);
 
             // if we are a dynamically compiled type (via DynamicClassCompiler) we should update the dropdown accordingly.
             if (isDynamicLoad)
-                dropdown.AddDropdownItem($"dynamic ({testType.Name})", testType.Assembly);
+                dropdown.AddDropdownItem($"{dynamic} ({testType.Name})", testType.Assembly);
             else
-                TestTypes.RemoveAll(t => t.Assembly.FullName.Contains(DynamicClassCompiler.DYNAMIC_ASSEMBLY_NAME));
+                TestTypes.RemoveAll(t => t.Assembly.FullName.Contains(dynamic));
 
             dropdown.Current.Value = testType.Assembly;
 


### PR DESCRIPTION
The old method was using one global namespace across all projects, incorrectly giving `osu.Game` access to `osu.Framework` internals.