### PR TITLE
Make FrameworkTestCase abstract

### DIFF
--- a/osu.Framework.Tests/Visual/FrameworkTestCase.cs
+++ b/osu.Framework.Tests/Visual/FrameworkTestCase.cs
@@ -8,7 +8,7 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual
 {
-    public class FrameworkTestCase : TestCase
+    public abstract class FrameworkTestCase : TestCase
     {
         public override void RunTest()
         {


### PR DESCRIPTION
Should not be instantiated on its own. Was showing up in TestBrowser for no reason.