### PR TITLE
Significantly reduce number of IsMaskedAway calculations

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -374,6 +374,9 @@ namespace osu.Framework.Graphics
         /// <returns>Whether masking calculations have taken place.</returns>
         public virtual bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
         {
+            if (!IsPresent)
+                return false;
+
             if (HasProxy && source != proxy)
                 return false;
 


### PR DESCRIPTION
Reduces anywhere from 1.5-2.5K IsMaskedAway calculations, depending on the screen. Results in about 35-45 update fps boost (270/280 - 310/320) in gameplay (mania), about 30fps in SongSelect.

This would've previously been computed during drawnode creation only if we were present anyway (basically just before the `IsMaskedAway` check in `addFromComposite`).