### PR TITLE
HandleMouseInput/HandleKeyboardInput should consider children

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
@@ -173,13 +174,23 @@ osu! is written in C# on the .NET Framework. On August 28, 2016, osu!'s source c
                 }
             });
 
-            AddAssert("Handle input properties", () => !textFlowContainer.HandleKeyboardInput && !textFlowContainer.HandleMouseInput, $"Handle input properties of the {nameof(textFlowContainer)} are set to false");
+            AddAssert(@"handle input false", () => !textFlowContainer.HandleKeyboardInput && !textFlowContainer.HandleMouseInput, $"Handle input properties of the {nameof(textFlowContainer)} are set to false");
             AddStep(@"resize paragraph 1", () => { paragraphContainer.Width = 1f; });
             AddStep(@"resize paragraph 2", () => { paragraphContainer.Width = 0.6f; });
             AddStep(@"header inset", () => { textFlowContainer.FirstLineIndent += 2; });
             AddStep(@"body inset", () => { textFlowContainer.ContentIndent += 4; });
             AddToggleStep(@"Zero paragraph spacing", state => textFlowContainer.ParagraphSpacing = state ? 0 : 0.5f);
             AddToggleStep(@"Non-zero line spacing", state => textFlowContainer.LineSpacing = state ? 1 : 0);
+            AddAssert(@"child with input support", () =>
+            {
+                Button btn;
+                textFlowContainer.AddInternal(btn = new Button { Text = "Button inside of the TextFlowContainer" });
+                var check1 = !textFlowContainer.HandleKeyboardInput && textFlowContainer.HandleMouseInput;
+                textFlowContainer.RemoveInternal(btn);
+                var check2 = !textFlowContainer.HandleKeyboardInput && !textFlowContainer.HandleMouseInput;
+                return check1 && check2;
+            });
+
         }
 
         private class LineBaseBox : Box, IHasLineBaseHeight

--- a/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextFlow.cs
@@ -173,6 +173,7 @@ osu! is written in C# on the .NET Framework. On August 28, 2016, osu!'s source c
                 }
             });
 
+            AddAssert("Handle input properties", () => !textFlowContainer.HandleKeyboardInput && !textFlowContainer.HandleMouseInput, $"Handle input properties of the {nameof(textFlowContainer)} are set to false");
             AddStep(@"resize paragraph 1", () => { paragraphContainer.Width = 1f; });
             AddStep(@"resize paragraph 2", () => { paragraphContainer.Width = 0.6f; });
             AddStep(@"header inset", () => { textFlowContainer.FirstLineIndent += 2; });

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -5,6 +5,7 @@ using osu.Framework.Lists;
 using System.Collections.Generic;
 using System;
 using System.Diagnostics;
+using System.Linq;
 using OpenTK;
 using osu.Framework.Graphics.OpenGL;
 using OpenTK.Graphics;
@@ -879,10 +880,32 @@ namespace osu.Framework.Graphics.Containers
 
         #region Interaction / Input
 
-        // Required to pass through input to children by default.
-        // TODO: Evaluate effects of this on performance and address.
-        public override bool HandleKeyboardInput => true;
-        public override bool HandleMouseInput => true;
+        /// <summary>
+        /// Whether <see cref="HandleMouseInput"/> and <see cref="HandleKeyboardInput"/> values of this <see cref="CompositeDrawable"/> should be affected by its <see cref="AliveInternalChildren"/>.
+        /// </summary>
+        public virtual bool ConsiderChildrenHandleInput => true;
+
+        public override bool HandleKeyboardInput
+        {
+            get
+            {
+                var ownValue = base.HandleKeyboardInput;
+                if (ConsiderChildrenHandleInput)
+                    return ownValue || AliveInternalChildren.Any(ch => ch.HandleKeyboardInput);
+                return ownValue;
+            }
+        }
+
+        public override bool HandleMouseInput
+        {
+            get
+            {
+                var ownValue = base.HandleMouseInput;
+                if (ConsiderChildrenHandleInput)
+                    return ownValue || AliveInternalChildren.Any(ch => ch.HandleMouseInput);
+                return ownValue;
+            }
+        }
 
         public override bool Contains(Vector2 screenSpacePos)
         {

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -118,9 +118,6 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        public override bool HandleKeyboardInput => false;
-        public override bool HandleMouseInput => false;
-
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
             if ((invalidation & Invalidation.DrawSize) > 0)


### PR DESCRIPTION
resolves #1456

@smoogipoo since I'm not sure what to do with `HandleMouseInput`/`HandleKeyboardInput` overrides, I removed them only from the `TextFlowContainer`(for testing).