### PR TITLE
Implement IBindable interfaces for get-only support

### DIFF
--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -12,14 +12,24 @@ namespace osu.Framework.Configuration
     /// A generic implementation of a <see cref="IBindable"/>
     /// </summary>
     /// <typeparam name="T">The type of our stored <see cref="Value"/>.</typeparam>
-    public class Bindable<T> : IBindable
+    public class Bindable<T> : IBindable<T>, IBindable
     {
+        /// <summary>
+        /// An event which is raised when <see cref="Value"/> has changed (or manually via <see cref="TriggerValueChange"/>).
+        /// </summary>
+        public event Action<T> ValueChanged;
+
+        /// <summary>
+        /// An event which is raised when <see cref="Disabled"/>'s state has changed (or manually via <see cref="TriggerDisabledChange"/>).
+        /// </summary>
+        public event Action<bool> DisabledChanged;
+
         private T value;
 
         /// <summary>
         /// The default value of this bindable. Used when calling <see cref="SetDefault"/> or querying <see cref="IsDefault"/>.
         /// </summary>
-        public T Default;
+        public T Default { get; set; }
 
         private bool disabled;
 
@@ -48,16 +58,6 @@ namespace osu.Framework.Configuration
         /// Revert the current <see cref="Value"/> to the defined <see cref="Default"/>.
         /// </summary>
         public void SetDefault() => Value = Default;
-
-        /// <summary>
-        /// An event which is raised when <see cref="Value"/> has changed (or manually via <see cref="TriggerValueChange"/>).
-        /// </summary>
-        public event Action<T> ValueChanged;
-
-        /// <summary>
-        /// An event which is raised when <see cref="Disabled"/>'s state has changed (or manually via <see cref="TriggerDisabledChange"/>).
-        /// </summary>
-        public event Action<bool> DisabledChanged;
 
         /// <summary>
         /// The current value of this bindable.
@@ -93,9 +93,23 @@ namespace osu.Framework.Configuration
 
         private WeakReference<Bindable<T>> weakReference => new WeakReference<Bindable<T>>(this);
 
+        void IBindable.BindTo(IBindable them)
+        {
+            if (!(them is Bindable<T> tThem))
+                throw new InvalidCastException($"Can't bind to a bindable of type {them.GetType()} from a bindable of type {GetType()}.");
+            BindTo(tThem);
+        }
+
+        void IBindable<T>.BindTo(IBindable<T> them)
+        {
+            if (!(them is Bindable<T> tThem))
+                throw new InvalidCastException($"Can't bind to a bindable of type {them.GetType()} from a bindable of type {GetType()}.");
+            BindTo(tThem);
+        }
+
         /// <summary>
-        /// Binds outselves to another bindable such that they receive bi-directional updates.
-        /// We will take on any value limitations of the bindable we bind width.
+        /// Binds outselves to another bindable such that bi-directional updates are propagated.
+        /// We will take on any values and value limitations of the bindable we bind width.
         /// </summary>
         /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
         public virtual void BindTo(Bindable<T> them)

--- a/osu.Framework/Configuration/IBindable.cs
+++ b/osu.Framework/Configuration/IBindable.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
+
 namespace osu.Framework.Configuration
 {
     /// <summary>
@@ -8,5 +10,51 @@ namespace osu.Framework.Configuration
     /// </summary>
     public interface IBindable : IParseable
     {
+        /// <summary>
+        /// An event which is raised when <see cref="Disabled"/>'s state has changed.
+        /// </summary>
+        event Action<bool> DisabledChanged;
+
+        /// <summary>
+        /// Whether this bindable has been disabled.
+        /// </summary>
+        bool Disabled { get; }
+
+        /// <summary>
+        /// Check whether this bindable has its default value.
+        /// </summary>
+        bool IsDefault { get; }
+
+        /// <summary>
+        /// Binds outselves to another bindable such that we receive any value limitations of the bindable we bind width.
+        /// </summary>
+        /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
+        void BindTo(IBindable them);
+    }
+
+    public interface IBindable<T>
+    {
+        /// <summary>
+        /// An event which is raised when <see cref="Value"/> has changed.
+        /// </summary>
+        event Action<T> ValueChanged;
+
+        /// <summary>
+        /// The current value of this bindable.
+        /// </summary>
+        T Value { get; }
+
+        /// <summary>
+        /// The default value of this bindable. Used when querying <see cref="IBindable.IsDefault"/>.
+        /// </summary>
+        T Default { get; }
+
+        string Description { get; }
+
+        /// <summary>
+        /// Binds outselves to another bindable such that we receive any values and value limitations of the bindable we bind width.
+        /// </summary>
+        /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
+        void BindTo(IBindable<T> them);
     }
 }


### PR DESCRIPTION
Doesn't change existing code, but will now allow us to expose bindables as `IBindable` and `IBindable<T>` with get-only access, disallowing external objects from setting values.

Bindables must be exposed as the same interface to be able to bind to each other, or must use potentially unsafe casting to bind to interface-types. The following compile-time behaviour is observed:

```
IBindable bindable1 = new Bindable<int>();
IBindable bindable2 = new Bindable<int>();
IBindable<int> bindable3 = new Bindable<int>();
IBindable<int> bindable4 = new Bindable<int>();
Bindable<int> bindable5 = new Bindable<int>();
Bindable<int> bindable6 = new Bindable<int>();

bindable1.BindTo(bindable2); // Allowed
bindable1.BindTo(bindable3); // Not allowed (not assignable)
bindable1.BindTo(bindable5); // Allowed

bindable3.BindTo(bindable1); // Not allowed (not assignable)
bindable3.BindTo(bindable4); // Allowed
bindable3.BindTo(bindable6); // Allowed

bindable5.BindTo(bindable1); // Not allowed (not assignable)
bindable5.BindTo(bindable3); // Not allowed
bindable5.BindTo(bindable6); // Allowed

bindable5.BindTo((Bindable<int>)bindable1); // Allowed, but unsafe and may lead to InvalidCastExceptions
bindable5.BindTo((Bindable<int>)bindable3); // Allowed, but unsafe and may lead to InvalidCastExceptions
```