### PR TITLE
Make sure each TestCase runs all tests under one GameHost

### DIFF
--- a/osu.Framework.Tests/Visual/FrameworkTestCase.cs
+++ b/osu.Framework.Tests/Visual/FrameworkTestCase.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Tests.Visual
 {
     public abstract class FrameworkTestCase : TestCase
     {
-        protected override TestCaseTestRunner CreateRunner() => new FrameworkTestCaseTestRunner();
+        protected override ITestCaseTestRunner CreateRunner() => new FrameworkTestCaseTestRunner();
 
         private class FrameworkTestCaseTestRunner : TestCaseTestRunner
         {

--- a/osu.Framework.Tests/Visual/FrameworkTestCase.cs
+++ b/osu.Framework.Tests/Visual/FrameworkTestCase.cs
@@ -3,26 +3,16 @@
 
 using osu.Framework.Allocation;
 using osu.Framework.IO.Stores;
-using osu.Framework.Platform;
 using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual
 {
     public abstract class FrameworkTestCase : TestCase
     {
-        public override void RunTest()
-        {
-            using (var host = new HeadlessGameHost())
-                host.Run(new FrameworkTestCaseTestRunner(this));
-        }
+        protected override TestCaseTestRunner CreateRunner() => new FrameworkTestCaseTestRunner();
 
         private class FrameworkTestCaseTestRunner : TestCaseTestRunner
         {
-            public FrameworkTestCaseTestRunner(TestCase testCase)
-                : base(testCase)
-            {
-            }
-
             [BackgroundDependencyLoader]
             private void load()
             {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -42,6 +42,11 @@ namespace osu.Framework.Platform
 
         private FrameworkDebugConfigManager debugConfig;
 
+        internal void Run(object p)
+        {
+            throw new NotImplementedException();
+        }
+
         private FrameworkConfigManager config;
 
         public LocalisationEngine Localisation { get; private set; }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -42,11 +42,6 @@ namespace osu.Framework.Platform
 
         private FrameworkDebugConfigManager debugConfig;
 
-        internal void Run(object p)
-        {
-            throw new NotImplementedException();
-        }
-
         private FrameworkConfigManager config;
 
         public LocalisationEngine Localisation { get; private set; }

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -48,6 +48,7 @@ namespace osu.Framework.Testing
         {
             host.Exit();
             runTask.Wait();
+            host.Dispose();
 
             try
             {
@@ -57,8 +58,6 @@ namespace osu.Framework.Testing
             catch
             {
             }
-
-            host.Dispose();
         }
 
 

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -16,7 +16,6 @@ using osu.Framework.Threading;
 using OpenTK;
 using OpenTK.Graphics;
 using System.Threading.Tasks;
-using System.Threading;
 
 namespace osu.Framework.Testing
 {
@@ -60,7 +59,6 @@ namespace osu.Framework.Testing
             }
         }
 
-
         /// <summary>
         /// Runs prior to all tests except <see cref="TestConstructor"/> to ensure that the <see cref="TestCase"/>
         /// is reverted to a clean state for all tests.
@@ -72,13 +70,7 @@ namespace osu.Framework.Testing
         }
 
         [TearDown]
-        public void RunTests()
-        {
-            var task = runner.Schedule(() => runner.RunTest(this));
-
-            while (!task.Completed || IsPartOfComposite)
-                Thread.Sleep(10);
-        }
+        public void RunTests() => runner.RunTestFromOtherThread(this);
 
         /// <summary>
         /// Most derived usages of this start with TestCase. This will be removed for display purposes.

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -27,11 +27,11 @@ namespace osu.Framework.Testing
 
         protected override Container<Drawable> Content => content;
 
-        protected virtual TestCaseTestRunner CreateRunner() => new TestCaseTestRunner();
+        protected virtual ITestCaseTestRunner CreateRunner() => new TestCaseTestRunner();
 
         private GameHost host;
         private Task runTask;
-        private TestCaseTestRunner runner;
+        private ITestCaseTestRunner runner;
 
         [OneTimeSetUp]
         public void SetupGameHost()
@@ -39,7 +39,10 @@ namespace osu.Framework.Testing
             host = new HeadlessGameHost($"test-{Guid.NewGuid()}", realtime: false);
             runner = CreateRunner();
 
-            runTask = Task.Factory.StartNew(() => host.Run(runner), TaskCreationOptions.LongRunning);
+            if (!(runner is Game game))
+                throw new InvalidCastException($"The test runner must be a {nameof(Game)}.");
+
+            runTask = Task.Factory.StartNew(() => host.Run(game), TaskCreationOptions.LongRunning);
         }
 
         [OneTimeTearDown]

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -31,17 +31,15 @@ namespace osu.Framework.Testing
         protected virtual TestCaseTestRunner CreateRunner() => new TestCaseTestRunner();
 
         private GameHost host;
-        private Storage storage;
         private Task runTask;
-
         private TestCaseTestRunner runner;
 
         [OneTimeSetUp]
         public void SetupGameHost()
         {
             host = new HeadlessGameHost($"test-{Guid.NewGuid()}", realtime: false);
-            storage = host.Storage;
             runner = CreateRunner();
+
             runTask = Task.Factory.StartNew(() => host.Run(runner), TaskCreationOptions.LongRunning);
         }
 
@@ -50,16 +48,17 @@ namespace osu.Framework.Testing
         {
             host.Exit();
             runTask.Wait();
-            host?.Dispose();
 
             try
             {
                 // clean up after each run
-                storage.DeleteDirectory(string.Empty);
+                host.Storage.DeleteDirectory(string.Empty);
             }
             catch
             {
             }
+
+            host.Dispose();
         }
 
 

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Testing
         }
 
         [TearDown]
-        public void RunTests() => runner.RunTestFromOtherThread(this);
+        public void RunTests() => runner.RunTestBlocking(this);
 
         /// <summary>
         /// Most derived usages of this start with TestCase. This will be removed for display purposes.

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -66,7 +66,8 @@ namespace osu.Framework.Testing
         [SetUp]
         public void SetupTest()
         {
-            StepsContainer.Clear();
+            if (TestContext.CurrentContext.Test.MethodName != nameof(TestConstructor))
+                StepsContainer.Clear();
         }
 
         [TearDown]

--- a/osu.Framework/Testing/TestCaseTestRunner.cs
+++ b/osu.Framework/Testing/TestCaseTestRunner.cs
@@ -10,7 +10,7 @@ using osu.Framework.Screens;
 
 namespace osu.Framework.Testing
 {
-    public class TestCaseTestRunner : Game
+    public class TestCaseTestRunner : Game, ITestCaseTestRunner
     {
         private readonly TestRunner runner;
 
@@ -25,7 +25,7 @@ namespace osu.Framework.Testing
         /// <param name="test">The <see cref="TestCase"/> to run.</param>
         public void RunTestBlocking(TestCase test) => runner.RunTestBlocking(test);
 
-        private class TestRunner : Screen
+        public class TestRunner : Screen
         {
             private const double time_between_tests = 200;
 
@@ -99,5 +99,14 @@ namespace osu.Framework.Testing
                     Thread.Sleep(10);
             }
         }
+    }
+
+    public interface ITestCaseTestRunner
+    {
+        /// <summary>
+        /// Blocks execution until a provided <see cref="TestCase"/> runs to completion.
+        /// </summary>
+        /// <param name="test">The <see cref="TestCase"/> to run.</param>
+        void RunTestBlocking(TestCase test);
     }
 }

--- a/osu.Framework/Testing/TestCaseTestRunner.cs
+++ b/osu.Framework/Testing/TestCaseTestRunner.cs
@@ -11,10 +11,14 @@ namespace osu.Framework.Testing
 {
     public class TestCaseTestRunner : Game
     {
-        public TestCaseTestRunner(TestCase testCase)
+        private readonly TestRunner runner;
+
+        public TestCaseTestRunner()
         {
-            Add(new TestRunner(testCase));
+            Add(runner = new TestRunner());
         }
+
+        public void RunTest(TestCase test) => runner.RunTest(test);
 
         public class TestRunner : Screen
         {
@@ -23,13 +27,7 @@ namespace osu.Framework.Testing
             private Bindable<double> volume;
             private double volumeAtStartup;
 
-            private readonly TestCase test;
             private GameHost host;
-
-            public TestRunner(TestCase test)
-            {
-                this.test = test;
-            }
 
             [BackgroundDependencyLoader]
             private void load(GameHost host, FrameworkConfigManager config)
@@ -54,7 +52,10 @@ namespace osu.Framework.Testing
                 host.MaximumDrawHz = int.MaxValue;
                 host.MaximumUpdateHz = int.MaxValue;
                 host.MaximumInactiveHz = int.MaxValue;
+             }
 
+            public void RunTest(TestCase test)
+            {
                 Add(test);
 
                 Console.WriteLine($@"{(int)Time.Current}: Running {test} visual test cases...");
@@ -67,7 +68,6 @@ namespace osu.Framework.Testing
                     Scheduler.AddDelayed(() =>
                     {
                         Remove(test);
-                        host.Exit();
                     }, time_between_tests);
                 }, e =>
                 {

--- a/osu.Framework/Testing/TestCaseTestRunner.cs
+++ b/osu.Framework/Testing/TestCaseTestRunner.cs
@@ -20,13 +20,13 @@ namespace osu.Framework.Testing
         }
 
         /// <summary>
-        /// Blocks execution until TestCase runs to completion.
+        /// Blocks execution until a provided <see cref="TestCase"/> runs to completion.
         /// </summary>
-        /// <param name="testCase">The TestCase to run.</param>
-        public void RunTestFromOtherThread(TestCase testCase)
+        /// <param name="test">The <see cref="TestCase"/> to run.</param>
+        public void RunTestBlocking(TestCase test)
         {
             bool completed = false;
-            Schedule(() => runner.RunTest(testCase, () => completed = true));
+            Schedule(() => runner.RunTest(test, () => completed = true));
             while (!completed)
                 Thread.Sleep(10);
         }
@@ -82,10 +82,10 @@ namespace osu.Framework.Testing
                         onCompletion?.Invoke();
                     }, time_between_tests);
                 }, e =>
-
                 {
                     // Other tests may run even if this one failed, so the TestCase still needs to be removed
                     Remove(test);
+                    onCompletion?.Invoke();
                     throw new Exception("The test case threw an exception while running", e);
                 });
             }


### PR DESCRIPTION
Aligns headless nUnit testing to how we expect tests to behave in VisualTests.