### PR TITLE
Fix testcase SetUp methods not being properly run

### DIFF
--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -394,11 +395,11 @@ namespace osu.Framework.Testing
 
                 var methods = testType.GetMethods();
 
-                var setUpMethod = methods.FirstOrDefault(m => m.GetCustomAttributes(typeof(SetUpAttribute), false).Length > 0);
+                var setUpMethods = methods.Where(m => m.GetCustomAttributes(typeof(SetUpAttribute), false).Length > 0);
 
                 foreach (var m in methods.Where(m => m.Name != "TestConstructor" && m.GetCustomAttributes(typeof(TestAttribute), false).Length > 0))
                 {
-                    var step = CurrentTest.AddStep(m.Name, () => { setUpMethod?.Invoke(CurrentTest, null); });
+                    var step = CurrentTest.AddStep($"Setup: {m.Name}", () => setUpMethods.ForEach(s => s.Invoke(CurrentTest, null)));
                     step.LightColour = Color4.Teal;
                     m.Invoke(CurrentTest, null);
                 }

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -32,10 +32,13 @@ namespace osu.Framework.Testing
         private GameHost host;
         private Task runTask;
         private ITestCaseTestRunner runner;
+        private bool isUnitTestRunning;
 
         [OneTimeSetUp]
         public void SetupGameHost()
         {
+            isUnitTestRunning = true;
+
             host = new HeadlessGameHost($"test-{Guid.NewGuid()}", realtime: false);
             runner = CreateRunner();
 
@@ -69,7 +72,7 @@ namespace osu.Framework.Testing
         [SetUp]
         public void SetupTest()
         {
-            if (TestContext.CurrentContext.Test.MethodName != nameof(TestConstructor))
+            if (isUnitTestRunning && TestContext.CurrentContext.Test.MethodName != nameof(TestConstructor))
                 StepsContainer.Clear();
         }
 


### PR DESCRIPTION
1. Steps would be cleared. Barring string-checking for "AdhocTestMethod", this is the only way I've found to determine if we're running under nunit.
2. All `SetUp` methods must be run to ensure compatibility with nunit.