### PR TITLE
Fix dynamic compilation not working for some users

### DIFF
--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -68,6 +68,7 @@ namespace osu.Framework.Testing
                     };
 
                     fsw.Changed += onChange;
+                    fsw.Created += onChange;
 
                     watchers.Add(fsw);
                 }


### PR DESCRIPTION
Some file systems / editors don't change files, but delete and create them. This should cover those cases.