### PR TITLE
Add a way to transform bindables

### DIFF
--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Threading;
 using System;
+using osu.Framework.Configuration;
 
 namespace osu.Framework.Graphics
 {
@@ -232,5 +233,13 @@ namespace osu.Framework.Graphics
         public static TransformSequence<T> TransformSpacingTo<T>(this TransformSequence<T> t, Vector2 newSpacing, double duration = 0, Easing easing = Easing.None)
             where T : IFillFlowContainer =>
             t.Append(o => o.TransformSpacingTo(newSpacing, duration, easing));
+
+        /// <summary>
+        /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
+        /// </summary>
+        /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
+        public static TransformSequence<T> TransformBindableTo<T, TValue>(this TransformSequence<T> t, Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
+            where T : ITransformable =>
+            t.Append(o => o.TransformBindableTo(bindable, newValue, duration, easing));
     }
 }

--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.Threading;
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Configuration;
 
 namespace osu.Framework.Graphics
@@ -238,7 +239,7 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformBindableTo<T, TValue>(this TransformSequence<T> t, Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
+        public static TransformSequence<T> TransformBindableTo<T, TValue>(this TransformSequence<T> t, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
             where T : ITransformable =>
             t.Append(o => o.TransformBindableTo(bindable, newValue, duration, easing));
     }

--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -10,6 +10,7 @@ using osu.Framework.Threading;
 using System;
 using JetBrains.Annotations;
 using osu.Framework.Configuration;
+using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics
 {
@@ -239,8 +240,9 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformBindableTo<T, TValue>(this TransformSequence<T> t, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
+        public static TransformSequence<T> TransformBindableTo<T, TValue>(this TransformSequence<T> t, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None,
+                                                                          InterpolationFunc<TValue> interpolationFunc = null)
             where T : ITransformable =>
-            t.Append(o => o.TransformBindableTo(bindable, newValue, duration, easing));
+            t.Append(o => o.TransformBindableTo(bindable, newValue, duration, easing, interpolationFunc));
     }
 }

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;
 using System;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Configuration;
 
 namespace osu.Framework.Graphics
@@ -412,7 +413,7 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformBindableTo<T, TValue>(this T drawable, Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
+        public static TransformSequence<T> TransformBindableTo<T, TValue>(this T drawable, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
             where T : ITransformable =>
             drawable.TransformTo(drawable.PopulateTransform(new TransformBindable<TValue, T>(bindable), newValue, duration, easing));
     }

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Transforms;
 using System;
 using System.Linq;
+using osu.Framework.Configuration;
 
 namespace osu.Framework.Graphics
 {
@@ -407,5 +408,12 @@ namespace osu.Framework.Graphics
             where T : IContainer =>
             container.TransformTo(nameof(container.EdgeEffect), newParameters, duration, easing);
 
+        /// <summary>
+        /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
+        /// </summary>
+        /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
+        public static TransformSequence<T> TransformBindableTo<T, TValue>(this T drawable, Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
+            where T : ITransformable =>
+            drawable.TransformTo(drawable.PopulateTransform(new TransformBindable<TValue, T>(bindable), newValue, duration, easing));
     }
 }

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -10,6 +10,7 @@ using System;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Configuration;
+using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics
 {
@@ -413,8 +414,9 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformBindableTo<T, TValue>(this T drawable, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
+        public static TransformSequence<T> TransformBindableTo<T, TValue>(this T drawable, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None,
+                                                                          InterpolationFunc<TValue> interpolationFunc = null)
             where T : ITransformable =>
-            drawable.TransformTo(drawable.PopulateTransform(new TransformBindable<TValue, T>(bindable), newValue, duration, easing));
+            drawable.TransformTo(drawable.PopulateTransform(new TransformBindable<TValue, T>(bindable, interpolationFunc), newValue, duration, easing));
     }
 }

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Configuration;
+using osu.Framework.MathUtils;
+
+namespace osu.Framework.Graphics.Transforms
+{
+    internal class TransformBindable<TValue, T> : Transform<TValue, T>
+        where T : ITransformable
+    {
+        public override string TargetMember { get; }
+
+        private readonly Bindable<TValue> targetBindable;
+
+        public TransformBindable(Bindable<TValue> targetBindable)
+        {
+            this.targetBindable = targetBindable;
+            TargetMember = $"{targetBindable.GetHashCode()}.Value";
+        }
+
+        private TValue valueAt(double time)
+        {
+            if (time < StartTime) return StartValue;
+            if (time >= EndTime) return EndValue;
+
+            return Interpolation<TValue>.ValueAt(time, StartValue, EndValue, StartTime, EndTime, Easing);
+        }
+
+        protected override void Apply(T d, double time) => targetBindable.Value = valueAt(time);
+        protected override void ReadIntoStartValue(T d) => StartValue = targetBindable.Value;
+    }
+}

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -12,10 +12,13 @@ namespace osu.Framework.Graphics.Transforms
         public override string TargetMember { get; }
 
         private readonly Bindable<TValue> targetBindable;
+        private readonly InterpolationFunc<TValue> interpolationFunc;
 
-        public TransformBindable(Bindable<TValue> targetBindable)
+        public TransformBindable(Bindable<TValue> targetBindable, InterpolationFunc<TValue> interpolationFunc)
         {
             this.targetBindable = targetBindable;
+            this.interpolationFunc = interpolationFunc ?? Interpolation<TValue>.ValueAt;
+
             TargetMember = $"{targetBindable.GetHashCode()}.Value";
         }
 
@@ -24,7 +27,7 @@ namespace osu.Framework.Graphics.Transforms
             if (time < StartTime) return StartValue;
             if (time >= EndTime) return EndValue;
 
-            return Interpolation<TValue>.ValueAt(time, StartValue, EndValue, StartTime, EndTime, Easing);
+            return interpolationFunc(time, StartValue, EndValue, StartTime, EndTime, Easing);
         }
 
         protected override void Apply(T d, double time) => targetBindable.Value = valueAt(time);

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Configuration;
 using osu.Framework.MathUtils;

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using System.Linq;
 using osu.Framework.Graphics;
 using OpenTK;
 using OpenTK.Graphics;
@@ -278,4 +279,25 @@ namespace osu.Framework.MathUtils
             }
         }
     }
+
+    internal static class Interpolation<TValue>
+    {
+        private static readonly InterpolationFunc<TValue> interpolation_func;
+
+        static Interpolation()
+        {
+            interpolation_func =
+                (InterpolationFunc<TValue>)typeof(Interpolation).GetMethod(
+                    nameof(Interpolation.ValueAt),
+                    typeof(InterpolationFunc<TValue>)
+                        .GetMethod(nameof(InterpolationFunc<TValue>.Invoke))
+                        ?.GetParameters().Select(p => p.ParameterType).ToArray()
+                )?.CreateDelegate(typeof(InterpolationFunc<TValue>));
+        }
+
+        public static TValue ValueAt(double time, TValue val1, TValue val2, double startTime, double endTime, Easing easing = Easing.None)
+            => interpolation_func(time, val1, val2, startTime, endTime, easing);
+    }
+
+    public delegate TValue InterpolationFunc<TValue>(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easingType);
 }

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -293,6 +293,9 @@ namespace osu.Framework.MathUtils
                         .GetMethod(nameof(InterpolationFunc<TValue>.Invoke))
                         ?.GetParameters().Select(p => p.ParameterType).ToArray()
                 )?.CreateDelegate(typeof(InterpolationFunc<TValue>));
+
+            if (interpolation_func == null)
+                throw new InvalidOperationException($"Type {typeof(TValue)} has no automatic interpolation function. The value must be interpolated manually.");
         }
 
         public static TValue ValueAt(double time, TValue val1, TValue val2, double startTime, double endTime, Easing easing = Easing.None)


### PR DESCRIPTION
Adds:

* `ITransformable.TransformBindableTo()`
* `TransformSequence.TransformBindableTo()`

Simplifies cases such as:

* https://github.com/ppy/osu-framework/pull/1538/files#diff-2af10bd70f4a7f83f67a8ab2d0444b90R16
* https://github.com/ppy/osu/blob/master/osu.Game/Rulesets/UI/Scrolling/ScrollingPlayfield.cs#L111