### PR TITLE
Make children life update in BDL-load

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -77,7 +77,9 @@ namespace osu.Framework.Graphics.Containers
             // for their correct alive state in the case LifetimeStart is set to a definite value.
             internalChildren.ForEach(loadChild);
 
-            // Let's also perform an update on our children's life to add any alive children.
+            // At this point we can assume that we are loaded although we're not in the "ready" state, because we'll be given
+            // a "ready" state soon after this method terminates. Therefore we can perform an early check to add any alive children
+            // while we're still in an asynchronous context and avoid putting pressure on the main thread during UpdateSubTree
             checkChildrenLife();
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Graphics.Containers
             internalChildren.ForEach(loadChild);
 
             // Let's also perform an update on our children's life to add any alive children.
-            UpdateChildrenLife();
+            checkChildrenLife();
         }
 
         private void loadChild(Drawable child)
@@ -320,7 +320,9 @@ namespace osu.Framework.Graphics.Containers
                 loadChild(drawable);
 
             internalChildren.Add(drawable);
-            checkChildLife(drawable);
+
+            if (LoadState >= LoadState.Ready)
+                checkChildLife(drawable);
 
             if (AutoSizeAxes != Axes.None)
                 InvalidateFromChild(Invalidation.RequiredParentSizeToFit);
@@ -379,6 +381,24 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>True iff the life status of at least one child changed.</returns>
         protected virtual bool UpdateChildrenLife()
         {
+            // Can not have alive children if we are not loaded.
+            if (LoadState < LoadState.Ready)
+                return false;
+
+            if (!checkChildrenLife())
+                return false;
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether the alive state of any child has changed and processes it. This will add or remove
+        /// children from <see cref="aliveInternalChildren"/> depending on their alive states.
+        /// <para>Note that this does NOT check the load state of this <see cref="CompositeDrawable"/> to check if it can hold any alive children.</para>
+        /// </summary>
+        /// <returns>Whether any child's alive state has changed.</returns>
+        private bool checkChildrenLife()
+        {
             bool anyAliveChanged = false;
 
             // checkChildLife may remove a child from internalChildren. In order to not skip children,
@@ -394,18 +414,15 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Checks whether the alive state of a child has changed processes it. This will add or remove
+        /// Checks whether the alive state of a child has changed and processes it. This will add or remove
         /// the child from <see cref="aliveInternalChildren"/> depending on its alive state.
+        /// <para>Note that this does NOT check the load state of this <see cref="CompositeDrawable"/> to check if it can hold any alive children.</para>
         /// </summary>
         /// <param name="child">The child to check.</param>
         /// <returns>Whether the child's alive state has changed.</returns>
         private bool checkChildLife(Drawable child)
         {
             Debug.Assert(internalChildren.Contains(child), "Can only check and react to the life of our own children.");
-
-            // Can not have alive children if we are not loaded.
-            if (LoadState < LoadState.Ready)
-                return false;
 
             bool changed = false;
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -76,10 +76,15 @@ namespace osu.Framework.Graphics.Containers
             // regardless of their alive state. this also gives children a clock so they can be checked
             // for their correct alive state in the case LifetimeStart is set to a definite value.
             internalChildren.ForEach(loadChild);
+        }
+
+        protected override void LoadAsyncComplete()
+        {
+            base.LoadAsyncComplete();
 
             // At this point we can assume that we are loaded although we're not in the "ready" state, because we'll be given
             // a "ready" state soon after this method terminates. Therefore we can perform an early check to add any alive children
-            // while we're still in an asynchronous context and avoid putting pressure on the main thread during UpdateSubTree
+            // while we're still in an asynchronous context and avoid putting pressure on the main thread during UpdateSubTree.
             checkChildrenLife();
         }
 


### PR DESCRIPTION
The issue that sparked this: https://github.com/ppy/osu/pull/2496

**Explanation**:
`DrawableMedal` binds to `medalContainer.OnLoadComplete`, to set the position of some text contained within that container (i.e. `unlocked.Position = new Vector2(0f, medalContainer.DrawSize.Y / 2 + 10);`).

This is expecting two things:
1. The children of `medalContainer` are loaded.
2. The children of `medalContainer` is alive.

(1) Is fulfilled by `LoadComplete` being called from `UpdateSubTree`, which occurs post-all-children-being-loaded.
(2) Is where the issue occurs. `CompositeDrawable.load()` called `UpdateChildrenLife`, but it would get blocked by load state check in `checkChildLife`: https://github.com/ppy/osu-framework/compare/master...smoogipoo:async-child-life?expand=1#diff-2f079688019880634dc5249946a02502L407.
The next time child life gets updated is _post_-LoadComplete. So the children of `medalContainer` were loaded, but not alive.
This results in autosize not finding alive children and giving a `DrawSize` of 0.

A similar change as proposed in this PR was submitted some ~6 months ago (https://github.com/ppy/osu-framework/pull/1072) but then reverted (https://github.com/ppy/osu-framework/pull/1083). The reasoning was that some elements were broken (https://streamable.com/6pwqf, https://github.com/ppy/osu/issues/1366). Although these elements are not broken with the same changes as in the original PR, I chose to go down a different route and maintain that "children are not alive or loaded before their parent is loaded".

There are a few significant changes here:
1. `checkChildLife` no longer does load state checking. This is now done in `UpdateChildrenLife` and `AddInternal` - the only other use-case of `checkChildLife` through publicly-acccessible methods.
2. The previous functionality of `UpdateChildrenLife` has been moved to a new private method `checkChildrenLife`. The new method, like `checkChildLife`, does not perform load state checking.
3. BDL-load now uses `checkChildLife`, bypassing the load state checking of `UpdateChildrenLife`.

Additionally, I think the following will result in some discussion:
I've moved the call to check children life to `LoadAsyncComplete`, which happens _after_ BDL-load, 
but still on the asynchronous context, and prior to the drawable being given a `Ready` load state.
This was done because the alive state of children defined in BDL-load would previously be computed on the Update thread, when UpdateChildrenLife would be normally invoked.

**Testing**

It's hard to define exactly what to test with this. Obviously I've tested that it fixes the issue that sparked this, but I've also gone through all visual tests (osu! and framework-side) and found nothing breaking.