### PR TITLE
Clean up BufferedContainer and fix alignment issues

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -333,12 +333,12 @@ namespace osu.Framework.Graphics.Containers
                 ForceRedraw();
             else if (!screenSpaceSizeBacking.IsValid)
             {
-                var rect = ScreenSpaceDrawQuad.AABBFloat;
+                var screenSpaceSize = ScreenSpaceDrawQuad.AABBFloat.Size;
 
-                if (!Precision.AlmostEquals(lastScreenSpaceSize, rect.Size))
+                if (!Precision.AlmostEquals(lastScreenSpaceSize, screenSpaceSize))
                 {
                     ++updateVersion;
-                    lastScreenSpaceSize = rect.Size;
+                    lastScreenSpaceSize = screenSpaceSize;
                 }
 
                 screenSpaceSizeBacking.Validate();

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.MathUtils;
 using System;
+using System.Linq;
 using osu.Framework.Caching;
 
 namespace osu.Framework.Graphics.Containers
@@ -338,7 +339,7 @@ namespace osu.Framework.Graphics.Containers
             childrenUpdateVersion = updateVersion;
         }
 
-        private readonly long[] drawNodeVersions = new long[3];
+        private readonly long[] drawNodeVersions = Enumerable.Repeat(-1L, 3).ToArray();
 
         private bool addChildDrawNodes;
         internal override bool AddChildDrawNodes => addChildDrawNodes;

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -236,8 +236,6 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         private long childrenUpdateVersion;
 
-        private readonly AtomicCounter drawVersion = new AtomicCounter();
-
         private readonly QuadBatch<TexturedVertex2D> quadBatch = new QuadBatch<TexturedVertex2D>(1, 3);
 
         private readonly List<RenderbufferInternalFormat> attachedFormats = new List<RenderbufferInternalFormat>();
@@ -276,7 +274,6 @@ namespace osu.Framework.Graphics.Containers
             n.Formats = new List<RenderbufferInternalFormat>(attachedFormats);
             n.FilteringMode = pixelSnapping ? All.Nearest : All.Linear;
 
-            n.DrawVersion = drawVersion;
             n.UpdateVersion = updateVersion;
             n.BackgroundColour = backgroundColour;
 

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Collections.Generic;
-using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using OpenTK;
@@ -19,10 +18,38 @@ using System.Diagnostics;
 
 namespace osu.Framework.Graphics.Containers
 {
+    public class BufferedContainerDrawNodeSharedData
+    {
+        /// <summary>
+        /// The <see cref="Shader"/> to use when rendering blur effects.
+        /// </summary>
+        public Shader BlurShader;
+
+        /// <summary>
+        /// The <see cref="FrameBuffer"/>s to render to.
+        /// These are used in a ping-pong manner to render effects <see cref="BufferedContainerDrawNode"/>.
+        /// </summary>
+        public readonly FrameBuffer[] FrameBuffers = new FrameBuffer[3];
+
+        /// <summary>
+        /// The version of drawn contents currently present in <see cref="FrameBuffers"/>.
+        /// </summary>
+        public readonly AtomicCounter DrawVersion = new AtomicCounter();
+
+        /// <summary>
+        /// The <see cref="RenderbufferInternalFormat"/>s to use when drawing children.
+        /// </summary>
+        public readonly List<RenderbufferInternalFormat> Formats = new List<RenderbufferInternalFormat>();
+
+        public BufferedContainerDrawNodeSharedData()
+        {
+            for (int i = 0; i < FrameBuffers.Length; ++i)
+                FrameBuffers[i] = new FrameBuffer();
+        }
+    }
+
     public class BufferedContainerDrawNode : CompositeDrawNode
     {
-        public FrameBuffer[] FrameBuffers;
-
         public bool DrawOriginal;
         public Color4 BackgroundColour;
         public ColourInfo EffectColour;
@@ -33,16 +60,12 @@ namespace osu.Framework.Graphics.Containers
         public Vector2I BlurRadius;
         public float BlurRotation;
 
-        public Shader BlurShader;
-
         public long UpdateVersion = -1;
 
         public RectangleF ScreenSpaceDrawRectangle;
-        public QuadBatch<TexturedVertex2D> Batch;
-        public List<RenderbufferInternalFormat> Formats;
         public All FilteringMode;
 
-        private readonly AtomicCounter drawVersion = new AtomicCounter();
+        public new BufferedContainerDrawNodeSharedData Shared;
 
         private InvokeOnDisposal establishFrameBufferViewport(Vector2 roundedSize)
         {
@@ -77,7 +100,7 @@ namespace osu.Framework.Graphics.Containers
 
             // These additional render buffers are only required if e.g. depth
             // or stencil information needs to also be stored somewhere.
-            foreach (var f in Formats)
+            foreach (var f in Shared.Formats)
                 frameBuffer.Attach(f);
 
             // This setter will also take care of allocating a texture of appropriate size within the framebuffer.
@@ -128,27 +151,27 @@ namespace osu.Framework.Graphics.Containers
 
             using (bindFrameBuffer(target, source.Size))
             {
-                BlurShader.GetUniform<int>(@"g_Radius").Value = kernelRadius;
-                BlurShader.GetUniform<float>(@"g_Sigma").Value = sigma;
-                BlurShader.GetUniform<Vector2>(@"g_TexSize").Value = source.Size;
+                Shared.BlurShader.GetUniform<int>(@"g_Radius").Value = kernelRadius;
+                Shared.BlurShader.GetUniform<float>(@"g_Sigma").Value = sigma;
+                Shared.BlurShader.GetUniform<Vector2>(@"g_TexSize").Value = source.Size;
 
                 float radians = -MathHelper.DegreesToRadians(blurRotation);
-                BlurShader.GetUniform<Vector2>(@"g_BlurDirection").Value = new Vector2((float)Math.Cos(radians), (float)Math.Sin(radians));
+                Shared.BlurShader.GetUniform<Vector2>(@"g_BlurDirection").Value = new Vector2((float)Math.Cos(radians), (float)Math.Sin(radians));
 
-                BlurShader.Bind();
+                Shared.BlurShader.Bind();
                 drawFrameBufferToBackBuffer(source, new RectangleF(0, 0, source.Texture.Width, source.Texture.Height), ColourInfo.SingleColour(Color4.White));
-                BlurShader.Unbind();
+                Shared.BlurShader.Unbind();
             }
         }
 
         private int currentFrameBufferIndex;
-        private FrameBuffer currentFrameBuffer => FrameBuffers[currentFrameBufferIndex];
-        private FrameBuffer advanceFrameBuffer() => FrameBuffers[currentFrameBufferIndex = (currentFrameBufferIndex + 1) % 2];
+        private FrameBuffer currentFrameBuffer => Shared.FrameBuffers[currentFrameBufferIndex];
+        private FrameBuffer advanceFrameBuffer() => Shared.FrameBuffers[currentFrameBufferIndex = (currentFrameBufferIndex + 1) % 2];
 
         /// <summary>
         /// Makes sure the first frame buffer is always the one we want to draw from.
         /// This saves us the need to sync the draw indices across draw node trees
-        /// since the FrameBuffers array is already shared.
+        /// since the Shared.FrameBuffers array is already shared.
         /// </summary>
         private void finalizeFrameBuffer()
         {
@@ -157,9 +180,9 @@ namespace osu.Framework.Graphics.Containers
                 Trace.Assert(currentFrameBufferIndex == 1,
                     $"Only the first two framebuffers should be the last to be written to at the end of {nameof(Draw)}.");
 
-                FrameBuffer temp = FrameBuffers[0];
-                FrameBuffers[0] = FrameBuffers[1];
-                FrameBuffers[1] = temp;
+                FrameBuffer temp = Shared.FrameBuffers[0];
+                Shared.FrameBuffers[0] = Shared.FrameBuffers[1];
+                Shared.FrameBuffers[1] = temp;
 
                 currentFrameBufferIndex = 0;
             }
@@ -175,9 +198,9 @@ namespace osu.Framework.Graphics.Containers
             currentFrameBufferIndex = originalIndex;
 
             Vector2 frameBufferSize = new Vector2((float)Math.Ceiling(ScreenSpaceDrawRectangle.Width), (float)Math.Ceiling(ScreenSpaceDrawRectangle.Height));
-            if (UpdateVersion > drawVersion.Value)
+            if (UpdateVersion > Shared.DrawVersion.Value)
             {
-                drawVersion.Value = UpdateVersion;
+                Shared.DrawVersion.Value = UpdateVersion;
 
                 using (establishFrameBufferViewport(frameBufferSize))
                 {
@@ -207,7 +230,7 @@ namespace osu.Framework.Graphics.Containers
             if (DrawOriginal && EffectPlacement == EffectPlacement.InFront)
             {
                 GLWrapper.SetBlend(DrawInfo.Blending);
-                drawFrameBufferToBackBuffer(FrameBuffers[originalIndex], drawRectangle, DrawInfo.Colour);
+                drawFrameBufferToBackBuffer(Shared.FrameBuffers[originalIndex], drawRectangle, DrawInfo.Colour);
             }
 
             // Blit the final framebuffer to screen.
@@ -215,12 +238,12 @@ namespace osu.Framework.Graphics.Containers
 
             ColourInfo effectColour = DrawInfo.Colour;
             effectColour.ApplyChild(EffectColour);
-            drawFrameBufferToBackBuffer(FrameBuffers[0], drawRectangle, effectColour);
+            drawFrameBufferToBackBuffer(Shared.FrameBuffers[0], drawRectangle, effectColour);
 
             if (DrawOriginal && EffectPlacement == EffectPlacement.Behind)
             {
                 GLWrapper.SetBlend(DrawInfo.Blending);
-                drawFrameBufferToBackBuffer(FrameBuffers[originalIndex], drawRectangle, DrawInfo.Colour);
+                drawFrameBufferToBackBuffer(Shared.FrameBuffers[originalIndex], drawRectangle, DrawInfo.Colour);
             }
 
             Shader.Unbind();

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.OpenGL.Buffers;
 using OpenTK;
 using OpenTK.Graphics.ES30;
 using OpenTK.Graphics;
-using osu.Framework.Threading;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shaders;
@@ -32,14 +31,15 @@ namespace osu.Framework.Graphics.Containers
         public readonly FrameBuffer[] FrameBuffers = new FrameBuffer[3];
 
         /// <summary>
-        /// The version of drawn contents currently present in <see cref="FrameBuffers"/>.
-        /// </summary>
-        public readonly AtomicCounter DrawVersion = new AtomicCounter();
-
-        /// <summary>
         /// The <see cref="RenderbufferInternalFormat"/>s to use when drawing children.
         /// </summary>
         public readonly List<RenderbufferInternalFormat> Formats = new List<RenderbufferInternalFormat>();
+
+        /// <summary>
+        /// The version of drawn contents currently present in <see cref="FrameBuffers"/>.
+        /// This should only be modified by <see cref="BufferedContainerDrawNode"/>.
+        /// </summary>
+        public long DrawVersion = -1;
 
         public BufferedContainerDrawNodeSharedData()
         {
@@ -60,7 +60,7 @@ namespace osu.Framework.Graphics.Containers
         public Vector2I BlurRadius;
         public float BlurRotation;
 
-        public long UpdateVersion = -1;
+        public long UpdateVersion;
 
         public RectangleF ScreenSpaceDrawRectangle;
         public All FilteringMode;
@@ -198,9 +198,9 @@ namespace osu.Framework.Graphics.Containers
             currentFrameBufferIndex = originalIndex;
 
             Vector2 frameBufferSize = new Vector2((float)Math.Ceiling(ScreenSpaceDrawRectangle.Width), (float)Math.Ceiling(ScreenSpaceDrawRectangle.Height));
-            if (UpdateVersion > Shared.DrawVersion.Value)
+            if (UpdateVersion > Shared.DrawVersion)
             {
-                Shared.DrawVersion.Value = UpdateVersion;
+                Shared.DrawVersion = UpdateVersion;
 
                 using (establishFrameBufferViewport(frameBufferSize))
                 {

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -14,7 +14,6 @@ using System;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using System.Diagnostics;
-using System.Linq;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -29,13 +28,19 @@ namespace osu.Framework.Graphics.Containers
         /// The <see cref="FrameBuffer"/>s to render to.
         /// These are used in a ping-pong manner to render effects <see cref="BufferedContainerDrawNode"/>.
         /// </summary>
-        public readonly FrameBuffer[] FrameBuffers = Enumerable.Repeat(new FrameBuffer(), 3).ToArray();
+        public readonly FrameBuffer[] FrameBuffers = new FrameBuffer[3];
 
         /// <summary>
         /// The version of drawn contents currently present in <see cref="FrameBuffers"/>.
         /// This should only be modified by <see cref="BufferedContainerDrawNode"/>.
         /// </summary>
         public long DrawVersion = -1;
+
+        public BufferedContainerDrawNodeSharedData()
+        {
+            for (int i = 0; i < FrameBuffers.Length; i++)
+                FrameBuffers[i] = new FrameBuffer();
+        }
     }
 
     public class BufferedContainerDrawNode : CompositeDrawNode

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -67,6 +67,11 @@ namespace osu.Framework.Graphics.Containers
 
         public new BufferedContainerDrawNodeSharedData Shared;
 
+        /// <summary>
+        /// Whether this <see cref="BufferedContainerDrawNode"/> should have its children re-drawn.
+        /// </summary>
+        public bool RequiresRedraw => UpdateVersion > Shared.DrawVersion;
+
         private InvokeOnDisposal establishFrameBufferViewport(Vector2 roundedSize)
         {
             // Disable masking for generating the frame buffer since masking will be re-applied
@@ -198,7 +203,7 @@ namespace osu.Framework.Graphics.Containers
             currentFrameBufferIndex = originalIndex;
 
             Vector2 frameBufferSize = new Vector2((float)Math.Ceiling(ScreenSpaceDrawRectangle.Width), (float)Math.Ceiling(ScreenSpaceDrawRectangle.Height));
-            if (UpdateVersion > Shared.DrawVersion)
+            if (RequiresRedraw)
             {
                 Shared.DrawVersion = UpdateVersion;
 

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -14,6 +14,7 @@ using System;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using System.Diagnostics;
+using System.Linq;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -28,7 +29,7 @@ namespace osu.Framework.Graphics.Containers
         /// The <see cref="FrameBuffer"/>s to render to.
         /// These are used in a ping-pong manner to render effects <see cref="BufferedContainerDrawNode"/>.
         /// </summary>
-        public readonly FrameBuffer[] FrameBuffers = new FrameBuffer[3];
+        public readonly FrameBuffer[] FrameBuffers = Enumerable.Repeat(new FrameBuffer(), 3).ToArray();
 
         /// <summary>
         /// The <see cref="RenderbufferInternalFormat"/>s to use when drawing children.
@@ -40,12 +41,6 @@ namespace osu.Framework.Graphics.Containers
         /// This should only be modified by <see cref="BufferedContainerDrawNode"/>.
         /// </summary>
         public long DrawVersion = -1;
-
-        public BufferedContainerDrawNodeSharedData()
-        {
-            for (int i = 0; i < FrameBuffers.Length; ++i)
-                FrameBuffers[i] = new FrameBuffer();
-        }
     }
 
     public class BufferedContainerDrawNode : CompositeDrawNode

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -32,11 +32,6 @@ namespace osu.Framework.Graphics.Containers
         public readonly FrameBuffer[] FrameBuffers = Enumerable.Repeat(new FrameBuffer(), 3).ToArray();
 
         /// <summary>
-        /// The <see cref="RenderbufferInternalFormat"/>s to use when drawing children.
-        /// </summary>
-        public readonly List<RenderbufferInternalFormat> Formats = new List<RenderbufferInternalFormat>();
-
-        /// <summary>
         /// The version of drawn contents currently present in <see cref="FrameBuffers"/>.
         /// This should only be modified by <see cref="BufferedContainerDrawNode"/>.
         /// </summary>
@@ -59,6 +54,11 @@ namespace osu.Framework.Graphics.Containers
 
         public RectangleF ScreenSpaceDrawRectangle;
         public All FilteringMode;
+
+        /// <summary>
+        /// The <see cref="RenderbufferInternalFormat"/>s to use when drawing children.
+        /// </summary>
+        public readonly List<RenderbufferInternalFormat> Formats = new List<RenderbufferInternalFormat>();
 
         public new BufferedContainerDrawNodeSharedData Shared;
 
@@ -95,7 +95,7 @@ namespace osu.Framework.Graphics.Containers
 
             // These additional render buffers are only required if e.g. depth
             // or stencil information needs to also be stored somewhere.
-            foreach (var f in Shared.Formats)
+            foreach (var f in Formats)
                 frameBuffer.Attach(f);
 
             // This setter will also take care of allocating a texture of appropriate size within the framebuffer.

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -35,13 +35,14 @@ namespace osu.Framework.Graphics.Containers
 
         public Shader BlurShader;
 
-        public AtomicCounter DrawVersion;
         public long UpdateVersion = -1;
 
         public RectangleF ScreenSpaceDrawRectangle;
         public QuadBatch<TexturedVertex2D> Batch;
         public List<RenderbufferInternalFormat> Formats;
         public All FilteringMode;
+
+        private readonly AtomicCounter drawVersion = new AtomicCounter();
 
         private InvokeOnDisposal establishFrameBufferViewport(Vector2 roundedSize)
         {
@@ -174,9 +175,9 @@ namespace osu.Framework.Graphics.Containers
             currentFrameBufferIndex = originalIndex;
 
             Vector2 frameBufferSize = new Vector2((float)Math.Ceiling(ScreenSpaceDrawRectangle.Width), (float)Math.Ceiling(ScreenSpaceDrawRectangle.Height));
-            if (UpdateVersion > DrawVersion.Value)
+            if (UpdateVersion > drawVersion.Value)
             {
-                DrawVersion.Value = UpdateVersion;
+                drawVersion.Value = UpdateVersion;
 
                 using (establishFrameBufferViewport(frameBufferSize))
                 {


### PR DESCRIPTION
Fixes ppy/osu#2268

At this point I've spent about 1.5 days trying to nail down the exact frame-by-frame issue, to no avail, so I'm going to PR this as it is a sane change.

The issue that sparked this is https://github.com/ppy/osu/issues/2268 and similar issues happening in BreakOverlay:
<img width="567" alt="screen shot 2018-05-09 at 12 44 35 pm" src="https://user-images.githubusercontent.com/1329837/39851023-8ae1f682-544f-11e8-812e-e097447ee6b8.png">

It seems that the issue is a mix of invalidation + frame timings + values of `AddChildDrawNodes` / `RequiresChildrenUpdate`, causing what I imagine: the `BufferedContainerDrawNode` receives an updated `ScreenSpaceDrawRectangle` which it uses for the ortho projection, but the child of the `BufferedContainerDrawNode` doesn't get updated.

Went through and sanity checked most of `BufferedContainer` - making it use the common "shared data" paradigm that's used for other drawnodes, adjusting draw/child update versions to start at -1 when no draw/update has happened, cleaning up the mess that was overriding `GenerateDrawNodeSubtree`, etc.

## 730ef7d - **Fix child drawnodes generation**

This is the change that fixed the aforementioned issues. It:

1. Removes the extra version array. This by itself doesn't fix the issues.
2. Shares the same conditional to check if the drawnode will be redrawn. This by itself doesn't fix the issues.
3. Moves the setting of `AddChildDrawNodes` to `ApplyDrawNode`. This seems to be what fixes the issues.

In regards to (3) - it's a sane change regardless of it fixing the issue, as the only time `AddChildDrawNodes` needs to be evaluated is when the `DrawNode` is invalidated (i.e. `ApplyDrawNode` is called), in all other times it should be `false`.

## Replication

I replicated this in a testcase, though unreliably, through the following code. It'll eventually replicate if you keep reloading the testcase.

```
public class TestCaseScratch : FrameworkTestCase
{
    public TestCaseScratch()
    {
        Child = new TestBlurredIcon
        {
            Anchor = Anchor.Centre,
            Origin = Anchor.Centre
        };
    }

    private class TestBlurredIcon : BufferedContainer
    {
        public TestBlurredIcon()
        {
            CacheDrawnFrameBuffer = true;

            BlurSigma = new Vector2(40);
            Size = new Vector2(50) + BlurSigma * 2.5f;

            EffectColour = Colour.MultiplyAlpha(4);
            Colour = Color4.LightSkyBlue;

            X = -75; // Important!

            Child = new CircularContainer
            {
                Anchor = Anchor.Centre,
                Origin = Anchor.Centre,
                Size = new Vector2(50),
                Masking = true,
                Child = new Box { RelativeSizeAxes = Axes.Both }
            };
        }

        private long frame;

        protected override void Update()
        {
            base.Update();

            frame++;

            // Technically any value > 1 should work here, but the issue occurred most readily with 4 for me
            if (frame == 4)
                X = 0;
        }
    }
}
```