### PR TITLE
Fix SpriteText size not being computer when set to empty

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseSpriteTextPresence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSpriteTextPresence.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.MathUtils;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseSpriteTextPresence : FrameworkTestCase
+    {
+        /// <summary>
+        /// Tests with a normal <see cref="SpriteText"/> which changes presence based on whether text is empty.
+        /// </summary>
+        [Test]
+        public void TestNormalSpriteText()
+        {
+            Container container = null;
+            SpriteText text = null;
+
+            AddStep("reset", () =>
+            {
+                Child = container = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Red.Opacity(0.3f)
+                        },
+                        text = new SpriteText
+                        {
+                            Text = "Hello world!",
+                            TextSize = 12,
+                        }
+                    }
+                };
+            });
+
+            AddAssert("is present", () => text.IsPresent);
+            AddAssert("height == 12", () => Precision.AlmostEquals(12, container.Height));
+            AddStep("empty text", () => text.Text = string.Empty);
+            AddAssert("not present", () => !text.IsPresent);
+            AddAssert("height == 0", () => Precision.AlmostEquals(0, container.Height));
+        }
+
+        /// <summary>
+        /// Tests with a special <see cref="SpriteText"/> that always remains present regardless of whether text is empty.
+        /// </summary>
+        [Test]
+        public void TestAlwaysPresentSpriteText()
+        {
+            Container container = null;
+            SpriteText text = null;
+
+            AddStep("reset", () =>
+            {
+                Child = container = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Red.Opacity(0.3f)
+                        },
+                        text = new AlwaysPresentSpriteText
+                        {
+                            Text = "Hello world!",
+                            TextSize = 12,
+                        }
+                    }
+                };
+            });
+
+            AddAssert("is present", () => text.IsPresent);
+            AddAssert("height == 12", () => Precision.AlmostEquals(12, container.Height));
+            AddStep("empty text", () => text.Text = string.Empty);
+            AddAssert("is present", () => text.IsPresent);
+            AddAssert("height == 0", () => Precision.AlmostEquals(0, container.Height));
+        }
+
+        private class AlwaysPresentSpriteText : SpriteText
+        {
+            public override bool IsPresent => true;
+        }
+    }
+}

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="..\osu.Framework.props" />
   <PropertyGroup Label="Project">
     <TargetFrameworks>net471;netcoreapp2.0</TargetFrameworks>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2206,7 +2206,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         MiscGeometry = 1 << 2,
         /// <summary>
-        /// Our colour changed.
+        /// <see cref="Drawable.Colour"/> or <see cref="Drawable.IsPresent"/> has changed.
         /// </summary>
         Colour = 1 << 3,
         /// <summary>

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -279,6 +279,10 @@ namespace osu.Framework.Graphics.Sprites
             if (text.Length == 0)
             {
                 lastText = string.Empty;
+
+                // We're going to become not present, so parents need to be signalled to recompute size/layout
+                Invalidate(InvalidationFromParentSize | Invalidation.Colour);
+
                 return;
             }
 

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -277,7 +277,10 @@ namespace osu.Framework.Graphics.Sprites
             Clear();
 
             if (text.Length == 0)
+            {
+                lastText = string.Empty;
                 return;
+            }
 
             if (FixedWidth && !constantWidth.HasValue)
                 constantWidth = CreateCharacterDrawable('D').DrawWidth;

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.Sprites
         /// </summary>
         public bool UseFullGlyphHeight = true;
 
-        public override bool IsPresent => base.IsPresent && !string.IsNullOrEmpty(text);
+        public override bool IsPresent => base.IsPresent && (!layout.IsValid || !string.IsNullOrEmpty(text));
 
         /// <summary>
         /// True if the text should be wrapped if it gets too wide. Note that \n does NOT cause a line break. If you need explicit line breaks, use <see cref="TextFlowContainer"/> instead.

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.Sprites
         /// </summary>
         public bool UseFullGlyphHeight = true;
 
-        public override bool IsPresent => base.IsPresent && (!layout.IsValid || !string.IsNullOrEmpty(text));
+        public override bool IsPresent => base.IsPresent && (!string.IsNullOrEmpty(text) || !layout.IsValid);
 
         /// <summary>
         /// True if the text should be wrapped if it gets too wide. Note that \n does NOT cause a line break. If you need explicit line breaks, use <see cref="TextFlowContainer"/> instead.


### PR DESCRIPTION
When a `SpriteText`'s text becomes `string.Empty`, it will become `!IsPresent`, and will:
1. Not clear its children
2. Not alert parents of this presence change.

This fixes both of those.