### PR TITLE
Fix autosize invalidations occurring with BypassAutoSIzeAxes

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -254,7 +254,7 @@ namespace osu.Framework.Graphics.Containers
             drawable.IsAlive = false;
 
             if (AutoSizeAxes != Axes.None)
-                InvalidateFromChild(Invalidation.RequiredParentSizeToFit);
+                InvalidateFromChild(Invalidation.RequiredParentSizeToFit, drawable);
 
             return true;
         }
@@ -332,7 +332,7 @@ namespace osu.Framework.Graphics.Containers
                 checkChildLife(drawable);
 
             if (AutoSizeAxes != Axes.None)
-                InvalidateFromChild(Invalidation.RequiredParentSizeToFit);
+                InvalidateFromChild(Invalidation.RequiredParentSizeToFit, drawable);
         }
 
         /// <summary>
@@ -608,8 +608,13 @@ namespace osu.Framework.Graphics.Containers
         /// Informs this <see cref="CompositeDrawable"/> that a child has been invalidated.
         /// </summary>
         /// <param name="invalidation">The type of invalidation applied to the child.</param>
-        public virtual void InvalidateFromChild(Invalidation invalidation)
+        /// <param name="source">The child which caused this invalidation. May be null to indicate that a specific child wasn't specified.</param>
+        public virtual void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
         {
+            // We only want to recompute autosize if the child isn't bypassing all of our autosize axes
+            if (source != null && (source.BypassAutoSizeAxes & AutoSizeAxes) == AutoSizeAxes)
+                return;
+
             //Colour captures potential changes in IsPresent. If this ever becomes a bottleneck,
             //Invalidation could be further separated into presence changes.
             if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -140,14 +140,14 @@ namespace osu.Framework.Graphics.Containers
             return changed;
         }
 
-        public override void InvalidateFromChild(Invalidation invalidation)
+        public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
         {
             //Colour captures potential changes in IsPresent. If this ever becomes a bottleneck,
             //Invalidation could be further separated into presence changes.
             if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
                 InvalidateLayout();
 
-            base.InvalidateFromChild(invalidation);
+            base.InvalidateFromChild(invalidation, source);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -89,12 +89,12 @@ namespace osu.Framework.Graphics.Containers
             return base.Invalidate(invalidation, source, shallPropagate);
         }
 
-        public override void InvalidateFromChild(Invalidation invalidation)
+        public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
         {
             if ((invalidation & Invalidation.RequiredParentSizeToFit) > 0)
                 cellLayout.Invalidate();
 
-            base.InvalidateFromChild(invalidation);
+            base.InvalidateFromChild(invalidation, source);
         }
 
         private Cached cellContent = new Cached();

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -787,7 +787,7 @@ namespace osu.Framework.Graphics
                     return;
 
                 bypassAutoSizeAxes = value;
-                Parent?.InvalidateFromChild(Invalidation.RequiredParentSizeToFit);
+                Parent?.InvalidateFromChild(Invalidation.RequiredParentSizeToFit, this);
             }
         }
 
@@ -1510,7 +1510,7 @@ namespace osu.Framework.Graphics
                 return false;
 
             if (shallPropagate && Parent != null && source != Parent)
-                Parent.InvalidateFromChild(invalidation);
+                Parent.InvalidateFromChild(invalidation, this);
 
             bool alreadyInvalidated = true;
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -316,11 +316,11 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         protected virtual void AnimateClose() => Hide();
 
-        public override void InvalidateFromChild(Invalidation invalidation)
+        public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
         {
             if ((invalidation & Invalidation.RequiredParentSizeToFit) > 0)
                 sizeCache.Invalidate();
-            base.InvalidateFromChild(invalidation);
+            base.InvalidateFromChild(invalidation, source);
         }
 
         protected override void UpdateAfterChildren()


### PR DESCRIPTION
In the case of, e.g.:

```
container1 = Container
    AutoSizeAxes = Axes.Both
    Children =
        {{ other children }}
        container2 = Container
            AutoSizeAxes = Axes.Both // Want to maintain a size
            BypassAutoSizeAxes = Axes.Both // But we don't want the parent to size to us
```

If the size of `container2` was changed, it will propagate a `DrawSize` invalidation to `container1` which will cause `container1` to recompute its autosize.
When `container1` recomputes its autosize, it finds that `container2` has `BypassAutoSizeAxes`, so skips it.

This extra computation is unnecessary.