### PR TITLE
Move custom AppearDelay into its own interface

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTooltip.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTooltip.cs
@@ -90,6 +90,7 @@ namespace osu.Framework.Tests.Visual
                         Children = new Drawable[]
                         {
                             new TooltipSpriteText("this text has a tooltip!"),
+                            new InstantTooltipSpriteText("this text has an instant tooltip!"),
                             new TooltipSpriteText("this one too!"),
                             new CustomTooltipSpriteText("this text has an empty tooltip!", string.Empty),
                             new CustomTooltipSpriteText("this text has a nulled tooltip!", null),
@@ -150,8 +151,6 @@ namespace osu.Framework.Tests.Visual
 
             public string TooltipText => tooltipText;
 
-            public double? AppearDelay => null;
-
             public CustomTooltipSpriteText(string displayedText, string tooltipText)
             {
                 this.tooltipText = tooltipText;
@@ -175,11 +174,19 @@ namespace osu.Framework.Tests.Visual
             }
         }
 
+        private class InstantTooltipSpriteText : CustomTooltipSpriteText, IHasAppearDelay
+        {
+            public InstantTooltipSpriteText(string tooltipText)
+                : base(tooltipText, tooltipText)
+            {
+            }
+
+            public double AppearDelay => 0;
+        }
+
         private class TooltipTooltipContainer : TooltipContainer, IHasTooltip
         {
             public string TooltipText { get; set; }
-
-            double? IHasTooltip.AppearDelay => null;
 
             public TooltipTooltipContainer(string tooltipText)
             {
@@ -190,15 +197,11 @@ namespace osu.Framework.Tests.Visual
         private class TooltipTextbox : TextBox, IHasTooltip
         {
             public string TooltipText => Text;
-
-            public double? AppearDelay => null;
         }
 
         private class TooltipBox : Box, IHasTooltip
         {
             public string TooltipText { get; set; }
-
-            public double? AppearDelay => null;
 
             public override bool HandleKeyboardInput => true;
             public override bool HandleMouseInput => true;

--- a/osu.Framework/Graphics/Cursor/IHasAppearDelay.cs
+++ b/osu.Framework/Graphics/Cursor/IHasAppearDelay.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics.Cursor
+{
+    /// <summary>
+    /// A tooltip which provides a custom delay until it appears, override the <see cref="TooltipContainer"/>-wide default.
+    /// </summary>
+    public interface IHasAppearDelay : IDrawable
+    {
+        /// <summary>
+        /// The delay until the tooltip should be displayed. Null means the <see cref="TooltipContainer.AppearDelay"/> from the <see cref="TooltipContainer"/> containing the <see cref="Drawable"/> implementing this interface will be used.
+        /// </summary>
+        double AppearDelay { get; }
+    }
+}

--- a/osu.Framework/Graphics/Cursor/IHasAppearDelay.cs
+++ b/osu.Framework/Graphics/Cursor/IHasAppearDelay.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Graphics.Cursor
     public interface IHasAppearDelay : IDrawable
     {
         /// <summary>
-        /// The delay until the tooltip should be displayed. Null means the <see cref="TooltipContainer.AppearDelay"/> from the <see cref="TooltipContainer"/> containing the <see cref="Drawable"/> implementing this interface will be used.
+        /// The delay until the tooltip should be displayed.
         /// </summary>
         double AppearDelay { get; }
     }

--- a/osu.Framework/Graphics/Cursor/IHasAppearDelay.cs
+++ b/osu.Framework/Graphics/Cursor/IHasAppearDelay.cs
@@ -6,7 +6,7 @@ namespace osu.Framework.Graphics.Cursor
     /// <summary>
     /// A tooltip which provides a custom delay until it appears, override the <see cref="TooltipContainer"/>-wide default.
     /// </summary>
-    public interface IHasAppearDelay : IDrawable
+    public interface IHasAppearDelay : IHasTooltip
     {
         /// <summary>
         /// The delay until the tooltip should be displayed.

--- a/osu.Framework/Graphics/Cursor/IHasTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasTooltip.cs
@@ -14,10 +14,5 @@ namespace osu.Framework.Graphics.Cursor
         /// Tooltip that shows when hovering the drawable.
         /// </summary>
         string TooltipText { get; }
-
-        /// <summary>
-        /// The delay until the tooltip should be displayed. Null means the <see cref="TooltipContainer.AppearDelay"/> from the <see cref="TooltipContainer"/> containing the <see cref="Drawable"/> implementing this interface will be used.
-        /// </summary>
-        double? AppearDelay { get; }
     }
 }

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -178,7 +178,7 @@ namespace osu.Framework.Graphics.Cursor
             if (targetCandidate == null)
                 return null;
 
-            double appearDelay = targetCandidate.AppearDelay ?? AppearDelay;
+            double appearDelay = (targetCandidate as IHasAppearDelay)?.AppearDelay ?? AppearDelay;
             // Always keep 10 positions at equally-sized time intervals that add up to AppearDelay.
             double positionRecordInterval = appearDelay / 10;
             if (Time.Current - lastRecordedPositionTime >= positionRecordInterval)


### PR DESCRIPTION
Avoids the requirement of adding a `null` `AppearDelay` to every usage of `IHasTooltip`