### PR TITLE
Added padding to the checkbox for running all steps.

### DIFF
--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -516,6 +516,7 @@ namespace osu.Framework.Testing
                                             RunAllSteps = new BasicCheckbox
                                             {
                                                 LabelText = "Run all steps",
+                                                LabelPadding = new MarginPadding { Left = 5, Right = 10 },
                                                 AutoSizeAxes = Axes.Y,
                                                 Width = 140,
                                                 Anchor = Anchor.CentreLeft,


### PR DESCRIPTION
Previously, the label text was touching the checkbox. This minor change adds padding between the label and the checkbox to improve aesthetics.

Before:

![original](https://user-images.githubusercontent.com/1411294/40274340-5c0e7560-5ba2-11e8-9096-43b1a4d6f763.png)

After:

![screenshot from 2018-05-19 20-21-37](https://user-images.githubusercontent.com/1411294/40274342-5fe29c20-5ba2-11e8-817e-bf718e06eb1f.png)

