### PR TITLE
Make IBindable and IBindable<T> share some common interfaces

### DIFF
--- a/osu.Framework/Configuration/IBindable.cs
+++ b/osu.Framework/Configuration/IBindable.cs
@@ -6,25 +6,10 @@ using System;
 namespace osu.Framework.Configuration
 {
     /// <summary>
-    /// An interface which can be bound to in order to watch for (and react to) value changes.
+    /// An interface which can be bound to other <see cref="IBindable"/>s in order to watch for (and react to) <see cref="IBindable.Disabled"/> changes.
     /// </summary>
-    public interface IBindable : IParseable
+    public interface IBindable : IParseable, ICanBeDisabled, IHasDefaultValue, IHasDescription
     {
-        /// <summary>
-        /// An event which is raised when <see cref="Disabled"/>'s state has changed.
-        /// </summary>
-        event Action<bool> DisabledChanged;
-
-        /// <summary>
-        /// Whether this bindable has been disabled.
-        /// </summary>
-        bool Disabled { get; }
-
-        /// <summary>
-        /// Check whether this bindable has its default value.
-        /// </summary>
-        bool IsDefault { get; }
-
         /// <summary>
         /// Binds outselves to another bindable such that we receive any value limitations of the bindable we bind width.
         /// </summary>
@@ -40,7 +25,11 @@ namespace osu.Framework.Configuration
         IBindable GetBoundCopy();
     }
 
-    public interface IBindable<T>
+    /// <summary>
+    /// An interface which can be bound to other <see cref="IBindable{T}"/>s in order to watch for (and react to) <see cref="IBindable{T}.Disabled"/> and <see cref="IBindable{T}.Value"/> changes.
+    /// </summary>
+    /// <typeparam name="T">The type of value encapsulated by this <see cref="IBindable{T}"/>.</typeparam>
+    public interface IBindable<T> : IParseable, ICanBeDisabled, IHasDefaultValue, IHasDescription
     {
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed.
@@ -53,11 +42,9 @@ namespace osu.Framework.Configuration
         T Value { get; }
 
         /// <summary>
-        /// The default value of this bindable. Used when querying <see cref="IBindable.IsDefault"/>.
+        /// The default value of this bindable. Used when querying <see cref="IBindable{T}.IsDefault"/>.
         /// </summary>
         T Default { get; }
-
-        string Description { get; }
 
         /// <summary>
         /// Binds outselves to another bindable such that we receive any values and value limitations of the bindable we bind width.

--- a/osu.Framework/Configuration/IBindable.cs
+++ b/osu.Framework/Configuration/IBindable.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Configuration
     /// <summary>
     /// An interface which can be bound to other <see cref="IBindable"/>s in order to watch for (and react to) <see cref="IBindable.Disabled"/> changes.
     /// </summary>
-    public interface IBindable : IParseable, ICanBeDisabled, IHasDefaultValue, IHasDescription
+    public interface IBindable : IParseable, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
     {
         /// <summary>
         /// Binds outselves to another bindable such that we receive any value limitations of the bindable we bind width.
@@ -29,7 +29,7 @@ namespace osu.Framework.Configuration
     /// An interface which can be bound to other <see cref="IBindable{T}"/>s in order to watch for (and react to) <see cref="IBindable{T}.Disabled"/> and <see cref="IBindable{T}.Value"/> changes.
     /// </summary>
     /// <typeparam name="T">The type of value encapsulated by this <see cref="IBindable{T}"/>.</typeparam>
-    public interface IBindable<T> : IParseable, ICanBeDisabled, IHasDefaultValue, IHasDescription
+    public interface IBindable<T> : IParseable, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
     {
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed.

--- a/osu.Framework/Configuration/ICanBeDisabled.cs
+++ b/osu.Framework/Configuration/ICanBeDisabled.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Configuration
+{
+    /// <summary>
+    /// Interface for objects that have a disabled state.
+    /// </summary>
+    public interface ICanBeDisabled
+    {
+        /// <summary>
+        /// An event which is raised when <see cref="Disabled"/>'s state has changed.
+        /// </summary>
+        event Action<bool> DisabledChanged;
+
+        /// <summary>
+        /// Whether this object has been disabled.
+        /// </summary>
+        bool Disabled { get; }
+    }
+}

--- a/osu.Framework/Configuration/IHasDefaultValue.cs
+++ b/osu.Framework/Configuration/IHasDefaultValue.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Configuration
+{
+    /// <summary>
+    /// Interface for objects that have a default value.
+    /// </summary>
+    public interface IHasDefaultValue
+    {
+        /// <summary>
+        /// Check whether this object has its default value.
+        /// </summary>
+        bool IsDefault { get; }
+    }
+}

--- a/osu.Framework/Configuration/IHasDescription.cs
+++ b/osu.Framework/Configuration/IHasDescription.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Configuration
+{
+    /// <summary>
+    /// Interface for objects that have a description.
+    /// </summary>
+    public interface IHasDescription
+    {
+        /// <summary>
+        /// The description for this object.
+        /// </summary>
+        string Description { get; }
+    }
+}

--- a/osu.Framework/Configuration/IUnbindable.cs
+++ b/osu.Framework/Configuration/IUnbindable.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+namespace osu.Framework.Configuration
+{
+    public interface IUnbindable
+    {
+        /// <summary>
+        /// Unbinds all bound events.
+        /// </summary>
+        void UnbindEvents();
+
+        /// <summary>
+        /// Unbinds all bound <see cref="IBindable"/>s.
+        /// </summary>
+        void UnbindBindings();
+
+        /// <summary>
+        /// Calls <see cref="UnbindEvents"/> and <see cref="UnbindBindings"/>
+        /// </summary>
+        void UnbindAll();
+    }
+}

--- a/osu.Framework/Configuration/IUnbindable.cs
+++ b/osu.Framework/Configuration/IUnbindable.cs
@@ -3,6 +3,9 @@
 
 namespace osu.Framework.Configuration
 {
+    /// <summary>
+    /// Interface for objects that support publicly unbinding events or <see cref="IBindable"/>s.
+    /// </summary>
     public interface IUnbindable
     {
         /// <summary>

--- a/osu.Framework/Configuration/IUnbindable.cs
+++ b/osu.Framework/Configuration/IUnbindable.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 namespace osu.Framework.Configuration
 {


### PR DESCRIPTION
Previously, `IBindable` didn't have `Description`, and `IBindable<T>` didn't have `IsDefault`, `Disabled` or `DisabledChanged`.

This splits those properties out into interfaces common to both interfaces.

I didn't want to make `IBindable<T> : IBindable` as it would break the restrictions described [in the original implementation](https://github.com/ppy/osu-framework/pull/1517).