### PR TITLE
Fix mouse input state inconsistencies and add unit tests

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
@@ -1,0 +1,443 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osu.Framework.Testing.Input;
+using OpenTK;
+using OpenTK.Graphics;
+using OpenTK.Input;
+using MouseEventArgs = osu.Framework.Input.MouseEventArgs;
+using MouseState = osu.Framework.Input.MouseState;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseMouseStates : TestCase
+    {
+        private readonly Box marginBox;
+        private readonly ManualInputManager manual;
+        private readonly FrameworkActionContainer actionContainer;
+
+        private readonly StateTracker s1, s2;
+
+        public TestCaseMouseStates()
+        {
+            Children = new Drawable[]
+            {
+                manual = new ManualInputManager
+                {
+                    FillMode = FillMode.Fit,
+                    FillAspectRatio = 1,
+                    RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(0.7f),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = new Color4(1, 1, 1, 0.2f),
+                        },
+                        actionContainer = new FrameworkActionContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Size = new Vector2(0.7f),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Children = new Drawable[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = new Color4(1, 1, 1, 0.2f),
+                                },
+                                marginBox = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Size = new Vector2(0.8f),
+                                    Colour = Color4.SkyBlue.Opacity(0.1f),
+                                },
+                                s2 = new StateTracker(2),
+                            }
+                        },
+                        s1 = new StateTracker(1),
+                    }
+                },
+                new StateTracker(0)
+            };
+
+            AddStep("return input", () => manual.UseParentState = true);
+
+            // TODO: blocking event testing
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            // grab manual input control
+            manual.AddStates(new InputState { Mouse = new MouseState() });
+
+            s1.Reset();
+            s2.Reset();
+        }
+
+        [Test]
+        public void BasicWheel()
+        {
+            eventCounts.Clear();
+
+            AddStep("move to centre", () => manual.MoveMouseTo(actionContainer));
+            checkEventCount("Move", 1);
+
+            AddStep("scroll some", () => manual.ScrollBy(1));
+            checkEventCount("Move");
+            checkEventCount("Wheel", 1);
+            checkLastWheelDelta(1);
+
+            AddStep("scroll some", () => manual.ScrollBy(-1));
+            checkEventCount("Wheel", 1);
+            checkLastWheelDelta(-1);
+        }
+
+        [Test]
+        public void BasicMovement()
+        {
+            eventCounts.Clear();
+
+            AddStep("push move state", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
+            checkEventCount("Move", 1);
+            checkEventCount("Wheel");
+
+            AddStep("push move state", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopRight));
+            checkEventCount("Move", 1);
+            checkEventCount("Wheel");
+            checkLastPositionDelta(() => marginBox.ScreenSpaceDrawQuad.Width);
+
+            AddStep("push move state", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomRight));
+            checkEventCount("Move", 1);
+            checkLastPositionDelta(() => marginBox.ScreenSpaceDrawQuad.Height);
+
+            AddStep("push two move states", () => manual.AddStates(
+                new InputState { Mouse = new MouseState { Position = marginBox.ScreenSpaceDrawQuad.TopLeft } },
+                new InputState { Mouse = new MouseState { Position = marginBox.ScreenSpaceDrawQuad.BottomLeft } }
+            ));
+            checkEventCount("Move", 2);
+            checkLastPositionDelta(() => Vector2.Distance(marginBox.ScreenSpaceDrawQuad.TopLeft, marginBox.ScreenSpaceDrawQuad.BottomLeft));
+        }
+
+        [Test]
+        public void BasicButtons()
+        {
+            eventCounts.Clear();
+            AddStep("move to centre", () => manual.MoveMouseTo(actionContainer));
+            checkEventCount("Move", 1);
+
+            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
+            checkEventCount("MouseDown", 1);
+
+            AddStep("press right button", () => manual.PressButton(MouseButton.Right));
+            checkEventCount("MouseDown", 1);
+
+            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            checkEventCount("MouseUp", 1);
+
+            AddStep("release right button", () => manual.ReleaseButton(MouseButton.Right));
+            checkEventCount("MouseUp", 1);
+
+            AddStep("press three buttons", () =>
+            {
+                var state = manual.CurrentState.Clone();
+                state.Mouse.SetPressed(MouseButton.Left, true);
+                state.Mouse.SetPressed(MouseButton.Right, true);
+                state.Mouse.SetPressed(MouseButton.Button1, true);
+                manual.AddStates(state);
+            });
+            checkEventCount("MouseDown", 3);
+
+            AddStep("push empty mouse state", () => manual.AddStates(new InputState { Mouse = new MouseState() }));
+            checkEventCount("MouseUp", 3);
+
+            AddStep("move to centre", () => manual.MoveMouseTo(actionContainer));
+            checkEventCount("Move", 1);
+
+            AddStep("press two buttons two states", () =>
+            {
+                var state = manual.CurrentState.Clone();
+                state.Mouse.SetPressed(MouseButton.Left, true);
+                manual.AddStates(state);
+                state = manual.CurrentState.Clone();
+                state.Mouse.SetPressed(MouseButton.Right, true);
+                manual.AddStates(state);
+            });
+
+            checkEventCount("MouseDown", 2);
+            checkEventCount("MouseUp", 1);
+
+            AddStep("release", () => manual.AddStates(
+                new InputState { Mouse = new MouseState { Position = manual.CurrentState.Mouse.Position } }));
+
+            checkEventCount("Move");
+            checkEventCount("MouseUp", 1);
+        }
+
+        [Test]
+        public void Drag()
+        {
+            eventCounts.Clear();
+
+            AddStep("move to centre", () => manual.MoveMouseTo(actionContainer));
+
+            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
+            checkEventCount("MouseDown", 1);
+
+            AddStep("move bottom left", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft));
+            checkEventCount("DragStart", 1);
+
+            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            checkEventCount("MouseUp", 1);
+        }
+
+        [Test]
+        public void CombinationChanges()
+        {
+            eventCounts.Clear();
+
+            AddStep("push move state", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft));
+            checkEventCount("Move", 1);
+
+            AddStep("push move wheel state", () => manual.AddStates(
+                new InputState { Mouse = new MouseState { Position = marginBox.ScreenSpaceDrawQuad.Centre, Wheel = 2 } }
+            ));
+            checkEventCount("Move", 1);
+            checkEventCount("Wheel", 1);
+            checkLastWheelDelta(2);
+            checkLastPositionDelta(() => Vector2.Distance(marginBox.ScreenSpaceDrawQuad.BottomLeft, marginBox.ScreenSpaceDrawQuad.Centre));
+
+            AddStep("push empty state", () => manual.AddStates(
+                new InputState()
+            ));
+
+            checkEventCount("Move");
+            checkEventCount("Wheel");
+
+            AddStep("push empty mouse state", () => manual.AddStates(new InputState { Mouse = new MouseState() }));
+
+            // outside the bounds so should not increment.
+            checkEventCount("Move");
+            checkEventCount("Wheel");
+        }
+
+        private readonly Dictionary<string, int> eventCounts = new Dictionary<string, int>();
+
+        private void checkEventCount(string type, int change = 0)
+        {
+            eventCounts.TryGetValue(type, out var count);
+
+            count += change;
+
+            AddAssert($"{type} event count {count}", () => s1.CounterFor(type).Count == count && s2.CounterFor(type).Count == count);
+            eventCounts[type] = count;
+        }
+
+        private void checkLastPositionDelta(Func<float> expected) => AddAssert("correct position delta", () =>
+            s1.CounterFor("Move").LastState.Mouse.NativeState.Delta.Length == expected() &&
+            s2.CounterFor("Move").LastState.Mouse.NativeState.Delta.Length == expected());
+
+        private void checkLastWheelDelta(int expected) => AddAssert("correct wheel delta", () =>
+            s1.CounterFor("Wheel").LastState.Mouse.WheelDelta == expected &&
+            s2.CounterFor("Wheel").LastState.Mouse.WheelDelta == expected);
+
+        public class StateTracker : Container
+        {
+            private readonly SpriteText keyboard;
+            private readonly SpriteText mouse;
+            private readonly SpriteText source;
+
+            public EventCounter CounterFor(string type) => counterLookup[type];
+
+            private readonly Dictionary<string, EventCounter> counterLookup = new Dictionary<string, EventCounter>();
+
+            public StateTracker(int number)
+            {
+                RelativeSizeAxes = Axes.Both;
+                Margin = new MarginPadding(5);
+                Children = new Drawable[]
+                {
+                    new FillFlowContainer
+                    {
+                        Direction = FillDirection.Vertical,
+                        Children = new Drawable[]
+                        {
+                            source = new SmallText(),
+                            keyboard = new SmallText(),
+                            mouse = new SmallText(),
+                            addCounter(new EventCounter("Wheel")),
+                            addCounter(new EventCounter("Move")),
+                            addCounter(new EventCounter("DragStart")),
+                            addCounter(new EventCounter("MouseDown")),
+                            addCounter(new EventCounter("MouseUp"))
+                        }
+                    },
+                    new BoundedCursorContainer(number)
+                };
+            }
+
+            protected override bool OnWheel(InputState state) => CounterFor("Wheel").NewState(state);
+            protected override bool OnMouseMove(InputState state) => CounterFor("Move").NewState(state);
+            protected override bool OnDragStart(InputState state) => CounterFor("DragStart").NewState(state);
+
+            protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => CounterFor("MouseDown").NewState(state, args);
+            protected override bool OnMouseUp(InputState state, MouseUpEventArgs args) => CounterFor("MouseUp").NewState(state, args);
+
+            private EventCounter addCounter(EventCounter counter)
+            {
+                counterLookup.Add(counter.Name, counter);
+                return counter;
+            }
+
+            public void Reset()
+            {
+                foreach (var kvp in counterLookup)
+                    kvp.Value.Reset();
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                var state = GetContainingInputManager().CurrentState;
+
+                source.Text = GetContainingInputManager().ToString();
+                keyboard.Text = state.Keyboard.ToString();
+                mouse.Text = state.Mouse.ToString();
+            }
+
+            public class SmallText : SpriteText
+            {
+                public SmallText()
+                {
+                    TextSize = 14;
+                }
+            }
+
+            public class EventCounter : CompositeDrawable
+            {
+                public InputState LastState;
+                public MouseEventArgs LastArgs;
+
+                private int count;
+                private readonly SpriteText text;
+
+                public EventCounter(string name)
+                {
+                    AutoSizeAxes = Axes.Both;
+
+                    InternalChild = text = new SmallText();
+                    Name = name;
+                    Reset();
+                }
+
+                public int Count
+                {
+                    get { return count; }
+                    set
+                    {
+                        count = value;
+                        text.Text = $"{Name}: {Count}";
+                    }
+                }
+
+                public void Reset()
+                {
+                    Count = 0;
+                    LastState = null;
+                }
+
+                public bool NewState(InputState state, MouseEventArgs args = null)
+                {
+                    LastState = state;
+                    LastArgs = args;
+                    Count++;
+
+                    return false;
+                }
+            }
+
+            private class BoundedCursorContainer : Container
+            {
+                private readonly Circle circle;
+
+                public BoundedCursorContainer(int number)
+                {
+                    RelativeSizeAxes = Axes.Both;
+
+                    Child = new Container
+                    {
+                        Size = new Vector2(5),
+                        Origin = Anchor.Centre,
+                        Children = new Drawable[]
+                        {
+                            new Circle
+                            {
+                                Origin = Anchor.Centre,
+                                Size = new Vector2(40),
+                                Alpha = 0.1f,
+                            },
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Origin = Anchor.Centre,
+                                X = -5 + number * 5,
+                                Y = -8,
+                                Child = circle = new Circle
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                }
+                            }
+                        }
+                    };
+                }
+
+                protected override bool OnMouseMove(InputState state)
+                {
+                    Child.MoveTo(state.Mouse.Position, 100, Easing.OutQuint);
+                    return base.OnMouseMove(state);
+                }
+
+                protected override bool OnWheel(InputState state)
+                {
+                    circle.MoveToY(circle.Y - state.Mouse.WheelDelta * 10).MoveToY(0, 500, Easing.OutQuint);
+                    return base.OnWheel(state);
+                }
+
+                protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
+                {
+                    adjustForMouseDown(state);
+                    return base.OnMouseDown(state, args);
+                }
+
+                protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
+                {
+                    adjustForMouseDown(state);
+                    return base.OnMouseUp(state, args);
+                }
+
+                private void adjustForMouseDown(InputState state)
+                {
+                    circle.FadeColour(state.Mouse.HasAnyButtonPressed ? Color4.Green.Lighten((state.Mouse.Buttons.Count - 1) * 0.3f) : Color4.White, 50);
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2098,24 +2098,33 @@ namespace osu.Framework.Graphics
         {
             public IMouseState NativeState { get; }
 
-            public IMouseState LastState { get; set; }
-
             private readonly Drawable us;
 
             public LocalMouseState(IMouseState state, Drawable us)
             {
                 NativeState = state;
-                LastState = null;
                 this.us = us;
             }
 
-            public IReadOnlyList<MouseButton> Buttons => NativeState.Buttons;
+            public IReadOnlyList<MouseButton> Buttons
+            {
+                get => NativeState.Buttons;
+                set => NativeState.Buttons = value;
+            }
 
             public Vector2 Delta => Position - LastPosition;
 
-            public Vector2 Position => us.Parent?.ToLocalSpace(NativeState.Position) ?? NativeState.Position;
+            public Vector2 Position
+            {
+                get => us.Parent?.ToLocalSpace(NativeState.Position) ?? NativeState.Position;
+                set => throw new NotImplementedException();
+            }
 
-            public Vector2 LastPosition => us.Parent?.ToLocalSpace(NativeState.LastPosition) ?? NativeState.LastPosition;
+            public Vector2 LastPosition
+            {
+                get => us.Parent?.ToLocalSpace(NativeState.LastPosition) ?? NativeState.LastPosition;
+                set => throw new NotImplementedException();
+            }
 
             public Vector2? PositionMouseDown
             {
@@ -2127,7 +2136,18 @@ namespace osu.Framework.Graphics
 
             public bool HasAnyButtonPressed => NativeState.HasAnyButtonPressed;
 
-            public int Wheel => NativeState.Wheel;
+            public int Wheel
+            {
+                get => NativeState.Wheel;
+                set => throw new NotSupportedException();
+            }
+
+            public int LastWheel
+            {
+                get => NativeState.LastWheel;
+                set => throw new NotSupportedException();
+            }
+
             public int WheelDelta => NativeState.WheelDelta;
 
             public bool IsPressed(MouseButton button) => NativeState.IsPressed(button);

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Input
 
         protected override bool Prioritised => true;
 
-        protected override IEnumerable<Drawable> KeyBindingInputQueue => base.KeyBindingInputQueue.Prepend(Child);
+        protected override IEnumerable<Drawable> KeyBindingInputQueue => base.KeyBindingInputQueue.Prepend(Children.First());
     }
 
     public enum FrameworkAction

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
@@ -90,10 +90,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                                 if (lastState != null && state.Equals(lastState.RawState))
                                     continue;
 
-                                var newState = new OpenTKPollMouseState(state, host.IsActive, getUpdatedPosition(state, lastState))
-                                {
-                                    LastState = lastState
-                                };
+                                var newState = new OpenTKPollMouseState(state, host.IsActive, getUpdatedPosition(state, lastState));
 
                                 lastStates[i] = newState;
 

--- a/osu.Framework/Input/IJoystickState.cs
+++ b/osu.Framework/Input/IJoystickState.cs
@@ -24,17 +24,6 @@ namespace osu.Framework.Input
         /// <returns>The axis' current value.</returns>
         float AxisValue(int axisIndex);
 
-        /// <summary>
-        /// Finds the change in value of an axis.
-        /// </summary>
-        /// <param name="axisIndex">The index of the axis to find the delta for.</param>
-        /// <returns>The change from the axis' last value.</returns>
-        float AxisDelta(int axisIndex);
-
-        // Todo: Hats?
-
-        IJoystickState LastState { get; set; }
-
         IJoystickState Clone();
     }
 }

--- a/osu.Framework/Input/IMouseState.cs
+++ b/osu.Framework/Input/IMouseState.cs
@@ -11,14 +11,13 @@ namespace osu.Framework.Input
     {
         IMouseState NativeState { get; }
 
-        IMouseState LastState { get; set; }
-
-        IReadOnlyList<MouseButton> Buttons { get; }
+        IReadOnlyList<MouseButton> Buttons { get; set; }
 
         Vector2 Delta { get; }
-        Vector2 Position { get; }
 
-        Vector2 LastPosition { get; }
+        Vector2 Position { get; set; }
+
+        Vector2 LastPosition { get; set; }
 
         Vector2? PositionMouseDown { get; set; }
 
@@ -30,7 +29,9 @@ namespace osu.Framework.Input
 
         void SetPressed(MouseButton button, bool pressed);
 
-        int Wheel { get; }
+        int Wheel { get; set; }
+
+        int LastWheel { get; set; }
 
         int WheelDelta { get; }
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -814,110 +814,103 @@ namespace osu.Framework.Input
         /// main loop in <see cref="InputManager"/> after each and every button or key change. This allows
         /// correct behaviour in a case where the input queues change based on triggered by a button or key.
         /// </summary>
-        /// <param name="newStates">One ore more states which are to be converted to distinct states.</param>
+        /// <param name="states">One ore more states which are to be converted to distinct states.</param>
         /// <returns>Processed states such that at most one attribute change occurs between any two consecutive states.</returns>
-        private IEnumerable<InputState> createDistinctStates(IEnumerable<InputState> newStates)
+        private IEnumerable<InputState> createDistinctStates(IEnumerable<InputState> states)
         {
-            IKeyboardState lastKeyboard = CurrentState.Keyboard;
-            IMouseState lastMouse = CurrentState.Mouse;
-            IJoystickState lastJoystick = CurrentState.Joystick;
+            InputState transientState = CurrentState;
+            IKeyboardState lastKeyboard = CurrentState.Keyboard ?? new KeyboardState();
+            IMouseState lastMouse = CurrentState.Mouse ?? new MouseState();
+            IJoystickState lastJoystick = CurrentState.Joystick ?? new JoystickState();
 
-            foreach (var state in newStates)
+            InputState createDistinctState(Action<InputState> application)
             {
-                if (state.Mouse == null && state.Keyboard == null && state.Joystick == null)
+                var lastState = transientState;
+                lastState.Last = null;
+
+                transientState = lastState.Clone();
+                transientState.Last = lastState;
+
+                application?.Invoke(transientState);
+
+                lastKeyboard = transientState.Keyboard ?? lastKeyboard;
+                lastMouse = transientState.Mouse ?? lastMouse;
+                lastJoystick = transientState.Joystick ?? lastJoystick;
+
+                return transientState;
+            }
+
+            foreach (var incoming in states)
+            {
+                if (incoming.Mouse == null && incoming.Keyboard == null && incoming.Joystick == null)
                 {
                     // we still want to return at least one state change.
-                    yield return state;
+                    yield return incoming;
                 }
 
-                if (state.Mouse != null)
+                if (incoming.Mouse != null)
                 {
-                    // first we want to create a copy of ourselves without any button changes
-                    // this is done only for mouse handlers, as they have positional data we want to handle in a separate pass.
-                    var iWithoutButtons = state.Mouse.Clone();
-
-                    for (MouseButton b = 0; b < MouseButton.LastButton; b++)
-                        iWithoutButtons.SetPressed(b, lastMouse?.IsPressed(b) ?? false);
-
-                    //we start by adding this state to the processed list...
-                    var newState = state.Clone();
-                    newState.Mouse = lastMouse = iWithoutButtons;
-                    yield return newState;
-
-                    //and then iterate over each button/key change, adding intermediate states along the way.
-                    for (MouseButton b = 0; b < MouseButton.LastButton; b++)
+                    // necessary for high precision input (we always want to add at least one state)
+                    // this also cleans out any remnant delta values
+                    yield return createDistinctState(s =>
                     {
-                        if (state.Mouse.IsPressed(b) != (lastMouse?.IsPressed(b) ?? false))
+                        s.Mouse = ((MouseState)s.Mouse).CloneWithoutDeltas();
+                        s.Mouse.Position = incoming.Mouse.Position;
+                    });
+
+                    if (lastMouse.Wheel != incoming.Mouse.Wheel)
+                        yield return createDistinctState(s =>
                         {
-                            lastMouse = lastMouse?.Clone() ?? new MouseState();
+                            s.Mouse = s.Mouse.Clone();
+                            s.Mouse.Wheel = incoming.Mouse.Wheel;
+                        });
 
-                            //add our single local change
-                            lastMouse.SetPressed(b, state.Mouse.IsPressed(b));
+                    foreach (var releasedButton in lastMouse.Buttons.Except(incoming.Mouse.Buttons))
+                        yield return createDistinctState(s =>
+                        {
+                            s.Mouse = s.Mouse.Clone();
+                            s.Mouse.Buttons = s.Mouse.Buttons.Where(d => d != releasedButton).ToArray();
+                        });
 
-                            newState = state.Clone();
-                            newState.Mouse = lastMouse;
-                            yield return newState;
-                        }
-                    }
+                    foreach (var pressedButton in incoming.Mouse.Buttons.Except(lastMouse.Buttons))
+                        yield return createDistinctState(s =>
+                        {
+                            s.Mouse = s.Mouse.Clone();
+                            s.Mouse.Buttons = s.Mouse.Buttons.Union(new[] { pressedButton }).ToArray();
+                        });
                 }
 
-                if (state.Keyboard != null)
+                if (incoming.Keyboard != null)
                 {
-                    if (lastKeyboard != null)
-                        foreach (var releasedKey in lastKeyboard.Keys.Except(state.Keyboard.Keys))
-                        {
-                            var newState = state.Clone();
-                            newState.Keyboard = lastKeyboard = new KeyboardState { Keys = lastKeyboard.Keys.Where(d => d != releasedKey).ToArray() };
-                            yield return newState;
-                        }
+                    foreach (var releasedKey in lastKeyboard.Keys.Except(incoming.Keyboard.Keys))
+                        yield return createDistinctState(s => s.Keyboard = new KeyboardState { Keys = s.Keyboard.Keys.Where(d => d != releasedKey).ToArray() });
 
-                    foreach (var pressedKey in state.Keyboard.Keys.Except(lastKeyboard?.Keys ?? Array.Empty<Key>()))
-                    {
-                        var newState = state.Clone();
-                        newState.Keyboard = lastKeyboard = new KeyboardState { Keys = lastKeyboard?.Keys.Union(new[] { pressedKey }) ?? new[] { pressedKey } };
-                        yield return newState;
-                    }
+                    foreach (var pressedKey in incoming.Keyboard.Keys.Except(lastKeyboard.Keys))
+                        yield return createDistinctState(s => s.Keyboard = new KeyboardState { Keys = s.Keyboard.Keys.Union(new[] { pressedKey }) });
                 }
 
-                if (state.Joystick != null)
+                if (incoming.Joystick != null)
                 {
-                    // Push a state for the axes
-                    if (lastJoystick != null)
+                    // push a state for the axes
+                    yield return createDistinctState(s => s.Joystick = new JoystickState
                     {
-                        var newState = state.Clone();
-                        newState.Joystick = lastJoystick = new JoystickState
+                        Axes = incoming.Joystick.Axes,
+                        Buttons = s.Joystick.Buttons
+                    });
+
+                    foreach (var releasedButton in lastJoystick.Buttons.Except(incoming.Joystick.Buttons))
+                        yield return createDistinctState(s => s.Joystick = new JoystickState
                         {
-                            Axes = state.Joystick.Axes,
-                            Buttons = lastJoystick.Buttons
-                        };
+                            Axes = s.Joystick.Axes,
+                            Buttons = s.Joystick.Buttons.Where(d => d != releasedButton).ToArray()
+                        });
 
-                        yield return newState;
-                    }
-
-                    if (lastJoystick != null)
-                        foreach (var releasedButton in lastJoystick.Buttons.Except(state.Joystick.Buttons))
+                    foreach (var pressedButton in incoming.Joystick.Buttons.Except(lastJoystick.Buttons))
+                        yield return createDistinctState(s => s.Joystick = new JoystickState
                         {
-                            var newState = state.Clone();
-                            newState.Joystick = lastJoystick = new JoystickState
-                            {
-                                Axes = lastJoystick.Axes,
-                                Buttons = lastJoystick.Buttons.Where(d => d != releasedButton).ToArray()
-                            };
-
-                            yield return newState;
-                        }
-
-                    foreach (var pressedButton in state.Joystick.Buttons.Except(lastJoystick?.Buttons ?? Array.Empty<JoystickButton>()))
-                    {
-                        var newState = state.Clone();
-                        newState.Joystick = lastJoystick = new JoystickState
-                        {
-                            Axes = lastJoystick.Axes,
-                            Buttons = lastJoystick.Buttons.Union(new[] { pressedButton }).ToArray()
-                        };
-
-                        yield return newState;
-                    }
+                            Axes = s.Joystick.Axes,
+                            Buttons = s.Joystick.Buttons.Union(new[] { pressedButton }).ToArray()
+                        });
                 }
             }
         }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -433,7 +433,10 @@ namespace osu.Framework.Input
         {
             MouseState mouse = (MouseState)state.Mouse;
 
-            if (!(state.Last?.Mouse is MouseState last)) return;
+            if (!(state.Last.Mouse is MouseState last)) return;
+
+            mouse.LastPosition = last.Position;
+            mouse.LastWheel = last.Wheel;
 
             if (mouse.Position != last.Position)
             {
@@ -460,10 +463,12 @@ namespace osu.Framework.Input
 
             if (mouse.HasAnyButtonPressed)
             {
+                mouse.PositionMouseDown = last.PositionMouseDown;
+
                 if (!last.HasAnyButtonPressed)
                 {
                     //stuff which only happens once after the mousedown state
-                    mouse.PositionMouseDown = state.Mouse.Position;
+                    mouse.PositionMouseDown = mouse.Position;
                     LastActionTime = Time.Current;
 
                     if (mouse.IsPressed(MouseButton.Left))
@@ -491,7 +496,7 @@ namespace osu.Framework.Input
             }
             else if (last.HasAnyButtonPressed)
             {
-                if (isValidClick && (DraggedDrawable == null || Vector2Extensions.Distance(mouse.PositionMouseDown ?? mouse.Position, mouse.Position) <= click_drag_distance))
+                if (isValidClick && (DraggedDrawable == null || Vector2Extensions.Distance(last.PositionMouseDown ?? last.Position, mouse.Position) <= click_drag_distance))
                     handleMouseClick(state);
 
                 mouseDownInputQueue = null;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -458,7 +458,7 @@ namespace osu.Framework.Input
                 }
             }
 
-            if (mouse.WheelDelta != 0 && Host.Window.CursorInWindow)
+            if (mouse.WheelDelta != 0 && (Host.Window?.CursorInWindow ?? true))
                 handleWheel(state);
 
             if (mouse.HasAnyButtonPressed)

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -250,27 +250,6 @@ namespace osu.Framework.Input
             //move above?
             updateInputQueues(CurrentState);
 
-            // we only want to set a last state if both the new and old state are of the same type.
-            // this avoids giving the new state a false impression of being able to calculate delta values based on a last
-            // state potentially from a different input source.
-            if (last.Mouse != null && state.Mouse != null)
-            {
-                // only set the last state if one hasn't already been set (in addition to being the same type of state).
-                // a smarter InputHandler may do this internally, if they are handling input from multiple distinct devices.
-                if (state.Mouse.LastState == null && last.Mouse.GetType() == state.Mouse.GetType())
-                    state.Mouse.LastState = last.Mouse;
-
-                if (last.Mouse.HasAnyButtonPressed)
-                    state.Mouse.PositionMouseDown = last.Mouse.PositionMouseDown;
-            }
-
-            if (last.Joystick != null && state.Joystick != null)
-            {
-                // Only set the last state if one hasn't already been set
-                if (state.Joystick.LastState == null)
-                    state.Joystick.LastState = last.Joystick;
-            }
-
             //hover could change even when the mouse state has not.
             updateHoverEvents(CurrentState);
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -16,7 +16,7 @@ using OpenTK.Input;
 
 namespace osu.Framework.Input
 {
-    public abstract class InputManager : Container, IRequireHighFrequencyMousePosition
+    public abstract class InputManager : Container
     {
         /// <summary>
         /// The initial delay before key repeat begins.

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -854,7 +854,7 @@ namespace osu.Framework.Input
                     // this also cleans out any remnant delta values
                     yield return createDistinctState(s =>
                     {
-                        s.Mouse = ((MouseState)s.Mouse).CloneWithoutDeltas();
+                        s.Mouse = (s.Mouse as MouseState)?.CloneWithoutDeltas() ?? new MouseState();
                         s.Mouse.Position = incoming.Mouse.Position;
                     });
 

--- a/osu.Framework/Input/JoystickState.cs
+++ b/osu.Framework/Input/JoystickState.cs
@@ -13,25 +13,12 @@ namespace osu.Framework.Input
         public IReadOnlyList<JoystickAxis> Axes { get; set; } = Array.Empty<JoystickAxis>();
 
         public float AxisValue(int axisIndex) => Axes.FirstOrDefault(a => a.Axis == axisIndex).Value;
-        public float AxisDelta(int axisIndex) => AxisValue(axisIndex) - LastState.AxisValue(axisIndex);
-
-        private IJoystickState lastState;
-        public IJoystickState LastState
-        {
-            get => lastState;
-            set
-            {
-                lastState = value;
-                if (lastState != null) lastState.LastState = null;
-            }
-        }
 
         public IJoystickState Clone()
         {
             var clone = (JoystickState)MemberwiseClone();
             clone.Buttons = new List<JoystickButton>(Buttons);
             clone.Axes = new List<JoystickAxis>(Axes);
-            clone.LastState = LastState;
 
             return clone;
         }

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using OpenTK;
 using OpenTK.Input;
 using System.Linq;
+using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Input
 {
@@ -80,6 +81,12 @@ namespace osu.Framework.Input
                 buttons.Add(button);
             else
                 buttons.Remove(button);
+        }
+
+        public override string ToString()
+        {
+            string down = PositionMouseDown != null ? $"(down @ {PositionMouseDown.Value.X:#,0},{PositionMouseDown.Value.Y:#,0})" : string.Empty;
+            return $@"{GetType().ReadableName()} ({Position.X:#,0},{Position.Y:#,0}) {down} {string.Join(",", Buttons.Select(b => b.ToString()))} Wheel {Wheel}/{WheelDelta}";
         }
     }
 }

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -61,6 +61,14 @@ namespace osu.Framework.Input
             return clone;
         }
 
+        public MouseState CloneWithoutDeltas()
+        {
+            var clone = (MouseState)Clone();
+            clone.lastWheel = null;
+            clone.lastPosition = null;
+            return clone;
+        }
+
         public bool IsPressed(MouseButton button) => buttons.Contains(button);
 
         public void SetPressed(MouseButton button, bool pressed)

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -10,8 +10,6 @@ namespace osu.Framework.Input
 {
     public class MouseState : IMouseState
     {
-        private IMouseState lastState;
-
         public IReadOnlyList<MouseButton> Buttons
         {
             get { return buttons; }
@@ -26,19 +24,17 @@ namespace osu.Framework.Input
 
         public IMouseState NativeState => this;
 
-        public IMouseState LastState
-        {
-            get { return lastState; }
-            set
-            {
-                lastState = value;
-                if (lastState != null) lastState.LastState = null;
-            }
-        }
-
-        public virtual int WheelDelta => Wheel - LastState?.Wheel ?? 0;
+        public virtual int WheelDelta => Wheel - LastWheel;
 
         public int Wheel { get; set; }
+
+        private int? lastWheel;
+
+        public int LastWheel
+        {
+            get => lastWheel ?? Wheel;
+            set => lastWheel = value;
+        }
 
         public bool HasMainButtonPressed => IsPressed(MouseButton.Left) || IsPressed(MouseButton.Right);
 
@@ -48,7 +44,13 @@ namespace osu.Framework.Input
 
         public Vector2 Position { get; set; }
 
-        public Vector2 LastPosition => LastState?.Position ?? Position;
+        private Vector2? lastPosition;
+
+        public Vector2 LastPosition
+        {
+            get => lastPosition ?? Position;
+            set => lastPosition = value;
+        }
 
         public Vector2? PositionMouseDown { get; set; }
 
@@ -56,7 +58,6 @@ namespace osu.Framework.Input
         {
             var clone = (MouseState)MemberwiseClone();
             clone.buttons = new List<MouseButton>(buttons);
-            clone.LastState = LastState;
             return clone;
         }
 

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -67,6 +67,8 @@ namespace osu.Framework.Input
 
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args) => acceptState(state);
 
+        protected override bool OnWheel(InputState state) => acceptState(state);
+
         protected override bool OnKeyUp(InputState state, KeyUpEventArgs args) => acceptState(state);
 
         protected override bool OnJoystickPress(InputState state, JoystickEventArgs args) => acceptState(state);
@@ -83,6 +85,7 @@ namespace osu.Framework.Input
                 Mouse = (state.Mouse.NativeState as MouseState)?.Clone();
                 Keyboard = (state.Keyboard as KeyboardState)?.Clone();
                 Joystick = (state.Joystick as JoystickState)?.Clone();
+                Last = state.Last;
             }
         }
     }


### PR DESCRIPTION
This started as a fix for ppy/osu#2158, but ended up as quite a serious improvement to testing and readability of input handling (with a focus on mouse).

The eventual goal is to remove delta values from `MouseState` and only provide them in `MouseEventArgs`, but as this is a breaking change I decided to first fix the majority of issues without this reorganisation to begin with.

- Removes `LastState` from `MouseHandler` and `JoystickHandler` in favour of private fields storing previous values.
- Refactors `createDistinctStates` to use similar logic for each device. Should be quite a bit easier to follow now.
- Removes `IRequireHighFrequencyMousePosition` from `InputManager` as it was deemed unneeded.
- Adds unit/visual tests for mouse states, including nested inside a `PassThroughInputManager` or two.
- Equalises wheel values inside `OpenTKMouseHandler`, removing the need for type checking in `InputManager` to ignore differing values.
- Resolves ppy/osu#2158.
- Fixes crash when mouse wheel events are triggered form a headless context.