### PR TITLE
Improvement to project files using Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,10 +1,10 @@
 <!-- Contains required properties for osu!framework projects. -->
 <Project>
   <PropertyGroup Label="C#">
-    <LangVersion>7</LangVersion>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup Label="License">
-    <None Include="..\osu-framework.licenseheader">
+    <None Include="$(MSBuildThisFileDirectory)osu-framework.licenseheader">
       <Link>osu-framework.licenseheader</Link>
     </None>
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <!-- Contains required properties for osu!framework projects. -->
 <Project>
   <PropertyGroup Label="C#">
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>7</LangVersion>
   </PropertyGroup>
   <ItemGroup Label="License">
     <None Include="$(MSBuildThisFileDirectory)osu-framework.licenseheader">

--- a/SampleGame/SampleGame.csproj
+++ b/SampleGame/SampleGame.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\osu.Framework.props" />
   <PropertyGroup Label="Project">
     <TargetFrameworks>net471;netcoreapp2.0</TargetFrameworks>
     <OutputType>WinExe</OutputType>

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\osu.Framework.props" />
   <PropertyGroup Label="Project">
     <TargetFrameworks>net471;netcoreapp2.0</TargetFrameworks>
     <OutputType>WinExe</OutputType>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Import Project="..\osu.Framework.props" />
   <PropertyGroup Label="Project">
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
@@ -9,9 +8,6 @@
     <Description>Framework to support osu!</Description>
     <Product>osu!framework</Product>
   </PropertyGroup>
-  <ItemGroup Label="Service">
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="CoreCompat.System.Drawing.v2" Version="5.2.0-preview1-r131" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />


### PR DESCRIPTION
*I'm working on my own project these days, and found some noticeable things.*

The special name `Directory.Build.props` will be automatically imported by latest MSBuild.
Common property file should use relative path from itself.
The service guid is for unit test, so it's sure to keep it only in test project. (If ci is happy for this)

###### Justification:
Should latest language version be introduced? C# releases minor versions rapidly now, and third-party tools may not understand it, especially for non-Visual Studio users.
But C# 7.x has improved some performance (span and readonly struct), making minor version update worth while.

Roslyn team is interested in enforcing code style at build time. Should I introduce rules in editor config now?
