### PR TITLE
Immediately update new tooltips

### DIFF
--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -149,6 +149,7 @@ namespace osu.Framework.Graphics.Cursor
                 AddInternal((Drawable)currentTooltip);
 
                 currentTooltip.Show();
+                RefreshTooltip(currentTooltip, target);
             }
         }
 


### PR DESCRIPTION
This avoids the 1-frame delay that new tooltips usually have before
displaying the correct contents.

To elaborate a bit: If you have a setup in which there is only one TTC which uses only one tooltip, that tooltip gets toggled with Hide() and Show().
But when Show() is called because the tooltip is needed for a new tooltip-target, the tooltip is not immediately refreshed. Since the tooltip is being reused (because there is only one tooltip) there is a single frame in which it still displays the old and incorrect contents (and if it auto-sizes, has the old and incorrect size), which in some situations can cause a noticeable flicker when the tooltip gets displayed.

All this patch does is immediately call RefreshTooltip() to circumvent this issue.