### PR TITLE
Fix ITransformable.Spin() only spinning once

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseSpinForever.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSpinForever.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseSpinForever : TestCase
+    {
+        private readonly Container box;
+
+        public TestCaseSpinForever()
+        {
+            Child = box = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Size = new Vector2(0.25f),
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                EdgeEffect = new EdgeEffectParameters
+                {
+                    Type = EdgeEffectType.Glow,
+                    Radius = 20,
+                    Colour = Color4.Blue,
+                },
+                Child = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            box.Spin(1000, RotationDirection.Clockwise);
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/TestCaseSpinForever.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSpinForever.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Globalization;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.MathUtils;
 using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
@@ -13,32 +16,78 @@ namespace osu.Framework.Tests.Visual
     public class TestCaseSpinForever : TestCase
     {
         private readonly Container box;
+        private double startTime;
+        private SpriteText textActual;
+        private SpriteText textRotationCount;
+        private SpriteText textExpected;
+        private SpriteText textDrift;
 
         public TestCaseSpinForever()
         {
-            Child = box = new Container
+            Children = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Size = new Vector2(0.25f),
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                EdgeEffect = new EdgeEffectParameters
-                {
-                    Type = EdgeEffectType.Glow,
-                    Radius = 20,
-                    Colour = Color4.Blue,
-                },
-                Child = new Box
+                box = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(0.25f),
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    EdgeEffect = new EdgeEffectParameters
+                    {
+                        Type = EdgeEffectType.Glow,
+                        Radius = 20,
+                        Colour = Color4.Blue,
+                    },
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                    }
+                },
+                new FillFlowContainer
+                {
+                    Direction = FillDirection.Vertical,
+                    AutoSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        new SpriteText { Text = "Rotation Count: " },
+                        textRotationCount = new SpriteText(),
+                        new SpriteText { Text = "Actual Angle: " },
+                        textActual = new SpriteText(),
+                        new SpriteText { Text = "Expected Angle: " },
+                        textExpected = new SpriteText(),
+                        new SpriteText { Text = "Drift: " },
+                        textDrift = new SpriteText(),
+                    }
                 }
             };
+        }
+
+        private const double spin_duration = 1;
+
+        private float expectedRotation => (float)(((box.Time.Current - startTime) % spin_duration) / spin_duration * 360);
+
+        private int rotationCount => (int)((box.Time.Current - startTime) / spin_duration);
+
+        protected override void UpdateAfterChildren()
+        {
+            base.UpdateAfterChildren();
+
+            textRotationCount.Text = rotationCount.ToString();
+            textActual.Text = box.Rotation.ToString(CultureInfo.InvariantCulture);
+            textExpected.Text = expectedRotation.ToString(CultureInfo.InvariantCulture);
+            textDrift.Text = (box.Rotation - expectedRotation).ToString(CultureInfo.InvariantCulture);
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            box.Spin(1000, RotationDirection.Clockwise);
+
+            startTime = box.Time.Current;
+
+            box.Spin(spin_duration, RotationDirection.Clockwise);
+
+            AddUntilStep(() => rotationCount > 10000);
+            AddAssert("ensure no dirft", () => Precision.AlmostEquals(box.Rotation, expectedRotation));
         }
     }
 }

--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics
             float endRotation = startRotation + (direction == RotationDirection.Clockwise ? 360 : -360);
 
             var sequence = t.RotateTo(startRotation).RotateTo(endRotation, revolutionDuration);
-            sequence.OnComplete(o => o.Spin(revolutionDuration, direction, endRotation));
+            sequence.OnComplete(o => o.Spin(revolutionDuration, direction, startRotation));
 
             return sequence;
         }

--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -31,11 +31,8 @@ namespace osu.Framework.Graphics
         public static TransformSequence<T> Spin<T>(this TransformSequence<T> t, double revolutionDuration, RotationDirection direction, float startRotation = 0)
             where T : Drawable
         {
-            float endRotation = startRotation + (direction == RotationDirection.Clockwise ? 360 : -360);
-
-            var sequence = t.RotateTo(startRotation).RotateTo(endRotation, revolutionDuration);
+            var sequence = t.Spin(revolutionDuration, direction, startRotation, 1);
             sequence.OnComplete(o => o.Spin(revolutionDuration, direction, startRotation));
-
             return sequence;
         }
 

--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -29,12 +29,25 @@ namespace osu.Framework.Graphics
             t.Append(o => o.Schedule(scheduledAction), out scheduledDelegate);
 
         public static TransformSequence<T> Spin<T>(this TransformSequence<T> t, double revolutionDuration, RotationDirection direction, float startRotation = 0)
-            where T : Drawable =>
-            t.Loop(d => d.RotateTo(startRotation).RotateTo(startRotation + (direction == RotationDirection.Clockwise ? 360 : -360), revolutionDuration));
+            where T : Drawable
+        {
+            float endRotation = startRotation + (direction == RotationDirection.Clockwise ? 360 : -360);
+
+            var sequence = t.RotateTo(startRotation).RotateTo(endRotation, revolutionDuration);
+            sequence.OnComplete(o => o.Spin(revolutionDuration, direction, endRotation));
+
+            return sequence;
+        }
 
         public static TransformSequence<T> Spin<T>(this TransformSequence<T> t, double revolutionDuration, RotationDirection direction, float startRotation, int numRevolutions)
-            where T : Drawable =>
-            t.Loop(0, numRevolutions, d => d.RotateTo(startRotation).RotateTo(startRotation + (direction == RotationDirection.Clockwise ? 360 : -360), revolutionDuration));
+            where T : Drawable
+        {
+            if (numRevolutions < 1)
+                throw new InvalidOperationException($"May not {nameof(Spin)} for fewer than 1 revolutions ({numRevolutions} attempted).");
+
+            float endRotation = startRotation + (direction == RotationDirection.Clockwise ? 360 : -360);
+            return t.RotateTo(startRotation).RotateTo(endRotation * numRevolutions, revolutionDuration * numRevolutions);
+        }
 
         /// <summary>
         /// Smoothly adjusts <see cref="Drawable.Alpha"/> to 1 over time.

--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -32,7 +32,13 @@ namespace osu.Framework.Graphics
             where T : Drawable
         {
             var sequence = t.Spin(revolutionDuration, direction, startRotation, 1);
-            sequence.OnComplete(o => o.Spin(revolutionDuration, direction, startRotation));
+
+            sequence.OnComplete(o =>
+            {
+                using (o.BeginAbsoluteSequence(sequence.EndTime))
+                    o.Spin(revolutionDuration, direction, startRotation);
+            });
+
             return sequence;
         }
 

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Transforms
 
         private readonly double startTime;
         private double currentTime;
-        private double endTime => Math.Max(currentTime, lastEndTime);
+        public double EndTime => Math.Max(currentTime, lastEndTime);
 
         private Transform last;
         private double lastEndTime;
@@ -266,7 +266,7 @@ namespace osu.Framework.Graphics.Transforms
             if (!hasEnd)
                 throw new InvalidOperationException($"Can not perform {nameof(Loop)} on an endless {nameof(TransformSequence<T>)}.");
 
-            var iterDuration = endTime - startTime + pause;
+            var iterDuration = EndTime - startTime + pause;
             var toLoop = transforms.ToArray();
 
             // Duplicate existing transforms numIters times
@@ -326,7 +326,7 @@ namespace osu.Framework.Graphics.Transforms
             if (!hasEnd)
                 throw new InvalidOperationException($"Can not perform {nameof(Loop)} on an endless {nameof(TransformSequence<T>)}.");
 
-            var iterDuration = endTime - startTime + pause;
+            var iterDuration = EndTime - startTime + pause;
             foreach (var t in transforms)
             {
                 t.IsLooping = true;
@@ -362,7 +362,7 @@ namespace osu.Framework.Graphics.Transforms
 
             // "Then" simply sets the currentTime to endTime to continue where the last transform left off,
             // followed by a subsequent delay call.
-            currentTime = endTime;
+            currentTime = EndTime;
             return Delay(delay, childGenerators);
         }
 


### PR DESCRIPTION
Fixes #1520.

Temporary fix for `Spin()` while #1577 is a thing, by not relying on looping.