### PR TITLE
Fix broken TransformSequence.Loop

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTransformSequence.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Tests.Visual
         private readonly Container[] boxes;
 
         public TestCaseTransformSequence()
-            : base(3, 3)
+            : base(4, 3)
         {
             boxes = new Container[Rows * Cols];
         }
@@ -71,6 +71,9 @@ namespace osu.Framework.Tests.Visual
             string[] labels =
             {
                 "Spin after 2 seconds",
+                "Spin immediately",
+                "Spin 2 seconds in the past",
+                "Complex rotation with preemption",
                 "Loop(1 sec pause; 1 sec rotate)",
                 "Complex transform 1 (should end in sync with CT2)",
                 "Complex transform 2 (should end in sync with CT1)",
@@ -120,9 +123,17 @@ namespace osu.Framework.Tests.Visual
                 b => b.Delay(500).Spin(1000, RotationDirection.CounterClockwise)
             );
 
-            boxes[1].Delay(1000).Loop(1000, 10, b => b.RotateTo(0).RotateTo(340, 1000));
+            boxes[1].Spin(1000, RotationDirection.CounterClockwise);
 
-            boxes[2].RotateTo(0).ScaleTo(1).RotateTo(360, 1000)
+            boxes[2].Delay(-2000).Spin(1000, RotationDirection.CounterClockwise);
+
+            boxes[3].RotateTo(90)
+            .Then().Delay(1000).RotateTo(0)
+            .Then().RotateTo(180, 1000).Loop();
+
+            boxes[4].Delay(1000).Loop(1000, 10, b => b.RotateTo(0).RotateTo(340, 1000));
+
+            boxes[5].RotateTo(0).ScaleTo(1).RotateTo(360, 1000)
             .Then(1000,
                 b => b.RotateTo(0, 1000),
                 b => b.ScaleTo(2, 500)
@@ -130,7 +141,7 @@ namespace osu.Framework.Tests.Visual
             .Then().RotateTo(360, 1000).ScaleTo(0.5f, 1000)
             .Then().FadeEdgeEffectTo(Color4.Red, 1000).ScaleTo(2, 500);
 
-            boxes[3].RotateTo(0).ScaleTo(1).RotateTo(360, 500)
+            boxes[6].RotateTo(0).ScaleTo(1).RotateTo(360, 500)
             .Then(1000,
                 b => b.RotateTo(0),
                 b => b.ScaleTo(2)
@@ -142,7 +153,7 @@ namespace osu.Framework.Tests.Visual
             .Finally(_ => finalizeTriggered = true);
 
 
-            boxes[4].RotateTo(0).ScaleTo(1).RotateTo(360, 500)
+            boxes[7].RotateTo(0).ScaleTo(1).RotateTo(360, 500)
             .Then(1000,
                 b => b.RotateTo(0),
                 b => b.ScaleTo(2)
@@ -154,7 +165,7 @@ namespace osu.Framework.Tests.Visual
             .OnAbort(b => b.FadeEdgeEffectTo(Color4.Red, 1000));
 
 
-            boxes[5].RotateTo(0).ScaleTo(1).RotateTo(360, 500)
+            boxes[8].RotateTo(0).ScaleTo(1).RotateTo(360, 500)
             .Then(1000,
                 b => b.RotateTo(0),
                 b => b.ScaleTo(2)
@@ -165,13 +176,13 @@ namespace osu.Framework.Tests.Visual
             )
             .Finally(b => b.FadeEdgeEffectTo(Color4.Red, 1000));
 
-            boxes[6].RotateTo(200)
+            boxes[9].RotateTo(200)
             .Finally(b => b.FadeEdgeEffectTo(Color4.Red, 1000));
 
-            boxes[7].Delay(-1000).RotateTo(200)
+            boxes[10].Delay(-1000).RotateTo(200)
             .Finally(b => b.FadeEdgeEffectTo(Color4.Red, 1000));
 
-            boxes[8].Delay(-1000).RotateTo(200, 1000)
+            boxes[11].Delay(-1000).RotateTo(200, 1000)
             .Finally(b => b.FadeEdgeEffectTo(Color4.Red, 1000));
         }
     }

--- a/osu.Framework/Graphics/Transforms/ITransformable.cs
+++ b/osu.Framework/Graphics/Transforms/ITransformable.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Allocation;
+using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.Transforms
 {
@@ -10,6 +11,11 @@ namespace osu.Framework.Graphics.Transforms
         InvokeOnDisposal BeginDelayedSequence(double delay, bool recursive = false);
 
         InvokeOnDisposal BeginAbsoluteSequence(double newTransformStartTime, bool recursive = false);
+
+        /// <summary>
+        /// The current frame's time as observed by this class's <see cref="Clock"/>.
+        /// </summary>
+        FrameTimeInfo Time { get; }
 
         double TransformStartTime { get; }
 

--- a/osu.Framework/Graphics/Transforms/ITransformable.cs
+++ b/osu.Framework/Graphics/Transforms/ITransformable.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.Transforms
         InvokeOnDisposal BeginAbsoluteSequence(double newTransformStartTime, bool recursive = false);
 
         /// <summary>
-        /// The current frame's time as observed by this class's <see cref="Clock"/>.
+        /// The current frame's time as observed by this class's <see cref="Transform"/>s.
         /// </summary>
         FrameTimeInfo Time { get; }
 

--- a/osu.Framework/Graphics/Transforms/ITransformable.cs
+++ b/osu.Framework/Graphics/Transforms/ITransformable.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Transforms
 
         double TransformStartTime { get; }
 
-        void AddTransform(Transform transform);
+        void AddTransform(Transform transform, ulong? customTransformID = null);
 
         void RemoveTransform(Transform toRemove);
     }

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -3,6 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using osu.Framework.Lists;
+using osu.Framework.Logging;
 
 namespace osu.Framework.Graphics.Transforms
 {
@@ -275,8 +278,13 @@ namespace osu.Framework.Graphics.Transforms
                 foreach (var t in toLoop)
                 {
                     var clone = t.Clone();
+
                     clone.StartTime += i * iterDuration;
                     clone.EndTime += i * iterDuration;
+
+                    clone.AppliedToEnd = false;
+                    clone.Applied = false;
+
                     Add(clone);
                     t.TargetTransformable.AddTransform(clone);
                 }
@@ -329,9 +337,36 @@ namespace osu.Framework.Graphics.Transforms
             var iterDuration = endTime - startTime + pause;
             foreach (var t in transforms)
             {
+                Action tmpOnAbort = t.OnAbort;
+                t.OnAbort = null;
+                t.TargetTransformable.RemoveTransform(t);
+                t.OnAbort = tmpOnAbort;
+
+                // Update start and end times such that no transformations need to be instantly
+                // looped right after they're added. This is required so that transforms can be
+                // inserted in the correct order such that none of them trigger abortions on
+                // each other due to instant re-sorting upon adding.
+                double currentTime = t.TargetTransformable.Time.Current;
+                while (t.EndTime <= currentTime)
+                {
+                    t.StartTime += iterDuration;
+                    t.EndTime += iterDuration;
+                }
+            }
+
+            // This sort is required such that no abortions happen.
+            var sortedTransforms = new SortedList<Transform>(Transform.COMPARER);
+            sortedTransforms.AddRange(transforms);
+
+            foreach (var t in sortedTransforms)
+            {
                 t.IsLooping = true;
                 t.LoopDelay = iterDuration;
+
+                t.Applied = false;
                 t.AppliedToEnd = false; // we want to force a reprocess of this transform. it may have been applied-to-end in the Add, but not correctly looped as a result.
+
+                t.TargetTransformable.AddTransform(t);
             }
 
             onLoopingTransform();

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using osu.Framework.Lists;
 
 namespace osu.Framework.Graphics.Transforms
 {

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using osu.Framework.Lists;
-using osu.Framework.Logging;
 
 namespace osu.Framework.Graphics.Transforms
 {

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -353,8 +353,8 @@ namespace osu.Framework.Graphics.Transforms
             }
 
             // This sort is required such that no abortions happen.
-            var sortedTransforms = new SortedList<Transform>(Transform.COMPARER);
-            sortedTransforms.AddRange(transforms);
+            var sortedTransforms = new List<Transform>(transforms);
+            sortedTransforms.Sort(Transform.COMPARER);
 
             foreach (var t in sortedTransforms)
             {

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -364,7 +364,7 @@ namespace osu.Framework.Graphics.Transforms
                 t.Applied = false;
                 t.AppliedToEnd = false; // we want to force a reprocess of this transform. it may have been applied-to-end in the Add, but not correctly looped as a result.
 
-                t.TargetTransformable.AddTransform(t);
+                t.TargetTransformable.AddTransform(t, t.TransformID);
             }
 
             onLoopingTransform();

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -344,8 +344,8 @@ namespace osu.Framework.Graphics.Transforms
                 // looped right after they're added. This is required so that transforms can be
                 // inserted in the correct order such that none of them trigger abortions on
                 // each other due to instant re-sorting upon adding.
-                double currentTime = t.TargetTransformable.Time.Current;
-                while (t.EndTime <= currentTime)
+                double currentTransformTime = t.TargetTransformable.Time.Current;
+                while (t.EndTime <= currentTransformTime)
                 {
                     t.StartTime += iterDuration;
                     t.EndTime += iterDuration;

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -406,7 +406,7 @@ namespace osu.Framework.Graphics.Transforms
         /// If <see cref="Clock"/> is null, e.g. because this object has just been constructed, then the given transform will be finished instantaneously.
         /// </summary>
         /// <param name="transform">The <see cref="Transform"/> to be added.</param>
-        public void AddTransform(Transform transform)
+        public void AddTransform(Transform transform, ulong? customTransformID = null)
         {
             if (transform == null)
                 throw new ArgumentNullException(nameof(transform));
@@ -429,7 +429,7 @@ namespace osu.Framework.Graphics.Transforms
             if (transform.TransformID != 0 && transforms.Contains(transform))
                 throw new InvalidOperationException($"{nameof(Transformable)} may not contain the same {nameof(Transform)} more than once.");
 
-            transform.TransformID = ++currentTransformID;
+            transform.TransformID = customTransformID ?? ++currentTransformID;
             int insertionIndex = transforms.Add(transform);
 
             // Remove all existing following transforms touching the same property as this one.

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -406,6 +406,7 @@ namespace osu.Framework.Graphics.Transforms
         /// If <see cref="Clock"/> is null, e.g. because this object has just been constructed, then the given transform will be finished instantaneously.
         /// </summary>
         /// <param name="transform">The <see cref="Transform"/> to be added.</param>
+        /// <param name="customTransformID">When not null, the <see cref="Transform.TransformID"/> to assign for ordering.</param>
         public void AddTransform(Transform transform, ulong? customTransformID = null)
         {
             if (transform == null)


### PR DESCRIPTION
Supersedes https://github.com/ppy/osu-framework/pull/1578
Fixes #1520.

- Fixes regressed loop with finite iteration counts due to missing reset of `Applied` and `AppliedToEnd` of cloned `Transforms`
- Fixes infinite loops containing `Transforms` that initially were instantaneously applied