### PR TITLE
Generalize scrolling from an integer to a Vector2

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -118,9 +118,9 @@ namespace osu.Framework.Tests.Visual
                 return false;
             }
 
-            protected override bool OnWheel(InputState state)
+            protected override bool OnScroll(InputState state)
             {
-                base.OnWheel(state);
+                base.OnScroll(state);
                 return false;
             }
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -87,9 +87,9 @@ namespace osu.Framework.Graphics.Containers
         private float displayableContent => ChildSize[ScrollDim];
 
         /// <summary>
-        /// Controls the distance scrolled when turning the mouse wheel a single notch.
+        /// Controls the distance scrolled per unit of mouse scroll.
         /// </summary>
-        public float MouseWheelScrollDistance = 80;
+        public float ScrollDistance = 80;
 
         /// <summary>
         /// This limits how far out of clamping bounds we allow the target position to be at most.
@@ -109,9 +109,9 @@ namespace osu.Framework.Graphics.Containers
         public double DistanceDecayDrag = 0.0035;
 
         /// <summary>
-        /// Controls the rate with which the target position is approached after using the mouse wheel. Default is 0.01
+        /// Controls the rate with which the target position is approached after scrolling. Default is 0.01
         /// </summary>
-        public double DistanceDecayWheel = 0.01;
+        public double DistanceDecayScroll = 0.01;
 
         /// <summary>
         /// Controls the rate with which the target position is approached after jumping to a specific location. Default is 0.01.
@@ -120,7 +120,7 @@ namespace osu.Framework.Graphics.Containers
 
         /// <summary>
         /// Controls the rate with which the target position is approached. It is automatically set after
-        /// dragging or using the mouse wheel.
+        /// dragging or scrolling.
         /// </summary>
         private double distanceDecay;
 
@@ -324,9 +324,9 @@ namespace osu.Framework.Graphics.Containers
             return true;
         }
 
-        protected override bool OnWheel(InputState state)
+        protected override bool OnScroll(InputState state)
         {
-            offset(-MouseWheelScrollDistance * state.Mouse.WheelDelta, true, DistanceDecayWheel);
+            offset(-ScrollDistance * state.Mouse.ScrollDelta.Y, true, DistanceDecayScroll);
             return true;
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1808,17 +1808,17 @@ namespace osu.Framework.Graphics
         protected virtual bool OnDragEnd(InputState state) => false;
 
         /// <summary>
-        /// Triggers <see cref="OnWheel(InputState)"/> with a local version of the given <see cref="InputState"/>.
+        /// Triggers <see cref="OnScroll(InputState)"/> with a local version of the given <see cref="InputState"/>.
         /// </summary>
-        public bool TriggerOnWheel(InputState screenSpaceState) => OnWheel(createCloneInParentSpace(screenSpaceState));
+        public bool TriggerOnScroll(InputState screenSpaceState) => OnScroll(createCloneInParentSpace(screenSpaceState));
 
         /// <summary>
-        /// Triggered whenever the mouse wheel was turned over this Drawable.
+        /// Triggered whenever the mouse scrolled over this Drawable.
         /// </summary>
-        /// <param name="state">The state after the wheel was turned.</param>
+        /// <param name="state">The state after scrolling happened.</param>
         /// <returns>True if this Drawable handled the event. If false, then the event
         /// is propagated up the scene graph to the next eligible Drawable.</returns>
-        protected virtual bool OnWheel(InputState state) => false;
+        protected virtual bool OnScroll(InputState state) => false;
 
         /// <summary>
         /// Triggers <see cref="OnFocus(InputState)"/> with a local version of the given <see cref="InputState"/>
@@ -1951,7 +1951,7 @@ namespace osu.Framework.Graphics
                 nameof(OnDragStart),
                 nameof(OnDrag),
                 nameof(OnDragEnd),
-                nameof(OnWheel),
+                nameof(OnScroll),
                 nameof(OnFocus),
                 nameof(OnFocusLost),
                 nameof(OnMouseMove)
@@ -2136,19 +2136,19 @@ namespace osu.Framework.Graphics
 
             public bool HasAnyButtonPressed => NativeState.HasAnyButtonPressed;
 
-            public int Wheel
+            public Vector2 Scroll
             {
-                get => NativeState.Wheel;
+                get => NativeState.Scroll;
                 set => throw new NotSupportedException();
             }
 
-            public int LastWheel
+            public Vector2 LastScroll
             {
-                get => NativeState.LastWheel;
+                get => NativeState.LastScroll;
                 set => throw new NotSupportedException();
             }
 
-            public int WheelDelta => NativeState.WheelDelta;
+            public Vector2 ScrollDelta => NativeState.ScrollDelta;
 
             public bool IsPressed(MouseButton button) => NativeState.IsPressed(button);
 

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -61,13 +61,13 @@ namespace osu.Framework.Input.Bindings
         /// </summary>
         protected virtual bool Prioritised => false;
 
-        protected override bool OnWheel(InputState state)
+        protected override bool OnScroll(InputState state)
         {
-            InputKey key = state.Mouse.WheelDelta > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
+            InputKey key = state.Mouse.ScrollDelta.Y > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
 
             // we need to create a local cloned state to ensure the underlying code in handleNewReleased thinks we are in a sane state,
             // even though we are pressing and releasing an InputKey in a single frame.
-            // the important part of this cloned state is the value of Wheel reset to zero.
+            // the important part of this cloned state is the value of Scroll reset to zero.
             var clonedState = state.Clone();
             clonedState.Mouse = new MouseState { Buttons = clonedState.Mouse.Buttons };
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -250,8 +250,8 @@ namespace osu.Framework.Input.Bindings
                 foreach (var button in state.Mouse.Buttons)
                     keys.Add(FromMouseButton(button));
 
-                if (state.Mouse.WheelDelta > 0) keys.Add(InputKey.MouseWheelUp);
-                if (state.Mouse.WheelDelta < 0) keys.Add(InputKey.MouseWheelDown);
+                if (state.Mouse.ScrollDelta.Y > 0) keys.Add(InputKey.MouseWheelUp);
+                if (state.Mouse.ScrollDelta.Y < 0) keys.Add(InputKey.MouseWheelDown);
             }
 
             if (state.Keyboard != null)

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKMouseHandler.cs
@@ -86,9 +86,9 @@ namespace osu.Framework.Input.Handlers.Mouse
 
         private void handleState(MouseState state)
         {
-            // combine wheel values to avoid discrepancy between sources.
+            // combine scroll values to avoid discrepancy between sources.
             state = (MouseState)state.Clone();
-            state.Wheel = (lastEventState?.Wheel ?? 0) + (lastPollState?.Wheel ?? 0);
+            state.Scroll = (lastEventState?.Scroll ?? Vector2.Zero) + (lastPollState?.Scroll ?? Vector2.Zero);
 
             PendingStates.Enqueue(new InputState { Mouse = state });
             FrameStatistics.Increment(StatisticsCounterType.MouseEvents);

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKMouseState.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKMouseState.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Input.Handlers.Mouse
 
         public OpenTK.Input.MouseState RawState;
 
-        public override int WheelDelta => WasActive ? base.WheelDelta : 0;
+        public override Vector2 ScrollDelta => WasActive ? base.ScrollDelta : Vector2.Zero;
 
         protected OpenTKMouseState(OpenTK.Input.MouseState tkState, bool active, Vector2? mappedPosition)
         {
@@ -30,7 +30,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                 addIfPressed(tkState.XButton2, MouseButton.Button2);
             }
 
-            Wheel = tkState.Wheel;
+            Scroll = new Vector2(-tkState.Scroll.X, tkState.Scroll.Y);
             Position = new Vector2(mappedPosition?.X ?? tkState.X, mappedPosition?.Y ?? tkState.Y);
         }
 

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
@@ -189,7 +189,7 @@ namespace osu.Framework.Input.Handlers.Mouse
         {
             // combine wheel values to avoid discrepancy between sources.
             state = (MouseState)state.Clone();
-            state.Wheel = (lastUnfocusedState?.Wheel ?? 0) + (lastRawState?.Wheel ?? 0);
+            state.Scroll = (lastUnfocusedState?.Scroll ?? Vector2.Zero) + (lastRawState?.Scroll ?? Vector2.Zero);
 
             PendingStates.Enqueue(new InputState { Mouse = state });
             FrameStatistics.Increment(StatisticsCounterType.MouseEvents);

--- a/osu.Framework/Input/IMouseState.cs
+++ b/osu.Framework/Input/IMouseState.cs
@@ -29,11 +29,11 @@ namespace osu.Framework.Input
 
         void SetPressed(MouseButton button, bool pressed);
 
-        int Wheel { get; set; }
+        Vector2 Scroll { get; set; }
 
-        int LastWheel { get; set; }
+        Vector2 LastScroll { get; set; }
 
-        int WheelDelta { get; }
+        Vector2 ScrollDelta { get; }
 
         IMouseState Clone();
     }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -436,7 +436,7 @@ namespace osu.Framework.Input
             if (!(state.Last.Mouse is MouseState last)) return;
 
             mouse.LastPosition = last.Position;
-            mouse.LastWheel = last.Wheel;
+            mouse.LastScroll = last.Scroll;
             mouse.PositionMouseDown = last.PositionMouseDown;
 
             if (mouse.Position != last.Position)
@@ -459,8 +459,8 @@ namespace osu.Framework.Input
                 }
             }
 
-            if (mouse.WheelDelta != 0 && (Host.Window?.CursorInWindow ?? true))
-                handleWheel(state);
+            if (mouse.ScrollDelta != Vector2.Zero && (Host.Window?.CursorInWindow ?? true))
+                handleScroll(state);
 
             if (mouse.HasAnyButtonPressed)
             {
@@ -662,23 +662,23 @@ namespace osu.Framework.Input
             return result;
         }
 
-        private bool handleWheel(InputState state)
+        private bool handleScroll(InputState state)
         {
-            return PropagateWheel(positionalInputQueue, state);
+            return PropagateScroll(positionalInputQueue, state);
         }
 
         /// <summary>
-        /// Triggers wheel events on drawables in <paramref cref="drawables"/> until it is handled.
+        /// Triggers scroll events on drawables in <paramref cref="drawables"/> until it is handled.
         /// </summary>
         /// <param name="drawables">The drawables in the queue.</param>
         /// <param name="state">The input state.</param>
         /// <returns></returns>
-        protected virtual bool PropagateWheel(IEnumerable<Drawable> drawables, InputState state)
+        protected virtual bool PropagateScroll(IEnumerable<Drawable> drawables, InputState state)
         {
-            var handledBy = drawables.FirstOrDefault(target => target.TriggerOnWheel(state));
+            var handledBy = drawables.FirstOrDefault(target => target.TriggerOnScroll(state));
 
             if (handledBy != null)
-                Logger.Log($"Wheel ({state.Mouse.WheelDelta}) handled by {handledBy}.", LoggingTarget.Runtime, LogLevel.Debug);
+                Logger.Log($"Scroll ({state.Mouse.ScrollDelta.X:#,2},{state.Mouse.ScrollDelta.Y:#,2}) handled by {handledBy}.", LoggingTarget.Runtime, LogLevel.Debug);
 
             return handledBy != null;
         }
@@ -850,11 +850,11 @@ namespace osu.Framework.Input
                             s.Mouse.Position = incoming.Mouse.Position;
                         });
 
-                    if (lastMouse.Wheel != incoming.Mouse.Wheel)
+                    if (lastMouse.Scroll != incoming.Mouse.Scroll)
                         yield return createDistinctState(s =>
                         {
                             s.Mouse = s.Mouse.Clone();
-                            s.Mouse.Wheel = incoming.Mouse.Wheel;
+                            s.Mouse.Scroll = incoming.Mouse.Scroll;
                         });
 
                     foreach (var releasedButton in lastMouse.Buttons.Except(incoming.Mouse.Buttons))

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -25,16 +25,16 @@ namespace osu.Framework.Input
 
         public IMouseState NativeState => this;
 
-        public virtual int WheelDelta => Wheel - LastWheel;
+        public virtual Vector2 ScrollDelta => Scroll - LastScroll;
 
-        public int Wheel { get; set; }
+        public Vector2 Scroll { get; set; }
 
-        private int? lastWheel;
+        private Vector2? lastScroll;
 
-        public int LastWheel
+        public Vector2 LastScroll
         {
-            get => lastWheel ?? Wheel;
-            set => lastWheel = value;
+            get => lastScroll ?? Scroll;
+            set => lastScroll = value;
         }
 
         public bool HasMainButtonPressed => IsPressed(MouseButton.Left) || IsPressed(MouseButton.Right);
@@ -65,7 +65,7 @@ namespace osu.Framework.Input
         public MouseState CloneWithoutDeltas()
         {
             var clone = (MouseState)Clone();
-            clone.lastWheel = null;
+            clone.lastScroll = null;
             clone.lastPosition = null;
             return clone;
         }
@@ -86,7 +86,7 @@ namespace osu.Framework.Input
         public override string ToString()
         {
             string down = PositionMouseDown != null ? $"(down @ {PositionMouseDown.Value.X:#,0},{PositionMouseDown.Value.Y:#,0})" : string.Empty;
-            return $@"{GetType().ReadableName()} ({Position.X:#,0},{Position.Y:#,0}) {down} {string.Join(",", Buttons.Select(b => b.ToString()))} Wheel {Wheel}/{WheelDelta}";
+            return $@"{GetType().ReadableName()} ({Position.X:#,0},{Position.Y:#,0}) {down} {string.Join(",", Buttons.Select(b => b.ToString()))} Scroll ({Scroll.X:#,2},{Scroll.Y:#,2})/({ScrollDelta.X:#,2},{ScrollDelta.Y:#,2})";
         }
     }
 }

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Input
 
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args) => acceptState(state);
 
-        protected override bool OnWheel(InputState state) => acceptState(state);
+        protected override bool OnScroll(InputState state) => acceptState(state);
 
         protected override bool OnKeyUp(InputState state, KeyUpEventArgs args) => acceptState(state);
 

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -34,11 +34,15 @@ namespace osu.Framework.Testing.Input
             handler.ReleaseKey(key);
         }
 
-        public void ScrollBy(int delta)
+        public void ScrollBy(Vector2 delta)
         {
             UseParentState = false;
             handler.ScrollBy(delta);
         }
+
+        public void ScrollHorizontalBy(float delta) => ScrollBy(new Vector2(delta, 0));
+
+        public void ScrollVerticalBy(float delta) => ScrollBy(new Vector2(0, delta));
 
         public void MoveMouseTo(Drawable drawable)
         {
@@ -110,12 +114,16 @@ namespace osu.Framework.Testing.Input
                 EnqueueState(new InputState { Mouse = state });
             }
 
-            public void ScrollBy(int delta)
+            public void ScrollBy(Vector2 delta)
             {
                 var state = lastMouseState.Clone();
-                state.Wheel += delta;
+                state.Scroll += delta;
                 EnqueueState(new InputState { Mouse = state });
             }
+
+            public void ScrollVerticalBy(float delta) => ScrollBy(new Vector2(0, delta));
+
+            public void ScrollHorizontalBy(float delta) => ScrollBy(new Vector2(delta, 0));
 
             public void MoveMouseTo(Vector2 position)
             {


### PR DESCRIPTION
Refactored `int Wheel;` to `Vector2 Scroll;`. This lays the groundwork for eventually having smooth scrolling when devices support it (e.g. some trackpads, such as on MacBooks).