### PR TITLE
Add support for precise and horizontal scrolling

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -326,7 +326,8 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnScroll(InputState state)
         {
-            offset(-ScrollDistance * state.Mouse.ScrollDelta.Y, true, DistanceDecayScroll);
+            bool isPrecise = state.Mouse.HasPreciseScroll;
+            offset((isPrecise ? 10 : 80) * -state.Mouse.ScrollDelta.Y, true, isPrecise ? 1 : DistanceDecayScroll);
             return true;
         }
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -327,7 +327,13 @@ namespace osu.Framework.Graphics.Containers
         protected override bool OnScroll(InputState state)
         {
             bool isPrecise = state.Mouse.HasPreciseScroll;
-            offset((isPrecise ? 10 : 80) * -state.Mouse.ScrollDelta.Y, true, isPrecise ? 1 : DistanceDecayScroll);
+
+            Vector2 scrollDelta = state.Mouse.ScrollDelta;
+            float scrollDeltaFloat = scrollDelta.Y;
+            if (ScrollDirection == Direction.Horizontal && scrollDelta.X != 0)
+                scrollDeltaFloat = scrollDelta.X;
+
+            offset((isPrecise ? 10 : 80) * -scrollDeltaFloat, true, isPrecise ? 1 : DistanceDecayScroll);
             return true;
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2150,6 +2150,12 @@ namespace osu.Framework.Graphics
 
             public Vector2 ScrollDelta => NativeState.ScrollDelta;
 
+            public bool HasPreciseScroll
+            {
+                get => NativeState.HasPreciseScroll;
+                set => NativeState.HasPreciseScroll = value;
+            }
+
             public bool IsPressed(MouseButton button) => NativeState.IsPressed(button);
 
             public void SetPressed(MouseButton button, bool pressed) => NativeState.SetPressed(button, pressed);

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKMouseState.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKMouseState.cs
@@ -31,6 +31,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             }
 
             Scroll = new Vector2(-tkState.Scroll.X, tkState.Scroll.Y);
+            HasPreciseScroll = tkState.HasPreciseScroll;
             Position = new Vector2(mappedPosition?.X ?? tkState.X, mappedPosition?.Y ?? tkState.Y);
         }
 

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKMouseState.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKMouseState.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             }
 
             Scroll = new Vector2(-tkState.Scroll.X, tkState.Scroll.Y);
-            HasPreciseScroll = tkState.HasPreciseScroll;
+            HasPreciseScroll = (tkState.Flags & MouseStateFlags.HasPreciseScroll) > 0;
             Position = new Vector2(mappedPosition?.X ?? tkState.X, mappedPosition?.Y ?? tkState.Y);
         }
 

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
@@ -10,7 +10,6 @@ using osu.Framework.Platform;
 using osu.Framework.Statistics;
 using osu.Framework.Threading;
 using OpenTK;
-using OpenTK.Platform.Windows;
 
 namespace osu.Framework.Input.Handlers.Mouse
 {
@@ -125,7 +124,7 @@ namespace osu.Framework.Input.Handlers.Mouse
         {
             Vector2 currentPosition;
 
-            if ((state.RawFlags & RawMouseFlags.MOUSE_MOVE_ABSOLUTE) > 0)
+            if ((state.Flags & OpenTK.Input.MouseStateFlags.MoveAbsolute) > 0)
             {
                 const int raw_input_resolution = 65536;
 
@@ -138,7 +137,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                 }
                 else
                 {
-                    Rectangle screenRect = (state.RawFlags & RawMouseFlags.MOUSE_VIRTUAL_DESKTOP) > 0
+                    Rectangle screenRect = (state.Flags & OpenTK.Input.MouseStateFlags.VirtualDesktop) > 0
                         ? Platform.Windows.Native.Input.GetVirtualScreenRect()
                         : new Rectangle(0, 0, DisplayDevice.Default.Width, DisplayDevice.Default.Height);
 

--- a/osu.Framework/Input/IMouseState.cs
+++ b/osu.Framework/Input/IMouseState.cs
@@ -35,6 +35,8 @@ namespace osu.Framework.Input
 
         Vector2 ScrollDelta { get; }
 
+        bool HasPreciseScroll { get; set; }
+
         IMouseState Clone();
     }
 }

--- a/osu.Framework/Input/MouseState.cs
+++ b/osu.Framework/Input/MouseState.cs
@@ -37,6 +37,8 @@ namespace osu.Framework.Input
             set => lastScroll = value;
         }
 
+        public bool HasPreciseScroll { get; set; }
+
         public bool HasMainButtonPressed => IsPressed(MouseButton.Left) || IsPressed(MouseButton.Right);
 
         public bool HasAnyButtonPressed => buttons.Any();

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
     <PackageReference Include="runtime.linux-x64.CoreCompat.System.Drawing" Version="1.0.0-beta009" />
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.4.0-r8" />
-    <PackageReference Include="ppy.OpenTK.NS20" Version="1.0.4" />
+    <PackageReference Include="ppy.OpenTK.NS20" Version="1.0.5" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="ppy.Microsoft.Diagnostics.Runtime" Version="0.9.180305.1" />
     <PackageReference Include="NUnit" Version="3.10.1" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
     <PackageReference Include="runtime.linux-x64.CoreCompat.System.Drawing" Version="1.0.0-beta009" />
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.4.0-r8" />
-    <PackageReference Include="ppy.OpenTK.NS20" Version="1.0.5" />
+    <PackageReference Include="ppy.OpenTK.NS20" Version="1.0.6" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="ppy.Microsoft.Diagnostics.Runtime" Version="0.9.180305.1" />
     <PackageReference Include="NUnit" Version="3.10.1" />


### PR DESCRIPTION
- Adds support for precise scrolling on macOS trackpads. Verified to work correctly with non-precise input (tested with linear _and_ accelerated modes via SteerMouse)
- Allows scrolling through horizontal `ScrollContainer`s by scrolling horizontally.
- Fixes https://github.com/ppy/osu-framework/issues/1177
- [x] Depends on https://github.com/ppy/opentk/pull/19.
- [x] Depends on https://github.com/ppy/osu-framework/pull/1584.

Resolves #1177 🎉 🎈 
