### PR TITLE
Mark time spent waiting for update thread as sleep time

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -290,7 +290,8 @@ namespace osu.Framework.Platform
                 {
                     if (buffer?.Object == null || buffer.FrameId == lastDrawFrameId)
                     {
-                        Thread.Sleep(1);
+                        using (drawMonitor.BeginCollecting(PerformanceCollectionType.Sleep))
+                            Thread.Sleep(1);
                         continue;
                     }
 


### PR DESCRIPTION
Previously it would misleadingly show as "work" making is hard to discern which thread was bottlenecking.

![image](https://user-images.githubusercontent.com/191335/41092431-d23dd0ba-6a83-11e8-978e-ea4be8757f7c.png)