### PR TITLE
Add HighFrequency interface back to PassThroughInputManager

### DIFF
--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -7,7 +7,7 @@ using OpenTK;
 
 namespace osu.Framework.Input
 {
-    public class PassThroughInputManager : CustomInputManager
+    public class PassThroughInputManager : CustomInputManager, IRequireHighFrequencyMousePosition
     {
         /// <summary>
         /// If there's an InputManager above us, decide whether we should use their available state.


### PR DESCRIPTION
Turns out that without this any `PassThroughInputMnager` is in an incorrect state until the mouse moves once.

Resolves ppy/osu#2754.