### PR TITLE
Fix failing async logic in WaveformGraph

### DIFF
--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -185,6 +185,8 @@ namespace osu.Framework.Audio.Track
 
                 for (float i = 0; i < points.Count; i += pointsPerGeneratedPoint)
                 {
+                    if (cancellationToken.IsCancellationRequested) break;
+
                     int startIndex = (int)i;
                     int endIndex = (int)Math.Min(points.Count, Math.Ceiling(i + pointsPerGeneratedPoint));
 

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -236,9 +236,12 @@ namespace osu.Framework.Graphics.Audio
                 {
                     points = value;
 
-                    highMax = points?.Max(p => p.HighIntensity) ?? 0;
-                    midMax = points?.Max(p => p.MidIntensity) ?? 0;
-                    lowMax = points?.Max(p => p.LowIntensity) ?? 0;
+                    if (points?.Any() == true)
+                    {
+                        highMax = points.Max(p => p.HighIntensity);
+                        midMax = points.Max(p => p.MidIntensity);
+                        lowMax = points.Max(p => p.LowIntensity);
+                    }
                 }
             }
 


### PR DESCRIPTION
Possible thread race condition causing a nullref of the cancellation token (cross-thread access to private field)