### PR TITLE
Apply a small degree of smoothing to precise scroll

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -332,7 +332,7 @@ namespace osu.Framework.Graphics.Containers
             if (ScrollDirection == Direction.Horizontal && scrollDelta.X != 0)
                 scrollDeltaFloat = scrollDelta.X;
 
-            offset((isPrecise ? 10 : 80) * -scrollDeltaFloat, true, isPrecise ? 1 : DistanceDecayScroll);
+            offset((isPrecise ? 10 : 80) * -scrollDeltaFloat, true, isPrecise ? 0.05 : DistanceDecayScroll);
             return true;
         }
 


### PR DESCRIPTION
This prevents most jittery behavior when "letting go" of a scroll flick and running the game at low frame rates.