### PR TITLE
Use ImageSharp to load textures

### DIFF
--- a/osu.Framework/Graphics/Textures/RawTexture.cs
+++ b/osu.Framework/Graphics/Textures/RawTexture.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System.Diagnostics;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
+using SixLabors.ImageSharp;
 using PixelFormat = OpenTK.Graphics.ES30.PixelFormat;
 
 namespace osu.Framework.Graphics.Textures
@@ -17,50 +15,14 @@ namespace osu.Framework.Graphics.Textures
 
         public static RawTexture FromStream(Stream stream)
         {
-            using (Bitmap bitmap = new Bitmap(stream))
-            {
-                var data = bitmap.LockBits(new Rectangle(Point.Empty, bitmap.Size), ImageLockMode.ReadOnly, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-
-                RawTexture t = new RawTexture
+            using (var img = Image.Load(stream))
+                return new RawTexture
                 {
-                    Width = bitmap.Width,
-                    Height = bitmap.Height,
-                    Pixels = new byte[data.Width * data.Height * 4],
+                    Width = img.Width,
+                    Height = img.Height,
+                    Pixels = img.SavePixelData(),
                     PixelFormat = PixelFormat.Rgba
                 };
-
-                unsafe
-                {
-                    //convert from BGRA (System.Drawing) to RGBA
-                    //don't need to consider stride because we're in a raw format
-                    var src = (byte*)data.Scan0;
-
-                    Debug.Assert(src != null);
-
-                    fixed (byte* pixels = t.Pixels)
-                    {
-                        var dest = pixels;
-
-                        int length = t.Pixels.Length / 4;
-                        for (int i = 0; i < length; i++)
-                        {
-                            //BGRA -> RGBA
-                            // ReSharper disable once PossibleNullReferenceException
-                            dest[0] = src[2];
-                            dest[1] = src[1];
-                            dest[2] = src[0];
-                            dest[3] = src[3];
-
-                            src += 4;
-                            dest += 4;
-                        }
-                    }
-                }
-
-                bitmap.UnlockBits(data);
-
-                return t;
-            }
         }
     }
 }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -21,6 +21,7 @@
     <PackageTags>osu game framework</PackageTags>
   </PropertyGroup>
   <ItemGroup Label="Package References">
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0004" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
     <PackageReference Include="runtime.linux-x64.CoreCompat.System.Drawing" Version="1.0.0-beta009" />


### PR DESCRIPTION
Benchmarks to be slightly faster on macOS. Needs further benchmarking on windows (I have a branch `image-benchmark` if anyone is interested; requires manual path changing).

Removes unsafe code; removes native dependencies; removes GDI+ calls (completely native solution). Brings benefits of avoiding font cache initialisation on non-windows platforms.

Going forward we can likely remove the remaining `System.Drawing` dependencies, which consist of

- Screenshot logic (I attempted to make this work but ran into a `memcpy` exception)
- Primitives (ImageSharp provides its own which we can likely make use of)
- Icon logic (windows only; we can either continue using `System.Drawing` here or make an alternative solution).