### PR TITLE
Add naive concurrency limiting for drawable async load

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseConcurrentLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseConcurrentLoad.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Threading;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseConcurrentLoad : TestCase
+    {
+        private readonly FillFlowContainer flow;
+
+        public TestCaseConcurrentLoad()
+        {
+            Child = flow = new FillFlowContainer
+            {
+                Direction = FillDirection.Full,
+                RelativeSizeAxes = Axes.Both,
+                Spacing = new Vector2(5)
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            for (int i = 0; i < 1000; i++)
+                LoadComponentAsync(new TimeDrawable(), flow.Add);
+        }
+
+        public class TimeDrawable : CompositeDrawable
+        {
+            public TimeDrawable()
+            {
+                Size = new Vector2(15);
+                InternalChild = new Box
+                {
+                    Colour = Color4.NavajoWhite,
+                    RelativeSizeAxes = Axes.Both
+                };
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Thread.Sleep(20);
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -81,8 +81,15 @@ namespace osu.Framework.Graphics
             if (isDisposed)
                 return;
 
-            //we can't dispose if we are mid-load, else our children may get in a bad state.
-            loadTask?.Wait();
+            try
+            {
+                //we can't dispose if we are mid-load, else our children may get in a bad state.
+                loadTask?.Wait();
+            }
+            catch
+            {
+                // task may have been cancelled.
+            }
 
             Dispose(isDisposing);
 
@@ -135,14 +142,24 @@ namespace osu.Framework.Graphics
         /// <see cref="Clock"/> and <see cref="Dependencies"/> are inherited from the target.
         /// </param>
         /// <param name="onLoaded">Callback to be invoked on the update thread after loading is complete.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel any async loading tasks.</param>
         /// <returns>The task which is used for loading and callbacks.</returns>
-        internal Task LoadAsync(Game game, Drawable target, Action onLoaded = null)
+        internal Task LoadAsync(Game game, Drawable target, CancellationToken cancellationToken, Action onLoaded = null)
         {
             if (loadState == LoadState.NotLoaded)
             {
                 Debug.Assert(loadTask == null);
                 loadState = LoadState.Loading;
-                loadTask = Task.Factory.StartNew(() => Load(target.Clock, target.Dependencies), TaskCreationOptions.LongRunning);
+                loadTask = Task.Factory.StartNew(() =>
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                        return;
+
+                    if (isDisposed || target.isDisposed)
+                        return;
+
+                    Load(target.Clock, target.Dependencies);
+                }, cancellationToken, TaskCreationOptions.None, task_schedulers.ConcurrentScheduler);
             }
 
             return (loadTask ?? Task.CompletedTask).ContinueWith(task => game.Schedule(() =>
@@ -150,8 +167,10 @@ namespace osu.Framework.Graphics
                 task.ThrowIfFaulted(typeof(RecursiveLoadException));
                 onLoaded?.Invoke();
                 loadTask = null;
-            }));
+            }), cancellationToken);
         }
+
+        private static readonly ConcurrentExclusiveSchedulerPair task_schedulers = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, 8);
 
         private static readonly StopwatchClock perf = new StopwatchClock(true);
 
@@ -760,6 +779,7 @@ namespace osu.Framework.Graphics
                     v.Y /= fillAspectRatio;
                 }
             }
+
             return v;
         }
 
@@ -796,7 +816,9 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Called whenever the <see cref="RelativeSizeAxes"/> of this drawable is changed, or when the <see cref="Container{T}.AutoSizeAxes"/> are changed if this drawable is a <see cref="Container{T}"/>.
         /// </summary>
-        protected virtual void OnSizingChanged() { }
+        protected virtual void OnSizingChanged()
+        {
+        }
 
         #endregion
 
@@ -1185,6 +1207,7 @@ namespace osu.Framework.Graphics
                 Invalidate(Invalidation.Colour);
             }
         }
+
         #endregion
 
         #region Timekeeping
@@ -1273,6 +1296,7 @@ namespace osu.Framework.Graphics
 
                 search = search.Parent;
             }
+
             return null;
         }
 
@@ -1927,7 +1951,8 @@ namespace osu.Framework.Graphics
             private static readonly ConcurrentDictionary<Type, bool> mouse_cached_values = new ConcurrentDictionary<Type, bool>();
             private static readonly ConcurrentDictionary<Type, bool> keyboard_cached_values = new ConcurrentDictionary<Type, bool>();
 
-            private static readonly string[] mouse_input_methods = {
+            private static readonly string[] mouse_input_methods =
+            {
                 nameof(OnHover),
                 nameof(OnHoverLost),
                 nameof(OnMouseDown),
@@ -1943,7 +1968,8 @@ namespace osu.Framework.Graphics
                 nameof(OnMouseMove)
             };
 
-            private static readonly string[] keyboard_input_methods = {
+            private static readonly string[] keyboard_input_methods =
+            {
                 nameof(OnFocus),
                 nameof(OnFocusLost),
                 nameof(OnKeyDown),
@@ -2176,7 +2202,8 @@ namespace osu.Framework.Graphics
             {
                 double min = double.MaxValue;
                 foreach (Transform t in Transforms)
-                    if (t.StartTime < min) min = t.StartTime;
+                    if (t.StartTime < min)
+                        min = t.StartTime;
                 LifetimeStart = min < int.MaxValue ? min : int.MinValue;
             }
         }
@@ -2242,19 +2269,23 @@ namespace osu.Framework.Graphics
         /// is assumed unless indicated by additional flags.
         /// </summary>
         DrawInfo = 1 << 0,
+
         /// <summary>
         /// <see cref="Drawable.DrawSize"/> has changed.
         /// </summary>
         DrawSize = 1 << 1,
+
         /// <summary>
         /// Captures all other geometry changes than <see cref="Drawable.DrawSize"/>, such as
         /// <see cref="Drawable.Rotation"/>, <see cref="Drawable.Shear"/>, and <see cref="Drawable.DrawPosition"/>.
         /// </summary>
         MiscGeometry = 1 << 2,
+
         /// <summary>
         /// <see cref="Drawable.Colour"/> or <see cref="Drawable.IsPresent"/> has changed.
         /// </summary>
         Colour = 1 << 3,
+
         /// <summary>
         /// <see cref="Drawable.ApplyDrawNode(Graphics.DrawNode)"/> has to be invoked on all old draw nodes.
         /// </summary>
@@ -2264,10 +2295,12 @@ namespace osu.Framework.Graphics
         /// No invalidation.
         /// </summary>
         None = 0,
+
         /// <summary>
         /// <see cref="Drawable.RequiredParentSizeToFit"/> has to be recomputed.
         /// </summary>
         RequiredParentSizeToFit = MiscGeometry | DrawSize,
+
         /// <summary>
         /// All possible things are affected.
         /// </summary>
@@ -2361,17 +2394,20 @@ namespace osu.Framework.Graphics
         /// Not loaded, and no load has been initiated yet.
         /// </summary>
         NotLoaded,
+
         /// <summary>
         /// Currently loading (possibly and usually on a background
-        /// thread via <see cref="Drawable.LoadAsync(Game, Drawable, Action)"/>).
+        /// thread via <see cref="Drawable.LoadAsync(Game, Drawable, CancellationToken, Action)"/>).
         /// </summary>
         Loading,
+
         /// <summary>
         /// Loading is complete, but has not yet been finalized on the update thread
         /// (<see cref="Drawable.LoadComplete"/> has not been called yet, which
         /// always runs on the update thread and requires <see cref="Drawable.IsAlive"/>).
         /// </summary>
         Ready,
+
         /// <summary>
         /// Loading is fully completed and the Drawable is now part of the scene graph.
         /// </summary>
@@ -2387,11 +2423,13 @@ namespace osu.Framework.Graphics
         /// Completely fill the parent with a relative size of 1 at the cost of stretching the aspect ratio (default).
         /// </summary>
         Stretch,
+
         /// <summary>
         /// Always maintains aspect ratio while filling the portion of the parent's size denoted by the relative size.
         /// A relative size of 1 results in completely filling the parent by scaling the smaller axis of the drawable to fill the parent.
         /// </summary>
         Fill,
+
         /// <summary>
         /// Always maintains aspect ratio while fitting into the portion of the parent's size denoted by the relative size.
         /// A relative size of 1 results in fitting exactly into the parent by scaling the larger axis of the drawable to fit into the parent.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -159,7 +159,7 @@ namespace osu.Framework.Graphics
                         return;
 
                     Load(target.Clock, target.Dependencies);
-                }, cancellationToken, TaskCreationOptions.None, task_schedulers.ConcurrentScheduler);
+                }, cancellationToken, TaskCreationOptions.None, target.Dependencies.Get<TaskScheduler>());
             }
 
             return (loadTask ?? Task.CompletedTask).ContinueWith(task => game.Schedule(() =>
@@ -169,8 +169,6 @@ namespace osu.Framework.Graphics
                 loadTask = null;
             }), cancellationToken);
         }
-
-        private static readonly ConcurrentExclusiveSchedulerPair task_schedulers = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, 8);
 
         private static readonly StopwatchClock perf = new StopwatchClock(true);
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -479,6 +479,8 @@ namespace osu.Framework.Platform
         /// </summary>
         protected virtual IFrameBasedClock SceneGraphClock => UpdateThread.Clock;
 
+        private static readonly ConcurrentExclusiveSchedulerPair async_schedulers = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, 2);
+
         private void bootstrapSceneGraph(Game game)
         {
             var root = new UserInputManager
@@ -494,6 +496,7 @@ namespace osu.Framework.Platform
 
             Dependencies.Cache(root);
             Dependencies.CacheAs(game);
+            Dependencies.CacheAs(async_schedulers.ConcurrentScheduler);
 
             game.SetHost(this);
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -382,15 +382,14 @@ namespace osu.Framework.Testing
                 OnCaughtError = compileFailed
             });
 
+            if (lastTest?.Parent != null)
+            {
+                testContentContainer.Remove(lastTest.Parent);
+                lastTest.Dispose();
+            }
+
             newTest.OnLoadComplete = d => Schedule(() =>
             {
-                if (lastTest?.Parent != null)
-                {
-                    testContentContainer.Remove(lastTest.Parent);
-                    lastTest.Clear();
-                    lastTest.Dispose();
-                }
-
                 if (CurrentTest != newTest)
                 {
                     // There could have been multiple loads fired after us. In such a case we want to silently remove ourselves.


### PR DESCRIPTION
Will probably require more control over the scheduler being used, but this should be a sane starting point. PRing for further testing with osu!.