### PR TITLE
Fix OpenInNativeExplorer so that it doesn't crash. The debug overlay also gets more elaborate for some reason

### DIFF
--- a/osu.Framework/Platform/DesktopStorage.cs
+++ b/osu.Framework/Platform/DesktopStorage.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Platform
 
         public override string[] GetDirectories(string path) => Directory.GetDirectories(GetUsablePathFor(path));
 
-        public override void OpenInNativeExplorer() => Process.Start(GetUsablePathFor(string.Empty));
+        public override void OpenInNativeExplorer() => Process.Start(new ProcessStartInfo { UseShellExecute = true, FileName = GetUsablePathFor(string.Empty) });
 
         public override Stream GetStream(string path, FileAccess access = FileAccess.Read, FileMode mode = FileMode.OpenOrCreate)
         {


### PR DESCRIPTION
Fixes #1639