### PR TITLE
Audio: rethrow exception from failed task

### DIFF
--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -65,7 +65,10 @@ namespace osu.Framework.Audio
             FrameStatistics.Increment(StatisticsCounterType.Components);
 
             while (!IsDisposed && PendingActions.TryDequeue(out Task task))
+            {
                 task.RunSynchronously();
+                task.Wait();
+            }
 
             if (!IsDisposed)
                 UpdateState();


### PR DESCRIPTION
It's make lib not found exception pop up if libbass_fx wasn't installed