### PR TITLE
Reduce log level for "Joystick Connected" messages

### DIFF
--- a/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
@@ -93,7 +93,7 @@ namespace osu.Framework.Input.Handlers.Joystick
                 if (!newDevice.Capabilities.IsConnected)
                     break;
 
-                Logger.Log($"Connected joystick device: {newDevice.Guid}", level: LogLevel.Important);
+                Logger.Log($"Connected joystick device: {newDevice.Guid}");
 
                 newDevices.Add(newDevice);
                 mostSeenDevices++;


### PR DESCRIPTION
These log events were too noisy and unimportant.

Closes ppy/osu#2864.