### PR TITLE
Fix clicks not occurring if drag events weren't handled

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
@@ -286,7 +286,7 @@ namespace osu.Framework.Tests.Visual
             checkIsDragged(true);
             checkEventCount("DragEnd");
             AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
-            checkEventCount("Click", 1);
+            checkEventCount("Click");
             checkEventCount("DragEnd", 1);
             checkIsDragged(false);
 

--- a/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Tests.Visual
 {
     public class TestCaseMouseStates : TestCase
     {
-        private readonly Box marginBox;
+        private readonly Box marginBox, outerMarginBox;
         private readonly ManualInputManager manual;
         private readonly FrameworkActionContainer actionContainer;
 
@@ -33,12 +33,13 @@ namespace osu.Framework.Tests.Visual
         {
             Children = new Drawable[]
             {
+                new StateTracker(0),
                 manual = new ManualInputManager
                 {
                     FillMode = FillMode.Fit,
                     FillAspectRatio = 1,
                     RelativeSizeAxes = Axes.Both,
-                    Size = new Vector2(0.7f),
+                    Size = new Vector2(0.75f),
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                     Children = new Drawable[]
@@ -48,39 +49,51 @@ namespace osu.Framework.Tests.Visual
                             RelativeSizeAxes = Axes.Both,
                             Colour = new Color4(1, 1, 1, 0.2f),
                         },
-                        actionContainer = new FrameworkActionContainer
+                        s1 = new StateTracker(1),
+                        new Container
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Size = new Vector2(0.7f),
-                            Anchor = Anchor.Centre,
-                            Origin = Anchor.Centre,
                             Children = new Drawable[]
                             {
-                                new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = new Color4(1, 1, 1, 0.2f),
-                                },
-                                marginBox = new Box
+                                outerMarginBox = new Box
                                 {
                                     RelativeSizeAxes = Axes.Both,
                                     Anchor = Anchor.Centre,
                                     Origin = Anchor.Centre,
-                                    Size = new Vector2(0.8f),
+                                    Size = new Vector2(0.9f),
                                     Colour = Color4.SkyBlue.Opacity(0.1f),
                                 },
-                                s2 = new StateTracker(2),
+                                actionContainer = new FrameworkActionContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.6f),
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre,
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Colour = new Color4(1, 1, 1, 0.2f),
+                                        },
+                                        marginBox = new Box
+                                        {
+                                            RelativeSizeAxes = Axes.Both,
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Size = new Vector2(0.8f),
+                                            Colour = Color4.SkyBlue.Opacity(0.1f),
+                                        },
+                                        s2 = new DraggableStateTracker(2),
+                                    }
+                                }
                             }
                         },
-                        s1 = new StateTracker(1),
                     }
-                },
-                new StateTracker(0)
+                }
             };
 
             AddStep("return input", () => manual.UseParentInput = true);
-
-            // TODO: blocking event testing
         }
 
         [SetUp]
@@ -88,18 +101,25 @@ namespace osu.Framework.Tests.Visual
         {
             // grab manual input control
             manual.UseParentInput = false;
+            manual.MoveMouseTo(actionContainer);
+        }
 
-            s1.Reset();
-            s2.Reset();
+        private void initTestCase()
+        {
+            eventCounts1.Clear();
+            eventCounts2.Clear();
+            AddStep("move mouse to center", () => manual.MoveMouseTo(actionContainer));
+            AddStep("reset event counters", () =>
+            {
+                s1.Reset();
+                s2.Reset();
+            });
         }
 
         [Test]
         public void BasicScroll()
         {
-            eventCounts.Clear();
-
-            AddStep("move to centre", () => manual.MoveMouseTo(actionContainer));
-            checkEventCount("Move", 1);
+            initTestCase();
 
             AddStep("scroll some", () => manual.ScrollBy(new Vector2(-1, 1)));
             checkEventCount("Move");
@@ -114,7 +134,7 @@ namespace osu.Framework.Tests.Visual
         [Test]
         public void BasicMovement()
         {
-            eventCounts.Clear();
+            initTestCase();
 
             AddStep("push move", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
             checkEventCount("Move", 1);
@@ -141,9 +161,7 @@ namespace osu.Framework.Tests.Visual
         [Test]
         public void BasicButtons()
         {
-            eventCounts.Clear();
-            AddStep("move to centre", () => manual.MoveMouseTo(actionContainer));
-            checkEventCount("Move", 1);
+            initTestCase();
 
             AddStep("press left button", () => manual.PressButton(MouseButton.Left));
             checkEventCount("MouseDown", 1);
@@ -192,28 +210,25 @@ namespace osu.Framework.Tests.Visual
         [Test]
         public void Drag()
         {
-            eventCounts.Clear();
-
-            AddStep("move to centre", () => manual.MoveMouseTo(actionContainer));
+            initTestCase();
 
             AddStep("press left button", () => manual.PressButton(MouseButton.Left));
             checkEventCount("MouseDown", 1);
+            checkIsDragged(false);
 
             AddStep("move bottom left", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft));
             checkEventCount("DragStart", 1);
+            checkIsDragged(true);
 
             AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
             checkEventCount("MouseUp", 1);
+            checkIsDragged(false);
         }
 
         [Test]
         public void CombinationChanges()
         {
-            eventCounts.Clear();
-            AddStep("init mouse position", () =>
-            {
-                manual.MoveMouseTo(Vector2.Zero);
-            });
+            initTestCase();
 
             AddStep("push move", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft));
             checkEventCount("Move", 1);
@@ -229,10 +244,7 @@ namespace osu.Framework.Tests.Visual
             checkLastScrollDelta(new Vector2(1, 2));
             checkLastPositionDelta(() => Vector2.Distance(marginBox.ScreenSpaceDrawQuad.BottomLeft, marginBox.ScreenSpaceDrawQuad.Centre));
 
-            AddStep("Move mouse to out of bounds", () =>
-            {
-                manual.MoveMouseTo(Vector2.Zero);
-            });
+            AddStep("Move mouse to out of bounds", () => manual.MoveMouseTo(Vector2.Zero));
 
             checkEventCount("Move");
             checkEventCount("Scroll");
@@ -248,16 +260,103 @@ namespace osu.Framework.Tests.Visual
             checkEventCount("Scroll");
         }
 
-        private readonly Dictionary<string, int> eventCounts = new Dictionary<string, int>();
-
-        private void checkEventCount(string type, int change = 0)
+        [Test]
+        public void DragAndClick()
         {
-            eventCounts.TryGetValue(type, out var count);
+            initTestCase();
 
-            count += change;
+            // mouseDown on a non-draggable -> mouseUp on a distant position: drag-clicking
+            AddStep("move mouse", () => manual.MoveMouseTo(outerMarginBox.ScreenSpaceDrawQuad.TopLeft));
+            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
+            checkEventCount("DragStart");
+            AddStep("drag non-draggable", () => manual.MoveMouseTo(marginBox));
+            checkEventCount("DragStart", 1, true);
+            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            checkEventCount("Click", 1, true);
+            checkEventCount("DragEnd");
 
-            AddAssert($"{type} event count {count}", () => s1.CounterFor(type).Count == count && s2.CounterFor(type).Count == count);
-            eventCounts[type] = count;
+            // mouseDown on a draggable -> mouseUp on the original position: drag-clicking
+            // do we desire this behaviour?
+            AddStep("move mouse", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
+            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
+            AddStep("drag draggable", () => manual.MoveMouseTo(outerMarginBox.ScreenSpaceDrawQuad.BottomRight));
+            checkEventCount("DragStart", 1);
+            checkIsDragged(true);
+            AddStep("return mouse position", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
+            checkIsDragged(true);
+            checkEventCount("DragEnd");
+            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            checkEventCount("Click", 1);
+            checkEventCount("DragEnd", 1);
+            checkIsDragged(false);
+
+            // mouseDown on a draggable -> mouseUp on a distant position: no drag-clicking
+            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
+            AddStep("drag draggable", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomRight));
+            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            checkEventCount("DragStart", 1);
+            checkEventCount("DragEnd", 1);
+            checkEventCount("Click");
+        }
+
+        [Test]
+        public void ClickAndDoubleClick()
+        {
+            initTestCase();
+
+            waitDoubleClickTime();
+            AddStep("click", () => manual.Click(MouseButton.Left));
+            checkEventCount("Click", 1);
+            waitDoubleClickTime();
+            AddStep("click", () => manual.Click(MouseButton.Left));
+            checkEventCount("Click", 1);
+            waitDoubleClickTime();
+            AddStep("double click", () =>
+            {
+                manual.Click(MouseButton.Left);
+                manual.Click(MouseButton.Left);
+            });
+            checkEventCount("Click", 1);
+            checkEventCount("DoubleClick", 1);
+            waitDoubleClickTime();
+            AddStep("triple click", () =>
+            {
+                manual.Click(MouseButton.Left);
+                manual.Click(MouseButton.Left);
+                manual.Click(MouseButton.Left);
+            });
+            checkEventCount("Click", 2);
+            checkEventCount("DoubleClick", 1);
+        }
+
+        private void waitDoubleClickTime()
+        {
+            AddWaitStep(2, "wait to don't double click");
+        }
+
+        private readonly Dictionary<string, int> eventCounts1 = new Dictionary<string, int>(),
+                                                 eventCounts2 = new Dictionary<string, int>();
+        private void checkEventCount(string type, int change = 0, bool outer = false)
+        {
+            eventCounts1.TryGetValue(type, out var count1);
+            eventCounts2.TryGetValue(type, out var count2);
+
+            if (outer)
+            {
+                count1 += change;
+            }
+            else
+            {
+                // those types are handled by state tracker 2
+                if (type != "Click" && type != "DoubleClick" && type != "DragStart" && type != "DragEnd")
+                    count1 += change;
+                count2 += change;
+            }
+
+            AddAssert($"{type} event count {count1}, {count2}", () => s1.CounterFor(type).Count == count1 && s2.CounterFor(type).Count == count2);
+
+            eventCounts1[type] = count1;
+            eventCounts2[type] = count2;
         }
 
         private void checkLastPositionDelta(Func<float> expected) => AddAssert("correct position delta", () =>
@@ -268,11 +367,14 @@ namespace osu.Framework.Tests.Visual
             Precision.AlmostEquals(s1.CounterFor("Scroll").LastState.Mouse.ScrollDelta, expected) &&
             Precision.AlmostEquals(s2.CounterFor("Scroll").LastState.Mouse.ScrollDelta, expected));
 
+        private void checkIsDragged(bool isDragged) => AddAssert(isDragged ? "dragged" : "not dragged", () => s2.IsDragged == isDragged);
+
         public class StateTracker : Container
         {
             private readonly SpriteText keyboard;
             private readonly SpriteText mouse;
             private readonly SpriteText source;
+            protected readonly FillFlowContainer TextContainer;
 
             public EventCounter CounterFor(string type) => counterLookup[type];
 
@@ -284,7 +386,7 @@ namespace osu.Framework.Tests.Visual
                 Margin = new MarginPadding(5);
                 Children = new Drawable[]
                 {
-                    new FillFlowContainer
+                    TextContainer = new FillFlowContainer
                     {
                         Direction = FillDirection.Vertical,
                         Children = new Drawable[]
@@ -295,8 +397,11 @@ namespace osu.Framework.Tests.Visual
                             addCounter(new EventCounter("Scroll")),
                             addCounter(new EventCounter("Move")),
                             addCounter(new EventCounter("DragStart")),
+                            addCounter(new EventCounter("DragEnd")),
                             addCounter(new EventCounter("MouseDown")),
-                            addCounter(new EventCounter("MouseUp"))
+                            addCounter(new EventCounter("MouseUp")),
+                            addCounter(new EventCounter("Click")),
+                            addCounter(new EventCounter("DoubleClick"))
                         }
                     },
                     new BoundedCursorContainer(number)
@@ -306,9 +411,22 @@ namespace osu.Framework.Tests.Visual
             protected override bool OnScroll(InputState state) => CounterFor("Scroll").NewState(state);
             protected override bool OnMouseMove(InputState state) => CounterFor("Move").NewState(state);
             protected override bool OnDragStart(InputState state) => CounterFor("DragStart").NewState(state);
+            protected override bool OnDragEnd(InputState state) => CounterFor("DragEnd").NewState(state);
 
             protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => CounterFor("MouseDown").NewState(state, args);
             protected override bool OnMouseUp(InputState state, MouseUpEventArgs args) => CounterFor("MouseUp").NewState(state, args);
+
+            protected override bool OnClick(InputState state)
+            {
+                CounterFor("Click").NewState(state);
+                return true;
+            }
+
+            protected override bool OnDoubleClick(InputState state)
+            {
+                CounterFor("DoubleClick").NewState(state);
+                return true;
+            }
 
             private EventCounter addCounter(EventCounter counter)
             {
@@ -447,6 +565,29 @@ namespace osu.Framework.Tests.Visual
                 {
                     circle.FadeColour(state.Mouse.HasAnyButtonPressed ? Color4.Green.Lighten((state.Mouse.Buttons.Count() - 1) * 0.3f) : Color4.White, 50);
                 }
+            }
+        }
+
+        public class DraggableStateTracker : StateTracker
+        {
+            private readonly SmallText dragStatus;
+
+            public DraggableStateTracker(int number)
+                : base(number)
+            {
+                TextContainer.Add(dragStatus = new SmallText());
+            }
+
+            protected override bool OnDragStart(InputState state)
+            {
+                base.OnDragStart(state);
+                return true;
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+                dragStatus.Text = $"IsDragged = {IsDragged}";
             }
         }
     }

--- a/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
@@ -336,6 +336,7 @@ namespace osu.Framework.Tests.Visual
 
         private readonly Dictionary<string, int> eventCounts1 = new Dictionary<string, int>(),
                                                  eventCounts2 = new Dictionary<string, int>();
+
         private void checkEventCount(string type, int change = 0, bool outer = false)
         {
             eventCounts1.TryGetValue(type, out var count1);

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -426,12 +426,7 @@ namespace osu.Framework.Input
 
                 if (button == MouseButton.Left)
                 {
-                    if (isDragging)
-                    {
-                        isDragging = false;
-                        handleMouseDragEnd(state);
-                    }
-                    else
+                    if (DraggedDrawable == null || Vector2Extensions.Distance(mouse.PositionMouseDown ?? mouse.Position, mouse.Position) <= click_drag_distance)
                     {
                         bool isValidClick = true;
                         if (Time.Current - lastClickTime < double_click_time)
@@ -449,6 +444,12 @@ namespace osu.Framework.Input
                             lastClickTime = Time.Current;
                             handleMouseClick(state);
                         }
+                    }
+
+                    if (isDragging)
+                    {
+                        isDragging = false;
+                        handleMouseDragEnd(state);
                     }
 
                     mouse.PositionMouseDown = null;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -50,7 +50,10 @@ namespace osu.Framework.Input
         private double keyboardRepeatTime;
         private Key? keyboardRepeatKey;
 
-        private bool isDragging;
+        /// <summary>
+        /// Whether a drag operation has started and <see cref="DraggedDrawable"/> has been searched for.
+        /// </summary>
+        private bool dragStarted;
 
         /// <summary>
         /// The initial input state. <see cref="CurrentState"/> is always equal (as a reference) to the value returned from this.
@@ -387,13 +390,10 @@ namespace osu.Framework.Input
 
             handleMouseMove(state);
 
-            if (!isDragging)
+            if (!dragStarted)
             {
                 if (mouse.IsPressed(MouseButton.Left) && Vector2Extensions.Distance(mouse.PositionMouseDown ?? mouse.Position, mouse.Position) > click_drag_distance)
-                {
-                    isDragging = true;
                     handleMouseDragStart(state);
-                }
             }
             else
             {
@@ -416,8 +416,9 @@ namespace osu.Framework.Input
 
                 if (button == MouseButton.Left)
                 {
-                    mouse.PositionMouseDown = mouse.Position;
-                    isDragging = false;
+                    // only update the mouse down position if we aren't already in a drag.
+                    if (!dragStarted)
+                        mouse.PositionMouseDown = mouse.Position;
                 }
             }
             else
@@ -426,7 +427,7 @@ namespace osu.Framework.Input
 
                 if (button == MouseButton.Left)
                 {
-                    if (DraggedDrawable == null || Vector2Extensions.Distance(mouse.PositionMouseDown ?? mouse.Position, mouse.Position) <= click_drag_distance)
+                    if (DraggedDrawable == null)
                     {
                         bool isValidClick = true;
                         if (Time.Current - lastClickTime < double_click_time)
@@ -446,11 +447,7 @@ namespace osu.Framework.Input
                         }
                     }
 
-                    if (isDragging)
-                    {
-                        isDragging = false;
-                        handleMouseDragEnd(state);
-                    }
+                    handleMouseDragEnd(state);
 
                     mouse.PositionMouseDown = null;
                 }
@@ -599,7 +596,11 @@ namespace osu.Framework.Input
 
         private bool handleMouseDragStart(InputState state)
         {
-            Trace.Assert(DraggedDrawable == null, "The draggingDrawable was not set to null by handleMouseDragEnd.");
+            Trace.Assert(DraggedDrawable == null, $"The {nameof(DraggedDrawable)} was not set to null by {nameof(handleMouseDragEnd)}.");
+            Trace.Assert(!dragStarted, $"A {nameof(DraggedDrawable)} was already searched for. Call {nameof(handleMouseDragEnd)} first.");
+
+            dragStarted = true;
+
             DraggedDrawable = mouseDownInputQueue?.FirstOrDefault(target => target.IsAlive && target.IsPresent && target.TriggerOnDragStart(state));
             if (DraggedDrawable != null)
             {
@@ -612,6 +613,8 @@ namespace osu.Framework.Input
 
         private bool handleMouseDragEnd(InputState state)
         {
+            dragStarted = false;
+
             if (DraggedDrawable == null)
                 return false;
 


### PR DESCRIPTION
- Resolves ppy/osu#2862.

TestCaseMouseStates is modified to add tests for this behavior.

---

The recent rework of InputManager overlooked drag-clicking logic for the case where the object being "dragged" didn't handle the drag. The objects expect to receive click events in this case, as per the previous functionality.