### PR TITLE
Add library loading and load libbass.so globally on linux

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -12,6 +12,7 @@ using osu.Framework.Threading;
 using System.Linq;
 using System.Diagnostics;
 using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Logging;
 
 namespace osu.Framework.Audio
 {
@@ -267,6 +268,12 @@ namespace osu.Framework.Audio
             }
 
             Trace.Assert(Bass.LastError == Errors.OK);
+
+            Logger.Log($@"BASS Initialized
+                          BASS Version:               {Bass.Version}
+                          BASS FX Version:            {ManagedBass.Fx.BassFx.Version}
+                          Device:                     {newDeviceInfo.Name}
+                          Drive:                      {newDeviceInfo.Driver}", LoggingTarget.Runtime, LogLevel.Important);
 
             //we have successfully initialised a new device.
             currentAudioDevice = newDevice;

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -18,8 +18,12 @@ namespace osu.Framework.Platform.Linux
                     OnDeactivated();
             };
             Library.Load("libbass.so", Library.Flags.RTLD_LAZY | Library.Flags.RTLD_GLOBAL);
-            Library.GetBassVersion();
+            Library.LogVersion("libbass.so", GetBassVersion);
+            Library.LogVersion("libbass_fx.so", GetBassFxVersion);
+
         }
+        public static System.Version GetBassVersion() => ManagedBass.Bass.Version;
+        public static System.Version GetBassFxVersion() => ManagedBass.Fx.BassFx.Version;
 
         protected override Storage GetStorage(string baseName) => new LinuxStorage(baseName, this);
 

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -16,6 +16,7 @@ namespace osu.Framework.Platform.Linux
                 else
                     OnDeactivated();
             };
+            Native.Library.LoadLazyGlobal("libbass.so");
         }
 
         protected override Storage GetStorage(string baseName) => new LinuxStorage(baseName, this);

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -4,6 +4,7 @@
 namespace osu.Framework.Platform.Linux
 {
     using Native;
+
     public class LinuxGameHost : DesktopGameHost
     {
         internal LinuxGameHost(string gameName, bool bindIPC = false)
@@ -17,13 +18,9 @@ namespace osu.Framework.Platform.Linux
                 else
                     OnDeactivated();
             };
-            Library.Load("libbass.so", Library.Flags.RTLD_LAZY | Library.Flags.RTLD_GLOBAL);
-            Library.LogVersion("libbass.so", GetBassVersion);
-            Library.LogVersion("libbass_fx.so", GetBassFxVersion);
 
+            Library.Load("libbass.so", Library.Flags.RTLD_LAZY | Library.Flags.RTLD_GLOBAL);
         }
-        public static System.Version GetBassVersion() => ManagedBass.Bass.Version;
-        public static System.Version GetBassFxVersion() => ManagedBass.Fx.BassFx.Version;
 
         protected override Storage GetStorage(string baseName) => new LinuxStorage(baseName, this);
 

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Platform.Linux
                 else
                     OnDeactivated();
             };
-            Native.Library.LoadLazyGlobal("libbass.so");
+            Native.Library.LoadLibrary("libbass.so", "RTLD_GLOBAL+RTLD_LAZY");
         }
 
         protected override Storage GetStorage(string baseName) => new LinuxStorage(baseName, this);

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Platform.Linux
                     OnDeactivated();
             };
 
-            Library.Load("libbass.so", Library.Flags.RTLD_LAZY | Library.Flags.RTLD_GLOBAL);
+            Library.Load("libbass.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
         }
 
         protected override Storage GetStorage(string baseName) => new LinuxStorage(baseName, this);

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -17,7 +17,8 @@ namespace osu.Framework.Platform.Linux
                 else
                     OnDeactivated();
             };
-            Library.LoadLibrary("libbass.so", Library.Flags.RTLD_LAZY | Library.Flags.RTLD_GLOBAL);
+            Library.Load("libbass.so", Library.Flags.RTLD_LAZY | Library.Flags.RTLD_GLOBAL);
+            Library.GetBassVersion();
         }
 
         protected override Storage GetStorage(string baseName) => new LinuxStorage(baseName, this);

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -3,6 +3,7 @@
 
 namespace osu.Framework.Platform.Linux
 {
+    using Native;
     public class LinuxGameHost : DesktopGameHost
     {
         internal LinuxGameHost(string gameName, bool bindIPC = false)
@@ -16,7 +17,7 @@ namespace osu.Framework.Platform.Linux
                 else
                     OnDeactivated();
             };
-            Native.Library.LoadLibrary("libbass.so", "RTLD_GLOBAL+RTLD_LAZY");
+            Library.LoadLibrary("libbass.so", Library.Flags.RTLD_LAZY | Library.Flags.RTLD_GLOBAL);
         }
 
         protected override Storage GetStorage(string baseName) => new LinuxStorage(baseName, this);

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -19,6 +19,7 @@ namespace osu.Framework.Platform.Linux
                     OnDeactivated();
             };
 
+            // required for the time being to address libbass_fx.so load failures (see https://github.com/ppy/osu/issues/2852)
             Library.Load("libbass.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
         }
 

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -1,10 +1,10 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using osu.Framework.Platform.Linux.Native;
+
 namespace osu.Framework.Platform.Linux
 {
-    using Native;
-
     public class LinuxGameHost : DesktopGameHost
     {
         internal LinuxGameHost(string gameName, bool bindIPC = false)

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -11,7 +11,7 @@ namespace osu.Framework.Platform.Linux.Native
         private static extern IntPtr dlopen(string filename, int flags);
         public static void LoadLazyLocal(string filename)
         {
-            dlopen(filename, 0x001); // RTLD_LOCAL + RTLD_NOW
+            dlopen(filename, 0x001); // RTLD_LOCAL + RTLD_LAZY
         }
         public static void LoadNowLocal(string filename)
         {

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -32,25 +32,15 @@ namespace osu.Framework.Platform.Linux.Native
         /// <summary>
         /// Check that bass and bass_fx has been loaded, log the versions.
         /// </summary>
-        public static void GetBassVersion()
+        public static void LogVersion(string libraryName, Func<Version> version)
         {
             try
             {
-                var bassVersion = ManagedBass.Bass.Version;
-                Logger.Log("Libbass.so version = " + bassVersion, LoggingTarget.Runtime, LogLevel.Verbose);
+                Logger.Log(libraryName + " version = " + version(), LoggingTarget.Runtime, LogLevel.Verbose);
             }
             catch (Exception e)
             {
-                Logger.Log("Failed to load libbass, trace: \n" + e, LoggingTarget.Runtime, LogLevel.Important);
-            }
-            try
-            {
-                var bassFxVersion = ManagedBass.Fx.BassFx.Version;
-                Logger.Log("Libbass_fx.so version = " + bassFxVersion, LoggingTarget.Runtime, LogLevel.Verbose);
-            }
-            catch (Exception e)
-            {
-                Logger.Log("Failed to load libbass_fx, trace:\n" + e, LoggingTarget.Runtime, LogLevel.Important);
+                Logger.Log("Failed to load " + libraryName + ", trace: \n" + e, LoggingTarget.Runtime, LogLevel.Important);
             }
         }
     }

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Platform.Linux.Native
     public static class Library
     {
         [DllImport("libdl.so", EntryPoint = "dlopen")]
-        static extern IntPtr dlopen(string filename, int flags);
+        private static extern IntPtr dlopen(string filename, int flags);
         public static void LoadLazyLocal(string filename)
         {
             dlopen(filename, 0x001); // RTLD_LOCAL + RTLD_NOW
@@ -19,11 +19,11 @@ namespace osu.Framework.Platform.Linux.Native
         }
         public static void LoadLazyGlobal(string filename)
         {
-            dlopen(filename, 0x101);
+            dlopen(filename, 0x101); // RTLD_GLOBAL + RTLD_LAZY
         }
         public static void LoadNowGlobal(string filename)
         {
-            dlopen(filename, 0x102);
+            dlopen(filename, 0x102); // RTLD_GLOBAL + RTLD_NOW
         }
     }
 }

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -1,5 +1,6 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
 using System;
 using System.Runtime.InteropServices;
 
@@ -7,8 +8,18 @@ namespace osu.Framework.Platform.Linux.Native
 {
     public static class Library
     {
+        [DllImport("libdl.so", EntryPoint = "dlopen")]
+        private static extern IntPtr dlopen(string library, LoadFlags flags);
+
+        /// <summary>
+        /// Loads a library with an enum of flags to use with dlopen. Uses <see cref="LoadFlags"/> for the flags
+        /// </summary>
+        /// <param name="library">See 'man dlopen' for more information about the flags.</param>>
+        /// <param name="flags">See 'man ld.so' for more information about how the libraries are loaded.</param>>
+        public static void Load(string library, LoadFlags flags) => dlopen(library, flags);
+
         [Flags]
-        public enum Flags
+        public enum LoadFlags
         {
             RTLD_LAZY = 0x00001,
             RTLD_NOW = 0x00002,
@@ -19,15 +30,5 @@ namespace osu.Framework.Platform.Linux.Native
             RTLD_LOCAL = 0x00000,
             RTLD_NODELETE = 0x01000
         }
-
-        [DllImport("libdl.so", EntryPoint = "dlopen")]
-        private static extern IntPtr dlopen(string library, Flags flags);
-
-        /// <summary>
-        /// Loads a library with an enum of flags to use with dlopen. Uses <see cref="Flags"/> for the flags
-        /// <para/>See 'man dlopen' for more information about the flags.
-        /// <para/>See 'man ld.so' for more information about how the libraries are loaded.
-        /// </summary>
-        public static void Load(string library, Flags flags) => dlopen(library, flags);
     }
 }

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -2,51 +2,58 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Logging;
 
 namespace osu.Framework.Platform.Linux.Native
 {
     public static class Library
     {
+        [Flags]
+        public enum Flags
+        {
+            RTLD_LAZY = 0x00001,
+            RTLD_NOW = 0x00002,
+            RTLD_BINDING_MASK = 0x00003,
+            RTLD_NOLOAD = 0x00004,
+            RTLD_DEEPBIND = 0x00008,
+            RTLD_GLOBAL = 0x00100,
+            RTLD_LOCAL = 0x00000,
+            RTLD_NODELETE = 0x01000
+        }
         [DllImport("libdl.so", EntryPoint = "dlopen")]
         private static extern IntPtr dlopen(string library, int flags);
 
         /// <summary>
-        /// Load a library with specified flags as strings, the string only needs to contain the flags you want.
+        /// Loads a library with an enum of flags to use with dlopen. Uses <see cref="Flags"/> for flags
         /// <para/>See 'man dlopen' for more information about the flags.
-        /// <para/>See 'man ld.so for more information about how the libraries are loaded.
+        /// <para/>See 'man ld.so' for more information about how the libraries are loaded.
         /// </summary>
-        public static void LoadLibrary(string library, string flags)
+        public static void LoadLibrary(string library, Flags flags)
         {
-            int flag = 0x00000;
-
-            const int rtld_lazy = 0x00001;
-            const int rtld_now = 0x00002;
-            const int rtld_binding_mask = 0x00003;
-            const int rtld_noload = 0x00004;
-            const int rtld_deepbind = 0x00008;
-            const int rtld_global = 0x00100;
-            const int rtld_local = 0x00000;
-            const int rtld_nodelete = 0x01000;
-
-            if (flags.ToUpper().Contains("RTLD_LAZY"))
-                flag+=rtld_lazy;
-            else if (flags.ToUpper().Contains("RTLD_NOW"))
-                flag+=rtld_now;
-
-            if (flags.ToUpper().Contains("RTLD_BINDING_MASK"))
-                flag+=rtld_binding_mask;
-            if (flags.ToUpper().Contains("RTLD_NOLOAD"))
-                flag+=rtld_noload;
-            if (flags.ToUpper().Contains("RTLD_DEEPBIND"))
-                flag+=rtld_deepbind;
-            if (flags.ToUpper().Contains("RTLD_GLOBAL"))
-                flag+=rtld_global;
-            if (flags.ToUpper().Contains("RTLD_LOCAL"))
-                flag+=rtld_local;
-            if (flags.ToUpper().Contains("RTLD_NODELETE"))
-                flag+=rtld_nodelete;
-
-            dlopen(library, flag);
+            int used_flag = 0x00000;
+            // Combine flags that were used with LoadLibrary into one integer.
+            foreach (var flag in (Flags[]) Enum.GetValues(typeof(Flags)))
+            {
+                if(flags.HasFlag(flag))
+                    used_flag+=(int)flag;
+            }
+            dlopen(library, used_flag);
+            try
+            {
+                var BASS_Version = ManagedBass.Bass.Version;
+            }
+            catch (Exception e)
+            {
+                Logger.Log("Failed to load libbass, trace: \n" + e, LoggingTarget.Runtime, LogLevel.Important);
+            }
+            try
+            {
+                var BASS_FX_Version = ManagedBass.Fx.BassFx.Version;
+            }
+            catch (Exception e)
+            {
+                Logger.Log("Failed to load libbass_fx, trace:\n" + e, LoggingTarget.Runtime, LogLevel.Important);
+            }
         }
     }
 }

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -21,27 +21,23 @@ namespace osu.Framework.Platform.Linux.Native
             RTLD_NODELETE = 0x01000
         }
         [DllImport("libdl.so", EntryPoint = "dlopen")]
-        private static extern IntPtr dlopen(string library, int flags);
+        private static extern IntPtr dlopen(string library, Flags flags);
 
         /// <summary>
-        /// Loads a library with an enum of flags to use with dlopen. Uses <see cref="Flags"/> for flags
+        /// Loads a library with an enum of flags to use with dlopen. Uses <see cref="Flags"/> for the flags
         /// <para/>See 'man dlopen' for more information about the flags.
         /// <para/>See 'man ld.so' for more information about how the libraries are loaded.
         /// </summary>
-        public static void LoadLibrary(string library, Flags flags)
+        public static void Load(string library, Flags flags) => dlopen(library, flags);
+        /// <summary>
+        /// Check that bass and bass_fx has been loaded, log the versions.
+        /// </summary>
+        public static void GetBassVersion()
         {
-            int usedFlag = 0x00000;
-            // Combine flags that were used with LoadLibrary into one integer.
-            foreach (var flag in (Flags[]) Enum.GetValues(typeof(Flags)))
-            {
-                if(flags.HasFlag(flag))
-                    usedFlag+=(int)flag;
-            }
-            dlopen(library, usedFlag);
             try
             {
                 var bassVersion = ManagedBass.Bass.Version;
-                Logger.Log("Libbass.so version = " + bassVersion, LoggingTarget.Runtime, LogLevel.Debug);
+                Logger.Log("Libbass.so version = " + bassVersion, LoggingTarget.Runtime, LogLevel.Verbose);
             }
             catch (Exception e)
             {
@@ -50,7 +46,7 @@ namespace osu.Framework.Platform.Linux.Native
             try
             {
                 var bassFxVersion = ManagedBass.Fx.BassFx.Version;
-                Logger.Log("Libbass_fx.so version = " + bassFxVersion, LoggingTarget.Runtime, LogLevel.Debug);
+                Logger.Log("Libbass_fx.so version = " + bassFxVersion, LoggingTarget.Runtime, LogLevel.Verbose);
             }
             catch (Exception e)
             {

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 using System;
 using System.Runtime.InteropServices;
-using osu.Framework.Logging;
 
 namespace osu.Framework.Platform.Linux.Native
 {
@@ -20,6 +19,7 @@ namespace osu.Framework.Platform.Linux.Native
             RTLD_LOCAL = 0x00000,
             RTLD_NODELETE = 0x01000
         }
+
         [DllImport("libdl.so", EntryPoint = "dlopen")]
         private static extern IntPtr dlopen(string library, Flags flags);
 
@@ -29,19 +29,5 @@ namespace osu.Framework.Platform.Linux.Native
         /// <para/>See 'man ld.so' for more information about how the libraries are loaded.
         /// </summary>
         public static void Load(string library, Flags flags) => dlopen(library, flags);
-        /// <summary>
-        /// Check that bass and bass_fx has been loaded, log the versions.
-        /// </summary>
-        public static void LogVersion(string libraryName, Func<Version> version)
-        {
-            try
-            {
-                Logger.Log(libraryName + " version = " + version());
-            }
-            catch (Exception e)
-            {
-                Logger.Log("Failed to load " + libraryName + ", trace: \n" + e, LoggingTarget.Runtime, LogLevel.Error);
-            }
-        }
     }
 }

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Platform.Linux.Native
             try
             {
                 var bassVersion = ManagedBass.Bass.Version;
-                Logger.Log("Libbass.so version = " + bassVersion, LoggingTarget.Runtime, LogLevel.Verbose);
+                Logger.Log("Libbass.so version = " + bassVersion, LoggingTarget.Runtime, LogLevel.Debug);
             }
             catch (Exception e)
             {
@@ -50,7 +50,7 @@ namespace osu.Framework.Platform.Linux.Native
             try
             {
                 var bassFxVersion = ManagedBass.Fx.BassFx.Version;
-                Logger.Log("Libbass_fx.so version = " + bassFxVersion, LoggingTarget.Runtime, LogLevel.Verbose);
+                Logger.Log("Libbass_fx.so version = " + bassFxVersion, LoggingTarget.Runtime, LogLevel.Debug);
             }
             catch (Exception e)
             {

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+using System;
+using System.Runtime.InteropServices;
+
+namespace osu.Framework.Platform.Linux.Native
+{
+    public static class Library
+    {
+        [DllImport("libdl.so", EntryPoint = "dlopen")]
+        static extern IntPtr dlopen(string filename, int flags);
+        public static void LoadLazyLocal(string filename)
+        {
+            dlopen(filename, 0x001); // RTLD_LOCAL + RTLD_NOW
+        }
+        public static void LoadNowLocal(string filename)
+        {
+            dlopen(filename, 0x002); // RTLD_LOCAL + RTLD_NOW
+        }
+        public static void LoadLazyGlobal(string filename)
+        {
+            dlopen(filename, 0x101);
+        }
+        public static void LoadNowGlobal(string filename)
+        {
+            dlopen(filename, 0x102);
+        }
+    }
+}

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -8,22 +8,45 @@ namespace osu.Framework.Platform.Linux.Native
     public static class Library
     {
         [DllImport("libdl.so", EntryPoint = "dlopen")]
-        private static extern IntPtr dlopen(string filename, int flags);
-        public static void LoadLazyLocal(string filename)
+        private static extern IntPtr dlopen(string library, int flags);
+
+        /// <summary>
+        /// Load a library with specified flags as strings, the string only needs to contain the flags you want.
+        /// <para/>See 'man dlopen' for more information about the flags.
+        /// <para/>See 'man ld.so for more information about how the libraries are loaded.
+        /// </summary>
+        public static void LoadLibrary(string library, string flags)
         {
-            dlopen(filename, 0x001); // RTLD_LOCAL + RTLD_LAZY
-        }
-        public static void LoadNowLocal(string filename)
-        {
-            dlopen(filename, 0x002); // RTLD_LOCAL + RTLD_NOW
-        }
-        public static void LoadLazyGlobal(string filename)
-        {
-            dlopen(filename, 0x101); // RTLD_GLOBAL + RTLD_LAZY
-        }
-        public static void LoadNowGlobal(string filename)
-        {
-            dlopen(filename, 0x102); // RTLD_GLOBAL + RTLD_NOW
+            int flag = 0x00000;
+
+            const int RTLD_LAZY = 0x00001;
+            const int RTLD_NOW = 0x00002;
+            const int RTLD_BINDING_MASK = 0x00003;
+            const int RTLD_NOLOAD = 0x00004;
+            const int RTLD_DEEPBIND = 0x00008;
+            const int RTLD_GLOBAL = 0x00100;
+            const int RTLD_LOCAL = 0x00000;
+            const int RTLD_NODELETE = 0x01000;
+
+            if (flags.Contains("RTLD_LAZY"))
+                flag+=RTLD_LAZY;
+            else if (flags.Contains("RTLD_NOW"))
+                flag+=RTLD_NOW;
+
+            if (flags.Contains("RTLD_BINDING_MASK"))
+                flag+=RTLD_BINDING_MASK;
+            if (flags.Contains("RTLD_NOLOAD"))
+                flag+=RTLD_NOLOAD;
+            if (flags.Contains("RTLD_DEEPBIND"))
+                flag+=RTLD_DEEPBIND;
+            if (flags.Contains("RTLD_GLOBAL"))
+                flag+=RTLD_GLOBAL;
+            if (flags.Contains("RTLD_LOCAL"))
+                flag+=RTLD_LOCAL;
+            if (flags.Contains("RTLD_NODELETE"))
+                flag+=RTLD_NODELETE;
+
+            dlopen(library, flag);
         }
     }
 }

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -19,32 +19,32 @@ namespace osu.Framework.Platform.Linux.Native
         {
             int flag = 0x00000;
 
-            const int RTLD_LAZY = 0x00001;
-            const int RTLD_NOW = 0x00002;
-            const int RTLD_BINDING_MASK = 0x00003;
-            const int RTLD_NOLOAD = 0x00004;
-            const int RTLD_DEEPBIND = 0x00008;
-            const int RTLD_GLOBAL = 0x00100;
-            const int RTLD_LOCAL = 0x00000;
-            const int RTLD_NODELETE = 0x01000;
+            const int rtld_lazy = 0x00001;
+            const int rtld_now = 0x00002;
+            const int rtld_binding_mask = 0x00003;
+            const int rtld_noload = 0x00004;
+            const int rtld_deepbind = 0x00008;
+            const int rtld_global = 0x00100;
+            const int rtld_local = 0x00000;
+            const int rtld_nodelete = 0x01000;
 
-            if (flags.Contains("RTLD_LAZY"))
-                flag+=RTLD_LAZY;
-            else if (flags.Contains("RTLD_NOW"))
-                flag+=RTLD_NOW;
+            if (flags.ToUpper().Contains("RTLD_LAZY"))
+                flag+=rtld_lazy;
+            else if (flags.ToUpper().Contains("RTLD_NOW"))
+                flag+=rtld_now;
 
-            if (flags.Contains("RTLD_BINDING_MASK"))
-                flag+=RTLD_BINDING_MASK;
-            if (flags.Contains("RTLD_NOLOAD"))
-                flag+=RTLD_NOLOAD;
-            if (flags.Contains("RTLD_DEEPBIND"))
-                flag+=RTLD_DEEPBIND;
-            if (flags.Contains("RTLD_GLOBAL"))
-                flag+=RTLD_GLOBAL;
-            if (flags.Contains("RTLD_LOCAL"))
-                flag+=RTLD_LOCAL;
-            if (flags.Contains("RTLD_NODELETE"))
-                flag+=RTLD_NODELETE;
+            if (flags.ToUpper().Contains("RTLD_BINDING_MASK"))
+                flag+=rtld_binding_mask;
+            if (flags.ToUpper().Contains("RTLD_NOLOAD"))
+                flag+=rtld_noload;
+            if (flags.ToUpper().Contains("RTLD_DEEPBIND"))
+                flag+=rtld_deepbind;
+            if (flags.ToUpper().Contains("RTLD_GLOBAL"))
+                flag+=rtld_global;
+            if (flags.ToUpper().Contains("RTLD_LOCAL"))
+                flag+=rtld_local;
+            if (flags.ToUpper().Contains("RTLD_NODELETE"))
+                flag+=rtld_nodelete;
 
             dlopen(library, flag);
         }

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -30,17 +30,18 @@ namespace osu.Framework.Platform.Linux.Native
         /// </summary>
         public static void LoadLibrary(string library, Flags flags)
         {
-            int used_flag = 0x00000;
+            int usedFlag = 0x00000;
             // Combine flags that were used with LoadLibrary into one integer.
             foreach (var flag in (Flags[]) Enum.GetValues(typeof(Flags)))
             {
                 if(flags.HasFlag(flag))
-                    used_flag+=(int)flag;
+                    usedFlag+=(int)flag;
             }
-            dlopen(library, used_flag);
+            dlopen(library, usedFlag);
             try
             {
-                var BASS_Version = ManagedBass.Bass.Version;
+                var bassVersion = ManagedBass.Bass.Version;
+                Logger.Log("Libbass.so version = " + bassVersion, LoggingTarget.Runtime, LogLevel.Verbose);
             }
             catch (Exception e)
             {
@@ -48,7 +49,8 @@ namespace osu.Framework.Platform.Linux.Native
             }
             try
             {
-                var BASS_FX_Version = ManagedBass.Fx.BassFx.Version;
+                var bassFxVersion = ManagedBass.Fx.BassFx.Version;
+                Logger.Log("Libbass_fx.so version = " + bassFxVersion, LoggingTarget.Runtime, LogLevel.Verbose);
             }
             catch (Exception e)
             {

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -36,11 +36,11 @@ namespace osu.Framework.Platform.Linux.Native
         {
             try
             {
-                Logger.Log(libraryName + " version = " + version(), LoggingTarget.Runtime, LogLevel.Verbose);
+                Logger.Log(libraryName + " version = " + version(), LoggingTarget.Runtime);
             }
             catch (Exception e)
             {
-                Logger.Log("Failed to load " + libraryName + ", trace: \n" + e, LoggingTarget.Runtime, LogLevel.Important);
+                Logger.Log("Failed to load " + libraryName + ", trace: \n" + e, LoggingTarget.Runtime, LogLevel.Error);
             }
         }
     }

--- a/osu.Framework/Platform/Linux/Native/Library.cs
+++ b/osu.Framework/Platform/Linux/Native/Library.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Platform.Linux.Native
         {
             try
             {
-                Logger.Log(libraryName + " version = " + version(), LoggingTarget.Runtime);
+                Logger.Log(libraryName + " version = " + version());
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Because libbass_fx does not specify libbass as a dependency, we need  to load libbass globally so that libbass_fx knows where to look for it. This patch also adds a way to load libraries with some of the flags of dlopen.

- Closes https://github.com/ppy/osu/issues/2852

---

Fix beatmaps not playing on linux.