### PR TITLE
Fix KeyBindingContainer incorrectly reading ScrollDelta

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -13,25 +15,208 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing.Input;
+using OpenTK.Input;
 
 namespace osu.Framework.Tests.Visual
 {
-    public class TestCaseKeyBindings : GridTestCase
+    public class TestCaseKeyBindings : TestCase
     {
-        public TestCaseKeyBindings()
-            : base(2, 2)
-        {
+        private readonly ManualInputManager manual;
+        private readonly KeyBindingTester none, noneExact, unique, all;
 
+        public TestCaseKeyBindings()
+        {
+            Child = manual = new ManualInputManager
+            {
+                Child = new GridContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Content = new []
+                    {
+                        new Drawable[]
+                        {
+                            none = new KeyBindingTester(SimultaneousBindingMode.None),
+                            noneExact = new KeyBindingTester(SimultaneousBindingMode.NoneExact)
+                        },
+                        new Drawable[]
+                        {
+                            unique = new KeyBindingTester(SimultaneousBindingMode.Unique),
+                            all = new KeyBindingTester(SimultaneousBindingMode.All)
+                        },
+                    }
+                }
+            };
+
+            AddStep("return input", () => manual.UseParentInput = true);
         }
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
+        private readonly List<Key> pressedKeys = new List<Key>();
+        private readonly List<MouseButton> pressedMouseButtons = new List<MouseButton>();
+        private readonly Dictionary<TestButton, (int OnPressedCount, int OnReleasedCount)> lastEventCounts = new Dictionary<TestButton, (int, int)>();
 
-            Cell(0).Add(new KeyBindingTester(SimultaneousBindingMode.None));
-            Cell(1).Add(new KeyBindingTester(SimultaneousBindingMode.NoneExact));
-            Cell(2).Add(new KeyBindingTester(SimultaneousBindingMode.Unique));
-            Cell(3).Add(new KeyBindingTester(SimultaneousBindingMode.All));
+        private void toggleKey(Key key)
+        {
+            if (!pressedKeys.Contains(key))
+            {
+                pressedKeys.Add(key);
+                AddStep($"press {key}", () => manual.PressKey(key));
+            }
+            else
+            {
+                pressedKeys.Remove(key);
+                AddStep($"release {key}", () => manual.ReleaseKey(key));
+            }
+        }
+        private void toggleMouseButton(MouseButton button)
+        {
+            if (!pressedMouseButtons.Contains(button))
+            {
+                pressedMouseButtons.Add(button);
+                AddStep($"press {button}", () => manual.PressButton(button));
+            }
+            else
+            {
+                pressedMouseButtons.Remove(button);
+                AddStep($"release {button}", () => manual.ReleaseButton(button));
+            }
+        }
+        private void scrollMouseWheel(int dy)
+        {
+            AddStep($"scroll wheel {dy}", () => manual.ScrollVerticalBy(dy));
+        }
+
+        private void check(TestAction action, params (KeyBindingTester tester, int OnPressedDelta, int OnReleasedDelta)[] entries)
+        {
+            AddAssert($"check {action}", () =>
+            {
+                Assert.Multiple(() =>
+                {
+                    foreach (var (tester, onPressedDelta, onReleasedDelta) in entries)
+                    {
+                        var testButton = tester[action];
+                        lastEventCounts.TryGetValue(testButton, out var count);
+                        count.OnPressedCount += onPressedDelta;
+                        count.OnReleasedCount += onReleasedDelta;
+                        lastEventCounts[testButton] = count;
+                        var actual = (testButton.OnPressedCount, testButton.OnReleasedCount);
+                        Assert.AreEqual(count, actual, $"{testButton.Concurrency} {testButton.Action}");
+                    }
+                });
+                return true;
+            });
+        }
+
+        private void checkPressed(TestAction action, int noneDelta, int noneExactDelta, int uniqueDelta, int allDelta)
+        {
+            check(action, (none, noneDelta, 0), (noneExact, noneExactDelta, 0), (unique, uniqueDelta, 0), (all, allDelta, 0));
+        }
+
+        private void checkReleased(TestAction action, int noneDelta, int noneExactDelta, int uniqueDelta, int allDelta)
+        {
+            check(action, (none, 0, noneDelta), (noneExact, 0, noneExactDelta), (unique, 0, uniqueDelta), (all, 0, allDelta));
+        }
+        
+        private void wrapTest(Action inner)
+        {
+            AddStep("init", () =>
+            {
+                manual.UseParentInput = false;
+                foreach (var mode in new[] { none, noneExact, unique, all })
+                {
+                    foreach (var action in Enum.GetValues(typeof(TestAction)).Cast<TestAction>())
+                    {
+                        mode[action].Reset();
+                    }
+                }
+                lastEventCounts.Clear();
+            });
+            pressedKeys.Clear();
+            pressedMouseButtons.Clear();
+            inner();
+            foreach (var key in pressedKeys.ToArray())
+                toggleKey(key);
+            foreach (var button in pressedMouseButtons.ToArray())
+                toggleMouseButton(button);
+            foreach (var mode in new[] { none, noneExact, unique, all })
+            {
+                foreach (var action in Enum.GetValues(typeof(TestAction)).Cast<TestAction>())
+                {
+                    var testButton = mode[action];
+                    Trace.Assert(testButton.OnPressedCount == testButton.OnReleasedCount);
+                }
+            }
+        }
+        
+        [Test]
+        public void SimultaneousBindingModes()
+        {
+            wrapTest(() =>
+            {
+                toggleKey(Key.A);
+                checkPressed(TestAction.A, 1, 1, 1, 1);
+                toggleKey(Key.S);
+                checkReleased(TestAction.A, 1, 1, 0, 0);
+                checkPressed(TestAction.S, 1, 0, 1, 1);
+                toggleKey(Key.A);
+                checkReleased(TestAction.A, 0, 0, 1, 1);
+                checkPressed(TestAction.S, 0, 0, 0, 0);
+                toggleKey(Key.S);
+                checkReleased(TestAction.S, 1, 0, 1, 1);
+
+                toggleKey(Key.D);
+                checkPressed(TestAction.D_or_F, 1, 1, 1, 1);
+                toggleKey(Key.F);
+                check(TestAction.D_or_F, (none, 1, 1), (noneExact, 0, 1), (unique, 0, 0), (all, 1, 0));
+                toggleKey(Key.F);
+                checkReleased(TestAction.D_or_F, 0, 0, 0, 1);
+                toggleKey(Key.D);
+                checkReleased(TestAction.D_or_F, 1, 0, 1, 1);
+            });
+        }
+        
+        [Test]
+        public void ModifierKeys()
+        {
+            wrapTest(() =>
+            {
+                toggleKey(Key.ShiftLeft);
+                checkPressed(TestAction.Shift, 1, 1, 1, 1);
+                toggleKey(Key.A);
+                checkReleased(TestAction.Shift, 1, 1, 0, 0);
+                checkPressed(TestAction.Shift_A, 1, 1, 1, 1);
+                toggleKey(Key.ShiftRight);
+                checkPressed(TestAction.Shift, 0, 0, 0, 0);
+                checkReleased(TestAction.Shift_A, 0, 0, 0, 0);
+                toggleKey(Key.ShiftLeft);
+                checkReleased(TestAction.Shift, 0, 0, 0, 0);
+                checkReleased(TestAction.Shift_A, 0, 0, 0, 0);
+                toggleKey(Key.ShiftRight);
+                checkReleased(TestAction.Shift, 0, 0, 1, 1);
+                checkReleased(TestAction.Shift_A, 1, 1, 1, 1);
+                toggleKey(Key.A);
+
+                toggleKey(Key.ControlLeft);
+                toggleKey(Key.ShiftLeft);
+                checkPressed(TestAction.Ctrl_and_Shift, 1, 1, 1, 1);
+            });
+        }
+
+        [Test]
+        public void MouseScrollAndButtons()
+        {
+            var allPressAndReleased = new[] {(none, 1, 1), (noneExact, 1, 1), (unique, 1, 1), (all, 1, 1)};
+            scrollMouseWheel(1);
+            check(TestAction.MouseWheelUp, allPressAndReleased);
+            scrollMouseWheel(-1);
+            check(TestAction.MouseWheelDown, allPressAndReleased);
+            toggleMouseButton(MouseButton.Left);
+            toggleMouseButton(MouseButton.Left);
+            check(TestAction.LeftMouse, allPressAndReleased);
+            toggleMouseButton(MouseButton.Right);
+            toggleMouseButton(MouseButton.Right);
+            check(TestAction.RightMouse, allPressAndReleased);
         }
 
         private enum TestAction
@@ -50,10 +235,12 @@ namespace osu.Framework.Tests.Visual
             Ctrl_Shift_D_or_F,
             Ctrl,
             Shift,
-            Ctrl_And_Shift,
-            Ctrl_Or_Shift,
+            Ctrl_and_Shift,
+            Ctrl_or_Shift,
             LeftMouse,
-            RightMouse
+            RightMouse,
+            MouseWheelUp,
+            MouseWheelDown
         }
 
         private class TestInputManager : KeyBindingContainer<TestAction>
@@ -86,12 +273,14 @@ namespace osu.Framework.Tests.Visual
 
                 new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl),
                 new KeyBinding(new[] { InputKey.Shift }, TestAction.Shift),
-                new KeyBinding(new[] { InputKey.Control, InputKey.Shift }, TestAction.Ctrl_And_Shift),
-                new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl_Or_Shift),
-                new KeyBinding(new[] { InputKey.Shift }, TestAction.Ctrl_Or_Shift),
+                new KeyBinding(new[] { InputKey.Control, InputKey.Shift }, TestAction.Ctrl_and_Shift),
+                new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl_or_Shift),
+                new KeyBinding(new[] { InputKey.Shift }, TestAction.Ctrl_or_Shift),
 
                 new KeyBinding(new[] { InputKey.MouseLeft }, TestAction.LeftMouse),
                 new KeyBinding(new[] { InputKey.MouseRight }, TestAction.RightMouse),
+                new KeyBinding(new[] { InputKey.MouseWheelUp }, TestAction.MouseWheelUp),
+                new KeyBinding(new[] { InputKey.MouseWheelDown }, TestAction.MouseWheelDown),
             };
 
             protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
@@ -129,14 +318,22 @@ namespace osu.Framework.Tests.Visual
 
         private class TestButton : Button, IKeyBindingHandler<TestAction>
         {
-            private readonly TestAction action;
+            public new readonly TestAction Action;
+            public readonly SimultaneousBindingMode Concurrency;
+            public int OnPressedCount { get; protected set; }
+            public int OnReleasedCount { get; protected set; }
 
-            public TestButton(TestAction action)
+            private readonly Box highlight;
+            private readonly string actionText;
+
+            public TestButton(TestAction action, SimultaneousBindingMode concurrency)
             {
-                this.action = action;
+                Action = action;
+                Concurrency = concurrency;
 
                 BackgroundColour = Color4.SkyBlue;
-                Text = action.ToString().Replace('_', ' ');
+                SpriteText.TextSize *= .8f;
+                actionText = action.ToString().Replace('_', ' ');
 
                 RelativeSizeAxes = Axes.X;
                 Height = 40;
@@ -144,16 +341,36 @@ namespace osu.Framework.Tests.Visual
                 Padding = new MarginPadding(2);
 
                 Background.Alpha = alphaTarget;
+
+                Add(highlight = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0,
+                });
+            }
+
+            protected override void Update()
+            {
+                Text = $"{actionText}: {OnPressedCount}, {OnReleasedCount}";
+                base.Update();
             }
 
             private float alphaTarget = 0.5f;
 
             public bool OnPressed(TestAction action)
             {
-                if (this.action == action)
+                if (Action == action)
                 {
+                    if (Concurrency != SimultaneousBindingMode.All)
+                        Trace.Assert(OnPressedCount == OnReleasedCount);
+                    ++OnPressedCount;
+
                     alphaTarget += 0.2f;
-                    Background.FadeTo(alphaTarget, 100, Easing.OutQuint);
+                    Background.Alpha = alphaTarget;
+
+                    highlight.ClearTransforms();
+                    highlight.Alpha = 1f;
+                    highlight.FadeOut(200);
 
                     return true;
                 }
@@ -163,23 +380,38 @@ namespace osu.Framework.Tests.Visual
 
             public bool OnReleased(TestAction action)
             {
-                if (this.action == action)
+                if (Action == action)
                 {
+                    ++OnReleasedCount;
+                    if (Concurrency != SimultaneousBindingMode.All)
+                        Trace.Assert(OnPressedCount == OnReleasedCount);
+                    else
+                        Trace.Assert(OnReleasedCount <= OnPressedCount);
+
                     alphaTarget -= 0.2f;
-                    Background.FadeTo(alphaTarget, 100, Easing.OutQuint);
+                    Background.Alpha = alphaTarget;
 
                     return true;
                 }
 
                 return false;
             }
+
+            public void Reset()
+            {
+                OnPressedCount = 0;
+                OnReleasedCount = 0;
+            }
         }
 
         private class KeyBindingTester : Container
         {
+            private readonly TestButton[] testButtons;
             public KeyBindingTester(SimultaneousBindingMode concurrency)
             {
                 RelativeSizeAxes = Axes.Both;
+
+                testButtons = Enum.GetValues(typeof(TestAction)).Cast<TestAction>().Select(t => new TestButton(t, concurrency)).ToArray();
 
                 Children = new Drawable[]
                 {
@@ -194,11 +426,13 @@ namespace osu.Framework.Tests.Visual
                         Child = new FillFlowContainer
                         {
                             RelativeSizeAxes = Axes.Both,
-                            ChildrenEnumerable = Enum.GetValues(typeof(TestAction)).Cast<TestAction>().Select(t => new TestButton(t))
+                            Children = testButtons
                         }
                     },
                 };
             }
+
+            public TestButton this[TestAction action] => testButtons.First(x => x.Action == action);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Tests.Visual
                 Child = new GridContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Content = new []
+                    Content = new[]
                     {
                         new Drawable[]
                         {
@@ -69,6 +69,7 @@ namespace osu.Framework.Tests.Visual
                 AddStep($"release {key}", () => manual.ReleaseKey(key));
             }
         }
+
         private void toggleMouseButton(MouseButton button)
         {
             if (!pressedMouseButtons.Contains(button))
@@ -82,6 +83,7 @@ namespace osu.Framework.Tests.Visual
                 AddStep($"release {button}", () => manual.ReleaseButton(button));
             }
         }
+
         private void scrollMouseWheel(int dy)
         {
             AddStep($"scroll wheel {dy}", () => manual.ScrollVerticalBy(dy));
@@ -117,7 +119,7 @@ namespace osu.Framework.Tests.Visual
         {
             check(action, (none, 0, noneDelta), (noneExact, 0, noneExactDelta), (unique, 0, uniqueDelta), (all, 0, allDelta));
         }
-        
+
         private void wrapTest(Action inner)
         {
             AddStep("init", () =>
@@ -130,6 +132,7 @@ namespace osu.Framework.Tests.Visual
                         mode[action].Reset();
                     }
                 }
+
                 lastEventCounts.Clear();
             });
             pressedKeys.Clear();
@@ -148,7 +151,7 @@ namespace osu.Framework.Tests.Visual
                 }
             }
         }
-        
+
         [Test]
         public void SimultaneousBindingModes()
         {
@@ -175,7 +178,7 @@ namespace osu.Framework.Tests.Visual
                 checkReleased(TestAction.D_or_F, 1, 0, 1, 1);
             });
         }
-        
+
         [Test]
         public void ModifierKeys()
         {
@@ -206,7 +209,7 @@ namespace osu.Framework.Tests.Visual
         [Test]
         public void MouseScrollAndButtons()
         {
-            var allPressAndReleased = new[] {(none, 1, 1), (noneExact, 1, 1), (unique, 1, 1), (all, 1, 1)};
+            var allPressAndReleased = new[] { (none, 1, 1), (noneExact, 1, 1), (unique, 1, 1), (all, 1, 1) };
             scrollMouseWheel(1);
             check(TestAction.MouseWheelUp, allPressAndReleased);
             scrollMouseWheel(-1);
@@ -245,28 +248,29 @@ namespace osu.Framework.Tests.Visual
 
         private class TestInputManager : KeyBindingContainer<TestAction>
         {
-            public TestInputManager(SimultaneousBindingMode concurrencyMode = SimultaneousBindingMode.None) : base(concurrencyMode)
+            public TestInputManager(SimultaneousBindingMode concurrencyMode = SimultaneousBindingMode.None)
+                : base(concurrencyMode)
             {
             }
 
             public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
             {
-                new KeyBinding(InputKey.A, TestAction.A ),
-                new KeyBinding(InputKey.S, TestAction.S ),
-                new KeyBinding(InputKey.D, TestAction.D_or_F ),
-                new KeyBinding(InputKey.F, TestAction.D_or_F ),
+                new KeyBinding(InputKey.A, TestAction.A),
+                new KeyBinding(InputKey.S, TestAction.S),
+                new KeyBinding(InputKey.D, TestAction.D_or_F),
+                new KeyBinding(InputKey.F, TestAction.D_or_F),
 
-                new KeyBinding(new[] { InputKey.Control, InputKey.A }, TestAction.Ctrl_A ),
-                new KeyBinding(new[] { InputKey.Control, InputKey.S }, TestAction.Ctrl_S ),
-                new KeyBinding(new[] { InputKey.Control, InputKey.D }, TestAction.Ctrl_D_or_F ),
-                new KeyBinding(new[] { InputKey.Control, InputKey.F }, TestAction.Ctrl_D_or_F ),
+                new KeyBinding(new[] { InputKey.Control, InputKey.A }, TestAction.Ctrl_A),
+                new KeyBinding(new[] { InputKey.Control, InputKey.S }, TestAction.Ctrl_S),
+                new KeyBinding(new[] { InputKey.Control, InputKey.D }, TestAction.Ctrl_D_or_F),
+                new KeyBinding(new[] { InputKey.Control, InputKey.F }, TestAction.Ctrl_D_or_F),
 
-                new KeyBinding(new[] { InputKey.Shift, InputKey.A }, TestAction.Shift_A ),
-                new KeyBinding(new[] { InputKey.Shift, InputKey.S }, TestAction.Shift_S ),
-                new KeyBinding(new[] { InputKey.Shift, InputKey.D }, TestAction.Shift_D_or_F ),
-                new KeyBinding(new[] { InputKey.Shift, InputKey.F }, TestAction.Shift_D_or_F ),
+                new KeyBinding(new[] { InputKey.Shift, InputKey.A }, TestAction.Shift_A),
+                new KeyBinding(new[] { InputKey.Shift, InputKey.S }, TestAction.Shift_S),
+                new KeyBinding(new[] { InputKey.Shift, InputKey.D }, TestAction.Shift_D_or_F),
+                new KeyBinding(new[] { InputKey.Shift, InputKey.F }, TestAction.Shift_D_or_F),
 
-                new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.A }, TestAction.Ctrl_Shift_A ),
+                new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.A }, TestAction.Ctrl_Shift_A),
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.S }, TestAction.Ctrl_Shift_S),
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.D }, TestAction.Ctrl_Shift_D_or_F),
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.F }, TestAction.Ctrl_Shift_D_or_F),
@@ -407,6 +411,7 @@ namespace osu.Framework.Tests.Visual
         private class KeyBindingTester : Container
         {
             private readonly TestButton[] testButtons;
+
             public KeyBindingTester(SimultaneousBindingMode concurrency)
             {
                 RelativeSizeAxes = Axes.Both;

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -64,15 +64,7 @@ namespace osu.Framework.Input.Bindings
         protected override bool OnScroll(InputState state)
         {
             InputKey key = state.Mouse.ScrollDelta.Y > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
-
-            // we need to create a local cloned state to ensure the underlying code in handleNewReleased thinks we are in a sane state,
-            // even though we are pressing and releasing an InputKey in a single frame.
-            // the important part of this cloned state is the value of Scroll reset to zero.
-            var clonedState = state.Clone();
-            clonedState.Mouse = new MouseState();
-            clonedState.Mouse.Buttons.Set(state.Mouse.Buttons);
-
-            return handleNewPressed(state, key, false) | handleNewReleased(clonedState, key);
+            return handleNewPressed(state, key, false) | handleNewReleased(state, key);
         }
 
         internal override bool BuildKeyboardInputQueue(List<Drawable> queue)

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -112,6 +112,7 @@ namespace osu.Framework.Input.Bindings
         private bool handleNewPressed(InputState state, InputKey newKey, bool repeat)
         {
             var pressedCombination = KeyCombination.FromInputState(state);
+            // MouseWheelUp/Down cannot be obtained from KeyCombination.FromInputState so we manually add that here.
             if (!pressedCombination.Keys.Contains(newKey))
                 pressedCombination = new KeyCombination(pressedCombination.Keys.Concat(new[] { newKey }));
 

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -112,6 +112,8 @@ namespace osu.Framework.Input.Bindings
         private bool handleNewPressed(InputState state, InputKey newKey, bool repeat)
         {
             var pressedCombination = KeyCombination.FromInputState(state);
+            if (!pressedCombination.Keys.Contains(newKey))
+                pressedCombination = new KeyCombination(pressedCombination.Keys.Concat(new[] { newKey }));
 
             bool handled = false;
             var bindings = repeat ? KeyBindings : KeyBindings.Except(pressedBindings);

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -249,9 +249,6 @@ namespace osu.Framework.Input.Bindings
             {
                 foreach (var button in state.Mouse.Buttons)
                     keys.Add(FromMouseButton(button));
-
-                if (state.Mouse.ScrollDelta.Y > 0) keys.Add(InputKey.MouseWheelUp);
-                if (state.Mouse.ScrollDelta.Y < 0) keys.Add(InputKey.MouseWheelDown);
             }
 
             if (state.Keyboard != null)


### PR DESCRIPTION
ScrollDelta should be only read at OnScroll.
- Resolves ppy/osu#2872

Also, test cases of KeyBidings are added.