### PR TITLE
Embed JetBrains' annotations assembly during dynamic compilation

### DIFF
--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -127,6 +127,8 @@ namespace osu.Framework.Testing
                     assemblies.Add(ass.Location);
             }
 
+            assemblies.Add(typeof(JetBrains.Annotations.NotNullAttribute).Assembly.Location);
+
             var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
 
             // ReSharper disable once RedundantExplicitArrayCreation this doesn't compile when the array is empty


### PR DESCRIPTION
- Resolves ppy/osu#2656

---

JetBrains [suggest](https://www.jetbrains.com/help/resharper/Code_Analysis__Annotations_in_Source_Code.html#embedding-declarations-of-code-annotations-in-your-source-code) that you can embed annotations in code by using the JetBrains.Annotations namespace. This leads to issues where our code may try to reference internal types from other assemblies instead of JetBrains'.

EF Core does this, as discovered in [this comment](https://github.com/ppy/osu/issues/2656#issuecomment-397685950), leading to osu!-side issues, however this is potentially not limited to EF Core. As such, I'm applying a universal fix at a framework level.