### PR TITLE
Remove escape handling logic from FocusedOverlayContainer

### DIFF
--- a/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using osu.Framework.Input;
-using OpenTK.Input;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -14,21 +12,6 @@ namespace osu.Framework.Graphics.Containers
         public override bool RequestsFocus => State == Visibility.Visible;
 
         public override bool AcceptsFocus => true;
-
-        protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
-        {
-            if (HasFocus && State == Visibility.Visible && !args.Repeat)
-            {
-                switch (args.Key)
-                {
-                    case Key.Escape:
-                        Hide();
-                        return true;
-                }
-            }
-
-            return base.OnKeyDown(state, args);
-        }
 
         protected override void PopIn()
         {


### PR DESCRIPTION
This removes the only handling of the escape key outside of common UI controls (menus/textboxes). I feel this should be up to the developer to decide and implement locally.

In osu!, we allow key binding the "back" key and do not want the escape default to be handled in this way, which is why this change is being made.

---

Allows for applications to decide how they close focused overlays.