### PR TITLE
Expose the ability to kill focus of a textbox

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -617,7 +617,7 @@ namespace osu.Framework.Graphics.UserInterface
                 case Key.KeypadEnter:
                 case Key.Enter:
                     if (ReleaseFocusOnCommit)
-                        KillFocus();
+                        killFocus();
 
                     Background.Colour = ReleaseFocusOnCommit ? BackgroundUnfocused : BackgroundFocused;
                     Background.ClearTransforms();
@@ -631,7 +631,12 @@ namespace osu.Framework.Graphics.UserInterface
             return handledUserTextInput;
         }
 
-        protected virtual void KillFocus()
+        /// <summary>
+        /// Removes focus from this <see cref="TextBox"/> if it currently has focus.
+        /// </summary>
+        protected virtual void KillFocus() => killFocus();
+
+        private void killFocus()
         {
             var manager = GetContainingInputManager();
             if (manager.FocusedDrawable == this)

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -608,7 +608,7 @@ namespace osu.Framework.Graphics.UserInterface
             switch (args.Key)
             {
                 case Key.Escape:
-                    GetContainingInputManager().ChangeFocus(null);
+                    KillFocus();
                     return true;
 
                 case Key.Tab:
@@ -617,7 +617,7 @@ namespace osu.Framework.Graphics.UserInterface
                 case Key.KeypadEnter:
                 case Key.Enter:
                     if (ReleaseFocusOnCommit)
-                        GetContainingInputManager().ChangeFocus(null);
+                        KillFocus();
 
                     Background.Colour = ReleaseFocusOnCommit ? BackgroundUnfocused : BackgroundFocused;
                     Background.ClearTransforms();
@@ -629,6 +629,13 @@ namespace osu.Framework.Graphics.UserInterface
             }
 
             return handledUserTextInput;
+        }
+
+        protected void KillFocus()
+        {
+            var manager = GetContainingInputManager();
+            if (manager.FocusedDrawable == this)
+                manager.ChangeFocus(null);
         }
 
         protected override bool OnKeyUp(InputState state, KeyUpEventArgs args)

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -631,7 +631,7 @@ namespace osu.Framework.Graphics.UserInterface
             return handledUserTextInput;
         }
 
-        protected void KillFocus()
+        protected virtual void KillFocus()
         {
             var manager = GetContainingInputManager();
             if (manager.FocusedDrawable == this)


### PR DESCRIPTION
Required for osu! to provide alternative exit sequences for textboxes.

---
