### PR TITLE
Decouple TextBox blocking behaviour from underlying text consumption

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -619,7 +619,7 @@ namespace osu.Framework.Graphics.UserInterface
                 return false;
 
             // we only care about keys which can result in text output.
-            if (args.Key >= Key.Keypad0)
+            if (keyProducesCharacter(args.Key))
                 BeginConsumingText();
 
             switch (args.Key)
@@ -635,6 +635,8 @@ namespace osu.Framework.Graphics.UserInterface
 
             return base.OnKeyDown(state, args) || consumingText;
         }
+
+        private bool keyProducesCharacter(Key key) => key == Key.Space || key >= Key.Keypad0;
 
         protected void Commit()
         {

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -636,7 +636,7 @@ namespace osu.Framework.Graphics.UserInterface
             return base.OnKeyDown(state, args) || consumingText;
         }
 
-        private bool keyProducesCharacter(Key key) => key == Key.Space || key >= Key.Keypad0;
+        private bool keyProducesCharacter(Key key) => (key == Key.Space || key >= Key.Keypad0) && key != Key.KeypadEnter;
 
         /// <summary>
         /// Removes focus from this <see cref="TextBox"/> if it currently has focus.

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -569,73 +569,90 @@ namespace osu.Framework.Graphics.UserInterface
 
         public string SelectedText => selectionLength > 0 ? Text.Substring(selectionLeft, selectionLength) : string.Empty;
 
-        protected bool HandlePendingText(InputState state)
+        private bool consumingText;
+
+        /// <summary>
+        /// Begin consuming text from an <see cref="ITextInputSource"/>.
+        /// Continues to consume every <see cref="Drawable.Update"/> loop until <see cref="EndConsumingText"/> is called.
+        /// </summary>
+        protected void BeginConsumingText()
         {
-            string str = textInput?.GetPendingText();
-            if (string.IsNullOrEmpty(str) || ReadOnly)
-                return false;
-
-            if (state.Keyboard.ShiftPressed)
-                audio.Sample.Get(@"Keyboard/key-caps")?.Play();
-            else
-                audio.Sample.Get($@"Keyboard/key-press-{RNG.Next(1, 5)}")?.Play();
-            insertString(str);
-
-            // as we are grabbing *all* waiting text, we may receive two or more characters.
-            // each of these characters will still fire OnKeyDown events (which we want to block) so we need to
-            // store our "handled" state until all keys are released.
-            handledUserTextInput = true;
-            return true;
+            consumingText = true;
+            Schedule(consumePendingText);
         }
 
-        private bool handledUserTextInput;
+        /// <summary>
+        /// Stops consuming text from an <see cref="ITextInputSource"/>.
+        /// </summary>
+        protected void EndConsumingText()
+        {
+            consumingText = false;
+        }
+
+        /// <summary>
+        /// Consumes any pending characters and adds them to the textbox if not <see cref="ReadOnly"/>.
+        /// </summary>
+        /// <returns>Whether any characters were consumed.</returns>
+        private void consumePendingText()
+        {
+            string pendingText = textInput?.GetPendingText();
+
+            if (!string.IsNullOrEmpty(pendingText) && !ReadOnly)
+            {
+                if (pendingText.Any(char.IsUpper))
+                    audio.Sample.Get(@"Keyboard/key-caps")?.Play();
+                else
+                    audio.Sample.Get($@"Keyboard/key-press-{RNG.Next(1, 5)}")?.Play();
+
+                insertString(pendingText);
+            }
+
+            if (consumingText)
+                Schedule(consumePendingText);
+        }
 
         protected override bool OnKeyDown(InputState state, KeyDownEventArgs args)
         {
-            if (textInput?.ImeActive == true) return true;
+            if (textInput?.ImeActive == true || ReadOnly) return true;
 
-            if (args.Key <= Key.F35)
+            if (state.Keyboard.ControlPressed || state.Keyboard.SuperPressed)
                 return false;
 
-            if (HandlePendingText(state))
-                return true;
-
-            if (ReadOnly) return true;
-
-            if (state.Keyboard.AltPressed || state.Keyboard.ControlPressed || state.Keyboard.SuperPressed)
-                return false;
+            // we only care about keys which can result in text output.
+            if (args.Key >= Key.Keypad0)
+                BeginConsumingText();
 
             switch (args.Key)
             {
                 case Key.Escape:
                     GetContainingInputManager().ChangeFocus(null);
                     return true;
-
-                case Key.Tab:
-                    return base.OnKeyDown(state, args);
-
                 case Key.KeypadEnter:
                 case Key.Enter:
-                    if (ReleaseFocusOnCommit)
-                        GetContainingInputManager().ChangeFocus(null);
-
-                    Background.Colour = ReleaseFocusOnCommit ? BackgroundUnfocused : BackgroundFocused;
-                    Background.ClearTransforms();
-                    Background.FlashColour(BackgroundCommit, 400);
-
-                    audio.Sample.Get(@"Keyboard/key-confirm")?.Play();
-                    OnCommit?.Invoke(this, true);
+                    Commit();
                     return true;
             }
 
-            return handledUserTextInput;
+            return base.OnKeyDown(state, args) || consumingText;
+        }
+
+        protected void Commit()
+        {
+            if (ReleaseFocusOnCommit)
+                GetContainingInputManager().ChangeFocus(null);
+
+            Background.Colour = ReleaseFocusOnCommit ? BackgroundUnfocused : BackgroundFocused;
+            Background.ClearTransforms();
+            Background.FlashColour(BackgroundCommit, 400);
+
+            audio.Sample.Get(@"Keyboard/key-confirm")?.Play();
+            OnCommit?.Invoke(this, true);
         }
 
         protected override bool OnKeyUp(InputState state, KeyUpEventArgs args)
         {
-            HandlePendingText(state);
-
-            handledUserTextInput &= state.Keyboard.Keys.Any();
+            if (!state.Keyboard.Keys.Any())
+                EndConsumingText();
 
             return base.OnKeyUp(state, args);
         }


### PR DESCRIPTION
Add any details pertaining to developers above the break.

- Closes ppy/osu#2447

---

Fixes keys not always being blocked by text boxes, leading to unexpected UI actions.