### PR TITLE
Make mouse wheel bind actions know amount of scroll

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -423,7 +423,7 @@ namespace osu.Framework.Tests.Visual
                 Text += $", {OnMouseWheelCount}, {LastMouseWheelAmount}";
             }
 
-            public bool OnMouseWheel(TestAction action, float amount, bool isPrecise)
+            public bool OnScroll(TestAction action, float amount, bool isPrecise)
             {
                 if (Action == action)
                 {

--- a/osu.Framework/Input/Bindings/IMouseWheelBindingHandler.cs
+++ b/osu.Framework/Input/Bindings/IMouseWheelBindingHandler.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Input.Bindings
+{
+    /// <summary>
+    /// A drawable that handles mouse wheel actions.
+    /// </summary>
+    /// <typeparam name="T">The type of bindings.</typeparam>
+    public interface IMouseWheelBindingHandler<in T> : IKeyBindingHandler<T>
+        where T : struct
+    {
+        /// <summary>
+        /// Triggered when a scroll action is pressed.
+        /// </summary>
+        /// <remarks>
+        /// When the action is not handled by any <see cref="IMouseWheelBindingHandler{T}"/>, <see cref="IKeyBindingHandler{T}.OnPressed"/> is called.
+        /// In either cases, <see cref="IKeyBindingHandler{T}.OnReleased"/> will be called once.</remarks>
+        /// <param name="action">The action.</param>
+        /// <param name="amount">The amount of mouse wheel move.</param>
+        /// <param name="isPrecise">Whether the action is from a precise scrolling.</param>
+        /// <returns>True if this Drawable handled the event. If false, then the event
+        /// is propagated up the scene graph to the next eligible Drawable.</returns>
+        bool OnMouseWheel(T action, float amount, bool isPrecise);
+    }
+}

--- a/osu.Framework/Input/Bindings/IMouseWheelBindingHandler.cs
+++ b/osu.Framework/Input/Bindings/IMouseWheelBindingHandler.cs
@@ -21,6 +21,6 @@ namespace osu.Framework.Input.Bindings
         /// <param name="isPrecise">Whether the action is from a precise scrolling.</param>
         /// <returns>True if this Drawable handled the event. If false, then the event
         /// is propagated up the scene graph to the next eligible Drawable.</returns>
-        bool OnMouseWheel(T action, float amount, bool isPrecise);
+        bool OnScroll(T action, float amount, bool isPrecise);
     }
 }

--- a/osu.Framework/Input/Bindings/IScrollBindingHandler.cs
+++ b/osu.Framework/Input/Bindings/IScrollBindingHandler.cs
@@ -7,17 +7,17 @@ namespace osu.Framework.Input.Bindings
     /// A drawable that handles mouse wheel actions.
     /// </summary>
     /// <typeparam name="T">The type of bindings.</typeparam>
-    public interface IMouseWheelBindingHandler<in T> : IKeyBindingHandler<T>
+    public interface IScrollBindingHandler<in T> : IKeyBindingHandler<T>
         where T : struct
     {
         /// <summary>
         /// Triggered when a scroll action is pressed.
         /// </summary>
         /// <remarks>
-        /// When the action is not handled by any <see cref="IMouseWheelBindingHandler{T}"/>, <see cref="IKeyBindingHandler{T}.OnPressed"/> is called.
+        /// When the action is not handled by any <see cref="IScrollBindingHandler{T}"/>, <see cref="IKeyBindingHandler{T}.OnPressed"/> is called.
         /// In either cases, <see cref="IKeyBindingHandler{T}.OnReleased"/> will be called once.</remarks>
         /// <param name="action">The action.</param>
-        /// <param name="amount">The amount of mouse wheel move.</param>
+        /// <param name="amount">The amount of mouse scroll.</param>
         /// <param name="isPrecise">Whether the action is from a precise scrolling.</param>
         /// <returns>True if this Drawable handled the event. If false, then the event
         /// is propagated up the scene graph to the next eligible Drawable.</returns>

--- a/osu.Framework/Input/Bindings/IScrollBindingHandler.cs
+++ b/osu.Framework/Input/Bindings/IScrollBindingHandler.cs
@@ -4,7 +4,7 @@
 namespace osu.Framework.Input.Bindings
 {
     /// <summary>
-    /// A drawable that handles mouse wheel actions.
+    /// A drawable that handles scroll actions.
     /// </summary>
     /// <typeparam name="T">The type of bindings.</typeparam>
     public interface IScrollBindingHandler<in T> : IKeyBindingHandler<T>

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -170,7 +170,10 @@ namespace osu.Framework.Input.Bindings
             {
                 pressedActions.Add(pressed);
                 if (wheelAmount != 0)
+                {
+                    // ReSharper disable once SuspiciousCast
                     handled = drawables.OfType<IMouseWheelBindingHandler<T>>().FirstOrDefault(d => d.OnMouseWheel(pressed, wheelAmount, isPrecise));
+                }
                 if (handled == null)
                     handled = drawables.OfType<IKeyBindingHandler<T>>().FirstOrDefault(d => d.OnPressed(pressed));
             }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -123,7 +123,11 @@ namespace osu.Framework.Input.Bindings
 
         private bool handleNewPressed(InputState state, InputKey newKey, bool repeat, Vector2? scrollDelta = null, bool isPrecise = false)
         {
-            var wheelAmount = (newKey == InputKey.MouseWheelUp ? scrollDelta?.Y : newKey == InputKey.MouseWheelDown ? -scrollDelta?.Y : 0) ?? 0;
+            float wheelAmount = 0;
+            if (newKey == InputKey.MouseWheelUp)
+                wheelAmount = scrollDelta?.Y ?? 0;
+            else if (newKey == InputKey.MouseWheelDown)
+                wheelAmount = -(scrollDelta?.Y ?? 0);
             var pressedCombination = KeyCombination.FromInputState(state, scrollDelta);
 
             bool handled = false;

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -8,6 +8,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
+using OpenTK;
 
 namespace osu.Framework.Input.Bindings
 {
@@ -63,8 +64,14 @@ namespace osu.Framework.Input.Bindings
 
         protected override bool OnScroll(InputState state)
         {
-            InputKey key = state.Mouse.ScrollDelta.Y > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
-            return handleNewPressed(state, key, false) | handleNewReleased(state, key);
+            var scrollDelta = state.Mouse.ScrollDelta;
+            var isPrecise = state.Mouse.HasPreciseScroll;
+            if (scrollDelta.Y != 0)
+            {
+                InputKey key = scrollDelta.Y > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
+                return handleNewPressed(state, key, false, scrollDelta, isPrecise) | handleNewReleased(state, key);
+            }
+            return false;
         }
 
         internal override bool BuildKeyboardInputQueue(List<Drawable> queue)
@@ -109,12 +116,10 @@ namespace osu.Framework.Input.Bindings
 
         protected override bool OnJoystickRelease(InputState state, JoystickEventArgs args) => handleNewReleased(state, KeyCombination.FromJoystickButton(args.Button));
 
-        private bool handleNewPressed(InputState state, InputKey newKey, bool repeat)
+        private bool handleNewPressed(InputState state, InputKey newKey, bool repeat, Vector2? scrollDelta = null, bool isPrecise = false)
         {
-            var pressedCombination = KeyCombination.FromInputState(state);
-            // MouseWheelUp/Down cannot be obtained from KeyCombination.FromInputState so we manually add that here.
-            if (!pressedCombination.Keys.Contains(newKey))
-                pressedCombination = new KeyCombination(pressedCombination.Keys.Concat(new[] { newKey }));
+            var wheelAmount = (newKey == InputKey.MouseWheelUp ? scrollDelta?.Y : newKey == InputKey.MouseWheelDown ? -scrollDelta?.Y : 0) ?? 0;
+            var pressedCombination = KeyCombination.FromInputState(state, scrollDelta);
 
             bool handled = false;
             var bindings = repeat ? KeyBindings : KeyBindings.Except(pressedBindings);
@@ -142,7 +147,7 @@ namespace osu.Framework.Input.Bindings
 
             foreach (var newBinding in newlyPressed)
             {
-                handled |= PropagatePressed(KeyBindingInputQueue, newBinding.GetAction<T>());
+                handled |= PropagatePressed(KeyBindingInputQueue, newBinding.GetAction<T>(), wheelAmount, isPrecise);
 
                 // we only want to handle the first valid binding (the one with the most keys) in non-simultaneous mode.
                 if ((simultaneousMode == SimultaneousBindingMode.None || simultaneousMode == SimultaneousBindingMode.NoneExact) && handled)
@@ -152,7 +157,7 @@ namespace osu.Framework.Input.Bindings
             return handled;
         }
 
-        protected virtual bool PropagatePressed(IEnumerable<Drawable> drawables, T pressed)
+        protected virtual bool PropagatePressed(IEnumerable<Drawable> drawables, T pressed, float wheelAmount = 0, bool isPrecise = false)
         {
             IDrawable handled = null;
 
@@ -164,7 +169,10 @@ namespace osu.Framework.Input.Bindings
             if (simultaneousMode == SimultaneousBindingMode.All || !pressedActions.Contains(pressed))
             {
                 pressedActions.Add(pressed);
-                handled = drawables.OfType<IKeyBindingHandler<T>>().FirstOrDefault(d => d.OnPressed(pressed));
+                if (wheelAmount != 0)
+                    handled = drawables.OfType<IMouseWheelBindingHandler<T>>().FirstOrDefault(d => d.OnMouseWheel(pressed, wheelAmount, isPrecise));
+                if (handled == null)
+                    handled = drawables.OfType<IKeyBindingHandler<T>>().FirstOrDefault(d => d.OnPressed(pressed));
             }
 
             if (handled != null)

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -123,11 +123,11 @@ namespace osu.Framework.Input.Bindings
 
         private bool handleNewPressed(InputState state, InputKey newKey, bool repeat, Vector2? scrollDelta = null, bool isPrecise = false)
         {
-            float wheelAmount = 0;
+            float scrollAmount = 0;
             if (newKey == InputKey.MouseWheelUp)
-                wheelAmount = scrollDelta?.Y ?? 0;
+                scrollAmount = scrollDelta?.Y ?? 0;
             else if (newKey == InputKey.MouseWheelDown)
-                wheelAmount = -(scrollDelta?.Y ?? 0);
+                scrollAmount = -(scrollDelta?.Y ?? 0);
             var pressedCombination = KeyCombination.FromInputState(state, scrollDelta);
 
             bool handled = false;
@@ -156,7 +156,7 @@ namespace osu.Framework.Input.Bindings
 
             foreach (var newBinding in newlyPressed)
             {
-                handled |= PropagatePressed(KeyBindingInputQueue, newBinding.GetAction<T>(), wheelAmount, isPrecise);
+                handled |= PropagatePressed(KeyBindingInputQueue, newBinding.GetAction<T>(), scrollAmount, isPrecise);
 
                 // we only want to handle the first valid binding (the one with the most keys) in non-simultaneous mode.
                 if ((simultaneousMode == SimultaneousBindingMode.None || simultaneousMode == SimultaneousBindingMode.NoneExact) && handled)
@@ -166,7 +166,7 @@ namespace osu.Framework.Input.Bindings
             return handled;
         }
 
-        protected virtual bool PropagatePressed(IEnumerable<Drawable> drawables, T pressed, float wheelAmount = 0, bool isPrecise = false)
+        protected virtual bool PropagatePressed(IEnumerable<Drawable> drawables, T pressed, float scrollAmount = 0, bool isPrecise = false)
         {
             IDrawable handled = null;
 
@@ -178,8 +178,8 @@ namespace osu.Framework.Input.Bindings
             if (simultaneousMode == SimultaneousBindingMode.All || !pressedActions.Contains(pressed))
             {
                 pressedActions.Add(pressed);
-                if (wheelAmount != 0)
-                    handled = drawables.OfType<IMouseWheelBindingHandler<T>>().FirstOrDefault(d => d.OnScroll(pressed, wheelAmount, isPrecise));
+                if (scrollAmount != 0)
+                    handled = drawables.OfType<IScrollBindingHandler<T>>().FirstOrDefault(d => d.OnScroll(pressed, scrollAmount, isPrecise));
                 if (handled == null)
                     handled = drawables.OfType<IKeyBindingHandler<T>>().FirstOrDefault(d => d.OnPressed(pressed));
             }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -170,10 +170,7 @@ namespace osu.Framework.Input.Bindings
             {
                 pressedActions.Add(pressed);
                 if (wheelAmount != 0)
-                {
-                    // ReSharper disable once SuspiciousCast
                     handled = drawables.OfType<IMouseWheelBindingHandler<T>>().FirstOrDefault(d => d.OnMouseWheel(pressed, wheelAmount, isPrecise));
-                }
                 if (handled == null)
                     handled = drawables.OfType<IKeyBindingHandler<T>>().FirstOrDefault(d => d.OnPressed(pressed));
             }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -179,7 +179,7 @@ namespace osu.Framework.Input.Bindings
             {
                 pressedActions.Add(pressed);
                 if (wheelAmount != 0)
-                    handled = drawables.OfType<IMouseWheelBindingHandler<T>>().FirstOrDefault(d => d.OnMouseWheel(pressed, wheelAmount, isPrecise));
+                    handled = drawables.OfType<IMouseWheelBindingHandler<T>>().FirstOrDefault(d => d.OnScroll(pressed, wheelAmount, isPrecise));
                 if (handled == null)
                     handled = drawables.OfType<IKeyBindingHandler<T>>().FirstOrDefault(d => d.OnPressed(pressed));
             }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -76,12 +76,9 @@ namespace osu.Framework.Input.Bindings
         {
             var scrollDelta = state.Mouse.ScrollDelta;
             var isPrecise = state.Mouse.HasPreciseScroll;
-            if (scrollDelta.Y != 0)
-            {
-                InputKey key = scrollDelta.Y > 0 ? InputKey.MouseWheelUp : InputKey.MouseWheelDown;
-                return handleNewPressed(state, key, false, scrollDelta, isPrecise) | handleNewReleased(state, key);
-            }
-            return false;
+            var key = KeyCombination.FromScrollDelta(scrollDelta);
+            if (key == InputKey.None) return false;
+            return handleNewPressed(state, key, false, scrollDelta, isPrecise) | handleNewReleased(state, key);
         }
 
         internal override bool BuildKeyboardInputQueue(List<Drawable> queue, bool allowBlocking = true)

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -242,6 +242,13 @@ namespace osu.Framework.Input.Bindings
             return InputKey.FirstJoystickButton + (int)button;
         }
 
+        public static InputKey FromScrollDelta(Vector2 scrollDelta)
+        {
+            if (scrollDelta.Y > 0) return InputKey.MouseWheelUp;
+            if (scrollDelta.Y < 0) return InputKey.MouseWheelDown;
+            return InputKey.None;
+        }
+
         public static KeyCombination FromInputState(InputState state, Vector2? scrollDelta = null)
         {
             List<InputKey> keys = new List<InputKey>();
@@ -252,10 +259,8 @@ namespace osu.Framework.Input.Bindings
                     keys.Add(FromMouseButton(button));
             }
 
-            if (scrollDelta?.Y > 0)
-                keys.Add(InputKey.MouseWheelUp);
-            if (scrollDelta?.Y < 0)
-                keys.Add(InputKey.MouseWheelDown);
+            if (scrollDelta is Vector2 sd && sd.Y != 0)
+                keys.Add(FromScrollDelta(sd));
 
             if (state.Keyboard != null)
             {

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -259,8 +259,8 @@ namespace osu.Framework.Input.Bindings
                     keys.Add(FromMouseButton(button));
             }
 
-            if (scrollDelta is Vector2 sd && sd.Y != 0)
-                keys.Add(FromScrollDelta(sd));
+            if (scrollDelta.HasValue && scrollDelta.Value.Y != 0)
+                keys.Add(FromScrollDelta(scrollDelta.Value));
 
             if (state.Keyboard != null)
             {

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OpenTK;
 using OpenTK.Input;
 
 namespace osu.Framework.Input.Bindings
@@ -241,7 +242,7 @@ namespace osu.Framework.Input.Bindings
             return InputKey.FirstJoystickButton + (int)button;
         }
 
-        public static KeyCombination FromInputState(InputState state)
+        public static KeyCombination FromInputState(InputState state, Vector2? scrollDelta = null)
         {
             List<InputKey> keys = new List<InputKey>();
 
@@ -250,6 +251,11 @@ namespace osu.Framework.Input.Bindings
                 foreach (var button in state.Mouse.Buttons)
                     keys.Add(FromMouseButton(button));
             }
+
+            if (scrollDelta?.Y > 0)
+                keys.Add(InputKey.MouseWheelUp);
+            if (scrollDelta?.Y < 0)
+                keys.Add(InputKey.MouseWheelDown);
 
             if (state.Keyboard != null)
             {


### PR DESCRIPTION
Required for a solution of ppy/osu#2881.

Mouse wheel actions are actions which is bind to mouse wheel. The amount of scroll and whether it is a precise scrolling is informed. In this way we can bind opposite direction of wheel easily for example.
When this type of action is fired then it first searches for `IMouseWheelBindingHandler` and then searchs for usual IKeyBindingHandler.

Also, I made KeyCombination.FromInputState to receive scroll delta if any and essentially rewrote #1648 with a simpler solution.