### PR TITLE
Cleanup ManualInputManager and make a common base class for test cases which use ManualInputManager

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseInputQueueChange.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputQueueChange.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Tests.Visual
                 box2 = new HittableBox(2),
                 box1 = new HittableBox(1),
             };
-            
+
             // TODO: blocking event testing
         }
 

--- a/osu.Framework.Tests/Visual/TestCaseInputQueueChange.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputQueueChange.cs
@@ -9,59 +9,47 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Testing;
-using osu.Framework.Testing.Input;
 using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Input;
 
 namespace osu.Framework.Tests.Visual
 {
-    public class TestCaseInputQueueChange : TestCase
+    public class TestCaseInputQueueChange : ManualInputManagerTestCase
     {
-        private readonly ManualInputManager manual;
-
         private readonly HittableBox box1;
         private readonly HittableBox box2;
         private readonly HittableBox box3;
 
         public TestCaseInputQueueChange()
         {
+            RelativeSizeAxes = Axes.Both;
             Children = new Drawable[]
             {
-                manual = new ManualInputManager
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Children = new Drawable[]
-                    {
-                        box3 = new HittableBox(3),
-                        box2 = new HittableBox(2),
-                        box1 = new HittableBox(1),
-                    }
-                },
+                box3 = new HittableBox(3),
+                box2 = new HittableBox(2),
+                box1 = new HittableBox(1),
             };
-
-            AddStep("return input", () => manual.UseParentInput = true);
-
+            
             // TODO: blocking event testing
         }
 
         [SetUp]
-        public void SetUp()
+        public override void SetUp()
         {
-            // grab manual input control
-            manual.UseParentInput = false;
-            foreach (var b in manual.Children.OfType<HittableBox>())
+            base.SetUp();
+            foreach (var b in Children.OfType<HittableBox>())
                 b.Reset();
         }
 
         [Test]
         public void SeparateClicks()
         {
-            AddStep("move", () => manual.MoveMouseTo(manual.Children.First().ScreenSpaceDrawQuad.Centre));
-            AddStep("press 1", () => manual.PressButton(MouseButton.Button1));
-            AddStep("press 2", () => manual.PressButton(MouseButton.Button2));
-            AddStep("release 1", () => manual.ReleaseButton(MouseButton.Button1));
-            AddStep("release 2", () => manual.ReleaseButton(MouseButton.Button2));
+            AddStep("move", () => InputManager.MoveMouseTo(InputManager.Children.First().ScreenSpaceDrawQuad.Centre));
+            AddStep("press 1", () => InputManager.PressButton(MouseButton.Button1));
+            AddStep("press 2", () => InputManager.PressButton(MouseButton.Button2));
+            AddStep("release 1", () => InputManager.ReleaseButton(MouseButton.Button1));
+            AddStep("release 2", () => InputManager.ReleaseButton(MouseButton.Button2));
             AddAssert("box 1 was pressed", () => box1.HitCount == 1);
             AddAssert("box 2 was pressed", () => box2.HitCount == 1);
             AddAssert("box 3 not pressed", () => box3.HitCount == 0);
@@ -70,16 +58,16 @@ namespace osu.Framework.Tests.Visual
         [Test]
         public void CombinedClicks()
         {
-            AddStep("move", () => manual.MoveMouseTo(manual.Children.First().ScreenSpaceDrawQuad.Centre));
+            AddStep("move", () => InputManager.MoveMouseTo(Children.First().ScreenSpaceDrawQuad.Centre));
             AddStep("press 1+2", () =>
             {
-                manual.PressButton(MouseButton.Button1);
-                manual.PressButton(MouseButton.Button2);
+                InputManager.PressButton(MouseButton.Button1);
+                InputManager.PressButton(MouseButton.Button2);
             });
             AddStep("release 1+2", () =>
             {
-                manual.ReleaseButton(MouseButton.Button1);
-                manual.ReleaseButton(MouseButton.Button2);
+                InputManager.ReleaseButton(MouseButton.Button1);
+                InputManager.ReleaseButton(MouseButton.Button2);
             });
             AddAssert("box 1 was pressed", () => box1.HitCount == 1);
             AddAssert("box 2 was pressed", () => box2.HitCount == 1);

--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -16,40 +16,33 @@ using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing.Input;
 using OpenTK.Input;
 
 namespace osu.Framework.Tests.Visual
 {
-    public class TestCaseKeyBindings : TestCase
+    public class TestCaseKeyBindings : ManualInputManagerTestCase
     {
-        private readonly ManualInputManager manual;
         private readonly KeyBindingTester none, noneExact, unique, all;
 
         public TestCaseKeyBindings()
         {
-            Child = manual = new ManualInputManager
+            Child = new GridContainer
             {
-                Child = new GridContainer
+                RelativeSizeAxes = Axes.Both,
+                Content = new[]
                 {
-                    RelativeSizeAxes = Axes.Both,
-                    Content = new[]
+                    new Drawable[]
                     {
-                        new Drawable[]
-                        {
-                            none = new KeyBindingTester(SimultaneousBindingMode.None),
-                            noneExact = new KeyBindingTester(SimultaneousBindingMode.NoneExact)
-                        },
-                        new Drawable[]
-                        {
-                            unique = new KeyBindingTester(SimultaneousBindingMode.Unique),
-                            all = new KeyBindingTester(SimultaneousBindingMode.All)
-                        },
-                    }
+                        none = new KeyBindingTester(SimultaneousBindingMode.None),
+                        noneExact = new KeyBindingTester(SimultaneousBindingMode.NoneExact)
+                    },
+                    new Drawable[]
+                    {
+                        unique = new KeyBindingTester(SimultaneousBindingMode.Unique),
+                        all = new KeyBindingTester(SimultaneousBindingMode.All)
+                    },
                 }
             };
-
-            AddStep("return input", () => manual.UseParentInput = true);
         }
 
         private readonly List<Key> pressedKeys = new List<Key>();
@@ -61,12 +54,12 @@ namespace osu.Framework.Tests.Visual
             if (!pressedKeys.Contains(key))
             {
                 pressedKeys.Add(key);
-                AddStep($"press {key}", () => manual.PressKey(key));
+                AddStep($"press {key}", () => InputManager.PressKey(key));
             }
             else
             {
                 pressedKeys.Remove(key);
-                AddStep($"release {key}", () => manual.ReleaseKey(key));
+                AddStep($"release {key}", () => InputManager.ReleaseKey(key));
             }
         }
 
@@ -75,18 +68,18 @@ namespace osu.Framework.Tests.Visual
             if (!pressedMouseButtons.Contains(button))
             {
                 pressedMouseButtons.Add(button);
-                AddStep($"press {button}", () => manual.PressButton(button));
+                AddStep($"press {button}", () => InputManager.PressButton(button));
             }
             else
             {
                 pressedMouseButtons.Remove(button);
-                AddStep($"release {button}", () => manual.ReleaseButton(button));
+                AddStep($"release {button}", () => InputManager.ReleaseButton(button));
             }
         }
 
         private void scrollMouseWheel(int dy)
         {
-            AddStep($"scroll wheel {dy}", () => manual.ScrollVerticalBy(dy));
+            AddStep($"scroll wheel {dy}", () => InputManager.ScrollVerticalBy(dy));
         }
 
         private void check(TestAction action, params CheckConditions[] entries)
@@ -135,7 +128,6 @@ namespace osu.Framework.Tests.Visual
         {
             AddStep("init", () =>
             {
-                manual.UseParentInput = false;
                 foreach (var mode in new[] { none, noneExact, unique, all })
                 {
                     foreach (var action in Enum.GetValues(typeof(TestAction)).Cast<TestAction>())
@@ -143,7 +135,6 @@ namespace osu.Framework.Tests.Visual
                         mode[action].Reset();
                     }
                 }
-
                 lastEventCounts.Clear();
             });
             pressedKeys.Clear();

--- a/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
@@ -12,7 +12,6 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Testing;
-using osu.Framework.Testing.Input;
 using OpenTK;
 using OpenTK.Graphics;
 using OpenTK.Input;
@@ -21,94 +20,85 @@ using osu.Framework.MathUtils;
 
 namespace osu.Framework.Tests.Visual
 {
-    public class TestCaseMouseStates : TestCase
+    public class TestCaseMouseStates : ManualInputManagerTestCase
     {
         private readonly Box marginBox, outerMarginBox;
-        private readonly ManualInputManager manual;
         private readonly FrameworkActionContainer actionContainer;
 
         private readonly StateTracker s1, s2;
 
         public TestCaseMouseStates()
         {
-            Children = new Drawable[]
-            {
-                new StateTracker(0),
-                manual = new ManualInputManager
+            Child = new Container {
+                FillMode = FillMode.Fit,
+                FillAspectRatio = 1,
+                RelativeSizeAxes = Axes.Both,
+                Size = new Vector2(0.75f),
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Children = new Drawable[]
                 {
-                    FillMode = FillMode.Fit,
-                    FillAspectRatio = 1,
-                    RelativeSizeAxes = Axes.Both,
-                    Size = new Vector2(0.75f),
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    Children = new Drawable[]
+                    new Box
                     {
-                        new Box
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = new Color4(1, 1, 1, 0.2f),
+                    },
+                    s1 = new StateTracker(1),
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Children = new Drawable[]
                         {
-                            RelativeSizeAxes = Axes.Both,
-                            Colour = new Color4(1, 1, 1, 0.2f),
-                        },
-                        s1 = new StateTracker(1),
-                        new Container
-                        {
-                            RelativeSizeAxes = Axes.Both,
-                            Children = new Drawable[]
+                            outerMarginBox = new Box
                             {
-                                outerMarginBox = new Box
+                                RelativeSizeAxes = Axes.Both,
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Size = new Vector2(0.9f),
+                                Colour = Color4.SkyBlue.Opacity(0.1f),
+                            },
+                            actionContainer = new FrameworkActionContainer
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Size = new Vector2(0.6f),
+                                Anchor = Anchor.Centre,
+                                Origin = Anchor.Centre,
+                                Children = new Drawable[]
                                 {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Size = new Vector2(0.9f),
-                                    Colour = Color4.SkyBlue.Opacity(0.1f),
-                                },
-                                actionContainer = new FrameworkActionContainer
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Size = new Vector2(0.6f),
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Children = new Drawable[]
+                                    new Box
                                     {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = new Color4(1, 1, 1, 0.2f),
-                                        },
-                                        marginBox = new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Anchor = Anchor.Centre,
-                                            Origin = Anchor.Centre,
-                                            Size = new Vector2(0.8f),
-                                            Colour = Color4.SkyBlue.Opacity(0.1f),
-                                        },
-                                        s2 = new DraggableStateTracker(2),
-                                    }
+                                        RelativeSizeAxes = Axes.Both,
+                                        Colour = new Color4(1, 1, 1, 0.2f),
+                                    },
+                                    marginBox = new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre,
+                                        Size = new Vector2(0.8f),
+                                        Colour = Color4.SkyBlue.Opacity(0.1f),
+                                    },
+                                    s2 = new DraggableStateTracker(2),
                                 }
                             }
-                        },
+                        }
                     }
                 }
             };
-
-            AddStep("return input", () => manual.UseParentInput = true);
         }
 
-        [SetUp]
-        public void SetUp()
+        protected override void LoadComplete()
         {
-            // grab manual input control
-            manual.UseParentInput = false;
-            manual.MoveMouseTo(actionContainer);
+            ((Container)InputManager.Parent).Add(new StateTracker(0));
         }
+
+        protected override Vector2? InitialMousePosition => actionContainer.LayoutRectangle.Centre;
 
         private void initTestCase()
         {
             eventCounts1.Clear();
             eventCounts2.Clear();
-            AddStep("move mouse to center", () => manual.MoveMouseTo(actionContainer));
+            AddStep("move mouse to center", () => InputManager.MoveMouseTo(actionContainer));
             AddStep("reset event counters", () =>
             {
                 s1.Reset();
@@ -121,12 +111,12 @@ namespace osu.Framework.Tests.Visual
         {
             initTestCase();
 
-            AddStep("scroll some", () => manual.ScrollBy(new Vector2(-1, 1)));
+            AddStep("scroll some", () => InputManager.ScrollBy(new Vector2(-1, 1)));
             checkEventCount("Move");
             checkEventCount("Scroll", 1);
             checkLastScrollDelta(new Vector2(-1, 1));
 
-            AddStep("scroll some", () => manual.ScrollBy(new Vector2(1, -1)));
+            AddStep("scroll some", () => InputManager.ScrollBy(new Vector2(1, -1)));
             checkEventCount("Scroll", 1);
             checkLastScrollDelta(new Vector2(1, -1));
         }
@@ -136,23 +126,23 @@ namespace osu.Framework.Tests.Visual
         {
             initTestCase();
 
-            AddStep("push move", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
+            AddStep("push move", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
             checkEventCount("Move", 1);
             checkEventCount("Scroll");
 
-            AddStep("push move", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopRight));
+            AddStep("push move", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopRight));
             checkEventCount("Move", 1);
             checkEventCount("Scroll");
             checkLastPositionDelta(() => marginBox.ScreenSpaceDrawQuad.Width);
 
-            AddStep("push move", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomRight));
+            AddStep("push move", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomRight));
             checkEventCount("Move", 1);
             checkLastPositionDelta(() => marginBox.ScreenSpaceDrawQuad.Height);
 
             AddStep("push two moves", () =>
             {
-                manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft);
-                manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft);
+                InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft);
+                InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft);
             });
             checkEventCount("Move", 2);
             checkLastPositionDelta(() => Vector2.Distance(marginBox.ScreenSpaceDrawQuad.TopLeft, marginBox.ScreenSpaceDrawQuad.BottomLeft));
@@ -163,45 +153,45 @@ namespace osu.Framework.Tests.Visual
         {
             initTestCase();
 
-            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
+            AddStep("press left button", () => InputManager.PressButton(MouseButton.Left));
             checkEventCount("MouseDown", 1);
 
-            AddStep("press right button", () => manual.PressButton(MouseButton.Right));
+            AddStep("press right button", () => InputManager.PressButton(MouseButton.Right));
             checkEventCount("MouseDown", 1);
 
-            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            AddStep("release left button", () => InputManager.ReleaseButton(MouseButton.Left));
             checkEventCount("MouseUp", 1);
 
-            AddStep("release right button", () => manual.ReleaseButton(MouseButton.Right));
+            AddStep("release right button", () => InputManager.ReleaseButton(MouseButton.Right));
             checkEventCount("MouseUp", 1);
 
             AddStep("press three buttons", () =>
             {
-                manual.PressButton(MouseButton.Left);
-                manual.PressButton(MouseButton.Right);
-                manual.PressButton(MouseButton.Button1);
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.PressButton(MouseButton.Right);
+                InputManager.PressButton(MouseButton.Button1);
             });
             checkEventCount("MouseDown", 3);
 
             AddStep("Release mouse buttons", () =>
             {
-                manual.ReleaseButton(MouseButton.Left);
-                manual.ReleaseButton(MouseButton.Right);
-                manual.ReleaseButton(MouseButton.Button1);
+                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.ReleaseButton(MouseButton.Right);
+                InputManager.ReleaseButton(MouseButton.Button1);
             });
             checkEventCount("MouseUp", 3);
 
             AddStep("press two buttons", () =>
             {
-                manual.PressButton(MouseButton.Left);
-                manual.ReleaseButton(MouseButton.Left);
-                manual.PressButton(MouseButton.Right);
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.PressButton(MouseButton.Right);
             });
 
             checkEventCount("MouseDown", 2);
             checkEventCount("MouseUp", 1);
 
-            AddStep("release", () => manual.ReleaseButton(MouseButton.Right));
+            AddStep("release", () => InputManager.ReleaseButton(MouseButton.Right));
 
             checkEventCount("Move");
             checkEventCount("MouseUp", 1);
@@ -212,15 +202,15 @@ namespace osu.Framework.Tests.Visual
         {
             initTestCase();
 
-            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
+            AddStep("press left button", () => InputManager.PressButton(MouseButton.Left));
             checkEventCount("MouseDown", 1);
             checkIsDragged(false);
 
-            AddStep("move bottom left", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft));
+            AddStep("move bottom left", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft));
             checkEventCount("DragStart", 1);
             checkIsDragged(true);
 
-            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            AddStep("release left button", () => InputManager.ReleaseButton(MouseButton.Left));
             checkEventCount("MouseUp", 1);
             checkIsDragged(false);
         }
@@ -230,13 +220,13 @@ namespace osu.Framework.Tests.Visual
         {
             initTestCase();
 
-            AddStep("push move", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft));
+            AddStep("push move", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft));
             checkEventCount("Move", 1);
 
             AddStep("push move and scroll", () =>
             {
-                manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.Centre);
-                manual.ScrollBy(new Vector2(1, 2));
+                InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.Centre);
+                InputManager.ScrollBy(new Vector2(1, 2));
             });
 
             checkEventCount("Move", 1);
@@ -244,15 +234,15 @@ namespace osu.Framework.Tests.Visual
             checkLastScrollDelta(new Vector2(1, 2));
             checkLastPositionDelta(() => Vector2.Distance(marginBox.ScreenSpaceDrawQuad.BottomLeft, marginBox.ScreenSpaceDrawQuad.Centre));
 
-            AddStep("Move mouse to out of bounds", () => manual.MoveMouseTo(Vector2.Zero));
+            AddStep("Move mouse to out of bounds", () => InputManager.MoveMouseTo(Vector2.Zero));
 
             checkEventCount("Move");
             checkEventCount("Scroll");
 
             AddStep("Move mouse", () =>
             {
-                manual.MoveMouseTo(new Vector2(10));
-                manual.ScrollBy(new Vector2(10));
+                InputManager.MoveMouseTo(new Vector2(10));
+                InputManager.ScrollBy(new Vector2(10));
             });
 
             // outside the bounds so should not increment.
@@ -266,33 +256,33 @@ namespace osu.Framework.Tests.Visual
             initTestCase();
 
             // mouseDown on a non-draggable -> mouseUp on a distant position: drag-clicking
-            AddStep("move mouse", () => manual.MoveMouseTo(outerMarginBox.ScreenSpaceDrawQuad.TopLeft));
-            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
+            AddStep("move mouse", () => InputManager.MoveMouseTo(outerMarginBox.ScreenSpaceDrawQuad.TopLeft));
+            AddStep("press left button", () => InputManager.PressButton(MouseButton.Left));
             checkEventCount("DragStart");
-            AddStep("drag non-draggable", () => manual.MoveMouseTo(marginBox));
+            AddStep("drag non-draggable", () => InputManager.MoveMouseTo(marginBox));
             checkEventCount("DragStart", 1, true);
-            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            AddStep("release left button", () => InputManager.ReleaseButton(MouseButton.Left));
             checkEventCount("Click", 1, true);
             checkEventCount("DragEnd");
 
             // mouseDown on a draggable -> mouseUp on the original position: no drag-clicking
-            AddStep("move mouse", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
-            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
-            AddStep("drag draggable", () => manual.MoveMouseTo(outerMarginBox.ScreenSpaceDrawQuad.BottomRight));
+            AddStep("move mouse", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
+            AddStep("press left button", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("drag draggable", () => InputManager.MoveMouseTo(outerMarginBox.ScreenSpaceDrawQuad.BottomRight));
             checkEventCount("DragStart", 1);
             checkIsDragged(true);
-            AddStep("return mouse position", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
+            AddStep("return mouse position", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.TopLeft));
             checkIsDragged(true);
             checkEventCount("DragEnd");
-            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            AddStep("release left button", () => InputManager.ReleaseButton(MouseButton.Left));
             checkEventCount("Click");
             checkEventCount("DragEnd", 1);
             checkIsDragged(false);
 
             // mouseDown on a draggable -> mouseUp on a distant position: no drag-clicking
-            AddStep("press left button", () => manual.PressButton(MouseButton.Left));
-            AddStep("drag draggable", () => manual.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomRight));
-            AddStep("release left button", () => manual.ReleaseButton(MouseButton.Left));
+            AddStep("press left button", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("drag draggable", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomRight));
+            AddStep("release left button", () => InputManager.ReleaseButton(MouseButton.Left));
             checkEventCount("DragStart", 1);
             checkEventCount("DragEnd", 1);
             checkEventCount("Click");
@@ -304,25 +294,25 @@ namespace osu.Framework.Tests.Visual
             initTestCase();
 
             waitDoubleClickTime();
-            AddStep("click", () => manual.Click(MouseButton.Left));
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
             checkEventCount("Click", 1);
             waitDoubleClickTime();
-            AddStep("click", () => manual.Click(MouseButton.Left));
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
             checkEventCount("Click", 1);
             waitDoubleClickTime();
             AddStep("double click", () =>
             {
-                manual.Click(MouseButton.Left);
-                manual.Click(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
             });
             checkEventCount("Click", 1);
             checkEventCount("DoubleClick", 1);
             waitDoubleClickTime();
             AddStep("triple click", () =>
             {
-                manual.Click(MouseButton.Left);
-                manual.Click(MouseButton.Left);
-                manual.Click(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
+                InputManager.Click(MouseButton.Left);
             });
             checkEventCount("Click", 2);
             checkEventCount("DoubleClick", 1);

--- a/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
@@ -29,7 +29,8 @@ namespace osu.Framework.Tests.Visual
 
         public TestCaseMouseStates()
         {
-            Child = new Container {
+            Child = new Container
+            {
                 FillMode = FillMode.Fit,
                 FillAspectRatio = 1,
                 RelativeSizeAxes = Axes.Both,

--- a/osu.Framework.Tests/Visual/TestCaseNestedMenus.cs
+++ b/osu.Framework.Tests/Visual/TestCaseNestedMenus.cs
@@ -10,13 +10,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
-using osu.Framework.Testing.Input;
 using OpenTK;
 using OpenTK.Input;
 
 namespace osu.Framework.Tests.Visual
 {
-    public class TestCaseNestedMenus : TestCase
+    public class TestCaseNestedMenus : ManualInputManagerTestCase
     {
         private const int max_depth = 5;
         private const int max_count = 5;
@@ -25,29 +24,26 @@ namespace osu.Framework.Tests.Visual
 
         private Random rng;
 
-        private ManualInputManager inputManager;
         private MenuStructure menus;
 
         [SetUp]
-        public void SetUp()
+        public override void SetUp()
         {
+            base.SetUp();
             Clear();
 
             rng = new Random(1337);
 
             Menu menu;
-            Add(inputManager = new ManualInputManager
+            Children = new Drawable[]
             {
-                Children = new Drawable[]
+                new CursorContainer(),
+                new Container
                 {
-                    new CursorContainer(),
-                    new Container
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        Child = menu = createMenu()
-                    }
+                    RelativeSizeAxes = Axes.Both,
+                    Child = menu = createMenu()
                 }
-            });
+            };
 
             menus = new MenuStructure(menu);
         }
@@ -83,7 +79,7 @@ namespace osu.Framework.Tests.Visual
         [Test]
         public void TestAlwaysOpen()
         {
-            AddStep("Click outside", () => inputManager.Click(MouseButton.Left));
+            AddStep("Click outside", () => InputManager.Click(MouseButton.Left));
             AddAssert("Check AlwaysOpen = true", () => menus.GetSubMenu(0).State == MenuState.Open);
         }
 
@@ -94,7 +90,7 @@ namespace osu.Framework.Tests.Visual
         public void TestHoverState()
         {
             AddAssert("Check submenu closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetMenuItems()[0]));
+            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetMenuItems()[0]));
             AddAssert("Check item hovered", () => menus.GetMenuItems()[0].IsHovered);
         }
 
@@ -104,10 +100,10 @@ namespace osu.Framework.Tests.Visual
         [Test]
         public void TestTopLevelMenu()
         {
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItems()[0]));
+            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItems()[0]));
             AddAssert("Check closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
             AddAssert("Check closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
-            AddStep("Click item", () => inputManager.Click(MouseButton.Left));
+            AddStep("Click item", () => InputManager.Click(MouseButton.Left));
             AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
         }
 
@@ -154,10 +150,10 @@ namespace osu.Framework.Tests.Visual
         public void TestHoverOpen()
         {
             AddStep("Click item", () => clickItem(0, 1));
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[0]));
+            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[0]));
             AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
             AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(2).GetMenuItems()[0]));
+            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(2).GetMenuItems()[0]));
             AddAssert("Check closed", () => menus.GetSubMenu(3)?.State != MenuState.Open);
             AddAssert("Check open", () => menus.GetSubMenu(3).State == MenuState.Open);
         }
@@ -181,7 +177,7 @@ namespace osu.Framework.Tests.Visual
             });
 
             AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItems()[1]));
+            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItems()[1]));
             AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
 
             AddAssert("Check new items", () => !menus.GetSubMenu(1).Items.SequenceEqual(currentItems));
@@ -211,13 +207,13 @@ namespace osu.Framework.Tests.Visual
         public void TestDelayedHoverChange()
         {
             AddStep("Click item", () => clickItem(0, 2));
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[0]));
+            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[0]));
             AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
             AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
 
             AddStep("Hover item", () =>
             {
-                inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[1]);
+                InputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[1]);
             });
 
             AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
@@ -256,9 +252,9 @@ namespace osu.Framework.Tests.Visual
             for (int i = 3; i >= 1; i--)
             {
                 int menuIndex = i;
-                AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItems()[0]));
+                AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItems()[0]));
                 AddAssert("Check submenu open", () => menus.GetSubMenu(menuIndex + 1).State == MenuState.Open);
-                AddStep("Click item", () => inputManager.Click(MouseButton.Left));
+                AddStep("Click item", () => InputManager.Click(MouseButton.Left));
                 AddAssert("Check all open", () =>
                 {
                     for (int j = 0; j <= menuIndex; j++)
@@ -343,10 +339,10 @@ namespace osu.Framework.Tests.Visual
                 }
 
                 if (hoverPrevious && i > 0)
-                    AddStep("Hover previous", () => inputManager.MoveMouseTo(menus.GetSubStructure(i2 - 1).GetMenuItems()[i2 > 1 ? 0 : 1]));
+                    AddStep("Hover previous", () => InputManager.MoveMouseTo(menus.GetSubStructure(i2 - 1).GetMenuItems()[i2 > 1 ? 0 : 1]));
 
-                AddStep("Remove hover", () => inputManager.MoveMouseTo(Vector2.Zero));
-                AddStep("Click outside", () => inputManager.Click(MouseButton.Left));
+                AddStep("Remove hover", () => InputManager.MoveMouseTo(Vector2.Zero));
+                AddStep("Click outside", () => InputManager.Click(MouseButton.Left));
                 AddAssert("Check submenus closed", () =>
                 {
                     for (int j = 1; j <= i2 + 1; j++)
@@ -370,7 +366,7 @@ namespace osu.Framework.Tests.Visual
             AddStep("Click item", () => clickItem(0, 2));
             AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
 
-            AddStep("Hover item", () => inputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[1]));
+            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[1]));
             AddAssert("Check closed 1", () => menus.GetSubMenu(2)?.State != MenuState.Open);
             AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
             AddAssert("Check selected index 1", () => menus.GetSubStructure(1).GetSelectedIndex() == 1);
@@ -393,8 +389,8 @@ namespace osu.Framework.Tests.Visual
         /// <param name="itemIndex">The item to click in the menu.</param>
         private void clickItem(int menuIndex, int itemIndex)
         {
-            inputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItems()[itemIndex]);
-            inputManager.Click(MouseButton.Left);
+            InputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItems()[itemIndex]);
+            InputManager.Click(MouseButton.Left);
         }
 
         private MenuItem generateRandomMenuItem(string name = "Menu Item", int currDepth = 1)

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -20,100 +20,36 @@ namespace osu.Framework.Testing.Input
             AddHandler(handler = new ManualInputHandler());
         }
 
-        public void PressKey(Key key)
+        public void Input(IInput input)
         {
             UseParentInput = false;
-            handler.PressKey(key);
+            handler.EnqueueInput(input);
         }
 
-        public void ReleaseKey(Key key)
-        {
-            UseParentInput = false;
-            handler.ReleaseKey(key);
-        }
+        public void PressKey(Key key) => Input(new KeyboardKeyInput(key, true));
+        public void ReleaseKey(Key key) => Input(new KeyboardKeyInput(key, false));
 
-        public void ScrollBy(Vector2 delta)
-        {
-            UseParentInput = false;
-            handler.ScrollBy(delta);
-        }
+        public void ScrollBy(Vector2 delta, bool isPrecise = false) => Input(new MouseScrollRelativeInput { Delta = delta, IsPrecise = isPrecise });
+        public void ScrollHorizontalBy(float delta, bool isPrecise = false) => ScrollBy(new Vector2(delta, 0), isPrecise);
+        public void ScrollVerticalBy(float delta, bool isPrecise = false) => ScrollBy(new Vector2(0, delta), isPrecise);
 
-        public void ScrollHorizontalBy(float delta) => ScrollBy(new Vector2(delta, 0));
-
-        public void ScrollVerticalBy(float delta) => ScrollBy(new Vector2(0, delta));
-
-        public void MoveMouseTo(Drawable drawable)
-        {
-            UseParentInput = false;
-            MoveMouseTo(drawable.ToScreenSpace(drawable.LayoutRectangle.Centre));
-        }
-
-        public void MoveMouseTo(Vector2 position)
-        {
-            UseParentInput = false;
-            handler.MoveMouseTo(position);
-        }
+        public void MoveMouseTo(Drawable drawable) => MoveMouseTo(drawable.ToScreenSpace(drawable.LayoutRectangle.Centre));
+        public void MoveMouseTo(Vector2 position) => Input(new MousePositionAbsoluteInput { Position = position });
 
         public void Click(MouseButton button)
         {
-            UseParentInput = false;
-            handler.Click(button);
+            PressButton(button);
+            ReleaseButton(button);
         }
 
-        public void PressButton(MouseButton button)
-        {
-            UseParentInput = false;
-            handler.PressButton(button);
-        }
-
-        public void ReleaseButton(MouseButton button)
-        {
-            UseParentInput = false;
-            handler.ReleaseButton(button);
-        }
+        public void PressButton(MouseButton button) => Input(new MouseButtonInput(button, true));
+        public void ReleaseButton(MouseButton button) => Input(new MouseButtonInput(button, false));
+        
+        public void PressJoystickButton(JoystickButton button) => Input(new JoystickButtonInput(button, true));
+        public void ReleaseJoystickButton(JoystickButton button) => Input(new JoystickButtonInput(button, false));
 
         private class ManualInputHandler : InputHandler
         {
-            public void PressKey(Key key)
-            {
-                PendingInputs.Enqueue(new KeyboardKeyInput(key, true));
-            }
-
-            public void ReleaseKey(Key key)
-            {
-                PendingInputs.Enqueue(new KeyboardKeyInput(key, false));
-            }
-
-            public void PressButton(MouseButton button)
-            {
-                PendingInputs.Enqueue(new MouseButtonInput(button, true));
-            }
-
-            public void ReleaseButton(MouseButton button)
-            {
-                PendingInputs.Enqueue(new MouseButtonInput(button, false));
-            }
-
-            public void ScrollBy(Vector2 delta)
-            {
-                PendingInputs.Enqueue(new MouseScrollRelativeInput { Delta = delta, IsPrecise = false });
-            }
-
-            public void ScrollVerticalBy(float delta) => ScrollBy(new Vector2(0, delta));
-
-            public void ScrollHorizontalBy(float delta) => ScrollBy(new Vector2(delta, 0));
-
-            public void MoveMouseTo(Vector2 position)
-            {
-                PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = position });
-            }
-
-            public void Click(MouseButton button)
-            {
-                PressButton(button);
-                ReleaseButton(button);
-            }
-
             public override bool Initialize(GameHost host) => true;
             public override bool IsActive => true;
             public override int Priority => 0;

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Testing.Input
 
         public void PressButton(MouseButton button) => Input(new MouseButtonInput(button, true));
         public void ReleaseButton(MouseButton button) => Input(new MouseButtonInput(button, false));
-        
+
         public void PressJoystickButton(JoystickButton button) => Input(new JoystickButtonInput(button, true));
         public void ReleaseJoystickButton(JoystickButton button) => Input(new JoystickButtonInput(button, false));
 

--- a/osu.Framework/Testing/ManualInputManagerTestCase.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestCase.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing.Input;
+using OpenTK;
+
+namespace osu.Framework.Testing
+{
+    /// <summary>
+    /// An abstract test case which is tested with manual input management.
+    /// </summary>
+    public abstract class ManualInputManagerTestCase : TestCase
+    {
+        protected override Container<Drawable> Content => InputManager;
+
+        protected virtual Vector2? InitialMousePosition => null;
+
+        protected ManualInputManager InputManager { get; }
+
+        protected ManualInputManagerTestCase()
+        {
+            base.Content.Add(InputManager = new ManualInputManager());
+            AddStep("return user input", () => InputManager.UseParentInput = true);
+        }
+
+        protected void ResetInput()
+        {
+            InputManager.UseParentInput = false;
+            var currentState = InputManager.CurrentState;
+
+            var mouse = currentState.Mouse;
+            var position = InitialMousePosition;
+            if (position != null) InputManager.MoveMouseTo(position.Value);
+            mouse.Buttons.ForEach(InputManager.ReleaseButton);
+
+            var keyboard = currentState.Keyboard;
+            keyboard.Keys.ForEach(InputManager.ReleaseKey);
+        }
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            ResetInput();
+        }
+    }
+}

--- a/osu.Framework/Testing/ManualInputManagerTestCase.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestCase.cs
@@ -39,6 +39,9 @@ namespace osu.Framework.Testing
 
             var keyboard = currentState.Keyboard;
             keyboard.Keys.ForEach(InputManager.ReleaseKey);
+
+            var joystick = currentState.Joystick;
+            joystick.Buttons.ForEach(InputManager.ReleaseJoystickButton);
         }
 
         [SetUp]

--- a/osu.Framework/Testing/ManualInputManagerTestCase.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestCase.cs
@@ -17,8 +17,15 @@ namespace osu.Framework.Testing
     {
         protected override Container<Drawable> Content => InputManager;
 
+        /// <summary>
+        /// The position which is used to initialize the mouse position before at setup.
+        /// If the value is null, the mouse position is not moved.
+        /// </summary>
         protected virtual Vector2? InitialMousePosition => null;
 
+        /// <summary>
+        /// The <see cref="ManualInputManager"/>.
+        /// </summary>
         protected ManualInputManager InputManager { get; }
 
         protected ManualInputManagerTestCase()
@@ -27,6 +34,9 @@ namespace osu.Framework.Testing
             AddStep("return user input", () => InputManager.UseParentInput = true);
         }
 
+        /// <summary>
+        /// Releases all pressed keys and buttons and initialize mouse position.
+        /// </summary>
         protected void ResetInput()
         {
             InputManager.UseParentInput = false;


### PR DESCRIPTION
- Cleanup ManualInputManager
  - Add support for joystick button, precise scrolling and arbitrary `IInput`.
- ManualInputManagerTestCase
  - Automatically initialize input state for each test case setup. This prevents a test fail when manually test using the test browser.
  - Use this for existing tests.
  - I noticed that osu.Game has ManualInputManagerTestCase after coded. This framework's version cannot replace that because the osu.Game version is an OsuTestCase and this is completely independent to that for now.