### PR TITLE
Compute CircularContainer's corner radius as late as possible

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseCircularContainerSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseCircularContainerSizing.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using OpenTK;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseCircularContainerSizing : TestCase
+    {
+        [Test]
+        public void TestLateSizing()
+        {
+            HookedContainer container;
+            CircularContainer circular;
+            Child = container = new HookedContainer
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Child = circular = new CircularContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Masking = true,
+                    Child = new Box { RelativeSizeAxes = Axes.Both }
+                }
+            };
+
+            container.OnUpdate = () => onUpdate(container);
+            container.OnUpdateAfterChildren = () => onUpdateAfterChildren(container, circular);
+
+            bool hasCorrectCornerRadius = false;
+
+            AddAssert("has correct corner radius", () => hasCorrectCornerRadius);
+
+            void onUpdate(Container parent)
+            {
+                // Suppose the parent has some arbitrary size prior to the child being updated...
+                parent.Size = Vector2.One;
+            }
+
+            void onUpdateAfterChildren(Container parent, CircularContainer nested)
+            {
+                // ... and the size of the parent is changed to the desired value after the child has been updated
+                // This could happen just by ordering of events in the hierarchy, regardless of auto or relative size
+                parent.Size = new Vector2(200);
+                hasCorrectCornerRadius = nested.CornerRadius == 100;
+            }
+        }
+
+        private class HookedContainer : Container
+        {
+            public new Action OnUpdate;
+            public Action OnUpdateAfterChildren;
+
+            protected override void Update()
+            {
+                base.Update();
+                OnUpdate?.Invoke();
+            }
+
+            protected override void UpdateAfterChildren()
+            {
+                OnUpdateAfterChildren?.Invoke();
+                base.UpdateAfterChildren();
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CircularContainer.cs
+++ b/osu.Framework/Graphics/Containers/CircularContainer.cs
@@ -12,7 +12,10 @@ namespace osu.Framework.Graphics.Containers
     {
         internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex)
         {
+            // this shouldn't have to be done here, but it's the only place it works correctly.
+            // see https://github.com/ppy/osu-framework/pull/1666
             CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) / 2f;
+
             return base.GenerateDrawNodeSubtree(frame, treeIndex);
         }
     }

--- a/osu.Framework/Graphics/Containers/CircularContainer.cs
+++ b/osu.Framework/Graphics/Containers/CircularContainer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using osu.Framework.Caching;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -11,27 +10,10 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public class CircularContainer : Container
     {
-        private Cached cornerRadius = new Cached();
-
-        public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
+        internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex)
         {
-            bool result = base.Invalidate(invalidation, source, shallPropagate);
-
-            if ((invalidation & (Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit)) > 0)
-                cornerRadius.Invalidate();
-
-            return result;
-        }
-
-        protected override void UpdateAfterAutoSize()
-        {
-            base.UpdateAfterAutoSize();
-
-            if (!cornerRadius.IsValid)
-            {
-                CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) / 2f;
-                cornerRadius.Validate();
-            }
+            CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) / 2f;
+            return base.GenerateDrawNodeSubtree(frame, treeIndex);
         }
     }
 }


### PR DESCRIPTION
- Closes ppy/osu#2578

PRing while testing in osu!.

This is a temporary fix, while ppy/osu-framework#1665 is a thing.

I removed the `Cached` here because we are guaranteed to have `DrawSize` validated here (`UpdateSubTreeMasking` has run), and thus this is not an expensive computation.

---

Fixes random squares appearing instead of circles for 1 frame in various areas.