### PR TITLE
Fix specific scenarios where Drawables can get drawn before they're updated

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseUpdateBeforeDraw.cs
+++ b/osu.Framework.Tests/Visual/TestCaseUpdateBeforeDraw.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Tests.Visual
+{
+    [Description("Tests whether drawable updates occur before drawing.")]
+    public class TestCaseUpdateBeforeDraw : TestCase
+    {
+        /// <summary>
+        /// Tests whether a <see cref="Drawable"/> is updated before being drawn when it is added to a parent
+        /// late enough into the frame that the <see cref="Drawable"/> shouldn't be drawn for the frame.
+        /// </summary>
+        [Test]
+        public void TestUpdateBeforeDrawFromLateAddition()
+        {
+            var receiver = new Container
+            {
+                Size = new Vector2(100),
+                Child = new Box
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(50),
+                    Colour = Color4.Red
+                }
+            };
+
+            var sender = new HookableContainer();
+            var greenBox = new TestBox { Colour = Color4.Green };
+
+            Children = new Drawable[]
+            {
+                new SpriteText { Text = "Red box should be visible, green should not be visible" },
+                // Order is important
+                receiver,
+                sender,
+            };
+
+            sender.OnUpdateAfterChildren = () => receiver.Add(greenBox);
+
+            AddStep("wait one frame", () => { });
+            AddAssert("green not present", () => !greenBox.IsPresent);
+        }
+
+        private class HookableContainer : Container
+        {
+            /// <summary>
+            /// Invoked once.
+            /// </summary>
+            public Action OnUpdateAfterChildren;
+
+            private bool hasInvoked;
+
+            protected override void UpdateAfterChildren()
+            {
+                base.UpdateAfterChildren();
+
+                if (hasInvoked)
+                    return;
+                hasInvoked = true;
+
+                OnUpdateAfterChildren?.Invoke();
+            }
+        }
+
+        /// <summary>
+        /// A box which sets its alpha to 0 in <see cref="Update"/> if it hasn't been drawn yet.
+        /// </summary>
+        private class TestBox : Box
+        {
+            private bool hasDrawn;
+
+            public TestBox()
+            {
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                Size = new Vector2(50);
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                if (hasDrawn)
+                    return;
+
+                Alpha = 0;
+            }
+
+            internal override DrawNode GenerateDrawNodeSubtree(ulong frame, int treeIndex)
+            {
+                hasDrawn = true;
+                return base.GenerateDrawNodeSubtree(frame, treeIndex);
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -328,9 +328,6 @@ namespace osu.Framework.Graphics.Containers
 
             internalChildren.Add(drawable);
 
-            if (LoadState >= LoadState.Ready)
-                checkChildLife(drawable);
-
             if (AutoSizeAxes != Axes.None)
                 InvalidateFromChild(Invalidation.RequiredParentSizeToFit, drawable);
         }


### PR DESCRIPTION
Relates to ppy/osu#2578

We don't want the drawables to come alive and then proceed to potentially not be updated for the rest of the frame, and then being drawn.

---