### PR TITLE
Manage separately for each mouse button

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
@@ -317,7 +317,7 @@ namespace osu.Framework.Tests.Visual
             checkEventCount("Click", 2);
             checkEventCount("DoubleClick", 1);
         }
-        
+
         [Test]
         public void SeparateMouseDown()
         {

--- a/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMouseStates.cs
@@ -93,13 +93,12 @@ namespace osu.Framework.Tests.Visual
             ((Container)InputManager.Parent).Add(new StateTracker(0));
         }
 
-        protected override Vector2? InitialMousePosition => actionContainer.LayoutRectangle.Centre;
+        protected override Vector2? InitialMousePosition => actionContainer.ScreenSpaceDrawQuad.Centre;
 
         private void initTestCase()
         {
             eventCounts1.Clear();
             eventCounts2.Clear();
-            AddStep("move mouse to center", () => InputManager.MoveMouseTo(actionContainer));
             AddStep("reset event counters", () =>
             {
                 s1.Reset();
@@ -317,6 +316,21 @@ namespace osu.Framework.Tests.Visual
             });
             checkEventCount("Click", 2);
             checkEventCount("DoubleClick", 1);
+        }
+        
+        [Test]
+        public void SeparateMouseDown()
+        {
+            initTestCase();
+
+            AddStep("right down", () => InputManager.PressButton(MouseButton.Right));
+            checkEventCount("MouseDown", 1);
+            AddStep("move away", () => InputManager.MoveMouseTo(outerMarginBox.ScreenSpaceDrawQuad.TopLeft));
+            AddStep("left click", () => InputManager.Click(MouseButton.Left));
+            checkEventCount("MouseDown", 1, true);
+            checkEventCount("MouseUp", 1, true);
+            AddStep("right up", () => InputManager.ReleaseButton(MouseButton.Right));
+            checkEventCount("MouseUp", 1);
         }
 
         private void waitDoubleClickTime()

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -125,9 +125,7 @@ namespace osu.Framework.Input
         {
             foreach (var button in Enum.GetValues(typeof(MouseButton)).Cast<MouseButton>())
             {
-                var manager = button == MouseButton.Left ?
-                    new MouseLeftButtonEventManager(this, button) as MouseButtonEventManager : 
-                    new MouseMinorButtonEventManager(this, button);
+                var manager = button == MouseButton.Left ? new MouseLeftButtonEventManager(this, button) as MouseButtonEventManager : new MouseMinorButtonEventManager(this, button);
                 mouseButtonEventManagers.Add(button, manager);
             }
         }
@@ -408,7 +406,7 @@ namespace osu.Framework.Input
         {
             handleScroll(state);
         }
-        
+
         public void HandleMouseButtonStateChange(InputState state, MouseButton button, ButtonStateChangeKind kind)
         {
             if (mouseButtonEventManagers.TryGetValue(button, out var manager))
@@ -594,7 +592,6 @@ namespace osu.Framework.Input
         public override bool ChangeFocusForClick => true;
     }
 
-    
     public class MouseMinorButtonEventManager : MouseButtonEventManager
     {
         public MouseMinorButtonEventManager(InputManager inputManager, MouseButton button)

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -29,31 +28,14 @@ namespace osu.Framework.Input
         /// </summary>
         private const int repeat_tick_rate = 70;
 
-        /// <summary>
-        /// The maximum time between two clicks for a double-click to be considered.
-        /// </summary>
-        private const int double_click_time = 250;
-
-        /// <summary>
-        /// The distance that must be moved until a dragged click becomes invalid.
-        /// </summary>
-        private const float click_drag_distance = 10;
-
         protected GameHost Host;
 
         internal Drawable FocusedDrawable;
 
         protected abstract IEnumerable<InputHandler> InputHandlers { get; }
 
-        private double lastClickTime;
-
         private double keyboardRepeatTime;
         private Key? keyboardRepeatKey;
-
-        /// <summary>
-        /// Whether a drag operation has started and <see cref="DraggedDrawable"/> has been searched for.
-        /// </summary>
-        private bool dragStarted;
 
         /// <summary>
         /// The initial input state. <see cref="CurrentState"/> is always equal (as a reference) to the value returned from this.
@@ -74,7 +56,14 @@ namespace osu.Framework.Input
         /// <summary>
         /// The <see cref="Drawable"/> which is currently being dragged. null if none is.
         /// </summary>
-        public Drawable DraggedDrawable { get; private set; }
+        public Drawable DraggedDrawable
+        {
+            get
+            {
+                mouseButtonEventManagers.TryGetValue(MouseButton.Left, out var manager);
+                return manager?.DraggedDrawable;
+            }
+        }
 
         /// <summary>
         /// Contains the previously hovered <see cref="Drawable"/>s prior to when
@@ -118,6 +107,8 @@ namespace osu.Framework.Input
         /// </summary>
         public IEnumerable<Drawable> InputQueue => buildInputQueue();
 
+        private readonly Dictionary<MouseButton, MouseButtonEventManager> mouseButtonEventManagers = new Dictionary<MouseButton, MouseButtonEventManager>();
+
         protected InputManager()
         {
             CurrentState = CreateInitialState();
@@ -128,6 +119,17 @@ namespace osu.Framework.Input
         private void load(GameHost host)
         {
             Host = host;
+        }
+
+        protected override void LoadComplete()
+        {
+            foreach (var button in Enum.GetValues(typeof(MouseButton)).Cast<MouseButton>())
+            {
+                var manager = button == MouseButton.Left ?
+                    new MouseLeftButtonEventManager(this, button) as MouseButtonEventManager : 
+                    new MouseMinorButtonEventManager(this, button);
+                mouseButtonEventManagers.Add(button, manager);
+            }
         }
 
         /// <summary>
@@ -396,14 +398,9 @@ namespace osu.Framework.Input
 
             handleMouseMove(state);
 
-            if (!dragStarted)
+            foreach (var manager in mouseButtonEventManagers.Values)
             {
-                if (mouse.IsPressed(MouseButton.Left) && Vector2Extensions.Distance(mouse.PositionMouseDown ?? mouse.Position, mouse.Position) > click_drag_distance)
-                    handleMouseDragStart(state);
-            }
-            else
-            {
-                handleMouseDrag(state);
+                manager.HandlePositionChange(state);
             }
         }
 
@@ -411,52 +408,12 @@ namespace osu.Framework.Input
         {
             handleScroll(state);
         }
-
-        public virtual void HandleMouseButtonStateChange(InputState state, MouseButton button, ButtonStateChangeKind kind)
+        
+        public void HandleMouseButtonStateChange(InputState state, MouseButton button, ButtonStateChangeKind kind)
         {
-            var mouse = state.Mouse;
-
-            if (kind == ButtonStateChangeKind.Pressed)
+            if (mouseButtonEventManagers.TryGetValue(button, out var manager))
             {
-                handleMouseDown(state, button);
-
-                if (button == MouseButton.Left)
-                {
-                    // only update the mouse down position if we aren't already in a drag.
-                    if (!dragStarted)
-                        mouse.PositionMouseDown = mouse.Position;
-                }
-            }
-            else
-            {
-                handleMouseUp(state, button);
-
-                if (button == MouseButton.Left)
-                {
-                    if (DraggedDrawable == null)
-                    {
-                        bool isValidClick = true;
-                        if (Time.Current - lastClickTime < double_click_time)
-                        {
-                            if (handleMouseDoubleClick(state))
-                            {
-                                //when we handle a double-click we want to block a normal click from firing.
-                                isValidClick = false;
-                                lastClickTime = 0;
-                            }
-                        }
-
-                        if (isValidClick)
-                        {
-                            lastClickTime = Time.Current;
-                            handleMouseClick(state);
-                        }
-                    }
-
-                    handleMouseDragEnd(state);
-
-                    mouse.PositionMouseDown = null;
-                }
+                manager.HandleButtonStateChange(state, kind);
             }
         }
 
@@ -464,171 +421,9 @@ namespace osu.Framework.Input
         {
         }
 
-        private List<Drawable> mouseDownInputQueue;
-
-        private bool handleMouseDown(InputState state, MouseButton button)
-        {
-            MouseDownEventArgs args = new MouseDownEventArgs
-            {
-                Button = button
-            };
-
-            var positionalInputQueue = PositionalInputQueue.ToList();
-            var result = PropagateMouseDown(positionalInputQueue, state, args, out Drawable handledBy);
-
-            // only drawables up to the one that handled mouse down should handle mouse up
-            mouseDownInputQueue = positionalInputQueue;
-            if (result)
-            {
-                var count = mouseDownInputQueue.IndexOf(handledBy) + 1;
-                mouseDownInputQueue.RemoveRange(count, mouseDownInputQueue.Count - count);
-            }
-
-            return result;
-        }
-
-        private bool handleMouseUp(InputState state, MouseButton button)
-        {
-            if (mouseDownInputQueue == null) return false;
-
-            MouseUpEventArgs args = new MouseUpEventArgs
-            {
-                Button = button
-            };
-
-            //extra check for IsAlive because we are using an outdated queue.
-            return PropagateMouseUp(mouseDownInputQueue.Where(target => target.IsAlive && target.IsPresent), state, args);
-        }
-
-        /// <summary>
-        /// Triggers mouse up events on drawables in <paramref cref="drawables"/> until it is handled.
-        /// </summary>
-        /// <param name="drawables">The drawables in the queue.</param>
-        /// <param name="state">The input state.</param>
-        /// <param name="args">The args.</param>
-        /// <returns>Whether the mouse up event was handled.</returns>
-        protected virtual bool PropagateMouseUp(IEnumerable<Drawable> drawables, InputState state, MouseUpEventArgs args)
-        {
-            var handledBy = drawables.FirstOrDefault(target => target.TriggerOnMouseUp(state, args));
-
-            if (handledBy != null)
-                Logger.Log($"MouseUp ({args.Button}) handled by {handledBy}.", LoggingTarget.Runtime, LogLevel.Debug);
-
-            return handledBy != null;
-        }
-
-        /// <summary>
-        /// Triggers mouse down events on drawables in <paramref cref="drawables"/> until it is handled.
-        /// </summary>
-        /// <param name="drawables">The drawables in the queue.</param>
-        /// <param name="state">The input state.</param>
-        /// <param name="args">The args.</param>
-        /// <param name="handledBy"></param>
-        /// <returns>Whether the mouse down event was handled.</returns>
-        protected virtual bool PropagateMouseDown(IEnumerable<Drawable> drawables, InputState state, MouseDownEventArgs args, out Drawable handledBy)
-        {
-            handledBy = drawables.FirstOrDefault(target => target.TriggerOnMouseDown(state, args));
-
-            if (handledBy != null)
-                Logger.Log($"MouseDown ({args.Button}) handled by {handledBy}.", LoggingTarget.Runtime, LogLevel.Debug);
-
-            return handledBy != null;
-        }
-
         private bool handleMouseMove(InputState state)
         {
             return PositionalInputQueue.Any(target => target.TriggerOnMouseMove(state));
-        }
-
-        private Drawable clickedDrawable;
-
-        private bool handleMouseClick(InputState state)
-        {
-            var intersectingQueue = PositionalInputQueue.Intersect(mouseDownInputQueue);
-
-            Drawable focusTarget = null;
-
-            // click pass, triggering an OnClick on all drawables up to the first which returns true.
-            // an extra IsHovered check is performed because we are using an outdated queue (for valid reasons which we need to document).
-            clickedDrawable = intersectingQueue.FirstOrDefault(t => t.CanReceiveMouseInput && t.ReceiveMouseInputAt(state.Mouse.Position) && t.TriggerOnClick(state));
-
-            if (clickedDrawable != null)
-            {
-                focusTarget = clickedDrawable;
-
-                if (!focusTarget.AcceptsFocus)
-                {
-                    // search upwards from the clicked drawable until we find something to handle focus.
-                    Drawable previousFocused = FocusedDrawable;
-
-                    while (focusTarget?.AcceptsFocus == false)
-                        focusTarget = focusTarget.Parent;
-
-                    if (focusTarget != null && previousFocused != null)
-                    {
-                        // we found a focusable target above us.
-                        // now search upwards from previousFocused to check whether focusTarget is a common parent.
-                        Drawable search = previousFocused;
-                        while (search != null && search != focusTarget)
-                            search = search.Parent;
-
-                        if (focusTarget == search)
-                            // we have a common parent, so let's keep focus on the previously focused target.
-                            focusTarget = previousFocused;
-                    }
-                }
-            }
-
-            ChangeFocus(focusTarget, state);
-
-            if (clickedDrawable != null)
-                Logger.Log($"MouseClick handled by {clickedDrawable}.", LoggingTarget.Runtime, LogLevel.Debug);
-
-            return clickedDrawable != null;
-        }
-
-        private bool handleMouseDoubleClick(InputState state)
-        {
-            if (clickedDrawable == null) return false;
-
-            return clickedDrawable.ReceiveMouseInputAt(state.Mouse.Position) && clickedDrawable.TriggerOnDoubleClick(state);
-        }
-
-        private bool handleMouseDrag(InputState state)
-        {
-            //Once a drawable is dragged, it remains in a dragged state until the drag is finished.
-            return DraggedDrawable?.TriggerOnDrag(state) ?? false;
-        }
-
-        private bool handleMouseDragStart(InputState state)
-        {
-            Trace.Assert(DraggedDrawable == null, $"The {nameof(DraggedDrawable)} was not set to null by {nameof(handleMouseDragEnd)}.");
-            Trace.Assert(!dragStarted, $"A {nameof(DraggedDrawable)} was already searched for. Call {nameof(handleMouseDragEnd)} first.");
-
-            dragStarted = true;
-
-            DraggedDrawable = mouseDownInputQueue?.FirstOrDefault(target => target.IsAlive && target.IsPresent && target.TriggerOnDragStart(state));
-            if (DraggedDrawable != null)
-            {
-                DraggedDrawable.IsDragged = true;
-                Logger.Log($"MouseDragStart handled by {DraggedDrawable}.", LoggingTarget.Runtime, LogLevel.Debug);
-            }
-
-            return DraggedDrawable != null;
-        }
-
-        private bool handleMouseDragEnd(InputState state)
-        {
-            dragStarted = false;
-
-            if (DraggedDrawable == null)
-                return false;
-
-            bool result = DraggedDrawable.TriggerOnDragEnd(state);
-            DraggedDrawable.IsDragged = false;
-            DraggedDrawable = null;
-
-            return result;
         }
 
         private bool handleScroll(InputState state)
@@ -783,5 +578,34 @@ namespace osu.Framework.Input
         Never,
         Fullscreen,
         Always
+    }
+
+    public class MouseLeftButtonEventManager : MouseButtonEventManager
+    {
+        public MouseLeftButtonEventManager(InputManager inputManager, MouseButton button)
+            : base(inputManager, button)
+        {
+        }
+
+        public override bool EnableDrag => true;
+
+        public override bool EnableClick => true;
+
+        public override bool ChangeFocusForClick => true;
+    }
+
+    
+    public class MouseMinorButtonEventManager : MouseButtonEventManager
+    {
+        public MouseMinorButtonEventManager(InputManager inputManager, MouseButton button)
+            : base(inputManager, button)
+        {
+        }
+
+        public override bool EnableDrag => false;
+
+        public override bool EnableClick => false;
+
+        public override bool ChangeFocusForClick => false;
     }
 }

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -1,0 +1,340 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using OpenTK;
+using OpenTK.Input;
+using System.Linq;
+using System.Diagnostics;
+using osu.Framework.Logging;
+
+namespace osu.Framework.Input
+{
+    /// <summary>
+    /// Manages mouse events which is initiated by a state change of a button
+    /// namely drag, click and double click.
+    /// An instance manages those events for only one button.
+    /// </summary>
+    public abstract class MouseButtonEventManager
+    {
+        /// <summary>
+        /// The input manager.
+        /// </summary>
+        public readonly InputManager InputManager;
+
+        /// <summary>
+        /// The mouse button this manager manages for.
+        /// </summary>
+        public readonly MouseButton Button;
+
+        /// <summary>
+        /// Whether dragging is handled with the button.
+        /// </summary>
+        public abstract bool EnableDrag { get; }
+
+        /// <summary>
+        /// Whether click and double click is handled with the button.
+        /// </summary>
+        public abstract bool EnableClick { get; }
+
+        /// <summary>
+        /// Whether focus is changed when the button is clicked.
+        /// </summary>
+        public abstract bool ChangeFocusForClick { get; }
+
+        protected MouseButtonEventManager(InputManager inputManager, MouseButton button)
+        {
+            InputManager = inputManager;
+            Button = button;
+        }
+
+        /// <summary>
+        /// The current time.
+        /// Used for double click judgement.
+        /// </summary>
+        protected virtual double CurrentTime => InputManager.Time.Current;
+
+        /// <summary>
+        /// The positional input queue used for events.
+        /// </summary>
+        protected virtual IEnumerable<Drawable> PositionalInputQueue => InputManager.PositionalInputQueue;
+
+        /// <summary>
+        /// The maximum time between two clicks for a double-click to be considered.
+        /// </summary>
+        public virtual float DoubleClickTime => 250;
+
+        /// <summary>
+        /// The distance that must be moved until a dragged click becomes invalid.
+        /// </summary>
+        public virtual float ClickDragDistance => 10;
+
+        /// <summary>
+        /// The position of the mouse when the last time the button is pressed.
+        /// </summary>
+        public Vector2? MouseDownPosition { get; protected set; }
+
+        /// <summary>
+        /// The time of last click.
+        /// </summary>
+        protected double? LastClickTime;
+
+        /// <summary>
+        /// The drawable which is clicked by the last click.
+        /// </summary>
+        protected Drawable ClickedDrawable;
+
+        /// <summary>
+        /// Whether a drag operation has started and <see cref="DraggedDrawable"/> has been searched for.
+        /// </summary>
+        protected bool DragStarted;
+
+        /// <summary>
+        /// The input queue for propagating <see cref="Drawable.OnMouseUp"/>.
+        /// This is created from the <see cref="PositionalInputQueue"/> when the last time the button is pressed.
+        /// </summary>
+        protected List<Drawable> MouseDownInputQueue;
+
+        /// <summary>
+        /// The <see cref="Drawable"/> which is currently being dragged. null if none is.
+        /// </summary>
+        public Drawable DraggedDrawable { get; protected set; }
+
+        public virtual void HandlePositionChange(InputState state)
+        {
+            if (EnableDrag)
+            {
+                if (!DragStarted)
+                {
+                    var mouse = state.Mouse;
+                    if (mouse.IsPressed(Button) && Vector2Extensions.Distance(MouseDownPosition ?? mouse.Position, mouse.Position) > ClickDragDistance)
+                        HandleMouseDragStart(state);
+                }
+                else
+                {
+                    HandleMouseDrag(state);
+                }
+            }
+        }
+
+        public virtual void HandleButtonStateChange(InputState state, ButtonStateChangeKind kind)
+        {
+            Trace.Assert(state.Mouse.IsPressed(Button) == (kind == ButtonStateChangeKind.Pressed));
+
+            if (kind == ButtonStateChangeKind.Pressed)
+            {
+                if (state.Mouse.IsPositionValid)
+                    MouseDownPosition = state.Mouse.Position;
+                HandleMouseDown(state);
+            }
+            else
+            {
+                HandleMouseUp(state);
+
+                if (EnableClick && DraggedDrawable == null)
+                {
+                    bool isValidClick = true;
+                    if (LastClickTime != null && CurrentTime - LastClickTime < DoubleClickTime)
+                    {
+                        if (HandleMouseDoubleClick(state))
+                        {
+                            //when we handle a double-click we want to block a normal click from firing.
+                            isValidClick = false;
+                            LastClickTime = null;
+                        }
+                    }
+
+                    if (isValidClick)
+                    {
+                        LastClickTime = CurrentTime;
+                        HandleMouseClick(state);
+                    }
+                }
+
+                if (EnableDrag)
+                    HandleMouseDragEnd(state);
+
+                MouseDownPosition = null;
+            }
+        }
+
+        protected virtual bool HandleMouseDown(InputState state)
+        {
+            MouseDownEventArgs args = new MouseDownEventArgs { Button = Button };
+
+            var positionalInputQueue = PositionalInputQueue.ToList();
+            var result = PropagateMouseDown(positionalInputQueue, state, args, out Drawable handledBy);
+
+            // only drawables up to the one that handled mouse down should handle mouse up
+            MouseDownInputQueue = positionalInputQueue;
+            if (result)
+            {
+                var count = MouseDownInputQueue.IndexOf(handledBy) + 1;
+                MouseDownInputQueue.RemoveRange(count, MouseDownInputQueue.Count - count);
+            }
+
+            return result;
+        }
+
+        // set PositionMouseDown right before the event is invoked so it can be used as the mouse down position for each button
+        private void setPositionMouseDown(InputState state)
+        {
+            state.Mouse.PositionMouseDown = MouseDownPosition;
+        }
+
+        protected virtual bool HandleMouseUp(InputState state)
+        {
+            if (MouseDownInputQueue == null) return false;
+
+            MouseUpEventArgs args = new MouseUpEventArgs { Button = Button };
+
+            setPositionMouseDown(state);
+
+            //extra check for IsAlive because we are using an outdated queue.
+            return PropagateMouseUp(MouseDownInputQueue.Where(target => target.IsAlive && target.IsPresent), state, args);
+        }
+
+        protected virtual bool HandleMouseClick(InputState state)
+        {
+            var intersectingQueue = PositionalInputQueue.Intersect(MouseDownInputQueue);
+
+            setPositionMouseDown(state);
+
+            // click pass, triggering an OnClick on all drawables up to the first which returns true.
+            // an extra IsHovered check is performed because we are using an outdated queue (for valid reasons which we need to document).
+            ClickedDrawable = intersectingQueue.FirstOrDefault(t => t.CanReceiveMouseInput && t.ReceiveMouseInputAt(state.Mouse.Position) && t.TriggerOnClick(state));
+
+            if (ChangeFocusForClick)
+                ChangeFocusToClickedDrawable();
+
+            if (ClickedDrawable != null)
+                Logger.Log($"MouseClick handled by {ClickedDrawable}.", LoggingTarget.Runtime, LogLevel.Debug);
+
+            return ClickedDrawable != null;
+        }
+
+        protected virtual bool HandleMouseDoubleClick(InputState state)
+        {
+            if (ClickedDrawable == null) return false;
+
+            setPositionMouseDown(state);
+
+            return ClickedDrawable.ReceiveMouseInputAt(state.Mouse.Position) && ClickedDrawable.TriggerOnDoubleClick(state);
+        }
+
+        protected virtual bool HandleMouseDrag(InputState state)
+        {
+            setPositionMouseDown(state);
+
+            //Once a drawable is dragged, it remains in a dragged state until the drag is finished.
+            return DraggedDrawable?.TriggerOnDrag(state) ?? false;
+        }
+
+        protected virtual bool HandleMouseDragStart(InputState state)
+        {
+            Trace.Assert(DraggedDrawable == null, $"The {nameof(DraggedDrawable)} was not set to null by {nameof(HandleMouseDragEnd)}.");
+            Trace.Assert(!DragStarted, $"A {nameof(DraggedDrawable)} was already searched for. Call {nameof(HandleMouseDragEnd)} first.");
+
+            Trace.Assert(MouseDownPosition != null);
+
+            DragStarted = true;
+
+            setPositionMouseDown(state);
+
+            DraggedDrawable = MouseDownInputQueue?.FirstOrDefault(target => target.IsAlive && target.IsPresent && target.TriggerOnDragStart(state));
+            if (DraggedDrawable != null)
+            {
+                DraggedDrawable.IsDragged = true;
+                Logger.Log($"MouseDragStart handled by {DraggedDrawable}.", LoggingTarget.Runtime, LogLevel.Debug);
+            }
+
+            return DraggedDrawable != null;
+        }
+
+        protected virtual bool HandleMouseDragEnd(InputState state)
+        {
+            DragStarted = false;
+
+            if (DraggedDrawable == null)
+                return false;
+
+            setPositionMouseDown(state);
+
+            bool result = DraggedDrawable.TriggerOnDragEnd(state);
+            DraggedDrawable.IsDragged = false;
+            DraggedDrawable = null;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Triggers mouse down events on drawables in <paramref cref="drawables"/> until it is handled.
+        /// </summary>
+        /// <param name="drawables">The drawables in the queue.</param>
+        /// <param name="state">The input state.</param>
+        /// <param name="args">The args.</param>
+        /// <param name="handledBy"></param>
+        /// <returns>Whether the mouse down event was handled.</returns>
+        protected virtual bool PropagateMouseDown(IEnumerable<Drawable> drawables, InputState state, MouseDownEventArgs args, out Drawable handledBy)
+        {
+            handledBy = drawables.FirstOrDefault(target => target.TriggerOnMouseDown(state, args));
+
+            if (handledBy != null)
+                Logger.Log($"MouseDown ({args.Button}) handled by {handledBy}.", LoggingTarget.Runtime, LogLevel.Debug);
+
+            return handledBy != null;
+        }
+
+        /// <summary>
+        /// Triggers mouse up events on drawables in <paramref cref="drawables"/> until it is handled.
+        /// </summary>
+        /// <param name="drawables">The drawables in the queue.</param>
+        /// <param name="state">The input state.</param>
+        /// <param name="args">The args.</param>
+        /// <returns>Whether the mouse up event was handled.</returns>
+        protected virtual bool PropagateMouseUp(IEnumerable<Drawable> drawables, InputState state, MouseUpEventArgs args)
+        {
+            var handledBy = drawables.FirstOrDefault(target => target.TriggerOnMouseUp(state, args));
+
+            if (handledBy != null)
+                Logger.Log($"MouseUp ({args.Button}) handled by {handledBy}.", LoggingTarget.Runtime, LogLevel.Debug);
+
+            return handledBy != null;
+        }
+
+        protected virtual void ChangeFocusToClickedDrawable()
+        {
+            Drawable focusTarget = null;
+
+            if (ClickedDrawable != null)
+            {
+                focusTarget = ClickedDrawable;
+
+                if (!focusTarget.AcceptsFocus)
+                {
+                    // search upwards from the clicked drawable until we find something to handle focus.
+                    Drawable previousFocused = InputManager.FocusedDrawable;
+
+                    while (focusTarget?.AcceptsFocus == false)
+                        focusTarget = focusTarget.Parent;
+
+                    if (focusTarget != null && previousFocused != null)
+                    {
+                        // we found a focusable target above us.
+                        // now search upwards from previousFocused to check whether focusTarget is a common parent.
+                        Drawable search = previousFocused;
+                        while (search != null && search != focusTarget)
+                            search = search.Parent;
+
+                        if (focusTarget == search)
+                            // we have a common parent, so let's keep focus on the previously focused target.
+                            focusTarget = previousFocused;
+                    }
+                }
+            }
+
+            InputManager.ChangeFocus(focusTarget);
+        }
+    }
+}


### PR DESCRIPTION
Events which is initiated with a mouse button, namely drag, click and double click, can be managed separately for each mouse button.
This is a preparation for #1594.
- Moves some code and capitalize things from `InputManager` to a separate file.
- Add a test for #1594.
- Closes #1676
