### PR TITLE
Populate Logger's version with assembly version information by default

### DIFF
--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -383,7 +383,7 @@ namespace osu.Framework.Logging
 
             add("----------------------------------------------------------", outputToListeners: false);
             add($"{Target} Log for {UserIdentifier}", outputToListeners: false);
-            add($"{GameIdentifier} version {VersionIdentifier}", outputToListeners: false);
+            add($"{GameIdentifier} {VersionIdentifier}", outputToListeners: false);
             add($"Running on {Environment.OSVersion}, {Environment.ProcessorCount} cores", outputToListeners: false);
             add("----------------------------------------------------------", outputToListeners: false);
         }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -171,8 +171,17 @@ namespace osu.Framework.Platform
             Dependencies.CacheAs(this);
             Dependencies.CacheAs(Storage = GetStorage(gameName));
 
+            var assembly = Assembly.GetEntryAssembly();
+
+            // when running under nunit + netcore, entry assembly becomes nunit itself (testhost, Version=15.0.0.0), which isn't what we want.
+            // when running under nunit + net471, entry assembly is null.
+            if (assembly == null || assembly.Location.Contains("testhost"))
+                assembly = Assembly.GetCallingAssembly();
+
             Name = gameName;
+
             Logger.GameIdentifier = gameName;
+            Logger.VersionIdentifier = assembly.GetName().Version.ToString();
 
             threads = new List<GameThread>
             {
@@ -187,13 +196,6 @@ namespace osu.Framework.Platform
                 }),
                 (InputThread = new InputThread(null)), //never gets started.
             };
-
-            var assembly = Assembly.GetEntryAssembly();
-
-            // when running under nunit + netcore, entry assembly becomes nunit itself (testhost, Version=15.0.0.0), which isn't what we want.
-            // when running under nunit + net471, entry assembly is null.
-            if (assembly == null || assembly.Location.Contains("testhost"))
-                assembly = Assembly.GetCallingAssembly();
 
             var path = Path.GetDirectoryName(assembly.Location);
             if (path != null)


### PR DESCRIPTION
Fixes logs not having a version if not explicitly specified by the game.