### PR TITLE
Make PassThroughInputManager sync with parent input state

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseInputManager.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputManager.cs
@@ -116,48 +116,48 @@ namespace osu.Framework.Tests.Visual
                 base.Update();
             }
 
-            private int mouseDownCount;
+            public int MouseDownCount;
 
             protected override bool OnMouseDown(InputState state, MouseDownEventArgs args)
             {
-                ++mouseDownCount;
-                onMouseDownStatus.Text = $"OnMouseDown {mouseDownCount}: Position={state.Mouse.Position}";
+                ++MouseDownCount;
+                onMouseDownStatus.Text = $"OnMouseDown {MouseDownCount}: Position={state.Mouse.Position}";
                 return true;
             }
 
-            private int mouseUpCount;
+            public int MouseUpCount;
 
             protected override bool OnMouseUp(InputState state, MouseUpEventArgs args)
             {
-                ++mouseUpCount;
-                onMouseUpStatus.Text = $"OnMouseUp {mouseUpCount}: Position={state.Mouse.Position}, PositionMouseDown={state.Mouse.PositionMouseDown}";
+                ++MouseUpCount;
+                onMouseUpStatus.Text = $"OnMouseUp {MouseUpCount}: Position={state.Mouse.Position}, PositionMouseDown={state.Mouse.PositionMouseDown}";
                 return base.OnMouseUp(state, args);
             }
 
-            private int mouseMoveCount;
+            public int MouseMoveCount;
 
             protected override bool OnMouseMove(InputState state)
             {
-                ++mouseMoveCount;
-                onMouseMoveStatus.Text = $"OnMouseMove {mouseMoveCount}: Position={state.Mouse.Position}, Delta={state.Mouse.Delta}";
+                ++MouseMoveCount;
+                onMouseMoveStatus.Text = $"OnMouseMove {MouseMoveCount}: Position={state.Mouse.Position}, Delta={state.Mouse.Delta}";
                 return base.OnMouseMove(state);
             }
 
-            private int scrollCount;
+            public int ScrollCount;
 
             protected override bool OnScroll(InputState state)
             {
-                ++scrollCount;
-                onScrollStatus.Text = $"OnScroll {scrollCount}: Scroll={state.Mouse.Scroll}, ScrollDelta={state.Mouse.ScrollDelta}, HasPreciseScroll={state.Mouse.HasPreciseScroll}";
+                ++ScrollCount;
+                onScrollStatus.Text = $"OnScroll {ScrollCount}: Scroll={state.Mouse.Scroll}, ScrollDelta={state.Mouse.ScrollDelta}, HasPreciseScroll={state.Mouse.HasPreciseScroll}";
                 return base.OnScroll(state);
             }
 
-            private int hoverCount;
+            public int HoverCount;
 
             protected override bool OnHover(InputState state)
             {
-                ++hoverCount;
-                onHoverStatus.Text = $"OnHover {hoverCount}: Position={state.Mouse.Position}";
+                ++HoverCount;
+                onHoverStatus.Text = $"OnHover {HoverCount}: Position={state.Mouse.Position}";
                 return base.OnHover(state);
             }
 

--- a/osu.Framework.Tests/Visual/TestCasePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/TestCasePassThroughInputManager.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osu.Framework.Testing.Input;
+using OpenTK;
+using OpenTK.Input;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCasePassThroughInputManager : ManualInputManagerTestCase
+    {
+        public TestCasePassThroughInputManager()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        private TestInputManager testInputManager;
+        private InputState state;
+        private IMouseState mouse;
+        private IKeyboardState keyboard;
+        private IJoystickState joystick;
+        private void addTestInputManagerStep()
+        {
+            AddStep("Add InputManager", () =>
+            {
+                testInputManager = new TestInputManager();
+                Add(testInputManager);
+                state = testInputManager.CurrentState;
+                mouse = state.Mouse;
+                keyboard = state.Keyboard;
+                joystick = state.Joystick;
+            });
+        }
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+            ChildrenEnumerable = Enumerable.Empty<Drawable>();
+        }
+
+        [Test]
+        public void ReceiveInitialState()
+        {
+            AddStep("Press mouse left", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("Press A", () => InputManager.PressKey(Key.A));
+            AddStep("Press Joystick", () => InputManager.PressJoystickButton(JoystickButton.Button1));
+            addTestInputManagerStep();
+            AddAssert("mouse left not pressed", () => !mouse.IsPressed(MouseButton.Left));
+            AddAssert("A pressed", () => keyboard.IsPressed(Key.A));
+            AddAssert("Joystick pressed", () => joystick.Buttons.IsPressed(JoystickButton.Button1));
+            AddStep("Release", () =>
+            {
+                InputManager.ReleaseButton(MouseButton.Left);
+                InputManager.ReleaseKey(Key.A);
+                InputManager.ReleaseJoystickButton(JoystickButton.Button1);
+            });
+            AddAssert("All released", () => !mouse.HasAnyButtonPressed && !keyboard.Keys.HasAnyButtonPressed && !joystick.Buttons.HasAnyButtonPressed);
+        }
+
+        [Test]
+        public void UseParentInputChange()
+        {
+            addTestInputManagerStep();
+            AddStep("Press buttons", () =>
+            {
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.PressKey(Key.A);
+                InputManager.PressJoystickButton(JoystickButton.Button1);
+            });
+            AddAssert("pressed", () => mouse.IsPressed(MouseButton.Left) && keyboard.IsPressed(Key.A) && joystick.Buttons.IsPressed(JoystickButton.Button1));
+            AddStep("UseParentInput = false", () => testInputManager.UseParentInput = false);
+            AddAssert("pressed", () => !mouse.IsPressed(MouseButton.Left) && !keyboard.IsPressed(Key.A) && !joystick.Buttons.IsPressed(JoystickButton.Button1));
+            AddStep("UseParentInput = true", () => testInputManager.UseParentInput = true);
+            AddAssert("mouse not pressed", () => !mouse.IsPressed(MouseButton.Left));
+            AddAssert("others pressed", () => keyboard.IsPressed(Key.A) && joystick.Buttons.IsPressed(JoystickButton.Button1));
+        }
+
+        public class TestInputManager : ManualInputManager
+        {
+            public TestInputManager()
+            {
+                Size = new Vector2(0.8f);
+                Origin = Anchor.Centre;
+                Anchor = Anchor.Centre;
+                Child = new TestCaseInputManager.ContainingInputManagerStatusText();
+            }
+        }
+    }
+}

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -122,7 +122,7 @@ namespace osu.Framework.Input.Bindings
                 pressedCombination = new KeyCombination(pressedCombination.Keys.Concat(new[] { newKey }));
 
             bool handled = false;
-            var bindings = repeat ? KeyBindings : KeyBindings.Except(pressedBindings);
+            var bindings = (repeat ? KeyBindings : KeyBindings?.Except(pressedBindings)) ?? Enumerable.Empty<KeyBinding>();
             var newlyPressed = bindings.Where(m =>
                 m.KeyCombination.Keys.Contains(newKey) // only handle bindings matching current key (not required for correct logic)
                 && m.KeyCombination.IsPressed(pressedCombination, simultaneousMode == SimultaneousBindingMode.NoneExact));

--- a/osu.Framework/Input/ButtonInput.cs
+++ b/osu.Framework/Input/ButtonInput.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Input
         /// <param name="previous">The older <see cref="ButtonStates{TButton}"/>.</param>
         protected ButtonInput(ButtonStates<TButton> current, ButtonStates<TButton> previous)
         {
-            var difference = current.EnumerateDifference(previous ?? new ButtonStates<TButton>());
+            var difference = (current ?? new ButtonStates<TButton>()).EnumerateDifference(previous ?? new ButtonStates<TButton>());
 
             Entries = difference.Released.Select(button => new ButtonInputEntry<TButton>(button, false))
                                 .Concat(difference.Pressed.Select(button => new ButtonInputEntry<TButton>(button, true)));

--- a/osu.Framework/Input/ButtonInput.cs
+++ b/osu.Framework/Input/ButtonInput.cs
@@ -15,6 +15,11 @@ namespace osu.Framework.Input
     {
         public IEnumerable<ButtonInputEntry<TButton>> Entries;
 
+        protected ButtonInput(IEnumerable<ButtonInputEntry<TButton>> entries)
+        {
+            Entries = entries;
+        }
+
         /// <summary>
         /// Creates a <see cref="ButtonInput{TButton}"/> with a single <see cref="TButton"/> state.
         /// </summary>

--- a/osu.Framework/Input/ButtonStates.cs
+++ b/osu.Framework/Input/ButtonStates.cs
@@ -55,9 +55,9 @@ namespace osu.Framework.Input
         /// Enumerates the differences between ourselves and a previous <see cref="ButtonStates{TButton}"/>.
         /// </summary>
         /// <param name="lastButtons">The previous <see cref="ButtonStates{TButton}"/>.</param>
-        public (IEnumerable<TButton> Released, IEnumerable<TButton> Pressed) EnumerateDifference(ButtonStates<TButton> lastButtons)
+        public ButtonStateDifference EnumerateDifference(ButtonStates<TButton> lastButtons)
         {
-            return (lastButtons.pressedButtons.Except(pressedButtons), pressedButtons.Except(lastButtons.pressedButtons));
+            return new ButtonStateDifference(lastButtons.Except(this).ToArray(), this.Except(lastButtons).ToArray());
         }
 
         /// <summary>
@@ -75,17 +75,22 @@ namespace osu.Framework.Input
             return $@"{GetType().ReadableName()}({String.Join(" ", pressedButtons)})";
         }
 
-        public IEnumerator<TButton> GetEnumerator()
-        {
-            return ((IEnumerable<TButton>)pressedButtons).GetEnumerator();
-        }
-
-        IEnumerator IEnumerable.GetEnumerator()
-        {
-            return ((IEnumerable<TButton>)pressedButtons).GetEnumerator();
-        }
+        public IEnumerator<TButton> GetEnumerator() => ((IEnumerable<TButton>)pressedButtons).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         // for collection initializer
         public void Add(TButton button) => SetPressed(button, true);
+
+        public struct ButtonStateDifference
+        {
+            public readonly IEnumerable<TButton> Released;
+            public readonly IEnumerable<TButton> Pressed;
+
+            public ButtonStateDifference(IEnumerable<TButton> released, IEnumerable<TButton> pressed)
+            {
+                Released = released;
+                Pressed = pressed;
+            }
+        }
     }
 }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -257,10 +257,6 @@ namespace osu.Framework.Input
             return inputs;
         }
 
-        protected virtual void TransformState(InputState inputState)
-        {
-        }
-
         private IEnumerable<Drawable> buildInputQueue()
         {
             var inputQueue = new List<Drawable>();

--- a/osu.Framework/Input/JoystickButtonInput.cs
+++ b/osu.Framework/Input/JoystickButtonInput.cs
@@ -1,10 +1,17 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Collections.Generic;
+
 namespace osu.Framework.Input
 {
     public class JoystickButtonInput : ButtonInput<JoystickButton>
     {
+        public JoystickButtonInput(IEnumerable<ButtonInputEntry<JoystickButton>> entries)
+            : base(entries)
+        {
+        }
+
         public JoystickButtonInput(JoystickButton button, bool isPressed)
             : base(button, isPressed)
         {

--- a/osu.Framework/Input/KeyboardKeyInput.cs
+++ b/osu.Framework/Input/KeyboardKeyInput.cs
@@ -1,12 +1,18 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Collections.Generic;
 using OpenTK.Input;
 
 namespace osu.Framework.Input
 {
     public class KeyboardKeyInput : ButtonInput<Key>
     {
+        public KeyboardKeyInput(IEnumerable<ButtonInputEntry<Key>> entries)
+            : base(entries)
+        {
+        }
+
         public KeyboardKeyInput(Key button, bool isPressed)
             : base(button, isPressed)
         {

--- a/osu.Framework/Input/MouseButtonInput.cs
+++ b/osu.Framework/Input/MouseButtonInput.cs
@@ -1,12 +1,18 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Collections.Generic;
 using OpenTK.Input;
 
 namespace osu.Framework.Input
 {
     public class MouseButtonInput : ButtonInput<MouseButton>
     {
+        public MouseButtonInput(IEnumerable<ButtonInputEntry<MouseButton>> entries)
+            : base(entries)
+        {
+        }
+
         public MouseButtonInput(MouseButton button, bool isPressed)
             : base(button, isPressed)
         {

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -97,9 +97,8 @@ namespace osu.Framework.Input
             if (UseParentInput)
             {
                 // safe-guard for edge cases.
-                if (!CurrentState.Mouse.IsPressed(args.Button))
-                    new MouseButtonInput(args.Button, true).Apply(CurrentState, this);
-                new MouseButtonInput(args.Button, false).Apply(CurrentState, this);
+                if (CurrentState.Mouse.IsPressed(args.Button))
+                    new MouseButtonInput(args.Button, false).Apply(CurrentState, this);
             }
 
             return false;

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -11,6 +11,7 @@ namespace osu.Framework.Input
     /// <remarks>
     /// This <see cref="InputManager"/> can be used in one of two states.
     /// When <see cref="UseParentInput"/> is false, this input manager gets inputs only from own input handlers.
+    /// When <see cref="UseParentInput"/> becomes false, all pressed buttons and keys are released.
     /// When <see cref="UseParentInput"/> is true, this input manager ignore own input handlers and
     /// gets inputs from the parent (an ancestor in the scene graph) <see cref="InputManager"/> in the following way:
     /// For mouse input, this only considers input that is passed as events such as <see cref="OnMouseDown"/>.
@@ -30,7 +31,11 @@ namespace osu.Framework.Input
             {
                 if (useParentInput == value) return;
                 useParentInput = value;
-                if (UseParentInput) Sync();
+
+                if (UseParentInput)
+                    Sync();
+                else
+                    Reset();
             }
         }
 
@@ -170,6 +175,16 @@ namespace osu.Framework.Input
         {
             new KeyboardKeyInput(parentState?.Keyboard?.Keys, CurrentState.Keyboard.Keys).Apply(CurrentState, this);
             new JoystickButtonInput(parentState?.Joystick?.Buttons, CurrentState.Joystick.Buttons).Apply(CurrentState, this);
+        }
+
+        /// <summary>
+        /// Reset all input state.
+        /// </summary>
+        protected virtual void Reset()
+        {
+            new MouseButtonInput(null, CurrentState.Mouse.Buttons).Apply(CurrentState, this);
+            new KeyboardKeyInput(null, CurrentState.Keyboard.Keys).Apply(CurrentState, this);
+            new JoystickButtonInput(null, CurrentState.Joystick.Buttons).Apply(CurrentState, this);
         }
     }
 }

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -150,6 +150,7 @@ namespace osu.Framework.Input
         protected override void Update()
         {
             base.Update();
+
             // Some keyboard/joystick events are blocked. Sync every frame.
             if (UseParentInput) Sync(true);
         }
@@ -162,8 +163,10 @@ namespace osu.Framework.Input
         public void Sync(bool useCachedParentInputManager = false)
         {
             if (!UseParentInput) return;
+
             if (!useCachedParentInputManager)
                 parentInputManager = GetContainingInputManager();
+
             SyncInputState(parentInputManager?.CurrentState);
         }
 

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -175,8 +175,8 @@ namespace osu.Framework.Input
         protected virtual void SyncInputState(InputState parentState)
         {
             // release all buttons that is not pressed on parent state
-            var mosueButtonDifference = (parentState?.Mouse?.Buttons ?? new ButtonStates<MouseButton>()).EnumerateDifference(CurrentState.Mouse.Buttons);
-            new MouseButtonInput(mosueButtonDifference.Released.Select(button => new ButtonInputEntry<MouseButton>(button, false))).Apply(CurrentState, this);
+            var mouseButtonDifference = (parentState?.Mouse?.Buttons ?? new ButtonStates<MouseButton>()).EnumerateDifference(CurrentState.Mouse.Buttons);
+            new MouseButtonInput(mouseButtonDifference.Released.Select(button => new ButtonInputEntry<MouseButton>(button, false))).Apply(CurrentState, this);
 
             new KeyboardKeyInput(parentState?.Keyboard?.Keys, CurrentState.Keyboard.Keys).Apply(CurrentState, this);
             new JoystickButtonInput(parentState?.Joystick?.Buttons, CurrentState.Joystick.Buttons).Apply(CurrentState, this);

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics;
 using OpenTK;
+using OpenTK.Input;
 
 namespace osu.Framework.Input
 {
@@ -167,11 +169,15 @@ namespace osu.Framework.Input
         }
 
         /// <summary>
-        /// Sync keyboard and joystick state to parent state.
+        /// Sync current state to parent state.
         /// </summary>
         /// <param name="parentState">Parent's state. If this is null, it is regarded as an empty state.</param>
         protected virtual void SyncInputState(InputState parentState)
         {
+            // release all buttons that is not pressed on parent state
+            var mosueButtonDifference = (parentState?.Mouse?.Buttons ?? new ButtonStates<MouseButton>()).EnumerateDifference(CurrentState.Mouse.Buttons);
+            new MouseButtonInput(mosueButtonDifference.Released.Select(button => new ButtonInputEntry<MouseButton>(button, false))).Apply(CurrentState, this);
+
             new KeyboardKeyInput(parentState?.Keyboard?.Keys, CurrentState.Keyboard.Keys).Apply(CurrentState, this);
             new JoystickButtonInput(parentState?.Joystick?.Buttons, CurrentState.Joystick.Buttons).Apply(CurrentState, this);
         }

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -17,7 +17,6 @@ namespace osu.Framework.Input
     /// For keyboard and other inputs, this input manager try to reflect parent <see cref="InputManager"/>'s <see cref="InputState"/> closely as possible.
     /// Thus, when this is attached to the scene graph initially and when <see cref="UseParentInput"/> becomes true,
     /// multiple events may fire to synchronise the local <see cref="InputState"/> with the parent's.
-    /// Conversely, when <see cref="UseParentInput"/> becomes false, all pressed buttons and keys are released.
     /// </remarks>
     public class PassThroughInputManager : CustomInputManager, IRequireHighFrequencyMousePosition
     {
@@ -34,8 +33,6 @@ namespace osu.Framework.Input
 
                 if (UseParentInput)
                     Sync();
-                else
-                    Reset();
             }
         }
 
@@ -178,16 +175,6 @@ namespace osu.Framework.Input
         {
             new KeyboardKeyInput(parentState?.Keyboard?.Keys, CurrentState.Keyboard.Keys).Apply(CurrentState, this);
             new JoystickButtonInput(parentState?.Joystick?.Buttons, CurrentState.Joystick.Buttons).Apply(CurrentState, this);
-        }
-
-        /// <summary>
-        /// Reset all input state.
-        /// </summary>
-        protected virtual void Reset()
-        {
-            new MouseButtonInput(null, CurrentState.Mouse.Buttons).Apply(CurrentState, this);
-            new KeyboardKeyInput(null, CurrentState.Keyboard.Keys).Apply(CurrentState, this);
-            new JoystickButtonInput(null, CurrentState.Joystick.Buttons).Apply(CurrentState, this);
         }
     }
 }

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -7,17 +7,17 @@ using OpenTK;
 
 namespace osu.Framework.Input
 {
-    /// <summary>An <see cref="InputManager"/> with an arbirity to use parent <see cref="InputManager"/>'s input.</summary>
+    /// <summary>An <see cref="InputManager"/> with an ability to use parent <see cref="InputManager"/>'s input.</summary>
     /// <remarks>
-    /// This <see cref="InputManager"/> can be used in one of two states.
+    /// There are two modes of operation for this class:
     /// When <see cref="UseParentInput"/> is false, this input manager gets inputs only from own input handlers.
-    /// When <see cref="UseParentInput"/> becomes false, all pressed buttons and keys are released.
-    /// When <see cref="UseParentInput"/> is true, this input manager ignore own input handlers and
-    /// gets inputs from the parent (an ancestor in the scene graph) <see cref="InputManager"/> in the following way:
+    /// When <see cref="UseParentInput"/> is true, this input manager ignore any local input handlers and
+    /// gets inputs from the parent (its ancestor in the scene graph) <see cref="InputManager"/> in the following way:
     /// For mouse input, this only considers input that is passed as events such as <see cref="OnMouseDown"/>.
     /// For keyboard and other inputs, this input manager try to reflect parent <see cref="InputManager"/>'s <see cref="InputState"/> closely as possible.
-    /// Thus, when this is attached to the scene graph initially and when <see cref="UseParentInput"/> is changed to true from false,
-    /// multiple keyboard events is called when the parent's <see cref="InputState"/> is a state with keys pressed for example.
+    /// Thus, when this is attached to the scene graph initially and when <see cref="UseParentInput"/> becomes true,
+    /// multiple events may fire to synchronise the local <see cref="InputState"/> with the parent's.
+    /// Conversely, when <see cref="UseParentInput"/> becomes false, all pressed buttons and keys are released.
     /// </remarks>
     public class PassThroughInputManager : CustomInputManager, IRequireHighFrequencyMousePosition
     {


### PR DESCRIPTION
When `UseParentInput` is true, a `PassThroughInputManager` syncs its keyboard and joystick state to parent `InputManager`'s state.
For mouse buttons, only input that reached event handlers (`OnMouseDown` and `OnMouseUp`) are applied. Click initiated at outside of the `PassThroughInputManager` and blocked inputs are not synced. However, always sync `MouseUp` to maintain an invariant (for a mouse button) `this.pressed <= parent.pressed`. This is because a mouse inputs are positional and this behavior is matching to regular `Drawable`s.
- Closes #1672 
- When `KeyBindingContainer` handles `OnKeyDown` before `KeyBindings` are set there was a null reference. I fixed this. However, the new `KeyBindingContainer` doesn't fire actions that is bind to keys pressed while the new `KeyBindingContainer` is initialized. For example, when entering osu!catch play while pressing an arrow key, the catcher isn't moving initially. I think this is allowable but maybe should fix if people need.