### PR TITLE
Add abstract GameWindow.GetCurrentDisplay() method

### DIFF
--- a/osu.Framework/Platform/DesktopGameWindow.cs
+++ b/osu.Framework/Platform/DesktopGameWindow.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Platform
 
         public readonly BindableBool MapAbsoluteInputToWindow = new BindableBool();
 
-        public IEnumerable<DisplayResolution> AvailableDisplayResolutions => DisplayDevice.Default.AvailableResolutions.Distinct();
+        public override DisplayDevice GetCurrentDisplay() => DisplayDevice.Default;
 
         protected DesktopGameWindow()
             : base(default_width, default_height)

--- a/osu.Framework/Platform/DesktopGameWindow.cs
+++ b/osu.Framework/Platform/DesktopGameWindow.cs
@@ -2,10 +2,8 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
 using osu.Framework.Configuration;
 using osu.Framework.Input;
 using OpenTK;

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -168,6 +168,12 @@ namespace osu.Framework.Platform
             set => throw new InvalidOperationException($@"{nameof(CursorGrabbed)} is not supported. Use {nameof(CursorState)}.");
         }
 
+        /// <summary>
+        /// Gets the <see cref="DisplayDevice"/> that this window is currently on.
+        /// </summary>
+        /// <returns></returns>
+        public abstract DisplayDevice GetCurrentDisplay();
+
         private string getVersionNumberSubstring(string version)
         {
             string result = version.Split(' ').FirstOrDefault(s => char.IsDigit(s, 0));


### PR DESCRIPTION
This will make it easier for consumers to implement DisplayDevice-related logic. Note that the main logic for this will be implemented in another PR (multi-monitor handling), this is just for compatibility (so that Toucan can update his PRs ASAP)

- breaks #1652 and ppy/osu#2715

---

Adds a method in preparation for fullscreen multi-monitor support.