### PR TITLE
Delay first setActive call until event handlers are set up

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -427,16 +427,21 @@ namespace osu.Framework.Platform
                 {
                     if (Window != null)
                     {
-                        setActive(Window.Focused);
-
                         Window.KeyDown += window_KeyDown;
 
                         Window.ExitRequested += OnExitRequested;
                         Window.Exited += OnExited;
                         Window.FocusedChanged += delegate { setActive(Window.Focused); };
 
+                        bool initialized = false;
+
                         Window.UpdateFrame += delegate
                         {
+                            if (!initialized)
+                            {
+                                setActive(Window.Focused);
+                                initialized = true;
+                            }
                             inputPerformanceCollectionPeriod?.Dispose();
                             InputThread.RunUpdate();
                             inputPerformanceCollectionPeriod = inputMonitor.BeginCollecting(PerformanceCollectionType.WndProc);


### PR DESCRIPTION
`UpdateFrame` is certainly called after the first `ProcessEvents` https://github.com/ppy/opentk/blob/21754ca665f1b6595c2ef0a02bd4e8ee6fe8dc99/src/OpenTK/GameWindow.cs#L368-L374.
- Closes #578

---

Fixes game not always being active on startup, even when window is.