### PR TITLE
Add multi-monitor support for custom fullscreen resolutions

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseFullscreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFullscreen.cs
@@ -59,6 +59,7 @@ namespace osu.Framework.Tests.Visual
             testResolution(1280, 960);
             testResolution(9999, 9999);
             AddStep("go back to windowed", () => windowMode.Value = WindowMode.Windowed);
+            AddStep("change to borderless", () => windowMode.Value = WindowMode.Borderless);
         }
 
         protected override void Update()

--- a/osu.Framework.Tests/Visual/TestCaseFullscreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFullscreen.cs
@@ -14,6 +14,7 @@ namespace osu.Framework.Tests.Visual
     public class TestCaseFullscreen : TestCase
     {
         private readonly SpriteText currentActualSize = new SpriteText();
+        private readonly SpriteText currentDisplay = new SpriteText();
 
         private GameWindow window;
         private readonly BindableSize sizeFullscreen = new BindableSize();
@@ -29,6 +30,7 @@ namespace osu.Framework.Tests.Visual
                 {
                     currentBindableSize,
                     currentActualSize,
+                    currentDisplay
                 },
             };
 
@@ -64,6 +66,7 @@ namespace osu.Framework.Tests.Visual
             base.Update();
 
             currentActualSize.Text = $"Window size: {window?.Bounds.Size}";
+            currentDisplay.Text = $"Current display device: {window?.GetCurrentDisplay()}";
         }
     }
 }

--- a/osu.Framework.Tests/Visual/TestCaseFullscreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFullscreen.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Tests.Visual
     {
         private readonly SpriteText currentActualSize = new SpriteText();
 
-        private DesktopGameWindow window;
+        private GameWindow window;
         private readonly BindableSize sizeFullscreen = new BindableSize();
         private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
 
@@ -43,7 +43,7 @@ namespace osu.Framework.Tests.Visual
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager config, GameHost host)
         {
-            window = (DesktopGameWindow)host.Window;
+            window = host.Window;
             config.BindWith(FrameworkSetting.SizeFullscreen, sizeFullscreen);
             config.BindWith(FrameworkSetting.WindowMode, windowMode);
 
@@ -55,6 +55,7 @@ namespace osu.Framework.Tests.Visual
             AddStep("change to fullscreen", () => windowMode.Value = WindowMode.Fullscreen);
             testResolution(1920, 1080);
             testResolution(1280, 960);
+            testResolution(9999, 9999);
             AddStep("go back to windowed", () => windowMode.Value = WindowMode.Windowed);
         }
 

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0004" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.7.0" />
-    <PackageReference Include="ppy.OpenTK.NS20" Version="1.0.6" />
+    <PackageReference Include="ppy.OpenTK.NS20" Version="1.0.7" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="ppy.Microsoft.Diagnostics.Runtime" Version="0.9.180305.1" />
     <PackageReference Include="NUnit" Version="3.10.1" />


### PR DESCRIPTION
`changeResolution` now takes a `display` parameter that specifies the display of which the resolution should be changed. 
Other than that, the window now tracks the last display that went into fullscreen: If you move the window to another monitor while being fullscreen (Win-Shift-Arrow Key on Windows), it should still restore resolution for the monitor that originally went fullscreen (since its resolution is still changed).

I also removed `Position = Vector2.Zero` in the borderless logic, because it's A) unnecessary (at least on Windows, needs testing) and B) always moves the borderless window to the same place, which is usually the first monitor.

- [x] Depends on ppy/opentk#24 (merged, but not in a new NuGet package yet)

---

Adds multi-monitor support for custom fullscreen resolutions.