### PR TITLE
Fix flashing in test case

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseInputManager.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputManager.cs
@@ -88,6 +88,8 @@ namespace osu.Framework.Tests.Visual
                     },
                     new FillFlowContainer
                     {
+                        RelativeSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
                         Children = new Drawable[]
                         {
                             inputManagerStatus = new SmallText(),


### PR DESCRIPTION
We can't have 0-size containers anchored to the sides of the screen (or a parenting container). This was causing the flow container to move between `IsMaskedAway = true` and `IsMaskedAway = false` while resizing the window.

---