### PR TITLE
Remove duplicate OpenGL initialisation

### DIFF
--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -88,12 +88,6 @@ namespace osu.Framework.Platform
             if (GLSLVersion == null)
                 GLSLVersion = new Version();
 
-            //Set up OpenGL related characteristics
-            GL.Disable(EnableCap.DepthTest);
-            GL.Disable(EnableCap.StencilTest);
-            GL.Enable(EnableCap.Blend);
-            GL.Enable(EnableCap.ScissorTest);
-
             Logger.Log($@"GL Initialized
                         GL Version:                 {GL.GetString(StringName.Version)}
                         GL Renderer:                {GL.GetString(StringName.Renderer)}


### PR DESCRIPTION
These are already initialised in GLWrapper, which is where they should be since GLWrapper is the class through which we pass, e.g. scissor and depth test from other classes.

---