### PR TITLE
Fix incorrect intersection logic

### DIFF
--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -189,12 +189,12 @@ namespace osu.Framework.Input
             setPositionMouseDown(state);
 
             //extra check for IsAlive because we are using an outdated queue.
-            return PropagateMouseUp(MouseDownInputQueue.Where(target => target.IsAlive && target.IsPresent), state, args);
+            return PropagateMouseUp(MouseDownInputQueue.Intersect(PositionalInputQueue).Where(target => target.IsAlive && target.IsPresent), state, args);
         }
 
         protected virtual bool HandleMouseClick(InputState state)
         {
-            var intersectingQueue = PositionalInputQueue.Intersect(MouseDownInputQueue);
+            var intersectingQueue = MouseDownInputQueue.Intersect(PositionalInputQueue);
 
             setPositionMouseDown(state);
 

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -189,7 +189,7 @@ namespace osu.Framework.Input
             setPositionMouseDown(state);
 
             //extra check for IsAlive because we are using an outdated queue.
-            return PropagateMouseUp(MouseDownInputQueue.Intersect(PositionalInputQueue).Where(target => target.IsAlive && target.IsPresent), state, args);
+            return PropagateMouseUp(MouseDownInputQueue, state, args);
         }
 
         protected virtual bool HandleMouseClick(InputState state)

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -188,7 +188,6 @@ namespace osu.Framework.Input
 
             setPositionMouseDown(state);
 
-            //extra check for IsAlive because we are using an outdated queue.
             return PropagateMouseUp(MouseDownInputQueue, state, args);
         }
 


### PR DESCRIPTION
- Intersection was done backwards in a few placing, causing incorrect ordering.
- MouseUp now always invokes on all drawables in the mouse down queue, regardless of `IsAlive`/`IsPresent` states.

---
