### PR TITLE
Turn cache back on for chocolatey packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,9 @@ version: '{build}'
 skip_tags: true
 image: Visual Studio 2017
 configuration: Debug
+cache:
+  - C:\ProgramData\chocolatey\bin -> appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> appveyor.yml
 install:
   - cmd: git submodule update --init --recursive
   - cmd: choco install resharper-clt -y


### PR DESCRIPTION
Due to multiple http failures recently, this is better to have turned on as a fallback.

---