### PR TITLE
Fix focus overlay focus

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseFocus.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFocus.cs
@@ -1,0 +1,299 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using OpenTK;
+using OpenTK.Graphics;
+using OpenTK.Input;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseFocus : ManualInputManagerTestCase
+    {
+        private FocusOverlay overlay;
+        private RequestingFocusBox requestingFocus;
+
+        private FocusBox focusTopLeft;
+        private FocusBox focusBottomLeft;
+        private FocusBox focusBottomRight;
+
+        public TestCaseFocus()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            Children = new Drawable[]
+            {
+                focusTopLeft = new FocusBox
+                {
+                    Anchor = Anchor.TopLeft,
+                    Origin = Anchor.TopLeft,
+                },
+                requestingFocus = new RequestingFocusBox
+                {
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
+                },
+                focusBottomLeft = new FocusBox
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                },
+                focusBottomRight = new FocusBox
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                },
+                overlay = new FocusOverlay
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                }
+            };
+        }
+
+        [Test]
+        public void FocusedOverlayTakesFocusOnShow()
+        {
+            AddAssert("overlay not visible", () => overlay.State == Visibility.Hidden);
+            checkNotFocused(() => overlay);
+
+            AddStep("show overlay", () => overlay.Show());
+            checkFocused(() => overlay);
+
+            AddStep("hide overlay", () => overlay.Hide());
+            checkNotFocused(() => overlay);
+        }
+
+        [Test]
+        public void FocusedOverlayLosesFocusOnClickAway()
+        {
+            AddAssert("overlay not visible", () => overlay.State == Visibility.Hidden);
+            checkNotFocused(() => overlay);
+
+            AddStep("show overlay", () => overlay.Show());
+            checkFocused(() => overlay);
+
+            AddStep("click away", () =>
+            {
+                InputManager.MoveMouseTo(Vector2.One);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            checkNotFocused(() => overlay);
+            checkFocused(() => requestingFocus);
+        }
+
+        [Test]
+        public void RequestsFocusKeepsFocusOnClickAway()
+        {
+            checkFocused(() => requestingFocus);
+
+            AddStep("click away", () =>
+            {
+                InputManager.MoveMouseTo(Vector2.One);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            checkFocused(() => requestingFocus);
+        }
+
+        [Test]
+        public void RequestsFocusLosesFocusOnClickingFocused()
+        {
+            checkFocused(() => requestingFocus);
+
+            AddStep("click top left", () =>
+            {
+                InputManager.MoveMouseTo(focusTopLeft);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            checkFocused(() => focusTopLeft);
+
+            AddStep("click bottom right", () =>
+            {
+                InputManager.MoveMouseTo(focusBottomRight);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            checkFocused(() => focusBottomRight);
+        }
+
+        [Test]
+        public void ShowOverlayInteractions()
+        {
+            AddStep("click bottom left", () =>
+            {
+                InputManager.MoveMouseTo(focusBottomLeft);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            checkFocused(() => focusBottomLeft);
+
+            AddStep("show overlay", () => overlay.Show());
+
+            checkFocused(() => overlay);
+            checkNotFocused(() => focusBottomLeft);
+
+            // click is blocked by overlay so doesn't select bottom left first click
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+            checkFocused(() => requestingFocus);
+
+            // second click selects bottom left
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+            checkFocused(() => focusBottomLeft);
+
+            // further click has no effect
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+            checkFocused(() => focusBottomLeft);
+        }
+
+        private void checkFocused(Func<Drawable> d) => AddAssert("check focus", () => d().HasFocus);
+        private void checkNotFocused(Func<Drawable> d) => AddAssert("check not focus", () => !d().HasFocus);
+
+
+        private class FocusOverlay : FocusedOverlayContainer
+        {
+            private readonly Box box;
+            private readonly SpriteText stateText;
+
+            public FocusOverlay()
+            {
+                RelativeSizeAxes = Axes.Both;
+
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.Gray.Opacity(0.5f),
+                    },
+                    box = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(0.4f),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        Colour = Color4.Blue,
+                    },
+                    new SpriteText
+                    {
+                        Text = "FocusedOverlay",
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    },
+                    stateText = new SpriteText
+                    {
+                        Text = "FocusedOverlay",
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre,
+                    }
+                };
+
+                this.FadeTo(0.2f);
+            }
+
+            protected override void PopIn()
+            {
+                base.PopIn();
+                stateText.Text = State.ToString();
+            }
+
+            protected override void PopOut()
+            {
+                base.PopOut();
+                stateText.Text = State.ToString();
+            }
+
+            public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => true;
+
+            protected override bool OnClick(InputState state)
+            {
+                if (!box.ReceiveMouseInputAt(state.Mouse.NativeState.Position))
+                {
+                    State = Visibility.Hidden;
+                    return true;
+                }
+
+                return base.OnClick(state);
+            }
+
+            protected override void OnFocus(InputState state)
+            {
+                base.OnFocus(state);
+                this.FadeTo(1);
+            }
+
+            protected override void OnFocusLost(InputState state)
+            {
+                base.OnFocusLost(state);
+                this.FadeTo(0.2f);
+            }
+        }
+
+        public class RequestingFocusBox : FocusBox
+        {
+            public override bool RequestsFocus => true;
+
+            public RequestingFocusBox()
+            {
+                Box.Colour = Color4.Green;
+
+                AddInternal(new SpriteText
+                {
+                    Text = "RequestsFocus",
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                });
+            }
+        }
+
+        public class FocusBox : CompositeDrawable
+        {
+            protected Box Box;
+
+            public FocusBox()
+            {
+                AddInternal(Box = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Alpha = 0.5f,
+                    Colour = Color4.Red
+                });
+
+                RelativeSizeAxes = Axes.Both;
+                Size = new Vector2(0.4f);
+            }
+
+            protected override bool OnClick(InputState state) => true;
+
+            public override bool AcceptsFocus => true;
+
+            protected override void OnFocus(InputState state)
+            {
+                base.OnFocus(state);
+                Box.FadeTo(1);
+            }
+
+            protected override void OnFocusLost(InputState state)
+            {
+                base.OnFocusLost(state);
+                Box.FadeTo(0.5f);
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
@@ -11,7 +11,7 @@ namespace osu.Framework.Graphics.Containers
     {
         public override bool RequestsFocus => State == Visibility.Visible;
 
-        public override bool AcceptsFocus => true;
+        public override bool AcceptsFocus => State == Visibility.Visible;
 
         protected override void PopIn()
         {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -198,7 +198,7 @@ namespace osu.Framework.Input
 
             FocusedDrawable = potentialFocusTarget;
 
-            Logger.Log($"Focus switched to {FocusedDrawable?.ToString() ?? "nothing"}.", LoggingTarget.Runtime, LogLevel.Debug);
+            Logger.Log($"Focus changed from {previousFocus?.ToString() ?? "nothing"} to {FocusedDrawable?.ToString() ?? "nothing"}.", LoggingTarget.Runtime, LogLevel.Debug);
 
             if (FocusedDrawable != null)
             {
@@ -567,6 +567,7 @@ namespace osu.Framework.Input
             if (stillValid)
                 return false;
 
+            Logger.Log($"Focus on \"{FocusedDrawable}\" no longer valid as a result of {nameof(unfocusIfNoLongerValid)}.", LoggingTarget.Runtime, LogLevel.Debug);
             ChangeFocus(null);
             return true;
         }
@@ -601,6 +602,7 @@ namespace osu.Framework.Input
                     }
                 }
             }
+
 
             ChangeFocus(focusTarget);
         }


### PR DESCRIPTION
- Closes ppy/osu#2989.

`AcceptsFocus` was still true even when overlay was hidden. this means that any overlay with a fade animation would keep focus when it shouldn't.

---

