### PR TITLE
Fix draw visualiser title bar ignoring drags in some cases

### DIFF
--- a/osu.Framework/Graphics/Visualisation/TitleBar.cs
+++ b/osu.Framework/Graphics/Visualisation/TitleBar.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Graphics.Visualisation
+{
+    internal class TitleBar : CompositeDrawable
+    {
+        private readonly Drawable movableTarget;
+
+        public TitleBar(string title, Drawable movableTarget)
+        {
+            this.movableTarget = movableTarget;
+
+            RelativeSizeAxes = Axes.X;
+            Size = new Vector2(1, 25);
+
+            InternalChildren = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.BlueViolet,
+                },
+                new SpriteText
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Text = title,
+                    Alpha = 0.8f,
+                },
+            };
+        }
+
+        protected override bool OnDragStart(InputState state) => true;
+
+        protected override bool OnDrag(InputState state)
+        {
+            movableTarget.Position += state.Mouse.Delta;
+            return base.OnDrag(state);
+        }
+
+        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => true;
+    }
+}

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -13,12 +13,6 @@ using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Graphics.Visualisation
 {
-    internal enum TreeContainerStatus
-    {
-        Onscreen,
-        Offscreen
-    }
-
     internal class TreeContainer : Container, IStateful<TreeContainerStatus>
     {
         private readonly ScrollContainer scroll;
@@ -30,8 +24,6 @@ namespace osu.Framework.Graphics.Visualisation
         public Action ToggleProperties;
 
         protected override Container<Drawable> Content => scroll;
-
-        private readonly Container titleBar;
 
         private const float width = 400;
         private const float height = 600;
@@ -95,26 +87,7 @@ namespace osu.Framework.Graphics.Visualisation
                     Direction = FillDirection.Vertical,
                     Children = new Drawable[]
                     {
-                        titleBar = new Container
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Size = new Vector2(1, 25),
-                            Children = new Drawable[]
-                            {
-                                new Box
-                                {
-                                    RelativeSizeAxes = Axes.Both,
-                                    Colour = Color4.BlueViolet,
-                                },
-                                new SpriteText
-                                {
-                                    Anchor = Anchor.Centre,
-                                    Origin = Anchor.Centre,
-                                    Text = "draw visualiser (Ctrl+F1 to toggle)",
-                                    Alpha = 0.8f,
-                                },
-                            }
-                        },
+                        new TitleBar("draw visualiser (Ctrl+F1 to toggle)", this),
                         new Container //toolbar
                         {
                             RelativeSizeAxes = Axes.X,
@@ -207,16 +180,6 @@ namespace osu.Framework.Graphics.Visualisation
             State = TreeContainerStatus.Offscreen;
             base.OnHoverLost(state);
         }
-
-        protected override bool OnDragStart(InputState state) => titleBar.ReceiveMouseInputAt(state.Mouse.NativeState.Position);
-
-        protected override bool OnDrag(InputState state)
-        {
-            Position += state.Mouse.Delta;
-            return base.OnDrag(state);
-        }
-
-        protected override bool OnMouseDown(InputState state, MouseDownEventArgs args) => true;
 
         protected override bool OnClick(InputState state) => true;
 

--- a/osu.Framework/Graphics/Visualisation/TreeContainerStatus.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainerStatus.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics.Visualisation
+{
+    internal enum TreeContainerStatus
+    {
+        Onscreen,
+        Offscreen
+    }
+}


### PR DESCRIPTION
It was manually checking positional conditions in `OnDragStart`, at which point the mouse may be outside the draggable region (but should still be considered a drag).

---