### PR TITLE
Fix empty tooltips being shown incorrectly

### DIFF
--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -230,7 +230,7 @@ namespace osu.Framework.Graphics.Cursor
         /// <param name="tooltipTarget">The target of the tooltip.</param>
         protected virtual void RefreshTooltip(ITooltip tooltip, IHasTooltip tooltipTarget)
         {
-            if (tooltipTarget != null)
+            if (tooltipTarget != null && hasValidTooltip(tooltipTarget))
             {
                 tooltip.TooltipText = tooltipTarget.TooltipText;
                 tooltip.Refresh();

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.Cursor
         private readonly CursorContainer cursorContainer;
         private readonly ITooltip defaultTooltip;
 
-        private ITooltip currentTooltip;
+        protected ITooltip CurrentTooltip;
 
         private InputManager inputManager;
 
@@ -63,8 +63,8 @@ namespace osu.Framework.Graphics.Cursor
             {
                 RelativeSizeAxes = Axes.Both,
             });
-            AddInternal((Drawable)(currentTooltip = CreateTooltip()));
-            defaultTooltip = currentTooltip;
+            AddInternal((Drawable)(CurrentTooltip = CreateTooltip()));
+            defaultTooltip = CurrentTooltip;
         }
 
         protected override void OnSizingChanged()
@@ -117,12 +117,12 @@ namespace osu.Framework.Graphics.Cursor
             Vector2 tooltipPos = cursorCentre + southEast * boundingRadius;
 
             // Clamp position to tooltip container
-            tooltipPos.X = Math.Min(tooltipPos.X, DrawWidth - currentTooltip.DrawSize.X - 5);
+            tooltipPos.X = Math.Min(tooltipPos.X, DrawWidth - CurrentTooltip.DrawSize.X - 5);
             float dX = Math.Max(0, tooltipPos.X - cursorCentre.X);
             float dY = (float)Math.Sqrt(boundingRadius * boundingRadius - dX * dX);
 
-            if (tooltipPos.Y > DrawHeight - currentTooltip.DrawSize.Y - 5)
-                tooltipPos.Y = cursorCentre.Y - dY - currentTooltip.DrawSize.Y;
+            if (tooltipPos.Y > DrawHeight - CurrentTooltip.DrawSize.Y - 5)
+                tooltipPos.Y = cursorCentre.Y - dY - CurrentTooltip.DrawSize.Y;
             else
                 tooltipPos.Y = cursorCentre.Y + dY;
 
@@ -146,17 +146,17 @@ namespace osu.Framework.Graphics.Cursor
 
                 var newTooltip = getTooltip(target);
 
-                if (newTooltip != currentTooltip)
+                if (newTooltip != CurrentTooltip)
                 {
-                    RemoveInternal((Drawable)currentTooltip);
-                    currentTooltip = newTooltip;
+                    RemoveInternal((Drawable)CurrentTooltip);
+                    CurrentTooltip = newTooltip;
                     AddInternal((Drawable)newTooltip);
                 }
 
                 if (hasValidTooltip(target))
-                    currentTooltip.Show();
+                    CurrentTooltip.Show();
 
-                RefreshTooltip(currentTooltip, target);
+                RefreshTooltip(CurrentTooltip, target);
             }
         }
 
@@ -207,7 +207,7 @@ namespace osu.Framework.Graphics.Cursor
 
             // For determining whether to show a tooltip we first select only those positions
             // which happened within a shorter, alpha-adjusted appear delay.
-            double alphaModifiedAppearDelay = (1 - currentTooltip.Alpha) * appearDelay;
+            double alphaModifiedAppearDelay = (1 - CurrentTooltip.Alpha) * appearDelay;
             var relevantPositions = recentMousePositions.Where(t => Time.Current - t.Time <= alphaModifiedAppearDelay);
 
             // We then check whether all relevant positions fall within a radius of AppearRadius within the
@@ -243,7 +243,7 @@ namespace osu.Framework.Graphics.Cursor
         {
             base.UpdateAfterChildren();
 
-            RefreshTooltip(currentTooltip, currentlyDisplayed);
+            RefreshTooltip(CurrentTooltip, currentlyDisplayed);
 
             if (currentlyDisplayed != null && ShallHideTooltip(currentlyDisplayed))
                 hideTooltip();
@@ -251,7 +251,7 @@ namespace osu.Framework.Graphics.Cursor
 
         private void hideTooltip()
         {
-            currentTooltip.Hide();
+            CurrentTooltip.Hide();
             currentlyDisplayed = null;
         }
 

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -144,11 +144,18 @@ namespace osu.Framework.Graphics.Cursor
             {
                 currentlyDisplayed = target;
 
-                RemoveInternal((Drawable)currentTooltip);
-                currentTooltip = getTooltip(target);
-                AddInternal((Drawable)currentTooltip);
+                var newTooltip = getTooltip(target);
 
-                currentTooltip.Show();
+                if (newTooltip != currentTooltip)
+                {
+                    RemoveInternal((Drawable)currentTooltip);
+                    currentTooltip = newTooltip;
+                    AddInternal((Drawable)newTooltip);
+                }
+
+                if (hasValidTooltip(target))
+                    currentTooltip.Show();
+
                 RefreshTooltip(currentTooltip, target);
             }
         }


### PR DESCRIPTION
- Fixes empty tooltips from being `Show`n when actually unnecessary.
- Closes ppy/osu#3003 (also supersedes and closes ppy/osu#3016).

TooltipContainer needs some serious reafactoring (see `Update` / `UpdateAfterChildren` mess), but I'm leaving this for another day.

---