### PR TITLE
Fix multiple issues surrounding textbox per-character fades

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -16,7 +16,7 @@ using OpenTK.Input;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Configuration;
-using osu.Framework.Graphics.Colour;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Platform;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Bindings;
@@ -484,10 +484,6 @@ namespace osu.Framework.Graphics.UserInterface
 
             TextFlow.Add(ch);
 
-            ch.FadeColour(Color4.Transparent)
-              .FadeColour(ColourInfo.GradientHorizontal(Color4.White, Color4.Transparent), caret_move_time / 2).Then()
-              .FadeColour(Color4.White, caret_move_time / 2);
-
             // Add back all the previously removed characters
             TextFlow.AddRange(charsRight);
 
@@ -505,7 +501,12 @@ namespace osu.Framework.Graphics.UserInterface
             if (string.IsNullOrEmpty(addText)) return;
 
             foreach (char c in addText)
-                addCharacter(c);
+            {
+                var ch = addCharacter(c);
+
+                var col = (Color4)ch.Colour;
+                ch.FadeColour(col.Opacity(0)).FadeColour(col, caret_move_time * 2, Easing.Out);
+            }
         }
 
         private Drawable addCharacter(char c)


### PR DESCRIPTION
- Removed per-character gradient. This looked bad if many characters were typed quickly. To ensure characters don't appear in front of the caret, they fade using double the duration.
- Read existing character colour rather than forcing white. Allows consumers to change character colour, where it was previously not possible.
- No longer applies fades when the source of a text change was programmatic (ie. via `Textbox.Text`). Closes #1711.