### PR TITLE
Fix joystick input not working when first disabled then enabled

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseJoystick.cs
+++ b/osu.Framework.Tests/Visual/TestCaseJoystick.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Tests.Visual
 
             public JoystickButtonHandler(int buttonIndex)
             {
-                button = (JoystickButton)buttonIndex;
+                button = JoystickButton.FirstButton + buttonIndex;
 
                 Size = new Vector2(50);
 

--- a/osu.Framework/Input/Bindings/InputKey.cs
+++ b/osu.Framework/Input/Bindings/InputKey.cs
@@ -615,12 +615,12 @@ namespace osu.Framework.Input.Bindings
         /// <summary>
         /// Indicates the first available joystick button.
         /// </summary>
-        FirstJoystickButton = 1024,
+        FirstJoystickButton = 1024 + 1,
 
         /// <summary>
         /// Joystick button 1.
         /// </summary>
-        Joystick1,
+        Joystick1 = FirstJoystickButton,
         /// <summary>
         /// Joystick button 2.
         /// </summary>
@@ -877,12 +877,12 @@ namespace osu.Framework.Input.Bindings
         /// <summary>
         /// Indicates the first available negative-axis joystick button.
         /// </summary>
-        FirstJoystickAxisNegativeButton = 2048,
+        FirstJoystickAxisNegativeButton = 2048 + 1,
 
         /// <summary>
         /// Joystick axis 1 negative button.
         /// </summary>
-        JoystickAxis1Negative,
+        JoystickAxis1Negative = FirstJoystickAxisNegativeButton,
         /// <summary>
         /// Joystick axis 2 negative button.
         /// </summary>
@@ -1139,12 +1139,12 @@ namespace osu.Framework.Input.Bindings
         /// <summary>
         /// Indicates the first available positive-axis joystick button.
         /// </summary>
-        FirstJoystickAxisPositiveButton = 3072,
+        FirstJoystickAxisPositiveButton = 3072 + 1,
 
         /// <summary>
         /// Joystick axis 1 positive button.
         /// </summary>
-        JoystickAxis1Positive,
+        JoystickAxis1Positive = FirstJoystickAxisPositiveButton,
         /// <summary>
         /// Joystick axis 2 positive button.
         /// </summary>
@@ -1401,12 +1401,12 @@ namespace osu.Framework.Input.Bindings
         /// <summary>
         /// Indicates the first available joystick hat up button.
         /// </summary>
-        FirstJoystickHatUpButton = 4096,
+        FirstJoystickHatUpButton = 4096 + 1,
 
         /// <summary>
         /// Joystick hat 1 up button.
         /// </summary>
-        JoystickHat1Up,
+        JoystickHat1Up = FirstJoystickHatUpButton,
         /// <summary>
         /// Joystick hat 2 up button.
         /// </summary>
@@ -1423,12 +1423,12 @@ namespace osu.Framework.Input.Bindings
         /// <summary>
         /// Indicates the first available joystick hat down button.
         /// </summary>
-        FirstJoystickHatDownButton = 5120,
+        FirstJoystickHatDownButton = 5120 + 1,
 
         /// <summary>
         /// Joystick hat 1 down button.
         /// </summary>
-        JoystickHat1Down,
+        JoystickHat1Down = FirstJoystickHatDownButton,
         /// <summary>
         /// Joystick hat 2 down button.
         /// </summary>
@@ -1445,12 +1445,12 @@ namespace osu.Framework.Input.Bindings
         /// <summary>
         /// Indicates the first available joystick hat left button.
         /// </summary>
-        FirstJoystickHatLeftButton = 6144,
+        FirstJoystickHatLeftButton = 6144 + 1,
 
         /// <summary>
         /// Joystick hat 1 left button.
         /// </summary>
-        JoystickHat1Left,
+        JoystickHat1Left = FirstJoystickHatLeftButton,
         /// <summary>
         /// Joystick hat 2 left button.
         /// </summary>
@@ -1467,12 +1467,12 @@ namespace osu.Framework.Input.Bindings
         /// <summary>
         /// Indicates the first available joystick hat right button.
         /// </summary>
-        FirstJoystickHatRightButton = 7168,
+        FirstJoystickHatRightButton = 7168 + 1,
 
         /// <summary>
         /// Joystick hat 1 right button.
         /// </summary>
-        JoystickHat1Right,
+        JoystickHat1Right = FirstJoystickHatRightButton,
         /// <summary>
         /// Joystick hat 2 right button.
         /// </summary>

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -80,19 +80,19 @@ namespace osu.Framework.Input.Bindings
         private string getReadableKey(InputKey key)
         {
             if (key >= InputKey.FirstJoystickHatRightButton)
-                return $"Joystick Hat {key - InputKey.FirstJoystickHatRightButton} Right";
+                return $"Joystick Hat {key - InputKey.FirstJoystickHatRightButton + 1} Right";
             if (key >= InputKey.FirstJoystickHatLeftButton)
-                return $"Joystick Hat {key - InputKey.FirstJoystickHatLeftButton} Left";
+                return $"Joystick Hat {key - InputKey.FirstJoystickHatLeftButton + 1} Left";
             if (key >= InputKey.FirstJoystickHatDownButton)
-                return $"Joystick Hat {key - InputKey.FirstJoystickHatDownButton} Down";
+                return $"Joystick Hat {key - InputKey.FirstJoystickHatDownButton + 1} Down";
             if (key >= InputKey.FirstJoystickHatUpButton)
-                return $"Joystick Hat {key - InputKey.FirstJoystickHatUpButton} Up";
+                return $"Joystick Hat {key - InputKey.FirstJoystickHatUpButton + 1} Up";
             if (key >= InputKey.FirstJoystickAxisPositiveButton)
-                return $"Joystick Axis {key - InputKey.FirstJoystickAxisPositiveButton} +";
+                return $"Joystick Axis {key - InputKey.FirstJoystickAxisPositiveButton + 1} +";
             if (key >= InputKey.FirstJoystickAxisNegativeButton)
-                return $"Joystick Axis {key - InputKey.FirstJoystickAxisNegativeButton} -";
+                return $"Joystick Axis {key - InputKey.FirstJoystickAxisNegativeButton + 1} -";
             if (key >= InputKey.FirstJoystickButton)
-                return $"Joystick {key - InputKey.FirstJoystickButton}";
+                return $"Joystick {key - InputKey.FirstJoystickButton + 1}";
 
             switch (key)
             {
@@ -239,7 +239,7 @@ namespace osu.Framework.Input.Bindings
                 return InputKey.FirstJoystickAxisPositiveButton + (button - JoystickButton.FirstAxisPositive);
             if (button >= JoystickButton.FirstAxisNegative)
                 return InputKey.FirstJoystickAxisNegativeButton + (button - JoystickButton.FirstAxisNegative);
-            return InputKey.FirstJoystickButton + (int)button;
+            return InputKey.FirstJoystickButton + (button - JoystickButton.FirstButton);
         }
 
         public static InputKey FromScrollDelta(Vector2 scrollDelta)

--- a/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
@@ -124,7 +124,7 @@ namespace osu.Framework.Input.Handlers.Joystick
                 for (int i = 0; i < JoystickDevice.MAX_BUTTONS; i++)
                 {
                     if (device.RawState.GetButton(i) == ButtonState.Pressed)
-                        Buttons.SetPressed((JoystickButton)i, true);
+                        Buttons.SetPressed(JoystickButton.FirstButton + i, true);
                 }
 
                 // Populate hat buttons

--- a/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Input.Handlers.Joystick
 
         public override bool Initialize(GameHost host)
         {
-            Enabled.ValueChanged += enabled =>
+            Enabled.BindValueChanged(enabled =>
             {
                 if (enabled)
                 {
@@ -52,9 +52,7 @@ namespace osu.Framework.Input.Handlers.Joystick
                     devices.Clear();
                     mostSeenDevices = 0;
                 }
-            };
-
-            Enabled.TriggerChange();
+            }, true);
 
             return true;
         }

--- a/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
@@ -50,6 +50,7 @@ namespace osu.Framework.Input.Handlers.Joystick
                     }
 
                     devices.Clear();
+                    mostSeenDevices = 0;
                 }
             };
 

--- a/osu.Framework/Input/Handlers/Keyboard/OpenTKKeyboardHandler.cs
+++ b/osu.Framework/Input/Handlers/Keyboard/OpenTKKeyboardHandler.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Input.Handlers.Keyboard
 
         public override bool Initialize(GameHost host)
         {
-            Enabled.ValueChanged += enabled =>
+            Enabled.BindValueChanged(enabled =>
             {
                 if (enabled)
                 {
@@ -35,8 +35,8 @@ namespace osu.Framework.Input.Handlers.Keyboard
                     lastRawState = null;
                     lastEventState = null;
                 }
-            };
-            Enabled.TriggerChange();
+            }, true);
+
             return true;
         }
 

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKMouseHandler.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Input.Handlers.Mouse
         {
             base.Initialize(host);
 
-            Enabled.ValueChanged += enabled =>
+            Enabled.BindValueChanged(enabled =>
             {
                 if (enabled)
                 {
@@ -60,8 +60,8 @@ namespace osu.Framework.Input.Handlers.Mouse
                     lastPollState = null;
                     lastEventState = null;
                 }
-            };
-            Enabled.TriggerChange();
+            }, true);
+
             return true;
         }
 

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                 mapAbsoluteInputToWindow.BindTo(desktopWindow.MapAbsoluteInputToWindow);
             }
 
-            Enabled.ValueChanged += enabled =>
+            Enabled.BindValueChanged(enabled =>
             {
                 if (enabled)
                 {
@@ -109,9 +109,8 @@ namespace osu.Framework.Input.Handlers.Mouse
                     lastEachDeviceStates.Clear();
                     lastUnfocusedState = null;
                 }
-            };
+            }, true);
 
-            Enabled.TriggerChange();
             return true;
         }
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -264,9 +264,7 @@ namespace osu.Framework.Input
 
             foreach (var h in InputHandlers)
             {
-                var list = h.GetPendingInputs();
-                if (h.IsActive && h.Enabled)
-                    inputs.AddRange(list);
+                inputs.AddRange(h.GetPendingInputs());
             }
 
             return inputs;


### PR DESCRIPTION
- Made `InputManager` to not ignore inputs from disabled input handlers.
  When an input handler is disabled, this disable produces release input of buttons and these input should be handled.
- Also fixed JoystickButton.FirstButton was not correctly used.
- Required for the correct function of ppy/osu#3022.