### PR TITLE
Use Enum.HasFlag

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseIsMaskedAway.cs
+++ b/osu.Framework.Tests/Visual/TestCaseIsMaskedAway.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Tests.Visual
                     Anchor = anchor,
                     Origin = anchor,
                     Size = new Vector2(10),
-                    Position = new Vector2((anchor & Anchor.x0) > 0 ? -5 : 5, (anchor & Anchor.y0) > 0 ? -5 : 5),
+                    Position = new Vector2(anchor.HasFlag(Anchor.x0) ? -5 : 5, anchor.HasFlag(Anchor.y0) ? -5 : 5),
                 }
             };
 
@@ -99,7 +99,7 @@ namespace osu.Framework.Tests.Visual
                     Anchor = anchor,
                     Origin = anchor,
                     Size = new Vector2(10),
-                    Position = new Vector2((anchor & Anchor.x0) > 0 ? -20 : 20, (anchor & Anchor.y0) > 0 ? -20 : 20),
+                    Position = new Vector2(anchor.HasFlag(Anchor.x0) ? -20 : 20, anchor.HasFlag(Anchor.y0) ? -20 : 20),
                 }
             };
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1278,7 +1278,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && (AutoSizeAxes & Axes.X) > 0)
+                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.X))
                     updateChildrenSizeDependencies();
                 return base.Width;
             }
@@ -1295,7 +1295,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && (AutoSizeAxes & Axes.Y) > 0)
+                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.Y))
                     updateChildrenSizeDependencies();
                 return base.Height;
             }
@@ -1349,16 +1349,16 @@ namespace osu.Framework.Graphics.Containers
 
                     Vector2 cBound = c.RequiredParentSizeToFit;
 
-                    if ((c.BypassAutoSizeAxes & Axes.X) == 0)
+                    if (!c.BypassAutoSizeAxes.HasFlag(Axes.X))
                         maxBoundSize.X = Math.Max(maxBoundSize.X, cBound.X);
 
-                    if ((c.BypassAutoSizeAxes & Axes.Y) == 0)
+                    if (!c.BypassAutoSizeAxes.HasFlag(Axes.Y))
                         maxBoundSize.Y = Math.Max(maxBoundSize.Y, cBound.Y);
                 }
 
-                if ((AutoSizeAxes & Axes.X) == 0)
+                if (!AutoSizeAxes.HasFlag(Axes.X))
                     maxBoundSize.X = DrawSize.X;
-                if ((AutoSizeAxes & Axes.Y) == 0)
+                if (!AutoSizeAxes.HasFlag(Axes.Y))
                     maxBoundSize.Y = DrawSize.Y;
 
                 return new Vector2(maxBoundSize.X, maxBoundSize.Y);
@@ -1378,8 +1378,8 @@ namespace osu.Framework.Graphics.Containers
             Vector2 b = computeAutoSize() + Padding.Total;
 
             autoSizeResizeTo(new Vector2(
-                (AutoSizeAxes & Axes.X) > 0 ? b.X : base.Width,
-                (AutoSizeAxes & Axes.Y) > 0 ? b.Y : base.Height
+                AutoSizeAxes.HasFlag(Axes.X) ? b.X : base.Width,
+                AutoSizeAxes.HasFlag(Axes.Y) ? b.Y : base.Height
             ), AutoSizeDuration, AutoSizeEasing);
 
             //note that this is called before autoSize becomes valid. may be something to consider down the line.

--- a/osu.Framework/Graphics/Containers/ContainerExtensions.cs
+++ b/osu.Framework/Graphics/Containers/ContainerExtensions.cs
@@ -42,13 +42,13 @@ namespace osu.Framework.Graphics.Containers
 
             // For anchor/origin positioning to be preserved correctly,
             // relatively sized axes must be lifted to the wrapping container.
-            if ((container.RelativeSizeAxes & Axes.X) > 0)
+            if (container.RelativeSizeAxes.HasFlag(Axes.X))
             {
                 container.Width = drawable.Width;
                 drawable.Width = 1;
             }
 
-            if ((container.RelativeSizeAxes & Axes.Y) > 0)
+            if (container.RelativeSizeAxes.HasFlag(Axes.Y))
             {
                 container.Height = drawable.Height;
                 drawable.Height = 1;

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -87,9 +87,9 @@ namespace osu.Framework.Graphics.Containers
         private Vector2 spacingFactor(Drawable c)
         {
             Vector2 result = c.RelativeOriginPosition;
-            if ((c.Anchor & Anchor.x2) > 0)
+            if (c.Anchor.HasFlag(Anchor.x2))
                 result.X = 1 - result.X;
-            if ((c.Anchor & Anchor.y2) > 0)
+            if (c.Anchor.HasFlag(Anchor.y2))
                 result.Y = 1 - result.Y;
             return result;
         }
@@ -103,8 +103,8 @@ namespace osu.Framework.Graphics.Containers
 
                 // If we are autosize and haven't specified a maximum size, we should allow infinite expansion.
                 // If we are inheriting then we need to use the parent size (our ActualSize).
-                max.X = (AutoSizeAxes & Axes.X) > 0 ? float.MaxValue : s.X;
-                max.Y = (AutoSizeAxes & Axes.Y) > 0 ? float.MaxValue : s.Y;
+                max.X = AutoSizeAxes.HasFlag(Axes.X) ? float.MaxValue : s.X;
+                max.Y = AutoSizeAxes.HasFlag(Axes.Y) ? float.MaxValue : s.Y;
             }
 
             var children = FlowingChildren.ToArray();
@@ -217,17 +217,17 @@ namespace osu.Framework.Graphics.Containers
                         break;
                 }
 
-                if ((c.Anchor & Anchor.x1) > 0)
+                if (c.Anchor.HasFlag(Anchor.x1))
                     // Begin flow at centre of row
                     result[i].X += rowOffsetsToMiddle[rowIndices[i]];
-                else if ((c.Anchor & Anchor.x2) > 0)
+                else if (c.Anchor.HasFlag(Anchor.x2))
                     // Flow right-to-left
                     result[i].X = -result[i].X;
 
-                if ((c.Anchor & Anchor.y1) > 0)
+                if (c.Anchor.HasFlag(Anchor.y1))
                     // Begin flow at centre of total height
                     result[i].Y -= height / 2;
-                else if ((c.Anchor & Anchor.y2) > 0)
+                else if (c.Anchor.HasFlag(Anchor.y2))
                     // Flow bottom-to-top
                     result[i].Y = -result[i].Y;
             }

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -143,7 +143,7 @@ namespace osu.Framework.Graphics.Containers
         {
             // FillFlowContainer will reverse the ordering of right-anchored words such that the (previously) first word would be
             // the right-most word, whereas it should still be flowed left-to-right. This is achieved by reversing the comparator.
-            if ((TextAnchor & Anchor.x2) > 0)
+            if (TextAnchor.HasFlag(Anchor.x2))
                 return base.Compare(y, x);
             return base.Compare(x, y);
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -526,10 +526,10 @@ namespace osu.Framework.Graphics
                 {
                     offset = Parent.RelativeChildOffset;
 
-                    if ((RelativePositionAxes & Axes.X) == 0)
+                    if (!RelativePositionAxes.HasFlag(Axes.X))
                         offset.X = 0;
 
-                    if ((RelativePositionAxes & Axes.Y) == 0)
+                    if (!RelativePositionAxes.HasFlag(Axes.Y))
                         offset.Y = 0;
                 }
 
@@ -649,8 +649,8 @@ namespace osu.Framework.Graphics
 
                 relativeSizeAxes = value;
 
-                if ((relativeSizeAxes & Axes.X) > 0 && Width == 0) Width = 1;
-                if ((relativeSizeAxes & Axes.Y) > 0 && Height == 0) Height = 1;
+                if (relativeSizeAxes.HasFlag(Axes.X) && Width == 0) Width = 1;
+                if (relativeSizeAxes.HasFlag(Axes.Y) && Height == 0) Height = 1;
 
                 OnSizingChanged();
             }
@@ -742,9 +742,9 @@ namespace osu.Framework.Graphics
             {
                 Vector2 conversion = relativeToAbsoluteFactor;
 
-                if ((relativeAxes & Axes.X) > 0)
+                if (relativeAxes.HasFlag(Axes.X))
                     v.X *= conversion.X;
-                if ((relativeAxes & Axes.Y) > 0)
+                if (relativeAxes.HasFlag(Axes.Y))
                     v.Y *= conversion.Y;
 
                 // FillMode only makes sense if both axes are relatively sized as the general rule
@@ -957,14 +957,14 @@ namespace osu.Framework.Graphics
                     throw new InvalidOperationException(@"Can not obtain relative origin position for custom origins.");
 
                 Vector2 result = Vector2.Zero;
-                if ((origin & Anchor.x1) > 0)
+                if (origin.HasFlag(Anchor.x1))
                     result.X = 0.5f;
-                else if ((origin & Anchor.x2) > 0)
+                else if (origin.HasFlag(Anchor.x2))
                     result.X = 1;
 
-                if ((origin & Anchor.y1) > 0)
+                if (origin.HasFlag(Anchor.y1))
                     result.Y = 0.5f;
-                else if ((origin & Anchor.y2) > 0)
+                else if (origin.HasFlag(Anchor.y2))
                     result.Y = 1;
 
                 return result;
@@ -1043,14 +1043,14 @@ namespace osu.Framework.Graphics
                     return customRelativeAnchorPosition;
 
                 Vector2 result = Vector2.Zero;
-                if ((anchor & Anchor.x1) > 0)
+                if (anchor.HasFlag(Anchor.x1))
                     result.X = 0.5f;
-                else if ((anchor & Anchor.x2) > 0)
+                else if (anchor.HasFlag(Anchor.x2))
                     result.X = 1;
 
-                if ((anchor & Anchor.y1) > 0)
+                if (anchor.HasFlag(Anchor.y1))
                     result.Y = 0.5f;
-                else if ((anchor & Anchor.y2) > 0)
+                else if (anchor.HasFlag(Anchor.y2))
                     result.Y = 1;
 
                 return result;
@@ -1083,14 +1083,14 @@ namespace osu.Framework.Graphics
         {
             Vector2 result = Vector2.Zero;
 
-            if ((anchor & Anchor.x1) > 0)
+            if (anchor.HasFlag(Anchor.x1))
                 result.X = size.X / 2f;
-            else if ((anchor & Anchor.x2) > 0)
+            else if (anchor.HasFlag(Anchor.x2))
                 result.X = size.X;
 
-            if ((anchor & Anchor.y1) > 0)
+            if (anchor.HasFlag(Anchor.y1))
                 result.Y = size.Y / 2f;
-            else if ((anchor & Anchor.y2) > 0)
+            else if (anchor.HasFlag(Anchor.y2))
                 result.Y = size.Y;
 
             return result;

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -48,8 +48,8 @@ namespace osu.Framework.Graphics.Lines
             positions.Clear();
             resetBounds();
 
-            if ((RelativeSizeAxes & Axes.X) == 0) Width = 0;
-            if ((RelativeSizeAxes & Axes.Y) == 0) Height = 0;
+            if (!RelativeSizeAxes.HasFlag(Axes.X)) Width = 0;
+            if (!RelativeSizeAxes.HasFlag(Axes.Y)) Height = 0;
 
             segmentsCache.Invalidate();
             Invalidate(Invalidation.DrawNode);
@@ -79,8 +79,8 @@ namespace osu.Framework.Graphics.Lines
             if (pos.Y + PathWidth > maxY) maxY = pos.Y + PathWidth;
 
             RectangleF b = bounds;
-            if ((RelativeSizeAxes & Axes.X) == 0) Width = b.Width;
-            if ((RelativeSizeAxes & Axes.Y) == 0) Height = b.Height;
+            if (!RelativeSizeAxes.HasFlag(Axes.X)) Width = b.Width;
+            if (!RelativeSizeAxes.HasFlag(Axes.Y)) Height = b.Height;
         }
 
         private void resetBounds()

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -351,8 +351,8 @@ namespace osu.Framework.Graphics.UserInterface
                 height = Math.Min(MaxHeight, height);
 
                 // Regardless of the above result, if we are relative-sizing, just use the stored width/height
-                width = (RelativeSizeAxes & Axes.X) > 0 ? Width : width;
-                height = (RelativeSizeAxes & Axes.Y) > 0 ? Height : height;
+                width = RelativeSizeAxes.HasFlag(Axes.X) ? Width : width;
+                height = RelativeSizeAxes.HasFlag(Axes.Y) ? Height : height;
 
                 if (State == MenuState.Closed && Direction == Direction.Horizontal)
                     width = 0;

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -85,8 +85,8 @@ namespace osu.Framework.Graphics.UserInterface
 
                 Add(Dropdown);
 
-                Trace.Assert((Dropdown.Header.Anchor & Anchor.x2) > 0, $@"The {nameof(Dropdown)} implementation should use a right-based anchor inside a TabControl.");
-                Trace.Assert((Dropdown.Header.RelativeSizeAxes & Axes.X) == 0, $@"The {nameof(Dropdown)} implementation's header should have a specific size.");
+                Trace.Assert(Dropdown.Header.Anchor.HasFlag(Anchor.x2), $@"The {nameof(Dropdown)} implementation should use a right-based anchor inside a TabControl.");
+                Trace.Assert(!Dropdown.Header.RelativeSizeAxes.HasFlag(Axes.X), $@"The {nameof(Dropdown)} implementation's header should have a specific size.");
 
                 // create tab items for already existing items in dropdown (if any).
                 tabMap = Dropdown.Items.ToDictionary(item => item.Value, item => addTab(item.Value, false));

--- a/osu.Framework/IO/File/FileSafety.cs
+++ b/osu.Framework/IO/File/FileSafety.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.IO.File
             foreach (string f in Directory.GetFiles(s))
             {
                 FileInfo myFile = new FileInfo(f);
-                if ((myFile.Attributes & FileAttributes.ReadOnly) > 0)
+                if (myFile.Attributes.HasFlag(FileAttributes.ReadOnly))
                     myFile.Attributes &= ~FileAttributes.ReadOnly;
             }
 
@@ -225,7 +225,7 @@ namespace osu.Framework.IO.File
                 {
                     DirectoryInfo newDirectoryInfo = Directory.CreateDirectory(newSubDirectory);
 
-                    if ((new DirectoryInfo(dir).Attributes & FileAttributes.Hidden) > 0)
+                    if (new DirectoryInfo(dir).Attributes.HasFlag(FileAttributes.Hidden))
                         newDirectoryInfo.Attributes |= FileAttributes.Hidden;
                 }
                 catch
@@ -241,7 +241,7 @@ namespace osu.Framework.IO.File
                 DirectoryInfo newDirectoryInfo = Directory.CreateDirectory(newDirectory);
                 try
                 {
-                    if ((new DirectoryInfo(oldDirectory).Attributes & FileAttributes.Hidden) > 0)
+                    if (new DirectoryInfo(oldDirectory).Attributes.HasFlag(FileAttributes.Hidden))
                         newDirectoryInfo.Attributes |= FileAttributes.Hidden;
                 }
                 catch

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKMouseState.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKMouseState.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             }
 
             Scroll = new Vector2(-tkState.Scroll.X, tkState.Scroll.Y);
-            HasPreciseScroll = (tkState.Flags & MouseStateFlags.HasPreciseScroll) > 0;
+            HasPreciseScroll = tkState.Flags.HasFlag(MouseStateFlags.HasPreciseScroll);
             Position = new Vector2(mappedPosition?.X ?? tkState.X, mappedPosition?.Y ?? tkState.Y);
         }
 

--- a/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OpenTKRawMouseHandler.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Input.Handlers.Mouse
 
                                 var newState = new OpenTKPollMouseState(rawState, host.IsActive, getUpdatedPosition(rawState, lastState));
 
-                                HandleState(newState, lastState, (rawState.Flags & MouseStateFlags.MoveAbsolute) > 0);
+                                HandleState(newState, lastState, rawState.Flags.HasFlag(MouseStateFlags.MoveAbsolute));
 
                                 lastEachDeviceStates[i] = newState;
                                 lastUnfocusedState = null;
@@ -129,7 +129,7 @@ namespace osu.Framework.Input.Handlers.Mouse
         {
             Vector2 currentPosition;
 
-            if ((state.Flags & MouseStateFlags.MoveAbsolute) > 0)
+            if (state.Flags.HasFlag(MouseStateFlags.MoveAbsolute))
             {
                 const int raw_input_resolution = 65536;
 
@@ -142,7 +142,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                 }
                 else
                 {
-                    Rectangle screenRect = (state.Flags & MouseStateFlags.VirtualDesktop) > 0
+                    Rectangle screenRect = state.Flags.HasFlag(MouseStateFlags.VirtualDesktop)
                         ? Platform.Windows.Native.Input.GetVirtualScreenRect()
                         : new Rectangle(0, 0, DisplayDevice.Default.Width, DisplayDevice.Default.Height);
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Input
         {
             var mouse = state.Mouse;
             // confine cursor
-            if (Host.Window != null && (Host.Window.CursorState & CursorState.Confined) > 0)
+            if (Host.Window != null && Host.Window.CursorState.HasFlag(CursorState.Confined))
                 mouse.Position = Vector2.Clamp(mouse.Position, Vector2.Zero, new Vector2(Host.Window.Width, Host.Window.Height));
             base.HandleMousePositionChange(state);
         }

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -119,11 +119,11 @@ namespace osu.Framework.Platform
             {
                 cursorState = value;
 
-                Implementation.Cursor = (cursorState & CursorState.Hidden) > 0 ? MouseCursor.Empty : MouseCursor.Default;
+                Implementation.Cursor = cursorState.HasFlag(CursorState.Hidden) ? MouseCursor.Empty : MouseCursor.Default;
 
                 try
                 {
-                    Implementation.CursorGrabbed = (cursorState & CursorState.Confined) > 0;
+                    Implementation.CursorGrabbed = cursorState.HasFlag(CursorState.Confined);
                 }
                 catch
                 {

--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -22,15 +22,6 @@ namespace osu.Framework.Platform.MacOS
         private MethodInfo methodKeyDown;
         private MethodInfo methodKeyUp;
 
-        private const int modifier_flag_left_control = 1 << 0;
-        private const int modifier_flag_left_shift = 1 << 1;
-        private const int modifier_flag_right_shift = 1 << 2;
-        private const int modifier_flag_left_command = 1 << 3;
-        private const int modifier_flag_right_command = 1 << 4;
-        private const int modifier_flag_left_alt = 1 << 5;
-        private const int modifier_flag_right_alt = 1 << 6;
-        private const int modifier_flag_right_control = 1 << 13;
-
         private object nativeWindow;
 
         public MacOSGameWindow()
@@ -65,7 +56,7 @@ namespace osu.Framework.Platform.MacOS
 
         private void flagsChanged(IntPtr self, IntPtr cmd, IntPtr sender)
         {
-            var modifierFlags = Cocoa.SendInt(sender, selModifierFlags);
+            var modifierFlags = (CocoaKeyModifiers)Cocoa.SendInt(sender, selModifierFlags);
             var keyCode = Cocoa.SendInt(sender, selKeyCode);
 
             bool keyDown;
@@ -75,42 +66,42 @@ namespace osu.Framework.Platform.MacOS
             {
                 case MacOSKeyCodes.LShift:
                     key = OpenTK.Input.Key.LShift;
-                    keyDown = (modifierFlags & modifier_flag_left_shift) > 0;
+                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.LeftShift);
                     break;
 
                 case MacOSKeyCodes.RShift:
                     key = OpenTK.Input.Key.RShift;
-                    keyDown = (modifierFlags & modifier_flag_right_shift) > 0;
+                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.RightShift);
                     break;
 
                 case MacOSKeyCodes.LControl:
                     key = OpenTK.Input.Key.LControl;
-                    keyDown = (modifierFlags & modifier_flag_left_control) > 0;
+                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.LeftControl);
                     break;
 
                 case MacOSKeyCodes.RControl:
                     key = OpenTK.Input.Key.RControl;
-                    keyDown = (modifierFlags & modifier_flag_right_control) > 0;
+                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.RightControl);
                     break;
 
                 case MacOSKeyCodes.LAlt:
                     key = OpenTK.Input.Key.LAlt;
-                    keyDown = (modifierFlags & modifier_flag_left_alt) > 0;
+                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.LeftAlt);
                     break;
 
                 case MacOSKeyCodes.RAlt:
                     key = OpenTK.Input.Key.RAlt;
-                    keyDown = (modifierFlags & modifier_flag_right_alt) > 0;
+                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.RightAlt);
                     break;
 
                 case MacOSKeyCodes.LCommand:
                     key = OpenTK.Input.Key.LWin;
-                    keyDown = (modifierFlags & modifier_flag_left_command) > 0;
+                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.LeftCommand);
                     break;
 
                 case MacOSKeyCodes.RCommand:
                     key = OpenTK.Input.Key.RWin;
-                    keyDown = (modifierFlags & modifier_flag_right_command) > 0;
+                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.RightCommand);
                     break;
 
                 default:
@@ -122,6 +113,18 @@ namespace osu.Framework.Platform.MacOS
             else
                 methodKeyUp.Invoke(nativeWindow, new object[] { key });
         }
+    }
+
+    internal enum CocoaKeyModifiers
+    {
+        LeftControl = 1 << 0,
+        LeftShift = 1 << 1,
+        RightShift = 1 << 2,
+        LeftCommand = 1 << 3,
+        RightCommand = 1 << 4,
+        LeftAlt = 1 << 5,
+        RightAlt = 1 << 6,
+        RightControl = 1 << 13,
     }
 
     internal enum MacOSKeyCodes


### PR DESCRIPTION
With .NET core 2.1+ this is as efficient as the ugly code we've been using. Skipping usage with invalidation logic since there's many cases we care about *any* of combined flags values matching (making it easy to get the usage pattern wrong).

---