### PR TITLE
Fixes font precache freezing

### DIFF
--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.IO.Stores
                         font.LoadText(s);
 
                     if (precache)
-                        for (int i = 0; i < Font.Pages.Length; i++)
+                        for (int i = 0; i < font.Pages.Length; i++)
                             getTexturePage(i);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Fixes an issue where requesting fonts be precached was making a reference to the `Font` property, which attempted to wait on its own task.

We do not currently precache fonts by default, so this has gone unnoticed since its inception.

Not really sure how to unit test this one, since loading fonts is part of the visual test bootstrap.

---