### PR TITLE
Add TryGet<T>() extension to dependency containers

### DIFF
--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -157,17 +157,7 @@ namespace osu.Framework.Allocation
         {
             if (cache.TryGetValue(type, out object ret))
                 return ret;
-
             return parentContainer?.Get(type);
-
-            //we don't ever want to instantiate for now, as this breaks expectations when using permitNull.
-            //need to revisit this when/if it is required.
-            //if (!activators.ContainsKey(type))
-            //    return null; // Or an exception?
-            //object instance = activators[type](this, null);
-            //if (cacheable.Contains(type))
-            //    cache[type] = instance;
-            //return instance;
         }
 
         /// <summary>

--- a/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
+++ b/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
@@ -36,7 +36,22 @@ namespace osu.Framework.Allocation
         /// <typeparam name="T">The dependency type to query for.</typeparam>
         /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
         /// <returns>The requested dependency, or null if not found.</returns>
-        public static T Get<T>(this IReadOnlyDependencyContainer container) where T : class =>
-            (T)container.Get(typeof(T));
+        public static T Get<T>(this IReadOnlyDependencyContainer container)
+            where T : class
+            => (T)container.Get(typeof(T));
+
+        /// <summary>
+        /// Tries to retrieve a cached dependency of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
+        /// <param name="value">The requested dependency, or null if not found.</param>
+        /// <typeparam name="T">The dependency type to query for.</typeparam>
+        /// <returns>Whether the requested dependency existed.</returns>
+        public static bool TryGet<T>(this IReadOnlyDependencyContainer container, out T value)
+            where T : class
+        {
+            value = container.Get<T>();
+            return value != null;
+        }
     }
 }


### PR DESCRIPTION
Small helper method to simplify cases like:

```
CreateChildDependencies:
    existing = dependencies.Get<T>();
    if (existing != null)
        existing = ...
```

Which now becomes:

```
CreateChildDependencies:
    if (!dependencies.TryGet<T>(out existing))
        existing = ...
```

---