### PR TITLE
Allow KeyCombinations to handle exact matches only on modifier keys

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Tests.Visual
 {
     public class TestCaseKeyBindings : ManualInputManagerTestCase
     {
-        private readonly KeyBindingTester none, noneExact, unique, all;
+        private readonly KeyBindingTester none, noneExact, noneModifiers, unique, all;
 
         public TestCaseKeyBindings()
         {
@@ -33,13 +33,14 @@ namespace osu.Framework.Tests.Visual
                 {
                     new Drawable[]
                     {
-                        none = new KeyBindingTester(SimultaneousBindingMode.None),
-                        noneExact = new KeyBindingTester(SimultaneousBindingMode.NoneExact)
+                        none = new KeyBindingTester(SimultaneousBindingMode.None, KeyCombinationMatchingMode.Any),
+                        noneExact = new KeyBindingTester(SimultaneousBindingMode.None, KeyCombinationMatchingMode.Exact),
+                        noneModifiers = new KeyBindingTester(SimultaneousBindingMode.None, KeyCombinationMatchingMode.Modifiers)
                     },
                     new Drawable[]
                     {
-                        unique = new KeyBindingTester(SimultaneousBindingMode.Unique),
-                        all = new KeyBindingTester(SimultaneousBindingMode.All)
+                        unique = new KeyBindingTester(SimultaneousBindingMode.Unique, KeyCombinationMatchingMode.Any),
+                        all = new KeyBindingTester(SimultaneousBindingMode.All, KeyCombinationMatchingMode.Any)
                     },
                 }
             };
@@ -113,20 +114,22 @@ namespace osu.Framework.Tests.Visual
             });
         }
 
-        private void checkPressed(TestAction action, int noneDelta, int noneExactDelta, int uniqueDelta, int allDelta)
+        private void checkPressed(TestAction action, int noneDelta, int noneExactDelta, int noneModifiersDelta, int uniqueDelta, int allDelta)
         {
             check(action,
                 new CheckConditions(none, noneDelta, 0),
                 new CheckConditions(noneExact, noneExactDelta, 0),
+                new CheckConditions(noneModifiers, noneModifiersDelta, 0),
                 new CheckConditions(unique, uniqueDelta, 0),
                 new CheckConditions(all, allDelta, 0));
         }
 
-        private void checkReleased(TestAction action, int noneDelta, int noneExactDelta, int uniqueDelta, int allDelta)
+        private void checkReleased(TestAction action, int noneDelta, int noneExactDelta, int noneModifiersDelta, int uniqueDelta, int allDelta)
         {
             check(action,
                 new CheckConditions(none, 0, noneDelta),
                 new CheckConditions(noneExact, 0, noneExactDelta),
+                new CheckConditions(noneModifiers, 0, noneModifiersDelta),
                 new CheckConditions(unique, 0, uniqueDelta),
                 new CheckConditions(all, 0, allDelta));
         }
@@ -135,7 +138,7 @@ namespace osu.Framework.Tests.Visual
         {
             AddStep("init", () =>
             {
-                foreach (var mode in new[] { none, noneExact, unique, all })
+                foreach (var mode in new[] { none, noneExact, noneModifiers, unique, all })
                 {
                     foreach (var action in Enum.GetValues(typeof(TestAction)).Cast<TestAction>())
                     {
@@ -151,7 +154,7 @@ namespace osu.Framework.Tests.Visual
                 toggleKey(key);
             foreach (var button in pressedMouseButtons.ToArray())
                 toggleMouseButton(button);
-            foreach (var mode in new[] { none, noneExact, unique, all })
+            foreach (var mode in new[] { none, noneExact, noneModifiers, unique, all })
             {
                 foreach (var action in Enum.GetValues(typeof(TestAction)).Cast<TestAction>())
                 {
@@ -169,24 +172,32 @@ namespace osu.Framework.Tests.Visual
             wrapTest(() =>
             {
                 toggleKey(Key.A);
-                checkPressed(TestAction.A, 1, 1, 1, 1);
+                checkPressed(TestAction.A, 1, 1, 1, 1, 1);
                 toggleKey(Key.S);
-                checkReleased(TestAction.A, 1, 1, 0, 0);
-                checkPressed(TestAction.S, 1, 0, 1, 1);
+                checkReleased(TestAction.A, 1, 1, 1, 0, 0);
+                checkPressed(TestAction.S, 1, 0, 1, 1, 1);
                 toggleKey(Key.A);
-                checkReleased(TestAction.A, 0, 0, 1, 1);
-                checkPressed(TestAction.S, 0, 0, 0, 0);
+                checkReleased(TestAction.A, 0, 0, 0, 1, 1);
+                checkPressed(TestAction.S, 0, 0, 0, 0, 0);
                 toggleKey(Key.S);
-                checkReleased(TestAction.S, 1, 0, 1, 1);
+                checkReleased(TestAction.S, 1, 0, 1, 1, 1);
 
                 toggleKey(Key.D);
-                checkPressed(TestAction.D_or_F, 1, 1, 1, 1);
+                checkPressed(TestAction.D_or_F, 1, 1, 1, 1, 1);
                 toggleKey(Key.F);
-                check(TestAction.D_or_F, new CheckConditions(none, 1, 1), new CheckConditions(noneExact, 0, 1), new CheckConditions(unique, 0, 0), new CheckConditions(all, 1, 0));
+                check(TestAction.D_or_F, new CheckConditions(none, 1, 1), new CheckConditions(noneExact, 0, 1), new CheckConditions(noneModifiers, 1, 1), new CheckConditions(unique, 0, 0), new CheckConditions(all, 1, 0));
                 toggleKey(Key.F);
-                checkReleased(TestAction.D_or_F, 0, 0, 0, 1);
+                checkReleased(TestAction.D_or_F, 0, 0, 0, 0, 1);
                 toggleKey(Key.D);
-                checkReleased(TestAction.D_or_F, 1, 0, 1, 1);
+                checkReleased(TestAction.D_or_F, 1, 0, 1, 1, 1);
+
+                toggleKey(Key.ShiftLeft);
+                toggleKey(Key.AltLeft);
+                checkPressed(TestAction.Alt_and_Shift, 1, 1, 1, 1, 1);
+                toggleKey(Key.A);
+                checkPressed(TestAction.Shift_A, 1, 0, 0, 1, 1);
+                toggleKey(Key.AltLeft);
+                toggleKey(Key.ShiftLeft);
             });
         }
 
@@ -196,24 +207,24 @@ namespace osu.Framework.Tests.Visual
             wrapTest(() =>
             {
                 toggleKey(Key.ShiftLeft);
-                checkPressed(TestAction.Shift, 1, 1, 1, 1);
+                checkPressed(TestAction.Shift, 1, 1, 1, 1, 1);
                 toggleKey(Key.A);
-                checkReleased(TestAction.Shift, 1, 1, 0, 0);
-                checkPressed(TestAction.Shift_A, 1, 1, 1, 1);
+                checkReleased(TestAction.Shift, 1, 1, 1, 0, 0);
+                checkPressed(TestAction.Shift_A, 1, 1, 1, 1, 1);
                 toggleKey(Key.ShiftRight);
-                checkPressed(TestAction.Shift, 0, 0, 0, 0);
-                checkReleased(TestAction.Shift_A, 0, 0, 0, 0);
+                checkPressed(TestAction.Shift, 0, 0, 0, 0, 0);
+                checkReleased(TestAction.Shift_A, 0, 0, 0, 0, 0);
                 toggleKey(Key.ShiftLeft);
-                checkReleased(TestAction.Shift, 0, 0, 0, 0);
-                checkReleased(TestAction.Shift_A, 0, 0, 0, 0);
+                checkReleased(TestAction.Shift, 0, 0, 0, 0, 0);
+                checkReleased(TestAction.Shift_A, 0, 0, 0, 0, 0);
                 toggleKey(Key.ShiftRight);
-                checkReleased(TestAction.Shift, 0, 0, 1, 1);
-                checkReleased(TestAction.Shift_A, 1, 1, 1, 1);
+                checkReleased(TestAction.Shift, 0, 0, 0, 1, 1);
+                checkReleased(TestAction.Shift_A, 1, 1, 1, 1, 1);
                 toggleKey(Key.A);
 
                 toggleKey(Key.ControlLeft);
                 toggleKey(Key.ShiftLeft);
-                checkPressed(TestAction.Ctrl_and_Shift, 1, 1, 1, 1);
+                checkPressed(TestAction.Ctrl_and_Shift, 1, 1, 1, 1, 1);
             });
         }
 
@@ -226,6 +237,7 @@ namespace osu.Framework.Tests.Visual
                 {
                     new CheckConditions(none, 1, 1),
                     new CheckConditions(noneExact, 1, 1),
+                    new CheckConditions(noneModifiers, 1, 1),
                     new CheckConditions(unique, 1, 1),
                     new CheckConditions(all, 1, 1)
                 };
@@ -256,6 +268,7 @@ namespace osu.Framework.Tests.Visual
                 {
                     new ScrollCheckConditions(none, 1, 1, 1, amount),
                     new ScrollCheckConditions(noneExact, 1, 1, 1, amount),
+                    new ScrollCheckConditions(noneModifiers, 1, 1, 1, amount),
                     new ScrollCheckConditions(unique, 1, 1, 1, amount),
                     new ScrollCheckConditions(all, 1, 1, 1, amount)
                 };
@@ -313,6 +326,9 @@ namespace osu.Framework.Tests.Visual
             Ctrl_A,
             Ctrl_S,
             Ctrl_D_or_F,
+            Alt_A,
+            Alt_S,
+            Alt_D_or_F,
             Shift_A,
             Shift_S,
             Shift_D_or_F,
@@ -321,6 +337,8 @@ namespace osu.Framework.Tests.Visual
             Ctrl_Shift_D_or_F,
             Ctrl,
             Shift,
+            Alt,
+            Alt_and_Shift,
             Ctrl_and_Shift,
             Ctrl_or_Shift,
             LeftMouse,
@@ -332,8 +350,8 @@ namespace osu.Framework.Tests.Visual
 
         private class TestInputManager : KeyBindingContainer<TestAction>
         {
-            public TestInputManager(SimultaneousBindingMode concurrencyMode = SimultaneousBindingMode.None)
-                : base(concurrencyMode)
+            public TestInputManager(SimultaneousBindingMode concurrencyMode = SimultaneousBindingMode.None, KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
+                : base(concurrencyMode, matchingMode)
             {
             }
 
@@ -354,6 +372,11 @@ namespace osu.Framework.Tests.Visual
                 new KeyBinding(new[] { InputKey.Shift, InputKey.D }, TestAction.Shift_D_or_F),
                 new KeyBinding(new[] { InputKey.Shift, InputKey.F }, TestAction.Shift_D_or_F),
 
+                new KeyBinding(new[] { InputKey.Alt, InputKey.A }, TestAction.Alt_A),
+                new KeyBinding(new[] { InputKey.Alt, InputKey.S }, TestAction.Alt_S),
+                new KeyBinding(new[] { InputKey.Alt, InputKey.D }, TestAction.Alt_D_or_F),
+                new KeyBinding(new[] { InputKey.Alt, InputKey.F }, TestAction.Alt_D_or_F),
+
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.A }, TestAction.Ctrl_Shift_A),
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.S }, TestAction.Ctrl_Shift_S),
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.D }, TestAction.Ctrl_Shift_D_or_F),
@@ -361,6 +384,8 @@ namespace osu.Framework.Tests.Visual
 
                 new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl),
                 new KeyBinding(new[] { InputKey.Shift }, TestAction.Shift),
+                new KeyBinding(new[] { InputKey.Alt }, TestAction.Alt),
+                new KeyBinding(new[] { InputKey.Alt, InputKey.Shift }, TestAction.Alt_and_Shift),
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift }, TestAction.Ctrl_and_Shift),
                 new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl_or_Shift),
                 new KeyBinding(new[] { InputKey.Shift }, TestAction.Ctrl_or_Shift),
@@ -462,7 +487,7 @@ namespace osu.Framework.Tests.Visual
                 actionText = action.ToString().Replace('_', ' ');
 
                 RelativeSizeAxes = Axes.X;
-                Height = 40;
+                Height = 35;
                 Width = 0.3f;
                 Padding = new MarginPadding(2);
 
@@ -534,7 +559,7 @@ namespace osu.Framework.Tests.Visual
         {
             private readonly TestButton[] testButtons;
 
-            public KeyBindingTester(SimultaneousBindingMode concurrency)
+            public KeyBindingTester(SimultaneousBindingMode concurrency, KeyCombinationMatchingMode matchingMode)
             {
                 RelativeSizeAxes = Axes.Both;
 
@@ -550,9 +575,9 @@ namespace osu.Framework.Tests.Visual
                 {
                     new SpriteText
                     {
-                        Text = concurrency.ToString(),
+                        Text = $"{concurrency} / {matchingMode}"
                     },
-                    new TestInputManager(concurrency)
+                    new TestInputManager(concurrency, matchingMode)
                     {
                         Y = 30,
                         RelativeSizeAxes = Axes.Both,

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -20,16 +20,18 @@ namespace osu.Framework.Input.Bindings
         where T : struct
     {
         private readonly SimultaneousBindingMode simultaneousMode;
+        private readonly KeyCombinationMatchingMode matchingMode;
 
         /// <summary>
         /// Create a new instance.
         /// </summary>
         /// <param name="simultaneousMode">Specify how to deal with multiple matches of <see cref="KeyCombination"/>s and <see cref="T"/>s.</param>
-        protected KeyBindingContainer(SimultaneousBindingMode simultaneousMode = SimultaneousBindingMode.None)
+        protected KeyBindingContainer(SimultaneousBindingMode simultaneousMode = SimultaneousBindingMode.None, KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
         {
             RelativeSizeAxes = Axes.Both;
 
             this.simultaneousMode = simultaneousMode;
+            this.matchingMode = matchingMode;
         }
 
         private readonly List<KeyBinding> pressedBindings = new List<KeyBinding>();
@@ -131,7 +133,7 @@ namespace osu.Framework.Input.Bindings
             var bindings = (repeat ? KeyBindings : KeyBindings?.Except(pressedBindings)) ?? Enumerable.Empty<KeyBinding>();
             var newlyPressed = bindings.Where(m =>
                 m.KeyCombination.Keys.Contains(newKey) // only handle bindings matching current key (not required for correct logic)
-                && m.KeyCombination.IsPressed(pressedCombination, simultaneousMode == SimultaneousBindingMode.NoneExact));
+                && m.KeyCombination.IsPressed(pressedCombination, matchingMode));
 
             if (isModifier(newKey))
                 // if the current key pressed was a modifier, only handle modifier-only bindings.
@@ -144,10 +146,10 @@ namespace osu.Framework.Input.Bindings
                 pressedBindings.AddRange(newlyPressed);
 
             // exact matching may result in no pressed (new or old) bindings, in which case we want to trigger releases for existing actions
-            if (simultaneousMode == SimultaneousBindingMode.NoneExact)
+            if (simultaneousMode == SimultaneousBindingMode.None && (matchingMode == KeyCombinationMatchingMode.Exact || matchingMode == KeyCombinationMatchingMode.Modifiers))
             {
                 // only want to release pressed actions if no existing bindings would still remain pressed
-                if (pressedBindings.Count > 0 && !pressedBindings.Any(m => m.KeyCombination.IsPressed(pressedCombination, simultaneousMode == SimultaneousBindingMode.NoneExact)))
+                if (pressedBindings.Count > 0 && !pressedBindings.Any(m => m.KeyCombination.IsPressed(pressedCombination, matchingMode)))
                     releasePressedActions();
             }
 
@@ -156,7 +158,7 @@ namespace osu.Framework.Input.Bindings
                 handled |= PropagatePressed(KeyBindingInputQueue, newBinding.GetAction<T>(), scrollAmount, isPrecise);
 
                 // we only want to handle the first valid binding (the one with the most keys) in non-simultaneous mode.
-                if ((simultaneousMode == SimultaneousBindingMode.None || simultaneousMode == SimultaneousBindingMode.NoneExact) && handled)
+                if (simultaneousMode == SimultaneousBindingMode.None && handled)
                     break;
             }
 
@@ -168,7 +170,7 @@ namespace osu.Framework.Input.Bindings
             IDrawable handled = null;
 
             // we handled a new binding and there is an existing one. if we don't want concurrency, let's propagate a released event.
-            if (simultaneousMode == SimultaneousBindingMode.None || simultaneousMode == SimultaneousBindingMode.NoneExact)
+            if (simultaneousMode == SimultaneousBindingMode.None)
                 releasePressedActions();
 
             // only handle if we are a new non-pressed action (or a concurrency mode that supports multiple simultaneous triggers).
@@ -204,7 +206,7 @@ namespace osu.Framework.Input.Bindings
             bool handled = false;
 
             // we don't want to consider exact matching here as we are dealing with bindings, not actions.
-            var newlyReleased = pressedBindings.Where(b => !b.KeyCombination.IsPressed(pressedCombination, false)).ToList();
+            var newlyReleased = pressedBindings.Where(b => !b.KeyCombination.IsPressed(pressedCombination, KeyCombinationMatchingMode.Any)).ToList();
 
             Trace.Assert(newlyReleased.All(b => b.KeyCombination.Keys.Contains(releasedKey)));
 
@@ -272,12 +274,6 @@ namespace osu.Framework.Input.Bindings
         /// If a new matching binding is encountered, any existing binding is first released.
         /// </summary>
         None,
-
-        /// <summary>
-        /// One action can be in a pressed state at once. Exact key combinations are required for actions to be triggered.
-        /// If a new matching binding is encountered, any existing binding is first released.
-        /// </summary>
-        NoneExact,
 
         /// <summary>
         /// Unique actions are allowed to be pressed at the same time. There may therefore be more than one action in an actuated state at once.

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -44,8 +44,6 @@ namespace osu.Framework.Input.Bindings
         /// </summary>
         public IEnumerable<T> PressedActions => pressedActions;
 
-        private bool isModifier(InputKey k) => k < InputKey.F1;
-
         /// <summary>
         /// The input queue to be used for processing key bindings. Based on the non-positional <see cref="InputManager.InputQueue"/>.
         /// Can be overridden to change priorities.
@@ -136,9 +134,9 @@ namespace osu.Framework.Input.Bindings
                 m.KeyCombination.Keys.Contains(newKey) // only handle bindings matching current key (not required for correct logic)
                 && m.KeyCombination.IsPressed(pressedCombination, matchingMode));
 
-            if (isModifier(newKey))
+            if (KeyCombination.IsModifierKey(newKey))
                 // if the current key pressed was a modifier, only handle modifier-only bindings.
-                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(isModifier));
+                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(KeyCombination.IsModifierKey));
 
             // we want to always handle bindings with more keys before bindings with less.
             newlyPressed = newlyPressed.OrderByDescending(b => b.KeyCombination.Keys.Count()).ToList();

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -26,6 +26,7 @@ namespace osu.Framework.Input.Bindings
         /// Create a new instance.
         /// </summary>
         /// <param name="simultaneousMode">Specify how to deal with multiple matches of <see cref="KeyCombination"/>s and <see cref="T"/>s.</param>
+        /// <param name="matchingMode">Specify how to deal with exact <see cref="KeyCombination"/> matches.</param>
         protected KeyBindingContainer(SimultaneousBindingMode simultaneousMode = SimultaneousBindingMode.None, KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
         {
             RelativeSizeAxes = Axes.Both;

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -56,8 +56,8 @@ namespace osu.Framework.Input.Bindings
                 case KeyCombinationMatchingMode.Modifiers:
                     if (Keys.Except(pressedKeys.Keys).Any())
                         return false;
-                    var pressedModifiers = pressedKeys.Keys.Where(isModifierKey);
-                    var requiredModifiers = Keys.Where(isModifierKey);
+                    var pressedModifiers = pressedKeys.Keys.Where(IsModifierKey);
+                    var requiredModifiers = Keys.Where(IsModifierKey);
                     return pressedModifiers.Count() == requiredModifiers.Count() && pressedModifiers.All(requiredModifiers.Contains);
 
                 default:
@@ -92,7 +92,7 @@ namespace osu.Framework.Input.Bindings
 
         public string ReadableString() => Keys?.Select(getReadableKey).Aggregate((s1, s2) => $"{s1}+{s2}") ?? string.Empty;
 
-        private static bool isModifierKey(InputKey key) => key == InputKey.Control || key == InputKey.Shift || key == InputKey.Alt || key == InputKey.Super;
+        public static bool IsModifierKey(InputKey key) => key == InputKey.Control || key == InputKey.Shift || key == InputKey.Alt || key == InputKey.Super;
 
         private string getReadableKey(InputKey key)
         {

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Input.Bindings
         /// Check whether the provided pressed keys are valid for this <see cref="KeyCombination"/>.
         /// </summary>
         /// <param name="pressedKeys">The potential pressed keys for this <see cref="KeyCombination"/>.</param>
-        /// <param name="exact">Whether <paramref name="pressedKeys"/> should exactly match the keys required for this <see cref="KeyCombination"/>.</param>
+        /// <param name="matchingMode">The method for handling exact key matches.</param>
         /// <returns>Whether the pressedKeys keys are valid.</returns>
         public bool IsPressed(KeyCombination pressedKeys, KeyCombinationMatchingMode matchingMode)
         {

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Input
         private GameHost host;
 
         public PlatformActionContainer()
-            : base(SimultaneousBindingMode.NoneExact)
+            : base(SimultaneousBindingMode.None, KeyCombinationMatchingMode.Modifiers)
         {
         }
 


### PR DESCRIPTION
Refactors the `SimultaneousBindingMode.NoneExact` into a separate enum, and provides support for only performing exact matches on modifier keys.

Allows `PlatformAction`s to be correctly recognised even if there are additional keypresses, as long as the required modifier keys match exactly.

Resolves #1702 