### PR TITLE
Fix macOS cursor reappearing on focus lost

### DIFF
--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Platform.MacOS
         {
             // If the cursor should be hidden, but something in the system has made it appear (such as a notification),
             // invalidate the cursor rects to hide it.  OpenTK has a private function that does this.
-            if ((CursorState & CursorState.Hidden) != 0 && Cocoa.CGCursorIsVisible())
+            if (CursorState.HasFlag(CursorState.Hidden) && Cocoa.CGCursorIsVisible())
                 methodInvalidateCursorRects.Invoke(nativeWindow, new object[0]);
         }
 

--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -32,7 +32,10 @@ namespace osu.Framework.Platform.MacOS
             FocusedChanged += focusedChanged;
         }
 
-        private void focusedChanged(object sender, EventArgs e) => Task.Delay(300).ContinueWith(arg => methodInvalidateCursorRects.Invoke(nativeWindow, new object[0]));
+        // When the window regains focus, the macOS cursor will often reappear regardless of the "hidden" state.
+        // Invalidating the cursor rects for the content view will solve the issue, and OpenTK already has a private function that does this.
+        // Note that there needs to be a short delay after we regain the focus, otherwise the cursor will not disappear until the user moves the mouse.
+        private void focusedChanged(object sender, EventArgs e) => Task.Delay(300).ContinueWith(_ => methodInvalidateCursorRects.Invoke(nativeWindow, new object[0]));
 
         protected void OnLoad(object sender, EventArgs e)
         {

--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Reflection;
 using osu.Framework.Logging;
 using osu.Framework.Platform.MacOS.Native;
+using System.Threading.Tasks;
 
 namespace osu.Framework.Platform.MacOS
 {
@@ -21,13 +22,17 @@ namespace osu.Framework.Platform.MacOS
         private readonly IntPtr selKeyCode = Selector.Get("keyCode");
         private MethodInfo methodKeyDown;
         private MethodInfo methodKeyUp;
+        private MethodInfo methodInvalidateCursorRects;
 
         private object nativeWindow;
 
         public MacOSGameWindow()
         {
             Load += OnLoad;
+            FocusedChanged += focusedChanged;
         }
+
+        private void focusedChanged(object sender, EventArgs e) => Task.Delay(300).ContinueWith(arg => methodInvalidateCursorRects.Invoke(nativeWindow, new object[0]));
 
         protected void OnLoad(object sender, EventArgs e)
         {
@@ -46,6 +51,7 @@ namespace osu.Framework.Platform.MacOS
 
                 methodKeyDown = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyDown");
                 methodKeyUp = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "OnKeyUp");
+                methodInvalidateCursorRects = nativeWindow.GetType().GetRuntimeMethods().Single(x => x.Name == "InvalidateCursorRects");
             }
             catch
             {

--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -11,6 +11,7 @@ namespace osu.Framework.Platform.MacOS.Native
     internal static class Cocoa
     {
         internal const string LIB_OBJ_C = "/usr/lib/libobjc.dylib";
+        internal const string LIB_APP_SERVICES = "/System/Library/Frameworks/ApplicationServices.framework/Versions/Current/ApplicationServices";
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector);
@@ -58,6 +59,9 @@ namespace osu.Framework.Platform.MacOS.Native
 
         public static IntPtr AppKitLibrary;
         public static IntPtr FoundationLibrary;
+
+        [DllImport(LIB_APP_SERVICES, EntryPoint = "CGCursorIsVisible")]
+        public static extern bool CGCursorIsVisible();
 
         static Cocoa()
         {


### PR DESCRIPTION
Fixes an issue where the macOS cursor would reappear on focus switch.

Delay is required to ensure the cursor rects are invalidated while the window has the focus, otherwise the cursor will not disappear until the user moves the mouse.

Resolves #1703
