### PR TITLE
TabControl.RemoveAllItems

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTabControl.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTabControl.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Tests.Visual
             AddStep("Add all items", () => items.AsEnumerable().ForEach(item => removeAllTabControl.AddItem(item.Value)));
             AddAssert("Ensure all items", () => removeAllTabControl.Items.Count() == items.Count);
 
-            AddStep("Remove all items", () => removeAllTabControl.RemoveAllItems());
+            AddStep("Remove all items", () => removeAllTabControl.Clear());
             AddAssert("Ensure no items", () => !removeAllTabControl.Items.Any());
         }
 

--- a/osu.Framework.Tests/Visual/TestCaseTabControl.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTabControl.cs
@@ -52,9 +52,16 @@ namespace osu.Framework.Tests.Visual
             };
             items.AsEnumerable().ForEach(item => switchingTabControl.AddItem(item.Value));
 
+            StyledTabControl removeAllTabControl = new StyledTabControl
+            {
+                Position = new Vector2(200, 350),
+                Size = new Vector2(200, 30)
+            };
+
             Add(simpleTabcontrol);
             Add(pinnedAndAutoSort);
             Add(platformActionContainer);
+            Add(removeAllTabControl);
 
             var nextTest = new Func<TestEnum>(() => items.AsEnumerable()
                                                          .Select(item => item.Value)
@@ -106,6 +113,12 @@ namespace osu.Framework.Tests.Visual
 
             AddStep("Switch forward", () => platformActionContainer.TriggerPressed(new PlatformAction(PlatformActionType.DocumentNext)));
             AddAssert("Ensure first tab", () => switchingTabControl.Current.Value == switchingTabControl.VisibleItems.First());
+
+            AddStep("Add all items", () => items.AsEnumerable().ForEach(item => removeAllTabControl.AddItem(item.Value)));
+            AddAssert("Ensure all items", () => removeAllTabControl.Items.Count() == items.Count);
+
+            AddStep("Remove all items", () => removeAllTabControl.RemoveAllItems());
+            AddAssert("Ensure no items", () => !removeAllTabControl.Items.Any());
         }
 
         private class StyledTabControl : TabControl<TestEnum>

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -167,7 +167,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// Removes all items from the control.
         /// </summary>
         public void RemoveAllItems() => tabMap.Keys.ToArray().ForEach(item => removeTab(item));
-        
+
         private TabItem<T> addTab(T value, bool addToDropdown = true)
         {
             // Do not allow duplicate adding

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Configuration;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
@@ -162,6 +163,11 @@ namespace osu.Framework.Graphics.UserInterface
         /// <param name="item">The item to remove.</param>
         public void RemoveItem(T item) => removeTab(item);
 
+        /// <summary>
+        /// Removes all items from the control.
+        /// </summary>
+        public void RemoveAllItems() => tabMap.Keys.ToArray().ForEach(item => removeTab(item));
+        
         private TabItem<T> addTab(T value, bool addToDropdown = true)
         {
             // Do not allow duplicate adding

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.UserInterface
     /// start of the list.
     /// </summary>
     /// <typeparam name="T">The type of item to be represented by tabs.</typeparam>
-    public abstract class TabControl<T> : Container, IHasCurrentValue<T>, IKeyBindingHandler<PlatformAction>
+    public abstract class TabControl<T> : CompositeDrawable, IHasCurrentValue<T>, IKeyBindingHandler<PlatformAction>
     {
         public Bindable<T> Current { get; } = new Bindable<T>();
 
@@ -84,7 +84,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Dropdown.Origin = Anchor.TopRight;
                 Dropdown.Current.BindTo(Current);
 
-                Add(Dropdown);
+                AddInternal(Dropdown);
 
                 Trace.Assert(Dropdown.Header.Anchor.HasFlag(Anchor.x2), $@"The {nameof(Dropdown)} implementation should use a right-based anchor inside a TabControl.");
                 Trace.Assert(!Dropdown.Header.RelativeSizeAxes.HasFlag(Axes.X), $@"The {nameof(Dropdown)} implementation's header should have a specific size.");
@@ -95,7 +95,7 @@ namespace osu.Framework.Graphics.UserInterface
             else
                 tabMap = new Dictionary<T, TabItem<T>>();
 
-            Add(TabContainer = CreateTabFlow());
+            AddInternal(TabContainer = CreateTabFlow());
             TabContainer.TabVisibilityChanged = updateDropdown;
             TabContainer.ChildrenEnumerable = tabMap.Values;
 
@@ -166,7 +166,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Removes all items from the control.
         /// </summary>
-        public void RemoveAllItems() => tabMap.Keys.ToArray().ForEach(item => removeTab(item));
+        public void Clear() => tabMap.Keys.ToArray().ForEach(item => removeTab(item));
 
         private TabItem<T> addTab(T value, bool addToDropdown = true)
         {


### PR DESCRIPTION
Adds the ability to remove all items from a `TabControl`.
Will be used in a future PR to dynamically replace the contents of the `SectionsContainer` used in the `UserProfileOverlay`.