### PR TITLE
Refactor FadeDuration into separate in and out durations

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseModelBackedDrawable.cs
+++ b/osu.Framework.Tests/Visual/TestCaseModelBackedDrawable.cs
@@ -161,7 +161,7 @@ namespace osu.Framework.Tests.Visual
         {
             protected override bool FadeOutImmediately => true;
 
-            protected override double FadeDuration => 0;
+            protected override double FadeOutDuration => 0;
         }
 
         private class DelayedTestModelBackedDrawable : TestModelBackedDrawable


### PR DESCRIPTION
Allows `ModelBackedDrawable` subclasses to customise the fade in and out durations, for situations where the source element should immediately hide.
Also fixes an issue where a null `Drawable` could cause a crash.