### PR TITLE
Improve performance of the screne graph visualiser

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseDrawVisualiser.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawVisualiser.cs
@@ -1,0 +1,35 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Visualisation;
+using osu.Framework.Testing;
+using OpenTK;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseDrawVisualiser : TestCase
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            DrawVisualiser vis;
+            Drawable target;
+
+            Children = new[]
+            {
+                target = new TestCaseDynamicDepth
+                {
+                    Anchor = Anchor.BottomRight,
+                    Origin = Anchor.BottomRight,
+                    Size = new Vector2(0.5f)
+                },
+                vis = new DrawVisualiser(),
+            };
+
+            vis.Show();
+            vis.Target = target;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -124,6 +124,12 @@ namespace osu.Framework.Graphics.Containers
         internal event Action<Drawable> ChildDied;
 
         /// <summary>
+        /// THIS EVENT PURELY EXISTS FOR THE SCENE GRAPH VISUALIZER. DO NOT USE.
+        /// This event will fire after a child's <see cref="Drawable.Depth"/> is changed.
+        /// </summary>
+        internal event Action<Drawable> ChildDepthChanged;
+
+        /// <summary>
         /// Gets or sets the only child in <see cref="InternalChildren"/>.
         /// </summary>
         protected internal Drawable InternalChild
@@ -367,6 +373,8 @@ namespace osu.Framework.Graphics.Containers
             internalChildren.Add(child);
             if (aliveIndex >= 0) // re-add if it used to be in aliveInternalChildren
                 aliveInternalChildren.Add(child);
+
+            ChildDepthChanged?.Invoke(child);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -99,6 +99,8 @@ namespace osu.Framework.Graphics
             // stop remotely rendering it.
             proxy?.Dispose();
 
+            OnDispose?.Invoke();
+
             isDisposed = true;
         }
 
@@ -332,6 +334,12 @@ namespace osu.Framework.Graphics
         /// This event is fired after the <see cref="Invalidate(Invalidation, Drawable, bool)"/> method is called.
         /// </summary>
         internal event Action<Drawable> OnInvalidate;
+
+        /// <summary>
+        /// THIS EVENT PURELY EXISTS FOR THE SCENE GRAPH VISUALIZER. DO NOT USE.
+        /// This event is fired after the <see cref="dispose(bool)"/> method is called.
+        /// </summary>
+        internal event Action OnDispose;
 
         private Scheduler scheduler;
         internal Thread MainThread { get; private set; }

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -171,6 +171,8 @@ namespace osu.Framework.Graphics.Visualisation
                 setHighlight(d);
             };
 
+            visualiser.Depth = 0;
+
             treeContainer.Child = targetVisualiser = visualiser;
         }
 

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -105,9 +105,17 @@ namespace osu.Framework.Graphics.Visualisation
             Searching = Target == null;
         }
 
-        protected override void PopOut() => this.FadeOut(100);
+        protected override void PopOut()
+        {
+            this.FadeOut(100);
 
+            treeContainer.Clear();
 
+            var visualisers = visCache.Values.ToList();
+            foreach (var v in visualisers)
+                v.Dispose();
+
+            visCache.Clear();
         }
 
         private Drawable findTargetIn(Drawable d, InputState state)
@@ -269,7 +277,10 @@ namespace osu.Framework.Graphics.Visualisation
             if (visCache.TryGetValue(drawable, out var existing))
                 return existing;
 
-            return visCache[drawable] = new VisualisedDrawable(drawable);
+            var vis = new VisualisedDrawable(drawable);
+            vis.OnDispose += () => visCache.Remove(vis.Target);
+
+            return visCache[drawable] = vis;
         }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -50,6 +50,8 @@ namespace osu.Framework.Graphics.Visualisation
 
                             Target = parent;
                             lastVisualiser.SetContainer(targetVisualiser);
+
+                            targetVisualiser.Expand();
                         }
 
                         // Rehighlight the last highlight

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -1,7 +1,9 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input;
@@ -10,9 +12,12 @@ using osu.Framework.Input.States;
 
 namespace osu.Framework.Graphics.Visualisation
 {
-    public class DrawVisualiser : OverlayContainer
+    [Cached]
+    internal class DrawVisualiser : OverlayContainer, IContainVisualisedDrawables
     {
+        [Cached]
         private readonly TreeContainer treeContainer;
+
         private VisualisedDrawable highlightedTarget;
 
         private readonly PropertyDisplay propertyDisplay;
@@ -35,13 +40,18 @@ namespace osu.Framework.Graphics.Visualisation
                         Drawable lastHighlight = highlightedTarget?.Target;
 
                         var parent = Target?.Parent;
-                        if (parent?.Parent != null)
-                            Target = Target?.Parent;
+                        if (parent != null)
+                        {
+                            var lastVisualiser = targetVisualiser;
+
+                            Target = parent;
+                            lastVisualiser.SetContainer(targetVisualiser);
+                        }
 
                         // Rehighlight the last highlight
                         if (lastHighlight != null)
                         {
-                            VisualisedDrawable visualised = targetDrawable.FindVisualisedDrawable(lastHighlight);
+                            VisualisedDrawable visualised = targetVisualiser.FindVisualisedDrawable(lastHighlight);
                             if (visualised != null)
                             {
                                 propertyDisplay.State = Visibility.Visible;
@@ -51,13 +61,13 @@ namespace osu.Framework.Graphics.Visualisation
                     },
                     ToggleProperties = delegate
                     {
-                        if (targetDrawable == null)
+                        if (targetVisualiser == null)
                             return;
 
                         propertyDisplay.ToggleVisibility();
 
                         if (propertyDisplay.State == Visibility.Visible)
-                            setHighlight(targetDrawable);
+                            setHighlight(targetVisualiser);
                     },
                 },
                 new CursorContainer()
@@ -88,20 +98,12 @@ namespace osu.Framework.Graphics.Visualisation
         protected override void PopIn()
         {
             this.FadeIn(100);
+
             if (Target == null)
                 chooseTarget();
-            else
-                createRootVisualisedDrawable();
         }
 
-        protected override void PopOut()
-        {
-            this.FadeOut(100);
-
-            // Don't keep resources for visualizing the target
-            // allocated; unbind callback events.
-            removeRootVisualisedDrawable();
-        }
+        protected override void PopOut() => this.FadeOut(100);
 
         private bool targetSearching;
 
@@ -152,58 +154,57 @@ namespace osu.Framework.Graphics.Visualisation
             return containedTarget ?? (containsCursor ? d : null);
         }
 
-        private VisualisedDrawable targetDrawable;
-
-        private void removeRootVisualisedDrawable(bool hideProperties = true)
+        void IContainVisualisedDrawables.AddVisualiser(VisualisedDrawable visualiser)
         {
-            if (hideProperties)
-                propertyDisplay.State = Visibility.Hidden;
-
-            if (targetDrawable != null)
+            visualiser.RequestTarget = d =>
             {
-                if (targetDrawable.Parent != null)
-                {
-                    // targetDrawable may have gotten purged from the TreeContainer
-                    treeContainer.Remove(targetDrawable);
-                    targetDrawable.Dispose();
-                }
-                targetDrawable = null;
-            }
-        }
-
-        private void createRootVisualisedDrawable()
-        {
-            removeRootVisualisedDrawable(target == null);
-
-            if (target == null)
-                return;
-
-            targetDrawable = new VisualisedDrawable(target, treeContainer)
-            {
-                RequestTarget = d => Target = d,
-                HighlightTarget = d =>
-                {
-                    propertyDisplay.State = Visibility.Visible;
-
-                    // Either highlight or dehighlight the target, depending on whether
-                    // it is currently highlighted
-                    setHighlight(d);
-
-                }
+                Target = d;
+                targetVisualiser.ExpandAll();
             };
 
-            treeContainer.Add(targetDrawable);
+            visualiser.HighlightTarget = d =>
+            {
+                propertyDisplay.State = Visibility.Visible;
+
+                // Either highlight or dehighlight the target, depending on whether
+                // it is currently highlighted
+                setHighlight(d);
+            };
+
+            treeContainer.Child = targetVisualiser = visualiser;
         }
 
-        private Drawable target;
+        void IContainVisualisedDrawables.RemoveVisualiser(VisualisedDrawable visualiser)
+        {
+            targetVisualiser = null;
+            treeContainer.Remove(visualiser);
 
+            if (Target == null)
+                propertyDisplay.State = Visibility.Hidden;
+        }
+
+        private VisualisedDrawable targetVisualiser;
+        private Drawable target;
         public Drawable Target
         {
             get => target;
             set
             {
+                if (target != null)
+                {
+                    GetVisualiserFor(target).SetContainer(null);
+                    targetVisualiser = null;
+                }
+
                 target = value;
-                createRootVisualisedDrawable();
+
+                if (target != null)
+                {
+                    targetVisualiser = GetVisualiserFor(target);
+                    targetVisualiser.SetContainer(this);
+
+                    targetSearching = false;
+                }
             }
         }
 
@@ -250,8 +251,8 @@ namespace osu.Framework.Graphics.Visualisation
 
                 if (Target != null)
                 {
-                    targetSearching = false;
                     overlay.Target = null;
+                    targetVisualiser.ExpandAll();
                     return true;
                 }
             }
@@ -263,6 +264,16 @@ namespace osu.Framework.Graphics.Visualisation
         {
             overlay.Target = targetSearching ? findTarget(state) : inputManager.HoveredDrawables.OfType<VisualisedDrawable>().FirstOrDefault()?.Target;
             return base.OnMouseMove(state);
+        }
+
+        private readonly Dictionary<Drawable, VisualisedDrawable> visCache = new Dictionary<Drawable, VisualisedDrawable>();
+
+        public VisualisedDrawable GetVisualiserFor(Drawable drawable)
+        {
+            if (visCache.TryGetValue(drawable, out var existing))
+                return existing;
+
+            return visCache[drawable] = new VisualisedDrawable(drawable);
         }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -118,6 +118,9 @@ namespace osu.Framework.Graphics.Visualisation
                 v.Dispose();
 
             visCache.Clear();
+
+            target = null;
+            targetVisualiser = null;
         }
 
         private Drawable findTargetIn(Drawable d, InputState state)

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -113,11 +113,10 @@ namespace osu.Framework.Graphics.Visualisation
 
             treeContainer.Clear();
 
+            // We don't really know where the visualised drawables are, so we have to dispose them manually
             var visualisers = visCache.Values.ToList();
             foreach (var v in visualisers)
                 v.Dispose();
-
-            visCache.Clear();
 
             target = null;
             targetVisualiser = null;

--- a/osu.Framework/Graphics/Visualisation/IContainVisualisedDrawables.cs
+++ b/osu.Framework/Graphics/Visualisation/IContainVisualisedDrawables.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics.Visualisation
+{
+    /// <summary>
+    /// An interface for <see cref="Drawable"/>s which can contain <see cref="VisualisedDrawable"/>s.
+    /// </summary>
+    internal interface IContainVisualisedDrawables
+    {
+        /// <summary>
+        /// Adds a <see cref="VisualisedDrawable"/> to this <see cref="Drawable"/>'s hierarchy.
+        /// </summary>
+        /// <remarks>
+        /// It is not necessary for this <see cref="Drawable"/> to contain the <see cref="VisualisedDrawable"/> as an immediate child,
+        /// but this <see cref="Drawable"/> will receive <see cref="RemoveVisualiser"/> if the <see cref="VisualisedDrawable"/> should ever be removed.
+        /// </remarks>
+        /// <param name="visualiser">The <see cref="VisualisedDrawable"/> to add.</param>
+        void AddVisualiser(VisualisedDrawable visualiser);
+
+        /// <summary>
+        /// Removes a <see cref="VisualisedDrawable"/> from this <see cref="Drawable"/>.
+        /// </summary>
+        /// <param name="visualiser">The <see cref="VisualisedDrawable"/> to remove.</param>
+        void RemoveVisualiser(VisualisedDrawable visualiser);
+    }
+}

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -29,6 +29,9 @@ namespace osu.Framework.Graphics.Visualisation
         private const float height = 600;
 
         internal PropertyDisplay PropertyDisplay { get; private set; }
+
+        [Resolved]
+        private DrawVisualiser visualiser { get; set; }
 
         private TreeContainerStatus state;
 
@@ -165,7 +168,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         protected override void Update()
         {
-            waitingText.Alpha = scroll.Children.Any() ? 0 : 1;
+            waitingText.Alpha = visualiser.Searching ? 1 : 0;
             base.Update();
         }
 

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -376,7 +376,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         private class VisualisedDrawableFlow : FillFlowContainer<VisualisedDrawable>
         {
-            public override IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent);
+            public override IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent).OrderBy(d => -d.Depth).ThenBy(d => ((VisualisedDrawable)d).Target.ChildID);
         }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -166,6 +166,7 @@ namespace osu.Framework.Graphics.Visualisation
                 da.OnAutoSize += onAutoSize;
                 da.ChildBecameAlive += addChild;
                 da.ChildDied += removeChild;
+                da.ChildDepthChanged += depthChanged;
             }
 
             if (Target is FlowContainer<Drawable> df) df.OnLayout += onLayout;
@@ -180,6 +181,7 @@ namespace osu.Framework.Graphics.Visualisation
                 da.OnAutoSize -= onAutoSize;
                 da.ChildBecameAlive -= addChild;
                 da.ChildDied -= removeChild;
+                da.ChildDepthChanged -= depthChanged;
             }
 
             if (Target is FlowContainer<Drawable> df) df.OnLayout -= onLayout;
@@ -198,11 +200,20 @@ namespace osu.Framework.Graphics.Visualisation
 
         private void removeChild(Drawable drawable) => visualiser.GetVisualiserFor(drawable).SetContainer(null);
 
+        private void depthChanged(Drawable drawable)
+        {
+            var vis = visualiser.GetVisualiserFor(drawable);
+
+            vis.currentContainer?.RemoveVisualiser(vis);
+            vis.currentContainer?.AddVisualiser(vis);
+        }
 
         void IContainVisualisedDrawables.AddVisualiser(VisualisedDrawable visualiser)
         {
             visualiser.RequestTarget = d => RequestTarget?.Invoke(d);
             visualiser.HighlightTarget = d => HighlightTarget?.Invoke(d);
+
+            visualiser.Depth = visualiser.Target.Depth;
 
             flow.Add(visualiser);
         }

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using OpenTK;
@@ -9,15 +11,17 @@ using OpenTK.Graphics;
 using osu.Framework.Extensions.Color4Extensions;
 using OpenTK.Input;
 using osu.Framework.Graphics.Shapes;
-using System.Collections.Generic;
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Input.EventArgs;
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Graphics.Visualisation
 {
-    internal class VisualisedDrawable : Container
+    internal class VisualisedDrawable : Container, IContainVisualisedDrawables
     {
+        private const int line_height = 12;
+
         public Drawable Target { get; }
 
         private bool isHighlighted;
@@ -41,34 +45,37 @@ namespace osu.Framework.Graphics.Visualisation
             }
         }
 
-        private readonly Box background;
-        private readonly Box highlightBackground;
-        private readonly SpriteText text;
-        private readonly Drawable previewBox;
-        private readonly Drawable activityInvalidate;
-        private readonly Drawable activityAutosize;
-        private readonly Drawable activityLayout;
-
         public Action<Drawable> RequestTarget;
         public Action<VisualisedDrawable> HighlightTarget;
 
-        private const int line_height = 12;
+        private Box background;
+        private Box highlightBackground;
+        private SpriteText text;
+        private Drawable previewBox;
+        private Drawable activityInvalidate;
+        private Drawable activityAutosize;
+        private Drawable activityLayout;
+        private VisualisedDrawableFlow flow;
 
-        private readonly FillFlowContainer<VisualisedDrawable> flow;
-        private readonly TreeContainer tree;
+        [Resolved]
+        private DrawVisualiser visualiser { get; set; }
 
-        public VisualisedDrawable(Drawable d, TreeContainer tree)
+        [Resolved]
+        private TreeContainer tree { get; set; }
+
+        public VisualisedDrawable(Drawable d)
         {
-            this.tree = tree;
-
             Target = d;
+        }
 
-            attachEvents();
-
-            var sprite = Target as Sprite;
-
+        [BackgroundDependencyLoader]
+        private void load()
+        {
             RelativeSizeAxes = Axes.X;
             AutoSizeAxes = Axes.Y;
+
+            var spriteTarget = Target as Sprite;
+
             AddRange(new[]
             {
                 activityInvalidate = new Box
@@ -92,12 +99,12 @@ namespace osu.Framework.Graphics.Visualisation
                     Position = new Vector2(0, 0),
                     Alpha = 0
                 },
-                previewBox = sprite?.Texture == null
+                previewBox = spriteTarget?.Texture == null
                     ? previewBox = new Box { Colour = Color4.White }
                     : new Sprite
                     {
-                        Texture = sprite.Texture,
-                        Scale = new Vector2(sprite.Texture.DisplayWidth / sprite.Texture.DisplayHeight, 1),
+                        Texture = spriteTarget.Texture,
+                        Scale = new Vector2(spriteTarget.Texture.DisplayWidth / spriteTarget.Texture.DisplayHeight, 1),
                     },
                 new Container
                 {
@@ -125,7 +132,7 @@ namespace osu.Framework.Graphics.Visualisation
                         text = new SpriteText()
                     }
                 },
-                flow = new FillFlowContainer<VisualisedDrawable>
+                flow = new VisualisedDrawableFlow
                 {
                     Direction = FillDirection.Vertical,
                     RelativeSizeAxes = Axes.X,
@@ -141,6 +148,13 @@ namespace osu.Framework.Graphics.Visualisation
             compositeTarget?.AliveInternalChildren.ForEach(addChild);
 
             updateSpecifics();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            attachEvents();
         }
 
         private void attachEvents()
@@ -171,33 +185,29 @@ namespace osu.Framework.Graphics.Visualisation
             if (Target is FlowContainer<Drawable> df) df.OnLayout -= onLayout;
         }
 
-        private readonly Dictionary<Drawable, VisualisedDrawable> visCache = new Dictionary<Drawable, VisualisedDrawable>();
         private void addChild(Drawable drawable)
         {
             // Make sure to never add the DrawVisualiser (recursive scenario)
-            if (drawable is DrawVisualiser) return;
+            if (drawable == visualiser) return;
 
             // Don't add individual characters of SpriteText
             if (Target is SpriteText) return;
 
-            if (!visCache.TryGetValue(drawable, out VisualisedDrawable vis))
-            {
-                vis = visCache[drawable] = new VisualisedDrawable(drawable, tree)
-                {
-                    RequestTarget = d => RequestTarget?.Invoke(d),
-                    HighlightTarget = d => HighlightTarget?.Invoke(d)
-                };
-            }
-
-            flow.Add(vis);
+            visualiser.GetVisualiserFor(drawable).SetContainer(this);
         }
 
-        private void removeChild(Drawable drawable)
+        private void removeChild(Drawable drawable) => visualiser.GetVisualiserFor(drawable).SetContainer(null);
+
+
+        void IContainVisualisedDrawables.AddVisualiser(VisualisedDrawable visualiser)
         {
-            if (!visCache.ContainsKey(drawable))
-                return;
-            flow.Remove(visCache[drawable]);
+            visualiser.RequestTarget = d => RequestTarget?.Invoke(d);
+            visualiser.HighlightTarget = d => HighlightTarget?.Invoke(d);
+
+            flow.Add(visualiser);
         }
+
+        void IContainVisualisedDrawables.RemoveVisualiser(VisualisedDrawable visualiser) => flow.Remove(visualiser);
 
         public VisualisedDrawable FindVisualisedDrawable(Drawable drawable)
         {
@@ -246,8 +256,8 @@ namespace osu.Framework.Graphics.Visualisation
         {
             if (isExpanded)
                 Collapse();
-            else Expand();
-
+            else
+                Expand();
             return true;
         }
 
@@ -265,6 +275,12 @@ namespace osu.Framework.Graphics.Visualisation
             updateSpecifics();
 
             isExpanded = true;
+        }
+
+        public void ExpandAll()
+        {
+            Expand();
+            flow.ForEach(f => f.Expand());
         }
 
         public void Collapse()
@@ -314,6 +330,34 @@ namespace osu.Framework.Graphics.Visualisation
         {
             updateSpecifics();
             base.Update();
+        }
+
+        private IContainVisualisedDrawables currentContainer;
+
+        /// <summary>
+        /// Moves this <see cref="VisualisedDrawable"/> to be contained by another target.
+        /// </summary>
+        /// <remarks>
+        /// The <see cref="VisualisedDrawable"/> is first removed from its current container via <see cref="IContainVisualisedDrawables.RemoveVisualiser"/>,
+        /// prior to being added to the new container via <see cref="IContainVisualisedDrawables.AddVisualiser"/>.
+        /// </remarks>
+        /// <param name="container">The target which should contain this <see cref="VisualisedDrawable"/>.</param>
+        public void SetContainer(IContainVisualisedDrawables container)
+        {
+            currentContainer?.RemoveVisualiser(this);
+
+            // The visualised may have previously been within a container (e.g. flow), which repositioned it
+            // We should make sure that the position is reset before it's added to another container
+            Y = 0;
+
+            container?.AddVisualiser(this);
+
+            currentContainer = container;
+        }
+
+        private class VisualisedDrawableFlow : FillFlowContainer<VisualisedDrawable>
+        {
+            public override IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent);
         }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -160,6 +160,7 @@ namespace osu.Framework.Graphics.Visualisation
         private void attachEvents()
         {
             Target.OnInvalidate += onInvalidate;
+            Target.OnDispose += onDispose;
 
             if (Target is CompositeDrawable da)
             {
@@ -175,6 +176,7 @@ namespace osu.Framework.Graphics.Visualisation
         private void detachEvents()
         {
             Target.OnInvalidate -= onInvalidate;
+            Target.OnDispose -= onDispose;
 
             if (Target is CompositeDrawable da)
             {
@@ -315,6 +317,12 @@ namespace osu.Framework.Graphics.Visualisation
         private void onInvalidate(Drawable d)
         {
             Scheduler.Add(() => activityInvalidate.FadeOutFromOne(1));
+        }
+
+        private void onDispose()
+        {
+            SetContainer(null);
+            Dispose();
         }
 
         private void updateSpecifics()


### PR DESCRIPTION
* Now retains the expanded/collapsed mode of tree items when going up parents.
  * https://streamable.com/5rdy7
* Huge performance improvement when visualised drawables can be reused - they were previously constructed every single time you went up a parent). They are now retained for the entire time the visualiser is active (not popped-out).
  * Old: https://streamable.com/4j56t
  * New: https://streamable.com/jlq77
  * The initial load is still very synchronous and lengthy, but going up parents is super quick now.
* Code is still very shocking. I'll do a refactoring pass on this at some point.