### PR TITLE
Add default constructor for BackgroundDependencyLoader

### DIFF
--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -20,6 +20,9 @@ namespace osu.Framework.Allocation
 
         private bool permitNulls { get; }
 
+        /// <summary>
+        /// Marks this method as the initializer for a class in the context of dependency injection.
+        /// </summary>
         public BackgroundDependencyLoaderAttribute()
         {
         }

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -20,11 +20,15 @@ namespace osu.Framework.Allocation
 
         private bool permitNulls { get; }
 
+        public BackgroundDependencyLoaderAttribute()
+        {
+        }
+
         /// <summary>
         /// Marks this method as the initializer for a class in the context of dependency injection.
         /// </summary>
         /// <param name="permitNulls">If true, the initializer may be passed null for the dependencies we can't fulfill.</param>
-        public BackgroundDependencyLoaderAttribute(bool permitNulls = false)
+        public BackgroundDependencyLoaderAttribute(bool permitNulls)
         {
             this.permitNulls = permitNulls;
         }


### PR DESCRIPTION
Just a small QOL improvement, removes the parentheses showing up when autocompleting BDL in some IDEs (Rider).

From: https://streamable.com/q325w
To: https://streamable.com/hmptm