### PR TITLE
Fix SliderBar binding to events too early

### DIFF
--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -47,10 +47,6 @@ namespace osu.Framework.Graphics.UserInterface
 
             if (CurrentNumber == null)
                 throw new NotSupportedException($"We don't support the generic type of {nameof(BindableNumber<T>)}.");
-
-            CurrentNumber.ValueChanged += _ => UpdateValue(NormalizedValue);
-            CurrentNumber.MinValueChanged += _ => UpdateValue(NormalizedValue);
-            CurrentNumber.MaxValueChanged += _ => UpdateValue(NormalizedValue);
         }
 
         protected float NormalizedValue
@@ -84,6 +80,11 @@ namespace osu.Framework.Graphics.UserInterface
         protected override void LoadComplete()
         {
             base.LoadComplete();
+
+            CurrentNumber.ValueChanged += _ => UpdateValue(NormalizedValue);
+            CurrentNumber.MinValueChanged += _ => UpdateValue(NormalizedValue);
+            CurrentNumber.MaxValueChanged += _ => UpdateValue(NormalizedValue);
+
             UpdateValue(NormalizedValue);
         }
 


### PR DESCRIPTION
Caused null ref exceptions in implementations using custom `UpdateValue` logic.