### PR TITLE
Disallow doubly-caching objects as dependencies

### DIFF
--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -118,6 +118,18 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(receivedObject, testObject2);
         }
 
+        [Test]
+        public void TestMultipleCacheFails()
+        {
+            var testObject1 = new BaseObject { TestValue = 1 };
+            var testObject2 = new BaseObject { TestValue = 2 };
+
+            var dependencies = new DependencyContainer();
+            dependencies.Cache(testObject1);
+
+            Assert.Throws<TypeAlreadyCachedException>(() => dependencies.Cache(testObject2));
+        }
+
         private class BaseObject
         {
             public int TestValue;

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -29,23 +29,15 @@ namespace osu.Framework.Allocation
         /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
         /// <param name="instance">The instance to cache.</param>
-        public void Cache<T>(T instance)
-            where T : class
-        {
-            if (instance == null)　throw new ArgumentNullException(nameof(instance));
-
-            cache[instance.GetType()] = instance;
-        }
+        public void Cache<T>(T instance) where T : class
+            => CacheAs(instance.GetType(), instance);
 
         /// <summary>
         /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
         /// <param name="instance">The instance to cache. Must be or derive from <typeparamref name="T"/>.</param>
-        public void CacheAs<T>(T instance)
-            where T : class
-        {
-            cache[typeof(T)] = instance ?? throw new ArgumentNullException(nameof(instance));
-        }
+        public void CacheAs<T>(T instance) where T : class
+            => CacheAs(typeof(T), instance);
 
         /// <summary>
         /// Caches an instance of a type as a type of <paramref name="type"/>. This instance will be returned each time you <see cref="Get(Type)"/>.

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -57,6 +57,11 @@ namespace osu.Framework.Allocation
             if (!type.IsInstanceOfType(instance))
                 throw new ArgumentException($"{instanceType.ReadableName()} must be a subclass of {type.ReadableName()}.", nameof(instance));
 
+            // We can theoretically make this work by adding a nested dependency container. That would be a pretty big change though.
+            // For now, let's throw an exception as this leads to unexpected behaviours (depends on ordering of processing of attributes vs CreateChildDependencies).
+            if (cache.ContainsKey(type))
+                throw new TypeAlreadyCachedException(type);
+
             cache[type] = instance;
         }
 
@@ -82,5 +87,13 @@ namespace osu.Framework.Allocation
         public void Inject<T>(T instance)
             where T : class
             => DependencyActivator.Activate(instance, this);
+    }
+
+    public class TypeAlreadyCachedException : InvalidOperationException
+    {
+        public TypeAlreadyCachedException(Type type)
+            : base($"An instance of type {type.ReadableName()} has already been cached to the dependency container.")
+        {
+        }
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -529,7 +529,14 @@ namespace osu.Framework.Platform
 
             game.SetHost(this);
 
-            root.Load(SceneGraphClock, Dependencies);
+            try
+            {
+                root.Load(SceneGraphClock, Dependencies);
+            }
+            catch (DependencyInjectionException e)
+            {
+                e.DispatchInfo.Throw();
+            }
 
             //publish bootstrapped scene graph to all threads.
             Root = root;


### PR DESCRIPTION
Disallows the case of something like:

```
class Base:
    [Cached]
    object myObject

class Sub : Base:
    [Cached]
    object myObject2
```

Because it's hard to determine exactly which object a resolver will receive with the way dependency container currently works.

Exception output changes e.g.:

```
Unhandled Exception: osu.Framework.Allocation.DependencyInjectionException: Exception of type 'osu.Framework.Allocation.DependencyInjectionException' was thrown.
   at osu.Framework.Allocation.BackgroundDependencyLoaderAttribute.<>c__DisplayClass6_1.<CreateActivator>b__4(Object target, DependencyContainer dc) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs:line 62
   at osu.Framework.Allocation.DependencyActivator.<>c__DisplayClass8_0.<activate>b__0(InjectDependencyDelegate a) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 72
   at System.Collections.Generic.List`1.ForEach(Action`1 action)
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 72
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 71
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 71
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 71
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 71
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 71
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 71
   at osu.Framework.Allocation.DependencyActivator.Activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 51
   at osu.Framework.Allocation.DependencyContainer.Inject[T](T instance) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyContainer.cs:line 89
   at osu.Framework.Graphics.Drawable.Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Drawable.cs:line 213
   at osu.Framework.Platform.GameHost.bootstrapSceneGraph(Game game) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 532
   at osu.Framework.Platform.GameHost.Run(Game game) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 438
   at osu.Framework.Tests.Program.Main(String[] args) in /Users/smoogipoo/Repos/osu-framework/osu.Framework.Tests/Program.cs:line 21

```

To:

```
Unhandled Exception: System.InvalidOperationException: The Size of a CompositeDrawable with AutoSizeAxes should only be manually set if it is relative to its parent.
   at osu.Framework.Graphics.Containers.CompositeDrawable.set_Size(Vector2 value) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 1326
   at osu.Framework.Graphics.Containers.CompositeDrawable.updateAutoSize() in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 1380
   at osu.Framework.Graphics.Containers.CompositeDrawable.updateChildrenSizeDependencies() in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 1398
   at osu.Framework.Graphics.Containers.CompositeDrawable.get_Size() in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 1318
   at osu.Framework.Graphics.Drawable.get_DrawSize() in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Drawable.cs:line 676
   at osu.Framework.Graphics.Containers.ScrollContainer`1.get_availableContent() in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/ScrollContainer.cs:line 85
   at osu.Framework.Graphics.Containers.ScrollContainer`1.updatePadding() in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/ScrollContainer.cs:line 226
   at osu.Framework.Graphics.Containers.ScrollContainer`1.set_ScrollbarOverlapsContent(Boolean value) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/ScrollContainer.cs:line 77
   at osu.Framework.Testing.TestBrowser.load(Storage storage, GameHost host, FrameworkConfigManager frameworkConfig) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Testing/TestBrowser.cs:line 113
--- End of stack trace from previous location where exception was thrown ---
   at osu.Framework.Platform.GameHost.bootstrapSceneGraph(Game game) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 538
   at osu.Framework.Platform.GameHost.Run(Game game) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 438
   at osu.Framework.Tests.Program.Main(String[] args) in /Users/smoogipoo/Repos/osu-framework/osu.Framework.Tests/Program.cs:line 21
```