### PR TITLE
Remove all LongRunning usage

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -128,6 +128,8 @@ namespace osu.Framework.Graphics
         private Task loadTask;
         private readonly object loadLock = new object();
 
+        private static readonly ConcurrentExclusiveSchedulerPair scheduler_pair = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, Math.Max(2, Environment.ProcessorCount / 2));
+
         /// <summary>
         /// Loads this Drawable asynchronously.
         /// </summary>
@@ -144,7 +146,7 @@ namespace osu.Framework.Graphics
             {
                 Debug.Assert(loadTask == null);
                 loadState = LoadState.Loading;
-                loadTask = Task.Factory.StartNew(() => Load(target.Clock, target.Dependencies), TaskCreationOptions.LongRunning);
+                loadTask = Task.Factory.StartNew(() => Load(target.Clock, target.Dependencies), CancellationToken.None, TaskCreationOptions.None, scheduler_pair.ConcurrentScheduler);
             }
 
             return (loadTask ?? Task.CompletedTask).ContinueWith(task => game.Schedule(() =>

--- a/osu.Framework/IO/AsyncBufferStream.cs
+++ b/osu.Framework/IO/AsyncBufferStream.cs
@@ -32,8 +32,6 @@ namespace osu.Framework.IO
 
         private readonly Stream underlyingStream;
 
-        private Thread thread;
-
         /// <summary>
         /// A stream that buffers the underlying stream to contiguous memory, reading until the whole file is eventually memory-backed.
         /// </summary>
@@ -60,7 +58,8 @@ namespace osu.Framework.IO
                 isLoaded = shared.isLoaded;
             }
 
-            thread = new Thread(loadRequiredBlocks) { IsBackground = true };
+            var thread = new Thread(loadRequiredBlocks) { IsBackground = true };
+            thread.Start();
         }
 
         ~AsyncBufferStream()
@@ -132,9 +131,6 @@ namespace osu.Framework.IO
         protected override void Dispose(bool disposing)
         {
             isDisposed = true;
-
-            thread?.Abort();
-            thread = null;
 
             if (!isClosed) Close();
             base.Dispose(disposing);

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -217,6 +217,8 @@ namespace osu.Framework.IO.Network
 
         private const string form_content_type = "multipart/form-data; boundary=" + form_boundary;
 
+        private static readonly ConcurrentExclusiveSchedulerPair scheduler_pair = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, 4);
+
         /// <summary>
         /// Performs the request asynchronously.
         /// </summary>
@@ -226,7 +228,7 @@ namespace osu.Framework.IO.Network
                 throw new InvalidOperationException($"The {nameof(WebRequest)} has already been run.");
             try
             {
-                await Task.Factory.StartNew(internalPerform, TaskCreationOptions.LongRunning);
+                await Task.Factory.StartNew(internalPerform, CancellationToken.None, TaskCreationOptions.None, scheduler_pair.ConcurrentScheduler);
             }
             catch (AggregateException ae)
             {

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Textures;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Logging;
 
@@ -55,6 +56,8 @@ namespace osu.Framework.IO.Stores
             fontLoadTask = readFontMetadataAsync(precache);
         }
 
+        private static readonly ConcurrentExclusiveSchedulerPair scheduler_pair = new ConcurrentExclusiveSchedulerPair(TaskScheduler.Default, Math.Max(1, Environment.ProcessorCount / 4));
+
         private async Task readFontMetadataAsync(bool precache)
         {
             await Task.Factory.StartNew(() =>
@@ -74,7 +77,7 @@ namespace osu.Framework.IO.Stores
                     Logger.Error(ex, $"Couldn't load font asset from {assetName}.");
                     throw;
                 }
-            }, TaskCreationOptions.LongRunning);
+            }, CancellationToken.None, TaskCreationOptions.None, scheduler_pair.ConcurrentScheduler);
 
             fontLoadTask = null;
         }

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -9,7 +9,6 @@ using System.IO;
 using osu.Framework.Platform;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using osu.Framework.Development;
 using osu.Framework.Threading;
 
@@ -386,17 +385,17 @@ namespace osu.Framework.Logging
 
         static Logger()
         {
-            Task.Factory.StartNew(() =>
+            var thread = new GameThread(() =>
             {
-                while (true)
-                {
-                    if ((Storage != null ? scheduler.Update() : 0) == 0)
-                        writer_idle.Set();
-                    Thread.Sleep(50);
-                }
+                if ((Storage != null ? scheduler.Update() : 0) == 0)
+                    writer_idle.Set();
+            }, "Logger")
+            {
+                ActiveHz = 20,
+                InactiveHz = 10,
+            };
 
-                // ReSharper disable once FunctionNeverReturns
-            }, TaskCreationOptions.LongRunning);
+            thread.Start();
         }
 
         /// <summary>

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -46,6 +46,7 @@ namespace osu.Framework.Platform
                 {
                     ipcProvider.MessageReceived += OnMessageReceived;
                     ipcThread = new Thread(ipcProvider.StartAsync) { IsBackground = true };
+                    ipcThread.Start();
                 }
             }
 

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Platform
     public abstract class DesktopGameHost : GameHost
     {
         private readonly TcpIpcProvider ipcProvider;
-        private readonly Task ipcTask;
+        private readonly Thread ipcThread;
 
         protected DesktopGameHost(string gameName = @"", bool bindIPCPort = false)
             : base(gameName)
@@ -45,7 +45,7 @@ namespace osu.Framework.Platform
                 if (IsPrimaryInstance)
                 {
                     ipcProvider.MessageReceived += OnMessageReceived;
-                    ipcTask = Task.Factory.StartNew(ipcProvider.StartAsync, TaskCreationOptions.LongRunning);
+                    ipcThread = new Thread(ipcProvider.StartAsync) { IsBackground = true };
                 }
             }
 
@@ -141,7 +141,7 @@ namespace osu.Framework.Platform
         protected override void Dispose(bool isDisposing)
         {
             ipcProvider?.Dispose();
-            ipcTask?.Wait(50);
+            ipcThread?.Join(50);
             base.Dispose(isDisposing);
         }
     }

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.Platform
             }
         }
 
-        public async Task StartAsync()
+        public async void StartAsync()
         {
             var token = cancelListener.Token;
             try


### PR DESCRIPTION
Alternative to #1631 (fewer changes). Hope to work-around slow macOS debugging.

Again, this PR is for testing purposes against osu!. As far as I can tell this resolves framework-side cases which could previously cause a slowdown.