### PR TITLE
Add more safety checks to dependency caching/injection

### DIFF
--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -129,6 +129,46 @@ namespace osu.Framework.Tests.Dependencies
             Assert.Throws<ArgumentException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
         }
 
+        [Test]
+        public void TestInvalidPublicAccessor()
+        {
+            var provider = new Provider13();
+
+            Assert.Throws<AccessModifierNotAllowedForCachedValueException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+        }
+
+        [Test]
+        public void TestInvalidProtectedAccessor()
+        {
+            var provider = new Provider14();
+
+            Assert.Throws<AccessModifierNotAllowedForCachedValueException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+        }
+
+        [Test]
+        public void TestInvalidInternalAccessor()
+        {
+            var provider = new Provider15();
+
+            Assert.Throws<AccessModifierNotAllowedForCachedValueException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+        }
+
+        [Test]
+        public void TestInvalidProtectedInternalAccessor()
+        {
+            var provider = new Provider16();
+
+            Assert.Throws<AccessModifierNotAllowedForCachedValueException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+        }
+
+        [Test]
+        public void TestValidPublicAccessor()
+        {
+            var provider = new Provider17();
+
+            Assert.DoesNotThrow(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+        }
+
         private interface IProvidedInterface1
         {
         }
@@ -223,6 +263,36 @@ namespace osu.Framework.Tests.Dependencies
         {
             [Cached(Type = typeof(IProvidedInterface1))]
             private IProvidedInterface1 provided1 = new ProvidedType3();
+        }
+
+        private class Provider13
+        {
+            [Cached]
+            public object Provided1 = new ProvidedType1();
+        }
+
+        private class Provider14
+        {
+            [Cached]
+            protected object Provided1 = new ProvidedType1();
+        }
+
+        private class Provider15
+        {
+            [Cached]
+            internal object Provided1 = new ProvidedType1();
+        }
+
+        private class Provider16
+        {
+            [Cached]
+            protected internal object Provided1 = new ProvidedType1();
+        }
+
+        private class Provider17
+        {
+            [Cached]
+            public readonly object Provided1 = new ProvidedType1();
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -130,6 +130,38 @@ namespace osu.Framework.Tests.Dependencies
             Assert.Throws<TypeAlreadyCachedException>(() => dependencies.Cache(testObject2));
         }
 
+        [Test]
+        public void TestInvalidPublicAccessor()
+        {
+            var receiver = new Receiver6();
+
+            Assert.Throws<AccessModifierNotAllowedForLoaderMethodException>(() => new DependencyContainer().Inject(receiver));
+        }
+
+        [Test]
+        public void TestInvalidProtectedAccessor()
+        {
+            var receiver = new Receiver7();
+
+            Assert.Throws<AccessModifierNotAllowedForLoaderMethodException>(() => new DependencyContainer().Inject(receiver));
+        }
+
+        [Test]
+        public void TestInvalidInternalAccessor()
+        {
+            var receiver = new Receiver8();
+
+            Assert.Throws<AccessModifierNotAllowedForLoaderMethodException>(() => new DependencyContainer().Inject(receiver));
+        }
+
+        [Test]
+        public void TestInvalidProtectedInternalAccessor()
+        {
+            var receiver = new Receiver9();
+
+            Assert.Throws<AccessModifierNotAllowedForLoaderMethodException>(() => new DependencyContainer().Inject(receiver));
+        }
+
         private class BaseObject
         {
             public int TestValue;
@@ -173,6 +205,38 @@ namespace osu.Framework.Tests.Dependencies
 
             [BackgroundDependencyLoader]
             private void load() => Loaded5?.Invoke();
+        }
+
+        private class Receiver6
+        {
+            [BackgroundDependencyLoader]
+            public void Load()
+            {
+            }
+        }
+
+        private class Receiver7
+        {
+            [BackgroundDependencyLoader]
+            protected void Load()
+            {
+            }
+        }
+
+        private class Receiver8
+        {
+            [BackgroundDependencyLoader]
+            internal void Load()
+            {
+            }
+        }
+
+        private class Receiver9
+        {
+            [BackgroundDependencyLoader]
+            protected internal void Load()
+            {
+            }
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.IEnumerableExtensions;
 
 namespace osu.Framework.Tests.Dependencies
 {
@@ -12,11 +13,9 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestInjectIntoNothing()
         {
-            var dependencies = new DependencyContainer();
-
             var receiver = new Receiver1();
 
-            dependencies.Inject(receiver);
+            createDependencies().Inject(receiver);
 
             Assert.AreEqual(null, receiver.Obj);
         }
@@ -24,14 +23,10 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestInjectIntoDependency()
         {
-            var testObject = new BaseObject();
-
-            var dependencies = new DependencyContainer();
-            dependencies.Cache(testObject);
-
             var receiver = new Receiver2();
 
-            dependencies.Inject(receiver);
+            BaseObject testObject;
+            createDependencies(testObject = new BaseObject()).Inject(receiver);
 
             Assert.AreEqual(testObject, receiver.Obj);
         }
@@ -39,37 +34,38 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestInjectNullIntoNonNull()
         {
-            var dependencies = new DependencyContainer();
-
             var receiver = new Receiver2();
 
-            Assert.Throws<DependencyNotRegisteredException>(() => dependencies.Inject(receiver));
+            Assert.Throws<DependencyNotRegisteredException>(() => createDependencies().Inject(receiver));
         }
 
         [Test]
         public void TestInjectNullIntoNullable()
         {
-            var dependencies = new DependencyContainer();
-
             var receiver = new Receiver3();
 
-            Assert.DoesNotThrow(() => dependencies.Inject(receiver));
+            Assert.DoesNotThrow(() => createDependencies().Inject(receiver));
         }
 
         [Test]
         public void TestInjectIntoSubClasses()
         {
-            var testObject = new BaseObject();
-
-            var dependencies = new DependencyContainer();
-            dependencies.Cache(testObject);
-
             var receiver = new Receiver4();
 
-            dependencies.Inject(receiver);
+            BaseObject testObject;
+            createDependencies(testObject = new BaseObject()).Inject(receiver);
 
             Assert.AreEqual(testObject, receiver.Obj);
             Assert.AreEqual(testObject, receiver.Obj2);
+        }
+
+        private DependencyContainer createDependencies(params object[] toCache)
+        {
+            var dependencies = new DependencyContainer();
+
+            toCache?.ForEach(o => dependencies.Cache(o));
+
+            return dependencies;
         }
 
         private class BaseObject

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -59,6 +59,46 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(testObject, receiver.Obj2);
         }
 
+        [Test]
+        public void TestInvalidPublicAccessor()
+        {
+            var receiver = new Receiver5();
+
+            Assert.Throws<AccessModifierNotAllowedForPropertySetterException>(() => createDependencies().Inject(receiver));
+        }
+
+        [Test]
+        public void TestInvalidExplicitProtectedAccessor()
+        {
+            var receiver = new Receiver6();
+
+            Assert.Throws<AccessModifierNotAllowedForPropertySetterException>(() => createDependencies().Inject(receiver));
+        }
+
+        [Test]
+        public void TestInvalidExplicitPrivateAccessor()
+        {
+            var receiver = new Receiver7();
+
+            Assert.Throws<AccessModifierNotAllowedForPropertySetterException>(() => createDependencies().Inject(receiver));
+        }
+
+        [Test]
+        public void TestExplicitPrivateAccessor()
+        {
+            var receiver = new Receiver8();
+
+            Assert.DoesNotThrow(() => createDependencies().Inject(receiver));
+        }
+
+        [Test]
+        public void TestExplicitInvalidProtectedInternalAccessor()
+        {
+            var receiver = new Receiver9();
+
+            Assert.Throws<AccessModifierNotAllowedForPropertySetterException>(() => createDependencies().Inject(receiver));
+        }
+
         private DependencyContainer createDependencies(params object[] toCache)
         {
             var dependencies = new DependencyContainer();
@@ -105,10 +145,33 @@ namespace osu.Framework.Tests.Dependencies
 
         private class Receiver5
         {
-            [Resolved]
-            private BaseObject obj { get; set; }
+            [Resolved(CanBeNull = true)]
+            public BaseObject Obj { get; set; }
+        }
 
-            public BaseObject Obj => obj;
+        private class Receiver6
+        {
+            [Resolved(CanBeNull = true)]
+            public BaseObject Obj { get; protected set; }
+        }
+
+        private class Receiver7
+        {
+            [Resolved(CanBeNull = true)]
+            public BaseObject Obj { get; internal set; }
+        }
+
+        private class Receiver8
+        {
+            [Resolved(CanBeNull = true)]
+            public BaseObject Obj { get; private set; }
+        }
+
+        private class Receiver9
+        {
+            [Resolved(CanBeNull = true)]
+            public BaseObject Obj { get; protected internal set; }
+        }
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -99,6 +99,14 @@ namespace osu.Framework.Tests.Dependencies
             Assert.Throws<AccessModifierNotAllowedForPropertySetterException>(() => createDependencies().Inject(receiver));
         }
 
+        [Test]
+        public void TestNoSetter()
+        {
+            var receiver = new Receiver10();
+
+            Assert.Throws<PropertyNotWritableException>(() => createDependencies().Inject(receiver));
+        }
+
         private DependencyContainer createDependencies(params object[] toCache)
         {
             var dependencies = new DependencyContainer();
@@ -172,6 +180,11 @@ namespace osu.Framework.Tests.Dependencies
             [Resolved(CanBeNull = true)]
             public BaseObject Obj { get; protected internal set; }
         }
+
+        private class Receiver10
+        {
+            [Resolved(CanBeNull = true)]
+            public BaseObject Obj { get; }
         }
     }
 }

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using JetBrains.Annotations;
+using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Allocation
 {
@@ -16,7 +17,7 @@ namespace osu.Framework.Allocation
     [AttributeUsage(AttributeTargets.Method)]
     public class BackgroundDependencyLoaderAttribute : Attribute
     {
-        private const BindingFlags activator_flags = BindingFlags.NonPublic | BindingFlags.Instance;
+        private const BindingFlags activator_flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
         private bool permitNulls { get; }
 
@@ -46,6 +47,11 @@ namespace osu.Framework.Allocation
                     return (_,__) => { };
                 case 1:
                     var method = loaderMethods[0];
+
+                    var modifier = method.GetAccessModifier();
+                    if (modifier != AccessModifier.Private)
+                        throw new AccessModifierNotAllowedForLoaderMethodException(modifier, method);
+
                     var permitNulls = method.GetCustomAttribute<BackgroundDependencyLoaderAttribute>().permitNulls;
                     var parameterGetters = method.GetParameters().Select(p => p.ParameterType).Select(t => getDependency(t, type, permitNulls));
 

--- a/osu.Framework/Allocation/CachedAttribute.cs
+++ b/osu.Framework/Allocation/CachedAttribute.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Allocation
             {
                 var modifier = field.GetAccessModifier();
                 if (modifier != AccessModifier.Private && !field.IsInitOnly)
-                    continue;
+                    throw new AccessModifierNotAllowedForCachedValueException(modifier, type, field.Name);
 
                 foreach (var attribute in field.GetCustomAttributes<CachedAttribute>())
                 {

--- a/osu.Framework/Allocation/CachedAttribute.cs
+++ b/osu.Framework/Allocation/CachedAttribute.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Allocation
             {
                 var modifier = field.GetAccessModifier();
                 if (modifier != AccessModifier.Private && !field.IsInitOnly)
-                    throw new AccessModifierNotAllowedForCachedValueException(modifier, type, field.Name);
+                    throw new AccessModifierNotAllowedForCachedValueException(modifier, field);
 
                 foreach (var attribute in field.GetCustomAttributes<CachedAttribute>())
                 {

--- a/osu.Framework/Allocation/DependencyActivator.cs
+++ b/osu.Framework/Allocation/DependencyActivator.cs
@@ -141,6 +141,17 @@ namespace osu.Framework.Allocation
     }
 
     /// <summary>
+    /// Occurs when the setter of a property with an attached <see cref="ResolvedAttribute"/> isn't private.
+    /// </summary>
+    public class AccessModifierNotAllowedForPropertySetterException : AccessModifierNotAllowedForMemberException
+    {
+        public AccessModifierNotAllowedForPropertySetterException(AccessModifier modifier, MemberInfo member)
+            : base(modifier, member, $"A property with an attached {nameof(ResolvedAttribute)} must have a private setter.")
+        {
+        }
+    }
+
+    /// <summary>
     /// Occurs when dependencies dependency injection into a <see cref="Drawable"/> fails.
     /// </summary>
     internal class DependencyInjectionException : Exception

--- a/osu.Framework/Allocation/DependencyActivator.cs
+++ b/osu.Framework/Allocation/DependencyActivator.cs
@@ -107,6 +107,19 @@ namespace osu.Framework.Allocation
     }
 
     /// <summary>
+    /// Occurs when a field was attempted to be cached with an unacceptable access modifier.
+    /// Fields can only be cached if they're private OR readonly public/protected/internal.
+    /// </summary>
+    public class AccessModifierNotAllowedForCachedValueException : InvalidOperationException
+    {
+        public AccessModifierNotAllowedForCachedValueException(AccessModifier modifier, Type type, string field)
+            : base($"The access modifier(s) [ {modifier.ToString()} ] are not allowed on \"{type.ReadableName()}.{field}\". "
+                   + "Cached fields must be private OR readonly.")
+        {
+        }
+    }
+
+    /// <summary>
     /// Occurs when dependencies dependency injection into a <see cref="Drawable"/> fails.
     /// </summary>
     internal class DependencyInjectionException : Exception

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Allocation
     [AttributeUsage(AttributeTargets.Property)]
     public class ResolvedAttribute : Attribute
     {
-        private const BindingFlags activator_flags = BindingFlags.NonPublic | BindingFlags.Instance;
+        private const BindingFlags activator_flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
         /// <summary>
         /// Whether a null value can be accepted if the value does not exist in the cache.
@@ -38,6 +38,10 @@ namespace osu.Framework.Allocation
             {
                 if (!property.CanWrite)
                     throw new PropertyNotWritableException(type, property.Name);
+
+                var modifier = property.SetMethod.GetAccessModifier();
+                if (modifier != AccessModifier.Private)
+                    throw new AccessModifierNotAllowedForPropertySetterException(modifier, property);
 
                 var attribute = property.GetCustomAttribute<ResolvedAttribute>();
                 var fieldGetter = getDependency(property.PropertyType, type, attribute.CanBeNull);

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -54,6 +54,24 @@ namespace osu.Framework.Extensions.TypeExtensions
 
             return ret;
         }
+
+        public static AccessModifier GetAccessModifier(this MethodInfo method)
+        {
+            AccessModifier ret = AccessModifier.None;
+
+            if (method.IsPublic)
+                ret |= AccessModifier.Public;
+            if (method.IsAssembly)
+                ret |= AccessModifier.Internal;
+            if (method.IsFamily)
+                ret |= AccessModifier.Protected;
+            if (method.IsPrivate)
+                ret |= AccessModifier.Private;
+            if (method.IsFamilyOrAssembly)
+                ret |= AccessModifier.Protected | AccessModifier.Internal;
+
+            return ret;
+        }
     }
 
     [Flags]

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace osu.Framework.Extensions.TypeExtensions
 {
@@ -35,5 +36,33 @@ namespace osu.Framework.Extensions.TypeExtensions
         }
 
         public static string ReadableName(this Type t) => readableName(t, new HashSet<Type>());
+
+        public static AccessModifier GetAccessModifier(this FieldInfo field)
+        {
+            AccessModifier ret = AccessModifier.None;
+
+            if (field.IsPublic)
+                ret |= AccessModifier.Public;
+            if (field.IsAssembly)
+                ret |= AccessModifier.Internal;
+            if (field.IsFamily)
+                ret |= AccessModifier.Protected;
+            if (field.IsPrivate)
+                ret |= AccessModifier.Private;
+            if (field.IsFamilyOrAssembly)
+                ret |= AccessModifier.Protected | AccessModifier.Internal;
+
+            return ret;
+        }
+    }
+
+    [Flags]
+    public enum AccessModifier
+    {
+        None = 0,
+        Public = 1 << 0,
+        Internal = 1 << 1,
+        Protected = 1 << 2,
+        Private = 1 << 3
     }
 }


### PR DESCRIPTION
* Throws more exceptions in disallowed scenarios to prevent user error.
* Allows caching readonly public/protected/internal/protected-internal fields.
* Allows resolving into public/protected/internal/protected-internal properties WITH private setters.