### PR TITLE
Move WebRequest to using pure async logic

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -21,7 +21,6 @@ namespace osu.Framework.Tests.IO
         private const string invalid_get_url = "a.ppy.shhhhh";
 
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestValidGet([Values("http", "https")] string protocol, [Values(true, false)] bool async)
         {
             var url = $"{protocol}://httpbin.org/get";
@@ -48,7 +47,6 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestInvalidGetExceptions([Values("http", "https")] string protocol, [Values(true, false)] bool async)
         {
             var request = new WebRequest($"{protocol}://{invalid_get_url}") { Method = HttpMethod.GET };
@@ -69,7 +67,6 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestBadStatusCode([Values(true, false)] bool async)
         {
             var request = new WebRequest("https://httpbin.org/hidden-basic-auth/user/passwd");
@@ -95,7 +92,6 @@ namespace osu.Framework.Tests.IO
         /// but before data has been read.
         /// </summary>
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestAbortReceive([Values(true, false)] bool async)
         {
             var request = new JsonWebRequest<HttpBinGetResponse>("https://httpbin.org/get") { Method = HttpMethod.GET };
@@ -121,7 +117,6 @@ namespace osu.Framework.Tests.IO
         /// Tests aborting the <see cref="WebRequest"/> before the request is sent to the server.
         /// </summary>
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestAbortRequest()
         {
             var request = new JsonWebRequest<HttpBinGetResponse>("https://httpbin.org/get") { Method = HttpMethod.GET };
@@ -147,7 +142,6 @@ namespace osu.Framework.Tests.IO
         /// Tests being able to abort + restart a request.
         /// </summary>
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestRestartAfterAbort([Values(true, false)] bool async)
         {
             var request = new JsonWebRequest<HttpBinGetResponse>("https://httpbin.org/get") { Method = HttpMethod.GET };
@@ -179,7 +173,6 @@ namespace osu.Framework.Tests.IO
         /// Tests that specifically-crafted <see cref="WebRequest"/> is completed after one timeout.
         /// </summary>
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestOneTimeout()
         {
             var request = new DelayedWebRequest
@@ -206,7 +199,6 @@ namespace osu.Framework.Tests.IO
         /// Tests that a <see cref="WebRequest"/> will only timeout a maximum of <see cref="WebRequest.MAX_RETRIES"/> times before being aborted.
         /// </summary>
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestFailTimeout()
         {
             var request = new WebRequest("https://httpbin.org/delay/4")
@@ -232,7 +224,6 @@ namespace osu.Framework.Tests.IO
         /// Tests being able to abort + restart a request.
         /// </summary>
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestEventUnbindOnCompletion([Values(true, false)] bool async)
         {
             var request = new JsonWebRequest<HttpBinGetResponse>("https://httpbin.org/get") { Method = HttpMethod.GET };
@@ -256,7 +247,6 @@ namespace osu.Framework.Tests.IO
         /// Tests being able to abort + restart a request.
         /// </summary>
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestUnbindOnDispose([Values(true, false)] bool async)
         {
             WebRequest request;
@@ -279,7 +269,6 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestPostWithJsonResponse([Values(true, false)] bool async)
         {
             var request = new JsonWebRequest<HttpBinPostResponse>("https://httpbin.org/post") { Method = HttpMethod.POST };
@@ -312,7 +301,6 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestPostWithJsonRequest([Values(true, false)] bool async)
         {
             var request = new JsonWebRequest<HttpBinPostResponse>("https://httpbin.org/post") { Method = HttpMethod.POST };
@@ -338,7 +326,6 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test, Retry(5)]
-        [Ignore("Broken (appveyor or httpbin.org, see https://ci.appveyor.com/project/peppy/osu-framework/build/5155)")]
         public void TestGetBinaryData([Values(true, false)] bool async, [Values(true, false)] bool chunked)
         {
             const int bytes_count = 65536;


### PR DESCRIPTION
Should hopefully fix web requests hogging `ThreadPool` threads during IO.