### PR TITLE
Allow framework types to cache structs as dependencies

### DIFF
--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -144,6 +144,12 @@ namespace osu.Framework.Tests.Dependencies
         }
 
         [Test]
+        public void TestGetValueNullInternal()
+        {
+            Assert.AreEqual(default(int), new DependencyContainer().GetValue<int>());
+        }
+
+        [Test]
         public void TestInvalidPublicAccessor()
         {
             var provider = new Provider13();

--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -183,6 +183,14 @@ namespace osu.Framework.Tests.Dependencies
             Assert.DoesNotThrow(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
         }
 
+        [Test]
+        public void TestCacheNullReferenceValue()
+        {
+            var provider = new Provider18();
+
+            Assert.Throws<NullReferenceException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+        }
+
         private interface IProvidedInterface1
         {
         }
@@ -307,6 +315,12 @@ namespace osu.Framework.Tests.Dependencies
         {
             [Cached]
             public readonly object Provided1 = new ProvidedType1();
+        }
+
+        private class Provider18
+        {
+            [Cached]
+            public readonly object Provided1;
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -341,8 +341,10 @@ namespace osu.Framework.Tests.Dependencies
 
         private class Provider18
         {
+#pragma warning disable 649
             [Cached]
             public readonly object Provided1;
+#pragma warning restore 649
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -149,6 +149,22 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(default(int), new DependencyContainer().GetValue<int>());
         }
 
+        /// <summary>
+        /// Test caching a nullable, where the providing type is within the osu.Framework assembly.
+        /// </summary>
+        [TestCase(null)]
+        [TestCase(10)]
+        public void TestCacheNullableInternal(int? testValue)
+        {
+            var provider = new CachedNullableProvider();
+
+            provider.SetValue(testValue);
+
+            var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
+
+            Assert.AreEqual(testValue, dependencies.GetValue<int?>());
+        }
+
         [Test]
         public void TestInvalidPublicAccessor()
         {

--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Testing.Dependencies;
 
 namespace osu.Framework.Tests.Dependencies
 {
@@ -127,6 +128,19 @@ namespace osu.Framework.Tests.Dependencies
             var provider = new Provider12();
 
             Assert.Throws<ArgumentException>(() => DependencyActivator.MergeDependencies(provider, new DependencyContainer()));
+        }
+
+        /// <summary>
+        /// Tests caching a struct, where the providing type is within the osu.Framework assembly.
+        /// </summary>
+        [Test]
+        public void TestCacheStructInternal()
+        {
+            var provider = new CachedStructProvider();
+
+            var dependencies = DependencyActivator.MergeDependencies(provider, new DependencyContainer());
+
+            Assert.AreEqual(provider.CachedObject.Value, dependencies.GetValue<CachedStructProvider.Struct>().Value);
         }
 
         private interface IProvidedInterface1

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Testing.Dependencies;
 
 namespace osu.Framework.Tests.Dependencies
 {
@@ -202,6 +203,19 @@ namespace osu.Framework.Tests.Dependencies
             Assert.Throws<AccessModifierNotAllowedForLoaderMethodException>(() => new DependencyContainer().Inject(receiver));
         }
 
+        [Test]
+        public void TestReceiveInternalStruct()
+        {
+            var receiver = new Receiver10();
+
+            var testObject = new CachedStructProvider();
+
+            var dependencies = DependencyActivator.MergeDependencies(testObject, new DependencyContainer());
+
+            Assert.DoesNotThrow(() => dependencies.Inject(receiver));
+            Assert.AreEqual(testObject.CachedObject.Value, receiver.TestObject.Value);
+        }
+
         private interface IBaseInterface
         {
         }
@@ -285,6 +299,16 @@ namespace osu.Framework.Tests.Dependencies
             protected internal void Load()
             {
             }
+        }
+
+        private class Receiver10
+        {
+            private CachedStructProvider.Struct testObject;
+
+            public CachedStructProvider.Struct TestObject => testObject;
+
+            [BackgroundDependencyLoader]
+            private void load(CachedStructProvider.Struct testObject) => this.testObject = testObject;
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -216,6 +216,29 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(testObject.CachedObject.Value, receiver.TestObject.Value);
         }
 
+        [TestCase(null)]
+        [TestCase(10)]
+        public void TestResolveNullableInternal(int? testValue)
+        {
+            var receiver = new Receiver11();
+
+            var testObject = new CachedNullableProvider();
+            testObject.SetValue(testValue);
+
+            var dependencies = DependencyActivator.MergeDependencies(testObject, new DependencyContainer());
+
+            dependencies.Inject(receiver);
+
+            Assert.AreEqual(testValue, receiver.TestObject);
+        }
+
+        [Test]
+        public void TestCacheNullInternal()
+        {
+            Assert.DoesNotThrow(() => new DependencyContainer().CacheValue<int?>(null));
+            Assert.DoesNotThrow(() => new DependencyContainer().CacheValueAs<object>(null));
+        }
+
         private interface IBaseInterface
         {
         }
@@ -303,12 +326,18 @@ namespace osu.Framework.Tests.Dependencies
 
         private class Receiver10
         {
-            private CachedStructProvider.Struct testObject;
-
-            public CachedStructProvider.Struct TestObject => testObject;
+            public CachedStructProvider.Struct TestObject { get; private set; }
 
             [BackgroundDependencyLoader]
-            private void load(CachedStructProvider.Struct testObject) => this.testObject = testObject;
+            private void load(CachedStructProvider.Struct testObject) => TestObject = testObject;
+        }
+
+        private class Receiver11
+        {
+            public int? TestObject { get; private set; }
+
+            [BackgroundDependencyLoader]
+            private void load(int? testObject) => TestObject = testObject;
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -130,9 +130,35 @@ namespace osu.Framework.Tests.Dependencies
             Assert.Throws<TypeAlreadyCachedException>(() => dependencies.Cache(testObject2));
         }
 
+        /// <summary>
+        /// Special case because "where T : class" also allows interfaces.
+        /// </summary>
+        [Test]
+        public void TestAttemptCacheStruct()
+        {
+            Assert.Throws<ArgumentException>(() => new DependencyContainer().Cache<IBaseInterface>(new BaseStructObject()));
+        }
+
+        /// <summary>
+        /// Special case because "where T : class" also allows interfaces.
+        /// </summary>
+        [Test]
+        public void TestAttemptCacheAsStruct()
+        {
+            Assert.Throws<ArgumentException>(() => new DependencyContainer().CacheAs<IBaseInterface>(new BaseStructObject()));
+        }
+
+        private interface IBaseInterface
+        {
+        }
+
         private class BaseObject
         {
             public int TestValue;
+        }
+
+        private struct BaseStructObject : IBaseInterface
+        {
         }
 
         private class DerivedObject : BaseObject

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -204,7 +204,7 @@ namespace osu.Framework.Tests.Dependencies
         }
 
         [Test]
-        public void TestReceiveInternalStruct()
+        public void TestReceiveStructInternal()
         {
             var receiver = new Receiver10();
 

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 
@@ -146,6 +147,27 @@ namespace osu.Framework.Tests.Dependencies
         public void TestAttemptCacheAsStruct()
         {
             Assert.Throws<ArgumentException>(() => new DependencyContainer().CacheAs<IBaseInterface>(new BaseStructObject()));
+        }
+
+        /// <summary>
+        /// Special value type that remains internally consistent through copies.
+        /// </summary>
+        [Test]
+        public void TestCacheCancellationToken()
+        {
+            var source = new CancellationTokenSource();
+            var token = source.Token;
+
+            var dependencies = new DependencyContainer();
+
+            Assert.DoesNotThrow(() => dependencies.CacheValue(token));
+
+            var retrieved = dependencies.GetValue<CancellationToken>();
+
+            source.Cancel();
+
+            Assert.IsTrue(token.IsCancellationRequested);
+            Assert.IsTrue(retrieved.IsCancellationRequested);
         }
 
         private interface IBaseInterface

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -239,6 +239,21 @@ namespace osu.Framework.Tests.Dependencies
             Assert.DoesNotThrow(() => new DependencyContainer().CacheValueAs<object>(null));
         }
 
+        [Test]
+        public void TestResolveStructWithoutNullPermits()
+        {
+            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver12()));
+        }
+
+        [Test]
+        public void TestResolveStructWithNullPermits()
+        {
+            var receiver = new Receiver13();
+
+            Assert.DoesNotThrow(() => new DependencyContainer().Inject(receiver));
+            Assert.AreEqual(0, receiver.TestObject);
+        }
+
         private interface IBaseInterface
         {
         }
@@ -338,6 +353,22 @@ namespace osu.Framework.Tests.Dependencies
 
             [BackgroundDependencyLoader]
             private void load(int? testObject) => TestObject = testObject;
+        }
+
+        private class Receiver12
+        {
+            [BackgroundDependencyLoader]
+            private void load(int testObject)
+            {
+            }
+        }
+
+        private class Receiver13
+        {
+            public int? TestObject { get; private set; } = 1;
+
+            [BackgroundDependencyLoader(true)]
+            private void load(int testObject) => TestObject = testObject;
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -150,6 +150,21 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(testValue, receiver.Obj);
         }
 
+        [Test]
+        public void TestResolveStructWithoutNullPermits()
+        {
+            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver14()));
+        }
+
+        [Test]
+        public void TestResolveStructWithNullPermits()
+        {
+            var receiver = new Receiver15();
+
+            Assert.DoesNotThrow(() => new DependencyContainer().Inject(receiver));
+            Assert.AreEqual(0, receiver.Obj);
+        }
+
         private DependencyContainer createDependencies(params object[] toCache)
         {
             var dependencies = new DependencyContainer();
@@ -244,6 +259,18 @@ namespace osu.Framework.Tests.Dependencies
         {
             [Resolved]
             public int? Obj { get; private set; }
+        }
+
+        private class Receiver14
+        {
+            [Resolved]
+            public int Obj { get; private set; }
+        }
+
+        private class Receiver15
+        {
+            [Resolved(CanBeNull = true)]
+            public int Obj { get; private set; } = 1;
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -4,6 +4,7 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Testing.Dependencies;
 
 namespace osu.Framework.Tests.Dependencies
 {
@@ -120,6 +121,19 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(testObject, receiver.Obj);
         }
 
+        [Test]
+        public void TestResolveInternalStruct()
+        {
+            var receiver = new Receiver12();
+
+            var testObject = new CachedStructProvider();
+
+            var dependencies = DependencyActivator.MergeDependencies(testObject, new DependencyContainer());
+
+            Assert.DoesNotThrow(() => dependencies.Inject(receiver));
+            Assert.AreEqual(testObject.CachedObject.Value, receiver.Obj.Value);
+        }
+
         private DependencyContainer createDependencies(params object[] toCache)
         {
             var dependencies = new DependencyContainer();
@@ -202,6 +216,12 @@ namespace osu.Framework.Tests.Dependencies
 
         private class Receiver11 : Receiver8
         {
+        }
+
+        private class Receiver12
+        {
+            [Resolved]
+            public CachedStructProvider.Struct Obj { get; private set; }
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -134,6 +134,22 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(testObject.CachedObject.Value, receiver.Obj.Value);
         }
 
+        [TestCase(null)]
+        [TestCase(10)]
+        public void TestResolveNullableInternal(int? testValue)
+        {
+            var receiver = new Receiver13();
+
+            var testObject = new CachedNullableProvider();
+            testObject.SetValue(testValue);
+
+            var dependencies = DependencyActivator.MergeDependencies(testObject, new DependencyContainer());
+
+            dependencies.Inject(receiver);
+
+            Assert.AreEqual(testValue, receiver.Obj);
+        }
+
         private DependencyContainer createDependencies(params object[] toCache)
         {
             var dependencies = new DependencyContainer();
@@ -222,6 +238,12 @@ namespace osu.Framework.Tests.Dependencies
         {
             [Resolved]
             public CachedStructProvider.Struct Obj { get; private set; }
+        }
+
+        private class Receiver13
+        {
+            [Resolved]
+            public int? Obj { get; private set; }
         }
     }
 }

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Allocation
                         throw new AccessModifierNotAllowedForLoaderMethodException(modifier, method);
 
                     var permitNulls = method.GetCustomAttribute<BackgroundDependencyLoaderAttribute>().permitNulls;
-                    var parameterGetters = method.GetParameters().Select(p => p.ParameterType).Select(t => getDependency(t, type, permitNulls));
+                    var parameterGetters = method.GetParameters().Select(p => p.ParameterType).Select(t => getDependency(t, type, permitNulls || t.IsNullable()));
 
                     return (target, dc) =>
                     {

--- a/osu.Framework/Allocation/CachedAttribute.cs
+++ b/osu.Framework/Allocation/CachedAttribute.cs
@@ -36,8 +36,11 @@ namespace osu.Framework.Allocation
         {
             var additionActivators = new List<Action<object, DependencyContainer>>();
 
+            // Types within the framework should be able to cache value types if they desire (e.g. cancellation tokens)
+            var allowValueTypes = type.Assembly == typeof(Drawable).Assembly;
+
             foreach (var attribute in type.GetCustomAttributes<CachedAttribute>())
-                additionActivators.Add((target, dc) => dc.CacheAs(attribute.Type ?? type, target));
+                additionActivators.Add((target, dc) => dc.CacheAs(attribute.Type ?? type, target, allowValueTypes));
 
             foreach (var field in type.GetFields(activator_flags).Where(f => f.GetCustomAttributes<CachedAttribute>().Any()))
             foreach (var attribute in field.GetCustomAttributes<CachedAttribute>())
@@ -45,7 +48,7 @@ namespace osu.Framework.Allocation
                 additionActivators.Add((target, dc) =>
                 {
                     var value = field.GetValue(target);
-                    dc.CacheAs(attribute.Type ?? value.GetType(), value);
+                    dc.CacheAs(attribute.Type ?? value.GetType(), value, allowValueTypes);
                 });
             }
 

--- a/osu.Framework/Allocation/CachedAttribute.cs
+++ b/osu.Framework/Allocation/CachedAttribute.cs
@@ -54,6 +54,15 @@ namespace osu.Framework.Allocation
                     additionActivators.Add((target, dc) =>
                     {
                         var value = field.GetValue(target);
+
+                        switch (value)
+                        {
+                            case null when allowValueTypes:
+                                return;
+                            case null:
+                                throw new NullReferenceException($"Attempted to cache a null value: {type.ReadableName()}.{field.Name}.");
+                        }
+
                         dc.CacheAs(attribute.Type ?? value.GetType(), value, allowValueTypes);
                     });
                 }

--- a/osu.Framework/Allocation/CachedAttribute.cs
+++ b/osu.Framework/Allocation/CachedAttribute.cs
@@ -55,12 +55,11 @@ namespace osu.Framework.Allocation
                     {
                         var value = field.GetValue(target);
 
-                        switch (value)
+                        if (value == null)
                         {
-                            case null when allowValueTypes:
+                            if (allowValueTypes)
                                 return;
-                            case null:
-                                throw new NullReferenceException($"Attempted to cache a null value: {type.ReadableName()}.{field.Name}.");
+                            throw new NullReferenceException($"Attempted to cache a null value: {type.ReadableName()}.{field.Name}.");
                         }
 
                         dc.CacheAs(attribute.Type ?? value.GetType(), value, allowValueTypes);

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -83,12 +83,11 @@ namespace osu.Framework.Allocation
         /// (e.g. <see cref="CancellationToken"/> or reference types).</param>
         internal void CacheAs(Type type, object instance, bool allowValueTypes)
         {
-            switch (instance)
+            if (instance == null)
             {
-                case null when allowValueTypes:
+                if (allowValueTypes)
                     return;
-                case null:
-                    throw new ArgumentNullException(nameof(instance));
+                throw new ArgumentNullException(nameof(instance));
             }
 
             var instanceType = instance.GetType();

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.Threading;
 using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Allocation
@@ -30,14 +31,14 @@ namespace osu.Framework.Allocation
         /// </summary>
         /// <param name="instance">The instance to cache.</param>
         public void Cache<T>(T instance) where T : class
-            => CacheAs(instance.GetType(), instance);
+            => CacheAs(instance.GetType(), instance, false);
 
         /// <summary>
         /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
         /// <param name="instance">The instance to cache. Must be or derive from <typeparamref name="T"/>.</param>
         public void CacheAs<T>(T instance) where T : class
-            => CacheAs(typeof(T), instance);
+            => CacheAs(typeof(T), instance, false);
 
         /// <summary>
         /// Caches an instance of a type as a type of <paramref name="type"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
@@ -45,13 +46,44 @@ namespace osu.Framework.Allocation
         /// <param name="type">The type to cache <paramref name="instance"/> as.</param>
         /// <param name="instance">The instance to cache. Must be or derive from <paramref name="type"/>.</param>
         public void CacheAs<T>(Type type, T instance) where T : class
+            => CacheAs(type, instance, false);
+
+        /// <summary>
+        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="DependencyContainer.Get(Type)"/>.
+        /// </summary>
+        /// <remarks>
+        /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
+        /// (e.g. <see cref="CancellationToken"/> or reference types).
+        /// </remarks>
+        /// <param name="instance">The instance to cache.</param>
+        internal void CacheValue<T>(T instance) => CacheAs(instance.GetType(), instance, true);
+
+        /// <summary>
+        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="DependencyContainer.Get(Type)"/>.
+        /// </summary>
+        /// <remarks>
+        /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
+        /// (e.g. <see cref="CancellationToken"/> or reference types).
+        /// </remarks>
+        /// <param name="instance">The instance to cache. Must be or derive from <typeparamref name="T"/>.</param>
+        internal void CacheValueAs<T>(T instance) => CacheAs(typeof(T), instance, true);
+
+        /// <summary>
+        /// Caches an instance of a type as a type of <paramref name="type"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
+        /// </summary>
+        /// <param name="type">The type to cache <paramref name="instance"/> as.</param>
+        /// <param name="instance">The instance to cache. Must be or derive from <paramref name="type"/>.</param>
+        /// <param name="allowValueTypes">Whether value types are allowed to be cached.
+        /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
+        /// (e.g. <see cref="CancellationToken"/> or reference types).</param>
+        internal void CacheAs(Type type, object instance, bool allowValueTypes)
         {
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));
 
             var instanceType = instance.GetType();
 
-            if (instanceType.IsValueType)
+            if (instanceType.IsValueType && !allowValueTypes)
                 throw new ArgumentException($"{instanceType.ReadableName()} must be a class to be cached as a dependency.", nameof(instance));
 
             if (!type.IsInstanceOfType(instance))

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Allocation
         /// </summary>
         /// <param name="type">The type to cache <paramref name="instance"/> as.</param>
         /// <param name="instance">The instance to cache. Must be or derive from <paramref name="type"/>.</param>
-        public void CacheAs(Type type, object instance)
+        public void CacheAs<T>(Type type, T instance) where T : class
         {
             if (instance == null)
                 throw new ArgumentNullException(nameof(instance));

--- a/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
+++ b/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
@@ -45,7 +45,12 @@ namespace osu.Framework.Allocation
         /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
         /// <returns>The requested dependency, or default(<typeparamref name="T"/>) if not found.</returns>
         internal static T GetValue<T>(this IReadOnlyDependencyContainer container)
-            => (T)container.Get(typeof(T));
+        {
+            var result = container.Get(typeof(T));
+            if (result == null)
+                return default(T);
+            return (T)container.Get(typeof(T));
+        }
 
         /// <summary>
         /// Tries to retrieve a cached dependency of type <typeparamref name="T"/>.

--- a/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
+++ b/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
@@ -29,13 +29,22 @@ namespace osu.Framework.Allocation
     public static class ReadOnlyDependencyContainerExtensions
     {
         /// <summary>
-        /// Retrieves a cached dependency of type <typeparamref name="T"/> if it exists and null otherwise.
+        /// Retrieves a cached dependency of type <typeparamref name="T"/> if it exists, and null otherwise.
         /// </summary>
         /// <typeparam name="T">The dependency type to query for.</typeparam>
         /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
         /// <returns>The requested dependency, or null if not found.</returns>
         public static T Get<T>(this IReadOnlyDependencyContainer container)
             where T : class
+            => (T)container.Get(typeof(T));
+
+        /// <summary>
+        /// Retrieves a cached dependency of type <typeparamref name="T"/> if it exists, and default(<typeparamref name="T"/>) otherwise.
+        /// </summary>
+        /// <typeparam name="T">The dependency type to query for.</typeparam>
+        /// <param name="container">The <see cref="IReadOnlyDependencyContainer"/> to query.</param>
+        /// <returns>The requested dependency, or default(<typeparamref name="T"/>) if not found.</returns>
+        internal static T GetValue<T>(this IReadOnlyDependencyContainer container)
             => (T)container.Get(typeof(T));
 
         /// <summary>

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Allocation
                     throw new AccessModifierNotAllowedForPropertySetterException(modifier, property);
 
                 var attribute = property.GetCustomAttribute<ResolvedAttribute>();
-                var fieldGetter = getDependency(property.PropertyType, type, attribute.CanBeNull);
+                var fieldGetter = getDependency(property.PropertyType, type, attribute.CanBeNull || property.PropertyType.IsNullable());
 
                 activators.Add((target, dc) => property.SetValue(target, fieldGetter(dc)));
             }

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -72,6 +72,12 @@ namespace osu.Framework.Extensions.TypeExtensions
 
             return ret;
         }
+
+        /// <summary>
+        /// Determines whether the specified type is a <see cref="Nullable{T}"/> type.
+        /// </summary>
+        /// <remarks>See: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/nullable-types/how-to-identify-a-nullable-type</remarks>
+        public static bool IsNullable(this Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
     }
 
     [Flags]

--- a/osu.Framework/Testing/Dependencies/CachedNullableProvider.cs
+++ b/osu.Framework/Testing/Dependencies/CachedNullableProvider.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Allocation;
+
+namespace osu.Framework.Testing.Dependencies
+{
+    /// <summary>
+    /// Used for internal <see cref="DependencyContainer"/> testing purposes.
+    /// </summary>
+    public class CachedNullableProvider
+    {
+        [Cached]
+        private int? cachedObject = 5;
+
+        public int? CachedObject => cachedObject;
+
+        public void SetValue(int? value) => cachedObject = value;
+    }
+}

--- a/osu.Framework/Testing/Dependencies/CachedStructProvider.cs
+++ b/osu.Framework/Testing/Dependencies/CachedStructProvider.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Allocation;
+
+namespace osu.Framework.Testing.Dependencies
+{
+    /// <summary>
+    /// This is used for internal <see cref="DependencyContainer"/> testing purposes.
+    /// </summary>
+    internal class CachedStructProvider
+    {
+        [Cached]
+        private Struct cachedObject = new Struct { Value = 10 };
+
+        public Struct CachedObject => cachedObject;
+
+        public struct Struct
+        {
+            public int Value;
+        }
+    }
+}


### PR DESCRIPTION
#### DependencyContainer
```diff
+ internal void CacheValue<T>(T instance)
+ internal void CacheValueAs<T>(T instance)
```

#### ReadOnlyDependencyContainerExtensions
```diff
+ internal static T GetValue<T>(this IReadOnlyDependencyContainer container)
```

Functionality is also provided through `[Cached]`, with the same soft limitation that only framework types can define this on structs. If another assembly tries to use `[Cached]` on structs, an `ArgumentException` will be thrown (as it already was).

Replaces the eventual implementation in https://github.com/peppy/osu-framework/tree/cancellation-drawables .