### PR TITLE
Fix incorrect DI error being reported by StepButton failures

### DIFF
--- a/osu.Framework/Testing/Drawables/Steps/StepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepButton.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -92,6 +93,8 @@ namespace osu.Framework.Testing.Drawables.Steps
             }
             catch (Exception e)
             {
+                if (e.InnerException is DependencyInjectionException die)
+                    e = die.DispatchInfo.SourceException;
                 Logging.Logger.Error(e, $"Step {this} triggered an error");
             }
 


### PR DESCRIPTION
From:

```
[runtime:important] System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> osu.Framework.Allocation.DependencyInjectionException: Exception of type 'osu.Framework.Allocation.DependencyInjectionException' was thrown.
   at osu.Framework.Allocation.BackgroundDependencyLoaderAttribute.<>c__DisplayClass6_1.<CreateActivator>b__4(Object target, IReadOnlyDependencyContainer dc) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs:line 73
   at osu.Framework.Allocation.DependencyActivator.<>c__DisplayClass8_0.<activate>b__0(InjectDependencyDelegate a) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 73
   at System.Collections.Generic.List`1.ForEach(Action`1 action)
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 73
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 72
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 72
   at osu.Framework.Allocation.DependencyActivator.activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 72
   at osu.Framework.Allocation.DependencyActivator.Activate(Object obj, DependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyActivator.cs:line 52
   at osu.Framework.Allocation.DependencyContainer.Inject[T](T instance) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyContainer.cs:line 89

[[ Trim ]]
```

To:

```
[runtime:important] osu.Framework.Allocation.TypeAlreadyCachedException: An instance of type ILocalisationEngine has already been cached to the dependency container.
   at osu.Framework.Allocation.DependencyContainer.CacheAs(Type type, Object instance) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyContainer.cs:line 65
   at osu.Framework.Allocation.DependencyContainer.CacheAs[T](T instance) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Allocation/DependencyContainer.cs:line 40
   at osu.Framework.Tests.Visual.TestCaseLocalisation.CustomEngineSpriteText.CreateChildDependencies(IReadOnlyDependencyContainer parent) in /Users/smoogipoo/Repos/osu-framework/osu.Framework.Tests/Visual/TestCaseLocalisation.cs:line 179
   at osu.Framework.Graphics.Drawable.Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Drawable.cs:line 211
   at osu.Framework.Graphics.Containers.CompositeDrawable.loadChild(Drawable child) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 92
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 22
   at osu.Framework.Graphics.Containers.CompositeDrawable.load(ShaderManager shaders) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 77
```