### PR TITLE
Fix assertions breaking rider/cli outputs

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -201,6 +201,7 @@ namespace osu.Framework.Platform
                 {
                     OnThreadStart = UpdateInitialize,
                     Monitor = { HandleGC = true },
+                    OnAssertion = e => InputThread.Scheduler.Add(e.Throw)
                 }),
                 (InputThread = new InputThread(null)), //never gets started.
             };


### PR DESCRIPTION
It looks like:
1. Assertion exceptions cannot be left unhandled. They seem to be handled by the parenting process if this is the case - crashing the test runner.
2. Assertions shouldn't be thrown on non-main threads. Related to (1) because they don't crash the main nunit thread.

Instead, this change handles assertion exceptions and then forwards them to the correct thread (InputThread).

From:

<img width="1882" alt="image" src="https://user-images.githubusercontent.com/1329837/44024917-95aa9b26-9f29-11e8-9837-4c7fa9982d42.png">

To:

<img width="1889" alt="image" src="https://user-images.githubusercontent.com/1329837/44024888-85836e76-9f29-11e8-8c0b-e2b653a75f9e.png">