### PR TITLE
Display frame times in addition to FPS

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Graphics.Performance
         private readonly Drawable[] legendMapping = new Drawable[FrameStatistics.NUM_PERFORMANCE_COLLECTION_TYPES];
         private readonly Dictionary<StatisticsCounterType, CounterBar> counterBars = new Dictionary<StatisticsCounterType, CounterBar>();
 
-        private readonly FpsDisplay fpsDisplay;
+        private readonly FrameTimeDisplay frameTimeDisplay;
 
         private FrameStatisticsMode state;
 
@@ -184,7 +184,7 @@ namespace osu.Framework.Graphics.Performance
                                     new TimeBar(atlas),
                                 },
                             },
-                            fpsDisplay = new FpsDisplay(monitor.Clock)
+                            frameTimeDisplay = new FrameTimeDisplay(monitor.Clock)
                             {
                                 Anchor = Anchor.BottomRight,
                                 Origin = Anchor.BottomRight,
@@ -280,7 +280,7 @@ namespace osu.Framework.Graphics.Performance
 
                 running = value;
 
-                fpsDisplay.Counting = running;
+                frameTimeDisplay.Counting = running;
                 processFrames = running;
             }
         }

--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -1,26 +1,27 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
+using System.Globalization;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.MathUtils;
 using osu.Framework.Timing;
-using System;
+using OpenTK;
 
 namespace osu.Framework.Graphics.Performance
 {
-    internal class FpsDisplay : Container
+    internal class FrameTimeDisplay : Container
     {
         private readonly SpriteText counter;
 
-        private readonly IFrameBasedClock clock;
-        private double displayFps;
+        private readonly ThrottledFrameClock clock;
 
         public bool Counting = true;
 
-        public FpsDisplay(IFrameBasedClock clock)
+        public FrameTimeDisplay(ThrottledFrameClock clock)
         {
             this.clock = clock;
 
@@ -39,6 +40,7 @@ namespace osu.Framework.Graphics.Performance
                 {
                     Anchor = Anchor.TopRight,
                     Origin = Anchor.TopRight,
+                    Spacing = new Vector2(-1, 0),
                     Text = @"...",
                     FixedWidth = true,
                 }
@@ -47,13 +49,13 @@ namespace osu.Framework.Graphics.Performance
 
         private float aimWidth;
 
+        private double displayFps;
+
         protected override void Update()
         {
             base.Update();
 
             if (!Counting) return;
-
-            displayFps = Interpolation.Damp(displayFps, clock.FramesPerSecond, 0.01, Math.Max(clock.ElapsedFrameTime, 0) / 1000);
 
             if (counter.DrawWidth != aimWidth)
             {
@@ -69,7 +71,10 @@ namespace osu.Framework.Graphics.Performance
                 aimWidth = counter.DrawWidth;
             }
 
-            counter.Text = displayFps.ToString(@"0");
+            displayFps = Interpolation.Damp(displayFps, clock.FramesPerSecond, 0.01, Math.Max(clock.ElapsedFrameTime, 0) / 1000);
+
+            counter.Text = $"{displayFps:0}fps({clock.AverageFrameTime:0.00}ms)"
+                           + $"{(clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString(CultureInfo.InvariantCulture) : "∞").PadLeft(4)}hz";
         }
     }
 }

--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Globalization;
 using OpenTK.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -74,7 +73,7 @@ namespace osu.Framework.Graphics.Performance
             displayFps = Interpolation.Damp(displayFps, clock.FramesPerSecond, 0.01, Math.Max(Clock.ElapsedFrameTime, 0) / 1000);
 
             counter.Text = $"{displayFps:0}fps({clock.AverageFrameTime:0.00}ms)"
-                           + $"{(clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString(CultureInfo.InvariantCulture) : "∞").PadLeft(4)}hz";
+                           + $"{(clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString("0") : "∞").PadLeft(4)}hz";
         }
     }
 }

--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -71,7 +71,7 @@ namespace osu.Framework.Graphics.Performance
                 aimWidth = counter.DrawWidth;
             }
 
-            displayFps = Interpolation.Damp(displayFps, clock.FramesPerSecond, 0.01, Math.Max(clock.ElapsedFrameTime, 0) / 1000);
+            displayFps = Interpolation.Damp(displayFps, clock.FramesPerSecond, 0.01, Math.Max(Clock.ElapsedFrameTime, 0) / 1000);
 
             counter.Text = $"{displayFps:0}fps({clock.AverageFrameTime:0.00}ms)"
                            + $"{(clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString(CultureInfo.InvariantCulture) : "∞").PadLeft(4)}hz";

--- a/osu.Framework/Timing/FramedClock.cs
+++ b/osu.Framework/Timing/FramedClock.cs
@@ -73,11 +73,13 @@ namespace osu.Framework.Timing
             timeUntilNextCalculation -= ElapsedFrameTime;
             timeSinceLastCalculation += ElapsedFrameTime;
 
-            AverageFrameTime = Interpolation.Damp(AverageFrameTime, ElapsedFrameTime, 0.01, Math.Max(ElapsedFrameTime, 0) / 1000);
+            AverageFrameTime = CalculateAverageFrameTime();
 
             LastFrameTime = CurrentTime;
             CurrentTime = SourceTime;
         }
+
+        protected virtual double CalculateAverageFrameTime() => Interpolation.Damp(AverageFrameTime, ElapsedFrameTime, 0.01, Math.Max(ElapsedFrameTime, 0) / 1000);
 
         public override string ToString() => $@"{GetType().ReadableName()} ({Math.Truncate(CurrentTime)}ms, {FramesPerSecond} FPS)";
     }


### PR DESCRIPTION
When doing performance testing, it is very hard to objectively use FPS as a gauge for whether you've made improvements due to rule of demising returns.

This exposes the frame times for each thread along with the thread's current target refresh rate. Note that these times do *not* include time spent sleeping, so they should be useful across all frame limiter modes.