### PR TITLE
Remove pointless and expensive assert

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -438,8 +438,6 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>Whether the child's alive state has changed.</returns>
         private bool checkChildLife(Drawable child)
         {
-            Debug.Assert(internalChildren.Contains(child), "Can only check and react to the life of our own children.");
-
             bool changed = false;
 
             if (child.ShouldBeAlive)


### PR DESCRIPTION
This was already guaranteed (it's a private function only used in one place) but was adding a non-trivial overhead during debug sessions.