### PR TITLE
Reduce allocations by ConcurrentQueue when collecting perf data

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -47,8 +47,6 @@ namespace osu.Framework.Graphics.Performance
         private int timeBarIndex => currentX / WIDTH;
         private int timeBarX => currentX % WIDTH;
 
-        private bool processFrames = true;
-
         private readonly Container overlayContainer;
         private readonly Drawable labelText;
         private readonly Sprite counterBarBackground;
@@ -281,7 +279,11 @@ namespace osu.Framework.Graphics.Performance
                 running = value;
 
                 fpsDisplay.Counting = running;
-                processFrames = running;
+
+                // dequeue all pending frames on state change.
+                while (monitor.PendingFrames.TryDequeue(out _))
+                {
+                }
             }
         }
 
@@ -389,12 +391,13 @@ namespace osu.Framework.Graphics.Performance
         {
             base.Update();
 
-            while (monitor.PendingFrames.TryDequeue(out FrameStatistics frame))
+            if (running)
             {
-                if (processFrames)
+                while (monitor.PendingFrames.TryDequeue(out FrameStatistics frame))
+                {
                     applyFrame(frame);
-
-                monitor.FramesHeap.FreeObject(frame);
+                    monitor.FramesHeap.FreeObject(frame);
+                }
             }
         }
 

--- a/osu.Framework/Statistics/PerformanceMonitor.cs
+++ b/osu.Framework/Statistics/PerformanceMonitor.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Statistics
 
         private FrameStatistics currentFrame;
 
-        private const int max_pending_frames = 100;
+        private const int max_pending_frames = 10;
 
         internal readonly ConcurrentQueue<FrameStatistics> PendingFrames = new ConcurrentQueue<FrameStatistics>();
         internal readonly ObjectStack<FrameStatistics> FramesHeap = new ObjectStack<FrameStatistics>(max_pending_frames);
@@ -106,14 +106,12 @@ namespace osu.Framework.Statistics
                     FrameStatistics.COUNTERS[i] = 0;
                 }
 
-            PendingFrames.Enqueue(currentFrame);
-            if (PendingFrames.Count >= max_pending_frames)
+            if (PendingFrames.Count < max_pending_frames - 1)
             {
-                PendingFrames.TryDequeue(out FrameStatistics oldFrame);
-                FramesHeap.FreeObject(oldFrame);
+                PendingFrames.Enqueue(currentFrame);
+                currentFrame = FramesHeap.ReserveObject();
             }
 
-            currentFrame = FramesHeap.ReserveObject();
             currentFrame.Clear();
 
             if (HandleGC)
@@ -172,6 +170,7 @@ namespace osu.Framework.Statistics
             Dispose(true);
             GC.SuppressFinalize(this);
         }
+
         #endregion
     }
 }


### PR DESCRIPTION
When the frame time display is not visible, collections are still being infinitely cycled though the queue. This stops that from happening (there's no point in storing these frames when they are not being used).