### PR TITLE
Reduce allocations for non-composite drawables' dependencies

### DIFF
--- a/osu.Framework/Allocation/DependencyActivator.cs
+++ b/osu.Framework/Allocation/DependencyActivator.cs
@@ -97,7 +97,7 @@ namespace osu.Framework.Allocation
     /// <summary>
     /// Occurs when an object requests the resolution of a dependency, but the dependency doesn't exist.
     /// This is caused by the dependency not being registered by parent <see cref="CompositeDrawable"/> through
-    /// <see cref="Drawable.CreateChildDependencies"/> or <see cref="CachedAttribute"/>.
+    /// <see cref="CompositeDrawable.CreateChildDependencies"/> or <see cref="CachedAttribute"/>.
     /// </summary>
     public class DependencyNotRegisteredException : Exception
     {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -47,10 +47,33 @@ namespace osu.Framework.Graphics.Containers
         [Resolved]
         private Game game { get; set; }
 
+        /// <summary>
+        /// Create a local dependency container which will be used by our nested children.
+        /// If not overridden, the load-time parent's dependency tree will be used.
+        /// </summary>
+        /// <param name="parent">The parent <see cref="IReadOnlyDependencyContainer"/> which should be passed through if we want fallback lookups to work.</param>
+        /// <returns>A new dependency container to be stored for this Drawable.</returns>
+        protected virtual IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) => DependencyActivator.MergeDependencies(this, parent);
+
+        /// <summary>
+        /// Contains all dependencies that can be injected into this CompositeDrawable's children using <see cref="BackgroundDependencyLoaderAttribute"/>.
+        /// Add or override dependencies by calling <see cref="DependencyContainer.Cache{T}(T)"/>.
+        /// </summary>
+        public IReadOnlyDependencyContainer Dependencies { get; private set; }
+
+        protected sealed override void InjectDependencies(IReadOnlyDependencyContainer dependencies)
+        {
+            // get our dependencies from our parent, but allow local overriding of our inherited dependency container
+            Dependencies = CreateChildDependencies(dependencies);
+
+            base.InjectDependencies(dependencies);
+        }
+
+
         private CancellationTokenSource cancellationSource;
 
         /// <summary>
-        /// Loads a future child or grand-child of this <see cref="CompositeDrawable"/> asyncronously. <see cref="Drawable.Dependencies"/>
+        /// Loads a future child or grand-child of this <see cref="CompositeDrawable"/> asyncronously. <see cref="Dependencies"/>
         /// and <see cref="Drawable.Clock"/> are inherited from this <see cref="CompositeDrawable"/>.
         ///
         /// Note that this will always use the dependencies and clock from this instance. If you must load to a nested container level,

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -142,12 +142,12 @@ namespace osu.Framework.Graphics
         /// <param name="game">The game to load this Drawable on.</param>
         /// <param name="target">
         /// The target this Drawable may eventually be loaded into.
-        /// <see cref="Clock"/> and <see cref="Dependencies"/> are inherited from the target.
+        /// <see cref="Clock"/> and <see cref="CompositeDrawable.Dependencies"/> are inherited from the target.
         /// </param>
         /// <param name="cancellation">A cancellation token.</param>
         /// <param name="onLoaded">Callback to be invoked on the update thread after loading is complete.</param>
         /// <returns>The task which is used for loading and callbacks.</returns>
-        internal Task LoadAsync(Game game, Drawable target, CancellationToken cancellation, Action onLoaded = null)
+        internal Task LoadAsync(Game game, CompositeDrawable target, CancellationToken cancellation, Action onLoaded = null)
         {
             if (loadState == LoadState.NotLoaded)
             {
@@ -170,24 +170,10 @@ namespace osu.Framework.Graphics
         private static readonly StopwatchClock perf = new StopwatchClock(true);
 
         /// <summary>
-        /// Create a local dependency container which will be used by our nested children.
-        /// If not overridden, the load-time parent's dependency tree will be used.
-        /// </summary>
-        /// <param name="parent">The parent <see cref="IReadOnlyDependencyContainer"/> which should be passed through if we want fallback lookups to work.</param>
-        /// <returns>A new dependency container to be stored for this Drawable.</returns>
-        protected virtual IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) => DependencyActivator.MergeDependencies(this, parent);
-
-        /// <summary>
-        /// Contains all dependencies that can be injected into this Drawable using <see cref="BackgroundDependencyLoaderAttribute"/>.
-        /// Add or override dependencies by calling <see cref="DependencyContainer.Cache{T}(T)"/>.
-        /// </summary>
-        public IReadOnlyDependencyContainer Dependencies { get; private set; }
-
-        /// <summary>
         /// Loads this drawable, including the gathering of dependencies and initialisation of required resources.
         /// </summary>
         /// <param name="clock">The clock we should use by default.</param>
-        /// <param name="dependencies">The dependency tree we will inherit by default. May be extended via <see cref="CreateChildDependencies"/></param>
+        /// <param name="dependencies">The dependency tree we will inherit by default. May be extended via <see cref="CompositeDrawable.CreateChildDependencies"/></param>
         /// <param name="cancellation">An optional cancellation token.</param>
         internal void Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies, CancellationToken? cancellation = null)
         {
@@ -225,10 +211,7 @@ namespace osu.Framework.Graphics
                     dependencies = cancellationDep;
                 }
 
-                // get our dependencies from our parent, but allow local overriding of our inherited dependency container
-                Dependencies = CreateChildDependencies(dependencies);
-
-                dependencies.Inject(this);
+                InjectDependencies(dependencies);
 
                 LoadAsyncComplete();
 
@@ -238,6 +221,12 @@ namespace osu.Framework.Graphics
                 loadState = LoadState.Ready;
             }
         }
+
+        /// <summary>
+        /// Perform dependency injection on self from provided dependencies.
+        /// </summary>
+        /// <param name="dependencies">The dependencies to inject.</param>
+        protected virtual void InjectDependencies(IReadOnlyDependencyContainer dependencies) => dependencies.Inject(this);
 
         /// <summary>
         /// Runs once on the update thread after loading has finished.
@@ -2405,7 +2394,7 @@ namespace osu.Framework.Graphics
         NotLoaded,
         /// <summary>
         /// Currently loading (possibly and usually on a background
-        /// thread via <see cref="Drawable.LoadAsync(Game,Drawable,CancellationToken,Action)"/>).
+        /// thread via <see cref="Drawable.LoadAsync(Game,CompositeDrawable,CancellationToken,Action)"/>).
         /// </summary>
         Loading,
         /// <summary>


### PR DESCRIPTION
We only ever use dependency overriding abilities at `CompositeDrawable`. This moves that logic out of `Drawable`, reducing the overhead when loading `Drawables`/`Sprites` significantly by skipping one unnecessary dependency merge operation.