### PR TITLE
Reduce allocations caused by joystick state polling

### DIFF
--- a/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OpenTKJoystickHandler.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Input.Handlers.Joystick
                             handleState(device, newState);
                             FrameStatistics.Increment(StatisticsCounterType.JoystickEvents);
                         }
-                    }, 0, 0));
+                    }, 0, 500));
                 }
                 else
                 {


### PR DESCRIPTION
Also reduces the poll rate, as there's no need to check 1,000 times a second.