### PR TITLE
Reduce cancellation token overhead

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -88,15 +88,17 @@ namespace osu.Framework.Graphics.Containers
             if (game == null)
                 throw new InvalidOperationException($"May not invoke {nameof(LoadComponentAsync)} prior to this {nameof(CompositeDrawable)} being loaded.");
 
+            var dependencies = Dependencies;
+
             if (cancellationSource == null)
             {
                 cancellationSource = new CancellationTokenSource();
-                var deps = new DependencyContainer(Dependencies);
-                deps.CacheValueAs(cancellationSource.Token);
-                Dependencies = deps;
+                var cancellationDeps = new DependencyContainer(Dependencies);
+                cancellationDeps.CacheValueAs(cancellationSource.Token);
+                dependencies = cancellationDeps;
             }
 
-            return component.LoadAsync(game, this, cancellationSource.Token, () => onLoaded?.Invoke(component));
+            return component.LoadAsync(game, Clock, dependencies, cancellationSource.Token, () => onLoaded?.Invoke(component));
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -154,7 +154,7 @@ namespace osu.Framework.Graphics
                 Debug.Assert(loadTask == null);
                 loadState = LoadState.Loading;
                 loadTaskCancellation = cancellation;
-                loadTask = Task.Factory.StartNew(() => Load(target.Clock, target.Dependencies, cancellation), cancellation, TaskCreationOptions.LongRunning, TaskScheduler.Current);
+                loadTask = Task.Factory.StartNew(() => Load(target.Clock, target.Dependencies), cancellation, TaskCreationOptions.LongRunning, TaskScheduler.Current);
             }
 
             return (loadTask ?? Task.CompletedTask).ContinueWith(task => game.Schedule(() =>
@@ -174,8 +174,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <param name="clock">The clock we should use by default.</param>
         /// <param name="dependencies">The dependency tree we will inherit by default. May be extended via <see cref="CompositeDrawable.CreateChildDependencies"/></param>
-        /// <param name="cancellation">An optional cancellation token.</param>
-        internal void Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies, CancellationToken? cancellation = null)
+        internal void Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies)
         {
             // Blocks when loading from another thread already.
             double t0 = perf.CurrentTime;
@@ -203,13 +202,6 @@ namespace osu.Framework.Graphics
                 UpdateClock(clock);
 
                 double t1 = perf.CurrentTime;
-
-                if (cancellation != null)
-                {
-                    var cancellationDep = new DependencyContainer(dependencies);
-                    cancellationDep.CacheValueAs(cancellation.Value);
-                    dependencies = cancellationDep;
-                }
 
                 InjectDependencies(dependencies);
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -140,21 +140,19 @@ namespace osu.Framework.Graphics
         /// Loads this Drawable asynchronously.
         /// </summary>
         /// <param name="game">The game to load this Drawable on.</param>
-        /// <param name="target">
-        /// The target this Drawable may eventually be loaded into.
-        /// <see cref="Clock"/> and <see cref="CompositeDrawable.Dependencies"/> are inherited from the target.
-        /// </param>
+        /// <param name="clock">The clock to be applied on load.</param>
+        /// <param name="dependencies">The source for DI lookups.</param>
         /// <param name="cancellation">A cancellation token.</param>
         /// <param name="onLoaded">Callback to be invoked on the update thread after loading is complete.</param>
         /// <returns>The task which is used for loading and callbacks.</returns>
-        internal Task LoadAsync(Game game, CompositeDrawable target, CancellationToken cancellation, Action onLoaded = null)
+        internal Task LoadAsync(Game game, IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies, CancellationToken cancellation, Action onLoaded = null)
         {
             if (loadState == LoadState.NotLoaded)
             {
                 Debug.Assert(loadTask == null);
                 loadState = LoadState.Loading;
                 loadTaskCancellation = cancellation;
-                loadTask = Task.Factory.StartNew(() => Load(target.Clock, target.Dependencies), cancellation, TaskCreationOptions.LongRunning, TaskScheduler.Current);
+                loadTask = Task.Factory.StartNew(() => Load(clock, dependencies), cancellation, TaskCreationOptions.LongRunning, TaskScheduler.Current);
             }
 
             return (loadTask ?? Task.CompletedTask).ContinueWith(task => game.Schedule(() =>
@@ -2386,7 +2384,7 @@ namespace osu.Framework.Graphics
         NotLoaded,
         /// <summary>
         /// Currently loading (possibly and usually on a background
-        /// thread via <see cref="Drawable.LoadAsync(Game,CompositeDrawable,CancellationToken,Action)"/>).
+        /// thread via <see cref="Drawable.LoadAsync(Game,IFrameBasedClock,IReadOnlyDependencyContainer,CancellationToken,Action)"/>).
         /// </summary>
         Loading,
         /// <summary>


### PR DESCRIPTION
Cancellation token only needs to be cached in `CompositeDrawable`.

- [x] Depends on #1789.