### PR TITLE
Limit rate of frame time display updates to reduce overhead

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -57,7 +57,8 @@ namespace osu.Framework.Graphics.Performance
 
             double lastUpdate = 0;
 
-            Scheduler.AddDelayed(() => {
+            Scheduler.AddDelayed(() =>
+            {
                 if (!Counting) return;
 
                 if (!Precision.AlmostEquals(counter.DrawWidth, aimWidth))


### PR DESCRIPTION
`SpriteText` currently has a pretty huge overhead. Due to the longer display format now, this actually eats in to frame time considerably.

This aims to reduce that so we can continue comparing performance using the minimal frame time display.