### PR TITLE
Remove completely incorrect BypassAutoSize optimisation

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSizing.cs
@@ -1,11 +1,14 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using NUnit.Framework;
+using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.States;
+using osu.Framework.MathUtils;
 using osu.Framework.Testing;
 using OpenTK;
 using OpenTK.Graphics;
@@ -15,9 +18,10 @@ namespace osu.Framework.Tests.Visual
     [System.ComponentModel.Description("potentially challenging size calculations")]
     public class TestCaseSizing : TestCase
     {
-        private readonly Container testContainer;
+        private Container testContainer;
 
-        public TestCaseSizing()
+        [Test]
+        public void TestVariousScenarios()
         {
             Add(testContainer = new Container
             {
@@ -50,6 +54,43 @@ namespace osu.Framework.Tests.Visual
 
             loadTest(0);
             addCrosshair();
+        }
+
+        [Test]
+        public void TestBypassAutoSizeAxes()
+        {
+            const float autosize_height = 300;
+
+            Container autoSizeContainer;
+            Box boxSizeReference;
+
+            Child = autoSizeContainer = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = 300,
+                AutoSizeAxes = Axes.Y,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        Colour = Color4.Green,
+                        RelativeSizeAxes = Axes.Both
+                    },
+                    boxSizeReference = new Box
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = autosize_height,
+                        Colour = Color4.Red.Opacity(0.2f),
+                    }
+                }
+            };
+
+            AddAssert($"height = {autosize_height}", () => Precision.AlmostEquals(autosize_height, autoSizeContainer.DrawHeight));
+            AddStep("bypass y", () => boxSizeReference.BypassAutoSizeAxes = Axes.Y);
+            AddAssert("height = 0", () => Precision.AlmostEquals(0, autoSizeContainer.DrawHeight));
+            AddStep("bypass none", () => boxSizeReference.BypassAutoSizeAxes = Axes.None);
+            AddAssert($"height = {autosize_height}", () => Precision.AlmostEquals(autosize_height, autoSizeContainer.DrawHeight));
         }
 
         private void addCrosshair()

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -658,10 +658,6 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="source">The child which caused this invalidation. May be null to indicate that a specific child wasn't specified.</param>
         public virtual void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
         {
-            // We only want to recompute autosize if the child isn't bypassing all of our autosize axes
-            if (source != null && (source.BypassAutoSizeAxes & AutoSizeAxes) == AutoSizeAxes)
-                return;
-
             //Colour captures potential changes in IsPresent. If this ever becomes a bottleneck,
             //Invalidation could be further separated into presence changes.
             if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)


### PR DESCRIPTION
There are multiple cases where this would break. One such case is that `BypassAutosizeAxes` is changed to `Axes.Both` post-construction, which wouldn't cause an invalidation due to this.

Similar things could happen when adding/removing drawables, changing scale, etc... The code was super wrong.

I've left the parameter in for now to preserve the API.

Have also tested mania and it _seems_ to be okay, which is what https://github.com/ppy/osu/pull/2564 / https://github.com/ppy/osu-framework/pull/1554 was addressing.