### PR TITLE
Fix layout invalidation issues related to BypassAutoSizeAxes

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1176,7 +1176,7 @@ namespace osu.Framework.Graphics.Containers
                 padding = value;
 
                 foreach (Drawable c in internalChildren)
-                    c.Invalidate(c.InvalidationFromParentSize);
+                    c.Invalidate(c.InvalidationFromParentSize | Invalidation.MiscGeometry);
             }
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -791,10 +791,10 @@ namespace osu.Framework.Graphics
             var value = RelativePositionAxes | RelativeSizeAxes | bypassAutoSizeAdditionalAxes;
             if (bypassAutoSizeAxes != value)
             {
-                if (((Parent?.AutoSizeAxes ?? 0) & ~(bypassAutoSizeAxes & value)) != 0)
-                    Parent?.InvalidateFromChild(Invalidation.RequiredParentSizeToFit, this);
-
+                var changedAxes = bypassAutoSizeAxes ^ value;
                 bypassAutoSizeAxes = value;
+                if (((Parent?.AutoSizeAxes ?? 0) & changedAxes) != 0)
+                    Parent?.InvalidateFromChild(Invalidation.RequiredParentSizeToFit, this);
             }
         }
 


### PR DESCRIPTION
Also fixes a Padding invalidation issue.
I found the issue by random test quick check #1800  and I made the changes so the test passes.

`BypassAutoSizeAxes` is a bit awkward due to its asymmetry between getter and setter.

---