### PR TITLE
Disallow TestCases to add/remove from InternalChildren

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseFillModes.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillModes.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -155,53 +154,5 @@ namespace osu.Framework.Tests.Visual
 
             protected override bool OnDragStart(InputState state) => true;
         }
-
-        #region Test Cases
-
-        private const float container_width = 60;
-        private Box fitBox;
-
-        /// <summary>
-        /// Tests that using <see cref="FillMode.Fit"/> inside a <see cref="FlowContainer{T}"/> that is autosizing in one axis doesn't result in autosize feedback loops.
-        /// Various sizes of the box are tested to ensure that non-one sizes also don't lead to erroneous sizes.
-        /// </summary>
-        /// <param name="value">The relative size of the box that is fitting.</param>
-        [TestCase(0f)]
-        [TestCase(0.5f)]
-        [TestCase(1f)]
-        public void TestFitInsideFlow(float value)
-        {
-            ClearInternal();
-            AddInternal(new FillFlowContainer
-            {
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-                AutoSizeAxes = Axes.Y,
-                Width = container_width,
-                Direction = FillDirection.Vertical,
-                Children = new Drawable[]
-                {
-                    fitBox = new Box
-                    {
-                        RelativeSizeAxes = Axes.Both,
-                        FillMode = FillMode.Fit
-                    },
-                    // A box which forces the minimum dimension of the autosize flow container to be the horizontal dimension
-                    new Box { Size = new Vector2(container_width, container_width * 2) }
-                }
-            });
-
-            AddStep("Set size", () => fitBox.Size = new Vector2(value));
-
-            var expectedSize = new Vector2(container_width * value, container_width * value);
-
-            AddAssert("Check size before invalidate (1/2)", () => fitBox.DrawSize == expectedSize);
-            AddAssert("Check size before invalidate (2/2)", () => fitBox.DrawSize == expectedSize);
-            AddStep("Invalidate", () => fitBox.Invalidate());
-            AddAssert("Check size after invalidate (1/2)", () => fitBox.DrawSize == expectedSize);
-            AddAssert("Check size after invalidate (2/2)", () => fitBox.DrawSize == expectedSize);
-        }
-
-        #endregion
     }
 }

--- a/osu.Framework.Tests/Visual/TestCaseFitInsideFlow.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFitInsideFlow.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using OpenTK;
+
+namespace osu.Framework.Tests.Visual
+{
+    [TestFixture]
+    public class TestCaseFitInsideFlow : TestCase
+    {
+        private const float container_width = 60;
+
+        private Box fitBox;
+
+        [SetUp]
+        public void SetUp()
+        {
+            Child = new FillFlowContainer
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Y,
+                Width = container_width,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    fitBox = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        FillMode = FillMode.Fit
+                    },
+                    // A box which forces the minimum dimension of the autosize flow container to be the horizontal dimension
+                    new Box { Size = new Vector2(container_width, container_width * 2) }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Tests that using <see cref="FillMode.Fit"/> inside a <see cref="FlowContainer{T}"/> that is autosizing in one axis doesn't result in autosize feedback loops.
+        /// Various sizes of the box are tested to ensure that non-one sizes also don't lead to erroneous sizes.
+        /// </summary>
+        /// <param name="value">The relative size of the box that is fitting.</param>
+        [TestCase(0f)]
+        [TestCase(0.5f)]
+        [TestCase(1f)]
+        public void TestFitInsideFlow(float value)
+        {
+            AddStep("Set size", () => fitBox.Size = new Vector2(value));
+
+            var expectedSize = new Vector2(container_width * value);
+
+            AddAssert("Check size before invalidate (1/2)", () => fitBox.DrawSize == expectedSize);
+            AddAssert("Check size before invalidate (2/2)", () => fitBox.DrawSize == expectedSize);
+            AddStep("Invalidate", () => fitBox.Invalidate());
+            AddAssert("Check size after invalidate (1/2)", () => fitBox.DrawSize == expectedSize);
+            AddAssert("Check size after invalidate (2/2)", () => fitBox.DrawSize == expectedSize);
+        }
+    }
+}

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -54,15 +54,9 @@ namespace osu.Framework.Testing
             }
         }
 
-        protected internal override void AddInternal(Drawable drawable)
-        {
-            throw new InvalidOperationException();
-        }
-
-        protected internal override void ClearInternal(bool disposeChildren = true)
-        {
-            throw new InvalidOperationException();
-        }
+        protected internal override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Modifying {nameof(InternalChildren)} will cause critical failure. Use {nameof(Add)} instead.");
+        protected internal override void ClearInternal(bool disposeChildren = true) => throw new InvalidOperationException($"Modifying {nameof(InternalChildren)} will cause critical failure. Use {nameof(Clear)} instead.");
+        protected internal override bool RemoveInternal(Drawable drawable) => throw new InvalidOperationException($"Modifying {nameof(InternalChildren)} will cause critical failure. Use {nameof(Remove)} instead.");
 
         [OneTimeTearDown]
         public void DestroyGameHost()

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -54,6 +54,16 @@ namespace osu.Framework.Testing
             }
         }
 
+        protected internal override void AddInternal(Drawable drawable)
+        {
+            throw new InvalidOperationException();
+        }
+
+        protected internal override void ClearInternal(bool disposeChildren = true)
+        {
+            throw new InvalidOperationException();
+        }
+
         [OneTimeTearDown]
         public void DestroyGameHost()
         {
@@ -120,47 +130,52 @@ namespace osu.Framework.Testing
             RelativeSizeAxes = Axes.Both;
             Masking = true;
 
-            InternalChildren = new Drawable[]
+            base.AddInternal(new Container
             {
-                new Box
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
                 {
-                    Colour = new Color4(25, 25, 25, 255),
-                    RelativeSizeAxes = Axes.Y,
-                    Width = steps_width,
-                },
-                scroll = new ScrollContainer
-                {
-                    Width = steps_width,
-                    Depth = float.MinValue,
-                    RelativeSizeAxes = Axes.Y,
-                    Padding = new MarginPadding(5),
-                    Child = StepsContainer = new FillFlowContainer<Drawable>
+                    new Box
                     {
-                        Direction = FillDirection.Vertical,
-                        Spacing = new Vector2(5),
-                        RelativeSizeAxes = Axes.X,
-                        AutoSizeAxes = Axes.Y,
+                        Colour = new Color4(25, 25, 25, 255),
+                        RelativeSizeAxes = Axes.Y,
+                        Width = steps_width,
                     },
-                },
-                new Container
-                {
-                    Masking = true,
-                    Padding = new MarginPadding
+                    scroll = new ScrollContainer
                     {
-                        Left = steps_width + padding,
-                        Right = padding,
-                        Top = padding,
-                        Bottom = padding,
+                        Width = steps_width,
+                        Depth = float.MinValue,
+                        RelativeSizeAxes = Axes.Y,
+                        Padding = new MarginPadding(5),
+                        Child = StepsContainer = new FillFlowContainer<Drawable>
+                        {
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(5),
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                        },
                     },
-                    RelativeSizeAxes = Axes.Both,
-                    Child = content = new DrawFrameRecordingContainer
+                    new Container
                     {
                         Masking = true,
-                        RelativeSizeAxes = Axes.Both
-                    }
-                },
-            };
+                        Padding = new MarginPadding
+                        {
+                            Left = steps_width + padding,
+                            Right = padding,
+                            Top = padding,
+                            Bottom = padding,
+                        },
+                        RelativeSizeAxes = Axes.Both,
+                        Child = content = new DrawFrameRecordingContainer
+                        {
+                            Masking = true,
+                            RelativeSizeAxes = Axes.Both
+                        }
+                    },
+                }
+            });
         }
+
 
         private const float steps_width = 180;
         private const float padding = 0;


### PR DESCRIPTION
Also fixes a `TestCase` which abused this (and never worked correctly as a result).