### PR TITLE
Fix non-zero AutoSizeDuration causing a potentially incorrect transformation

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseLayoutDurations.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLayoutDurations.cs
@@ -13,13 +13,13 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Tests.Visual
 {
-    public class TestCaseLayoutIdempotence : TestCase
+    public class TestCaseLayoutDurations : TestCase
     {
         private readonly ManualClock manualClock;
         private readonly Container autoSizeContainer;
         private readonly FillFlowContainer fillFlowContainer;
 
-        public TestCaseLayoutIdempotence()
+        public TestCaseLayoutDurations()
         {
             Box box1, box2;
             const float duration = 1000;
@@ -70,6 +70,7 @@ namespace osu.Framework.Tests.Visual
                 fillFlowContainer.LayoutDuration = 0;
                 fillFlowContainer.Size = new Vector2(200, 200);
             });
+
             AddStep("Start transformation", () =>
             {
                 timeStopped = true;
@@ -84,6 +85,7 @@ namespace osu.Framework.Tests.Visual
                 fillFlowContainer.LayoutDuration = duration;
                 fillFlowContainer.Width = 100;
             });
+
             foreach (var x in new[] { .25, .5, .75, 1 })
             {
                 var ratio = (float)x;

--- a/osu.Framework.Tests/Visual/TestCaseLayoutIdempotence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLayoutIdempotence.cs
@@ -27,7 +27,6 @@ namespace osu.Framework.Tests.Visual
             Add(autoSizeContainer = new Container
             {
                 Clock = new FramedClock(manualClock),
-                AutoSizeDuration = duration,
                 AutoSizeEasing = Easing.None,
                 Children = new [] {
                     new Box
@@ -47,7 +46,6 @@ namespace osu.Framework.Tests.Visual
             {
                 Clock = new FramedClock(manualClock),
                 Position = new Vector2(0, 200),
-                LayoutDuration = duration,
                 LayoutEasing = Easing.None,
                 Children = new Drawable[]
                 {
@@ -63,9 +61,11 @@ namespace osu.Framework.Tests.Visual
                 fillFlowContainer.FinishTransforms();
 
                 autoSizeContainer.AutoSizeAxes = Axes.None;
+                autoSizeContainer.AutoSizeDuration = 0;
                 autoSizeContainer.Size = Vector2.Zero;
                 box1.Size = Vector2.Zero;
 
+                fillFlowContainer.LayoutDuration = 0;
                 fillFlowContainer.Size = new Vector2(200, 200);
             });
             AddStep("Start transformation", () =>
@@ -76,7 +76,10 @@ namespace osu.Framework.Tests.Visual
                 fillFlowContainer.FinishTransforms();
 
                 autoSizeContainer.AutoSizeAxes = Axes.Both;
+                autoSizeContainer.AutoSizeDuration = duration;
                 box1.Size = new Vector2(100);
+
+                fillFlowContainer.LayoutDuration = duration;
                 fillFlowContainer.Width = 100;
             });
             foreach (var x in new[] { .25, .5, .75, 1 })

--- a/osu.Framework.Tests/Visual/TestCaseLayoutIdempotence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLayoutIdempotence.cs
@@ -1,0 +1,110 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.States;
+using osu.Framework.MathUtils;
+using osu.Framework.Testing;
+using osu.Framework.Timing;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseLayoutIdempotence : TestCase
+    {
+        private readonly ManualClock manualClock;
+        private readonly Container autoSizeContainer;
+        private readonly FillFlowContainer fillFlowContainer;
+        public TestCaseLayoutIdempotence()
+        {
+            Box box1, box2;
+            const float duration = 1000;
+
+            manualClock = new ManualClock();
+            Add(autoSizeContainer = new Container
+            {
+                Clock = new FramedClock(manualClock),
+                AutoSizeDuration = duration,
+                AutoSizeEasing = Easing.None,
+                Children = new [] {
+                    new Box
+                    {
+                        Colour = Color4.Red,
+                        RelativeSizeAxes = Axes.Both
+                    },
+                    box1 = new Box
+                    {
+                        Colour = Color4.Transparent,
+                        Size = Vector2.Zero,
+                    },
+                }
+            });
+
+            Add(fillFlowContainer = new FillFlowContainer
+            {
+                Clock = new FramedClock(manualClock),
+                Position = new Vector2(0, 200),
+                LayoutDuration = duration,
+                LayoutEasing = Easing.None,
+                Children = new Drawable[]
+                {
+                    new Box {Colour = Color4.Red, Size = new Vector2(100)},
+                    box2 = new Box {Colour = Color4.Blue, Size = new Vector2(100)},
+                }
+            });
+
+            AddStep("init", () =>
+            {
+                timeStopped = false;
+                autoSizeContainer.FinishTransforms();
+                fillFlowContainer.FinishTransforms();
+
+                autoSizeContainer.AutoSizeAxes = Axes.None;
+                autoSizeContainer.Size = Vector2.Zero;
+                box1.Size = Vector2.Zero;
+
+                fillFlowContainer.Size = new Vector2(200, 200);
+            });
+            AddStep("Start transformation", () =>
+            {
+                timeStopped = true;
+                manualClock.CurrentTime = 0;
+                autoSizeContainer.FinishTransforms();
+                fillFlowContainer.FinishTransforms();
+
+                autoSizeContainer.AutoSizeAxes = Axes.Both;
+                box1.Size = new Vector2(100);
+                fillFlowContainer.Width = 100;
+            });
+            foreach (var x in new[] { .25, .5, .75, 1 })
+            {
+                var ratio = (float)x;
+                var time = ratio * duration;
+                AddStep($"Time = {time}", () =>
+                {
+                    manualClock.CurrentTime = time;
+                });
+                AddAssert("Check", () => Precision.AlmostEquals(autoSizeContainer.Size, new Vector2(100 * ratio)) &&
+                                         Precision.AlmostEquals(box2.Position, new Vector2(100 * (1 - ratio), 100 * ratio)));
+            }
+        }
+
+        private bool timeStopped;
+        protected override void Update()
+        {
+            if (!timeStopped) manualClock.CurrentTime = Clock.CurrentTime;
+            autoSizeContainer.Children[0].Invalidate();
+            fillFlowContainer.Invalidate();
+            base.Update();
+        }
+
+        protected override bool OnClick(InputState state)
+        {
+            timeStopped = !timeStopped;
+            return base.OnClick(state);
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/TestCaseLayoutIdempotence.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLayoutIdempotence.cs
@@ -18,6 +18,7 @@ namespace osu.Framework.Tests.Visual
         private readonly ManualClock manualClock;
         private readonly Container autoSizeContainer;
         private readonly FillFlowContainer fillFlowContainer;
+
         public TestCaseLayoutIdempotence()
         {
             Box box1, box2;
@@ -28,7 +29,8 @@ namespace osu.Framework.Tests.Visual
             {
                 Clock = new FramedClock(manualClock),
                 AutoSizeEasing = Easing.None,
-                Children = new [] {
+                Children = new[]
+                {
                     new Box
                     {
                         Colour = Color4.Red,
@@ -49,8 +51,8 @@ namespace osu.Framework.Tests.Visual
                 LayoutEasing = Easing.None,
                 Children = new Drawable[]
                 {
-                    new Box {Colour = Color4.Red, Size = new Vector2(100)},
-                    box2 = new Box {Colour = Color4.Blue, Size = new Vector2(100)},
+                    new Box { Colour = Color4.Red, Size = new Vector2(100) },
+                    box2 = new Box { Colour = Color4.Blue, Size = new Vector2(100) },
                 }
             });
 
@@ -86,16 +88,14 @@ namespace osu.Framework.Tests.Visual
             {
                 var ratio = (float)x;
                 var time = ratio * duration;
-                AddStep($"Time = {time}", () =>
-                {
-                    manualClock.CurrentTime = time;
-                });
+                AddStep($"Time = {time}", () => { manualClock.CurrentTime = time; });
                 AddAssert("Check", () => Precision.AlmostEquals(autoSizeContainer.Size, new Vector2(100 * ratio)) &&
                                          Precision.AlmostEquals(box2.Position, new Vector2(100 * (1 - ratio), 100 * ratio)));
             }
         }
 
         private bool timeStopped;
+
         protected override void Update()
         {
             if (!timeStopped) manualClock.CurrentTime = Clock.CurrentTime;

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -5,6 +5,7 @@ using osu.Framework.Lists;
 using System.Collections.Generic;
 using System;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading;
 using OpenTK;
 using osu.Framework.Graphics.OpenGL;
@@ -1451,8 +1452,12 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private void autoSizeResizeTo(Vector2 newSize, double duration = 0, Easing easing = Easing.None) =>
-            this.TransformTo(this.PopulateTransform(new AutoSizeTransform { Rewindable = false }, newSize, duration, easing));
+        private void autoSizeResizeTo(Vector2 newSize, double duration = 0, Easing easing = Easing.None)
+        {
+            var currentTargetSize = ((AutoSizeTransform)Transforms.FirstOrDefault(t => t is AutoSizeTransform))?.EndValue ?? Size;
+            if (currentTargetSize != newSize)
+                this.TransformTo(this.PopulateTransform(new AutoSizeTransform { Rewindable = false }, newSize, duration, easing));
+        }
 
         /// <summary>
         /// A helper property for <see cref="autoSizeResizeTo(Vector2, double, Easing)"/> to change the size of <see cref="CompositeDrawable"/>s with <see cref="AutoSizeAxes"/>.

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -188,7 +188,8 @@ namespace osu.Framework.Graphics.Containers
                     throw new InvalidOperationException($"A flow container cannot contain a child with relative positioning (it is {d.RelativePositionAxes}).");
 
                 var finalPos = positions[i];
-                var currentTargetPos = ((FlowTransform)d.Transforms.FirstOrDefault(t => t is FlowTransform))?.EndValue ?? d.Position;
+                var currentTargetPos = d.Transforms.OfType<FlowTransform>().FirstOrDefault()?.EndValue ?? d.Position;
+
                 if (currentTargetPos != finalPos)
                     d.TransformTo(d.PopulateTransform(new FlowTransform { Rewindable = false }, finalPos, LayoutDuration, LayoutEasing));
 

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -188,7 +188,8 @@ namespace osu.Framework.Graphics.Containers
                     throw new InvalidOperationException($"A flow container cannot contain a child with relative positioning (it is {d.RelativePositionAxes}).");
 
                 var finalPos = positions[i];
-                if (d.Position != finalPos)
+                var currentTargetPos = ((FlowTransform)d.Transforms.FirstOrDefault(t => t is FlowTransform))?.EndValue ?? d.Position;
+                if (currentTargetPos != finalPos)
                     d.TransformTo(d.PopulateTransform(new FlowTransform { Rewindable = false }, finalPos, LayoutDuration, LayoutEasing));
 
                 ++i;


### PR DESCRIPTION
Don't apply layout transform when there is a same transformation already.
- Fixes #1804 (no.2 issue only. no.1 issue is a separate issue).
---
