### PR TITLE
Auto-unbind all bindables in drawables when disposed

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -659,4 +659,5 @@ Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-frame
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Bindables/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=shaders/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -291,6 +291,36 @@ namespace osu.Framework.Tests.Bindables
             TestUnbindOnDrawableDispose();
         }
 
+        [Test]
+        public void TestUnbindOnDrawableDisposeProperty()
+        {
+            var bindable = new Bindable<int>();
+
+            bool valueChanged = false;
+            bindable.ValueChanged += _ => valueChanged = true;
+
+            var drawable = new TestDrawable2 { GetBindable = () => bindable };
+
+            drawable.SetValue(1);
+            Assert.IsTrue(valueChanged, "bound correctly");
+
+            drawable.Dispose();
+            valueChanged = false;
+
+            drawable.SetValue(2);
+            Assert.IsFalse(valueChanged, "unbound correctly");
+        }
+
+        [Test]
+        public void TestUnbindOnDrawableDisposePropertyCached()
+        {
+            // Build cache
+            var drawable = new TestDrawable2();
+            drawable.Dispose();
+
+            TestUnbindOnDrawableDispose();
+        }
+
         private class TestDrawable : Drawable
         {
             public bool ValueChanged;
@@ -321,6 +351,14 @@ namespace osu.Framework.Tests.Bindables
                 bindable.Value = value;
                 base.SetValue(value);
             }
+        }
+
+        private class TestDrawable2 : Drawable
+        {
+            public Func<Bindable<int>> GetBindable;
+            private Bindable<int> bindable => GetBindable();
+
+            public void SetValue(int value) => bindable.Value = value;
         }
     }
 }

--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -281,6 +281,16 @@ namespace osu.Framework.Tests.Bindables
             Assert.IsFalse(drawable.ValueChanged2, "unbound correctly");
         }
 
+        [Test]
+        public void TestUnbindOnDrawableDisposeCached()
+        {
+            // Build cache
+            var drawable = new TestDrawable();
+            drawable.Dispose();
+
+            TestUnbindOnDrawableDispose();
+        }
+
         private class TestDrawable : Drawable
         {
             public bool ValueChanged;

--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Framework.Configuration;
+using osu.Framework.Graphics;
 
 namespace osu.Framework.Tests.Bindables
 {
@@ -245,6 +246,71 @@ namespace osu.Framework.Tests.Bindables
             // bindable1 should only receive the final value changed, skipping the intermediary (overidden) one.
             Assert.AreEqual(1, changed1);
             Assert.AreEqual(2, changed2);
+        }
+
+        [Test]
+        public void TestUnbindOnDrawableDispose()
+        {
+            var drawable = new TestDrawable();
+
+            drawable.SetValue(1);
+            Assert.IsTrue(drawable.ValueChanged, "bound correctly");
+
+            drawable.Dispose();
+            drawable.ValueChanged = false;
+
+            drawable.SetValue(2);
+            Assert.IsFalse(drawable.ValueChanged, "unbound correctly");
+        }
+
+        [Test]
+        public void TestUnbindOnDrawableDisposeSubClass()
+        {
+            var drawable = new TestSubDrawable();
+
+            drawable.SetValue(1);
+            Assert.IsTrue(drawable.ValueChanged, "bound correctly");
+            Assert.IsTrue(drawable.ValueChanged2, "bound correctly");
+
+            drawable.Dispose();
+            drawable.ValueChanged = false;
+            drawable.ValueChanged2 = false;
+
+            drawable.SetValue(2);
+            Assert.IsFalse(drawable.ValueChanged, "unbound correctly");
+            Assert.IsFalse(drawable.ValueChanged2, "unbound correctly");
+        }
+
+        private class TestDrawable : Drawable
+        {
+            public bool ValueChanged;
+
+            private readonly Bindable<int> bindable = new Bindable<int>();
+
+            public TestDrawable()
+            {
+                bindable.BindValueChanged(_ => ValueChanged = true);
+            }
+
+            public virtual void SetValue(int value) => bindable.Value = value;
+        }
+
+        private class TestSubDrawable : TestDrawable
+        {
+            public bool ValueChanged2;
+
+            private readonly Bindable<int> bindable = new Bindable<int>();
+
+            public TestSubDrawable()
+            {
+                bindable.BindValueChanged(_ => ValueChanged2 = true);
+            }
+
+            public override void SetValue(int value)
+            {
+                bindable.Value = value;
+                base.SetValue(value);
+            }
         }
     }
 }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -21,9 +21,11 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Framework.Configuration;
 using osu.Framework.Development;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Input.EventArgs;
@@ -94,6 +96,8 @@ namespace osu.Framework.Graphics
 
             Dispose(isDisposing);
 
+            unbindAllBindables();
+
             Parent = null;
 
             scheduler = null;
@@ -116,6 +120,65 @@ namespace osu.Framework.Graphics
         /// its <see cref="Parent"/> due to <see cref="ShouldBeAlive"/> being false.
         /// </summary>
         public virtual bool DisposeOnDeathRemoval => false;
+
+        private static readonly ConcurrentDictionary<Type, Action> unbind_action_cache = new ConcurrentDictionary<Type, Action>();
+
+        private void unbindAllBindables()
+        {
+            Type type = GetType();
+            do
+            {
+                unbind(type);
+                type = type.BaseType;
+            } while (type != null && type != typeof(object));
+
+            void unbind(Type t)
+            {
+                if (unbind_action_cache.TryGetValue(t, out var existing))
+                {
+                    existing();
+                    return;
+                }
+
+                var actions = new List<Action>();
+
+                var fields = t.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                              .Where(f => typeof(IUnbindable).IsAssignableFrom(f.FieldType));
+
+                foreach (var f in fields)
+                {
+                    var f2 = f;
+                    actions.Add(() => ((IUnbindable)f2.GetValue(this))?.UnbindAll());
+                }
+
+                var properties = t.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                                  .Where(p => typeof(IUnbindable).IsAssignableFrom(p.PropertyType) && p.CanRead);
+
+                foreach (var p in properties)
+                {
+                    var p2 = p;
+                    actions.Add(() => ((IUnbindable)p2.GetValue(this))?.UnbindAll());
+                }
+
+                unbind_action_cache[t] = performUnbind;
+                performUnbind();
+
+                void performUnbind()
+                {
+                    foreach (var a in actions)
+                    {
+                        try
+                        {
+                            a();
+                        }
+                        catch
+                        {
+                            // Execution should continue regardless of whether an unbind failed
+                        }
+                    }
+                }
+            }
+        }
 
         #endregion
 
@@ -776,6 +839,7 @@ namespace osu.Framework.Graphics
                     v.Y /= fillAspectRatio;
                 }
             }
+
             return v;
         }
 
@@ -812,7 +876,9 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Called whenever the <see cref="RelativeSizeAxes"/> of this drawable is changed, or when the <see cref="Container{T}.AutoSizeAxes"/> are changed if this drawable is a <see cref="Container{T}"/>.
         /// </summary>
-        protected virtual void OnSizingChanged() { }
+        protected virtual void OnSizingChanged()
+        {
+        }
 
         #endregion
 
@@ -1201,6 +1267,7 @@ namespace osu.Framework.Graphics
                 Invalidate(Invalidation.Colour);
             }
         }
+
         #endregion
 
         #region Timekeeping
@@ -1289,6 +1356,7 @@ namespace osu.Framework.Graphics
 
                 search = search.Parent;
             }
+
             return null;
         }
 
@@ -1944,7 +2012,8 @@ namespace osu.Framework.Graphics
             private static readonly ConcurrentDictionary<Type, bool> mouse_cached_values = new ConcurrentDictionary<Type, bool>();
             private static readonly ConcurrentDictionary<Type, bool> keyboard_cached_values = new ConcurrentDictionary<Type, bool>();
 
-            private static readonly string[] mouse_input_methods = {
+            private static readonly string[] mouse_input_methods =
+            {
                 nameof(OnHover),
                 nameof(OnHoverLost),
                 nameof(OnMouseDown),
@@ -1960,7 +2029,8 @@ namespace osu.Framework.Graphics
                 nameof(OnMouseMove)
             };
 
-            private static readonly string[] keyboard_input_methods = {
+            private static readonly string[] keyboard_input_methods =
+            {
                 nameof(OnFocus),
                 nameof(OnFocusLost),
                 nameof(OnKeyDown),
@@ -2204,7 +2274,8 @@ namespace osu.Framework.Graphics
             {
                 double min = double.MaxValue;
                 foreach (Transform t in Transforms)
-                    if (t.StartTime < min) min = t.StartTime;
+                    if (t.StartTime < min)
+                        min = t.StartTime;
                 LifetimeStart = min < int.MaxValue ? min : int.MinValue;
             }
         }
@@ -2270,19 +2341,23 @@ namespace osu.Framework.Graphics
         /// is assumed unless indicated by additional flags.
         /// </summary>
         DrawInfo = 1 << 0,
+
         /// <summary>
         /// <see cref="Drawable.DrawSize"/> has changed.
         /// </summary>
         DrawSize = 1 << 1,
+
         /// <summary>
         /// Captures all other geometry changes than <see cref="Drawable.DrawSize"/>, such as
         /// <see cref="Drawable.Rotation"/>, <see cref="Drawable.Shear"/>, and <see cref="Drawable.DrawPosition"/>.
         /// </summary>
         MiscGeometry = 1 << 2,
+
         /// <summary>
         /// <see cref="Drawable.Colour"/> or <see cref="Drawable.IsPresent"/> has changed.
         /// </summary>
         Colour = 1 << 3,
+
         /// <summary>
         /// <see cref="Drawable.ApplyDrawNode(Graphics.DrawNode)"/> has to be invoked on all old draw nodes.
         /// </summary>
@@ -2292,10 +2367,12 @@ namespace osu.Framework.Graphics
         /// No invalidation.
         /// </summary>
         None = 0,
+
         /// <summary>
         /// <see cref="Drawable.RequiredParentSizeToFit"/> has to be recomputed.
         /// </summary>
         RequiredParentSizeToFit = MiscGeometry | DrawSize,
+
         /// <summary>
         /// All possible things are affected.
         /// </summary>
@@ -2389,17 +2466,20 @@ namespace osu.Framework.Graphics
         /// Not loaded, and no load has been initiated yet.
         /// </summary>
         NotLoaded,
+
         /// <summary>
         /// Currently loading (possibly and usually on a background
         /// thread via <see cref="Drawable.LoadAsync(Game,IFrameBasedClock,IReadOnlyDependencyContainer,CancellationToken,Action)"/>).
         /// </summary>
         Loading,
+
         /// <summary>
         /// Loading is complete, but has not yet been finalized on the update thread
         /// (<see cref="Drawable.LoadComplete"/> has not been called yet, which
         /// always runs on the update thread and requires <see cref="Drawable.IsAlive"/>).
         /// </summary>
         Ready,
+
         /// <summary>
         /// Loading is fully completed and the Drawable is now part of the scene graph.
         /// </summary>
@@ -2415,11 +2495,13 @@ namespace osu.Framework.Graphics
         /// Completely fill the parent with a relative size of 1 at the cost of stretching the aspect ratio (default).
         /// </summary>
         Stretch,
+
         /// <summary>
         /// Always maintains aspect ratio while filling the portion of the parent's size denoted by the relative size.
         /// A relative size of 1 results in completely filling the parent by scaling the smaller axis of the drawable to fill the parent.
         /// </summary>
         Fill,
+
         /// <summary>
         /// Always maintains aspect ratio while fitting into the portion of the parent's size denoted by the relative size.
         /// A relative size of 1 results in fitting exactly into the parent by scaling the larger axis of the drawable to fit into the parent.


### PR DESCRIPTION
We have too many places where we're doing stuff like

```
override Dispose()
    myBindable.UnbindAll()
```

This is starting to become problematic, with cases like visual settings needing to unbind 5 of them. This does it automatically inside `Drawable.dispose()`.