### PR TITLE
Fix nunit not correctly catching input thread exceptions

### DIFF
--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -96,6 +96,9 @@ namespace osu.Framework.Testing
 
         private void checkForErrors()
         {
+            if (host.ExecutionState == ExecutionState.Stopping)
+                runTask.Wait();
+
             if (runTask.Exception != null)
                 throw runTask.Exception;
         }


### PR DESCRIPTION
It was previous the case that exceptions on the input thread may not correctly fail a test, as they were only encountered in `OneTimeTearDown` (too late).

Cannot add a test case for this, but has been tested locally.