### PR TITLE
Fix TestBrowser crashing when changing testcases

### DIFF
--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -385,7 +385,6 @@ namespace osu.Framework.Testing
                 if (lastTest?.Parent != null)
                 {
                     testContentContainer.Remove(lastTest.Parent);
-                    lastTest.Clear();
                     lastTest.Dispose();
                 }
 


### PR DESCRIPTION
Triggers the `ClearInternal()` exception, not sure why we were clearing in the first place - code is 2+ years old.