### PR TITLE
Make FlowContainer not set child's Position but by introduce a separate DrawPositionOffset property

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFillFlowContainer.cs
@@ -284,6 +284,22 @@ namespace osu.Framework.Tests.Visual
                 }
             });
 
+            AddToggleStep("Randomly set child position", state =>
+            {
+                if (state)
+                {
+                    foreach (var child in fillContainer.Children)
+                    {
+                        child.Position = new Vector2(RNG.NextSingle() * 2 - 1, RNG.NextSingle() * 2 - 1) * child.Size / 2;
+                    }
+                }
+                else
+                {
+                    foreach (var child in fillContainer.Children)
+                        child.Position = new Vector2();
+                }
+            });
+
             AddToggleStep("Stop adding children", state => { doNotAddChildren = state; });
 
             scheduledAdder?.Cancel();

--- a/osu.Framework.Tests/Visual/TestCaseLayoutDurations.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLayoutDurations.cs
@@ -79,7 +79,7 @@ namespace osu.Framework.Tests.Visual
 
         private void check(float ratio) =>
             AddAssert($"Check @{ratio}", () => Precision.AlmostEquals(autoSizeContainer.Size, new Vector2(changed_value * ratio)) &&
-                                               Precision.AlmostEquals(box2.Position, new Vector2(changed_value * (1 - ratio), changed_value * ratio)));
+                                               Precision.AlmostEquals(box2.DrawPositionOffset, new Vector2(changed_value * (1 - ratio), changed_value * ratio)));
 
         private void skipTo(float ratio) => AddStep($"skip to {ratio}", () => { manualClock.CurrentTime = duration * ratio; });
 

--- a/osu.Framework.Tests/Visual/TestCaseLayoutDurations.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLayoutDurations.cs
@@ -79,7 +79,7 @@ namespace osu.Framework.Tests.Visual
 
         private void check(float ratio) =>
             AddAssert($"Check @{ratio}", () => Precision.AlmostEquals(autoSizeContainer.Size, new Vector2(changed_value * ratio)) &&
-                                               Precision.AlmostEquals(box2.DrawPositionOffset, new Vector2(changed_value * (1 - ratio), changed_value * ratio)));
+                                               Precision.AlmostEquals(box2.DrawPosition, new Vector2(changed_value * (1 - ratio), changed_value * ratio)));
 
         private void skipTo(float ratio) => AddStep($"skip to {ratio}", () => { manualClock.CurrentTime = duration * ratio; });
 

--- a/osu.Framework.Tests/Visual/TestCaseLayoutTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLayoutTransformRewinding.cs
@@ -61,10 +61,10 @@ namespace osu.Framework.Tests.Visual
             });
 
             AddStep("Run to end", () => manualContainer.PerformUpdate(null));
-            AddAssert("Box2 @ (150, 0)", () => Precision.AlmostEquals(new Vector2(150, 0), box2.Position));
+            AddAssert("Box2 @ (150, 0)", () => Precision.AlmostEquals(new Vector2(150, 0), box2.DrawPositionOffset));
 
             AddStep("Rewind", () => manualContainer.PerformUpdate(() => manualContainer.ApplyTransformsAt(-1, true)));
-            AddAssert("Box2 @ (150, 0)", () => Precision.AlmostEquals(new Vector2(150, 0), box2.Position));
+            AddAssert("Box2 @ (150, 0)", () => Precision.AlmostEquals(new Vector2(150, 0), box2.DrawPositionOffset));
         }
 
         private class ManualUpdateSubTreeContainer : Container

--- a/osu.Framework.Tests/Visual/TestCaseLayoutTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/TestCaseLayoutTransformRewinding.cs
@@ -61,10 +61,10 @@ namespace osu.Framework.Tests.Visual
             });
 
             AddStep("Run to end", () => manualContainer.PerformUpdate(null));
-            AddAssert("Box2 @ (150, 0)", () => Precision.AlmostEquals(new Vector2(150, 0), box2.DrawPositionOffset));
+            AddAssert("Box2 @ (150, 0)", () => Precision.AlmostEquals(new Vector2(150, 0), box2.DrawPosition));
 
             AddStep("Rewind", () => manualContainer.PerformUpdate(() => manualContainer.ApplyTransformsAt(-1, true)));
-            AddAssert("Box2 @ (150, 0)", () => Precision.AlmostEquals(new Vector2(150, 0), box2.DrawPositionOffset));
+            AddAssert("Box2 @ (150, 0)", () => Precision.AlmostEquals(new Vector2(150, 0), box2.DrawPosition));
         }
 
         private class ManualUpdateSubTreeContainer : Container

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -190,7 +190,7 @@ namespace osu.Framework.Graphics.Containers
                 var finalPos = positions[i];
 
                 var existingTransform = d.Transforms.OfType<FlowTransform>().FirstOrDefault();
-                Vector2 currentTargetPos = existingTransform?.EndValue ?? d.Position;
+                Vector2 currentTargetPos = existingTransform?.EndValue ?? d.DrawPositionOffset;
 
                 if (currentTargetPos != finalPos)
                 {
@@ -199,7 +199,7 @@ namespace osu.Framework.Graphics.Containers
                     else
                     {
                         if (existingTransform != null) d.ClearTransforms(false, nameof(FlowTransform));
-                        d.Position = finalPos;
+                        d.DrawPositionOffset = finalPos;
                     }
                 }
 
@@ -225,7 +225,7 @@ namespace osu.Framework.Graphics.Containers
         private class FlowTransform : TransformCustom<Vector2, Drawable>
         {
             public FlowTransform()
-                : base(nameof(Position))
+                : base(nameof(DrawPositionOffset))
             {
             }
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -550,6 +550,27 @@ namespace osu.Framework.Graphics
             }
         }
 
+        private Vector2 drawPositionOffset;
+
+        /// <summary>
+        /// The positional offet applied to <see cref="DrawPosition"/>.
+        /// A <see cref="FlowContainer{T}"/> uses this property to layout its children.
+        /// </summary>
+        public Vector2 DrawPositionOffset
+        {
+            get => drawPositionOffset;
+            set
+            {
+                if (drawPositionOffset == value) return;
+
+                if (!Validation.IsFinite(value)) throw new ArgumentException($@"{nameof(DrawPositionOffset)} must be finite, but is {value}.");
+
+                drawPositionOffset = value;
+
+                Invalidate(Invalidation.MiscGeometry);
+            }
+        }
+
         private Axes relativePositionAxes;
 
         /// <summary>
@@ -608,7 +629,7 @@ namespace osu.Framework.Graphics
                         offset.Y = 0;
                 }
 
-                return applyRelativeAxes(RelativePositionAxes, Position - offset, FillMode.Stretch);
+                return DrawPositionOffset + applyRelativeAxes(RelativePositionAxes, Position - offset, FillMode.Stretch);
             }
         }
 


### PR DESCRIPTION
This is a breaking-change for a code reading Position property so should be make sure no regression occurs.
I believe this change is good for a future invalidation logic refactor.

---
