### PR TITLE
Add TestCaseSizing to demonstrate issue with querying Size after call to Add

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSizing.cs
@@ -38,7 +38,8 @@ namespace osu.Framework.Tests.Visual
                 @"Inner Margin",
                 @"Drawable Margin",
                 @"Relative Inside Autosize",
-                @"Negative sizing"
+                @"Negative sizing",
+                @"Weird edge case"
             };
 
             for (int i = 0; i < testNames.Length; i++)
@@ -973,6 +974,52 @@ namespace osu.Framework.Tests.Visual
                             }
                         });
 
+                        break;
+                    }
+                case 14:
+                    {
+                        Container entity = new Container
+                        {
+                            Origin = Anchor.Centre,
+                            Depth = -20,
+                            X = 1000f,
+                            Y = 1000f,
+                            AutoSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                                {
+                                    new SpriteText
+                                    {
+                                        Text = "Test Text",
+                                        Depth = -1f,
+                                        Colour = Color4.White,
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.Centre
+                                    }
+                                }
+                        };
+                        Container map = new Container
+                        {
+                            Width = 20000f,
+                            Height = 20000f,
+                            X = -1000f,
+                            Y = -1000f,
+                            Anchor = Anchor.Centre,
+                        };
+                        testContainer.Add(map);
+                        Schedule(() =>
+                        {
+                            Logging.Logger.Log($"Entity-Size before add = {entity.Size}");
+                            map.Add(entity);
+                            Logging.Logger.Log($"Entity-Size after add = {entity.Size}");
+                            Schedule(() =>
+                            {
+                                Logging.Logger.Log($"Entity-Size 1 frame after add = {entity.Size}");
+                                Schedule(() =>
+                                {
+                                    Logging.Logger.Log($"Entity-Size 2 frames after add = {entity.Size}");
+                                });
+                            });
+                        });
                         break;
                     }
             }


### PR DESCRIPTION
Not for merging.

Demonstrates an issue where
```C#
testContainer.Add(child);
var size = child.Size;
```

``size`` ends up being a nonsense value in this scenario.
Go to "TestCaseSizing" and select the "Weird edge case" test-case, then look at the console window where the size value gets tracked.

Example output:
```
[runtime:verbose] 27.08.2018 06:24:50: Entity-Size before add = (0; 0)
[runtime:verbose] 27.08.2018 06:24:50: Entity-Size after add = (1662,783; 818)
[runtime:verbose] 27.08.2018 06:24:50: Entity-Size 1 frame after add = (62,40002; 20,00006)
[runtime:verbose] 27.08.2018 06:24:50: Entity-Size 2 frames after add = (62,40002; 20,00006)
```