### PR TITLE
Fix LoadAsync ContinueWith not being cancelled

### DIFF
--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Tests.Dependencies
 
             var receiver = new Receiver1();
 
-            Assert.ThrowsAsync<DependencyNotRegisteredException>(async () => await dependencies.Inject(receiver));
+            Assert.Throws<DependencyNotRegisteredException>(() => DependencyContainer.UnwrapExceptions(dependencies.Inject(receiver).Wait));
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestResolveStructWithoutNullPermits()
         {
-            Assert.ThrowsAsync<DependencyNotRegisteredException>(async () => await new DependencyContainer().Inject(new Receiver12()));
+            Assert.Throws<DependencyNotRegisteredException>(() => DependencyContainer.UnwrapExceptions(new DependencyContainer().Inject(new Receiver12()).Wait));
         }
 
         [Test]

--- a/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
+++ b/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
@@ -113,7 +113,7 @@ namespace osu.Framework.Tests.Exceptions
                     while (loadable.LoadState < LoadState.Loading)
                         Thread.Sleep(1);
 
-                    loadable.Dispose();
+                    g.Dispose();
                 });
             });
         }
@@ -135,7 +135,7 @@ namespace osu.Framework.Tests.Exceptions
                     while (loadable.LoadState < LoadState.Loading)
                         Thread.Sleep(1);
 
-                    g.Clear();
+                    loadable.Dispose();
                 });
             });
         }

--- a/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
+++ b/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
@@ -140,6 +140,51 @@ namespace osu.Framework.Tests.Exceptions
             });
         }
 
+        /// <summary>
+        /// The async load completion callback is scheduled on the <see cref="Game"/>. The callback is generally used to add the child to the container,
+        /// however it is possible for the container to be disposed when this occurs due to being scheduled on the <see cref="Game"/>. If this occurs,
+        /// the cancellation is invoked and the completion task should not be run.
+        ///
+        /// This is a very timing-dependent test which performs the following sequence:
+        /// LoadAsync -> schedule Callback -> dispose parent -> invoke scheduled callback
+        /// </summary>
+        [Test]
+        public void TestDisposeAfterLoad()
+        {
+            Assert.DoesNotThrow(() =>
+            {
+                var loadTarget = new LoadTarget(new DelayedTestBoxAsync());
+
+                bool allowDispose = false;
+                bool disposeTriggered = false;
+                bool updatedAfterDispose = false;
+
+                runGameWithLogic(g =>
+                {
+                    g.Add(loadTarget);
+                    loadTarget.PerformAsyncLoad().ContinueWith(t => allowDispose = true);
+                }, g =>
+                {
+                    // The following code is done here for a very specific reason, but can occur naturally in normal use
+                    // This delegate is essentially the first item in the game's scheduler, so it will always run PRIOR to the async callback
+
+                    if (disposeTriggered)
+                        updatedAfterDispose = true;
+
+                    if (allowDispose)
+                    {
+                        // Async load has complete, the callback has been scheduled but NOT run yet
+                        // Dispose the parent container - this is done by clearing the game
+                        g.Clear(true);
+                        disposeTriggered = true;
+                    }
+
+                    // After disposing the parent, one update loop is required
+                    return updatedAfterDispose;
+                });
+            });
+        }
+
         [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
         private void runGameWithLogic(Action<Game> logic, Func<Game, bool> exitCondition = null)
         {

--- a/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
+++ b/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
@@ -185,6 +185,12 @@ namespace osu.Framework.Tests.Exceptions
             });
         }
 
+        [Test]
+        public void TestSyncLoadException()
+        {
+            Assert.Throws<AsyncTestException>(() => runGameWithLogic(g => g.Add(new DelayedTestBoxAsync(true))));
+        }
+
         [SuppressMessage("ReSharper", "AccessToDisposedClosure")]
         private void runGameWithLogic(Action<Game> logic, Func<Game, bool> exitCondition = null)
         {

--- a/osu.Framework.Tests/Visual/TestCaseDrawableLoadCancellation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawableLoadCancellation.cs
@@ -22,15 +22,16 @@ namespace osu.Framework.Tests.Visual
     {
         private readonly List<SlowLoader> loaders = new List<SlowLoader>();
 
+        [SetUp]
+        public void SetUp()
+        {
+            loaders.Clear();
+            Child = createLoader();
+        }
+
         [Test]
         public void TestConcurrentLoad()
         {
-            AddStep("add slow loader", () =>
-            {
-                loaders.Clear();
-                Child = createLoader();
-            });
-
             AddStep("replace slow loader", () => { Child = createLoader(); });
             AddStep("replace slow loader", () => { Child = createLoader(); });
             AddStep("replace slow loader", () => { Child = createLoader(); });

--- a/osu.Framework.Tests/Visual/TestCaseDrawableLoadCancellation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawableLoadCancellation.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -21,10 +22,9 @@ namespace osu.Framework.Tests.Visual
     {
         private readonly List<SlowLoader> loaders = new List<SlowLoader>();
 
-        protected override void LoadComplete()
+        [Test]
+        public void TestConcurrentLoad()
         {
-            base.LoadComplete();
-
             AddStep("add slow loader", () =>
             {
                 loaders.Clear();

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -131,9 +131,41 @@ namespace osu.Framework.Allocation
         /// </summary>
         /// <typeparam name="T">The type of the instance to inject dependencies into.</typeparam>
         /// <param name="instance">The instance to inject dependencies into.</param>
+        /// <exception cref="DependencyInjectionException">When any user error has occurred.
+        /// Rethrow <see cref="DependencyInjectionException.DispatchInfo"/> when appropriate to retrieve the original exception.</exception>
+        /// <exception cref="OperationCanceledException">When the injection process was cancelled.</exception>
         public async Task Inject<T>(T instance)
             where T : class
             => await DependencyActivator.Activate(instance, this);
+
+        /// <summary>
+        /// Invokes a delegate and re-throws any source exception wrapped by a <see cref="DependencyInjectionException"/>.
+        /// </summary>
+        /// <param name="action">The delegate to invoke.</param>
+        public static void UnwrapExceptions(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (AggregateException ae)
+            {
+                ae.Flatten().Handle(e =>
+                {
+                    if (e is DependencyInjectionException die)
+                    {
+                        die.DispatchInfo.Throw();
+                        return true;
+                    }
+
+                    return false;
+                });
+            }
+            catch (DependencyInjectionException die)
+            {
+                die.DispatchInfo.Throw();
+            }
+        }
     }
 
     public class TypeAlreadyCachedException : InvalidOperationException

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -150,16 +150,13 @@ namespace osu.Framework.Allocation
             }
             catch (AggregateException ae)
             {
-                ae.Flatten().Handle(e =>
+                foreach (var e in ae.Flatten().InnerExceptions)
                 {
                     if (e is DependencyInjectionException die)
-                    {
                         die.DispatchInfo.Throw();
-                        return true;
-                    }
 
-                    return false;
-                });
+                    throw e;
+                }
             }
             catch (DependencyInjectionException die)
             {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -101,9 +101,6 @@ namespace osu.Framework.Graphics.Containers
 
             return Task.Run(async () => await component.LoadAsync(Clock, dependencies), cancellationSource.Token).ContinueWith(t =>
             {
-                if (t.IsCanceled)
-                    return;
-
                 var exception = t.Exception?.AsSingular();
 
                 game.Schedule(() =>
@@ -113,7 +110,7 @@ namespace osu.Framework.Graphics.Containers
 
                     onLoaded?.Invoke(component);
                 });
-            });
+            }, cancellationSource.Token);
         }
 
         [BackgroundDependencyLoader(true)]

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -173,18 +173,13 @@ namespace osu.Framework.Graphics.Containers
             }
             catch (AggregateException ae)
             {
-                ae.Flatten().Handle(e =>
+                foreach (var e in ae.Flatten().InnerExceptions)
                 {
-                    switch (e)
-                    {
-                        case DependencyInjectionException die:
-                            throw die;
-                        case OperationCanceledException _:
-                            return true;
-                    }
+                    if (e is OperationCanceledException)
+                        continue;
 
-                    return false;
-                });
+                    throw e;
+                }
             }
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -108,7 +108,8 @@ namespace osu.Framework.Graphics.Containers
                     if (exception != null)
                         throw exception;
 
-                    onLoaded?.Invoke(component);
+                    if (!cancellationSource.IsCancellationRequested)
+                        onLoaded?.Invoke(component);
                 });
             }, cancellationSource.Token);
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -146,6 +146,8 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="child">The <see cref="Drawable"/> child to load.</param>
         /// <returns>The async task.</returns>
         /// <exception cref="ObjectDisposedException">If <paramref name="child"/> is disposed.</exception>
+        /// <exception cref="OperationCanceledException">When the loading process was cancelled.</exception>
+        /// <exception cref="DependencyInjectionException">When a user error occurred during dependency injection.</exception>
         private async Task loadChildAsync(Drawable child)
         {
             if (IsDisposed)
@@ -159,7 +161,7 @@ namespace osu.Framework.Graphics.Containers
         /// Loads a <see cref="Drawable"/> child. This will not throw in the event of the load being cancelled.
         /// </summary>
         /// <param name="child">The <see cref="Drawable"/> child to load.</param>
-        /// <exception cref="ObjectDisposedException">If <paramref name="child"/> is disposed.</exception>
+        /// <exception cref="DependencyInjectionException">When a user error occurred during dependency injection.</exception>
         private void loadChild(Drawable child)
         {
             try
@@ -176,8 +178,7 @@ namespace osu.Framework.Graphics.Containers
                     switch (e)
                     {
                         case DependencyInjectionException die:
-                            die.DispatchInfo.Throw();
-                            return true;
+                            throw die;
                         case OperationCanceledException _:
                             return true;
                     }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -171,7 +171,19 @@ namespace osu.Framework.Graphics.Containers
             }
             catch (AggregateException ae)
             {
-                ae.Flatten().Handle(e => e is OperationCanceledException);
+                ae.Flatten().Handle(e =>
+                {
+                    switch (e)
+                    {
+                        case DependencyInjectionException die:
+                            die.DispatchInfo.Throw();
+                            return true;
+                        case OperationCanceledException _:
+                            return true;
+                    }
+
+                    return false;
+                });
             }
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -390,6 +390,12 @@ namespace osu.Framework.Graphics
         protected Scheduler Scheduler => scheduler ?? (scheduler = new Scheduler(MainThread, Clock));
 
         /// <summary>
+        /// Updates this <see cref="Drawable"/> and all <see cref="Drawable"/>s further down the scene graph.
+        /// Only used by the game host.
+        /// </summary>
+        internal void UpdateSubTreeAsRoot() => UpdateSubTree();
+
+        /// <summary>
         /// Updates this Drawable and all Drawables further down the scene graph.
         /// Called once every frame.
         /// </summary>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -305,14 +305,7 @@ namespace osu.Framework.Platform
             // Ensure we maintain a valid size for any children immediately scaling by the window size
             Root.Size = Vector2.ComponentMax(Vector2.One, Root.Size);
 
-            try
-            {
-                Root.UpdateSubTree();
-            }
-            catch (DependencyInjectionException e)
-            {
-                e.DispatchInfo.Throw();
-            }
+            DependencyContainer.UnwrapExceptions(Root.UpdateSubTreeAsRoot);
 
             Root.UpdateSubTreeMasking(Root, Root.ScreenSpaceDrawQuad.AABBFloat);
 
@@ -551,18 +544,7 @@ namespace osu.Framework.Platform
 
             game.SetHost(this);
 
-            try
-            {
-                root.LoadAsync(SceneGraphClock, Dependencies).Wait();
-            }
-            catch (AggregateException ae) when (ae.InnerException is DependencyInjectionException inner)
-            {
-                inner.DispatchInfo.Throw();
-            }
-            catch (DependencyInjectionException e)
-            {
-                e.DispatchInfo.Throw();
-            }
+            DependencyContainer.UnwrapExceptions(root.LoadAsync(SceneGraphClock, Dependencies).Wait);
 
             //publish bootstrapped scene graph to all threads.
             Root = root;


### PR DESCRIPTION
We removed this because the `CancellationToken` could've been set multiple times when this code was entirely in `Drawable`. But we've since moved away from that.