### PR TITLE
Reduce allocation overhead of Track.CurrentAmplitudes

### DIFF
--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -119,7 +119,9 @@ namespace osu.Framework.Audio.Track
         /// LeftChannel and RightChannel represent the maximum current amplitude of all of the left and right channels respectively.
         /// The most recent values are returned. Synchronisation between channels should not be expected.
         /// </summary>
-        public virtual TrackAmplitudes CurrentAmplitudes => new TrackAmplitudes();
+        public TrackAmplitudes CurrentAmplitudes => CurrentAmplitudesInternal;
+
+        protected TrackAmplitudes CurrentAmplitudesInternal = new TrackAmplitudes();
 
         protected override void UpdateState()
         {

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -101,8 +101,11 @@ namespace osu.Framework.Audio.Track
             Trace.Assert(Bass.LastError == Errors.OK);
         }
 
+        private const int amplitude_length = 256; // half of DataFlag specification below.
+
         protected override void UpdateState()
         {
+            bool wasRunning = isRunning;
             isRunning = Bass.ChannelIsActive(activeStream) == PlaybackState.Playing;
 
             double currentTimeLocal = Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetPosition(activeStream)) * 1000;
@@ -112,7 +115,7 @@ namespace osu.Framework.Audio.Track
             var rightChannel = isPlayed ? Bass.ChannelGetLevelRight(activeStream) / 32768f : -1;
 
             if (CurrentAmplitudesInternal.FrequencyAmplitudes == null)
-                CurrentAmplitudesInternal.FrequencyAmplitudes = new float[256];
+                CurrentAmplitudesInternal.FrequencyAmplitudes = new float[amplitude_length];
 
             if (leftChannel >= 0 && rightChannel >= 0)
             {
@@ -125,6 +128,12 @@ namespace osu.Framework.Audio.Track
             {
                 CurrentAmplitudesInternal.LeftChannel = 0;
                 CurrentAmplitudesInternal.RightChannel = 0;
+
+                if (wasRunning && !isRunning)
+                {
+                    for (int i = 0; i < amplitude_length; i++)
+                        CurrentAmplitudesInternal.FrequencyAmplitudes[i] = 0;
+                }
             }
 
             base.UpdateState();

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -111,20 +111,20 @@ namespace osu.Framework.Audio.Track
             var leftChannel = isPlayed ? Bass.ChannelGetLevelLeft(activeStream) / 32768f : -1;
             var rightChannel = isPlayed ? Bass.ChannelGetLevelRight(activeStream) / 32768f : -1;
 
+            if (CurrentAmplitudesInternal.FrequencyAmplitudes == null)
+                CurrentAmplitudesInternal.FrequencyAmplitudes = new float[256];
+
             if (leftChannel >= 0 && rightChannel >= 0)
             {
-                currentAmplitudes.LeftChannel = leftChannel;
-                currentAmplitudes.RightChannel = rightChannel;
+                CurrentAmplitudesInternal.LeftChannel = leftChannel;
+                CurrentAmplitudesInternal.RightChannel = rightChannel;
 
-                float[] tempFrequencyData = new float[256];
-                Bass.ChannelGetData(activeStream, tempFrequencyData, (int)DataFlags.FFT512);
-                currentAmplitudes.FrequencyAmplitudes = tempFrequencyData;
+                Bass.ChannelGetData(activeStream, CurrentAmplitudesInternal.FrequencyAmplitudes, (int)DataFlags.FFT512);
             }
             else
             {
-                currentAmplitudes.LeftChannel = 0;
-                currentAmplitudes.RightChannel = 0;
-                currentAmplitudes.FrequencyAmplitudes = new float[256];
+                CurrentAmplitudesInternal.LeftChannel = 0;
+                CurrentAmplitudesInternal.RightChannel = 0;
             }
 
             base.UpdateState();
@@ -248,9 +248,5 @@ namespace osu.Framework.Audio.Track
             get => Frequency.Value;
             set => Frequency.Value = value;
         }
-
-        private TrackAmplitudes currentAmplitudes;
-
-        public override TrackAmplitudes CurrentAmplitudes => currentAmplitudes;
     }
 }


### PR DESCRIPTION
Was allocating 1kb worth of floats per frame ~1mb per second.