### PR TITLE
Use 3x2 matrix for coordinate transformation

### DIFF
--- a/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
+++ b/osu.Framework.Tests/Visual/TestCasePropertyBoundaries.cs
@@ -68,23 +68,17 @@ namespace osu.Framework.Tests.Visual
         private bool checkDrawInfo(DrawInfo drawInfo)
         {
             return checkFloat(drawInfo.Matrix.M11)
-                    && checkFloat(drawInfo.Matrix.M12)
-                    && checkFloat(drawInfo.Matrix.M13)
-                    && checkFloat(drawInfo.Matrix.M21)
-                    && checkFloat(drawInfo.Matrix.M22)
-                    && checkFloat(drawInfo.Matrix.M23)
-                    && checkFloat(drawInfo.Matrix.M31)
-                    && checkFloat(drawInfo.Matrix.M32)
-                    && checkFloat(drawInfo.Matrix.M33)
-                    && checkFloat(drawInfo.MatrixInverse.M11)
-                    && checkFloat(drawInfo.MatrixInverse.M12)
-                    && checkFloat(drawInfo.MatrixInverse.M13)
-                    && checkFloat(drawInfo.MatrixInverse.M21)
-                    && checkFloat(drawInfo.MatrixInverse.M22)
-                    && checkFloat(drawInfo.MatrixInverse.M23)
-                    && checkFloat(drawInfo.MatrixInverse.M31)
-                    && checkFloat(drawInfo.MatrixInverse.M32)
-                    && checkFloat(drawInfo.MatrixInverse.M33);
+                   && checkFloat(drawInfo.Matrix.M12)
+                   && checkFloat(drawInfo.Matrix.M21)
+                   && checkFloat(drawInfo.Matrix.M22)
+                   && checkFloat(drawInfo.Matrix.M31)
+                   && checkFloat(drawInfo.Matrix.M32)
+                   && checkFloat(drawInfo.MatrixInverse.M11)
+                   && checkFloat(drawInfo.MatrixInverse.M12)
+                   && checkFloat(drawInfo.MatrixInverse.M21)
+                   && checkFloat(drawInfo.MatrixInverse.M22)
+                   && checkFloat(drawInfo.MatrixInverse.M31)
+                   && checkFloat(drawInfo.MatrixInverse.M32);
         }
 
         private bool checkFloat(float value) => !float.IsNaN(value) && !float.IsInfinity(value) && !float.IsNegativeInfinity(value);

--- a/osu.Framework/Extensions/MatrixExtensions/MatrixExtensions.cs
+++ b/osu.Framework/Extensions/MatrixExtensions/MatrixExtensions.cs
@@ -110,7 +110,7 @@ namespace osu.Framework.Extensions.MatrixExtensions
             m.M31 = m31;
         }
 
-        public static Matrix3x2 Invert(Matrix3x2 value)
+        public static void Invert(ref Matrix3x2 value, out Matrix3x2 result)
         {
             float d11 = value.M22;
             float d12 = value.M21;
@@ -120,7 +120,8 @@ namespace osu.Framework.Extensions.MatrixExtensions
 
             if (Math.Abs(det) == 0.0f)
             {
-                return Matrix3x2.Zero;
+                result = Matrix3x2.Zero;
+                return;
             }
 
             det = 1f / det;
@@ -129,24 +130,35 @@ namespace osu.Framework.Extensions.MatrixExtensions
             float d22 = value.M11;
             float d23 = value.M11 * value.M32 + value.M12 * -value.M31;
 
-            return new Matrix3x2(
-                +d11 * det,
-                -d21 * det,
-                -d12 * det,
-                +d22 * det,
-                +d13 * det,
-                -d23 * det);
+            result.Row0.X = +d11 * det;
+            result.Row0.Y = -d21 * det;
+            result.Row1.X = -d12 * det;
+            result.Row1.Y = +d22 * det;
+            result.Row2.X = +d13 * det;
+            result.Row2.Y = -d23 * det;
+        }
+
+        public static Matrix3x2 Invert(Matrix3x2 value)
+        {
+            Invert(ref value, out Matrix3x2 result);
+            return result;
+        }
+
+
+        public static void Mult(ref Matrix3x2 a, ref Matrix3x2 b, out Matrix3x2 result)
+        {
+            result.Row0.X = a.M11 * b.M11 + a.M12 * b.M21;
+            result.Row0.Y = a.M11 * b.M12 + a.M12 * b.M22;
+            result.Row1.X = a.M21 * b.M11 + a.M22 * b.M21;
+            result.Row1.Y = a.M21 * b.M12 + a.M22 * b.M22;
+            result.Row2.X = a.M31 * b.M11 + a.M32 * b.M21 + b.M31;
+            result.Row2.Y = a.M31 * b.M12 + a.M32 * b.M22 + b.M32;
         }
 
         public static Matrix3x2 Mult(Matrix3x2 a, Matrix3x2 b)
         {
-            return new Matrix3x2(
-                a.M11 * b.M11 + a.M12 * b.M21,
-                a.M11 * b.M12 + a.M12 * b.M22,
-                a.M21 * b.M11 + a.M22 * b.M21,
-                a.M21 * b.M12 + a.M22 * b.M22,
-                a.M31 * b.M11 + a.M32 * b.M21 + b.M31,
-                a.M31 * b.M12 + a.M32 * b.M22 + b.M32);
+            Mult(ref a, ref b, out Matrix3x2 result);
+            return result;
         }
 
         public static Matrix3 ToMatrix3(Matrix3x2 m)

--- a/osu.Framework/Extensions/MatrixExtensions/MatrixExtensions.cs
+++ b/osu.Framework/Extensions/MatrixExtensions/MatrixExtensions.cs
@@ -110,7 +110,7 @@ namespace osu.Framework.Extensions.MatrixExtensions
             m.M31 = m31;
         }
 
-        public static void Invert(in Matrix3x2 value, out Matrix3x2 result)
+        public static Matrix3x2 Invert(Matrix3x2 value)
         {
             float d11 = value.M22;
             float d12 = value.M21;
@@ -120,8 +120,7 @@ namespace osu.Framework.Extensions.MatrixExtensions
 
             if (Math.Abs(det) == 0.0f)
             {
-                result = Matrix3x2.Zero;
-                return;
+                return Matrix3x2.Zero;
             }
 
             det = 1f / det;
@@ -130,35 +129,37 @@ namespace osu.Framework.Extensions.MatrixExtensions
             float d22 = value.M11;
             float d23 = value.M11 * value.M32 + value.M12 * -value.M31;
 
-            result.Row0.X = +d11 * det;
-            result.Row0.Y = -d21 * det;
-            result.Row1.X = -d12 * det;
-            result.Row1.Y = +d22 * det;
-            result.Row2.X = +d13 * det;
-            result.Row2.Y = -d23 * det;
+            return new Matrix3x2(
+                +d11 * det,
+                -d21 * det,
+                -d12 * det,
+                +d22 * det,
+                +d13 * det,
+                -d23 * det);
         }
 
-        public static void Mult(in Matrix3x2 a, in Matrix3x2 b, out Matrix3x2 result)
+        public static Matrix3x2 Mult(Matrix3x2 a, Matrix3x2 b)
         {
-            result.Row0.X = a.M11 * b.M11 + a.M12 * b.M21;
-            result.Row0.Y = a.M11 * b.M12 + a.M12 * b.M22;
-            result.Row1.X = a.M21 * b.M11 + a.M22 * b.M21;
-            result.Row1.Y = a.M21 * b.M12 + a.M22 * b.M22;
-            result.Row2.X = a.M31 * b.M11 + a.M32 * b.M21 + b.M31;
-            result.Row2.Y = a.M31 * b.M12 + a.M32 * b.M22 + b.M32;
+            return new Matrix3x2(
+                a.M11 * b.M11 + a.M12 * b.M21,
+                a.M11 * b.M12 + a.M12 * b.M22,
+                a.M21 * b.M11 + a.M22 * b.M21,
+                a.M21 * b.M12 + a.M22 * b.M22,
+                a.M31 * b.M11 + a.M32 * b.M21 + b.M31,
+                a.M31 * b.M12 + a.M32 * b.M22 + b.M32);
         }
 
-        public static Matrix3 ToMatrix3(in Matrix3x2 m)
+        public static Matrix3 ToMatrix3(Matrix3x2 m)
         {
             return new Matrix3(m.M11, m.M12, 0, m.M21, m.M22, 0, m.M31, m.M32, 1);
         }
 
-        public static Matrix2 RemoveTranslation(in Matrix3x2 m)
+        public static Matrix2 RemoveTranslation(Matrix3x2 m)
         {
             return new Matrix2(m.M11, m.M12, m.M21, m.M22);
         }
 
-        public static Vector3 ExtractScale(in Matrix3x2 m)
+        public static Vector3 ExtractScale(Matrix3x2 m)
         {
             return new Vector3(m.Row0.Length, m.Row1.Length, m.Row2.Length);
         }

--- a/osu.Framework/Extensions/MatrixExtensions/MatrixExtensions.cs
+++ b/osu.Framework/Extensions/MatrixExtensions/MatrixExtensions.cs
@@ -110,7 +110,7 @@ namespace osu.Framework.Extensions.MatrixExtensions
             m.M31 = m31;
         }
 
-        public static Matrix3x2 Invert(Matrix3x2 value)
+        public static void Invert(in Matrix3x2 value, out Matrix3x2 result)
         {
             float d11 = value.M22;
             float d12 = value.M21;
@@ -120,7 +120,8 @@ namespace osu.Framework.Extensions.MatrixExtensions
 
             if (Math.Abs(det) == 0.0f)
             {
-                return Matrix3x2.Zero;
+                result = Matrix3x2.Zero;
+                return;
             }
 
             det = 1f / det;
@@ -129,37 +130,35 @@ namespace osu.Framework.Extensions.MatrixExtensions
             float d22 = value.M11;
             float d23 = value.M11 * value.M32 + value.M12 * -value.M31;
 
-            return new Matrix3x2(
-                +d11 * det,
-                -d21 * det,
-                -d12 * det,
-                +d22 * det,
-                +d13 * det,
-                -d23 * det);
+            result.Row0.X = +d11 * det;
+            result.Row0.Y = -d21 * det;
+            result.Row1.X = -d12 * det;
+            result.Row1.Y = +d22 * det;
+            result.Row2.X = +d13 * det;
+            result.Row2.Y = -d23 * det;
         }
 
-        public static Matrix3x2 Mult(Matrix3x2 a, Matrix3x2 b)
+        public static void Mult(in Matrix3x2 a, in Matrix3x2 b, out Matrix3x2 result)
         {
-            return new Matrix3x2(
-                a.M11 * b.M11 + a.M12 * b.M21,
-                a.M11 * b.M12 + a.M12 * b.M22,
-                a.M21 * b.M11 + a.M22 * b.M21,
-                a.M21 * b.M12 + a.M22 * b.M22,
-                a.M31 * b.M11 + a.M32 * b.M21 + b.M31,
-                a.M31 * b.M12 + a.M32 * b.M22 + b.M32);
+            result.Row0.X = a.M11 * b.M11 + a.M12 * b.M21;
+            result.Row0.Y = a.M11 * b.M12 + a.M12 * b.M22;
+            result.Row1.X = a.M21 * b.M11 + a.M22 * b.M21;
+            result.Row1.Y = a.M21 * b.M12 + a.M22 * b.M22;
+            result.Row2.X = a.M31 * b.M11 + a.M32 * b.M21 + b.M31;
+            result.Row2.Y = a.M31 * b.M12 + a.M32 * b.M22 + b.M32;
         }
 
-        public static Matrix3 ToMatrix3(Matrix3x2 m)
+        public static Matrix3 ToMatrix3(in Matrix3x2 m)
         {
             return new Matrix3(m.M11, m.M12, 0, m.M21, m.M22, 0, m.M31, m.M32, 1);
         }
 
-        public static Matrix2 RemoveTranslation(Matrix3x2 m)
+        public static Matrix2 RemoveTranslation(in Matrix3x2 m)
         {
             return new Matrix2(m.M11, m.M12, m.M21, m.M22);
         }
 
-        public static Vector3 ExtractScale(Matrix3x2 m)
+        public static Vector3 ExtractScale(in Matrix3x2 m)
         {
             return new Vector3(m.Row0.Length, m.Row1.Length, m.Row2.Length);
         }

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
+using osu.Framework.Extensions.MatrixExtensions;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Primitives;
@@ -255,7 +256,7 @@ namespace osu.Framework.Graphics.Audio
                 Shader.Bind();
                 Texture.TextureGL.Bind();
 
-                Vector2 localInflationAmount = new Vector2(0, 1) * DrawInfo.MatrixInverse.ExtractScale().Xy;
+                Vector2 localInflationAmount = new Vector2(0, 1) * MatrixExtensions.ExtractScale(DrawInfo.MatrixInverse).Xy;
 
                 // We're dealing with a _large_ number of points, so we need to optimise the quadToDraw * drawInfo.Matrix multiplications below
                 // for points that are going to be masked out anyway. This allows for higher resolution graphs at larger scales with virtually no performance loss.

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -14,6 +14,7 @@ using System;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using System.Diagnostics;
+using osu.Framework.Extensions.MatrixExtensions;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -83,7 +84,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 ScreenSpaceAABB = screenSpaceMaskingRect,
                 MaskingRect = ScreenSpaceDrawRectangle,
-                ToMaskingSpace = Matrix3.Identity,
+                ToMaskingSpace = MatrixExtensions.TruncatedIdentityMatrix,
                 BlendRange = 1,
                 AlphaExponent = 1,
             }, true);

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -21,6 +21,7 @@ using osu.Framework.Threading;
 using osu.Framework.Statistics;
 using System.Threading.Tasks;
 using osu.Framework.Extensions.ExceptionExtensions;
+using osu.Framework.Extensions.MatrixExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.MathUtils;
 
@@ -776,7 +777,7 @@ namespace osu.Framework.Graphics.Containers
             if (!Masking && (BorderThickness != 0.0f || EdgeEffect.Type != EdgeEffectType.None))
                 throw new InvalidOperationException("Can not have border effects/edge effects if masking is disabled.");
 
-            Vector3 scale = DrawInfo.MatrixInverse.ExtractScale();
+            Vector3 scale = MatrixExtensions.ExtractScale(DrawInfo.MatrixInverse);
 
             n.MaskingInfo = !Masking
                 ? (MaskingInfo?)null

--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -12,15 +12,15 @@ namespace osu.Framework.Graphics
 {
     public struct DrawInfo : IEquatable<DrawInfo>
     {
-        public Matrix3 Matrix;
-        public Matrix3 MatrixInverse;
+        public Matrix3x2 Matrix;
+        public Matrix3x2 MatrixInverse;
         public ColourInfo Colour;
         public BlendingInfo Blending;
 
-        public DrawInfo(Matrix3? matrix = null, Matrix3? matrixInverse = null, ColourInfo? colour = null, BlendingInfo? blending = null)
+        public DrawInfo(Matrix3x2? matrix = null, Matrix3x2? matrixInverse = null, ColourInfo? colour = null, BlendingInfo? blending = null)
         {
-            Matrix = matrix ?? Matrix3.Identity;
-            MatrixInverse = matrixInverse ?? Matrix3.Identity;
+            Matrix = matrix ?? MatrixExtensions.TruncatedIdentityMatrix;
+            MatrixInverse = matrixInverse ?? MatrixExtensions.TruncatedIdentityMatrix;
             Colour = colour ?? ColourInfo.SingleColour(Color4.White);
             Blending = blending ?? new BlendingInfo();
         }
@@ -67,11 +67,7 @@ namespace osu.Framework.Graphics
                 MatrixExtensions.TranslateFromRight(ref MatrixInverse, origin);
             }
 
-            //========================================================================================
-            //== Uncomment the following 2 lines to use a ground-truth matrix inverse for debugging ==
-            //========================================================================================
-            //target.MatrixInverse = target.Matrix;
-            //MatrixExtensions.FastInvert(ref target.MatrixInverse);
+            // MatrixInverse = MatrixExtensions.Invert(Matrix);
         }
 
         public bool Equals(DrawInfo other)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1490,7 +1490,7 @@ namespace osu.Framework.Graphics
 
                 // Cannot use ToParentSpace here, because ToParentSpace depends on DrawInfo to be completed
                 // ReSharper disable once PossibleNullReferenceException
-                Quad interp = Quad.FromRectangle(DrawRectangle) * (di.Matrix * Parent.DrawInfo.MatrixInverse);
+                Quad interp = Quad.FromRectangle(DrawRectangle) * di.Matrix * Parent.DrawInfo.MatrixInverse;
                 Vector2 parentSize = Parent.DrawSize;
 
                 interp.TopLeft = Vector2.Divide(interp.TopLeft, parentSize);
@@ -1689,7 +1689,7 @@ namespace osu.Framework.Graphics
             if (other == this)
                 return input;
 
-            return Quad.FromRectangle(input) * (DrawInfo.Matrix * other.DrawInfo.MatrixInverse);
+            return Quad.FromRectangle(input) * DrawInfo.Matrix * other.DrawInfo.MatrixInverse;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -6,6 +6,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using osu.Framework.Development;
+using osu.Framework.Extensions.MatrixExtensions;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Shaders;
@@ -111,7 +112,7 @@ namespace osu.Framework.Graphics.OpenGL
             {
                 ScreenSpaceAABB = new RectangleI(0, 0, (int)size.X, (int)size.Y),
                 MaskingRect = new RectangleF(0, 0, size.X, size.Y),
-                ToMaskingSpace = Matrix3.Identity,
+                ToMaskingSpace = MatrixExtensions.TruncatedIdentityMatrix,
                 BlendRange = 1,
                 AlphaExponent = 1,
             }, true);
@@ -426,7 +427,7 @@ namespace osu.Framework.Graphics.OpenGL
                 maskingInfo.MaskingRect.Right,
                 maskingInfo.MaskingRect.Bottom));
 
-            GlobalPropertyManager.Set(GlobalProperty.ToMaskingSpace, maskingInfo.ToMaskingSpace);
+            GlobalPropertyManager.Set(GlobalProperty.ToMaskingSpace, MatrixExtensions.ToMatrix3(maskingInfo.ToMaskingSpace));
             GlobalPropertyManager.Set(GlobalProperty.CornerRadius, maskingInfo.CornerRadius);
 
             GlobalPropertyManager.Set(GlobalProperty.BorderThickness, maskingInfo.BorderThickness / maskingInfo.BlendRange);
@@ -647,7 +648,7 @@ namespace osu.Framework.Graphics.OpenGL
         /// space of the container doing the masking).
         /// It is used by a shader to determine which pixels to discard.
         /// </summary>
-        public Matrix3 ToMaskingSpace;
+        public Matrix3x2 ToMaskingSpace;
 
         public float CornerRadius;
 

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Graphics.Primitives
                 new Vector2(rectangle.Right, rectangle.Bottom));
         }
 
-        public static Quad operator *(Quad r, Matrix3 m)
+        public static Quad operator *(Quad r, Matrix3x2 m)
         {
             return new Quad(
                 Vector2Extensions.Transform(r.TopLeft, m),

--- a/osu.Framework/Graphics/Sprites/Sprite.cs
+++ b/osu.Framework/Graphics/Sprites/Sprite.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Textures;
 using OpenTK;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.MatrixExtensions;
 
 namespace osu.Framework.Graphics.Sprites
 {
@@ -125,7 +126,7 @@ namespace osu.Framework.Graphics.Sprites
                 throw new InvalidOperationException(
                     $"May not smooth more than {MAX_EDGE_SMOOTHNESS} or will leak neighboring textures in atlas. Tried to smooth by ({EdgeSmoothness.X}, {EdgeSmoothness.Y}).");
 
-            Vector3 scale = DrawInfo.MatrixInverse.ExtractScale();
+            Vector3 scale = MatrixExtensions.ExtractScale(DrawInfo.MatrixInverse);
 
             inflationAmount = new Vector2(scale.X * EdgeSmoothness.X, scale.Y * EdgeSmoothness.Y);
             return ToScreenSpace(DrawRectangle.Inflate(inflationAmount));

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             int amountPoints = (int)Math.Ceiling(Math.Abs(Angle) / step);
 
-            Matrix3 transformationMatrix = DrawInfo.Matrix;
+            Matrix3x2 transformationMatrix = DrawInfo.Matrix;
             MatrixExtensions.ScaleFromLeft(ref transformationMatrix, DrawSize);
 
             Vector2 current = origin + pointOnCircle(start_angle) * 0.5f;

--- a/osu.Framework/Graphics/Vector2Extensions.cs
+++ b/osu.Framework/Graphics/Vector2Extensions.cs
@@ -12,7 +12,17 @@ namespace osu.Framework.Graphics
         /// <param name="pos">The position to transform</param>
         /// <param name="mat">The desired transformation</param>
         /// <returns>The transformed position</returns>
-        public static Vector2 Transform(Vector2 pos, Matrix3 mat)
+        public static Vector2 Transform(Vector2 pos, Matrix3x2 mat)
+        {
+            Transform(ref pos, ref mat, out Vector2 result);
+            return result;
+        }
+
+        /// <summary>Transform a Position by the given Matrix</summary>
+        /// <param name="pos">The position to transform</param>
+        /// <param name="mat">The desired transformation</param>
+        /// <returns>The transformed position</returns>
+        public static Vector2 Transform(Vector2 pos, Matrix2 mat)
         {
             Transform(ref pos, ref mat, out Vector2 result);
             return result;
@@ -22,10 +32,20 @@ namespace osu.Framework.Graphics
         /// <param name="pos">The position to transform</param>
         /// <param name="mat">The desired transformation</param>
         /// <param name="result">The transformed vector</param>
-        public static void Transform(ref Vector2 pos, ref Matrix3 mat, out Vector2 result)
+        public static void Transform(ref Vector2 pos, ref Matrix3x2 mat, out Vector2 result)
         {
             result.X = mat.Row0.X * pos.X + mat.Row1.X * pos.Y + mat.Row2.X;
             result.Y = mat.Row0.Y * pos.X + mat.Row1.Y * pos.Y + mat.Row2.Y;
+        }
+
+        /// <summary>Transform a Position by the given Matrix</summary>
+        /// <param name="pos">The position to transform</param>
+        /// <param name="mat">The desired transformation</param>
+        /// <param name="result">The transformed vector</param>
+        public static void Transform(ref Vector2 pos, ref Matrix2 mat, out Vector2 result)
+        {
+            result.X = mat.Row0.X * pos.X + mat.Row1.X * pos.Y;
+            result.Y = mat.Row0.Y * pos.X + mat.Row1.Y * pos.Y;
         }
 
         /// <summary>

--- a/osu.Framework/Physics/RigidBodyContainer.cs
+++ b/osu.Framework/Physics/RigidBodyContainer.cs
@@ -94,7 +94,7 @@ namespace osu.Framework.Physics
         /// </summary>
         protected float ComputeI()
         {
-            MatrixExtensions.Mult(DrawInfo.Matrix, Parent.DrawInfo.MatrixInverse, out Matrix3x2 mat);
+            Matrix3x2 mat = MatrixExtensions.Mult(DrawInfo.Matrix, Parent.DrawInfo.MatrixInverse);
             Vector2 size = DrawSize;
 
             // Inertial moment for a linearly transformed rectangle with a given size around its center.
@@ -166,9 +166,8 @@ namespace osu.Framework.Physics
             }
 
             // To simulation space
-            MatrixExtensions.Mult(DrawInfo.Matrix, ScreenToSimulationSpace, out Matrix3x2 mat);
-            MatrixExtensions.Invert(mat, out Matrix3x2 invMat);
-            Matrix2 normMat = MatrixExtensions.RemoveTranslation(invMat);
+            Matrix3x2 mat = MatrixExtensions.Mult(DrawInfo.Matrix, ScreenToSimulationSpace);
+            Matrix2 normMat = MatrixExtensions.RemoveTranslation(MatrixExtensions.Invert(mat));
             normMat.Transpose();
 
             for (int i = 0; i < Vertices.Count; ++i)

--- a/osu.Framework/Physics/RigidBodyContainer.cs
+++ b/osu.Framework/Physics/RigidBodyContainer.cs
@@ -94,7 +94,7 @@ namespace osu.Framework.Physics
         /// </summary>
         protected float ComputeI()
         {
-            Matrix3x2 mat = MatrixExtensions.Mult(DrawInfo.Matrix, Parent.DrawInfo.MatrixInverse);
+            MatrixExtensions.Mult(DrawInfo.Matrix, Parent.DrawInfo.MatrixInverse, out Matrix3x2 mat);
             Vector2 size = DrawSize;
 
             // Inertial moment for a linearly transformed rectangle with a given size around its center.
@@ -166,8 +166,9 @@ namespace osu.Framework.Physics
             }
 
             // To simulation space
-            Matrix3x2 mat = MatrixExtensions.Mult(DrawInfo.Matrix, ScreenToSimulationSpace);
-            Matrix2 normMat = MatrixExtensions.RemoveTranslation(MatrixExtensions.Invert(mat));
+            MatrixExtensions.Mult(DrawInfo.Matrix, ScreenToSimulationSpace, out Matrix3x2 mat);
+            MatrixExtensions.Invert(mat, out Matrix3x2 invMat);
+            Matrix2 normMat = MatrixExtensions.RemoveTranslation(invMat);
             normMat.Transpose();
 
             for (int i = 0; i < Vertices.Count; ++i)

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -19,6 +19,7 @@
     <PackageReleaseNotes>Automated release.</PackageReleaseNotes>
     <copyright>Copyright (c) 2007-2018 ppy Pty Ltd contact@ppy.sh</copyright>
     <PackageTags>osu game framework</PackageTags>
+    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0004" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -19,7 +19,6 @@
     <PackageReleaseNotes>Automated release.</PackageReleaseNotes>
     <copyright>Copyright (c) 2007-2018 ppy Pty Ltd contact@ppy.sh</copyright>
     <PackageTags>osu game framework</PackageTags>
-    <LangVersion>7.2</LangVersion>
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0004" />


### PR DESCRIPTION
For coordinate transformation matrices `DrawInfo.Matrix` and `InverseMatrix`, its third column is always `[0 0 1]^T`. Thus we can omit this column. I think it is good because it is more no-implicit-assumption and potentially less space/computation.

---
