### PR TITLE
Fix parent setter's invalidation never occurring

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseSizing.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSizing.cs
@@ -87,6 +87,36 @@ namespace osu.Framework.Tests.Visual
             AddAssert($"height = {autosize_height}", () => Precision.AlmostEquals(autosize_height, autoSizeContainer.DrawHeight));
         }
 
+        [Test]
+        public void TestParentInvalidations()
+        {
+            Container child = null;
+            Vector2 initialSize = Vector2.Zero;
+
+            AddStep("add child", () =>
+            {
+                Child = child = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Child = new Container
+                    {
+                        // These two properties are important, as they make the parent's autosize 0
+                        Anchor = Anchor.TopLeft,
+                        Origin = Anchor.BottomRight,
+                        AutoSizeAxes = Axes.Both,
+                        Child = new Box { Size = new Vector2(100) },
+                    }
+                };
+
+                // Should already be 0
+                initialSize = child.Size;
+            });
+
+            // Upon LoadComplete(), one invalidation occurs which causes autosize to recompute
+            // Since nothing has changed since the previous frame, the size of the child should remain the same
+            AddAssert("size is the same after one frame", () => child.Size == initialSize);
+        }
+
         private void addCrosshair()
         {
             Add(new Box

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -130,7 +130,7 @@ namespace osu.Framework.Graphics.Containers
                 for (int c = 0; c < cellColumns; c++)
                 {
                     // Add cell
-                    cells[r, c] = new CellContainer { ChildInvalidated = i => InvalidateFromChild(i) };
+                    cells[r, c] = new CellContainer();
 
                     // Allow empty rows
                     if (Content[r] == null)
@@ -290,15 +290,11 @@ namespace osu.Framework.Graphics.Containers
             /// </summary>
             public bool DistributedHeight;
 
-            /// <summary>
-            /// Invoked whenever the child invalidates this <see cref="CellContainer"/>.
-            /// </summary>
-            public Action<Invalidation> ChildInvalidated;
-
             public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
             {
                 if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
-                    ChildInvalidated?.Invoke(invalidation);
+                    Parent?.InvalidateFromChild(invalidation, this);
+
                 base.InvalidateFromChild(invalidation, source);
             }
         }

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -130,7 +130,7 @@ namespace osu.Framework.Graphics.Containers
                 for (int c = 0; c < cellColumns; c++)
                 {
                     // Add cell
-                    cells[r, c] = new CellContainer();
+                    cells[r, c] = new CellContainer { OnChildInvalidation = i => InvalidateFromChild(i) };
 
                     // Allow empty rows
                     if (Content[r] == null)
@@ -290,10 +290,15 @@ namespace osu.Framework.Graphics.Containers
             /// </summary>
             public bool DistributedHeight;
 
+            /// <summary>
+            /// Invoked whenever the child invalidates this <see cref="CellContainer"/>.
+            /// </summary>
+            public Action<Invalidation> OnChildInvalidation;
+
             public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
             {
                 if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
-                    Parent.InvalidateFromChild(invalidation);
+                    OnChildInvalidation?.Invoke(invalidation);
                 base.InvalidateFromChild(invalidation, source);
             }
         }

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -130,7 +130,7 @@ namespace osu.Framework.Graphics.Containers
                 for (int c = 0; c < cellColumns; c++)
                 {
                     // Add cell
-                    cells[r, c] = new CellContainer { OnChildInvalidation = i => InvalidateFromChild(i) };
+                    cells[r, c] = new CellContainer { ChildInvalidated = i => InvalidateFromChild(i) };
 
                     // Allow empty rows
                     if (Content[r] == null)
@@ -293,12 +293,12 @@ namespace osu.Framework.Graphics.Containers
             /// <summary>
             /// Invoked whenever the child invalidates this <see cref="CellContainer"/>.
             /// </summary>
-            public Action<Invalidation> OnChildInvalidation;
+            public Action<Invalidation> ChildInvalidated;
 
             public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
             {
                 if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
-                    OnChildInvalidation?.Invoke(invalidation);
+                    ChildInvalidated?.Invoke(invalidation);
                 base.InvalidateFromChild(invalidation, source);
             }
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1567,10 +1567,10 @@ namespace osu.Framework.Graphics
         /// <returns>If the invalidate was actually necessary.</returns>
         public virtual bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
-            if (invalidation == Invalidation.None || !IsLoaded)
+            if (invalidation == Invalidation.None || Parent == null)
                 return false;
 
-            if (shallPropagate && Parent != null && source != Parent)
+            if (shallPropagate && source != Parent)
                 Parent.InvalidateFromChild(invalidation, this);
 
             bool alreadyInvalidated = true;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/pull/1816

`Parent` already performs an `Invalidate()` upon being set, but wouldn't do anything because `Drawable`s aren't usually not loaded by that point.