### PR TITLE
Restore pre-async BDL/activator logic

### DIFF
--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Tests.Dependencies
 
             var receiver = new Receiver1();
 
-            Assert.Throws<DependencyNotRegisteredException>(() => DependencyContainer.UnwrapExceptions(() => dependencies.Inject(receiver)));
+            Assert.Throws<DependencyNotRegisteredException>(() => dependencies.Inject(receiver));
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestResolveStructWithoutNullPermits()
         {
-            Assert.Throws<DependencyNotRegisteredException>(() => DependencyContainer.UnwrapExceptions(() => new DependencyContainer().Inject(new Receiver12())));
+            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver12()));
         }
 
         [Test]

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Tests.Dependencies
                 }
             };
 
-            dependencies.Inject(receiver).Wait();
+            dependencies.Inject(receiver);
 
             Assert.AreEqual(typeof(BaseObject), receivedBase.GetType());
             Assert.AreEqual(typeof(DerivedObject), receivedDerived.GetType());
@@ -52,7 +52,7 @@ namespace osu.Framework.Tests.Dependencies
 
             var receiver = new Receiver2();
 
-            Assert.DoesNotThrow(() => dependencies.Inject(receiver).Wait());
+            Assert.DoesNotThrow(() => dependencies.Inject(receiver));
         }
 
         [Test]
@@ -62,7 +62,7 @@ namespace osu.Framework.Tests.Dependencies
 
             var receiver = new Receiver1();
 
-            Assert.Throws<DependencyNotRegisteredException>(() => DependencyContainer.UnwrapExceptions(dependencies.Inject(receiver).Wait));
+            Assert.Throws<DependencyNotRegisteredException>(() => dependencies.Inject(receiver));
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace osu.Framework.Tests.Dependencies
 
             var receiver = new Receiver3();
 
-            Assert.DoesNotThrow(() => dependencies.Inject(receiver).Wait());
+            Assert.DoesNotThrow(() => dependencies.Inject(receiver));
         }
 
         [Test]
@@ -88,7 +88,7 @@ namespace osu.Framework.Tests.Dependencies
                 Loaded5 = () => derivedCount = ++count
             };
 
-            dependencies.Inject(receiver).Wait();
+            dependencies.Inject(receiver);
 
             Assert.AreEqual(1, baseCount);
             Assert.AreEqual(2, derivedCount);
@@ -113,10 +113,10 @@ namespace osu.Framework.Tests.Dependencies
                 OnLoad = o => receivedObject = o
             };
 
-            dependencies1.Inject(receiver).Wait();
+            dependencies1.Inject(receiver);
             Assert.AreEqual(receivedObject, testObject1);
 
-            dependencies2.Inject(receiver).Wait();
+            dependencies2.Inject(receiver);
             Assert.AreEqual(receivedObject, testObject2);
         }
 
@@ -176,7 +176,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver6();
 
-            Assert.ThrowsAsync<AccessModifierNotAllowedForLoaderMethodException>(async () => await new DependencyContainer().Inject(receiver));
+            Assert.Throws<AccessModifierNotAllowedForLoaderMethodException>(() => new DependencyContainer().Inject(receiver));
         }
 
         [Test]
@@ -184,7 +184,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver7();
 
-            Assert.ThrowsAsync<AccessModifierNotAllowedForLoaderMethodException>(async () => await new DependencyContainer().Inject(receiver));
+            Assert.Throws<AccessModifierNotAllowedForLoaderMethodException>(() => new DependencyContainer().Inject(receiver));
         }
 
         [Test]
@@ -192,7 +192,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver8();
 
-            Assert.ThrowsAsync<AccessModifierNotAllowedForLoaderMethodException>(async () => await new DependencyContainer().Inject(receiver));
+            Assert.Throws<AccessModifierNotAllowedForLoaderMethodException>(() => new DependencyContainer().Inject(receiver));
         }
 
         [Test]
@@ -200,7 +200,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver9();
 
-            Assert.ThrowsAsync<AccessModifierNotAllowedForLoaderMethodException>(async () => await new DependencyContainer().Inject(receiver));
+            Assert.Throws<AccessModifierNotAllowedForLoaderMethodException>(() => new DependencyContainer().Inject(receiver));
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestResolveStructWithoutNullPermits()
         {
-            Assert.Throws<DependencyNotRegisteredException>(() => DependencyContainer.UnwrapExceptions(new DependencyContainer().Inject(new Receiver12()).Wait));
+            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver12()));
         }
 
         [Test]
@@ -250,7 +250,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver13();
 
-            Assert.DoesNotThrow(() => new DependencyContainer().Inject(receiver).Wait());
+            Assert.DoesNotThrow(() => new DependencyContainer().Inject(receiver));
             Assert.AreEqual(0, receiver.TestObject);
         }
 

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Tests.Dependencies
 
             var receiver = new Receiver1();
 
-            Assert.Throws<DependencyNotRegisteredException>(() => dependencies.Inject(receiver));
+            Assert.Throws<DependencyNotRegisteredException>(() => DependencyContainer.UnwrapExceptions(() => dependencies.Inject(receiver)));
         }
 
         [Test]
@@ -242,7 +242,7 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestResolveStructWithoutNullPermits()
         {
-            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver12()));
+            Assert.Throws<DependencyNotRegisteredException>(() => DependencyContainer.UnwrapExceptions(() => new DependencyContainer().Inject(new Receiver12())));
         }
 
         [Test]

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver1();
 
-            createDependencies().Inject(receiver).Wait();
+            createDependencies().Inject(receiver);
 
             Assert.AreEqual(null, receiver.Obj);
         }
@@ -27,7 +27,7 @@ namespace osu.Framework.Tests.Dependencies
             var receiver = new Receiver2();
 
             BaseObject testObject;
-            createDependencies(testObject = new BaseObject()).Inject(receiver).Wait();
+            createDependencies(testObject = new BaseObject()).Inject(receiver);
 
             Assert.AreEqual(testObject, receiver.Obj);
         }
@@ -37,7 +37,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver2();
 
-            Assert.ThrowsAsync<DependencyNotRegisteredException>(async () => await createDependencies().Inject(receiver));
+            Assert.Throws<DependencyNotRegisteredException>(() => createDependencies().Inject(receiver));
         }
 
         [Test]
@@ -45,7 +45,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver3();
 
-            Assert.DoesNotThrowAsync(async () => await createDependencies().Inject(receiver));
+            Assert.DoesNotThrow(() => createDependencies().Inject(receiver));
         }
 
         [Test]
@@ -54,7 +54,7 @@ namespace osu.Framework.Tests.Dependencies
             var receiver = new Receiver4();
 
             BaseObject testObject;
-            createDependencies(testObject = new BaseObject()).Inject(receiver).Wait();
+            createDependencies(testObject = new BaseObject()).Inject(receiver);
 
             Assert.AreEqual(testObject, receiver.Obj);
             Assert.AreEqual(testObject, receiver.Obj2);
@@ -65,7 +65,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver5();
 
-            Assert.ThrowsAsync<AccessModifierNotAllowedForPropertySetterException>(async () => await createDependencies().Inject(receiver));
+            Assert.Throws<AccessModifierNotAllowedForPropertySetterException>(() => createDependencies().Inject(receiver));
         }
 
         [Test]
@@ -73,7 +73,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver6();
 
-            Assert.ThrowsAsync<AccessModifierNotAllowedForPropertySetterException>(async () => await createDependencies().Inject(receiver));
+            Assert.Throws<AccessModifierNotAllowedForPropertySetterException>(() => createDependencies().Inject(receiver));
         }
 
         [Test]
@@ -81,7 +81,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver7();
 
-            Assert.ThrowsAsync<AccessModifierNotAllowedForPropertySetterException>(async () => await createDependencies().Inject(receiver));
+            Assert.Throws<AccessModifierNotAllowedForPropertySetterException>(() => createDependencies().Inject(receiver));
         }
 
         [Test]
@@ -89,7 +89,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver8();
 
-            Assert.DoesNotThrowAsync(async () => await createDependencies().Inject(receiver));
+            Assert.DoesNotThrow(() => createDependencies().Inject(receiver));
         }
 
         [Test]
@@ -97,7 +97,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver9();
 
-            Assert.ThrowsAsync<AccessModifierNotAllowedForPropertySetterException>(async () => await createDependencies().Inject(receiver));
+            Assert.Throws<AccessModifierNotAllowedForPropertySetterException>(() => createDependencies().Inject(receiver));
         }
 
         [Test]
@@ -105,7 +105,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver10();
 
-            Assert.ThrowsAsync<PropertyNotWritableException>(async () => await createDependencies().Inject(receiver));
+            Assert.Throws<PropertyNotWritableException>(() => createDependencies().Inject(receiver));
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace osu.Framework.Tests.Dependencies
 
             var dependencies = createDependencies(testObject = new BaseObject());
 
-            Assert.DoesNotThrowAsync(async () => await dependencies.Inject(receiver));
+            Assert.DoesNotThrow(() => dependencies.Inject(receiver));
             Assert.AreEqual(testObject, receiver.Obj);
         }
 
@@ -153,7 +153,7 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestResolveStructWithoutNullPermits()
         {
-            Assert.ThrowsAsync<DependencyNotRegisteredException>(async () => await new DependencyContainer().Inject(new Receiver14()));
+            Assert.Throws<DependencyNotRegisteredException>(() => new DependencyContainer().Inject(new Receiver14()));
         }
 
         [Test]
@@ -161,7 +161,7 @@ namespace osu.Framework.Tests.Dependencies
         {
             var receiver = new Receiver15();
 
-            Assert.DoesNotThrowAsync(async () => await new DependencyContainer().Inject(receiver));
+            Assert.DoesNotThrow(() => new DependencyContainer().Inject(receiver));
             Assert.AreEqual(0, receiver.Obj);
         }
 

--- a/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
+++ b/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
@@ -235,9 +235,9 @@ namespace osu.Framework.Tests.Exceptions
             }
 
             [BackgroundDependencyLoader]
-            private async Task load()
+            private void load()
             {
-                await Task.Delay((int)(1000 / Clock.Rate));
+                Task.Delay((int)(1000 / Clock.Rate)).Wait();
                 if (throws)
                     throw new AsyncTestException();
             }

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -5,7 +5,6 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
-using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Extensions.TypeExtensions;
@@ -39,14 +38,14 @@ namespace osu.Framework.Allocation
             this.permitNulls = permitNulls;
         }
 
-        internal static InjectDependencyDelegateAsync CreateActivator(Type type)
+        internal static InjectDependencyDelegate CreateActivator(Type type)
         {
             var loaderMethods = type.GetMethods(activator_flags).Where(m => m.GetCustomAttribute<BackgroundDependencyLoaderAttribute>() != null).ToArray();
 
             switch (loaderMethods.Length)
             {
                 case 0:
-                    return (_, __) => Task.CompletedTask;
+                    return (_, __) => { };
                 case 1:
                     var method = loaderMethods[0];
 
@@ -57,20 +56,11 @@ namespace osu.Framework.Allocation
                     var permitNulls = method.GetCustomAttribute<BackgroundDependencyLoaderAttribute>().permitNulls;
                     var parameterGetters = method.GetParameters().Select(p => p.ParameterType).Select(t => getDependency(t, type, permitNulls || t.IsNullable()));
 
-                    return async (target, dc) =>
+                    return (target, dc) =>
                     {
                         try
                         {
-                            var parameters = parameterGetters.Select(p => p(dc)).ToArray();
-
-                            var ret = method.Invoke(target, parameters);
-
-                            switch (ret)
-                            {
-                                case Task t:
-                                    await t;
-                                    break;
-                            }
+                            method.Invoke(target, parameterGetters.Select(p => p(dc)).ToArray());
                         }
                         catch (TargetInvocationException exc) // During non-await invocations
                         {

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
 using JetBrains.Annotations;
-using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Allocation
@@ -76,23 +75,6 @@ namespace osu.Framework.Allocation
 
                             // This activator has failed (single reflection call) - preserve the original stacktrace while notifying of the error
                             throw new DependencyInjectionException { DispatchInfo = ExceptionDispatchInfo.Capture(exc.InnerException) };
-                        }
-                        catch (Exception exc) // During await invocations
-                        {
-                            if (exc is AggregateException ae) // Can be thrown by task cancellations
-                                exc = ae.AsSingular();
-
-                            switch (exc)
-                            {
-                                case OperationCanceledException _ :
-                                    // This or a nested activator was canceled - propagate the cancellation as-is (it will be handled silently)
-                                case DependencyInjectionException _:
-                                    // This or a nested activator has failed - propagate the original error
-                                    throw;
-                            }
-
-                            // This activator has failed - preserve the original stacktrace while notifying of the error
-                            throw new DependencyInjectionException { DispatchInfo = ExceptionDispatchInfo.Capture(exc) };
                         }
                     };
                 default:

--- a/osu.Framework/Allocation/DependencyActivator.cs
+++ b/osu.Framework/Allocation/DependencyActivator.cs
@@ -6,7 +6,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.ExceptionServices;
-using System.Threading.Tasks;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -27,7 +26,6 @@ namespace osu.Framework.Allocation
     {
         private static readonly ConcurrentDictionary<Type, DependencyActivator> activator_cache = new ConcurrentDictionary<Type, DependencyActivator>();
 
-        private readonly List<InjectDependencyDelegateAsync> injectionActivatorsAsync = new List<InjectDependencyDelegateAsync>();
         private readonly List<InjectDependencyDelegate> injectionActivators = new List<InjectDependencyDelegate>();
         private readonly List<CacheDependencyDelegate> buildCacheActivators = new List<CacheDependencyDelegate>();
 
@@ -36,7 +34,7 @@ namespace osu.Framework.Allocation
         private DependencyActivator(Type type)
         {
             injectionActivators.Add(ResolvedAttribute.CreateActivator(type));
-            injectionActivatorsAsync.Add(BackgroundDependencyLoaderAttribute.CreateActivator(type));
+            injectionActivators.Add(BackgroundDependencyLoaderAttribute.CreateActivator(type));
             buildCacheActivators.Add(CachedAttribute.CreateActivator(type));
 
             if (type.BaseType != typeof(object))
@@ -50,7 +48,7 @@ namespace osu.Framework.Allocation
         /// </summary>
         /// <param name="obj">The object to inject the dependencies into.</param>
         /// <param name="dependencies">The dependencies to use for injection.</param>
-        public static Task Activate(object obj, DependencyContainer dependencies)
+        public static void Activate(object obj, DependencyContainer dependencies)
             => getActivator(obj.GetType()).activate(obj, dependencies);
 
         /// <summary>
@@ -69,16 +67,12 @@ namespace osu.Framework.Allocation
             return existing;
         }
 
-        private async Task activate(object obj, DependencyContainer dependencies)
+        private void activate(object obj, DependencyContainer dependencies)
         {
-            if (baseActivator != null)
-                await baseActivator.activate(obj, dependencies);
+            baseActivator?.activate(obj, dependencies);
 
             foreach (var a in injectionActivators)
                 a(obj, dependencies);
-
-            foreach (var a in injectionActivatorsAsync)
-                await a(obj, dependencies);
         }
 
         private IReadOnlyDependencyContainer mergeDependencies(object obj, IReadOnlyDependencyContainer dependencies)
@@ -167,8 +161,6 @@ namespace osu.Framework.Allocation
     {
         public ExceptionDispatchInfo DispatchInfo;
     }
-
-    internal delegate Task InjectDependencyDelegateAsync(object target, IReadOnlyDependencyContainer dependencies);
 
     internal delegate void InjectDependencyDelegate(object target, IReadOnlyDependencyContainer dependencies);
 

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Allocation
@@ -134,7 +133,7 @@ namespace osu.Framework.Allocation
         /// <exception cref="DependencyInjectionException">When any user error has occurred.
         /// Rethrow <see cref="DependencyInjectionException.DispatchInfo"/> when appropriate to retrieve the original exception.</exception>
         /// <exception cref="OperationCanceledException">When the injection process was cancelled.</exception>
-        public Task Inject<T>(T instance)
+        public void Inject<T>(T instance)
             where T : class
             => DependencyActivator.Activate(instance, this);
 

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -136,32 +136,6 @@ namespace osu.Framework.Allocation
         public void Inject<T>(T instance)
             where T : class
             => DependencyActivator.Activate(instance, this);
-
-        /// <summary>
-        /// Invokes a delegate and re-throws any source exception wrapped by a <see cref="DependencyInjectionException"/>.
-        /// </summary>
-        /// <param name="action">The delegate to invoke.</param>
-        public static void UnwrapExceptions(Action action)
-        {
-            try
-            {
-                action();
-            }
-            catch (AggregateException ae)
-            {
-                foreach (var e in ae.Flatten().InnerExceptions)
-                {
-                    if (e is DependencyInjectionException die)
-                        die.DispatchInfo.Throw();
-
-                    throw e;
-                }
-            }
-            catch (DependencyInjectionException die)
-            {
-                die.DispatchInfo.Throw();
-            }
-        }
     }
 
     public class TypeAlreadyCachedException : InvalidOperationException

--- a/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
+++ b/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Threading.Tasks;
 
 namespace osu.Framework.Allocation
 {
@@ -24,7 +23,7 @@ namespace osu.Framework.Allocation
         /// </summary>
         /// <typeparam name="T">The type of the instance to inject dependencies into.</typeparam>
         /// <param name="instance">The instance to inject dependencies into.</param>
-        Task Inject<T>(T instance) where T : class;
+        void Inject<T>(T instance) where T : class;
     }
 
     public static class ReadOnlyDependencyContainerExtensions

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Allocation
     /// Properties marked with this attribute must be private and have a setter.
     /// </summary>
     /// <remarks>
-    /// The value of the property is resolved upon <see cref="Drawable.LoadAsync"/> for the target <see cref="Drawable"/>.
+    /// The value of the property is resolved upon <see cref="Drawable.Load"/> for the target <see cref="Drawable"/>.
     /// </remarks>
     [MeansImplicitUse]
     [AttributeUsage(AttributeTargets.Property)]

--- a/osu.Framework/IO/Stores/CachedResourceStore.cs
+++ b/osu.Framework/IO/Stores/CachedResourceStore.cs
@@ -79,7 +79,7 @@ namespace osu.Framework.IO.Stores
             if (cache.TryGetValue(name, out T result))
                 return result;
 
-            result = await GetAsync(name);
+            result = await base.GetAsync(name);
 
             if (result != null)
                 cache[name] = result;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -550,7 +550,7 @@ namespace osu.Framework.Platform
 
             game.SetHost(this);
 
-            DependencyContainer.UnwrapExceptions(root.LoadAsync(SceneGraphClock, Dependencies).Wait);
+            root.Load(SceneGraphClock, Dependencies);
 
             //publish bootstrapped scene graph to all threads.
             Root = root;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -310,7 +310,14 @@ namespace osu.Framework.Platform
             // Ensure we maintain a valid size for any children immediately scaling by the window size
             Root.Size = Vector2.ComponentMax(Vector2.One, Root.Size);
 
-            DependencyContainer.UnwrapExceptions(Root.UpdateSubTreeAsRoot);
+            try
+            {
+                Root.UpdateSubTreeAsRoot();
+            }
+            catch (DependencyInjectionException die)
+            {
+                die.DispatchInfo.Throw();
+            }
 
             Root.UpdateSubTreeMasking(Root, Root.ScreenSpaceDrawQuad.AABBFloat);
 


### PR DESCRIPTION
I think the description for this will be subject of a long blog post. A general summary of findings are in #1828.

- [x] Depends on / includes #1830.

There are likely some exception handling methods left behind which can now be removed or simplified. There are also some test cases which need to be tidied that still contain BDL async methods (while not harmful should probably be reverted).