### PR TITLE
Separate out colour and presence invalidations

### DIFF
--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -191,9 +191,9 @@ namespace osu.Framework.Graphics.Audio
             n.Shared = sharedData;
             n.Points = generatedWaveform?.GetPoints();
             n.Channels = generatedWaveform?.GetChannels() ?? 0;
-            n.LowColour = lowColour ?? DrawInfo.Colour;
-            n.MidColour = midColour ?? DrawInfo.Colour;
-            n.HighColour = highColour ?? DrawInfo.Colour;
+            n.LowColour = lowColour ?? DrawColourInfo.Colour;
+            n.MidColour = midColour ?? DrawColourInfo.Colour;
+            n.HighColour = highColour ?? DrawColourInfo.Colour;
 
             base.ApplyDrawNode(node);
         }
@@ -274,7 +274,7 @@ namespace osu.Framework.Graphics.Audio
                     if (leftX > localMaskingRectangle.Right)
                         break; // X is always increasing
 
-                    Color4 colour = DrawInfo.Colour;
+                    Color4 colour = DrawColourInfo.Colour;
 
                     // colouring is applied in the order of interest to a viewer.
                     colour = Interpolation.ValueAt(points[i].MidIntensity / midMax, colour, MidColour, 0, 1);

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -9,20 +9,6 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Graphics.Colour
 {
-    public struct DrawColourInfo : IEquatable<DrawColourInfo>
-    {
-        public ColourInfo Colour;
-        public BlendingInfo Blending;
-
-        public DrawColourInfo(ColourInfo? colour = null, BlendingInfo? blending = null)
-        {
-            Colour = colour ?? ColourInfo.SingleColour(Color4.White);
-            Blending = blending ?? new BlendingInfo();
-        }
-
-        public bool Equals(DrawColourInfo other) => Colour.Equals(other.Colour) && Blending.Equals(other.Blending);
-    }
-
     /// <summary>
     /// ColourInfo contains information about the colours of all 4 vertices of a quad.
     /// These colours are always stored in linear space.

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -9,6 +9,20 @@ using OpenTK.Graphics;
 
 namespace osu.Framework.Graphics.Colour
 {
+    public struct DrawColourInfo : IEquatable<DrawColourInfo>
+    {
+        public ColourInfo Colour;
+        public BlendingInfo Blending;
+
+        public DrawColourInfo(ColourInfo? colour = null, BlendingInfo? blending = null)
+        {
+            Colour = colour ?? ColourInfo.SingleColour(Color4.White);
+            Blending = blending ?? new BlendingInfo();
+        }
+
+        public bool Equals(DrawColourInfo other) => Colour.Equals(other.Colour) && Blending.Equals(other.Blending);
+    }
+
     /// <summary>
     /// ColourInfo contains information about the colours of all 4 vertices of a quad.
     /// These colours are always stored in linear space.

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -277,7 +277,7 @@ namespace osu.Framework.Graphics.Containers
 
             // Our own draw node should contain our correct color, hence we have
             // to undo our overridden DrawInfo getter here.
-            n.DrawInfo.Colour = base.DrawInfo.Colour;
+            n.DrawColourInfo.Colour = base.DrawColourInfo.Colour;
 
             // Only need to generate child draw nodes if the framebuffers will get redrawn this time around
             addChildDrawNodes = n.RequiresRedraw;
@@ -362,11 +362,11 @@ namespace osu.Framework.Graphics.Containers
             childrenUpdateVersion = updateVersion;
         }
 
-        public override DrawInfo DrawInfo
+        public override DrawColourInfo DrawColourInfo
         {
             get
             {
-                DrawInfo result = base.DrawInfo;
+                DrawColourInfo result = base.DrawColourInfo;
 
                 // When drawing our children to the frame buffer we do not
                 // want their colour to be polluted by their parent (us!)

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -325,7 +325,7 @@ namespace osu.Framework.Graphics.Containers
                 ++updateVersion;
 
             // We actually only care about Invalidation.MiscGeometry | Invalidation.DrawInfo, but must match the blanket invalidation logic in Drawable.Invalidate
-            if ((invalidation & (Invalidation.Colour | Invalidation.RequiredParentSizeToFit | Invalidation.DrawInfo)) > 0)
+            if ((invalidation & (Invalidation.Presence | Invalidation.RequiredParentSizeToFit | Invalidation.DrawInfo)) > 0)
                 screenSpaceSizeBacking.Invalidate();
 
             return base.Invalidate(invalidation, source, shallPropagate);

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -237,21 +237,21 @@ namespace osu.Framework.Graphics.Containers
 
             if (DrawOriginal && EffectPlacement == EffectPlacement.InFront)
             {
-                GLWrapper.SetBlend(DrawInfo.Blending);
-                drawFrameBufferToBackBuffer(Shared.FrameBuffers[originalIndex], drawRectangle, DrawInfo.Colour);
+                GLWrapper.SetBlend(DrawColourInfo.Blending);
+                drawFrameBufferToBackBuffer(Shared.FrameBuffers[originalIndex], drawRectangle, DrawColourInfo.Colour);
             }
 
             // Blit the final framebuffer to screen.
             GLWrapper.SetBlend(new BlendingInfo(EffectBlending));
 
-            ColourInfo effectColour = DrawInfo.Colour;
+            ColourInfo effectColour = DrawColourInfo.Colour;
             effectColour.ApplyChild(EffectColour);
             drawFrameBufferToBackBuffer(Shared.FrameBuffers[0], drawRectangle, effectColour);
 
             if (DrawOriginal && EffectPlacement == EffectPlacement.Behind)
             {
-                GLWrapper.SetBlend(DrawInfo.Blending);
-                drawFrameBufferToBackBuffer(Shared.FrameBuffers[originalIndex], drawRectangle, DrawInfo.Colour);
+                GLWrapper.SetBlend(DrawColourInfo.Blending);
+                drawFrameBufferToBackBuffer(Shared.FrameBuffers[originalIndex], drawRectangle, DrawColourInfo.Colour);
             }
 
             Shader.Unbind();

--- a/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
@@ -157,10 +157,10 @@ namespace osu.Framework.Graphics.Containers
             Shader.Bind();
 
             ColourInfo colour = ColourInfo.SingleColour(EdgeEffect.Colour);
-            colour.TopLeft.MultiplyAlpha(DrawInfo.Colour.TopLeft.Linear.A);
-            colour.BottomLeft.MultiplyAlpha(DrawInfo.Colour.BottomLeft.Linear.A);
-            colour.TopRight.MultiplyAlpha(DrawInfo.Colour.TopRight.Linear.A);
-            colour.BottomRight.MultiplyAlpha(DrawInfo.Colour.BottomRight.Linear.A);
+            colour.TopLeft.MultiplyAlpha(DrawColourInfo.Colour.TopLeft.Linear.A);
+            colour.BottomLeft.MultiplyAlpha(DrawColourInfo.Colour.BottomLeft.Linear.A);
+            colour.TopRight.MultiplyAlpha(DrawColourInfo.Colour.TopRight.Linear.A);
+            colour.BottomRight.MultiplyAlpha(DrawColourInfo.Colour.BottomRight.Linear.A);
 
             Texture.WhitePixel.DrawQuad(
                 ScreenSpaceMaskingQuad.Value,
@@ -205,7 +205,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 MaskingInfo info = MaskingInfo.Value;
                 if (info.BorderThickness > 0)
-                    info.BorderColour *= DrawInfo.Colour.AverageColour;
+                    info.BorderColour *= DrawColourInfo.Colour.AverageColour;
 
                 GLWrapper.PushMaskingInfo(info);
             }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -758,7 +758,10 @@ namespace osu.Framework.Graphics.Containers
                     childInvalidation |= Invalidation.DrawInfo;
 
                 // Other geometry things like rotation, shearing, etc don't affect child properties.
-                childInvalidation &= ~(Invalidation.MiscGeometry | Invalidation.Presence);
+                childInvalidation &= ~Invalidation.MiscGeometry;
+
+                // Presence also doesn't affect child properties
+                childInvalidation &= ~Invalidation.Presence;
 
                 // Relative positioning can however affect child geometry
                 // ReSharper disable once PossibleNullReferenceException

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -732,9 +732,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="source">The child which caused this invalidation. May be null to indicate that a specific child wasn't specified.</param>
         public virtual void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
         {
-            //Colour captures potential changes in IsPresent. If this ever becomes a bottleneck,
-            //Invalidation could be further separated into presence changes.
-            if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
+            if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Presence)) > 0)
                 childrenSizeDependencies.Invalidate();
         }
 
@@ -760,7 +758,7 @@ namespace osu.Framework.Graphics.Containers
                     childInvalidation |= Invalidation.DrawInfo;
 
                 // Other geometry things like rotation, shearing, etc don't affect child properties.
-                childInvalidation &= ~Invalidation.MiscGeometry;
+                childInvalidation &= ~(Invalidation.MiscGeometry | Invalidation.Presence);
 
                 // Relative positioning can however affect child geometry
                 // ReSharper disable once PossibleNullReferenceException

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -142,9 +142,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
         {
-            //Colour captures potential changes in IsPresent. If this ever becomes a bottleneck,
-            //Invalidation could be further separated into presence changes.
-            if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
+            if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Presence)) > 0)
                 InvalidateLayout();
 
             base.InvalidateFromChild(invalidation, source);

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -91,7 +91,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
         {
-            if ((invalidation & Invalidation.RequiredParentSizeToFit | Invalidation.Colour) > 0)
+            if ((invalidation & Invalidation.RequiredParentSizeToFit | Invalidation.Presence) > 0)
                 cellLayout.Invalidate();
 
             base.InvalidateFromChild(invalidation, source);
@@ -292,7 +292,7 @@ namespace osu.Framework.Graphics.Containers
 
             public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
             {
-                if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
+                if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Presence)) > 0)
                     Parent.InvalidateFromChild(invalidation);
                 base.InvalidateFromChild(invalidation, source);
             }

--- a/osu.Framework/Graphics/DrawColourInfo.cs
+++ b/osu.Framework/Graphics/DrawColourInfo.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using osu.Framework.Graphics.Colour;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Graphics
+{
+    public struct DrawColourInfo : IEquatable<DrawColourInfo>
+    {
+        public ColourInfo Colour;
+        public BlendingInfo Blending;
+
+        public DrawColourInfo(ColourInfo? colour = null, BlendingInfo? blending = null)
+        {
+            Colour = colour ?? ColourInfo.SingleColour(Color4.White);
+            Blending = blending ?? new BlendingInfo();
+        }
+
+        public bool Equals(DrawColourInfo other) => Colour.Equals(other.Colour) && Blending.Equals(other.Blending);
+    }
+}

--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -4,8 +4,6 @@
 using System;
 using osu.Framework.Extensions.MatrixExtensions;
 using OpenTK;
-using OpenTK.Graphics;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Graphics
@@ -14,15 +12,11 @@ namespace osu.Framework.Graphics
     {
         public Matrix3 Matrix;
         public Matrix3 MatrixInverse;
-        public ColourInfo Colour;
-        public BlendingInfo Blending;
 
-        public DrawInfo(Matrix3? matrix = null, Matrix3? matrixInverse = null, ColourInfo? colour = null, BlendingInfo? blending = null)
+        public DrawInfo(Matrix3? matrix = null, Matrix3? matrixInverse = null)
         {
             Matrix = matrix ?? Matrix3.Identity;
             MatrixInverse = matrixInverse ?? Matrix3.Identity;
-            Colour = colour ?? ColourInfo.SingleColour(Color4.White);
-            Blending = blending ?? new BlendingInfo();
         }
 
         /// <summary>
@@ -74,10 +68,7 @@ namespace osu.Framework.Graphics
             //MatrixExtensions.FastInvert(ref target.MatrixInverse);
         }
 
-        public bool Equals(DrawInfo other)
-        {
-            return Matrix.Equals(other.Matrix) && Colour.Equals(other.Colour) && Blending.Equals(other.Blending);
-        }
+        public bool Equals(DrawInfo other) => Matrix.Equals(other.Matrix);
 
         public override string ToString() => $@"{GetType().ReadableName().Replace(@"DrawInfo", string.Empty)} DrawInfo";
     }

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -3,7 +3,6 @@
 
 using osu.Framework.Graphics.OpenGL;
 using System;
-using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Vertices;
 
 namespace osu.Framework.Graphics

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics.OpenGL;
 using System;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Vertices;
 
 namespace osu.Framework.Graphics
@@ -19,6 +20,8 @@ namespace osu.Framework.Graphics
         /// </summary>
         public DrawInfo DrawInfo;
 
+        public DrawColourInfo DrawColourInfo;
+
         /// <summary>
         /// Identifies the state of this draw node with an invalidation state of its corresponding
         /// <see cref="Drawable"/>. Whenever the invalidation state of this draw node disagrees
@@ -34,7 +37,7 @@ namespace osu.Framework.Graphics
         /// textured sprites.</param>
         public virtual void Draw(Action<TexturedVertex2D> vertexAction)
         {
-            GLWrapper.SetBlend(DrawInfo.Blending);
+            GLWrapper.SetBlend(DrawColourInfo.Blending);
         }
     }
 }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -896,9 +896,14 @@ namespace osu.Framework.Graphics
 
                 if (!Validation.IsFinite(value)) throw new ArgumentException($@"{nameof(Scale)} must be finite, but is {value}.");
 
+                bool wasPresent = IsPresent;
+
                 scale = value;
 
-                Invalidate(Invalidation.MiscGeometry | Invalidation.Presence);
+                if (IsPresent != wasPresent)
+                    Invalidate(Invalidation.MiscGeometry | Invalidation.Presence);
+                else
+                    Invalidate(Invalidation.MiscGeometry);
             }
         }
 
@@ -1205,11 +1210,17 @@ namespace osu.Framework.Graphics
             get => alpha;
             set
             {
-                if (alpha == value) return;
+                if (alpha == value)
+                    return;
+
+                bool wasPresent = IsPresent;
 
                 alpha = value;
 
-                Invalidate(Invalidation.Colour | Invalidation.Presence);
+                if (IsPresent != wasPresent)
+                    Invalidate(Invalidation.Colour | Invalidation.Presence);
+                else
+                    Invalidate(Invalidation.Colour);
             }
         }
 
@@ -1235,9 +1246,13 @@ namespace osu.Framework.Graphics
             {
                 if (alwaysPresent == value)
                     return;
+
+                bool wasPresent = IsPresent;
+
                 alwaysPresent = value;
 
-                Invalidate(Invalidation.Presence);
+                if (IsPresent != wasPresent)
+                    Invalidate(Invalidation.Presence);
             }
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1604,11 +1604,19 @@ namespace osu.Framework.Graphics
                 return false;
 
             if (shallPropagate && Parent != null && source != Parent)
-                Parent.InvalidateFromChild(invalidation, this);
+            {
+                var parentInvalidation = invalidation;
+
+                // Colour doesn't affect parent's properties
+                parentInvalidation &= ~Invalidation.Colour;
+
+                if (parentInvalidation > 0)
+                    Parent.InvalidateFromChild(invalidation, this);
+            }
 
             bool alreadyInvalidated = true;
 
-            // Either ScreenSize OR ScreenPosition OR Colour
+            // Either ScreenSize OR ScreenPosition OR Presence
             if ((invalidation & (Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Presence)) > 0)
             {
                 if ((invalidation & Invalidation.RequiredParentSizeToFit) > 0)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -897,7 +897,7 @@ namespace osu.Framework.Graphics
 
                 scale = value;
 
-                Invalidate(Invalidation.MiscGeometry);
+                Invalidate(Invalidation.MiscGeometry | Invalidation.Presence);
             }
         }
 
@@ -1206,9 +1206,9 @@ namespace osu.Framework.Graphics
             {
                 if (alpha == value) return;
 
-                Invalidate(Invalidation.Colour);
-
                 alpha = value;
+
+                Invalidate(Invalidation.Colour | Invalidation.Presence);
             }
         }
 
@@ -1232,11 +1232,11 @@ namespace osu.Framework.Graphics
             get => alwaysPresent;
             set
             {
-                if (alwaysPresent == value) return;
-
-                Invalidate(Invalidation.Colour);
-
+                if (alwaysPresent == value)
+                    return;
                 alwaysPresent = value;
+
+                Invalidate(Invalidation.Presence);
             }
         }
 
@@ -1253,8 +1253,8 @@ namespace osu.Framework.Graphics
             {
                 if (blending.Equals(value))
                     return;
-
                 blending = value;
+
                 Invalidate(Invalidation.Colour);
             }
         }
@@ -1373,7 +1373,7 @@ namespace osu.Framework.Graphics
                     throw new InvalidOperationException("May not add a drawable to multiple containers.");
 
                 parent = value;
-                Invalidate(InvalidationFromParentSize | Invalidation.Colour);
+                Invalidate(InvalidationFromParentSize | Invalidation.Presence);
 
                 if (parent != null)
                 {
@@ -1576,7 +1576,7 @@ namespace osu.Framework.Graphics
             bool alreadyInvalidated = true;
 
             // Either ScreenSize OR ScreenPosition OR Colour
-            if ((invalidation & (Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Colour)) > 0)
+            if ((invalidation & (Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit | Invalidation.Presence)) > 0)
             {
                 if ((invalidation & Invalidation.RequiredParentSizeToFit) > 0)
                     alreadyInvalidated &= !requiredParentSizeToFitBacking.Invalidate();
@@ -2345,7 +2345,7 @@ namespace osu.Framework.Graphics
         MiscGeometry = 1 << 2,
 
         /// <summary>
-        /// <see cref="Drawable.Colour"/> or <see cref="Drawable.IsPresent"/> has changed.
+        /// <see cref="Drawable.Colour"/> has changed.
         /// </summary>
         Colour = 1 << 3,
 
@@ -2353,6 +2353,11 @@ namespace osu.Framework.Graphics
         /// <see cref="Drawable.ApplyDrawNode(Graphics.DrawNode)"/> has to be invoked on all old draw nodes.
         /// </summary>
         DrawNode = 1 << 4,
+
+        /// <summary>
+        /// <see cref="Drawable.IsPresent"/> has changed.
+        /// </summary>
+        Presence = 1 << 5,
 
         /// <summary>
         /// No invalidation.
@@ -2367,7 +2372,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// All possible things are affected.
         /// </summary>
-        All = DrawNode | RequiredParentSizeToFit | Colour | DrawInfo,
+        All = DrawNode | RequiredParentSizeToFit | Colour | DrawInfo | Presence,
     }
 
     /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1603,6 +1603,11 @@ namespace osu.Framework.Graphics
                 alreadyInvalidated &= !screenSpaceDrawQuadBacking.Invalidate();
                 alreadyInvalidated &= !drawInfoBacking.Invalidate();
                 alreadyInvalidated &= !drawSizeBacking.Invalidate();
+
+                // If we change size/position and have a non-singular colour, we need to invalidate the colour also,
+                // as we'll need to do some interpolation that's dependent on our draw info
+                if ((invalidation & Invalidation.Colour) == 0 && (!Colour.HasSingleColour || drawColourInfoBacking.IsValid && !drawColourInfoBacking.Value.Colour.HasSingleColour))
+                    invalidation |= Invalidation.Colour;
             }
 
             if ((invalidation & Invalidation.Colour) > 0)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1371,7 +1371,7 @@ namespace osu.Framework.Graphics
                     throw new InvalidOperationException("May not add a drawable to multiple containers.");
 
                 parent = value;
-                Invalidate(InvalidationFromParentSize | Invalidation.Presence);
+                Invalidate(InvalidationFromParentSize | Invalidation.Colour | Invalidation.Presence);
 
                 if (parent != null)
                 {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -30,7 +30,6 @@ using osu.Framework.Input.EventArgs;
 using osu.Framework.Input.States;
 using osu.Framework.MathUtils;
 using JoystickEventArgs = osu.Framework.Input.EventArgs.JoystickEventArgs;
-using System.Runtime.CompilerServices;
 
 namespace osu.Framework.Graphics
 {
@@ -1464,18 +1463,16 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
-        /// Contains a linear transformation, colour information, and blending information
-        /// of this drawable.
+        /// Contains the linear transformation of this <see cref="Drawable"/> that is used during draw.
         /// </summary>
         public virtual DrawInfo DrawInfo => drawInfoBacking.IsValid ? drawInfoBacking : (drawInfoBacking.Value = computeDrawInfo());
 
         private Cached<DrawColourInfo> drawColourInfoBacking;
 
-        public virtual DrawColourInfo DrawColourInfo
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => drawColourInfoBacking.IsValid? drawColourInfoBacking : (drawColourInfoBacking.Value = computeDrawColourInfo());
-        }
+        /// <summary>
+        /// Contains the colour and blending information of this <see cref="Drawable"/> that are used during draw.
+        /// </summary>
+        public virtual DrawColourInfo DrawColourInfo => drawColourInfoBacking.IsValid? drawColourInfoBacking : (drawColourInfoBacking.Value = computeDrawColourInfo());
 
         private DrawColourInfo computeDrawColourInfo()
         {
@@ -1497,12 +1494,10 @@ namespace osu.Framework.Graphics
 
             ci.Blending = new BlendingInfo(localBlending);
 
-            ColourInfo drawInfoColour = alpha != 1 ? colour.MultiplyAlpha(alpha) : colour;
+            ColourInfo ourColour = alpha != 1 ? colour.MultiplyAlpha(alpha) : colour;
 
-            // No need for a Parent null check here, because null parents always have
-            // a single colour (white).
             if (ci.Colour.HasSingleColour)
-                ci.Colour.ApplyChild(drawInfoColour);
+                ci.Colour.ApplyChild(ourColour);
             else
             {
                 Debug.Assert(Parent != null,
@@ -1518,7 +1513,7 @@ namespace osu.Framework.Graphics
                 interp.BottomLeft = Vector2.Divide(interp.BottomLeft, parentSize);
                 interp.BottomRight = Vector2.Divide(interp.BottomRight, parentSize);
 
-                ci.Colour.ApplyChild(drawInfoColour, interp);
+                ci.Colour.ApplyChild(ourColour, interp);
             }
 
             return ci;

--- a/osu.Framework/Graphics/Lines/PathDrawNode.cs
+++ b/osu.Framework/Graphics/Lines/PathDrawNode.cs
@@ -44,9 +44,9 @@ namespace osu.Framework.Graphics.Lines
 
         private Vector2 relativePosition(Vector2 localPos) => Vector2.Divide(localPos, DrawSize);
 
-        private Color4 colourAt(Vector2 localPos) => DrawInfo.Colour.HasSingleColour
-            ? (Color4)DrawInfo.Colour
-            : DrawInfo.Colour.Interpolate(relativePosition(localPos)).Linear;
+        private Color4 colourAt(Vector2 localPos) => DrawColourInfo.Colour.HasSingleColour
+            ? (Color4)DrawColourInfo.Colour
+            : DrawColourInfo.Colour.Interpolate(relativePosition(localPos)).Linear;
 
         private void addLineCap(Vector2 origin, float theta, float thetaDiff)
         {

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.Shapes
         {
             protected override void Blit(Action<TexturedVertex2D> vertexAction)
             {
-                Texture.DrawTriangle(toTriangle(ScreenSpaceDrawQuad), DrawInfo.Colour, null, null,
+                Texture.DrawTriangle(toTriangle(ScreenSpaceDrawQuad), DrawColourInfo.Colour, null, null,
                     new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
             }
         }

--- a/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Graphics.Sprites
 
         protected virtual void Blit(Action<TexturedVertex2D> vertexAction)
         {
-            Texture.DrawQuad(ScreenSpaceDrawQuad, DrawInfo.Colour, null, vertexAction,
+            Texture.DrawQuad(ScreenSpaceDrawQuad, DrawColourInfo.Colour, null, vertexAction,
                 new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
         }
 

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -504,7 +504,7 @@ namespace osu.Framework.Graphics.Sprites
             if (source == Parent)
             {
                 // Colour captures presence changes
-                if ((invalidation & (Invalidation.DrawSize | Invalidation.Colour)) > 0)
+                if ((invalidation & (Invalidation.DrawSize | Invalidation.Presence)) > 0)
                     invalidate(true);
 
                 if ((invalidation & Invalidation.DrawInfo) > 0)

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -280,7 +280,7 @@ namespace osu.Framework.Graphics.Sprites
                 lastText = string.Empty;
 
                 // We're going to become not present, so parents need to be signalled to recompute size/layout
-                Invalidate(InvalidationFromParentSize | Invalidation.Colour);
+                Invalidate(InvalidationFromParentSize | Invalidation.Presence);
 
                 return;
             }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -247,7 +247,7 @@ namespace osu.Framework.Graphics.Sprites
         {
             //adjust shadow alpha based on highest component intensity to avoid muddy display of darker text.
             //squared result for quadratic fall-off seems to give the best result.
-            var avgColour = (Color4)DrawInfo.Colour.AverageColour;
+            var avgColour = (Color4)DrawColourInfo.Colour.AverageColour;
             float shadowAlpha = (float)Math.Pow(Math.Max(Math.Max(avgColour.R, avgColour.G), avgColour.B), 2);
 
             //we can't keep existing drawabled if our shadow has changed, as the shadow is applied in the add-loop.

--- a/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
@@ -36,12 +36,12 @@ namespace osu.Framework.Graphics.Sprites
 
                 shader.Bind();
 
-                var avgColour = (Color4)DrawInfo.Colour.AverageColour;
+                var avgColour = (Color4)DrawColourInfo.Colour.AverageColour;
                 float shadowAlpha = (float)Math.Pow(Math.Max(Math.Max(avgColour.R, avgColour.G), avgColour.B), 2);
 
                 //adjust shadow alpha based on highest component intensity to avoid muddy display of darker text.
                 //squared result for quadratic fall-off seems to give the best result.
-                var shadowColour = DrawInfo.Colour;
+                var shadowColour = DrawColourInfo.Colour;
                 shadowColour.ApplyChild(ShadowColour.MultiplyAlpha(shadowAlpha));
 
                 for (int i = 0; i < Parts.Count; i++)
@@ -57,7 +57,7 @@ namespace osu.Framework.Graphics.Sprites
                         Parts[i].Texture.DrawQuad(shadowQuad, shadowColour, vertexAction: vertexAction);
                     }
 
-                    Parts[i].Texture.DrawQuad(Parts[i].DrawQuad, DrawInfo.Colour, vertexAction: vertexAction);
+                    Parts[i].Texture.DrawQuad(Parts[i].DrawQuad, DrawColourInfo.Colour, vertexAction: vertexAction);
                 }
 
                 shader.Unbind();

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -41,9 +41,9 @@ namespace osu.Framework.Graphics.UserInterface
         private float angleToUnitInterval(float angle) => angle / MathHelper.TwoPi + (angle >= 0 ? 0 : 1);
 
         // Gets colour at the localPos position in the unit square of our Colour gradient box.
-        private Color4 colourAt(Vector2 localPos) => DrawInfo.Colour.HasSingleColour
-            ? (Color4)DrawInfo.Colour
-            : DrawInfo.Colour.Interpolate(localPos).Linear;
+        private Color4 colourAt(Vector2 localPos) => DrawColourInfo.Colour.HasSingleColour
+            ? (Color4)DrawColourInfo.Colour
+            : DrawColourInfo.Colour.Interpolate(localPos).Linear;
 
         private static readonly Vector2 origin = new Vector2(0.5f, 0.5f);
         private void updateVertexBuffer()


### PR DESCRIPTION
- Creates a new invalidation value (`Invalidation.Presence`).
  - `Scale`, `Alpha`, and `AlwaysPresent` trigger this, if the IsPresent state changes.
  - Propagates upwards only.
- `Invalidation.Colour` propagates downwards only.
- Flow containers/other components that would handle colour invalidations for presence, now handle `Invalidation.Presence` instead.

Accepting suggestions for what to call `DrawColourInfo`...

I go up from 30 -> 55 FPS on the following stresstest:

```
public class TestCaseScratch : TestCase
{
    [BackgroundDependencyLoader]
    private void load()
    {
        var topContainer = new Container { Size = new Vector2(10) };
        var currentContainer = topContainer;

        for (int i = 0; i < 50; i++)
        {
            var newContainer = new Container { RelativeSizeAxes = Axes.Both };
            for (int j = 0; j < 200; j++)
                newContainer.Add(new Box { RelativeSizeAxes = Axes.Both });

            currentContainer.Add(newContainer);
            currentContainer = newContainer;
        }

        currentContainer.Add(new Box { RelativeSizeAxes = Axes.Both });

        Add(topContainer);

        Scheduler.AddDelayed(() => topContainer.Colour = Color4.White.Opacity(RNG.NextSingle()), 0, true);
    }
}
```