### PR TITLE
Don't block all invalidation when parent is null

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1553,10 +1553,10 @@ namespace osu.Framework.Graphics
         /// <returns>If the invalidate was actually necessary.</returns>
         public virtual bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
-            if (invalidation == Invalidation.None || Parent == null)
+            if (invalidation == Invalidation.None || LoadState < LoadState.Ready)
                 return false;
 
-            if (shallPropagate && source != Parent)
+            if (shallPropagate && Parent != null && source != Parent)
                 Parent.InvalidateFromChild(invalidation, this);
 
             bool alreadyInvalidated = true;


### PR DESCRIPTION
Apparently the root inputmanager requires invalidations to compute its size. Whoo'da thunk it?

I considered this fix previously, still fixes the original issue (parent invalidations weren't happening).