### PR TITLE
Allow controlling behaviour of expensive_operations_queue

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -71,14 +71,18 @@ namespace osu.Framework.Graphics.OpenGL
                 h.UpdateThread.Scheduler.Add(() => reset_scheduler.Add(disposalAction.Invoke));
         }
 
-        internal static void Reset(Vector2 size)
+        internal static void Reset(Vector2 size, int maxExpensiveOperations = 1)
         {
             Trace.Assert(shader_stack.Count == 0);
 
             reset_scheduler.Update();
 
-            if (expensive_operations_queue.TryDequeue(out Action action))
+            int executedOperations = 0;
+            while (executedOperations < maxExpensiveOperations && expensive_operations_queue.TryDequeue(out Action action))
+            {
                 action.Invoke();
+                ++executedOperations;
+            }
 
             lastBoundTexture = null;
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// The maximum number of allowed expensive GPU operations (shader/texture load fe) per frame. Default is 1.
         /// </summary>
-        public int MaxExpensiveGPUOperationsPerFrame { get; set; } = 1;
+        public int MaxExpensiveGpuOperationsPerFrame { get; set; } = 1;
 
         private void setActive(bool isActive)
         {
@@ -332,7 +332,7 @@ namespace osu.Framework.Platform
 
             setVSyncMode();
 
-            GLWrapper.Reset(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height), MaxExpensiveGPUOperationsPerFrame);
+            GLWrapper.Reset(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height), MaxExpensiveGpuOperationsPerFrame);
             GLWrapper.ClearColour(Color4.Black);
         }
 
@@ -356,7 +356,7 @@ namespace osu.Framework.Platform
 
                     using (drawMonitor.BeginCollecting(PerformanceCollectionType.GLReset))
                     {
-                        GLWrapper.Reset(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height), MaxExpensiveGPUOperationsPerFrame);
+                        GLWrapper.Reset(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height), MaxExpensiveGpuOperationsPerFrame);
                         GLWrapper.ClearColour(Color4.Black);
                     }
 


### PR DESCRIPTION
This adds an int-property to the GameHost that allows configuring how many
expensive operations (defined by the expensive_operations_queue of GLWrapper)
are allowed per frame.

This came up when checking memory usage of a preloader in my game.
The way my preloader works is by loading all textures the game needs at once, so that no loading lag happens during the actual gameplay. I found that due to the way the texture uploads get scheduled, the game would take up ~1 GB of RAM for quite a while, until all the uploads are flushed, which due to the nature of the preloader, usually happens around twenty to thirty seconds after the preloader is finished. And even then, memory usage only goes down when the GC decides to do a full collection.

Changing the behaviour of the expensive_operations_queue so it aggressively finished all its operations while the preloader runs (and then resetting it back to its normal mode of operation after the preloader is done) reduces memory usage from ~1GB to 200 MB in my case, and I don't think my use-case of messing with the way texture uploads are processed during a loading screen is all that rare of a pattern.