### PR TITLE
Have atlases return GL textures, not Textures

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -125,10 +125,7 @@ namespace osu.Framework
             Shaders = new ShaderManager(new NamespacedResourceStore<byte[]>(Resources, @"Shaders"));
             dependencies.Cache(Shaders);
 
-            Fonts = new FontStore(new GlyphStore(Resources, @"Fonts/OpenSans"))
-            {
-                ScaleAdjust = 100
-            };
+            Fonts = new FontStore(new GlyphStore(Resources, @"Fonts/OpenSans"));
             dependencies.Cache(Fonts);
         }
 

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -144,7 +144,7 @@ namespace osu.Framework.Graphics.Performance
                                     {
                                         counterBarBackground = new Sprite
                                         {
-                                            Texture = atlas.Add(1, HEIGHT),
+                                            Texture = new Texture(atlas.Add(1, HEIGHT)),
                                             RelativeSizeAxes = Axes.Both,
                                             Size = new Vector2(1, 1),
                                         },
@@ -501,7 +501,7 @@ namespace osu.Framework.Graphics.Performance
                 Size = new Vector2(WIDTH, HEIGHT);
                 Child = Sprite = new Sprite();
 
-                Sprite.Texture = atlas.Add(WIDTH, HEIGHT);
+                Sprite.Texture = new Texture(atlas.Add(WIDTH, HEIGHT));
             }
 
             public override bool HandleKeyboardInput => false;

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -63,7 +63,6 @@ namespace osu.Framework.Graphics.Textures
             Dispose(false);
         }
 
-
         public void Dispose()
         {
             Dispose(true);

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -14,25 +14,10 @@ namespace osu.Framework.Graphics.Textures
 {
     public class Texture : IDisposable
     {
-        private static TextureWhitePixel whitePixel;
+        // in case no other textures are used in the project, create a new atlas as a fallback source for the white pixel area (used to draw boxes etc.)
+        private static readonly Lazy<TextureWhitePixel> white_pixel = new Lazy<TextureWhitePixel>(() => new TextureAtlas(3, 3, true).WhitePixel);
 
-        public static Texture WhitePixel
-        {
-            get
-            {
-                if (whitePixel != null) return whitePixel;
-
-                // in case no other textures are used in the project, create a new atlas as a fallback source for the white pixel area (used to draw boxes etc.)
-                TextureAtlas atlas = new TextureAtlas(3, 3, true);
-
-                atlas.Reset();
-
-                whitePixel = new TextureWhitePixel(new TextureGLAtlasWhite(atlas.AtlasTexture));
-                whitePixel.SetData(new TextureUpload(new byte[] { 255, 255, 255, 255 }));
-
-                return whitePixel;
-            }
-        }
+        public static Texture WhitePixel => white_pixel.Value;
 
         public TextureGL TextureGL;
         public string Filename;

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -20,12 +20,15 @@ namespace osu.Framework.Graphics.Textures
         {
             get
             {
-                if (whitePixel == null)
-                {
-                    TextureAtlas atlas = new TextureAtlas(3, 3, true);
-                    whitePixel = atlas.GetWhitePixel();
-                    whitePixel.SetData(new TextureUpload(new byte[] { 255, 255, 255, 255 }));
-                }
+                if (whitePixel != null) return whitePixel;
+
+                // in case no other textures are used in the project, create a new atlas as a fallback source for the white pixel area (used to draw boxes etc.)
+                TextureAtlas atlas = new TextureAtlas(3, 3, true);
+
+                atlas.Reset();
+
+                whitePixel = new TextureWhitePixel(new TextureGLAtlasWhite(atlas.AtlasTexture));
+                whitePixel.SetData(new TextureUpload(new byte[] { 255, 255, 255, 255 }));
 
                 return whitePixel;
             }

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -28,6 +28,17 @@ namespace osu.Framework.Graphics.Textures
 
         private int mipmapLevels => (int)Math.Log(atlasWidth, 2);
 
+        internal TextureWhitePixel WhitePixel
+        {
+            get
+            {
+                if (AtlasTexture == null)
+                    Reset();
+
+                return new TextureWhitePixel(new TextureGLAtlasWhite(AtlasTexture));
+            }
+        }
+
         private readonly bool manualMipmaps;
         private readonly All filteringMode;
         private readonly object textureRetrievalLock = new object();

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -97,7 +97,7 @@ namespace osu.Framework.Graphics.Textures
             return res;
         }
 
-        internal Texture Add(int width, int height)
+        internal TextureGL Add(int width, int height)
         {
             lock (textureRetrievalLock)
             {
@@ -108,7 +108,7 @@ namespace osu.Framework.Graphics.Textures
                 RectangleI bounds = new RectangleI(position.X, position.Y, width, height);
                 subTextureBounds.Add(bounds);
 
-                return new Texture(new TextureGLSub(bounds, AtlasTexture));
+                return new TextureGLSub(bounds, AtlasTexture);
             }
         }
     }

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Textures
         private const int padding = (1 << TextureGLSingle.MAX_MIPMAP_LEVELS) + Sprite.MAX_EDGE_SMOOTHNESS * 2;
 
         private readonly List<RectangleI> subTextureBounds = new List<RectangleI>();
-        private TextureGLSingle atlasTexture;
+        internal TextureGLSingle AtlasTexture;
 
         private readonly int atlasWidth;
         private readonly int atlasHeight;
@@ -49,14 +49,15 @@ namespace osu.Framework.Graphics.Textures
             if (atlasWidth == 0 || atlasHeight == 0)
                 return;
 
-            if (atlasTexture == null)
+            if (AtlasTexture == null)
                 Logger.Log($"New TextureAtlas initialised {atlasWidth}x{atlasHeight}", LoggingTarget.Runtime, LogLevel.Debug);
 
-            atlasTexture = new TextureGLAtlas(atlasWidth, atlasHeight, manualMipmaps, filteringMode);
+            AtlasTexture = new TextureGLAtlas(atlasWidth, atlasHeight, manualMipmaps, filteringMode);
 
             using (var whiteTex = Add(3, 3))
             {
-                //add an empty white rect to use for solid box drawing (shader optimisation).
+                // add an empty white rect to use for solid box drawing (shader optimisation).
+                // see Texture.WhitePixel for usage.
                 var raw = new RawTexture(whiteTex.Width, whiteTex.Height);
                 for (int i = 0; i < raw.Data.Length; i++)
                     raw.Data[i] = 255;
@@ -100,23 +101,15 @@ namespace osu.Framework.Graphics.Textures
         {
             lock (textureRetrievalLock)
             {
-                if (atlasTexture == null)
+                if (AtlasTexture == null)
                     Reset();
 
                 Vector2I position = findPosition(width, height);
                 RectangleI bounds = new RectangleI(position.X, position.Y, width, height);
                 subTextureBounds.Add(bounds);
 
-                return new Texture(new TextureGLSub(bounds, atlasTexture));
+                return new Texture(new TextureGLSub(bounds, AtlasTexture));
             }
-        }
-
-        internal TextureWhitePixel GetWhitePixel()
-        {
-            if (atlasTexture == null)
-                Reset();
-
-            return new TextureWhitePixel(new TextureGLAtlasWhite(atlasTexture));
         }
     }
 }

--- a/osu.Framework/Graphics/Textures/TextureLoader.cs
+++ b/osu.Framework/Graphics/Textures/TextureLoader.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Graphics.Textures
             try
             {
                 RawTexture data = new RawTexture(stream);
-                Texture tex = atlas == null ? new Texture(data.Width, data.Height) : atlas.Add(data.Width, data.Height);
+                Texture tex = atlas == null ? new Texture(data.Width, data.Height) : new Texture(atlas.Add(data.Width, data.Height));
                 tex.SetData(new TextureUpload(data.Data));
                 return tex;
             }
@@ -65,7 +65,7 @@ namespace osu.Framework.Graphics.Textures
             if (data == null)
                 return null;
 
-            Texture tex = atlas == null ? new Texture(width, height) : atlas.Add(width, height);
+            Texture tex = atlas == null ? new Texture(width, height) : new Texture(atlas.Add(width, height));
 
             var upload = new TextureUpload(data) { Format = format };
             tex.SetData(upload);

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -49,7 +49,9 @@ namespace osu.Framework.Graphics.Textures
         {
             if (raw == null) return null;
 
-            Texture tex = atlas != null ? atlas.Add(raw.Width, raw.Height) : new Texture(raw.Width, raw.Height, manualMipmaps, filteringMode);
+            var glTexture = atlas != null ? atlas.Add(raw.Width, raw.Height) : new TextureGLSingle(raw.Width, raw.Height, manualMipmaps, filteringMode);
+
+            Texture tex = new Texture(glTexture) { ScaleAdjust = ScaleAdjust };
 
             tex.ScaleAdjust = ScaleAdjust;
             tex.SetData(new TextureUpload(raw));

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -52,8 +52,6 @@ namespace osu.Framework.Graphics.Textures
             var glTexture = atlas != null ? atlas.Add(raw.Width, raw.Height) : new TextureGLSingle(raw.Width, raw.Height, manualMipmaps, filteringMode);
 
             Texture tex = new Texture(glTexture) { ScaleAdjust = ScaleAdjust };
-
-            tex.ScaleAdjust = ScaleAdjust;
             tex.SetData(new TextureUpload(raw));
 
             return tex;

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -13,12 +13,8 @@ namespace osu.Framework.IO.Stores
     {
         private readonly List<GlyphStore> glyphStores = new List<GlyphStore>();
 
-        public FontStore()
-        {
-        }
-
-        public FontStore(GlyphStore glyphStore)
-            : base(glyphStore)
+        public FontStore(GlyphStore glyphStore, float scaleAdjust = 100)
+            : base(glyphStore, scaleAdjust: scaleAdjust)
         {
         }
 


### PR DESCRIPTION
Reduces overall object count, as `TextureStore`s now cache the Texture objects rather than TextureGLs.