### PR TITLE
Dispose drawables aggressively

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseProxyDrawables.cs
+++ b/osu.Framework.Tests/Visual/TestCaseProxyDrawables.cs
@@ -363,6 +363,7 @@ namespace osu.Framework.Tests.Visual
         private class NonAliveContainer : Container
         {
             protected internal override bool ShouldBeAlive => false;
+            public override bool DisposeOnDeathRemoval => false;
         }
 
         private class Visualiser : Container

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -112,7 +112,7 @@ namespace osu.Framework.Graphics
         /// Whether this Drawable should be disposed when it is automatically removed from
         /// its <see cref="Parent"/> due to <see cref="ShouldBeAlive"/> being false.
         /// </summary>
-        public virtual bool DisposeOnDeathRemoval => false;
+        public virtual bool DisposeOnDeathRemoval => RemoveCompletedTransforms;
 
         private static readonly ConcurrentDictionary<Type, Action<object>> unbind_action_cache = new ConcurrentDictionary<Type, Action<object>>();
 


### PR DESCRIPTION
We were placing a huge stress on the GC previously, with tens of thousands of drawables being finalised. There's no reason not to dispose eargerly.

Note that most of these were SpriteText characters, which will likely be fixed in the near future, but still a worthwhile optimisation.