### PR TITLE
Ignore parent size when it is computing RequiredParentSizeToFit

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1371,7 +1371,7 @@ namespace osu.Framework.Graphics.Containers
         public virtual Axes AutoSizeAxes
         {
             get => autoSizeAxes;
-            protected set
+            protected internal set
             {
                 if (value == autoSizeAxes)
                     return;
@@ -1408,7 +1408,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.X))
+                if (!StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.X))
                     updateChildrenSizeDependencies();
                 return base.Width;
             }
@@ -1425,7 +1425,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.Y))
+                if (!StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.Y))
                     updateChildrenSizeDependencies();
                 return base.Height;
             }
@@ -1438,13 +1438,11 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private bool isComputingChildrenSizeDependencies;
-
         public override Vector2 Size
         {
             get
             {
-                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && AutoSizeAxes != Axes.None)
+                if (!StaticCached.BypassCache && AutoSizeAxes != Axes.None)
                     updateChildrenSizeDependencies();
                 return base.Size;
             }
@@ -1487,9 +1485,9 @@ namespace osu.Framework.Graphics.Containers
                 }
 
                 if (!AutoSizeAxes.HasFlag(Axes.X))
-                    maxBoundSize.X = DrawSize.X;
+                    maxBoundSize.X = BaseSize.X;
                 if (!AutoSizeAxes.HasFlag(Axes.Y))
-                    maxBoundSize.Y = DrawSize.Y;
+                    maxBoundSize.Y = BaseSize.Y;
 
                 return new Vector2(maxBoundSize.X, maxBoundSize.Y);
             }
@@ -1519,25 +1517,16 @@ namespace osu.Framework.Graphics.Containers
 
         private void updateChildrenSizeDependencies()
         {
-            isComputingChildrenSizeDependencies = true;
-
-            try
+            if (!childrenSizeDependencies.IsValid)
             {
-                if (!childrenSizeDependencies.IsValid)
-                {
-                    updateAutoSize();
-                    childrenSizeDependencies.Validate();
-                }
-            }
-            finally
-            {
-                isComputingChildrenSizeDependencies = false;
+                updateAutoSize();
+                childrenSizeDependencies.Validate();
             }
         }
 
         private void autoSizeResizeTo(Vector2 newSize, double duration = 0, Easing easing = Easing.None)
         {
-            var currentTargetSize = ((AutoSizeTransform)Transforms.FirstOrDefault(t => t is AutoSizeTransform))?.EndValue ?? Size;
+            var currentTargetSize = ((AutoSizeTransform)Transforms.FirstOrDefault(t => t is AutoSizeTransform))?.EndValue ?? BaseSize;
             if (currentTargetSize != newSize)
                 this.TransformTo(this.PopulateTransform(new AutoSizeTransform { Rewindable = false }, newSize, duration, easing));
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1545,7 +1545,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// A helper property for <see cref="autoSizeResizeTo(Vector2, double, Easing)"/> to change the size of <see cref="CompositeDrawable"/>s with <see cref="AutoSizeAxes"/>.
         /// </summary>
-        private Vector2 baseSize
+        internal Vector2 BaseSize
         {
             get => new Vector2(base.Width, base.Height);
             set
@@ -1558,7 +1558,7 @@ namespace osu.Framework.Graphics.Containers
         private class AutoSizeTransform : TransformCustom<Vector2, CompositeDrawable>
         {
             public AutoSizeTransform()
-                : base(nameof(baseSize))
+                : base(nameof(BaseSize))
             {
             }
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1264,11 +1264,23 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        internal bool IgnoreAutoSizeForChildSize;
+
         /// <summary>
         /// The size of the coordinate space revealed to <see cref="InternalChildren"/>.
         /// Captures the effect of e.g. <see cref="Padding"/>.
         /// </summary>
-        public Vector2 ChildSize => DrawSize - new Vector2(Padding.TotalHorizontal, Padding.TotalVertical);
+        public Vector2 ChildSize
+        {
+            get
+            {
+                if (!IgnoreAutoSizeForChildSize) return DrawSize - Padding.Total;
+                var size = ApplyRelativeAxes(RelativeSizeAxes, BaseSize, FillMode);
+                if ((AutoSizeAxes & Axes.X) != 0) size.X = 0;
+                if ((AutoSizeAxes & Axes.Y) != 0) size.Y = 0;
+                return size - Padding.Total;
+            }
+        }
 
         /// <summary>
         /// Positional offset applied to <see cref="InternalChildren"/>.
@@ -1404,13 +1416,11 @@ namespace osu.Framework.Graphics.Containers
 
         private Cached childrenSizeDependencies = new Cached();
 
-        internal bool IgnoreAutoSize;
-
         public override float Width
         {
             get
             {
-                if (!IgnoreAutoSize && !StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.X))
+                if (!StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.X))
                     updateChildrenSizeDependencies();
                 return base.Width;
             }
@@ -1427,7 +1437,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!IgnoreAutoSize && !StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.Y))
+                if (!StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.Y))
                     updateChildrenSizeDependencies();
                 return base.Height;
             }
@@ -1444,7 +1454,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!IgnoreAutoSize && !StaticCached.BypassCache && AutoSizeAxes != Axes.None)
+                if (!StaticCached.BypassCache && AutoSizeAxes != Axes.None)
                     updateChildrenSizeDependencies();
                 return base.Size;
             }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1371,7 +1371,7 @@ namespace osu.Framework.Graphics.Containers
         public virtual Axes AutoSizeAxes
         {
             get => autoSizeAxes;
-            protected internal set
+            protected set
             {
                 if (value == autoSizeAxes)
                     return;
@@ -1404,11 +1404,13 @@ namespace osu.Framework.Graphics.Containers
 
         private Cached childrenSizeDependencies = new Cached();
 
+        internal bool IgnoreAutoSize;
+
         public override float Width
         {
             get
             {
-                if (!StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.X))
+                if (!IgnoreAutoSize && !StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.X))
                     updateChildrenSizeDependencies();
                 return base.Width;
             }
@@ -1425,7 +1427,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.Y))
+                if (!IgnoreAutoSize && !StaticCached.BypassCache && AutoSizeAxes.HasFlag(Axes.Y))
                     updateChildrenSizeDependencies();
                 return base.Height;
             }
@@ -1442,7 +1444,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!StaticCached.BypassCache && AutoSizeAxes != Axes.None)
+                if (!IgnoreAutoSize && !StaticCached.BypassCache && AutoSizeAxes != Axes.None)
                     updateChildrenSizeDependencies();
                 return base.Size;
             }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1264,19 +1264,24 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        internal bool ComputingChildRequiredParentSizeToFit;
+        /// <summary>
+        /// It is true while a child is computing <see cref="Drawable.RequiredParentSizeToFit"/>.
+        /// While it is true, this <see cref="CompositeDrawable"/> behaves as its size exposed to children is zero
+        /// in order to prevent an unwanted dependency.
+        /// </summary>
+        internal bool IsChildComputingRequiredParentSizeToFit;
 
         /// <summary>
         /// The size of the coordinate space revealed to <see cref="InternalChildren"/>.
         /// Captures the effect of e.g. <see cref="Padding"/>.
         /// </summary>
-        public Vector2 ChildSize => !ComputingChildRequiredParentSizeToFit ? DrawSize - Padding.Total : Vector2.Zero;
+        public Vector2 ChildSize => !IsChildComputingRequiredParentSizeToFit ? DrawSize - Padding.Total : Vector2.Zero;
 
         /// <summary>
         /// Positional offset applied to <see cref="InternalChildren"/>.
         /// Captures the effect of e.g. <see cref="Padding"/>.
         /// </summary>
-        public Vector2 ChildOffset => !ComputingChildRequiredParentSizeToFit ? new Vector2(Padding.Left, Padding.Top) : Vector2.Zero;
+        public Vector2 ChildOffset => !IsChildComputingRequiredParentSizeToFit ? new Vector2(Padding.Left, Padding.Top) : Vector2.Zero;
 
         private Vector2 relativeChildSize = Vector2.One;
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1270,17 +1270,7 @@ namespace osu.Framework.Graphics.Containers
         /// The size of the coordinate space revealed to <see cref="InternalChildren"/>.
         /// Captures the effect of e.g. <see cref="Padding"/>.
         /// </summary>
-        public Vector2 ChildSize
-        {
-            get
-            {
-                if (!ComputingChildRequiredParentSizeToFit) return DrawSize - Padding.Total;
-                var size = new Vector2(
-                    (AutoSizeAxes & Axes.X) != 0 ? 0 : BaseSize.X,
-                    (AutoSizeAxes & Axes.Y) != 0 ? 0 : BaseSize.Y);
-                return ApplyRelativeAxes(RelativeSizeAxes, size, FillMode.Stretch);
-            }
-        }
+        public Vector2 ChildSize => !ComputingChildRequiredParentSizeToFit ? DrawSize - Padding.Total : Vector2.Zero;
 
         /// <summary>
         /// Positional offset applied to <see cref="InternalChildren"/>.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1492,34 +1492,46 @@ namespace osu.Framework.Graphics
 
         private Vector2 computeRequiredParentSizeToFit()
         {
-            // Auxilary variables required for the computation
-            Vector2 ap = AnchorPosition;
-            Vector2 rap = RelativeAnchorPosition;
+            if (Parent == null) return Vector2.Zero;
 
-            Vector2 ratio1 = new Vector2(
-                rap.X <= 0 ? 0 : 1 / rap.X,
-                rap.Y <= 0 ? 0 : 1 / rap.Y);
+            var originalSize = Parent.BaseSize;
+            Parent.BaseSize = Vector2.Zero;
 
-            Vector2 ratio2 = new Vector2(
-                rap.X >= 1 ? 0 : 1 / (1 - rap.X),
-                rap.Y >= 1 ? 0 : 1 / (1 - rap.Y));
+            try
+            {
+                // Auxilary variables required for the computation
+                Vector2 ap = AnchorPosition;
+                Vector2 rap = RelativeAnchorPosition;
 
-            RectangleF bbox = BoundingBox;
+                Vector2 ratio1 = new Vector2(
+                    rap.X <= 0 ? 0 : 1 / rap.X,
+                    rap.Y <= 0 ? 0 : 1 / rap.Y);
 
-            // Compute the required size of the parent such that we fit in snugly when positioned
-            // at our relative anchor in the parent.
-            Vector2 topLeftOffset = ap - bbox.TopLeft;
-            Vector2 topLeftSize1 = topLeftOffset * ratio1;
-            Vector2 topLeftSize2 = -topLeftOffset * ratio2;
+                Vector2 ratio2 = new Vector2(
+                    rap.X >= 1 ? 0 : 1 / (1 - rap.X),
+                    rap.Y >= 1 ? 0 : 1 / (1 - rap.Y));
 
-            Vector2 bottomRightOffset = ap - bbox.BottomRight;
-            Vector2 bottomRightSize1 = bottomRightOffset * ratio1;
-            Vector2 bottomRightSize2 = -bottomRightOffset * ratio2;
+                RectangleF bbox = BoundingBox;
 
-            // Expand bounds according to clipped offset
-            return Vector2.ComponentMax(
-                Vector2.ComponentMax(topLeftSize1, topLeftSize2),
-                Vector2.ComponentMax(bottomRightSize1, bottomRightSize2));
+                // Compute the required size of the parent such that we fit in snugly when positioned
+                // at our relative anchor in the parent.
+                Vector2 topLeftOffset = ap - bbox.TopLeft;
+                Vector2 topLeftSize1 = topLeftOffset * ratio1;
+                Vector2 topLeftSize2 = -topLeftOffset * ratio2;
+
+                Vector2 bottomRightOffset = ap - bbox.BottomRight;
+                Vector2 bottomRightSize1 = bottomRightOffset * ratio1;
+                Vector2 bottomRightSize2 = -bottomRightOffset * ratio2;
+
+                // Expand bounds according to clipped offset
+                return Vector2.ComponentMax(
+                    Vector2.ComponentMax(topLeftSize1, topLeftSize2),
+                    Vector2.ComponentMax(bottomRightSize1, bottomRightSize2));
+            }
+            finally
+            {
+                Parent.BaseSize = originalSize;
+            }
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1495,7 +1495,9 @@ namespace osu.Framework.Graphics
             if (Parent == null) return Vector2.Zero;
 
             var originalSize = Parent.BaseSize;
+            var originalAutoSizeAxes = Parent.AutoSizeAxes;
             Parent.BaseSize = Vector2.Zero;
+            Parent.AutoSizeAxes = Axes.None;
 
             try
             {
@@ -1531,6 +1533,7 @@ namespace osu.Framework.Graphics
             finally
             {
                 Parent.BaseSize = originalSize;
+                Parent.AutoSizeAxes = originalAutoSizeAxes;
             }
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1495,14 +1495,12 @@ namespace osu.Framework.Graphics
             if (Parent == null) return Vector2.Zero;
 
             var originalSize = Parent.BaseSize;
-            var originalAutoSizeAxes = Parent.AutoSizeAxes;
+            var originalIgnoreAutoSize = Parent.IgnoreAutoSize;
             Parent.BaseSize = Vector2.Zero;
-            Parent.AutoSizeAxes = Axes.None;
+            Parent.IgnoreAutoSize = true;
 
             try
             {
-                // Auxilary variables required for the computation
-                Vector2 ap = AnchorPosition;
                 Vector2 rap = RelativeAnchorPosition;
 
                 Vector2 ratio1 = new Vector2(
@@ -1517,11 +1515,11 @@ namespace osu.Framework.Graphics
 
                 // Compute the required size of the parent such that we fit in snugly when positioned
                 // at our relative anchor in the parent.
-                Vector2 topLeftOffset = ap - bbox.TopLeft;
+                Vector2 topLeftOffset = -bbox.TopLeft;
                 Vector2 topLeftSize1 = topLeftOffset * ratio1;
                 Vector2 topLeftSize2 = -topLeftOffset * ratio2;
 
-                Vector2 bottomRightOffset = ap - bbox.BottomRight;
+                Vector2 bottomRightOffset = -bbox.BottomRight;
                 Vector2 bottomRightSize1 = bottomRightOffset * ratio1;
                 Vector2 bottomRightSize2 = -bottomRightOffset * ratio2;
 
@@ -1533,7 +1531,7 @@ namespace osu.Framework.Graphics
             finally
             {
                 Parent.BaseSize = originalSize;
-                Parent.AutoSizeAxes = originalAutoSizeAxes;
+                Parent.IgnoreAutoSize = originalIgnoreAutoSize;
             }
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1495,6 +1495,8 @@ namespace osu.Framework.Graphics
             if (Parent == null) return Vector2.Zero;
 
             var originalFlag = Parent.ComputingChildRequiredParentSizeToFit;
+            // if DrawSize is validated while Parent.ComputingChildRequiredParentSizeToFit is true, it should be invalidated.
+            var originalDrawSizeBacking = drawSizeBacking;
             Parent.ComputingChildRequiredParentSizeToFit = true;
 
             try
@@ -1529,6 +1531,7 @@ namespace osu.Framework.Graphics
             finally
             {
                 Parent.ComputingChildRequiredParentSizeToFit = originalFlag;
+                drawSizeBacking = originalDrawSizeBacking;
             }
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1494,10 +1494,12 @@ namespace osu.Framework.Graphics
         {
             if (Parent == null) return Vector2.Zero;
 
-            var originalFlag = Parent.ComputingChildRequiredParentSizeToFit;
-            // if DrawSize is validated while Parent.ComputingChildRequiredParentSizeToFit is true, it should be invalidated.
+            var originalFlag = Parent.IsChildComputingRequiredParentSizeToFit;
+            // If DrawSize is accessed while Parent.IsChildComputingRequiredParentSizeToFit is true,
+            // a wrong value is cached for DrawSize.
+            // We need to invalidate DrawSize after for such case.
             var originalDrawSizeBacking = drawSizeBacking;
-            Parent.ComputingChildRequiredParentSizeToFit = true;
+            Parent.IsChildComputingRequiredParentSizeToFit = true;
 
             try
             {
@@ -1530,7 +1532,7 @@ namespace osu.Framework.Graphics
             }
             finally
             {
-                Parent.ComputingChildRequiredParentSizeToFit = originalFlag;
+                Parent.IsChildComputingRequiredParentSizeToFit = originalFlag;
                 drawSizeBacking = originalDrawSizeBacking;
             }
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1494,10 +1494,8 @@ namespace osu.Framework.Graphics
         {
             if (Parent == null) return Vector2.Zero;
 
-            var originalSize = Parent.BaseSize;
-            var originalIgnoreAutoSize = Parent.IgnoreAutoSize;
-            Parent.BaseSize = Vector2.Zero;
-            Parent.IgnoreAutoSize = true;
+            var originalFlag = Parent.IgnoreAutoSizeForChildSize;
+            Parent.IgnoreAutoSizeForChildSize = true;
 
             try
             {
@@ -1530,8 +1528,7 @@ namespace osu.Framework.Graphics
             }
             finally
             {
-                Parent.BaseSize = originalSize;
-                Parent.IgnoreAutoSize = originalIgnoreAutoSize;
+                Parent.IgnoreAutoSizeForChildSize = originalFlag;
             }
         }
 
@@ -1687,14 +1684,24 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <param name="input">A vector in local coordinates.</param>
         /// <returns>The vector in Parent's coordinates.</returns>
-        public Vector2 ToParentSpace(Vector2 input) => ToSpaceOfOtherDrawable(input, Parent);
+        public Vector2 ToParentSpace(Vector2 input)
+        {
+            var di = new DrawInfo(null);
+            di.ApplyTransform(DrawPosition + AnchorPosition + (Parent?.ChildOffset ?? Vector2.Zero), DrawScale, Rotation, Shear, OriginPosition);
+            return Vector2Extensions.Transform(input, di.Matrix);
+        }
 
         /// <summary>
         /// Accepts a rectangle in local coordinates and converts it to a quad in Parent's space.
         /// </summary>
         /// <param name="input">A rectangle in local coordinates.</param>
         /// <returns>The quad in Parent's coordinates.</returns>
-        public Quad ToParentSpace(RectangleF input) => ToSpaceOfOtherDrawable(input, Parent);
+        public Quad ToParentSpace(RectangleF input)
+        {
+            var di = new DrawInfo(null);
+            di.ApplyTransform(DrawPosition + AnchorPosition + (Parent?.ChildOffset ?? Vector2.Zero), DrawScale, Rotation, Shear, OriginPosition);
+            return Quad.FromRectangle(input) * di.Matrix;
+        }
 
         /// <summary>
         /// Accepts a vector in local coordinates and converts it to coordinates in screen space.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1494,8 +1494,8 @@ namespace osu.Framework.Graphics
         {
             if (Parent == null) return Vector2.Zero;
 
-            var originalFlag = Parent.IgnoreAutoSizeForChildSize;
-            Parent.IgnoreAutoSizeForChildSize = true;
+            var originalFlag = Parent.ComputingChildRequiredParentSizeToFit;
+            Parent.ComputingChildRequiredParentSizeToFit = true;
 
             try
             {
@@ -1528,7 +1528,7 @@ namespace osu.Framework.Graphics
             }
             finally
             {
-                Parent.IgnoreAutoSizeForChildSize = originalFlag;
+                Parent.ComputingChildRequiredParentSizeToFit = originalFlag;
             }
         }
 


### PR DESCRIPTION
`RequiredParentSizeToFit` is required for parent auto size. But this was dependent on parent size. This causes layout invalidation issue (see #1803 `AutoSizeWithRotation` cases).

While it is possible to correctly compute auto sizing of edge cases such as `AutoSizeWithRotation` in theory, but this computation can be a bit complex. (in general, we need to find minimal (x,y) under inequalities `a_i x + b_i <= y` / `a_i y + b_i <= x` where `a >= 0`. while it can be solved by computing convex hull, it requires a sorting and I couldn't come up with a simpler way).
Thus, it is reasonable to give up to be correct (under a semantics) but rather find a consistent way (especially, extra invalidation calls should not affect the result).

`RequiredParentSizeToFit` is not computed assuming parent size is `(0, 0)`. It is currently implemented by temporary setting values and restoring but I think it should be done in a more straightforward way (just read relevant properties) in the feature. Note that `RequiredParentSizeToFit` is still dependent on `Parent` properties such as `RelativeChildSize` and `ChildOffset` but it should be okay as these properties are not affected by auto sizing.

`ToParentSpace` is modified to not depend on parent `DrawInfo`.

- Fix #1803's `AutoSizeWithRotation` and `AutoSizeWithShear`.

---
