### PR TITLE
Fix SpriteTexts with only spaces not getting a width

### DIFF
--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -60,9 +60,9 @@ namespace osu.Framework.Graphics.Sprites
                 {
                     // We'll become not present and won't update the characters to set the size to 0, so do it manually
                     if (requiresAutoSizedWidth)
-                        base.Width = 0;
+                        base.Width = Padding.TotalHorizontal;
                     if (requiresAutoSizedHeight)
-                        base.Height = 0;
+                        base.Height = Padding.TotalVertical;
                 }
 
                 invalidate(true);
@@ -428,9 +428,9 @@ namespace osu.Framework.Graphics.Sprites
             finally
             {
                 if (requiresAutoSizedWidth)
-                    base.Width = currentPos.X == 0 ? 0 : currentPos.X + Padding.Right;
+                    base.Width = currentPos.X + Padding.Right;
                 if (requiresAutoSizedHeight)
-                    base.Height = currentPos.Y == 0 ? 0 : currentPos.Y + Padding.Bottom;
+                    base.Height = currentPos.Y + Padding.Bottom;
 
                 isComputingCharacters = false;
                 charactersCache.Validate();

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -428,9 +428,9 @@ namespace osu.Framework.Graphics.Sprites
             finally
             {
                 if (requiresAutoSizedWidth)
-                    base.Width = charactersBacking.Count == 0 ? 0 : currentPos.X + Padding.Right;
+                    base.Width = currentPos.X == 0 ? 0 : currentPos.X + Padding.Right;
                 if (requiresAutoSizedHeight)
-                    base.Height = charactersBacking.Count == 0 ? 0 : currentPos.Y + Padding.Bottom;
+                    base.Height = currentPos.Y == 0 ? 0 : currentPos.Y + Padding.Bottom;
 
                 isComputingCharacters = false;
                 charactersCache.Validate();


### PR DESCRIPTION
Unsure if padding should be ignored on zero-width or not.