### PR TITLE
Add automated SpriteText invalidation tests

### DIFF
--- a/osu.Framework.Tests/Layout/LayoutTest.cs
+++ b/osu.Framework.Tests/Layout/LayoutTest.cs
@@ -1,0 +1,48 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Tests.Layout
+{
+    public abstract class LayoutTest
+    {
+        public static void Run(Drawable child, Func<int, bool> testAction)
+        {
+            using (var host = new HeadlessGameHost())
+            {
+                host.Run(new LayoutTestGame(child, testAction));
+            }
+        }
+
+        private class LayoutTestGame : Game
+        {
+            private readonly Drawable child;
+            private readonly Func<int, bool> callback;
+
+            public LayoutTestGame(Drawable child, Func<int, bool> callback)
+            {
+                this.child = child;
+                this.callback = callback;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                Add(child);
+            }
+
+            private int currentFrame;
+
+            public override bool UpdateSubTree()
+            {
+                if (callback?.Invoke(currentFrame++) ?? false)
+                    Exit();
+                return base.UpdateSubTree();
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Layout/LayoutTest.cs
+++ b/osu.Framework.Tests/Layout/LayoutTest.cs
@@ -1,16 +1,30 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Platform;
 
 namespace osu.Framework.Tests.Layout
 {
+    /// <summary>
+    /// Base class for a test that runs a game until required.
+    /// </summary>
     public abstract class LayoutTest
     {
-        public static void Run(Drawable child, Func<int, bool> testAction)
+        /// <summary>
+        /// A delegate invoked every <see cref="Drawable.UpdateSubTree"/>. Returning true will cause the game to exit.
+        /// </summary>
+        /// <param name="frameIndex">The index of invocation of <see cref="Drawable.UpdateSubTree"/>.
+        /// A value of 0 indicates the callback happened prior to the first <see cref="Drawable.UpdateSubTree"/>.</param>
+        public delegate bool TestDelegate(int frameIndex);
+
+        /// <summary>
+        /// Runs the game.
+        /// </summary>
+        /// <param name="child">The child to add to the hierarchy.</param>
+        /// <param name="testAction">A delegate to be executed every <see cref="Drawable.UpdateSubTree"/>. Returning true will cause the game to exit.</param>
+        public static void Run(Drawable child, TestDelegate testAction)
         {
             using (var host = new HeadlessGameHost())
             {
@@ -21,9 +35,9 @@ namespace osu.Framework.Tests.Layout
         private class LayoutTestGame : Game
         {
             private readonly Drawable child;
-            private readonly Func<int, bool> callback;
+            private readonly TestDelegate callback;
 
-            public LayoutTestGame(Drawable child, Func<int, bool> callback)
+            public LayoutTestGame(Drawable child, TestDelegate callback)
             {
                 this.child = child;
                 this.callback = callback;

--- a/osu.Framework.Tests/Layout/SpriteText/SpriteTextLayoutTest.cs
+++ b/osu.Framework.Tests/Layout/SpriteText/SpriteTextLayoutTest.cs
@@ -1,0 +1,219 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Containers;
+using OpenTK;
+using OpenTK.Graphics;
+
+namespace osu.Framework.Tests.Layout.SpriteText
+{
+    [TestFixture]
+    public class SpriteTextLayoutTest : LayoutTest
+    {
+        [Test]
+        public void TestInitiallyInvalid()
+        {
+            var text = new TestSpriteText();
+
+            Assert.IsFalse(text.CharactersCache.IsValid);
+            Assert.IsFalse(text.ScreenSpaceCharactersCache.IsValid);
+            Assert.IsFalse(text.ShadowOffsetCache.IsValid);
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestValidatedOnFirstFrame(bool withShadow)
+        {
+            var text = new TestSpriteText
+            {
+                Text = "A",
+                Shadow = withShadow
+            };
+
+            Run(text, i =>
+            {
+                if (i == 0)
+                    return false;
+
+                Assert.IsTrue(text.CharactersCache.IsValid);
+                Assert.IsTrue(text.ScreenSpaceCharactersCache.IsValid);
+                Assert.AreEqual(withShadow, text.ShadowOffsetCache.IsValid);
+                return true;
+            });
+        }
+
+        private static readonly object[] property_cases =
+        {
+            new object[] { nameof(TestSpriteText.Anchor), Anchor.Centre, false, true, false },
+            new object[] { nameof(TestSpriteText.Origin), Anchor.Centre, false, true, false },
+            new object[] { nameof(TestSpriteText.Text), "B", true, true, false },
+            new object[] { nameof(TestSpriteText.TextSize), 40, true, true, true },
+            new object[] { nameof(TestSpriteText.RelativeSizeAxes), Axes.Both, true, true, false },
+            new object[] { nameof(TestSpriteText.Width), 40, true, true, false },
+            new object[] { nameof(TestSpriteText.Height), 40, true, true, false },
+            new object[] { nameof(TestSpriteText.Size), new Vector2(40), true, true, false },
+            new object[] { nameof(TestSpriteText.Scale), new Vector2(40), false, true, false },
+            new object[] { nameof(TestSpriteText.Shear), new Vector2(40), false, true, false },
+            new object[] { nameof(TestSpriteText.Padding), new MarginPadding(10), true, true, false },
+            // Todo: This might be wrong for negative margins, but we only get a MiscGeometry invalidation...
+            new object[] { nameof(TestSpriteText.Margin), new MarginPadding(10), false, true, false },
+            new object[] { nameof(TestSpriteText.Spacing), new Vector2(10), true, true, false },
+            new object[] { nameof(TestSpriteText.Font), "newFont", true, true, false },
+            new object[] { nameof(TestSpriteText.AllowMultiline), false, true, true, false },
+            new object[] { nameof(TestSpriteText.UseFullGlyphHeight), false, true, true, false },
+            new object[] { nameof(TestSpriteText.FixedWidth), true, true, true, false },
+        };
+
+        [Test, TestCaseSource(nameof(property_cases))]
+        public void TestInvalidatedWhenPropertyChanges(string property, object value, bool shouldInvalidateCharacters, bool shouldInvalidateScreenSpaceCharacters, bool shouldInvalidateShadow)
+        {
+            var text = new TestSpriteText { Text = "A" };
+
+            Run(text, i =>
+            {
+                switch (i)
+                {
+                    default:
+                        return false;
+                    case 1:
+                        text.Set(property, value);
+
+                        Assert.AreEqual(!shouldInvalidateCharacters, text.CharactersCache.IsValid);
+                        Assert.AreEqual(!shouldInvalidateScreenSpaceCharacters, text.ScreenSpaceCharactersCache.IsValid);
+                        Assert.AreEqual(!shouldInvalidateShadow, text.ShadowOffsetCache.IsValid);
+                        return true;
+                }
+            });
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestInvalidatedWhenParentChanges(bool relativeSize)
+        {
+            var text = new TestSpriteText
+            {
+                Text = "A",
+                RelativeSizeAxes = relativeSize ? Axes.X : Axes.None
+            };
+
+            var firstParent = new Container { Child = text };
+            var secondParent = new Container();
+
+            Run(new Container { Children = new[] { firstParent, secondParent } }, i =>
+            {
+                switch (i)
+                {
+                    default:
+                        return false;
+                    case 1:
+                        firstParent.Remove(text);
+                        secondParent.Add(text);
+
+                        // Characters should only be invalidated if the size has possibly changed,
+                        // which can only happen if relatively sizing
+                        Assert.AreEqual(!relativeSize, text.CharactersCache.IsValid);
+
+                        Assert.IsFalse(text.ScreenSpaceCharactersCache.IsValid);
+                        Assert.IsFalse(text.ShadowOffsetCache.IsValid);
+
+                        return true;
+                }
+            });
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestInvalidatedWhenSuperParentChanges(bool relativeSize)
+        {
+            var text = new TestSpriteText
+            {
+                Text = "A",
+                RelativeSizeAxes = relativeSize ? Axes.X : Axes.None
+            };
+
+            var textParent = new Container
+            {
+                Child = text,
+                RelativeSizeAxes = text.RelativeSizeAxes
+            };
+
+            var firstParent = new Container { Child = textParent };
+            var secondParent = new Container();
+
+            Run(new Container { Children = new[] { firstParent, secondParent } }, i =>
+            {
+                switch (i)
+                {
+                    default:
+                        return false;
+                    case 1:
+                        firstParent.Remove(textParent);
+                        secondParent.Add(textParent);
+
+                        // Characters should only be invalidated if the size has possibly changed,
+                        // which can only happen if relatively sizing
+                        Assert.AreEqual(!relativeSize, text.CharactersCache.IsValid);
+
+                        Assert.IsFalse(text.ScreenSpaceCharactersCache.IsValid);
+                        Assert.IsFalse(text.ShadowOffsetCache.IsValid);
+
+                        return true;
+                }
+            });
+        }
+
+        private static readonly object[] parent_property_cases =
+        {
+            // These are almost all going to invalidate screen space characters + shadows, since they depend on DrawInfo
+            // Although it's probably not necessary for them to be invalidated unless a non-DrawSize/DrawScale component of DrawInfo is changed
+            new object[] { true, nameof(Container.RelativeSizeAxes), Axes.Both, true, true, true },
+            new object[] { false, nameof(Container.RelativeSizeAxes), Axes.Both, false, true, true },
+            new object[] { false, nameof(Container.Scale), new Vector2(2), false, true, true },
+            new object[] { false, nameof(Container.Rotation), 45f, false, true, true },
+            new object[] { false, nameof(Container.Colour), (ColourInfo)Color4.Red, false, false, false },
+            new object[] { false, nameof(Container.AutoSizeAxes), Axes.Both, false, false, false },
+            new object[] { true, nameof(Container.Width), 40, true, true, true },
+            new object[] { false, nameof(Container.Width), 40, false, true, true },
+            new object[] { true, nameof(Container.Height), 40, true, true, true },
+            new object[] { false, nameof(Container.Height), 40, false, true, true },
+            new object[] { true, nameof(Container.Size), new Vector2(40), true, true, true },
+            new object[] { false, nameof(Container.Size), new Vector2(40), false, true, true },
+            // new object[] { true, nameof(Container.Padding), new MarginPadding(10), true, true, true }, // Todo: Broken due to CompositeDrawable's implementation
+            // new object[] { true, nameof(Container.Margin), new MarginPadding(10), true, true, true }, // Todo: Broken due to CompositeDrawable's implementation
+            new object[] { true, nameof(Container.Position), new Vector2(40), false, true, true },
+            new object[] { false, nameof(Container.Position), new Vector2(40), false, true, true },
+        };
+
+        [Test, TestCaseSource(nameof(parent_property_cases))]
+        public void TestInvalidatedWhenParentPropertyChanges(bool relativeSize, string property, object value, bool shouldInvalidateCharacters, bool shouldInvalidateScreenSpaceCharacters,
+                                                             bool shouldInvalidateShadow)
+        {
+            var text = new TestSpriteText
+            {
+                Text = "A",
+                RelativeSizeAxes = relativeSize ? Axes.Both : Axes.None
+            };
+
+            var textParent = new Container { Child = text };
+
+            Run(textParent, i =>
+            {
+                switch (i)
+                {
+                    default:
+                        return false;
+                    case 1:
+                        textParent.Set(property, value);
+
+                        Assert.AreEqual(!shouldInvalidateCharacters, text.CharactersCache.IsValid);
+                        Assert.AreEqual(!shouldInvalidateScreenSpaceCharacters, text.ScreenSpaceCharactersCache.IsValid);
+                        Assert.AreEqual(!shouldInvalidateShadow, text.ShadowOffsetCache.IsValid);
+                        return true;
+                }
+            });
+        }
+    }
+}

--- a/osu.Framework.Tests/Layout/SpriteText/SpriteTextLayoutTest.cs
+++ b/osu.Framework.Tests/Layout/SpriteText/SpriteTextLayoutTest.cs
@@ -58,7 +58,6 @@ namespace osu.Framework.Tests.Layout.SpriteText
             new object[] { nameof(TestSpriteText.Scale), new Vector2(40), false, true, false },
             new object[] { nameof(TestSpriteText.Shear), new Vector2(40), false, true, false },
             new object[] { nameof(TestSpriteText.Padding), new MarginPadding(10), true, true, false },
-            // Todo: This might be wrong for negative margins, but we only get a MiscGeometry invalidation...
             new object[] { nameof(TestSpriteText.Margin), new MarginPadding(10), false, true, false },
             new object[] { nameof(TestSpriteText.Spacing), new Vector2(10), true, true, false },
             new object[] { nameof(TestSpriteText.Font), "newFont", true, true, false },

--- a/osu.Framework.Tests/Layout/SpriteText/TestSpriteText.cs
+++ b/osu.Framework.Tests/Layout/SpriteText/TestSpriteText.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Caching;
+using OpenTK;
+
+namespace osu.Framework.Tests.Layout.SpriteText
+{
+    public class TestSpriteText : Graphics.Sprites.SpriteText
+    {
+        public TestSpriteText()
+        {
+            Shadow = true;
+        }
+
+        public Cached CharactersCache => this.Get<Cached>("charactersCache");
+        public Cached ScreenSpaceCharactersCache => this.Get<Cached>("screenSpaceCharactersCache");
+        public Cached<Vector2> ShadowOffsetCache => this.Get<Cached<Vector2>>("shadowOffsetCache");
+    }
+}

--- a/osu.Framework.Tests/Layout/ValidationTestExtensions.cs
+++ b/osu.Framework.Tests/Layout/ValidationTestExtensions.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Reflection;
+using osu.Framework.Graphics;
+
+namespace osu.Framework.Tests.Layout
+{
+    internal static class ValidationTestExtensions
+    {
+        public static T Get<T>(this Drawable d, string fieldOrPropertyName, Type searchType = null)
+        {
+            Type type = searchType ?? d.GetType();
+
+            while (type != typeof(object))
+            {
+                // ReSharper disable once PossibleNullReferenceException
+                var fieldInfo = type.GetField(fieldOrPropertyName, BindingFlags.NonPublic | BindingFlags.Instance);
+                if (fieldInfo != null)
+                    return (T)fieldInfo.GetValue(d);
+
+                var propertyInfo = type.GetProperty(fieldOrPropertyName, BindingFlags.NonPublic | BindingFlags.Instance);
+                if (propertyInfo != null)
+                    return (T)propertyInfo.GetValue(d);
+
+                type = type.BaseType;
+            }
+
+            throw new Exception($"The property or field {fieldOrPropertyName} could not be reflected.");
+        }
+
+        public static void Set<T>(this Drawable d, string fieldOrPropertyName, T value)
+        {
+            Type type = d.GetType();
+
+            while (type != typeof(object))
+            {
+                // ReSharper disable once PossibleNullReferenceException
+                var fieldInfo = type.GetField(fieldOrPropertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (fieldInfo != null)
+                {
+                    fieldInfo.SetValue(d, value);
+                    return;
+                }
+
+                var propertyInfo = type.GetProperty(fieldOrPropertyName, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (propertyInfo != null)
+                {
+                    propertyInfo.SetValue(d, value);
+                    return;
+                }
+
+                type = type.BaseType;
+            }
+
+            throw new Exception($"The property or field {fieldOrPropertyName} could not be reflected.");
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/TestCaseSpriteTextScenarios.cs
+++ b/osu.Framework.Tests/Visual/TestCaseSpriteTextScenarios.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Tests.Visual
     public class TestCaseSpriteTextScenarios : GridTestCase
     {
         public TestCaseSpriteTextScenarios()
-            : base(4, 4)
+            : base(5, 4)
         {
             Cell(0, 0).Child = new SpriteText { Text = "Basic: Hello world!" };
 
@@ -187,6 +187,23 @@ namespace osu.Framework.Tests.Visual
                         Shadow = true,
                         Colour = Color4.Red,
                         ShadowColour = Color4.Pink.Opacity(0.5f)
+                    }
+                }
+            };
+
+            Cell(4, 0).Child = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box { RelativeSizeAxes = Axes.Both },
+                    new SpriteText
+                    {
+                        Margin = new MarginPadding(-10),
+                        Text = "Negative margins",
+                        Colour = Color4.Red,
                     }
                 }
             };

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -497,7 +497,7 @@ namespace osu.Framework.Graphics.Sprites
             if (source == Parent)
             {
                 // Colour captures presence changes
-                if ((invalidation & (Invalidation.DrawSize | Invalidation.Colour)) > 0)
+                if ((invalidation & Invalidation.DrawSize) > 0)
                     invalidate(true);
 
                 if ((invalidation & Invalidation.DrawInfo) > 0)


### PR DESCRIPTION
With a small layout validation framework, which will be used more in the future.

I didn't want to live on the dark side without knowing that invalidations are occurring as intended.

A single change to SpriteText - not handling parent colour invalidations, as their colour/presence has no effect on our layout. Presence changes are only applicable going children-to-parent, where it may affect, e.g. flow layout.