### PR TITLE
Move reference count exception from Dispose

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseRefCountTexture.cs
+++ b/osu.Framework.Tests/Visual/TestCaseRefCountTexture.cs
@@ -21,19 +21,19 @@ namespace osu.Framework.Tests.Visual
 
             Avatar avatar1 = null;
             Avatar avatar2 = null;
-            Texture texture = null;
+            TextureWithRefCount texture = null;
 
             AddStep("add disposable sprite", () => avatar1 = addSprite("https://a.ppy.sh/3"));
             AddStep("add disposable sprite", () => avatar2 = addSprite("https://a.ppy.sh/3"));
 
-            AddUntilStep(() => (texture = avatar1.Texture) != null, "wait for texture load");
+            AddUntilStep(() => (texture = (TextureWithRefCount)avatar1.Texture) != null, "wait for texture load");
 
             AddAssert("textures share gl texture", () => avatar1.Texture.TextureGL == avatar2.Texture.TextureGL);
             AddAssert("textures have different refcount textures", () => avatar1.Texture != avatar2.Texture);
 
             AddStep("remove delayed from children", Clear);
 
-            AddUntilStep(() => texture.TextureGL.IsDisposed, "gl textures disposed");
+            AddUntilStep(() => texture.ReferenceCount == 0, "gl textures disposed");
         }
 
         private Avatar addSprite(string url)

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -23,13 +23,13 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             Dispose(false);
         }
 
-        private int refCount;
+        internal int ReferenceCount;
 
-        public void Reference() => Interlocked.Increment(ref refCount);
+        public void Reference() => Interlocked.Increment(ref ReferenceCount);
 
         public void Dereference()
         {
-            if (Interlocked.Decrement(ref refCount) == 0)
+            if (Interlocked.Decrement(ref ReferenceCount) == 0)
                 Dispose();
         }
 

--- a/osu.Framework/Graphics/Sprites/Sprite.cs
+++ b/osu.Framework/Graphics/Sprites/Sprite.cs
@@ -91,8 +91,8 @@ namespace osu.Framework.Graphics.Sprites
                     return;
 
                 texture?.Dispose();
-
                 texture = value;
+
                 FillAspectRatio = (float)(texture?.Width ?? 1) / (texture?.Height ?? 1);
                 Invalidate(Invalidation.DrawNode);
 

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Textures
 
         public static Texture WhitePixel => white_pixel.Value;
 
-        public TextureGL TextureGL { get; }
+        public virtual TextureGL TextureGL { get; }
 
         public string Filename;
         public string AssetName;


### PR DESCRIPTION
With the previous implementation, it was possible that the following scenario occurred, causing double dereferencing:

- A Sprite with a Texture is ready for finalizing
- The texture gets finalized first, calling Dispose(false).
- The sprite then gets finalized, calling Texture.Dispose(true).