### PR TITLE
Don't set scheduler to null on disposal

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -360,7 +360,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         internal event Action OnDispose;
 
-        private Lazy<Scheduler> scheduler;
+        private readonly Lazy<Scheduler> scheduler;
 
         internal Thread MainThread { get; private set; }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -91,8 +91,6 @@ namespace osu.Framework.Graphics
 
                 Parent = null;
 
-                scheduler = null;
-
                 OnUpdate = null;
                 OnInvalidate = null;
 


### PR DESCRIPTION
We use the scheduler as a guard against running operations after disposal (ie. web request callbacks) and always assume it is non-null (even after disposal). This breaks that assumption.