### PR TITLE
Reduce allocations/performance overhead of draw nodes

### DIFF
--- a/osu.Framework/Allocation/ValueInvokeOnDisposal.cs
+++ b/osu.Framework/Allocation/ValueInvokeOnDisposal.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Allocation
+{
+    /// <summary>
+    /// Instances of this struct capture an action for later cleanup. The appropriate usage is:
+    /// <code>using (SomeMethod())
+    /// {
+    ///     // ...
+    /// }</code>
+    /// The using block will automatically dispose the returned instance, doing the necessary cleanup work.
+    /// </summary>
+    public struct ValueInvokeOnDisposal : IDisposable
+    {
+        private readonly Action action;
+
+        /// <summary>
+        /// Constructs a new instance, capturing the given action to be run during disposal.
+        /// </summary>
+        /// <param name="action">The action to invoke during disposal.</param>
+        public ValueInvokeOnDisposal(Action action) => this.action = action ?? throw new ArgumentNullException(nameof(action));
+
+        #region IDisposable Support
+
+        /// <summary>
+        /// Disposes this instance, calling the initially captured action.
+        /// </summary>
+        public void Dispose()
+        {
+            //no isDisposed check here so we can reuse these instances multiple times to save on allocations.
+            action();
+        }
+
+        #endregion
+    }
+}

--- a/osu.Framework/Allocation/ValueInvokeOnDisposal.cs
+++ b/osu.Framework/Allocation/ValueInvokeOnDisposal.cs
@@ -12,6 +12,8 @@ namespace osu.Framework.Allocation
     ///     // ...
     /// }</code>
     /// The using block will automatically dispose the returned instance, doing the necessary cleanup work.
+    ///
+    /// This is a struct version of <see cref="InvokeOnDisposal"/> to be used when allocations are to be minimised.
     /// </summary>
     public struct ValueInvokeOnDisposal : IDisposable
     {

--- a/osu.Framework/Graphics/Batches/VertexBatch.cs
+++ b/osu.Framework/Graphics/Batches/VertexBatch.cs
@@ -41,6 +41,8 @@ namespace osu.Framework.Graphics.Batches
             this.maxBuffers = maxBuffers;
 
             AddAction = Add;
+
+            GLWrapper.RegisterVertexBatch(this);
         }
 
         #region Disposal
@@ -61,6 +63,7 @@ namespace osu.Framework.Graphics.Batches
             if (disposing)
                 foreach (VertexBuffer<T> vbo in VertexBuffers)
                     vbo.Dispose();
+            GLWrapper.UnregisterVertexBatch(this);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -72,7 +72,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public bool RequiresRedraw => UpdateVersion > Shared.DrawVersion;
 
-        private InvokeOnDisposal establishFrameBufferViewport(Vector2 roundedSize)
+        private ValueInvokeOnDisposal establishFrameBufferViewport(Vector2 roundedSize)
         {
             // Disable masking for generating the frame buffer since masking will be re-applied
             // when actually drawing later on anyways. This allows more information to be captured
@@ -91,14 +91,16 @@ namespace osu.Framework.Graphics.Containers
             // Match viewport to FrameBuffer such that we don't draw unnecessary pixels.
             GLWrapper.PushViewport(new RectangleI(0, 0, (int)roundedSize.X, (int)roundedSize.Y));
 
-            return new InvokeOnDisposal(delegate
-            {
-                GLWrapper.PopViewport();
-                GLWrapper.PopMaskingInfo();
-            });
+            return new ValueInvokeOnDisposal(returnViewport);
         }
 
-        private InvokeOnDisposal bindFrameBuffer(FrameBuffer frameBuffer, Vector2 requestedSize)
+        private void returnViewport()
+        {
+            GLWrapper.PopViewport();
+            GLWrapper.PopMaskingInfo();
+        }
+
+        private ValueInvokeOnDisposal bindFrameBuffer(FrameBuffer frameBuffer, Vector2 requestedSize)
         {
             if (!frameBuffer.IsInitialized)
                 frameBuffer.Initialize(true, FilteringMode);
@@ -113,7 +115,7 @@ namespace osu.Framework.Graphics.Containers
 
             frameBuffer.Bind();
 
-            return new InvokeOnDisposal(frameBuffer.Unbind);
+            return new ValueInvokeOnDisposal(frameBuffer.Unbind);
         }
 
         private void drawFrameBufferToBackBuffer(FrameBuffer frameBuffer, RectangleF drawRectangle, ColourInfo colourInfo)

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -87,12 +87,8 @@ namespace osu.Framework.Graphics.OpenGL
             lastBlendingInfo = new BlendingInfo();
             lastBlendingEnabledState = null;
 
-            foreach (IVertexBatch b in this_frame_batches)
+            foreach (IVertexBatch b in all_batches)
                 b.ResetCounters();
-
-            this_frame_batches.Clear();
-            if (lastActiveBatch != null)
-                this_frame_batches.Add(lastActiveBatch);
 
             lastFrameBuffer = 0;
 
@@ -175,7 +171,7 @@ namespace osu.Framework.Graphics.OpenGL
 
         private static IVertexBatch lastActiveBatch;
 
-        private static readonly List<IVertexBatch> this_frame_batches = new List<IVertexBatch>();
+        private static readonly List<IVertexBatch> all_batches = new List<IVertexBatch>();
 
         /// <summary>
         /// Sets the last vertex batch used for drawing.
@@ -191,11 +187,20 @@ namespace osu.Framework.Graphics.OpenGL
 
             FlushCurrentBatch();
 
-            if (batch != null && !this_frame_batches.Contains(batch))
-                this_frame_batches.Add(batch);
-
             lastActiveBatch = batch;
         }
+
+        /// <summary>
+        /// Begins tracking a <see cref="IVertexBatch"/>, resetting its counters every frame. This should be invoked once for every <see cref="IVertexBatch"/> in use.
+        /// </summary>
+        /// <param name="batch">The batch to register.</param>
+        internal static void RegisterVertexBatch(IVertexBatch batch) => reset_scheduler.Add(() => all_batches.Add(batch));
+
+        /// <summary>
+        /// Stops tracking a <see cref="IVertexBatch"/>. This should be invoked once when a <see cref="IVertexBatch"/> is no longer in use.
+        /// </summary>
+        /// <param name="batch">The batch to unregister.</param>
+        internal static void UnregisterVertexBatch(IVertexBatch batch) => reset_scheduler.Add(() => all_batches.Remove(batch));
 
         private static TextureGL lastBoundTexture;
 

--- a/osu.Framework/Graphics/Shaders/UniformMapping.cs
+++ b/osu.Framework/Graphics/Shaders/UniformMapping.cs
@@ -40,8 +40,6 @@ namespace osu.Framework.Graphics.Shaders
         {
             Value = newValue;
 
-            // Iterate by index to remove an enumerator allocation
-            // ReSharper disable once ForCanBeConvertedToForeach
             for (int i = 0; i < LinkedUniforms.Count; i++)
                 LinkedUniforms[i].UpdateValue(this);
         }

--- a/osu.Framework/Graphics/Shaders/UniformMapping.cs
+++ b/osu.Framework/Graphics/Shaders/UniformMapping.cs
@@ -39,8 +39,11 @@ namespace osu.Framework.Graphics.Shaders
         public void UpdateValue(ref T newValue)
         {
             Value = newValue;
-            foreach (var linked in LinkedUniforms)
-                linked.UpdateValue(this);
+
+            // Iterate by index to remove an enumerator allocation
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (int i = 0; i < LinkedUniforms.Count; i++)
+                LinkedUniforms[i].UpdateValue(this);
         }
     }
 }


### PR DESCRIPTION
1. `BufferedContainerDrawNode` now spends most of its time binding render buffers, which can be improved further, but is a larger change.
2. Edge effect draw time has been almost halved - probably also a decent representation for masking in general.
