### PR TITLE
Implement a custom SortedList enumerator to reduce allocations

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -39,7 +39,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=EventNeverSubscribedTo_002ELocal/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FieldCanBeMadeReadOnly_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=FieldCanBeMadeReadOnly_002ELocal/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ForCanBeConvertedToForeach/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ForCanBeConvertedToForeach/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InconsistentNaming/@EntryIndexedValue">ERROR</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InheritdocConsiderUsage/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=InlineOutVariableDeclaration/@EntryIndexedValue">HINT</s:String>

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1473,7 +1473,7 @@ namespace osu.Framework.Graphics.Containers
                 Vector2 maxBoundSize = Vector2.Zero;
 
                 // Find the maximum width/height of children
-                foreach (Drawable c in AliveInternalChildren)
+                foreach (Drawable c in aliveInternalChildren)
                 {
                     if (!c.IsPresent)
                         continue;

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -635,8 +635,6 @@ namespace osu.Framework.Graphics.Containers
 
             UpdateAfterChildrenLife();
 
-            // We iterate by index to gain performance
-            // ReSharper disable once ForCanBeConvertedToForeach
             for (int i = 0; i < aliveInternalChildren.Count; ++i)
             {
                 Drawable c = aliveInternalChildren[i];
@@ -679,9 +677,6 @@ namespace osu.Framework.Graphics.Containers
             {
                 var childMaskingBounds = ComputeChildMaskingBounds(maskingBounds);
 
-
-                // We iterate by index to gain performance
-                // ReSharper disable once ForCanBeConvertedToForeach
                 for (int i = 0; i < aliveInternalChildren.Count; i++)
                     aliveInternalChildren[i].UpdateSubTreeMasking(this, childMaskingBounds);
             }
@@ -753,14 +748,9 @@ namespace osu.Framework.Graphics.Containers
 
             if (!shallPropagate) return true;
 
-            // This way of looping turns out to be slightly faster than a foreach
-            // or directly indexing a SortedList<T>. This part of the code is often
-            // hot, so an optimization like this makes sense here.
-            SortedList<Drawable> current = internalChildren;
-            // ReSharper disable once ForCanBeConvertedToForeach
-            for (int i = 0; i < current.Count; ++i)
+            for (int i = 0; i < internalChildren.Count; ++i)
             {
-                Drawable c = current[i];
+                Drawable c = internalChildren[i];
                 Debug.Assert(c != source);
 
                 Invalidation childInvalidation = invalidation;
@@ -857,11 +847,10 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="target">The target list to fill with DrawNodes.</param>
         private static void addFromComposite(ulong frame, int treeIndex, bool forceNewDrawNode, ref int j, CompositeDrawable parentComposite, List<DrawNode> target)
         {
-            SortedList<Drawable> current = parentComposite.aliveInternalChildren;
-            // ReSharper disable once ForCanBeConvertedToForeach
-            for (int i = 0; i < current.Count; ++i)
+            SortedList<Drawable> children = parentComposite.aliveInternalChildren;
+            for (int i = 0; i < children.Count; ++i)
             {
-                Drawable drawable = current[i];
+                Drawable drawable = children[i];
 
                 if (!drawable.IsProxy)
                 {
@@ -1062,8 +1051,6 @@ namespace osu.Framework.Graphics.Containers
             if (!base.BuildKeyboardInputQueue(queue, allowBlocking))
                 return false;
 
-            // We iterate by index to gain performance
-            // ReSharper disable once ForCanBeConvertedToForeach
             for (int i = 0; i < aliveInternalChildren.Count; ++i)
                 aliveInternalChildren[i].BuildKeyboardInputQueue(queue, allowBlocking);
 
@@ -1075,8 +1062,6 @@ namespace osu.Framework.Graphics.Containers
             if (!base.BuildMouseInputQueue(screenSpaceMousePos, queue) && (!CanReceiveMouseInput || Masking))
                 return false;
 
-            // We iterate by index to gain performance
-            // ReSharper disable once ForCanBeConvertedToForeach
             for (int i = 0; i < aliveInternalChildren.Count; ++i)
                 aliveInternalChildren[i].BuildMouseInputQueue(screenSpaceMousePos, queue);
 

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -35,7 +35,15 @@ namespace osu.Framework.Graphics.Lines
             var localPos = ToLocalSpace(screenSpacePos);
             var pathWidthSquared = PathWidth * PathWidth;
 
-            return segments.Any(s => s.DistanceSquaredToPoint(localPos) <= pathWidthSquared);
+            var list = segments;
+
+            foreach (var t in list)
+            {
+                if (t.DistanceSquaredToPoint(localPos) <= pathWidthSquared)
+                    return true;
+            }
+
+            return false;
         }
 
         public Vector2 PositionInBoundingBox(Vector2 pos) => pos - new Vector2(minX, minY);

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -35,14 +35,9 @@ namespace osu.Framework.Graphics.Lines
             var localPos = ToLocalSpace(screenSpacePos);
             var pathWidthSquared = PathWidth * PathWidth;
 
-            var list = segments;
-
-            foreach (var t in list)
-            {
+            foreach (var t in segments)
                 if (t.DistanceSquaredToPoint(localPos) <= pathWidthSquared)
                     return true;
-            }
-
             return false;
         }
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -311,8 +311,10 @@ namespace osu.Framework.Input
             if (this is UserInputManager)
                 FrameStatistics.Increment(StatisticsCounterType.MouseQueue);
 
-            foreach (Drawable d in AliveInternalChildren)
-                d.BuildMouseInputQueue(state.Mouse.Position, positionalInputQueue);
+            // for-loop is used to avoid boxing the enumerator
+            // ReSharper disable once ForCanBeConvertedToForeach
+            for (int i = 0; i < AliveInternalChildren.Count; i++)
+                AliveInternalChildren[i].BuildMouseInputQueue(state.Mouse.Position, positionalInputQueue);
 
             positionalInputQueue.Reverse();
             return positionalInputQueue;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -285,8 +285,9 @@ namespace osu.Framework.Input
             if (this is UserInputManager)
                 FrameStatistics.Increment(StatisticsCounterType.KeyboardQueue);
 
-            foreach (Drawable d in AliveInternalChildren)
-                d.BuildKeyboardInputQueue(inputQueue);
+            var children = AliveInternalChildren;
+            for (int i = 0; i < children.Count; i++)
+                children[i].BuildKeyboardInputQueue(inputQueue);
 
             if (!unfocusIfNoLongerValid())
             {
@@ -311,10 +312,9 @@ namespace osu.Framework.Input
             if (this is UserInputManager)
                 FrameStatistics.Increment(StatisticsCounterType.MouseQueue);
 
-            // for-loop is used to avoid boxing the enumerator
-            // ReSharper disable once ForCanBeConvertedToForeach
-            for (int i = 0; i < AliveInternalChildren.Count; i++)
-                AliveInternalChildren[i].BuildMouseInputQueue(state.Mouse.Position, positionalInputQueue);
+            var children = AliveInternalChildren;
+            for (int i = 0; i < children.Count; i++)
+                children[i].BuildMouseInputQueue(state.Mouse.Position, positionalInputQueue);
 
             positionalInputQueue.Reverse();
             return positionalInputQueue;

--- a/osu.Framework/Lists/SortedList.cs
+++ b/osu.Framework/Lists/SortedList.cs
@@ -163,7 +163,7 @@ namespace osu.Framework.Lists
 
             public bool MoveNext() => ++currentIndex < list.Count;
 
-            public void Reset() => currentIndex = 0;
+            public void Reset() => currentIndex = -1;
 
             public T Current => list[currentIndex];
 

--- a/osu.Framework/Lists/SortedList.cs
+++ b/osu.Framework/Lists/SortedList.cs
@@ -131,9 +131,11 @@ namespace osu.Framework.Lists
 
         void ICollection<T>.Add(T item) => Add(item);
 
-        public IEnumerator<T> GetEnumerator() => list.GetEnumerator();
+        public Enumerator GetEnumerator() => new Enumerator(this);
 
-        IEnumerator IEnumerable.GetEnumerator() => list.GetEnumerator();
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         public void SerializeTo(JsonWriter writer, JsonSerializer serializer)
         {
@@ -147,6 +149,31 @@ namespace osu.Framework.Lists
         }
 
         #endregion
+
+        public struct Enumerator : IEnumerator<T>
+        {
+            private SortedList<T> list;
+            private int currentIndex;
+
+            public Enumerator(SortedList<T> list)
+            {
+                this.list = list;
+                currentIndex = -1; // The first MoveNext() should bring the iterator to 0
+            }
+
+            public bool MoveNext() => ++currentIndex < list.Count;
+
+            public void Reset() => currentIndex = 0;
+
+            public T Current => list[currentIndex];
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+                list = null;
+            }
+        }
     }
 
     [JsonConverter(typeof(SortedListConverter))]

--- a/osu.Framework/Lists/SortedList.cs
+++ b/osu.Framework/Lists/SortedList.cs
@@ -155,7 +155,7 @@ namespace osu.Framework.Lists
             private SortedList<T> list;
             private int currentIndex;
 
-            public Enumerator(SortedList<T> list)
+            internal Enumerator(SortedList<T> list)
             {
                 this.list = list;
                 currentIndex = -1; // The first MoveNext() should bring the iterator to 0


### PR DESCRIPTION
```
             Method |     Mean |     Error |    StdDev |    Gen 0 | Allocated |
------------------- |---------:|----------:|----------:|---------:|----------:|
 NoCustomEnumerator | 67.27 ms | 0.3430 ms | 0.3209 ms | 125.0000 |  400000 B |
   CustomEnumerator | 11.46 ms | 0.0927 ms | 0.0774 ms |        - |       0 B |
```

```
    [MemoryDiagnoser]
    public class Bench
    {
        private SortedList<int> sortedList = new SortedList<int>();
        private SortedListCustomEnumerator<int> sortedListCustomEnumerator = new SortedListCustomEnumerator<int>();

        [GlobalSetup]
        public void Setup()
        {
            for (int i = 0; i < 1000; i++)
            {
                sortedList.Add(i);
                sortedListCustomEnumerator.Add(i);
            }
        }

        [Benchmark]
        public void NoCustomEnumerator()
        {
            int finalValue = 0;

            for (int i = 0; i < 10000; i++)
            {
                foreach (var val in sortedList)
                    finalValue += val;
            }
        }

        [Benchmark]
        public void CustomEnumerator()
        {
            int finalValue = 0;

            for (int i = 0; i < 10000; i++)
            {
                foreach (var val in sortedListCustomEnumerator)
                    finalValue += val;
            }
        }
    }
```

Providing a custom enumerator makes the compiler not box. (https://stackoverflow.com/a/13752402)

Note that this is bypassed if one of the interfaces of `SortedList<T>` is ever used. E.g. this is bypassed by autosize, which references `IReadOnlyList<T> AliveInternalChildren` rather than `SortedList<T> aliveInternalChildren`. But this happens for `List<T>` too.