### PR TITLE
Run aggressive disposal of drawables asynchronously

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -594,7 +594,7 @@ namespace osu.Framework.Graphics.Containers
                     RemoveInternal(child);
 
                     if (child.DisposeOnDeathRemoval)
-                        child.Dispose();
+                        Task.Run(() => child.Dispose());
                 }
             }
 

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -58,8 +58,6 @@ namespace osu.Framework.Screens
             base.Add(drawable);
         }
 
-        public override bool DisposeOnDeathRemoval => true;
-
         // in the case we don't have a parent screen, we still want to handle input as we are also responsible for
         // children inside childScreenContainer.
         // this means the root screen always received input.


### PR DESCRIPTION
Without this, long blocks can occur on the update thread when a large draw hierarchy is disposed. I believe this is better than relying on the finalizer still.

Fixes performance regression from #1849.