### PR TITLE
Disable mipmap generation for LargeTextureStore

### DIFF
--- a/osu.Framework/Graphics/Textures/LargeTextureStore.cs
+++ b/osu.Framework/Graphics/Textures/LargeTextureStore.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.IO.Stores;
+using OpenTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Textures
 {
@@ -11,7 +12,7 @@ namespace osu.Framework.Graphics.Textures
     public class LargeTextureStore : TextureStore
     {
         public LargeTextureStore(IResourceStore<TextureUpload> store = null)
-            : base(store, false)
+            : base(store, false, All.Linear, true)
         {
         }
 


### PR DESCRIPTION
Until we decide on the correct path forward for mipmapping, I believe this is a better default for LargeTextureStores. It will result in lower quality texture display when scaled below 1.0, but avoid large stutters due to CPU-based mipmap generation occurring on the draw thread.