### PR TITLE
Iterate by index in CompositeDrawNode for increased performance

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
@@ -211,8 +211,8 @@ namespace osu.Framework.Graphics.Containers
             }
 
             if (Children != null)
-                foreach (DrawNode child in Children)
-                    child.Draw(vertexAction);
+                for (int i = 0; i < Children.Count; i++)
+                    Children[i].Draw(vertexAction);
 
             if (MaskingInfo != null)
                 GLWrapper.PopMaskingInfo();


### PR DESCRIPTION
As determined previously, iterating by index in hot paths can be beneficial in terms of performance with minimal overhead. Just squeezing out as much as we can.