### PR TITLE
Fix disposal checks throwing exceptions in drawnodes

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTextures.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextures.cs
@@ -1,6 +1,7 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -10,15 +11,20 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual
 {
-    public class TestCaseRefCountTexture : TestCase
+    public class TestCaseTextures : TestCase
     {
         [Cached]
-        private LargeTextureStore largeStore;
+        private readonly TextureStore normalStore = new TextureStore(new TextureLoaderStore(new OnlineStore()));
 
-        public TestCaseRefCountTexture()
+        [Cached]
+        private readonly LargeTextureStore largeStore = new LargeTextureStore(new TextureLoaderStore(new OnlineStore()));
+
+        /// <summary>
+        /// Tests that a ref-counted texture is disposed when all references are lost.
+        /// </summary>
+        [Test]
+        public void TestRefCountTextureDisposal()
         {
-            largeStore = new LargeTextureStore(new TextureLoaderStore(new OnlineStore()));
-
             Avatar avatar1 = null;
             Avatar avatar2 = null;
             TextureWithRefCount texture = null;
@@ -34,6 +40,34 @@ namespace osu.Framework.Tests.Visual
             AddStep("remove delayed from children", Clear);
 
             AddUntilStep(() => texture.ReferenceCount == 0, "gl textures disposed");
+        }
+
+        /// <summary>
+        /// Tests that a ref-counted texture gets put in a non-available state when disposed.
+        /// </summary>
+        [Test]
+        public void TestRefCountTextureAvailability()
+        {
+            Texture texture = null;
+
+            AddStep("get texture", () => texture = largeStore.Get("https://a.ppy.sh/3"));
+            AddStep("dispose texture", () => texture.Dispose());
+
+            AddAssert("texture is not available", () => !texture.Available);
+        }
+
+        /// <summary>
+        /// Tests that a non-ref-counted texture remains in an available state when disposed.
+        /// </summary>
+        [Test]
+        public void TestTextureAvailability()
+        {
+            Texture texture = null;
+
+            AddStep("get texture", () => texture = normalStore.Get("https://a.ppy.sh/3"));
+            AddStep("dispose texture", () => texture.Dispose());
+
+            AddAssert("texture is still available", () => texture.Available);
         }
 
         private Avatar addSprite(string url)

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -249,7 +249,7 @@ namespace osu.Framework.Graphics.Audio
             {
                 base.Draw(vertexAction);
 
-                if (Texture?.IsDisposed != false || points == null || points.Count == 0)
+                if (Texture?.Available != true || points == null || points.Count == 0)
                     return;
 
                 Shader.Bind();

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -249,7 +249,7 @@ namespace osu.Framework.Graphics.Audio
             {
                 base.Draw(vertexAction);
 
-                if (points == null || points.Count == 0)
+                if (Texture?.IsDisposed != false || points == null || points.Count == 0)
                     return;
 
                 Shader.Bind();

--- a/osu.Framework/Graphics/Lines/PathDrawNode.cs
+++ b/osu.Framework/Graphics/Lines/PathDrawNode.cs
@@ -191,7 +191,7 @@ namespace osu.Framework.Graphics.Lines
         {
             base.Draw(vertexAction);
 
-            if (Texture?.TextureGL?.IsDisposed != false || Segments.Count == 0)
+            if (Texture?.IsDisposed != false || Segments.Count == 0)
                 return;
 
             GLWrapper.SetDepthTest(true);

--- a/osu.Framework/Graphics/Lines/PathDrawNode.cs
+++ b/osu.Framework/Graphics/Lines/PathDrawNode.cs
@@ -191,7 +191,7 @@ namespace osu.Framework.Graphics.Lines
         {
             base.Draw(vertexAction);
 
-            if (Texture?.IsDisposed != false || Segments.Count == 0)
+            if (Texture?.Available != true || Segments.Count == 0)
                 return;
 
             GLWrapper.SetDepthTest(true);

--- a/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.Sprites
         {
             base.Draw(vertexAction);
 
-            if (Texture?.IsDisposed != false)
+            if (Texture?.Available != true)
                 return;
 
             Shader shader = needsRoundedShader ? RoundedTextureShader : TextureShader;

--- a/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.Sprites
         {
             base.Draw(vertexAction);
 
-            if (Texture?.TextureGL?.IsDisposed != false)
+            if (Texture?.IsDisposed != false)
                 return;
 
             Shader shader = needsRoundedShader ? RoundedTextureShader : TextureShader;

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -133,7 +133,8 @@ namespace osu.Framework.Graphics.Textures
 
         #region Disposal
 
-        public bool IsDisposed { get; private set; }
+        public virtual bool IsDisposed => isDisposed;
+        private bool isDisposed;
 
         // Intentionally no finalizer implementation as our disposal is NOOP. Finalizer is implemented in TextureWithRefCount usage.
 
@@ -144,8 +145,9 @@ namespace osu.Framework.Graphics.Textures
 
         protected virtual void Dispose(bool isDisposing)
         {
-            if (IsDisposed) return;
-            IsDisposed = true;
+            if (isDisposed)
+                return;
+            isDisposed = true;
         }
 
         #endregion

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -134,7 +134,7 @@ namespace osu.Framework.Graphics.Textures
         /// <summary>
         /// Whether <see cref="TextureGL"/> is in a usable state.
         /// </summary>
-        public virtual bool Available => !TextureGL.IsDisposed;
+        public virtual bool Available => !IsDisposed && !TextureGL.IsDisposed;
 
         #region Disposal
 

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -131,10 +131,14 @@ namespace osu.Framework.Graphics.Textures
 
         public override string ToString() => $@"{AssetName} ({Width}, {Height})";
 
+        /// <summary>
+        /// Whether <see cref="TextureGL"/> is in a usable state.
+        /// </summary>
+        public virtual bool Available => !TextureGL.IsDisposed;
+
         #region Disposal
 
-        public virtual bool IsDisposed => isDisposed;
-        private bool isDisposed;
+        public bool IsDisposed { get; private set; }
 
         // Intentionally no finalizer implementation as our disposal is NOOP. Finalizer is implemented in TextureWithRefCount usage.
 
@@ -145,9 +149,9 @@ namespace osu.Framework.Graphics.Textures
 
         protected virtual void Dispose(bool isDisposing)
         {
-            if (isDisposed)
+            if (IsDisposed)
                 return;
-            isDisposed = true;
+            IsDisposed = true;
         }
 
         #endregion

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -134,11 +134,9 @@ namespace osu.Framework.Graphics.Textures
         /// <summary>
         /// Whether <see cref="TextureGL"/> is in a usable state.
         /// </summary>
-        public virtual bool Available => !IsDisposed && !TextureGL.IsDisposed;
+        public virtual bool Available => !TextureGL.IsDisposed;
 
         #region Disposal
-
-        public bool IsDisposed { get; private set; }
 
         // Intentionally no finalizer implementation as our disposal is NOOP. Finalizer is implemented in TextureWithRefCount usage.
 
@@ -149,9 +147,6 @@ namespace osu.Framework.Graphics.Textures
 
         protected virtual void Dispose(bool isDisposing)
         {
-            if (IsDisposed)
-                return;
-            IsDisposed = true;
         }
 
         #endregion

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Graphics.Textures
             //Laziness ensure we are only ever creating the texture once (and blocking on other access until it is done).
             var cachedTex = textureCache.GetOrAdd(name, lazyCreator).Value;
 
-            if (cachedTex?.TextureGL?.IsDisposed == true)
+            if (cachedTex?.IsDisposed == true)
             {
                 textureCache.TryRemove(name, out _);
                 return Get(name);

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Graphics.Textures
             //Laziness ensure we are only ever creating the texture once (and blocking on other access until it is done).
             var cachedTex = textureCache.GetOrAdd(name, lazyCreator).Value;
 
-            if (cachedTex?.IsDisposed == true)
+            if (cachedTex?.Available == false)
             {
                 textureCache.TryRemove(name, out _);
                 return Get(name);

--- a/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
+++ b/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
@@ -31,7 +31,8 @@ namespace osu.Framework.Graphics.Textures
         }
 
         // Can't reference our own TextureGL here as an exception may be thrown
-        public sealed override bool Available => !IsDisposed && !base.TextureGL.IsDisposed;
+        public sealed override bool Available => !isDisposed && !base.TextureGL.IsDisposed;
+        private bool isDisposed;
 
         #region Disposal
 
@@ -43,10 +44,11 @@ namespace osu.Framework.Graphics.Textures
 
         protected override void Dispose(bool isDisposing)
         {
-            if (IsDisposed)
-                return;
-
             base.Dispose(isDisposing);
+
+            if (isDisposed)
+                return;
+            isDisposed = true;
 
             base.TextureGL.Dereference();
             if (isDisposing) GC.SuppressFinalize(this);

--- a/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
+++ b/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Graphics.Textures
         }
 
         // Can't reference our own TextureGL here as an exception may be thrown
-        public sealed override bool Available => !base.TextureGL.IsDisposed;
+        public sealed override bool Available => !IsDisposed && !base.TextureGL.IsDisposed;
 
         #region Disposal
 

--- a/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
+++ b/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
@@ -30,10 +30,10 @@ namespace osu.Framework.Graphics.Textures
             }
         }
 
-        #region Disposal
+        // Can't reference our own TextureGL here as an exception may be thrown
+        public sealed override bool Available => !base.TextureGL.IsDisposed;
 
-        // We can't reference our own TextureGL here as we may throw an exception
-        public sealed override bool IsDisposed => base.IsDisposed || base.TextureGL.IsDisposed;
+        #region Disposal
 
         ~TextureWithRefCount()
         {

--- a/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
+++ b/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using osu.Framework.Graphics.OpenGL.Textures;
 
 namespace osu.Framework.Graphics.Textures
@@ -34,13 +32,14 @@ namespace osu.Framework.Graphics.Textures
 
         #region Disposal
 
+        // We can't reference our own TextureGL here as we may throw an exception
+        public sealed override bool IsDisposed => base.IsDisposed || base.TextureGL.IsDisposed;
+
         ~TextureWithRefCount()
         {
             // Finalizer implemented here rather than Texture to avoid GC overhead.
             Dispose(false);
         }
-
-        private readonly List<StackTrace> stackTraces = new List<StackTrace>();
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -126,7 +126,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             base.Draw(vertexAction);
 
-            if (Texture?.IsDisposed != false)
+            if (Texture?.Available != true)
                 return;
 
             Shader shader = needsRoundedShader ? RoundedTextureShader : TextureShader;

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -126,7 +126,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             base.Draw(vertexAction);
 
-            if (Texture?.TextureGL?.IsDisposed != false)
+            if (Texture?.IsDisposed != false)
                 return;
 
             Shader shader = needsRoundedShader ? RoundedTextureShader : TextureShader;


### PR DESCRIPTION
With these changes, `DrawNode` implementations must check `Texture?.Available == true` rather than `Texture?.TextureGL?.IsDisposed != false`.

Because `TextureWithRefCount` throws an exception when accessing `TextureGL`.