### PR TITLE
Reduce allocations when iterating over children of a container

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -98,17 +98,11 @@ namespace osu.Framework.Graphics.Containers
                 array[arrayIndex++] = c;
         }
 
-        /// <summary>
-        /// Gets the enumerator over <see cref="Children"/>.
-        /// </summary>
-        /// <returns>The enumerator over <see cref="Children"/>.</returns>
-        public IEnumerator<T> GetEnumerator() => Children.GetEnumerator();
+        public Enumerator GetEnumerator() => new Enumerator(this);
 
-        /// <summary>
-        /// Gets the enumerator over <see cref="Children"/>.
-        /// </summary>
-        /// <returns>The enumerator over <see cref="Children"/>.</returns>
-        IEnumerator IEnumerable.GetEnumerator() => Children.GetEnumerator();
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <summary>
         /// Sets all children of this container to the elements contained in the enumerable.
@@ -404,6 +398,31 @@ namespace osu.Framework.Graphics.Containers
         {
             get => base.AutoSizeEasing;
             set => base.AutoSizeEasing = value;
+        }
+
+        public struct Enumerator : IEnumerator<T>
+        {
+            private Container<T> container;
+            private int currentIndex;
+
+            internal Enumerator(Container<T> container)
+            {
+                this.container = container;
+                currentIndex = -1; // The first MoveNext() should bring the iterator to 0
+            }
+
+            public bool MoveNext() => ++currentIndex < container.Count;
+
+            public void Reset() => currentIndex = -1;
+
+            public T Current => container[currentIndex];
+
+            object IEnumerator.Current => Current;
+
+            public void Dispose()
+            {
+                container = null;
+            }
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -57,6 +57,9 @@ namespace osu.Framework.Graphics.Containers
         /// The publicly accessible list of children. Forwards to the children of <see cref="Content"/>.
         /// If <see cref="Content"/> is this container, then returns <see cref="CompositeDrawable.InternalChildren"/>.
         /// Assigning to this property will dispose all existing children of this Container.
+        /// <remarks>
+        /// If a foreach loop is used, iterate over the <see cref="Container"/> directly rather than its <see cref="Children"/>.
+        /// </remarks>
         /// </summary>
         public IReadOnlyList<T> Children
         {


### PR DESCRIPTION
Was about to iterate over a container in `Update()` then I realized this would be problematic:

```
         Method |     Mean |    Error |   StdDev |    Gen 0 | Allocated |
-------------   |---------:|---------:|---------:|---------:|----------:|
 NoEnumerator   | 326.4 us | 4.631 us | 4.106 us | 101.5625 |  312.5 KB |
 WithEnumerator | 177.8 us | 3.483 us | 4.146 us |        0 |       0 B |
```

There is a duplication of the enumerator with `SortedList<T>`, BUT baking it into `Container<T>` yields a ~25% (220us -> 170us) performance improvement, over extracting it out into a common generic struct.

Along with this, we should iterate over a container rather than its `Children`. E.g. `SectionsContainer.UpdateAfterChildren()` iterates over `Children`, which is an interface and will box the enumerator.