### PR TITLE
Add Drawable.Click method

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -29,6 +29,7 @@ using osu.Framework.Input.EventArgs;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.MathUtils;
+using OpenTK.Input;
 using JoystickEventArgs = osu.Framework.Input.EventArgs.JoystickEventArgs;
 
 namespace osu.Framework.Graphics
@@ -1832,6 +1833,12 @@ namespace osu.Framework.Graphics
             e.Target = this;
             return Handle(e);
         }
+
+        /// <summary>
+        /// Triggers a left click event for this <see cref="Drawable"/>.
+        /// </summary>
+        /// <returns>Whether the click event is handled.</returns>
+        public bool Click() => TriggerEvent(new ClickEvent(GetContainingInputManager()?.CurrentState ?? new InputState(), MouseButton.Left));
 
         #region Legacy event handling
         protected virtual bool OnMouseMove(InputState state) => false;


### PR DESCRIPTION
`TriggerOnXXX` is now removed by #1713 but triggering a left click is most used and most useful to have an own method. Will be used for osu! framework update PR.

---
