### PR TITLE
Prefer higher color depth when selecting fullscreen display mode

### DIFF
--- a/osu.Framework/Platform/DesktopGameWindow.cs
+++ b/osu.Framework/Platform/DesktopGameWindow.cs
@@ -87,6 +87,7 @@ namespace osu.Framework.Platform
             var newResolution = display.AvailableResolutions
                                               .Where(r => r.Width == newSize.Width && r.Height == newSize.Height)
                                               .OrderByDescending(r => r.RefreshRate)
+                                              .ThenByDescending(r => r.BitsPerPixel)
                                               .FirstOrDefault();
 
             if (newResolution == null)


### PR DESCRIPTION
Refresh rate stays the primary factor, but if multiple bpp modes share the highest refresh rate, the highest color depth will be selected.

- Closes ppy/osu#3417