### PR TITLE
Rename Keyboard/Mouse to NonPositional/Positional

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseConcurrentLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseConcurrentLoad.cs
@@ -68,8 +68,8 @@ namespace osu.Framework.Tests.Visual
 
         private class FillFlowContainerNoInput : FillFlowContainer<Drawable>
         {
-            public override bool HandleKeyboardInput => false;
-            public override bool HandleMouseInput => false;
+            public override bool HandleNonPositionaInput => false;
+            public override bool HandlePositionaInput => false;
         }
 
         public class DelayedTestBox : Box

--- a/osu.Framework.Tests/Visual/TestCaseConcurrentLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseConcurrentLoad.cs
@@ -68,8 +68,8 @@ namespace osu.Framework.Tests.Visual
 
         private class FillFlowContainerNoInput : FillFlowContainer<Drawable>
         {
-            public override bool HandleNonPositionaInput => false;
-            public override bool HandlePositionaInput => false;
+            public override bool HandleNonPositionalInput => false;
+            public override bool HandlePositionalInput => false;
         }
 
         public class DelayedTestBox : Box

--- a/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
@@ -66,8 +66,8 @@ namespace osu.Framework.Tests.Visual
 
         private class FillFlowContainerNoInput : FillFlowContainer<Container>
         {
-            public override bool HandleNonPositionaInput => false;
-            public override bool HandlePositionaInput => false;
+            public override bool HandleNonPositionalInput => false;
+            public override bool HandlePositionalInput => false;
         }
 
         public class TestBox : Container

--- a/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDelayedLoad.cs
@@ -66,8 +66,8 @@ namespace osu.Framework.Tests.Visual
 
         private class FillFlowContainerNoInput : FillFlowContainer<Container>
         {
-            public override bool HandleKeyboardInput => false;
-            public override bool HandleMouseInput => false;
+            public override bool HandleNonPositionaInput => false;
+            public override bool HandlePositionaInput => false;
         }
 
         public class TestBox : Container

--- a/osu.Framework.Tests/Visual/TestCaseDelayedUnload.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDelayedUnload.cs
@@ -73,8 +73,8 @@ namespace osu.Framework.Tests.Visual
 
         private class FillFlowContainerNoInput : FillFlowContainer<Container>
         {
-            public override bool HandleNonPositionaInput => false;
-            public override bool HandlePositionaInput => false;
+            public override bool HandleNonPositionalInput => false;
+            public override bool HandlePositionalInput => false;
         }
 
         public class TestBox : Container

--- a/osu.Framework.Tests/Visual/TestCaseDelayedUnload.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDelayedUnload.cs
@@ -73,8 +73,8 @@ namespace osu.Framework.Tests.Visual
 
         private class FillFlowContainerNoInput : FillFlowContainer<Container>
         {
-            public override bool HandleKeyboardInput => false;
-            public override bool HandleMouseInput => false;
+            public override bool HandleNonPositionaInput => false;
+            public override bool HandlePositionaInput => false;
         }
 
         public class TestBox : Container

--- a/osu.Framework.Tests/Visual/TestCaseFocus.cs
+++ b/osu.Framework.Tests/Visual/TestCaseFocus.cs
@@ -248,11 +248,11 @@ namespace osu.Framework.Tests.Visual
                 stateText.Text = State.ToString();
             }
 
-            public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => true;
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
             protected override bool OnClick(InputState state)
             {
-                if (!box.ReceiveMouseInputAt(state.Mouse.NativeState.Position))
+                if (!box.ReceivePositionalInputAt(state.Mouse.NativeState.Position))
                 {
                     State = Visibility.Hidden;
                     return true;

--- a/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
+++ b/osu.Framework.Tests/Visual/TestCaseKeyBindings.cs
@@ -429,7 +429,7 @@ namespace osu.Framework.Tests.Visual
                 return false;
             }
 
-            public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => true;
+            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
         }
 
         private class ScrollTestButton : TestButton, IScrollBindingHandler<TestAction>

--- a/osu.Framework.Tests/Visual/TestCasePathInput.cs
+++ b/osu.Framework.Tests/Visual/TestCasePathInput.cs
@@ -128,12 +128,12 @@ namespace osu.Framework.Tests.Visual
             path.Positions = vertices.ToList();
         });
 
-        private void test(Vector2 position, bool shouldReceiveMouseInput)
+        private void test(Vector2 position, bool shouldReceivePositionalInput)
         {
-            AddAssert($"Test @ {position} = {shouldReceiveMouseInput}", () =>
+            AddAssert($"Test @ {position} = {shouldReceivePositionalInput}", () =>
             {
                 testPoint.Position = position;
-                return path.ReceiveMouseInputAt(path.ToScreenSpace(position)) == shouldReceiveMouseInput;
+                return path.ReceivePositionalInputAt(path.ToScreenSpace(position)) == shouldReceivePositionalInput;
             });
         }
 

--- a/osu.Framework.Tests/Visual/TestCaseTooltip.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTooltip.cs
@@ -203,8 +203,8 @@ namespace osu.Framework.Tests.Visual
         {
             public string TooltipText { get; set; }
 
-            public override bool HandleNonPositionaInput => true;
-            public override bool HandlePositionaInput => true;
+            public override bool HandleNonPositionalInput => true;
+            public override bool HandlePositionalInput => true;
         }
 
         private class RectangleCursorContainer : CursorContainer

--- a/osu.Framework.Tests/Visual/TestCaseTooltip.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTooltip.cs
@@ -203,8 +203,8 @@ namespace osu.Framework.Tests.Visual
         {
             public string TooltipText { get; set; }
 
-            public override bool HandleKeyboardInput => true;
-            public override bool HandleMouseInput => true;
+            public override bool HandleNonPositionaInput => true;
+            public override bool HandlePositionaInput => true;
         }
 
         private class RectangleCursorContainer : CursorContainer

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1030,8 +1030,8 @@ namespace osu.Framework.Graphics.Containers
 
         // Required to pass through input to children by default.
         // TODO: Evaluate effects of this on performance and address.
-        public override bool HandleKeyboardInput => true;
-        public override bool HandleMouseInput => true;
+        public override bool HandleNonPositionaInput => true;
+        public override bool HandlePositionaInput => true;
 
         public override bool Contains(Vector2 screenSpacePos)
         {
@@ -1043,24 +1043,24 @@ namespace osu.Framework.Graphics.Containers
             return DrawRectangle.Shrink(cRadius).DistanceSquared(ToLocalSpace(screenSpacePos)) <= cRadius * cRadius;
         }
 
-        internal override bool BuildKeyboardInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
-            if (!base.BuildKeyboardInputQueue(queue, allowBlocking))
+            if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))
                 return false;
 
             for (int i = 0; i < aliveInternalChildren.Count; ++i)
-                aliveInternalChildren[i].BuildKeyboardInputQueue(queue, allowBlocking);
+                aliveInternalChildren[i].BuildNonPositionalInputQueue(queue, allowBlocking);
 
             return true;
         }
 
-        internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
+        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
-            if (!base.BuildMouseInputQueue(screenSpaceMousePos, queue) && (!CanReceiveMouseInput || Masking))
+            if (!base.BuildPositionalInputQueue(screenSpacePos, queue) && (!CanReceivePositionalInput || Masking))
                 return false;
 
             for (int i = 0; i < aliveInternalChildren.Count; ++i)
-                aliveInternalChildren[i].BuildMouseInputQueue(screenSpaceMousePos, queue);
+                aliveInternalChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
 
             return true;
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1030,8 +1030,8 @@ namespace osu.Framework.Graphics.Containers
 
         // Required to pass through input to children by default.
         // TODO: Evaluate effects of this on performance and address.
-        public override bool HandleNonPositionaInput => true;
-        public override bool HandlePositionaInput => true;
+        public override bool HandleNonPositionalInput => true;
+        public override bool HandlePositionalInput => true;
 
         public override bool Contains(Vector2 screenSpacePos)
         {

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -13,37 +13,37 @@ namespace osu.Framework.Graphics.Containers
     public abstract class OverlayContainer : VisibilityContainer
     {
         /// <summary>
-        /// Whether we should block any mouse input from interacting with things behind us.
+        /// Whether we should block any positional input from interacting with things behind us.
         /// </summary>
-        protected virtual bool BlockPassThroughMouse => true;
+        protected virtual bool BlockPositionalInput => true;
 
         /// <summary>
-        /// Whether we should block any keyboard input from interacting with things behind us.
+        /// Whether we should block any non-positional input from interacting with things behind us.
         /// </summary>
-        protected virtual bool BlockPassThroughKeyboard => false;
+        protected virtual bool BlockNonPositionalInput => false;
 
-        internal override bool BuildKeyboardInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
-            if (CanReceiveKeyboardInput && BlockPassThroughKeyboard)
+            if (CanReceiveNonPositionalInput && BlockNonPositionalInput)
             {
-                // when blocking keyboard input behind us, we still want to make sure the global handlers receive events
+                // when blocking non-positional input behind us, we still want to make sure the global handlers receive events
                 // but we don't want other drawables behind us handling them.
                 queue.RemoveAll(d => !(d is IHandleGlobalInput));
             }
 
-            return base.BuildKeyboardInputQueue(queue, allowBlocking);
+            return base.BuildNonPositionalInputQueue(queue, allowBlocking);
         }
 
-        internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
+        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
-            if (CanReceiveMouseInput && BlockPassThroughMouse && ReceiveMouseInputAt(screenSpaceMousePos))
+            if (CanReceivePositionalInput && BlockPositionalInput && ReceivePositionalInputAt(screenSpacePos))
             {
-                // when blocking mouse input behind us, we still want to make sure the global handlers receive events
+                // when blocking positional input behind us, we still want to make sure the global handlers receive events
                 // but we don't want other drawables behind us handling them.
                 queue.RemoveAll(d => !(d is IHandleGlobalInput));
             }
 
-            return base.BuildMouseInputQueue(screenSpaceMousePos, queue);
+            return base.BuildPositionalInputQueue(screenSpacePos, queue);
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -163,7 +163,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected virtual bool IsDragging { get; private set; }
 
-        public bool IsHandlingKeyboardScrolling => IsHovered || ReceiveMouseInputAt(GetContainingInputManager().CurrentState.Mouse.Position);
+        public bool IsHandlingKeyboardScrolling => IsHovered || ReceivePositionalInputAt(GetContainingInputManager().CurrentState.Mouse.Position);
 
         /// <summary>
         /// The direction in which scrolling is supported.

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -118,8 +118,8 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        public override bool HandleKeyboardInput => false;
-        public override bool HandleMouseInput => false;
+        public override bool HandleNonPositionaInput => false;
+        public override bool HandlePositionaInput => false;
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -118,8 +118,8 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        public override bool HandleNonPositionaInput => false;
-        public override bool HandlePositionaInput => false;
+        public override bool HandleNonPositionalInput => false;
+        public override bool HandlePositionalInput => false;
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {

--- a/osu.Framework/Graphics/Containers/VisibilityContainer.cs
+++ b/osu.Framework/Graphics/Containers/VisibilityContainer.cs
@@ -67,8 +67,8 @@ namespace osu.Framework.Graphics.Containers
 
         public override void Show() => State = Visibility.Visible;
 
-        public override bool HandleNonPositionaInput => State == Visibility.Visible;
-        public override bool HandlePositionaInput => State == Visibility.Visible;
+        public override bool HandleNonPositionalInput => State == Visibility.Visible;
+        public override bool HandlePositionalInput => State == Visibility.Visible;
 
         public event Action<Visibility> StateChanged;
 

--- a/osu.Framework/Graphics/Containers/VisibilityContainer.cs
+++ b/osu.Framework/Graphics/Containers/VisibilityContainer.cs
@@ -67,8 +67,8 @@ namespace osu.Framework.Graphics.Containers
 
         public override void Show() => State = Visibility.Visible;
 
-        public override bool HandleKeyboardInput => State == Visibility.Visible;
-        public override bool HandleMouseInput => State == Visibility.Visible;
+        public override bool HandleNonPositionaInput => State == Visibility.Visible;
+        public override bool HandlePositionaInput => State == Visibility.Visible;
 
         public event Action<Visibility> StateChanged;
 

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -31,9 +31,9 @@ namespace osu.Framework.Graphics.Cursor
 
         protected virtual Drawable CreateCursor() => new Cursor();
 
-        public override bool ReceiveMouseInputAt(Vector2 screenSpacePos) => true;
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
-        public override bool HandleMouseInput => IsPresent; // make sure we are still updating position during possible fade out.
+        public override bool HandlePositionaInput => IsPresent; // make sure we are still updating position during possible fade out.
 
         protected override bool OnMouseMove(InputState state)
         {

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Graphics.Cursor
 
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => true;
 
-        public override bool HandlePositionaInput => IsPresent; // make sure we are still updating position during possible fade out.
+        public override bool HandlePositionalInput => IsPresent; // make sure we are still updating position during possible fade out.
 
         protected override bool OnMouseMove(InputState state)
         {

--- a/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
@@ -5,7 +5,7 @@ namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
     /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a custom tooltip if it is the child of a <see cref="TooltipContainer"/>.
-    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasCustomTooltip"/> has <see cref="Drawable.HandlePositionaInput"/> set to true.
+    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasCustomTooltip"/> has <see cref="Drawable.HandlePositionalInput"/> set to true.
     /// </summary>
     public interface IHasCustomTooltip : IHasTooltip
     {

--- a/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasCustomTooltip.cs
@@ -5,7 +5,7 @@ namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
     /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a custom tooltip if it is the child of a <see cref="TooltipContainer"/>.
-    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasCustomTooltip"/> has <see cref="Drawable.HandleMouseInput"/> set to true.
+    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasCustomTooltip"/> has <see cref="Drawable.HandlePositionaInput"/> set to true.
     /// </summary>
     public interface IHasCustomTooltip : IHasTooltip
     {

--- a/osu.Framework/Graphics/Cursor/IHasTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasTooltip.cs
@@ -6,7 +6,7 @@ namespace osu.Framework.Graphics.Cursor
     /// <summary>
     /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a tooltip if it is the child of a <see cref="TooltipContainer"/>. The tooltip used is
     /// dependent on the implementation of the <see cref="TooltipContainer.CreateTooltip"/> method of the <see cref="TooltipContainer"/> containing this <see cref="Drawable"/>.
-    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasTooltip"/> has <see cref="Drawable.HandleMouseInput"/> set to true.
+    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasTooltip"/> has <see cref="Drawable.HandlePositionaInput"/> set to true.
     /// </summary>
     public interface IHasTooltip : IDrawable
     {

--- a/osu.Framework/Graphics/Cursor/IHasTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasTooltip.cs
@@ -6,7 +6,7 @@ namespace osu.Framework.Graphics.Cursor
     /// <summary>
     /// Implementing this interface allows the implementing <see cref="Drawable"/> to display a tooltip if it is the child of a <see cref="TooltipContainer"/>. The tooltip used is
     /// dependent on the implementation of the <see cref="TooltipContainer.CreateTooltip"/> method of the <see cref="TooltipContainer"/> containing this <see cref="Drawable"/>.
-    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasTooltip"/> has <see cref="Drawable.HandlePositionaInput"/> set to true.
+    /// Keep in mind that tooltips can only be displayed by a <see cref="TooltipContainer"/> if the <see cref="Drawable"/> implementing <see cref="IHasTooltip"/> has <see cref="Drawable.HandlePositionalInput"/> set to true.
     /// </summary>
     public interface IHasTooltip : IDrawable
     {

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -15,7 +15,7 @@ using System.Linq;
 namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
-    /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces. Keep in mind that only children with <see cref="Drawable.HandlePositionaInput"/> set to true will be checked for their tooltips.
+    /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces. Keep in mind that only children with <see cref="Drawable.HandlePositionalInput"/> set to true will be checked for their tooltips.
     /// </summary>
     public class TooltipContainer : CursorEffectContainer<TooltipContainer, IHasTooltip>, IHandleGlobalInput
     {
@@ -279,8 +279,8 @@ namespace osu.Framework.Graphics.Cursor
                 set => text.Text = value;
             }
 
-            public override bool HandleNonPositionaInput => false;
-            public override bool HandlePositionaInput => false;
+            public override bool HandleNonPositionalInput => false;
+            public override bool HandlePositionalInput => false;
 
             private const float text_size = 16;
 

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -15,7 +15,7 @@ using System.Linq;
 namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
-    /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces. Keep in mind that only children with <see cref="Drawable.HandleMouseInput"/> set to true will be checked for their tooltips.
+    /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces. Keep in mind that only children with <see cref="Drawable.HandlePositionaInput"/> set to true will be checked for their tooltips.
     /// </summary>
     public class TooltipContainer : CursorEffectContainer<TooltipContainer, IHasTooltip>, IHandleGlobalInput
     {
@@ -279,8 +279,8 @@ namespace osu.Framework.Graphics.Cursor
                 set => text.Text = value;
             }
 
-            public override bool HandleKeyboardInput => false;
-            public override bool HandleMouseInput => false;
+            public override bool HandleNonPositionaInput => false;
+            public override bool HandlePositionaInput => false;
 
             private const float text_size = 16;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -227,7 +227,7 @@ namespace osu.Framework.Graphics
 
             double t1 = getPerfTime();
 
-            handleNonPositionaInput = HandleInputCache.HandleNonPositionalInput(this);
+            handleNonPositionalInput = HandleInputCache.HandleNonPositionalInput(this);
             handlePositionalInput = HandleInputCache.HandlePositionalInput(this);
 
             InjectDependencies(dependencies);
@@ -1860,22 +1860,22 @@ namespace osu.Framework.Graphics
         protected virtual bool OnJoystickRelease(InputState state, JoystickEventArgs args) => false;
         #endregion
 
-        private bool handleNonPositionaInput, handlePositionalInput;
+        private bool handleNonPositionalInput, handlePositionalInput;
 
         /// <summary>
         /// Whether this <see cref="Drawable"/> handles non-positional input.
         /// This value is true by default if any keyboard and other non-positional "On-" input methods are overridden.
         /// </summary>
-        public virtual bool HandleNonPositionaInput => handleNonPositionaInput;
+        public virtual bool HandleNonPositionalInput => handleNonPositionalInput;
 
         /// <summary>
         /// Whether this <see cref="Drawable"/> handles positional input.
         /// This value is true by default if any mouse related "On-" input methods are overridden.
         /// </summary>
-        public virtual bool HandlePositionaInput => handlePositionalInput;
+        public virtual bool HandlePositionalInput => handlePositionalInput;
 
         /// <summary>
-        /// Nested class which is used for caching <see cref="Drawable.HandleNonPositionaInput"/>, <see cref="Drawable.HandlePositionaInput"/> values obtained via reflection.
+        /// Nested class which is used for caching <see cref="Drawable.HandleNonPositionalInput"/>, <see cref="Drawable.HandlePositionalInput"/> values obtained via reflection.
         /// </summary>
         private static class HandleInputCache
         {
@@ -1985,12 +1985,12 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Whether this Drawable can receive non-positional input, taking into account all optimizations and masking.
         /// </summary>
-        public bool CanReceiveNonPositionalInput => HandleNonPositionaInput && IsPresent && !IsMaskedAway;
+        public bool CanReceiveNonPositionalInput => HandleNonPositionalInput && IsPresent && !IsMaskedAway;
 
         /// <summary>
         /// Whether this Drawable can receive positional input, taking into account all optimizations and masking.
         /// </summary>
-        public bool CanReceivePositionalInput => HandlePositionaInput && IsPresent && !IsMaskedAway;
+        public bool CanReceivePositionalInput => HandlePositionalInput && IsPresent && !IsMaskedAway;
 
         /// <summary>
         /// Creates a new InputState with mouse coodinates converted to the coordinate space of our parent.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -227,8 +227,8 @@ namespace osu.Framework.Graphics
 
             double t1 = getPerfTime();
 
-            handleKeyboardInput = HandleInputCache.HandleKeyboardInput(this);
-            handleMouseInput = HandleInputCache.HandleMouseInput(this);
+            handleNonPositionaInput = HandleInputCache.HandleNonPositionalInput(this);
+            handlePositionalInput = HandleInputCache.HandlePositionalInput(this);
 
             InjectDependencies(dependencies);
 
@@ -1860,29 +1860,29 @@ namespace osu.Framework.Graphics
         protected virtual bool OnJoystickRelease(InputState state, JoystickEventArgs args) => false;
         #endregion
 
-        private bool handleKeyboardInput, handleMouseInput;
+        private bool handleNonPositionaInput, handlePositionalInput;
 
         /// <summary>
-        /// Whether this <see cref="Drawable"/> handles keyboard input.
-        /// This value is true by default if any keyboard related "On-" input methods are overridden.
+        /// Whether this <see cref="Drawable"/> handles non-positional input.
+        /// This value is true by default if any keyboard and other non-positional "On-" input methods are overridden.
         /// </summary>
-        public virtual bool HandleKeyboardInput => handleKeyboardInput;
+        public virtual bool HandleNonPositionaInput => handleNonPositionaInput;
 
         /// <summary>
-        /// Whether this <see cref="Drawable"/> handles mouse input.
+        /// Whether this <see cref="Drawable"/> handles positional input.
         /// This value is true by default if any mouse related "On-" input methods are overridden.
         /// </summary>
-        public virtual bool HandleMouseInput => handleMouseInput;
+        public virtual bool HandlePositionaInput => handlePositionalInput;
 
         /// <summary>
-        /// Nested class which is used for caching <see cref="HandleKeyboardInput"/>, <see cref="HandleMouseInput"/> values obtained via reflection.
+        /// Nested class which is used for caching <see cref="Drawable.HandleNonPositionaInput"/>, <see cref="Drawable.HandlePositionaInput"/> values obtained via reflection.
         /// </summary>
         private static class HandleInputCache
         {
-            private static readonly ConcurrentDictionary<Type, bool> mouse_cached_values = new ConcurrentDictionary<Type, bool>();
-            private static readonly ConcurrentDictionary<Type, bool> keyboard_cached_values = new ConcurrentDictionary<Type, bool>();
+            private static readonly ConcurrentDictionary<Type, bool> positional_cached_values = new ConcurrentDictionary<Type, bool>();
+            private static readonly ConcurrentDictionary<Type, bool> non_positional_cached_values = new ConcurrentDictionary<Type, bool>();
 
-            private static readonly string[] mouse_input_methods =
+            private static readonly string[] positional_input_methods =
             {
                 nameof(Handle),
                 nameof(OnHover),
@@ -1900,7 +1900,7 @@ namespace osu.Framework.Graphics
                 nameof(OnMouseMove)
             };
 
-            private static readonly string[] keyboard_input_methods =
+            private static readonly string[] non_positional_input_methods =
             {
                 nameof(Handle),
                 nameof(OnFocus),
@@ -1911,9 +1911,9 @@ namespace osu.Framework.Graphics
                 nameof(OnJoystickRelease)
             };
 
-            public static bool HandleKeyboardInput(Drawable drawable) => get(drawable, keyboard_cached_values, keyboard_input_methods);
+            public static bool HandleNonPositionalInput(Drawable drawable) => get(drawable, non_positional_cached_values, non_positional_input_methods);
 
-            public static bool HandleMouseInput(Drawable drawable) => get(drawable, mouse_cached_values, mouse_input_methods);
+            public static bool HandlePositionalInput(Drawable drawable) => get(drawable, positional_cached_values, positional_input_methods);
 
             private static bool get(Drawable drawable, ConcurrentDictionary<Type, bool> cache, string[] inputMethods)
             {
@@ -1967,12 +1967,12 @@ namespace osu.Framework.Graphics
         public bool IsDragged { get; internal set; }
 
         /// <summary>
-        /// Determines whether this drawable receives mouse input when the mouse is at the
+        /// Determines whether this drawable receives positional input when the mouse is at the
         /// given screen-space position.
         /// </summary>
         /// <param name="screenSpacePos">The screen-space position where input could be received.</param>
         /// <returns>True iff input is received at the given screen-space position.</returns>
-        public virtual bool ReceiveMouseInputAt(Vector2 screenSpacePos) => Contains(screenSpacePos);
+        public virtual bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Contains(screenSpacePos);
 
         /// <summary>
         /// Computes whether a given screen-space position is contained within this drawable.
@@ -1983,14 +1983,14 @@ namespace osu.Framework.Graphics
         public virtual bool Contains(Vector2 screenSpacePos) => DrawRectangle.Contains(ToLocalSpace(screenSpacePos));
 
         /// <summary>
-        /// Whether this Drawable can keyboard receive input, taking into account all optimizations and masking.
+        /// Whether this Drawable can receive non-positional input, taking into account all optimizations and masking.
         /// </summary>
-        public bool CanReceiveKeyboardInput => HandleKeyboardInput && IsPresent && !IsMaskedAway;
+        public bool CanReceiveNonPositionalInput => HandleNonPositionaInput && IsPresent && !IsMaskedAway;
 
         /// <summary>
-        /// Whether this Drawable can mouse receive input, taking into account all optimizations and masking.
+        /// Whether this Drawable can receive positional input, taking into account all optimizations and masking.
         /// </summary>
-        public bool CanReceiveMouseInput => HandleMouseInput && IsPresent && !IsMaskedAway;
+        public bool CanReceivePositionalInput => HandlePositionaInput && IsPresent && !IsMaskedAway;
 
         /// <summary>
         /// Creates a new InputState with mouse coodinates converted to the coordinate space of our parent.
@@ -2007,16 +2007,16 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
-        /// This method is responsible for building a queue of Drawables to receive keyboard input
-        /// in reverse order. This method is overridden by <see cref="T:Container"/> to be called on all
+        /// This method is responsible for building a queue of Drawables to receive non-positional input
+        /// in reverse order. This method is overridden by <see cref="CompositeDrawable"/> to be called on all
         /// children such that the entire scene graph is covered.
         /// </summary>
         /// <param name="queue">The input queue to be built.</param>
         /// <param name="allowBlocking">Whether blocking at <see cref="PassThroughInputManager"/>s should be allowed.</param>
         /// <returns>Whether we have added ourself to the queue.</returns>
-        internal virtual bool BuildKeyboardInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal virtual bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
-            if (!CanReceiveKeyboardInput)
+            if (!CanReceiveNonPositionalInput)
                 return false;
 
             queue.Add(this);
@@ -2024,16 +2024,16 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
-        /// This method is responsible for building a queue of Drawables to receive mouse input
-        /// in reverse order. This method is overridden by <see cref="T:Container"/> to be called on all
+        /// This method is responsible for building a queue of Drawables to receive positional input
+        /// in reverse order. This method is overridden by <see cref="CompositeDrawable"/> to be called on all
         /// children such that the entire scene graph is covered.
         /// </summary>
-        /// <param name="screenSpaceMousePos">The current position of the mouse cursor in screen space.</param>
+        /// <param name="screenSpacePos">The screen space position of the positional input.</param>
         /// <param name="queue">The input queue to be built.</param>
         /// <returns>Whether we have added ourself to the queue.</returns>
-        internal virtual bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
+        internal virtual bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
-            if (!CanReceiveMouseInput || !ReceiveMouseInputAt(screenSpaceMousePos))
+            if (!CanReceivePositionalInput || !ReceivePositionalInputAt(screenSpacePos))
                 return false;
 
             queue.Add(this);

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Graphics.Lines
             }
         }
 
-        public override bool ReceiveMouseInputAt(Vector2 screenSpacePos)
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
         {
             var localPos = ToLocalSpace(screenSpacePos);
             var pathWidthSquared = PathWidth * PathWidth;

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -498,8 +498,8 @@ namespace osu.Framework.Graphics.Performance
                 Sprite.Texture = new Texture(atlas.Add(WIDTH, HEIGHT));
             }
 
-            public override bool HandleKeyboardInput => false;
-            public override bool HandleMouseInput => false;
+            public override bool HandleNonPositionaInput => false;
+            public override bool HandlePositionaInput => false;
         }
 
         private class CounterBar : Container

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -498,8 +498,8 @@ namespace osu.Framework.Graphics.Performance
                 Sprite.Texture = new Texture(atlas.Add(WIDTH, HEIGHT));
             }
 
-            public override bool HandleNonPositionaInput => false;
-            public override bool HandlePositionaInput => false;
+            public override bool HandleNonPositionalInput => false;
+            public override bool HandlePositionalInput => false;
         }
 
         private class CounterBar : Container

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected Drawable Caret;
         protected Container TextContainer;
 
-        public override bool HandleKeyboardInput => HasFocus;
+        public override bool HandleNonPositionaInput => HasFocus;
 
         /// <summary>
         /// Padding to be used within the TextContainer. Requires special handling due to the sideways scrolling of text content.

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected Drawable Caret;
         protected Container TextContainer;
 
-        public override bool HandleNonPositionaInput => HasFocus;
+        public override bool HandleNonPositionalInput => HasFocus;
 
         /// <summary>
         /// Padding to be used within the TextContainer. Requires special handling due to the sideways scrolling of text content.

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -99,7 +99,7 @@ namespace osu.Framework.Graphics.Visualisation
             inputManager = GetContainingInputManager();
         }
 
-        protected override bool BlockPassThroughMouse => false;
+        protected override bool BlockPositionalInput => false;
 
         protected override void PopIn()
         {
@@ -124,9 +124,9 @@ namespace osu.Framework.Graphics.Visualisation
 
             bool containsCursor = d.ScreenSpaceDrawQuad.Contains(state.Mouse.NativeState.Position);
             // This is an optimization: We don't need to consider drawables which we don't hover, and which do not
-            // forward input further to children (via d.ReceiveMouseInputAt). If they do forward input to children, then there
+            // forward input further to children (via d.ReceivePositionalInputAt). If they do forward input to children, then there
             // is a good chance they have children poking out of their bounds, which we need to catch.
-            if (!containsCursor && !d.ReceiveMouseInputAt(state.Mouse.NativeState.Position))
+            if (!containsCursor && !d.ReceivePositionalInputAt(state.Mouse.NativeState.Position))
                 return null;
 
             var dAsContainer = d as CompositeDrawable;

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -153,8 +153,8 @@ namespace osu.Framework.Graphics.Visualisation
 
         private const float font_size = 14;
 
-        public override bool HandleNonPositionaInput => false;
-        public override bool HandlePositionaInput => false;
+        public override bool HandleNonPositionalInput => false;
+        public override bool HandlePositionalInput => false;
 
         public DrawableLogEntry(LogEntry entry)
         {

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Graphics.Visualisation
     {
         private readonly FillFlowContainer flow;
 
-        protected override bool BlockPassThroughMouse => false;
+        protected override bool BlockPositionalInput => false;
 
         private Bindable<bool> enabled;
 
@@ -153,8 +153,8 @@ namespace osu.Framework.Graphics.Visualisation
 
         private const float font_size = 14;
 
-        public override bool HandleKeyboardInput => false;
-        public override bool HandleMouseInput => false;
+        public override bool HandleNonPositionaInput => false;
+        public override bool HandlePositionaInput => false;
 
         public DrawableLogEntry(LogEntry entry)
         {

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Input.Bindings
         public IEnumerable<T> PressedActions => pressedActions;
 
         /// <summary>
-        /// The input queue to be used for processing key bindings. Based on the non-positional <see cref="InputManager.InputQueue"/>.
+        /// The input queue to be used for processing key bindings. Based on the non-positional <see cref="InputManager.NonPositionalInputQueue"/>.
         /// Can be overridden to change priorities.
         /// </summary>
         protected virtual IEnumerable<Drawable> KeyBindingInputQueue => childrenInputQueue;
@@ -59,7 +59,7 @@ namespace osu.Framework.Input.Bindings
             get
             {
                 queue.Clear();
-                BuildKeyboardInputQueue(queue, false);
+                BuildNonPositionalInputQueue(queue, false);
                 queue.Reverse();
 
                 return queue;
@@ -94,9 +94,9 @@ namespace osu.Framework.Input.Bindings
             return handleNewPressed(state, key, false, scrollDelta, isPrecise) | handleNewReleased(state, key);
         }
 
-        internal override bool BuildKeyboardInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
-            if (!base.BuildKeyboardInputQueue(queue, allowBlocking))
+            if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))
                 return false;
 
             if (Prioritised)

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -107,13 +107,13 @@ namespace osu.Framework.Input
         /// that the return value of <see cref="Drawable.OnHover(InputState)"/> is not taken
         /// into account.
         /// </summary>
-        public IEnumerable<Drawable> PositionalInputQueue => buildMouseInputQueue(CurrentState);
+        public IEnumerable<Drawable> PositionalInputQueue => buildPositionalInputQueue(CurrentState);
 
         /// <summary>
         /// Contains all <see cref="Drawable"/>s in top-down order which are considered
         /// for non-positional input.
         /// </summary>
-        public IEnumerable<Drawable> InputQueue => buildInputQueue();
+        public IEnumerable<Drawable> NonPositionalInputQueue => buildNonPositionalInputQueue();
 
         private readonly Dictionary<MouseButton, MouseButtonEventManager> mouseButtonEventManagers = new Dictionary<MouseButton, MouseButtonEventManager>();
 
@@ -211,15 +211,15 @@ namespace osu.Framework.Input
             return true;
         }
 
-        internal override bool BuildKeyboardInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
             if (!allowBlocking)
-                base.BuildKeyboardInputQueue(queue, false);
+                base.BuildNonPositionalInputQueue(queue, false);
 
             return false;
         }
 
-        internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue) => false;
+        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue) => false;
 
         private bool hoverEventsUpdated;
 
@@ -282,16 +282,16 @@ namespace osu.Framework.Input
 
         private readonly List<Drawable> inputQueue = new List<Drawable>();
 
-        private IEnumerable<Drawable> buildInputQueue()
+        private IEnumerable<Drawable> buildNonPositionalInputQueue()
         {
             inputQueue.Clear();
 
             if (this is UserInputManager)
-                FrameStatistics.Increment(StatisticsCounterType.KeyboardQueue);
+                FrameStatistics.Increment(StatisticsCounterType.InputQueue);
 
             var children = AliveInternalChildren;
             for (int i = 0; i < children.Count; i++)
-                children[i].BuildKeyboardInputQueue(inputQueue);
+                children[i].BuildNonPositionalInputQueue(inputQueue);
 
             if (!unfocusIfNoLongerValid())
             {
@@ -299,7 +299,7 @@ namespace osu.Framework.Input
                 inputQueue.Add(FocusedDrawable);
             }
 
-            // Keyboard and mouse queues were created in back-to-front order.
+            // queues were created in back-to-front order.
             // We want input to first reach front-most drawables, so the queues
             // need to be reversed.
             inputQueue.Reverse();
@@ -309,16 +309,16 @@ namespace osu.Framework.Input
 
         private readonly List<Drawable> positionalInputQueue = new List<Drawable>();
 
-        private IEnumerable<Drawable> buildMouseInputQueue(InputState state)
+        private IEnumerable<Drawable> buildPositionalInputQueue(InputState state)
         {
             positionalInputQueue.Clear();
 
             if (this is UserInputManager)
-                FrameStatistics.Increment(StatisticsCounterType.MouseQueue);
+                FrameStatistics.Increment(StatisticsCounterType.PositionalIQ);
 
             var children = AliveInternalChildren;
             for (int i = 0; i < children.Count; i++)
-                children[i].BuildMouseInputQueue(state.Mouse.Position, positionalInputQueue);
+                children[i].BuildPositionalInputQueue(state.Mouse.Position, positionalInputQueue);
 
             positionalInputQueue.Reverse();
             return positionalInputQueue;
@@ -497,22 +497,22 @@ namespace osu.Framework.Input
 
         private bool handleKeyDown(InputState state, Key key, bool repeat)
         {
-            return PropagateBlockableEvent(InputQueue, new KeyDownEvent(state, key, repeat));
+            return PropagateBlockableEvent(NonPositionalInputQueue, new KeyDownEvent(state, key, repeat));
         }
 
         private bool handleKeyUp(InputState state, Key key)
         {
-            return PropagateBlockableEvent(InputQueue, new KeyUpEvent(state, key));
+            return PropagateBlockableEvent(NonPositionalInputQueue, new KeyUpEvent(state, key));
         }
 
         private bool handleJoystickPress(InputState state, JoystickButton button)
         {
-            return PropagateBlockableEvent(InputQueue, new JoystickPressEvent(state, button));
+            return PropagateBlockableEvent(NonPositionalInputQueue, new JoystickPressEvent(state, button));
         }
 
         private bool handleJoystickRelease(InputState state, JoystickButton button)
         {
-            return PropagateBlockableEvent(InputQueue, new JoystickReleaseEvent(state, button));
+            return PropagateBlockableEvent(NonPositionalInputQueue, new JoystickReleaseEvent(state, button));
         }
 
         /// <summary>
@@ -603,7 +603,7 @@ namespace osu.Framework.Input
         private void focusTopMostRequestingDrawable()
         {
             // todo: don't rebuild input queue every frame
-            ChangeFocus(InputQueue.FirstOrDefault(target => target.RequestsFocus));
+            ChangeFocus(NonPositionalInputQueue.FirstOrDefault(target => target.RequestsFocus));
         }
 
         private class MouseLeftButtonEventManager : MouseButtonEventManager

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -191,7 +191,7 @@ namespace osu.Framework.Input
         {
             // due to the laziness of IEnumerable, .Where check should be done right before it is triggered for the event.
             var drawables = MouseDownInputQueue.Intersect(PositionalInputQueue)
-                                               .Where(t => t.CanReceiveMouseInput && t.ReceiveMouseInputAt(state.Mouse.Position));
+                                               .Where(t => t.CanReceivePositionalInput && t.ReceivePositionalInputAt(state.Mouse.Position));
 
             var clicked = PropagateMouseButtonEvent(drawables, new ClickEvent(state, Button, MouseDownPosition));
             ClickedDrawable.SetTarget(clicked);

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -44,13 +44,13 @@ namespace osu.Framework.Input
 
         private bool useParentInput = true;
 
-        internal override bool BuildKeyboardInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
-            if (!CanReceiveKeyboardInput) return false;
+            if (!CanReceiveNonPositionalInput) return false;
 
             if (!allowBlocking)
             {
-                base.BuildKeyboardInputQueue(queue, false);
+                base.BuildNonPositionalInputQueue(queue, false);
                 return false;
             }
 
@@ -59,9 +59,9 @@ namespace osu.Framework.Input
             return false;
         }
 
-        internal override bool BuildMouseInputQueue(Vector2 screenSpaceMousePos, List<Drawable> queue)
+        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
-            if (!CanReceiveMouseInput) return false;
+            if (!CanReceivePositionalInput) return false;
 
             if (UseParentInput)
                 queue.Add(this);
@@ -153,7 +153,7 @@ namespace osu.Framework.Input
         {
             base.Update();
 
-            // Some keyboard/joystick events are blocked. Sync every frame.
+            // Some non-positional events are blocked. Sync every frame.
             if (UseParentInput) Sync(true);
         }
 

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -61,8 +61,8 @@ namespace osu.Framework.Screens
         // in the case we don't have a parent screen, we still want to handle input as we are also responsible for
         // children inside childScreenContainer.
         // this means the root screen always received input.
-        public override bool HandleKeyboardInput => IsCurrentScreen || !hasExited && ParentScreen == null;
-        public override bool HandleMouseInput => IsCurrentScreen || !hasExited && ParentScreen == null;
+        public override bool HandleNonPositionaInput => IsCurrentScreen || !hasExited && ParentScreen == null;
+        public override bool HandlePositionaInput => IsCurrentScreen || !hasExited && ParentScreen == null;
 
         /// <summary>
         /// Called when this Screen is being entered. Only happens once, ever.
@@ -244,8 +244,8 @@ namespace osu.Framework.Screens
 
         protected class ContentContainer : Container
         {
-            public override bool HandleKeyboardInput => LifetimeEnd == double.MaxValue;
-            public override bool HandleMouseInput => LifetimeEnd == double.MaxValue;
+            public override bool HandleNonPositionaInput => LifetimeEnd == double.MaxValue;
+            public override bool HandlePositionaInput => LifetimeEnd == double.MaxValue;
             public override bool RemoveWhenNotAlive => false;
 
             public ContentContainer()

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -61,8 +61,8 @@ namespace osu.Framework.Screens
         // in the case we don't have a parent screen, we still want to handle input as we are also responsible for
         // children inside childScreenContainer.
         // this means the root screen always received input.
-        public override bool HandleNonPositionaInput => IsCurrentScreen || !hasExited && ParentScreen == null;
-        public override bool HandlePositionaInput => IsCurrentScreen || !hasExited && ParentScreen == null;
+        public override bool HandleNonPositionalInput => IsCurrentScreen || !hasExited && ParentScreen == null;
+        public override bool HandlePositionalInput => IsCurrentScreen || !hasExited && ParentScreen == null;
 
         /// <summary>
         /// Called when this Screen is being entered. Only happens once, ever.
@@ -244,8 +244,8 @@ namespace osu.Framework.Screens
 
         protected class ContentContainer : Container
         {
-            public override bool HandleNonPositionaInput => LifetimeEnd == double.MaxValue;
-            public override bool HandlePositionaInput => LifetimeEnd == double.MaxValue;
+            public override bool HandleNonPositionalInput => LifetimeEnd == double.MaxValue;
+            public override bool HandlePositionalInput => LifetimeEnd == double.MaxValue;
             public override bool RemoveWhenNotAlive => false;
 
             public ContentContainer()

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -48,8 +48,8 @@ namespace osu.Framework.Statistics
         DrawNodeCtor,
         DrawNodeAppl,
         ScheduleInvk,
-        KeyboardQueue,
-        MouseQueue,
+        InputQueue,
+        PositionalIQ,
 
         VBufBinds,
         VBufOverflow,

--- a/osu.Framework/Threading/UpdateThread.cs
+++ b/osu.Framework/Threading/UpdateThread.cs
@@ -21,8 +21,8 @@ namespace osu.Framework.Threading
             StatisticsCounterType.DrawNodeCtor,
             StatisticsCounterType.DrawNodeAppl,
             StatisticsCounterType.ScheduleInvk,
-            StatisticsCounterType.KeyboardQueue,
-            StatisticsCounterType.MouseQueue
+            StatisticsCounterType.InputQueue,
+            StatisticsCounterType.PositionalIQ
         };
     }
 }


### PR DESCRIPTION
There are couple of naming pairs such as `handleKeyboardInput`/`handleMouseInput` or `BuildKeyboardInputQueue`/`BuildMouseInputQueue`.
This is bad because "Keyboard" means not only keyboard but anything except mouse.
I propose to rename this things.

---
