### PR TITLE
Fix incorrect behavior of hollow offset edge effects

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseMasking.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMasking.cs
@@ -32,7 +32,8 @@ namespace osu.Framework.Tests.Visual
                 @"Round corner AABB 3",
                 @"Edge/border blurriness",
                 @"Nested masking",
-                @"Rounded corner input"
+                @"Rounded corner input",
+                @"Offset shadow",
             };
 
             for (int i = 0; i < testNames.Length; i++)
@@ -431,6 +432,38 @@ namespace osu.Framework.Tests.Visual
                                 }
                             }
                         });
+                        break;
+                    }
+
+                case 7:
+                    {
+                        Container box;
+                        TestContainer.Add(box = new InfofulBoxAutoSize
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Masking = true,
+                            CornerRadius = 100,
+                            Alpha = 0.8f,
+                            EdgeEffect = new EdgeEffectParameters
+                            {
+                                Type = EdgeEffectType.Shadow,
+                                Offset = new Vector2(0, 50),
+                                Hollow = true,
+                                Radius = 100,
+                                Colour = new Color4(0, 255, 255, 255),
+                            },
+                        });
+
+                        box.Add(box = new InfofulBox
+                        {
+                            Size = new Vector2(250, 250),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Colour = Color4.DarkSeaGreen,
+                        });
+
+                        box.OnUpdate += delegate { box.Rotation += 0.05f; };
                         break;
                     }
             }

--- a/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
@@ -148,6 +148,7 @@ namespace osu.Framework.Graphics.Containers
             // the edge effect along its radius using the same rounded-corners shader.
             edgeEffectMaskingInfo.BlendRange = EdgeEffect.Radius;
             edgeEffectMaskingInfo.AlphaExponent = 2;
+            edgeEffectMaskingInfo.EdgeOffset = EdgeEffect.Offset;
             edgeEffectMaskingInfo.Hollow = EdgeEffect.Hollow;
 
             GLWrapper.PushMaskingInfo(edgeEffectMaskingInfo);

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -441,6 +441,8 @@ namespace osu.Framework.Graphics.OpenGL
             GlobalPropertyManager.Set(GlobalProperty.MaskingBlendRange, maskingInfo.BlendRange);
             GlobalPropertyManager.Set(GlobalProperty.AlphaExponent, maskingInfo.AlphaExponent);
 
+            GlobalPropertyManager.Set(GlobalProperty.EdgeOffset, maskingInfo.EdgeOffset);
+
             GlobalPropertyManager.Set(GlobalProperty.DiscardInner, maskingInfo.Hollow);
 
             RectangleI actualRect = maskingInfo.ScreenSpaceAABB;
@@ -656,6 +658,8 @@ namespace osu.Framework.Graphics.OpenGL
         public float BlendRange;
         public float AlphaExponent;
 
+        public Vector2 EdgeOffset;
+
         public bool Hollow;
 
         public bool Equals(MaskingInfo other)
@@ -669,6 +673,7 @@ namespace osu.Framework.Graphics.OpenGL
                 BorderColour.Equals(other.BorderColour) &&
                 BlendRange == other.BlendRange &&
                 AlphaExponent == other.AlphaExponent &&
+                EdgeOffset == other.EdgeOffset &&
                 Hollow == other.Hollow;
         }
     }

--- a/osu.Framework/Graphics/Shaders/GlobalProperty.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalProperty.cs
@@ -16,6 +16,7 @@ namespace osu.Framework.Graphics.Shaders
         BorderColour,
         MaskingBlendRange,
         AlphaExponent,
+        EdgeOffset,
         DiscardInner,
     }
 }

--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -27,6 +27,7 @@ namespace osu.Framework.Graphics.Shaders
             global_properties[(int)GlobalProperty.BorderColour] = new UniformMapping<Vector4>("g_BorderColour");
             global_properties[(int)GlobalProperty.MaskingBlendRange] = new UniformMapping<float>("g_MaskingBlendRange");
             global_properties[(int)GlobalProperty.AlphaExponent] = new UniformMapping<float>("g_AlphaExponent");
+            global_properties[(int)GlobalProperty.EdgeOffset] = new UniformMapping<Vector2>("g_EdgeOffset");
             global_properties[(int)GlobalProperty.DiscardInner] = new UniformMapping<bool>("g_DiscardInner");
         }
 

--- a/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
@@ -20,13 +20,17 @@ uniform float g_MaskingBlendRange;
 
 uniform float g_AlphaExponent;
 
+uniform vec2 g_EdgeOffset;
+
 uniform bool g_DiscardInner;
 
-float distanceFromRoundedRect()
+float distanceFromRoundedRect(vec2 offset)
 {
+	vec2 maskingPosition = v_MaskingPosition + offset;
+
 	// Compute offset distance from masking rect in masking space.
-	vec2 topLeftOffset = g_MaskingRect.xy - v_MaskingPosition;
-	vec2 bottomRightOffset = v_MaskingPosition - g_MaskingRect.zw;
+	vec2 topLeftOffset = g_MaskingRect.xy - maskingPosition;
+	vec2 bottomRightOffset = maskingPosition - g_MaskingRect.zw;
 
 	vec2 distanceFromShrunkRect = max(
 		bottomRightOffset + vec2(g_CornerRadius),
@@ -60,17 +64,19 @@ float distanceFromDrawingRect()
 
 void main(void)
 {
-	float dist = distanceFromRoundedRect();
+	float dist = distanceFromRoundedRect(vec2(0.0));
 	float alphaFactor = 1.0;
 	vec4 texel = texture2D(m_Sampler, v_TexCoord, -0.9);
 
 	// Discard inner pixels
 	if (g_DiscardInner)
 	{
+		float innerDist = g_EdgeOffset == vec2(0.0) ? dist : distanceFromRoundedRect(g_EdgeOffset);
+
 		// v_BlendRange is set from outside in a hacky way to tell us the g_MaskingBlendRange used for the rounded
 		// corners of the edge effect container itself. We can then derive the alpha factor for smooth inner edge
 		// effect from that.
-		float innerBlendFactor = (g_CornerRadius - g_MaskingBlendRange - dist) / v_BlendRange.x;
+		float innerBlendFactor = (g_CornerRadius - g_MaskingBlendRange - innerDist) / v_BlendRange.x;
 		if (innerBlendFactor > 1.0)
 		{
 			gl_FragColor = vec4(0.0);
@@ -78,7 +84,7 @@ void main(void)
 		}
 
 		// We exponentiate our factor to exactly counteract the later exponentiation by g_AlphaExponent for a smoother inner border.
-		alphaFactor *= pow(min(1.0 - innerBlendFactor, 1.0), 1.0 / g_AlphaExponent);
+		alphaFactor = pow(min(1.0 - innerBlendFactor, 1.0), 1.0 / g_AlphaExponent);
 	}
 
 	dist /= g_MaskingBlendRange;


### PR DESCRIPTION
The hollow region should not be offset, but was before. Here is a comparison of before and after.
<img width="537" alt="screenshot 2018-09-26 08 04 58" src="https://user-images.githubusercontent.com/4923655/46060660-61699580-c164-11e8-9907-07187221f3a5.png">
<img width="544" alt="screenshot 2018-09-26 08 04 28" src="https://user-images.githubusercontent.com/4923655/46060662-63cbef80-c164-11e8-978c-5fb7e5b205ef.png">

- Closes #1936

---

Fixes incorrect behavior of hollow edge effects with an offset. The following images show before and after:
<img width="537" alt="screenshot 2018-09-26 08 04 58" src="https://user-images.githubusercontent.com/4923655/46060660-61699580-c164-11e8-9907-07187221f3a5.png">
<img width="544" alt="screenshot 2018-09-26 08 04 28" src="https://user-images.githubusercontent.com/4923655/46060662-63cbef80-c164-11e8-978c-5fb7e5b205ef.png">