### PR TITLE
Restore modifier key getters of KeyboardState

### DIFF
--- a/osu.Framework/Input/Events/UIEvent.cs
+++ b/osu.Framework/Input/Events/UIEvent.cs
@@ -7,7 +7,6 @@ using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Input.States;
 using OpenTK;
-using OpenTK.Input;
 
 namespace osu.Framework.Input.Events
 {
@@ -53,22 +52,22 @@ namespace osu.Framework.Input.Events
         /// <summary>
         /// Whether left or right control key is pressed.
         /// </summary>
-        public bool ControlPressed => CurrentState.Keyboard.Keys.IsPressed(Key.LControl) || CurrentState.Keyboard.Keys.IsPressed(Key.RControl);
+        public bool ControlPressed => CurrentState.Keyboard.ControlPressed;
 
         /// <summary>
         /// Whether left or right alt key is pressed.
         /// </summary>
-        public bool AltPressed => CurrentState.Keyboard.Keys.IsPressed(Key.LAlt) || CurrentState.Keyboard.Keys.IsPressed(Key.RAlt);
+        public bool AltPressed => CurrentState.Keyboard.AltPressed;
 
         /// <summary>
         /// Whether left or right shift key is pressed.
         /// </summary>
-        public bool ShiftPressed => CurrentState.Keyboard.Keys.IsPressed(Key.LShift) || CurrentState.Keyboard.Keys.IsPressed(Key.RShift);
+        public bool ShiftPressed => CurrentState.Keyboard.ShiftPressed;
 
         /// <summary>
         /// Whether left or right super key (Win key on Windows, or Command key on Mac) is pressed.
         /// </summary>
-        public bool SuperPressed => CurrentState.Keyboard.Keys.IsPressed(Key.LWin) || CurrentState.Keyboard.Keys.IsPressed(Key.RWin);
+        public bool SuperPressed => CurrentState.Keyboard.SuperPressed;
 
         protected UIEvent([NotNull] InputState state)
         {

--- a/osu.Framework/Input/States/KeyboardState.cs
+++ b/osu.Framework/Input/States/KeyboardState.cs
@@ -8,5 +8,25 @@ namespace osu.Framework.Input.States
     public class KeyboardState
     {
         public readonly ButtonStates<Key> Keys = new ButtonStates<Key>();
+
+        /// <summary>
+        /// Whether left or right control key is pressed.
+        /// </summary>
+        public bool ControlPressed => Keys.IsPressed(Key.LControl) || Keys.IsPressed(Key.RControl);
+
+        /// <summary>
+        /// Whether left or right alt key is pressed.
+        /// </summary>
+        public bool AltPressed => Keys.IsPressed(Key.LAlt) || Keys.IsPressed(Key.RAlt);
+
+        /// <summary>
+        /// Whether left or right shift key is pressed.
+        /// </summary>
+        public bool ShiftPressed => Keys.IsPressed(Key.LShift) || Keys.IsPressed(Key.RShift);
+
+        /// <summary>
+        /// Whether left or right super key (Win key on Windows, or Command key on Mac) is pressed.
+        /// </summary>
+        public bool SuperPressed => Keys.IsPressed(Key.LWin) || Keys.IsPressed(Key.RWin);
     }
 }


### PR DESCRIPTION
I moved modifier key getters from `KeyboardState` to `UIEvent` on #1922 but during osu side update of that PR I found there are couple of uses of modifier keys getters without access of `UIEvent`. This PR restores modifier key getters to avoid code duplication (checking both left and right key).

---
