### PR TITLE
Implement SmoothPath which provides antialiasing capabilities

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Tests.Visual
     public class TestCaseDrawablePath : GridTestCase
     {
         public TestCaseDrawablePath()
-            : base(2, 2)
+            : base(3, 2)
         {
             const int width = 20;
             Texture gradientTexture = new Texture(width, 1, true);
@@ -35,7 +35,7 @@ namespace osu.Framework.Tests.Visual
             Cell(0).AddRange(new[]
             {
                 createLabel("Simple path"),
-                new Path
+                new TexturedPath
                 {
                     RelativeSizeAxes = Axes.Both,
                     Positions = new List<Vector2> { Vector2.One * 50, Vector2.One * 100 },
@@ -47,15 +47,15 @@ namespace osu.Framework.Tests.Visual
             Cell(1).AddRange(new[]
             {
                 createLabel("Curved path"),
-                new Path
+                new TexturedPath
                 {
                     RelativeSizeAxes = Axes.Both,
                     Positions = new List<Vector2>
                     {
                         new Vector2(50, 50),
-                        new Vector2(50, 250),
-                        new Vector2(250, 250),
-                        new Vector2(250, 50),
+                        new Vector2(50, 150),
+                        new Vector2(150, 150),
+                        new Vector2(150, 50),
                         new Vector2(50, 50),
                     },
                     Texture = gradientTexture,
@@ -66,16 +66,16 @@ namespace osu.Framework.Tests.Visual
             Cell(2).AddRange(new[]
             {
                 createLabel("Self-overlapping path"),
-                new Path
+                new TexturedPath
                 {
                     RelativeSizeAxes = Axes.Both,
                     Positions = new List<Vector2>
                     {
                         new Vector2(50, 50),
-                        new Vector2(50, 250),
-                        new Vector2(250, 250),
-                        new Vector2(250, 150),
-                        new Vector2(20, 150),
+                        new Vector2(50, 150),
+                        new Vector2(150, 150),
+                        new Vector2(150, 100),
+                        new Vector2(20, 100),
                     },
                     Texture = gradientTexture,
                     Colour = Color4.Red,
@@ -83,6 +83,38 @@ namespace osu.Framework.Tests.Visual
             });
 
             Cell(3).AddRange(new[]
+            {
+                createLabel("Smoothed path"),
+                new SmoothPath
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    PathWidth = 5,
+                    Positions = new List<Vector2>
+                    {
+                        new Vector2(50, 50),
+                        new Vector2(125, 100),
+                    },
+                    Colour = Color4.White,
+                }
+            });
+
+            Cell(4).AddRange(new[]
+            {
+                createLabel("un-smoothed path"),
+                new Path
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    PathWidth = 5,
+                    Positions = new List<Vector2>
+                    {
+                        new Vector2(50, 50),
+                        new Vector2(125, 100),
+                    },
+                    Colour = Color4.White,
+                }
+            });
+
+            Cell(5).AddRange(new[]
             {
                 createLabel("Draw something ;)"),
                 new UserDrawnPath
@@ -101,7 +133,7 @@ namespace osu.Framework.Tests.Visual
             Colour = Color4.White,
         };
 
-        private class UserDrawnPath : Path
+        private class UserDrawnPath : TexturedPath
         {
             private Vector2 oldPos;
 

--- a/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
+++ b/osu.Framework.Tests/Visual/TestCaseInputResampler.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Tests.Visual
             Colour = Color4.White,
         };
 
-        private class SmoothedPath : Path
+        private class SmoothedPath : TexturedPath
         {
             protected SmoothedPath()
             {

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.Graphics.Lines
 
         private float pathWidth = 10f;
 
-        public float PathWidth
+        public virtual float PathWidth
         {
             get => pathWidth;
             set
@@ -142,6 +142,23 @@ namespace osu.Framework.Graphics.Lines
 
             segmentsCache.Validate();
             return segmentsBacking;
+        }
+
+        private Texture texture = Texture.WhitePixel;
+
+        protected Texture Texture
+        {
+            get => texture;
+            set
+            {
+                if (texture == value)
+                    return;
+
+                texture?.Dispose();
+                texture = value;
+
+                Invalidate(Invalidation.DrawNode);
+            }
         }
 
         private readonly PathDrawNodeSharedData pathDrawNodeSharedData = new PathDrawNodeSharedData();

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -14,6 +14,16 @@ namespace osu.Framework.Graphics.Lines
 {
     public class Path : Drawable
     {
+        private Shader roundedTextureShader;
+        private Shader textureShader;
+
+        [BackgroundDependencyLoader]
+        private void load(ShaderManager shaders)
+        {
+            roundedTextureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE_ROUNDED);
+            textureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE);
+        }
+
         private List<Vector2> positions = new List<Vector2>();
 
         public List<Vector2> Positions
@@ -23,6 +33,23 @@ namespace osu.Framework.Graphics.Lines
                 if (positions == value) return;
 
                 positions = value;
+                recomputeBounds();
+
+                segmentsCache.Invalidate();
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+
+        private float pathWidth = 10f;
+
+        public float PathWidth
+        {
+            get => pathWidth;
+            set
+            {
+                if (pathWidth == value) return;
+
+                pathWidth = value;
                 recomputeBounds();
 
                 segmentsCache.Invalidate();
@@ -98,23 +125,6 @@ namespace osu.Framework.Graphics.Lines
                 expandBounds(pos);
         }
 
-        private float pathWidth = 10f;
-
-        public float PathWidth
-        {
-            get => pathWidth;
-            set
-            {
-                if (pathWidth == value) return;
-
-                pathWidth = value;
-                recomputeBounds();
-
-                segmentsCache.Invalidate();
-                Invalidate(Invalidation.DrawNode);
-            }
-        }
-
         private readonly List<Line> segmentsBacking = new List<Line>();
         private Cached segmentsCache = new Cached();
         private List<Line> segments => segmentsCache.IsValid ? segmentsBacking : generateSegments();
@@ -134,22 +144,7 @@ namespace osu.Framework.Graphics.Lines
             return segmentsBacking;
         }
 
-        private Shader roundedTextureShader;
-        private Shader textureShader;
-
         private readonly PathDrawNodeSharedData pathDrawNodeSharedData = new PathDrawNodeSharedData();
-
-        #region Disposal
-
-        protected override void Dispose(bool isDisposing)
-        {
-            texture?.Dispose();
-            texture = null;
-
-            base.Dispose(isDisposing);
-        }
-
-        #endregion
 
         protected override DrawNode CreateDrawNode() => new PathDrawNode();
 
@@ -168,30 +163,6 @@ namespace osu.Framework.Graphics.Lines
             n.Segments = segments.ToList();
 
             base.ApplyDrawNode(node);
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(ShaderManager shaders)
-        {
-            roundedTextureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE_ROUNDED);
-            textureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE);
-        }
-
-        private Texture texture = Texture.WhitePixel;
-
-        public Texture Texture
-        {
-            get => texture;
-            set
-            {
-                if (value == texture)
-                    return;
-
-                texture?.Dispose();
-                texture = value;
-
-                Invalidate(Invalidation.DrawNode);
-            }
         }
     }
 }

--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -57,7 +57,9 @@ namespace osu.Framework.Graphics.Lines
             for (int i = 0; i < textureWidth; i++)
             {
                 float progress = (float)i / (textureWidth - 1);
-                raw[i, 0] = new Rgba32(1f, 1f, 1f, Math.Min(progress / aa_portion, 1));
+
+                var colour = ColourAt(progress);
+                raw[i, 0] = new Rgba32(colour.R, colour.G, colour.B, colour.A * Math.Min(progress / aa_portion, 1));
             }
 
             texture.SetData(new TextureUpload(raw));

--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -1,0 +1,83 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Caching;
+using osu.Framework.Graphics.Textures;
+using OpenTK.Graphics;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace osu.Framework.Graphics.Lines
+{
+    public class SmoothPath : Path
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            validateTexture();
+        }
+
+        public override float PathWidth
+        {
+            get => base.PathWidth;
+            set
+            {
+                if (base.PathWidth == value)
+                    return;
+                base.PathWidth = value;
+
+                InvalidateTexture();
+            }
+        }
+
+        private Cached textureCache = new Cached();
+
+        protected void InvalidateTexture()
+        {
+            textureCache.Invalidate();
+            Invalidate(Invalidation.DrawNode);
+        }
+
+        private void validateTexture()
+        {
+            if (textureCache.IsValid)
+                return;
+
+            int textureWidth = (int)PathWidth * 2;
+
+            var texture = new Texture(textureWidth, 1);
+
+            //initialise background
+            var raw = new Image<Rgba32>(textureWidth, 1);
+
+            const float aa_portion = 0.02f;
+
+            for (int i = 0; i < textureWidth; i++)
+            {
+                float progress = (float)i / (textureWidth - 1);
+                raw[i, 0] = new Rgba32(1f, 1f, 1f, Math.Min(progress / aa_portion, 1));
+            }
+
+            texture.SetData(new TextureUpload(raw));
+            Texture = texture;
+
+            textureCache.Validate();
+        }
+
+        /// <summary>
+        /// Retrieves the colour from a position in the texture of the <see cref="Path"/>.
+        /// </summary>
+        /// <param name="position">The position within the texture. 0 indicates the outermost-point of the path, 1 indicates the centre of the path.</param>
+        /// <returns></returns>
+        protected virtual Color4 ColourAt(float position) => Color4.White;
+
+        protected override void ApplyDrawNode(DrawNode node)
+        {
+            validateTexture();
+
+            base.ApplyDrawNode(node);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -1,5 +1,5 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
 using osu.Framework.Allocation;

--- a/osu.Framework/Graphics/Lines/TexturedPath.cs
+++ b/osu.Framework/Graphics/Lines/TexturedPath.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+
+using osu.Framework.Graphics.Textures;
+
+namespace osu.Framework.Graphics.Lines
+{
+    public class TexturedPath : Path
+    {
+        public new Texture Texture
+        {
+            get => base.Texture;
+            set => base.Texture = value;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Lines/TexturedPath.cs
+++ b/osu.Framework/Graphics/Lines/TexturedPath.cs
@@ -1,5 +1,5 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu/master/LICENCE
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Graphics.Textures;
 


### PR DESCRIPTION
* `Path` no longer exposes its `Texture` publicly.
  * Migration: Use `TexturedPath`.
* `SmoothPath` adds the AA capabilities of `SliderBody`
* `Path` exists by itself to either provide non-aa'd paths, or have subclasses provide the texture.