### PR TITLE
Fix FileSafety.PathStandardise only working on Windows

### DIFF
--- a/osu.Framework/IO/File/FileSafety.cs
+++ b/osu.Framework/IO/File/FileSafety.cs
@@ -98,7 +98,7 @@ namespace osu.Framework.IO.File
         /// </summary>
         public static string PathStandardise(string path)
         {
-            return path.Replace(Path.DirectorySeparatorChar, '/');
+            return path.Replace('\\', '/');
         }
 
         [Flags]


### PR DESCRIPTION
- Required for ppy/osu#3558

---

This change fixes `FileSafety.PathStandardise(string)`, which would not change Window path separators on Unix machines.