### PR TITLE
Add support for SDL clipboard on linux fix #1179

### DIFF
--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using osu.Framework.Platform.Linux.Native;
+using osu.Framework.Platform.SDL;
 
 namespace osu.Framework.Platform.Linux
 {
@@ -25,6 +26,16 @@ namespace osu.Framework.Platform.Linux
 
         protected override Storage GetStorage(string baseName) => new LinuxStorage(baseName, this);
 
-        public override Clipboard GetClipboard() => new LinuxClipboard();
+        public override Clipboard GetClipboard()
+        {
+            if (((LinuxGameWindow)Window).IsSDL)
+            {
+                return new SDLClipboard();
+            }
+            else
+            {
+                return new LinuxClipboard();
+            }
+        }
     }
 }

--- a/osu.Framework/Platform/Linux/LinuxGameWindow.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameWindow.cs
@@ -1,9 +1,31 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
+using System.Linq;
+using System.Reflection;
+using OpenTK;
+
 namespace osu.Framework.Platform.Linux
 {
     public class LinuxGameWindow : DesktopGameWindow
     {
+        private bool isSDL;
+
+        public bool IsSDL => isSDL;
+
+        public LinuxGameWindow()
+        {
+            Load += OnLoad;
+        }
+
+        private void OnLoad(object sender, EventArgs e)
+        {
+            var implementationField = typeof(NativeWindow).GetRuntimeFields().Single(x => x.Name == "implementation");
+
+            var windowImpl = implementationField.GetValue(Implementation);
+
+            isSDL = windowImpl.GetType().Name == "Sdl2NativeWindow";
+        }
     }
 }

--- a/osu.Framework/Platform/Linux/SDL/SDLClipboard.cs
+++ b/osu.Framework/Platform/Linux/SDL/SDLClipboard.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+// using System.Windows.Forms;
+
+using System.Runtime.InteropServices;
+
+namespace osu.Framework.Platform.SDL
+{
+    public class SDLClipboard : Clipboard
+    {
+        #if ANDROID
+        const string lib = "libSDL2.so";
+        #elif IPHONE
+        const string lib = "__Internal";
+        #else
+        private const string lib = "libSDL2-2.0.so.0";
+        #endif
+
+        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GetClipboardText", ExactSpelling = true)]
+        internal static extern string SDL_GetClipboardText();
+
+        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_SetClipboardText", ExactSpelling = true)]
+        internal static extern int SDL_SetClipboardText(string text);
+
+        public override string GetText()
+        {
+            return SDL_GetClipboardText();
+        }
+
+        public override void SetText(string selectedText)
+        {
+            SDL_SetClipboardText(selectedText);
+        }
+    }
+}


### PR DESCRIPTION
- Closes #1179

This only adds support for when the SDL backend is used as the X11 backend would require some event loop changes and because the SDL backend is the default.

I didn't make the SDL backend available for all platforms because the SDL library path is hardcoded to the linux version because there is currently no .dll.config which would handle mapping and it is also only used in the linux backend.