### PR TITLE
Expose vertices from Path

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawablePath.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Tests.Visual
                 new TexturedPath
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Positions = new List<Vector2> { Vector2.One * 50, Vector2.One * 100 },
+                    Vertices = new List<Vector2> { Vector2.One * 50, Vector2.One * 100 },
                     Texture = gradientTexture,
                     Colour = Color4.Green,
                 },
@@ -50,7 +50,7 @@ namespace osu.Framework.Tests.Visual
                 new TexturedPath
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Positions = new List<Vector2>
+                    Vertices = new List<Vector2>
                     {
                         new Vector2(50, 50),
                         new Vector2(50, 150),
@@ -69,7 +69,7 @@ namespace osu.Framework.Tests.Visual
                 new TexturedPath
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Positions = new List<Vector2>
+                    Vertices = new List<Vector2>
                     {
                         new Vector2(50, 50),
                         new Vector2(50, 150),
@@ -89,7 +89,7 @@ namespace osu.Framework.Tests.Visual
                 {
                     RelativeSizeAxes = Axes.Both,
                     PathWidth = 5,
-                    Positions = new List<Vector2>
+                    Vertices = new List<Vector2>
                     {
                         new Vector2(50, 50),
                         new Vector2(125, 100),
@@ -105,7 +105,7 @@ namespace osu.Framework.Tests.Visual
                 {
                     RelativeSizeAxes = Axes.Both,
                     PathWidth = 5,
-                    Positions = new List<Vector2>
+                    Vertices = new List<Vector2>
                     {
                         new Vector2(50, 50),
                         new Vector2(125, 100),

--- a/osu.Framework.Tests/Visual/TestCasePathInput.cs
+++ b/osu.Framework.Tests/Visual/TestCasePathInput.cs
@@ -125,7 +125,7 @@ namespace osu.Framework.Tests.Visual
         private void addPath(string name, params Vector2[] vertices) => AddStep(name, () =>
         {
             path.PathWidth = path_width;
-            path.Positions = vertices.ToList();
+            path.Vertices = vertices.ToList();
         });
 
         private void test(Vector2 position, bool shouldReceivePositionalInput)

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -24,15 +24,15 @@ namespace osu.Framework.Graphics.Lines
             textureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE);
         }
 
-        private List<Vector2> positions = new List<Vector2>();
+        private List<Vector2> vertices = new List<Vector2>();
 
-        public List<Vector2> Positions
+        public List<Vector2> Vertices
         {
             set
             {
-                if (positions == value) return;
+                if (vertices == value) return;
 
-                positions = value;
+                vertices = value;
                 recomputeBounds();
 
                 segmentsCache.Invalidate();
@@ -72,10 +72,10 @@ namespace osu.Framework.Graphics.Lines
 
         public void ClearVertices()
         {
-            if (positions.Count == 0)
+            if (vertices.Count == 0)
                 return;
 
-            positions.Clear();
+            vertices.Clear();
             resetBounds();
 
             if (!RelativeSizeAxes.HasFlag(Axes.X)) Width = 0;
@@ -87,7 +87,7 @@ namespace osu.Framework.Graphics.Lines
 
         public void AddVertex(Vector2 pos)
         {
-            positions.Add(pos);
+            vertices.Add(pos);
             expandBounds(pos);
 
             segmentsCache.Invalidate();
@@ -121,7 +121,7 @@ namespace osu.Framework.Graphics.Lines
         private void recomputeBounds()
         {
             resetBounds();
-            foreach (Vector2 pos in positions)
+            foreach (Vector2 pos in vertices)
                 expandBounds(pos);
         }
 
@@ -133,11 +133,11 @@ namespace osu.Framework.Graphics.Lines
         {
             segmentsBacking.Clear();
 
-            if (positions.Count > 1)
+            if (vertices.Count > 1)
             {
                 Vector2 offset = new Vector2(minX, minY);
-                for (int i = 0; i < positions.Count - 1; ++i)
-                    segmentsBacking.Add(new Line(positions[i] - offset, positions[i + 1] - offset));
+                for (int i = 0; i < vertices.Count - 1; ++i)
+                    segmentsBacking.Add(new Line(vertices[i] - offset, vertices[i + 1] - offset));
             }
 
             segmentsCache.Validate();

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -24,15 +24,15 @@ namespace osu.Framework.Graphics.Lines
             textureShader = shaders?.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE);
         }
 
-        private List<Vector2> vertices = new List<Vector2>();
+        private readonly List<Vector2> vertices = new List<Vector2>();
 
-        public List<Vector2> Vertices
+        public IReadOnlyList<Vector2> Vertices
         {
             set
             {
-                if (vertices == value) return;
+                vertices.Clear();
+                vertices.AddRange(value);
 
-                vertices = value;
                 recomputeBounds();
 
                 segmentsCache.Invalidate();

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -28,6 +28,7 @@ namespace osu.Framework.Graphics.Lines
 
         public IReadOnlyList<Vector2> Vertices
         {
+            get => vertices;
             set
             {
                 vertices.Clear();


### PR DESCRIPTION
No reason why:
* Groups of vertices were called "Positions", meanwhile there's `AddVertex()`, `ClearVertices()`.
* There was no getter of "Positions".

This addresses both of these issues.