### PR TITLE
Replace IStateful with State design pattern

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -173,27 +173,21 @@ namespace osu.Framework
             }
         }
 
-        protected FrameStatisticsMode FrameStatisticsMode
-        {
-            get => performanceContainer.State;
-            set => performanceContainer.State = value;
-        }
-
         public bool OnPressed(FrameworkAction action)
         {
             switch (action)
             {
                 case FrameworkAction.CycleFrameStatistics:
-                    switch (FrameStatisticsMode)
+                    switch (performanceContainer.State)
                     {
-                        case FrameStatisticsMode.None:
-                            FrameStatisticsMode = FrameStatisticsMode.Minimal;
+                        case PerformanceOverlayState.None _:
+                            performanceContainer.State.ToMinimal();
                             break;
-                        case FrameStatisticsMode.Minimal:
-                            FrameStatisticsMode = FrameStatisticsMode.Full;
+                        case PerformanceOverlayState.Minimal _:
+                            performanceContainer.State.ToFull();
                             break;
-                        case FrameStatisticsMode.Full:
-                            FrameStatisticsMode = FrameStatisticsMode.None;
+                        case PerformanceOverlayState.Full _:
+                            performanceContainer.State.ToNone();
                             break;
                     }
                     return true;

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplayState.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplayState.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using OpenTK;
+
+namespace osu.Framework.Graphics.Performance
+{
+    internal abstract class FrameStatisticsDisplayState : StateBase<FrameStatisticsDisplay>
+    {
+        protected FrameStatisticsDisplayState(FrameStatisticsDisplay context)
+            : base(context)
+        {
+        }
+
+        public virtual void ToNone()
+        {
+            Context.Running = true;
+            Context.Expanded = false;
+
+            Context.State = new None(Context);
+        }
+
+        public virtual void ToMinimal()
+        {
+            Context.MainContainer.AutoSizeAxes = Axes.Both;
+
+            Context.TimeBarsContainer.Hide();
+
+            Context.LabelText.Origin = Anchor.CentreRight;
+            Context.LabelText.Rotation = 0;
+
+            Context.State = new Minimal(Context);
+        }
+
+        public virtual void ToFull()
+        {
+            Context.MainContainer.AutoSizeAxes = Axes.None;
+            Context.MainContainer.Size = new Vector2(FrameStatisticsDisplay.WIDTH, FrameStatisticsDisplay.HEIGHT);
+
+            Context.TimeBarsContainer.Show();
+
+            Context.LabelText.Origin = Anchor.BottomCentre;
+            Context.LabelText.Rotation = -90;
+
+            Context.State = new Full(Context);
+        }
+
+        internal class None : FrameStatisticsDisplayState
+        {
+            public None(FrameStatisticsDisplay context)
+                : base(context)
+            {
+            }
+
+            public override void ToNone()
+            {
+            }
+        }
+
+        internal class Minimal : FrameStatisticsDisplayState
+        {
+            public Minimal(FrameStatisticsDisplay context)
+                : base(context)
+            {
+            }
+
+            public override void ToMinimal()
+            {
+            }
+        }
+
+        internal class Full : FrameStatisticsDisplayState
+        {
+            public Full(FrameStatisticsDisplay context)
+                : base(context)
+            {
+            }
+
+            public override void ToFull()
+            {
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -14,7 +14,6 @@ namespace osu.Framework.Graphics.Performance
     internal class PerformanceOverlay : FillFlowContainer<FrameStatisticsDisplay>, IState<PerformanceOverlayState>
     {
         private PerformanceOverlayState state;
-
         public PerformanceOverlayState State
         {
             get => state;
@@ -36,19 +35,7 @@ namespace osu.Framework.Graphics.Performance
             foreach (GameThread t in threads)
             {
                 var frameStatisticsDisplay = new FrameStatisticsDisplay(t, atlas);
-                switch (State)
-                {
-                    case PerformanceOverlayState.None _:
-                        frameStatisticsDisplay.State.ToNone();
-                        break;
-                    case PerformanceOverlayState.Minimal _:
-                        frameStatisticsDisplay.State.ToMinimal();
-                        break;
-                    case PerformanceOverlayState.Full _:
-                        frameStatisticsDisplay.State.ToFull();
-                        break;
-                }
-
+                frameStatisticsDisplay.State = State.CreateFrameStatisticsDisplayState(frameStatisticsDisplay);
                 Add(frameStatisticsDisplay);
             }
         }

--- a/osu.Framework/Graphics/Performance/PerformanceOverlayState.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlayState.cs
@@ -10,6 +10,8 @@ namespace osu.Framework.Graphics.Performance
         {
         }
 
+        public abstract FrameStatisticsDisplayState CreateFrameStatisticsDisplayState(FrameStatisticsDisplay context);
+
         public virtual void ToNone()
         {
             Context.FadeOut(100);
@@ -41,6 +43,8 @@ namespace osu.Framework.Graphics.Performance
             {
             }
 
+            public override FrameStatisticsDisplayState CreateFrameStatisticsDisplayState(FrameStatisticsDisplay context) => new FrameStatisticsDisplayState.None(context);
+
             public override void ToNone()
             {
             }
@@ -53,6 +57,8 @@ namespace osu.Framework.Graphics.Performance
             {
             }
 
+            public override FrameStatisticsDisplayState CreateFrameStatisticsDisplayState(FrameStatisticsDisplay context) => new FrameStatisticsDisplayState.Minimal(context);
+
             public override void ToMinimal()
             {
             }
@@ -64,6 +70,8 @@ namespace osu.Framework.Graphics.Performance
                 : base(context)
             {
             }
+
+            public override FrameStatisticsDisplayState CreateFrameStatisticsDisplayState(FrameStatisticsDisplay context) => new FrameStatisticsDisplayState.Full(context);
 
             public override void ToFull()
             {

--- a/osu.Framework/Graphics/Performance/PerformanceOverlayState.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlayState.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework.Graphics.Performance
+{
+    internal abstract class PerformanceOverlayState : StateBase<PerformanceOverlay>
+    {
+        protected PerformanceOverlayState(PerformanceOverlay context)
+            : base(context)
+        {
+        }
+
+        public virtual void ToNone()
+        {
+            Context.FadeOut(100);
+            foreach (FrameStatisticsDisplay d in Context.Children)
+                d.State.ToNone();
+            Context.State = new None(Context);
+        }
+
+        public virtual void ToMinimal()
+        {
+            Context.FadeIn(100);
+            foreach (FrameStatisticsDisplay d in Context.Children)
+                d.State.ToMinimal();
+            Context.State = new Minimal(Context);
+        }
+
+        public virtual void ToFull()
+        {
+            Context.FadeIn(100);
+            foreach (FrameStatisticsDisplay d in Context.Children)
+                d.State.ToFull();
+            Context.State = new Full(Context);
+        }
+
+        internal class None : PerformanceOverlayState
+        {
+            public None(PerformanceOverlay context)
+                : base(context)
+            {
+            }
+
+            public override void ToNone()
+            {
+            }
+        }
+
+        internal class Minimal : PerformanceOverlayState
+        {
+            public Minimal(PerformanceOverlay context)
+                : base(context)
+            {
+            }
+
+            public override void ToMinimal()
+            {
+            }
+        }
+
+        internal class Full : PerformanceOverlayState
+        {
+            public Full(PerformanceOverlay context)
+                : base(context)
+            {
+            }
+
+            public override void ToFull()
+            {
+            }
+        }
+    }
+}

--- a/osu.Framework/IState.cs
+++ b/osu.Framework/IState.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework
+{
+    public interface IState<PossibleStates>
+    {
+        PossibleStates State { get; set; }
+        event Action<PossibleStates> StateChanged;
+    }
+}

--- a/osu.Framework/StateBase.cs
+++ b/osu.Framework/StateBase.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+namespace osu.Framework
+{
+    public abstract class StateBase<T>
+    {
+        protected T Context;
+
+        protected StateBase(T context) => Context = context;
+    }
+}


### PR DESCRIPTION
Current object state code(`IStateful<T>` implementation with some enum) can be replaced with the State design pattern.
For demonstration I rewrote `FrameStatisticsDisplay` and `PerformanceOverlay`. I know that incapsulation is messed up, but it will be fixed if required. Pay attention to the state management logic(`PerformanceOverlayState`, `FrameStatisticsDisplayState`).