### PR TITLE
Add special case for resolving bindables

### DIFF
--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -173,32 +173,18 @@ namespace osu.Framework.Tests.Dependencies
 
             var bindable = new Bindable<int>(10);
             var dependencies = createDependencies(bindable);
-
-            dependencies.Inject(receiver);
-
-            Assert.AreNotSame(bindable, receiver.Obj);
-            Assert.AreEqual(bindable.Value, receiver.Obj.Value);
-
-            bindable.Value = 5;
-            Assert.AreEqual(bindable.Value, receiver.Obj.Value);
-        }
-
-        [Test]
-        public void TestResolveIBindable()
-        {
-            var receiver = new Receiver17();
-
-            var bindable = new Bindable<int>(10);
-            var dependencies = new DependencyContainer();
             dependencies.CacheAs<IBindable<int>>(bindable);
 
             dependencies.Inject(receiver);
 
             Assert.AreNotSame(bindable, receiver.Obj);
+            Assert.AreNotSame(bindable, receiver.Obj2);
             Assert.AreEqual(bindable.Value, receiver.Obj.Value);
+            Assert.AreEqual(bindable.Value, receiver.Obj2.Value);
 
             bindable.Value = 5;
             Assert.AreEqual(bindable.Value, receiver.Obj.Value);
+            Assert.AreEqual(bindable.Value, receiver.Obj2.Value);
         }
 
         private DependencyContainer createDependencies(params object[] toCache)
@@ -313,12 +299,9 @@ namespace osu.Framework.Tests.Dependencies
         {
             [Resolved]
             public Bindable<int> Obj { get; private set; }
-        }
 
-        private class Receiver17
-        {
             [Resolved]
-            public IBindable<int> Obj { get; private set; }
+            public IBindable<int> Obj2 { get; private set; }
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Configuration;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Testing.Dependencies;
 
@@ -165,6 +166,41 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(0, receiver.Obj);
         }
 
+        [Test]
+        public void TestResolveBindable()
+        {
+            var receiver = new Receiver16();
+
+            var bindable = new Bindable<int>(10);
+            var dependencies = createDependencies(bindable);
+
+            dependencies.Inject(receiver);
+
+            Assert.AreNotSame(bindable, receiver.Obj);
+            Assert.AreEqual(bindable.Value, receiver.Obj.Value);
+
+            bindable.Value = 5;
+            Assert.AreEqual(bindable.Value, receiver.Obj.Value);
+        }
+
+        [Test]
+        public void TestResolveIBindable()
+        {
+            var receiver = new Receiver17();
+
+            var bindable = new Bindable<int>(10);
+            var dependencies = new DependencyContainer();
+            dependencies.CacheAs<IBindable<int>>(bindable);
+
+            dependencies.Inject(receiver);
+
+            Assert.AreNotSame(bindable, receiver.Obj);
+            Assert.AreEqual(bindable.Value, receiver.Obj.Value);
+
+            bindable.Value = 5;
+            Assert.AreEqual(bindable.Value, receiver.Obj.Value);
+        }
+
         private DependencyContainer createDependencies(params object[] toCache)
         {
             var dependencies = new DependencyContainer();
@@ -271,6 +307,18 @@ namespace osu.Framework.Tests.Dependencies
         {
             [Resolved(CanBeNull = true)]
             public int Obj { get; private set; } = 1;
+        }
+
+        private class Receiver16
+        {
+            [Resolved]
+            public Bindable<int> Obj { get; private set; }
+        }
+
+        private class Receiver17
+        {
+            [Resolved]
+            public IBindable<int> Obj { get; private set; }
         }
     }
 }

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using JetBrains.Annotations;
+using osu.Framework.Configuration;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 
@@ -61,6 +62,10 @@ namespace osu.Framework.Allocation
             var val = dc.Get(type);
             if (val == null && !permitNulls)
                 throw new DependencyNotRegisteredException(requestingType, type);
+
+            if (val is IBindable bindableVal)
+                return bindableVal.GetBoundCopy();
+
             return val;
         };
     }


### PR DESCRIPTION
Currently if a bindable is `[Resolved]`, it'll copy the original bindable, which is unsafe and against the expected flow of bindables.

With this, the `[Resolved]` bindable becomes a bound copy of the original.