### PR TITLE
Fix propagation to bindings

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
@@ -62,5 +62,18 @@ namespace osu.Framework.Tests.Bindables
 
             Assert.AreEqual(value, bindable.Value);
         }
+
+        [Test]
+        public void TestPropagationToPlainBindable()
+        {
+            var number = new BindableDouble(1000);
+            var bindable = new Bindable<double>();
+
+            bindable.BindTo(number);
+
+            number.Precision = 0.5f;
+            number.MinValue = 0;
+            number.MaxValue = 10;
+        }
     }
 }

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -161,12 +161,16 @@ namespace osu.Framework.Configuration
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = precision;
+
             if (propagateToBindings)
+            {
                 Bindings?.ForEachAlive(b =>
                 {
                     if (b is BindableNumber<T> bn)
                         bn.Precision = precision;
                 });
+            }
+
             if (Equals(beforePropagation, precision))
                 PrecisionChanged?.Invoke(precision);
         }
@@ -175,12 +179,16 @@ namespace osu.Framework.Configuration
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = minValue;
+
             if (propagateToBindings)
+            {
                 Bindings?.ForEachAlive(b =>
                 {
                     if (b is BindableNumber<T> bn)
                         bn.MinValue = minValue;
                 });
+            }
+
             if (Equals(beforePropagation, minValue))
                 MinValueChanged?.Invoke(minValue);
         }
@@ -189,12 +197,16 @@ namespace osu.Framework.Configuration
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = maxValue;
+
             if (propagateToBindings)
+            {
                 Bindings?.ForEachAlive(b =>
                 {
                     if (b is BindableNumber<T> bn)
                         bn.MaxValue = maxValue;
                 });
+            }
+
             if (Equals(beforePropagation, maxValue))
                 MaxValueChanged?.Invoke(maxValue);
         }
@@ -220,7 +232,8 @@ namespace osu.Framework.Configuration
         /// </summary>
         public bool HasDefinedRange => !MinValue.Equals(DefaultMinValue) || !MaxValue.Equals(DefaultMaxValue);
 
-        public static implicit operator T(BindableNumber<T> value) => value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableNumber<T>)} to a {nameof(T)} is likely a mistake");
+        public static implicit operator T(BindableNumber<T> value) =>
+            value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableNumber<T>)} to a {nameof(T)} is likely a mistake");
 
         public bool IsInteger
         {

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -161,7 +161,12 @@ namespace osu.Framework.Configuration
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = precision;
-            if (propagateToBindings) Bindings?.ForEachAlive(b => ((BindableNumber<T>)b).Precision = precision);
+            if (propagateToBindings)
+                Bindings?.ForEachAlive(b =>
+                {
+                    if (b is BindableNumber<T> bn)
+                        bn.Precision = precision;
+                });
             if (Equals(beforePropagation, precision))
                 PrecisionChanged?.Invoke(precision);
         }
@@ -170,7 +175,12 @@ namespace osu.Framework.Configuration
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = minValue;
-            if (propagateToBindings) Bindings?.ForEachAlive(b => ((BindableNumber<T>)b).MinValue = minValue);
+            if (propagateToBindings)
+                Bindings?.ForEachAlive(b =>
+                {
+                    if (b is BindableNumber<T> bn)
+                        bn.MinValue = minValue;
+                });
             if (Equals(beforePropagation, minValue))
                 MinValueChanged?.Invoke(minValue);
         }
@@ -179,7 +189,12 @@ namespace osu.Framework.Configuration
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = maxValue;
-            if (propagateToBindings) Bindings?.ForEachAlive(b => ((BindableNumber<T>)b).MaxValue = maxValue);
+            if (propagateToBindings)
+                Bindings?.ForEachAlive(b =>
+                {
+                    if (b is BindableNumber<T> bn)
+                        bn.MaxValue = maxValue;
+                });
             if (Equals(beforePropagation, maxValue))
                 MaxValueChanged?.Invoke(maxValue);
         }


### PR DESCRIPTION
resolves #1976 
Also, if we need to propagate precision/max/min to `Bindable<T>` objects, it can be achieved with Proxy and Decorator patterns.