### PR TITLE
Concatenate Shader Includes

### DIFF
--- a/osu.Framework/Graphics/Shaders/ShaderPart.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderPart.cs
@@ -79,10 +79,10 @@ namespace osu.Framework.Graphics.Shaders
                         //                        if (File.Exists(includeName))
                         //                            rawData = File.ReadAllBytes(includeName);
                         //#endif
-                        shaderCodes.Add(loadFile(manager.LoadRaw(includeName)));
+                        code += loadFile(manager.LoadRaw(includeName)) + '\n';
                     }
                     else
-                        code += '\n' + line;
+                        code += line + '\n';
 
                     Match attributeMatch = attributeRegex.Match(line);
                     if (attributeMatch.Success)


### PR DESCRIPTION
Add included shader files inline rather than as additional shadercode entries.
Fixes an issue in OpenGL ES where the header was getting compiled before the float precision was set.

Also changed line splitting to ensure that a newline will appear at the end of the script rather than the start.