### PR TITLE
Fix incorrect hollow region with non-zero EdgeEffectParameters.Roundness

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseMasking.cs
+++ b/osu.Framework.Tests/Visual/TestCaseMasking.cs
@@ -450,7 +450,8 @@ namespace osu.Framework.Tests.Visual
                                 Type = EdgeEffectType.Shadow,
                                 Offset = new Vector2(0, 50),
                                 Hollow = true,
-                                Radius = 100,
+                                Radius = 50,
+                                Roundness = 50,
                                 Colour = new Color4(0, 255, 255, 255),
                             },
                         });

--- a/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawNode.cs
@@ -142,7 +142,7 @@ namespace osu.Framework.Graphics.Containers
             MaskingInfo edgeEffectMaskingInfo = MaskingInfo.Value;
             edgeEffectMaskingInfo.MaskingRect = effectRect;
             edgeEffectMaskingInfo.ScreenSpaceAABB = ScreenSpaceMaskingQuad.Value.AABB;
-            edgeEffectMaskingInfo.CornerRadius += EdgeEffect.Radius + EdgeEffect.Roundness;
+            edgeEffectMaskingInfo.CornerRadius = MaskingInfo.Value.CornerRadius + EdgeEffect.Radius + EdgeEffect.Roundness;
             edgeEffectMaskingInfo.BorderThickness = 0;
             // HACK HACK HACK. We abuse blend range to give us the linear alpha gradient of
             // the edge effect along its radius using the same rounded-corners shader.
@@ -150,6 +150,7 @@ namespace osu.Framework.Graphics.Containers
             edgeEffectMaskingInfo.AlphaExponent = 2;
             edgeEffectMaskingInfo.EdgeOffset = EdgeEffect.Offset;
             edgeEffectMaskingInfo.Hollow = EdgeEffect.Hollow;
+            edgeEffectMaskingInfo.HollowCornerRadius = MaskingInfo.Value.CornerRadius + EdgeEffect.Radius;
 
             GLWrapper.PushMaskingInfo(edgeEffectMaskingInfo);
 

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -444,6 +444,8 @@ namespace osu.Framework.Graphics.OpenGL
             GlobalPropertyManager.Set(GlobalProperty.EdgeOffset, maskingInfo.EdgeOffset);
 
             GlobalPropertyManager.Set(GlobalProperty.DiscardInner, maskingInfo.Hollow);
+            if (maskingInfo.Hollow)
+                GlobalPropertyManager.Set(GlobalProperty.InnerCornerRadius, maskingInfo.HollowCornerRadius);
 
             RectangleI actualRect = maskingInfo.ScreenSpaceAABB;
             actualRect.X += Viewport.X;
@@ -661,6 +663,7 @@ namespace osu.Framework.Graphics.OpenGL
         public Vector2 EdgeOffset;
 
         public bool Hollow;
+        public float HollowCornerRadius;
 
         public bool Equals(MaskingInfo other)
         {
@@ -674,7 +677,8 @@ namespace osu.Framework.Graphics.OpenGL
                 BlendRange == other.BlendRange &&
                 AlphaExponent == other.AlphaExponent &&
                 EdgeOffset == other.EdgeOffset &&
-                Hollow == other.Hollow;
+                Hollow == other.Hollow &&
+                HollowCornerRadius == other.HollowCornerRadius;
         }
     }
 }

--- a/osu.Framework/Graphics/Shaders/GlobalProperty.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalProperty.cs
@@ -18,5 +18,6 @@ namespace osu.Framework.Graphics.Shaders
         AlphaExponent,
         EdgeOffset,
         DiscardInner,
+        InnerCornerRadius,
     }
 }

--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -29,6 +29,7 @@ namespace osu.Framework.Graphics.Shaders
             global_properties[(int)GlobalProperty.AlphaExponent] = new UniformMapping<float>("g_AlphaExponent");
             global_properties[(int)GlobalProperty.EdgeOffset] = new UniformMapping<Vector2>("g_EdgeOffset");
             global_properties[(int)GlobalProperty.DiscardInner] = new UniformMapping<bool>("g_DiscardInner");
+            global_properties[(int)GlobalProperty.InnerCornerRadius] = new UniformMapping<float>("g_InnerCornerRadius");
         }
 
         /// <summary>


### PR DESCRIPTION
Adds a new shader uniform for controlling the corner radius of the hollow region. The uniform is only updated when actually required (i.e. when a hollow edge effect is actually rendered).

- Closes #1972

---

Fixes an incorrect hollow region whenever an edge effect with additional roundness is used.

Before:
<img width="590" alt="screenshot 2018-11-14 08 47 56" src="https://user-images.githubusercontent.com/4923655/48467718-05c59b00-e7ea-11e8-8fde-ff58a9512487.png">

After:
<img width="523" alt="screenshot 2018-11-14 08 47 04" src="https://user-images.githubusercontent.com/4923655/48467722-09f1b880-e7ea-11e8-8840-64daaf7d6ac4.png">
