### PR TITLE
Fix checkChildLife allocating anonymous delegates unnecessarily

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -614,12 +614,14 @@ namespace osu.Framework.Graphics.Containers
                     RemoveInternal(child);
 
                     if (child.DisposeOnDeathRemoval)
-                        Task.Run(() => child.Dispose());
+                        disposeChildAsync(child);
                 }
             }
 
             return changed;
         }
+
+        private void disposeChildAsync(Drawable drawable) => Task.Run(() => drawable.Dispose());
 
         internal override void UpdateClock(IFrameBasedClock clock)
         {


### PR DESCRIPTION
Not sure on the naming for such a method...