### PR TITLE
Remove generics from Cache method

### DIFF
--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -138,7 +138,7 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestAttemptCacheStruct()
         {
-            Assert.Throws<ArgumentException>(() => new DependencyContainer().Cache<IBaseInterface>(new BaseStructObject()));
+            Assert.Throws<ArgumentException>(() => new DependencyContainer().Cache(new BaseStructObject()));
         }
 
         /// <summary>

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -235,7 +235,7 @@ namespace osu.Framework.Tests.Dependencies
         [Test]
         public void TestCacheNullInternal()
         {
-            Assert.DoesNotThrow(() => new DependencyContainer().CacheValue<int?>(null));
+            Assert.DoesNotThrow(() => new DependencyContainer().CacheValue(null));
             Assert.DoesNotThrow(() => new DependencyContainer().CacheValueAs<object>(null));
         }
 

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Allocation
         /// (e.g. <see cref="CancellationToken"/> or reference types).
         /// </remarks>
         /// <param name="instance">The instance to cache.</param>
-        internal void CacheValue<T>(T instance)
+        internal void CacheValue(object instance)
         {
             if (instance == null)
                 return;

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Allocation
         /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
         /// <param name="instance">The instance to cache.</param>
-        public void Cache<T>(T instance) where T : class
+        public void Cache(object instance)
             => CacheAs(instance.GetType(), instance, false);
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Graphics.Containers
 
         /// <summary>
         /// Contains all dependencies that can be injected into this CompositeDrawable's children using <see cref="BackgroundDependencyLoaderAttribute"/>.
-        /// Add or override dependencies by calling <see cref="DependencyContainer.Cache{T}(T)"/>.
+        /// Add or override dependencies by calling <see cref="DependencyContainer.Cache"/>.
         /// </summary>
         public IReadOnlyDependencyContainer Dependencies { get; private set; }
 


### PR DESCRIPTION
THe previous method could cause accidental use of `Cache` when the consumer is meaning to use `CacheAs`.

ie.

```
Type obj = new Type();

deps.Cache(obj);        // caches as Type
deps.Cache<IType>(obj); // still caches as Type
deps.CacheAs<IType>(obj); // caches as IType
```