### PR TITLE
Improve filtering of waveform

### DIFF
--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using ManagedBass;

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -193,9 +193,9 @@ namespace osu.Framework.Audio.Track
                 // Should not effect overall appearance much, except when the value is too small.
                 // A gaussian contains almost all its mass within its first 3 standard deviations,
                 // so a factor of 3 is a very good choice here.
-                const int kernelWidthFactor = 3;
+                const int kernel_width_factor = 3;
 
-                int kernelWidth = (int)(pointsPerGeneratedPoint * kernelWidthFactor) + 1;
+                int kernelWidth = (int)(pointsPerGeneratedPoint * kernel_width_factor) + 1;
 
                 float[] filter = new float[kernelWidth + 1];
                 for (int i = 0; i < filter.Length; ++i) {


### PR DESCRIPTION
Make filtering of waveform more mathematically sound. The waveform now looks significantly smoother at lower resolutions and flickers much less when zooming in and out.

This was achieved by making the filter kernel gaussian and adjusting its shape to fit the Nyquist frequency (i.e. twice the sampling frequency) of the signal to be filtered.

---

The waveform now looks significantly smoother at lower resolutions and flickers much less when zooming in and out.