### PR TITLE
Disable sourcelink on mono

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,4 +15,8 @@
     <Company>ppy Pty Ltd</Company>
     <Copyright>ppy Pty Ltd 2007-2018</Copyright>
   </PropertyGroup>
+  <PropertyGroup Label="Sourcelink3">
+    <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>
+    <EnableSourceControlManagerQueries>$(EnableSourceLink)</EnableSourceControlManagerQueries>
+  </PropertyGroup>
 </Project>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -21,7 +21,7 @@
     <copyright>Copyright (c) 2007-2018 ppy Pty Ltd contact@ppy.sh</copyright>
     <PackageTags>osu game framework</PackageTags>
   </PropertyGroup>
-  <PropertyGroup Label="Sourcelink3">
+  <PropertyGroup Label="Sourcelink3" Condition=" '($EnableSourceLink)' == 'true' ">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>


### PR DESCRIPTION
- See https://github.com/dotnet/sourcelink/issues/155

---

Workaround to fix build errors like this on mono:

```
error MSB4018: The "Microsoft.Build.Tasks.Git.LocateRepository" task failed unexpectedly.
error MSB4018: System.BadImageFormatException: Method has no body
error MSB4018: File name: 'LibGit2Sharp'
```