### PR TITLE
Fix MakeCurrent throwing an error when no child is present

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseDrawableLoadCancellation.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawableLoadCancellation.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Tests.Visual
 
             AddStep("start async load", () => LoadComponentAsync(loader = new PausableLoadDrawable(0), _ => loaded = true, (cancellationSource = new CancellationTokenSource()).Token));
 
-            AddAssert("load started", () => loader.IsLoading);
+            AddUntilStep(() => loader.IsLoading, "load started");
 
             AddStep("cancel", () => cancellationSource.Cancel());
 

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -234,7 +234,7 @@ namespace osu.Framework.Screens
 
         public void MakeCurrent()
         {
-            if (IsCurrentScreen) return;
+            if (IsCurrentScreen || ChildScreen == null) return;
 
             Screen c;
             for (c = ChildScreen; c.ChildScreen != null; c = c.ChildScreen)


### PR DESCRIPTION
It's pretty safe to just noop in this case.