### PR TITLE
Rate limit console log output

### DIFF
--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -216,8 +216,6 @@ namespace osu.Framework.Graphics.Visualisation
                     return Color4.BlueViolet;
                 case LoggingTarget.Performance:
                     return Color4.HotPink;
-                case LoggingTarget.Debug:
-                    return Color4.DarkBlue;
                 case LoggingTarget.Information:
                     return Color4.CadetBlue;
                 default:

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -55,9 +55,9 @@ namespace osu.Framework.IO.Stores
 
                 try
                 {
-                    Logger.Log($"Loading Font {store.FontName}...", LoggingTarget.Debug);
+                    Logger.Log($"Loading Font {store.FontName}...", level: LogLevel.Debug);
                     await store.LoadFontAsync();
-                    Logger.Log($"Loaded Font {store.FontName}!", LoggingTarget.Debug);
+                    Logger.Log($"Loaded Font {store.FontName}!", level: LogLevel.Debug);
                 }
                 catch (OperationCanceledException)
                 {

--- a/osu.Framework/Logging/RollingTime.cs
+++ b/osu.Framework/Logging/RollingTime.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Logging
+{
+    /// <summary>
+    /// Keep track of a finite list of timed events for the purpose of rate limiting.
+    /// </summary>
+    internal class RollingTime
+    {
+        private readonly int size;
+        private readonly int span;
+        private readonly long[] time;
+
+        /// <summary>
+        /// Make a new object that keeps track of time for a number of events.
+        /// </summary>
+        /// <param name="size">The number of events to track.</param>
+        /// <param name="span">The time over which the number of events is governed.</param>
+        internal RollingTime(int size, int span)
+        {
+            this.size = size;
+            this.span = span;
+            time = new long[size];
+            RequestEntry();
+        }
+
+        private long now => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
+        public bool IsAtLimit => time[0] + span - now > 0;
+
+        internal bool RequestEntry()
+        {
+            if (IsAtLimit) return false;
+
+            for (int i = 0; i < size - 1; i++)
+                time[i] = time[i + 1];
+            time[size - 1] = now;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
- Limits console debug log output to 50 messages over 10 seconds.
- Removed debug log target (was confusing; use `LogLevel.Debug` instead).

This can mainly be seen as a performance fix. Outputting to an IDE's console can add a very noticeable (blocking) overhead to execution.