### PR TITLE
Add serialisation test for population of bindable

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableSerializationTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableSerializationTest.cs
@@ -100,6 +100,29 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(toSerialize.Value.Bindable2.Value, deserialized.Value.Bindable2.Value);
         }
 
+        [Test]
+        public void TestPopulateBindable()
+        {
+            var obj = new CustomObj2
+            {
+                Bindable =
+                {
+                    MaxValue = 500,
+                    Value = 500
+                }
+            };
+
+            var serialized = JsonConvert.SerializeObject(obj);
+            obj.Bindable.Value = 100;
+
+            bool valueChanged = false;
+            obj.Bindable.BindValueChanged(_ => valueChanged = true);
+
+            JsonConvert.PopulateObject(serialized, obj);
+
+            Assert.IsTrue(valueChanged);
+        }
+
         private class CustomObj
         {
             public Bindable<int> Bindable1 = new Bindable<int>();


### PR DESCRIPTION
It's something that requires custom parsing logic that I wasn't sure if I implemented correctly, but is supported.