### PR TITLE
Add UnbindFrom method to bindables

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -321,6 +321,21 @@ namespace osu.Framework.Tests.Bindables
             TestUnbindOnDrawableDispose();
         }
 
+        [Test]
+        public void TestUnbindFrom()
+        {
+            var bindable1 = new Bindable<int>(5);
+            var bindable2 = new Bindable<int>();
+            bindable2.BindTo(bindable1);
+
+            Assert.AreEqual(bindable1.Value, bindable2.Value);
+
+            bindable2.UnbindFrom(bindable1);
+            bindable1.Value = 10;
+
+            Assert.AreNotEqual(bindable1.Value, bindable2.Value);
+        }
+
         private class TestDrawable : Drawable
         {
             public bool ValueChanged;

--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -132,8 +132,8 @@ namespace osu.Framework.Configuration
             Disabled = them.Disabled;
             Default = them.Default;
 
-            AddWeakReference(them.weakReference);
-            them.AddWeakReference(weakReference);
+            addWeakReference(them.weakReference);
+            them.addWeakReference(weakReference);
         }
 
         /// <summary>
@@ -160,7 +160,7 @@ namespace osu.Framework.Configuration
                 onChange(Disabled);
         }
 
-        protected void AddWeakReference(WeakReference<Bindable<T>> weakReference)
+        private void addWeakReference(WeakReference<Bindable<T>> weakReference)
         {
             if (Bindings == null)
                 Bindings = new WeakList<Bindable<T>>();
@@ -168,7 +168,7 @@ namespace osu.Framework.Configuration
             Bindings.Add(weakReference);
         }
 
-        protected void RemoveWeakReference(WeakReference<Bindable<T>> weakReference) => Bindings?.Remove(weakReference);
+        private void removeWeakReference(WeakReference<Bindable<T>> weakReference) => Bindings?.Remove(weakReference);
 
         /// <summary>
         /// Parse an object into this instance.
@@ -254,8 +254,8 @@ namespace osu.Framework.Configuration
             if (!(them is Bindable<T> tThem))
                 throw new InvalidCastException($"Can't unbind a bindable of type {them.GetType()} from a bindable of type {GetType()}.");
 
-            RemoveWeakReference(tThem.weakReference);
-            tThem.RemoveWeakReference(weakReference);
+            removeWeakReference(tThem.weakReference);
+            tThem.removeWeakReference(weakReference);
         }
 
         public string Description { get; set; }

--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -81,11 +81,14 @@ namespace osu.Framework.Configuration
             }
         }
 
+        private readonly WeakReference<Bindable<T>> weakReference;
+
         /// <summary>
         /// Creates a new bindable instance. This is used for deserialization of bindables.
         /// </summary>
         [UsedImplicitly]
         private Bindable()
+            : this(default)
         {
         }
 
@@ -96,13 +99,13 @@ namespace osu.Framework.Configuration
         public Bindable(T value = default)
         {
             this.value = value;
+
+            weakReference = new WeakReference<Bindable<T>>(this);
         }
 
         public static implicit operator T(Bindable<T> value) => value.Value;
 
         protected WeakList<Bindable<T>> Bindings;
-
-        private WeakReference<Bindable<T>> weakReference => new WeakReference<Bindable<T>>(this);
 
         void IBindable.BindTo(IBindable them)
         {

--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -105,7 +105,7 @@ namespace osu.Framework.Configuration
 
         public static implicit operator T(Bindable<T> value) => value.Value;
 
-        protected WeakList<Bindable<T>> Bindings;
+        protected WeakList<Bindable<T>> Bindings { get; private set; }
 
         void IBindable.BindTo(IBindable them)
         {

--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -168,6 +168,8 @@ namespace osu.Framework.Configuration
             Bindings.Add(weakReference);
         }
 
+        protected void RemoveWeakReference(WeakReference<Bindable<T>> weakReference) => Bindings?.Remove(weakReference);
+
         /// <summary>
         /// Parse an object into this instance.
         /// An object deriving T can be parsed, or a string can be parsed if T is an enum type.
@@ -245,6 +247,15 @@ namespace osu.Framework.Configuration
         {
             UnbindEvents();
             UnbindBindings();
+        }
+
+        public void UnbindFrom(IUnbindable them)
+        {
+            if (!(them is Bindable<T> tThem))
+                throw new InvalidCastException($"Can't unbind a bindable of type {them.GetType()} from a bindable of type {GetType()}.");
+
+            RemoveWeakReference(tThem.weakReference);
+            tThem.RemoveWeakReference(weakReference);
         }
 
         public string Description { get; set; }

--- a/osu.Framework/Configuration/BindableCollection.cs
+++ b/osu.Framework/Configuration/BindableCollection.cs
@@ -13,7 +13,8 @@ namespace osu.Framework.Configuration
         // list allows to use methods like AddRange.
         private readonly List<T> collection = new List<T>();
 
-        private WeakReference<BindableCollection<T>> weakReference { get; }
+        private readonly WeakReference<BindableCollection<T>> weakReference;
+
         private WeakList<BindableCollection<T>> bindings;
 
         /// <summary>
@@ -254,6 +255,15 @@ namespace osu.Framework.Configuration
             UnbindBindings();
         }
 
+        public void UnbindFrom(IUnbindable them)
+        {
+            if (!(them is BindableCollection<T> tThem))
+                throw new InvalidCastException($"Can't unbind a bindable of type {them.GetType()} from a bindable of type {GetType()}.");
+
+            removeWeakReference(tThem.weakReference);
+            tThem.removeWeakReference(weakReference);
+        }
+
         private void unbind(BindableCollection<T> binding)
             => bindings.Remove(binding.weakReference);
 
@@ -329,6 +339,8 @@ namespace osu.Framework.Configuration
 
             bindings.Add(weakReference);
         }
+
+        private void removeWeakReference(WeakReference<BindableCollection<T>> weakReference) => bindings?.Remove(weakReference);
 
         IBindableCollection<T> IBindableCollection<T>.GetBoundCopy()
             => GetBoundCopy();

--- a/osu.Framework/Configuration/IBindable.cs
+++ b/osu.Framework/Configuration/IBindable.cs
@@ -11,7 +11,7 @@ namespace osu.Framework.Configuration
     public interface IBindable : IParseable, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
     {
         /// <summary>
-        /// Binds outselves to another bindable such that we receive any value limitations of the bindable we bind width.
+        /// Binds ourselves to another bindable such that we receive any value limitations of the bindable we bind width.
         /// </summary>
         /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
         void BindTo(IBindable them);
@@ -47,7 +47,7 @@ namespace osu.Framework.Configuration
         T Default { get; }
 
         /// <summary>
-        /// Binds outselves to another bindable such that we receive any values and value limitations of the bindable we bind width.
+        /// Binds ourselves to another bindable such that we receive any values and value limitations of the bindable we bind width.
         /// </summary>
         /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
         void BindTo(IBindable<T> them);

--- a/osu.Framework/Configuration/IUnbindable.cs
+++ b/osu.Framework/Configuration/IUnbindable.cs
@@ -22,5 +22,12 @@ namespace osu.Framework.Configuration
         /// Calls <see cref="UnbindEvents"/> and <see cref="UnbindBindings"/>
         /// </summary>
         void UnbindAll();
+
+        /// <summary>
+        /// Unbinds ourselves from another <see cref="IBindable"/> such that we stop receiving updates it.
+        /// The other <see cref="IBindable"/> will also stop receiving any events from us.
+        /// </summary>
+        /// <param name="them">The other bindable.</param>
+        void UnbindFrom(IUnbindable them);
     }
 }


### PR DESCRIPTION
Allows the following sort of usage:

```
var bindable1 = new Bindable<int>();
var bindable2 = new Bindable<int>();
var bindable3 = new Bindable<int>();

bindable2.BindTo(bindable1)
bindable3.BindTo(bindable1)

bindable1.UnbindFrom(bindable2)

bindable1.Value = 5;

// bindable1.Value == 5
// bindable2.Value == 0
// bindable3.Value == 5
```