### PR TITLE
Improve PropertyDisplay performance with debugger attached

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -255,6 +255,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Gets or sets the only child in <see cref="InternalChildren"/>.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         protected internal Drawable InternalChild
         {
             get

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -8,6 +8,7 @@ using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Colour;
 using osuTK;
 using System.Collections;
+using System.Diagnostics;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -122,6 +123,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Gets or sets the only child of this container.
         /// </summary>
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public T Child
         {
             get

--- a/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -56,7 +57,7 @@ namespace osu.Framework.Graphics.Visualisation
             while (type != null && type != typeof(object))
             {
                 type.GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
-                    .Where(m => m is FieldInfo || m is PropertyInfo pi && pi.GetMethod != null)
+                    .Where(m => m is FieldInfo || m is PropertyInfo pi && pi.GetMethod != null && !pi.GetIndexParameters().Any())
                     .ForEach(m => allMembers.Add(m));
 
                 type = type.BaseType;
@@ -65,6 +66,7 @@ namespace osu.Framework.Graphics.Visualisation
             // Order by upper then lower-case, and exclude auto-generated backing fields of properties
             AddRange(allMembers.OrderBy(m => m.Name[0]).ThenBy(m => m.Name)
                                .Where(m => m.GetCustomAttribute<CompilerGeneratedAttribute>() == null)
+                               .Where(m => m.GetCustomAttribute<DebuggerBrowsableAttribute>()?.State != DebuggerBrowsableState.Never)
                                .Select(m => new PropertyItem(m, source)));
         }
 

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -330,7 +330,6 @@ namespace osu.Framework.Graphics.Visualisation
         {
             // May come from the disposal thread, in which case they won't ever be reused and the container doesn't need to be reset
             Schedule(() => SetContainer(null));
-            Dispose();
         }
 
         private void updateSpecifics()

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Localisation
                 if (text.ShouldLocalise && storage.Value != null)
                     newText = storage.Value.Get(newText);
 
-                if (text.Args != null && !string.IsNullOrEmpty(newText))
+                if (text.Args?.Length > 0 && !string.IsNullOrEmpty(newText))
                 {
                     try
                     {


### PR DESCRIPTION
As we found out recently, CoreCLR exception handling takes some 60-120ms per exception with a debugger attached (depending on OS). This is likely due to having to wait for the debugger to respond to the event for breakpoints.

Presumably this is also at least partly the cause of object inspection being super slow in with execution paused.