### PR TITLE
Reimplement System.Drawing.Icon

### DIFF
--- a/osu.Framework/Platform/Windows/Native/Icon.cs
+++ b/osu.Framework/Platform/Windows/Native/Icon.cs
@@ -8,9 +8,16 @@ namespace osu.Framework.Platform.Windows.Native
 {
     internal class Icon : IDisposable
     {
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool DestroyIcon(IntPtr hIcon);
+
+        private bool disposed;
+
         public IntPtr Handle { get; private set; }
-        public int Width { get; private set; }
-        public int Height { get; private set; }
+
+        public readonly int Width;
+
+        public readonly int Height;
 
         internal Icon(IntPtr handle, int width, int height)
         {
@@ -21,17 +28,27 @@ namespace osu.Framework.Platform.Windows.Native
 
         ~Icon()
         {
-            Dispose();
+            Dispose(false);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+
+            if (Handle != IntPtr.Zero)
+            {
+                DestroyIcon(Handle);
+                Handle = IntPtr.Zero;
+            }
+
+            disposed = true;
         }
 
         public void Dispose()
         {
-            if (Handle != IntPtr.Zero)
-                DestroyIcon(Handle);
-            Handle = IntPtr.Zero;
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
-
-        [DllImport("user32.dll", SetLastError = true)]
-        private static extern bool DestroyIcon(IntPtr hIcon);
     }
 }

--- a/osu.Framework/Platform/Windows/Native/Icon.cs
+++ b/osu.Framework/Platform/Windows/Native/Icon.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace osu.Framework.Platform.Windows.Native
+{
+    internal class Icon : IDisposable
+    {
+        public IntPtr Handle { get; private set; }
+        public int Width { get; private set; }
+        public int Height { get; private set; }
+
+        internal Icon(IntPtr handle, int width, int height)
+        {
+            Handle = handle;
+            Width = width;
+            Height = height;
+        }
+
+        ~Icon()
+        {
+            Dispose();
+        }
+
+        public void Dispose()
+        {
+            if (Handle != IntPtr.Zero)
+                DestroyIcon(Handle);
+            Handle = IntPtr.Zero;
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        private static extern bool DestroyIcon(IntPtr hIcon);
+    }
+}

--- a/osu.Framework/Platform/Windows/Native/IconGroup.cs
+++ b/osu.Framework/Platform/Windows/Native/IconGroup.cs
@@ -107,7 +107,7 @@ namespace osu.Framework.Platform.Windows.Native
             var span = new ReadOnlySpan<byte>(data, (int)entry.ImageOffset, (int)entry.BytesInResource);
 
             if (!entry.HasRawData)
-                hIcon = CreateIconFromResourceEx(span.ToArray(), entry.BytesInResource, true, 0, width, height, lr_defaultcolor);
+                hIcon = CreateIconFromResourceEx(span.ToArray(), entry.BytesInResource, true, 0x00030000, width, height, lr_defaultcolor);
 
             if (hIcon == IntPtr.Zero)
                 throw new InvalidOperationException("Couldn't create native icon handle.");

--- a/osu.Framework/Platform/Windows/Native/IconGroup.cs
+++ b/osu.Framework/Platform/Windows/Native/IconGroup.cs
@@ -44,13 +44,13 @@ namespace osu.Framework.Platform.Windows.Native
             if (stream == null || stream.Length == 0)
                 throw new ArgumentException("Invalid icon stream.", nameof(stream));
 
-            using (MemoryStream ms = new MemoryStream())
+            using (var ms = new MemoryStream())
             {
                 stream.CopyTo(ms);
                 data = ms.GetBuffer();
                 ms.Position = 0;
 
-                BinaryReader reader = new BinaryReader(ms);
+                var reader = new BinaryReader(ms);
                 iconDir.Reserved = reader.ReadUInt16();
                 if (iconDir.Reserved != 0)
                     throw new ArgumentException("Invalid icon stream.", nameof(stream));

--- a/osu.Framework/Platform/Windows/Native/IconGroup.cs
+++ b/osu.Framework/Platform/Windows/Native/IconGroup.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.IO;
+using System.Runtime.InteropServices;
+using System;
+
+namespace osu.Framework.Platform.Windows.Native
+{
+    internal class IconGroup
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct IconDirEntry
+        {
+            internal byte Width;
+            internal byte Height;
+            internal byte ColourCount;
+            internal byte Reserved;
+            internal ushort Planes;
+            internal ushort BitCount;
+            internal uint BytesInResource;
+            internal uint ImageOffset;
+
+            // 256x256 icons are defined as 0x0 and point to PNG data
+            internal bool PNGIcon => Width == 0 && Height == 0;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct IconDir
+        {
+            internal ushort Reserved;
+            internal ushort Type;
+            internal ushort Count;
+            internal IconDirEntry[] Entries;
+        }
+
+        private const uint lr_defaultcolor = 0x00000000;
+
+        private IconDir iconDir;
+        private readonly byte[] data;
+
+        public IconGroup(Stream stream)
+        {
+            if (stream == null || stream.Length == 0)
+                throw new ArgumentException("Invalid icon stream.", nameof(stream));
+
+            using (MemoryStream ms = new MemoryStream())
+            {
+                stream.CopyTo(ms);
+                data = ms.GetBuffer();
+                ms.Position = 0;
+
+                BinaryReader reader = new BinaryReader(ms);
+                iconDir.Reserved = reader.ReadUInt16();
+                if (iconDir.Reserved != 0)
+                    throw new ArgumentException("Invalid icon stream.", nameof(stream));
+
+                iconDir.Type = reader.ReadUInt16();
+                if (iconDir.Type != 1)
+                    throw new ArgumentException("Invalid icon stream.", nameof(stream));
+
+                iconDir.Count = reader.ReadUInt16();
+                iconDir.Entries = new IconDirEntry[iconDir.Count];
+
+                for (int i = 0; i < iconDir.Count; i++)
+                {
+                    iconDir.Entries[i] = new IconDirEntry
+                    {
+                        Width = reader.ReadByte(),
+                        Height = reader.ReadByte(),
+                        ColourCount = reader.ReadByte(),
+                        Reserved = reader.ReadByte(),
+                        Planes = reader.ReadUInt16(),
+                        BitCount = reader.ReadUInt16(),
+                        BytesInResource = reader.ReadUInt32(),
+                        ImageOffset = reader.ReadUInt32()
+                    };
+                }
+            }
+        }
+
+        private int findClosestEntry(int width, int height)
+        {
+            int requested = Math.Min(width, height);
+            int closest = -1;
+            for (int i = 0; i < iconDir.Count; i++)
+            {
+                var entry = iconDir.Entries[i];
+                if (entry.Width == width && entry.Height == height || entry.PNGIcon && width == 256 && height == 256)
+                    return i;
+                if (entry.Width > requested || entry.Height > requested)
+                    continue;
+                if (closest < 0 || entry.Width > iconDir.Entries[closest].Width || entry.Height > iconDir.Entries[closest].Height)
+                    closest = i;
+            }
+            return closest;
+        }
+
+        public Icon CreateIcon(int width, int height)
+        {
+            int closest = findClosestEntry(width, height);
+            if (closest < 0)
+                throw new InvalidOperationException($"Couldn't find icon to match width {width} and height {height}.");
+
+            var entry = iconDir.Entries[closest];
+            IntPtr hIcon = IntPtr.Zero;
+            var span = new ReadOnlySpan<byte>(data, (int)entry.ImageOffset, (int)entry.BytesInResource);
+
+            if (entry.PNGIcon)
+            {
+                // TODO: read png
+            }
+            else
+                hIcon = CreateIconFromResourceEx(span.ToArray(), entry.BytesInResource, true, 0, width, height, lr_defaultcolor);
+
+            if (hIcon == IntPtr.Zero)
+                throw new InvalidOperationException($"Couldn't create native icon handle.");
+            return new Icon(hIcon, width, height);
+        }
+
+        [DllImport("user32.dll")]
+        private static extern IntPtr CreateIconFromResourceEx(byte[] pbIconBits, uint cbIconBits, bool fIcon, uint dwVersion, int cxDesired, int cyDesired, uint uFlags);
+    }
+}

--- a/osu.Framework/Platform/Windows/WindowsGameWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameWindow.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Drawing;
 using System.IO;
 using System.Runtime.InteropServices;
+using osu.Framework.Platform.Windows.Native;
 using osuTK.Input;
 
 namespace osu.Framework.Platform.Windows
@@ -13,6 +13,7 @@ namespace osu.Framework.Platform.Windows
     {
         private const int seticon_message = 0x0080;
 
+        private IconGroup iconGroup;
         private Icon smallIcon;
         private Icon largeIcon;
 
@@ -32,14 +33,10 @@ namespace osu.Framework.Platform.Windows
             if (WindowInfo.Handle == IntPtr.Zero)
                 throw new InvalidOperationException("Window must be created before an icon can be set.");
 
-            var secondStream = new MemoryStream();
-            stream.CopyTo(secondStream);
+            iconGroup = new IconGroup(stream);
 
-            stream.Position = 0;
-            secondStream.Position = 0;
-
-            smallIcon = new Icon(stream, 24, 24);
-            largeIcon = new Icon(secondStream, 256, 256);
+            smallIcon = iconGroup.CreateIcon(24, 24);
+            largeIcon = iconGroup.CreateIcon(256, 256);
 
             SendMessage(WindowInfo.Handle, seticon_message, (IntPtr)0, smallIcon.Handle);
             SendMessage(WindowInfo.Handle, seticon_message, (IntPtr)1, largeIcon.Handle);


### PR DESCRIPTION
Cut down version of `System.Drawing.Icon` to remove dependency on the aforementioned class.  Required for Xamarin projects to correctly link, since `System.Drawing.Icon` and similar classes are not available.  We currently only use the `Icon` class to load in a .ico from a `Stream` and create an `HICON`, all of which can be done manually with PInvoke.

---

Removes dependency on `System.Drawing.Icon` for Xamarin compatibility.
