### PR TITLE
Don't process web request responses on timeout

### DIFF
--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -421,9 +421,11 @@ namespace osu.Framework.IO.Network
             var we = e as WebException;
 
             bool allowRetry = AllowRetryOnTimeout;
+            bool wasTimeout = false;
 
             if (e != null)
-                allowRetry &= we?.Status == WebExceptionStatus.Timeout;
+                wasTimeout = we?.Status == WebExceptionStatus.Timeout;
+
             else if (!response.IsSuccessStatusCode)
             {
                 e = new WebException(response.StatusCode.ToString());
@@ -432,17 +434,12 @@ namespace osu.Framework.IO.Network
                 {
                     case HttpStatusCode.GatewayTimeout:
                     case HttpStatusCode.RequestTimeout:
-                        break;
-                    case HttpStatusCode.NotFound:
-                    case HttpStatusCode.MethodNotAllowed:
-                    case HttpStatusCode.Forbidden:
-                        allowRetry = false;
-                        break;
-                    case HttpStatusCode.Unauthorized:
-                        allowRetry = false;
+                        wasTimeout = true;
                         break;
                 }
             }
+
+            allowRetry &= wasTimeout;
 
             if (e != null)
             {
@@ -464,7 +461,8 @@ namespace osu.Framework.IO.Network
 
             try
             {
-                ProcessResponse();
+                if (!wasTimeout)
+                    ProcessResponse();
             }
             catch (Exception se)
             {

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -425,7 +425,6 @@ namespace osu.Framework.IO.Network
 
             if (e != null)
                 wasTimeout = we?.Status == WebExceptionStatus.Timeout;
-
             else if (!response.IsSuccessStatusCode)
             {
                 e = new WebException(response.StatusCode.ToString());


### PR DESCRIPTION
Can lead to pointless aggregate exceptions when trying to deserialize null strings, for instance.