### PR TITLE
Ignore components during drawvis search

### DIFF
--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -205,7 +205,7 @@ namespace osu.Framework.Graphics.Visualisation
                     if (compositeTarget == null)
                         compositeTarget = composite;
                 }
-                else
+                else if (!(drawable is Component))
                     drawableTarget = drawable;
             }
 


### PR DESCRIPTION
Since components are not meant to display anything.

This was causing the IdleTracker to always be selected in osu!.