### PR TITLE
Fix testbrowser continuously throwing exceptions

### DIFF
--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Containers
 
         private double timeVisible;
 
-        protected bool ShouldLoadContent => timeBeforeLoad == 0 || timeVisible > timeBeforeLoad;
+        protected virtual bool ShouldLoadContent => timeBeforeLoad == 0 || timeVisible > timeBeforeLoad;
 
         private Task loadTask;
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -461,6 +461,7 @@ namespace osu.Framework.Testing
                     if (!catchErrors)
                         throw;
 
+                    // without this we will enter an infinite loading loop (DelayedLoadWrapper will see the child removed below and retry).
                     hasCaught = true;
 
                     OnCaughtError?.Invoke(e);

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -440,6 +440,7 @@ namespace osu.Framework.Testing
         private class ErrorCatchingDelayedLoadWrapper : DelayedLoadWrapper
         {
             private readonly bool catchErrors;
+            private bool hasCaught;
 
             public Action<Exception> OnCaughtError;
 
@@ -460,12 +461,16 @@ namespace osu.Framework.Testing
                     if (!catchErrors)
                         throw;
 
+                    hasCaught = true;
+
                     OnCaughtError?.Invoke(e);
                     RemoveInternal(Content);
                 }
 
                 return false;
             }
+
+            protected override bool ShouldLoadContent => !hasCaught;
         }
     }
 


### PR DESCRIPTION
The resulting testcase of a dynamic compilation has `UpdateSubTree` exceptions caught and subsequently removes the testcase from the hierarchy.

Due to recent changes in `DelayedLoadWrapper`, the testcase would be re-loaded in the next frame, throwing the same errors again.