### PR TITLE
Update README about SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A game framework written with [osu!](https://github.com/ppy/osu) in mind.
 
 # Requirements
 
-- A desktop platform with the [.NET Core SDK 2.1](https://www.microsoft.com/net/learn/get-started) or higher installed.
+- A desktop platform with the [.NET Core SDK 2.2](https://www.microsoft.com/net/learn/get-started) or higher installed.
 - When working with the codebase, we recommend using an IDE with intellisense and syntax highlighting, such as [Visual Studio Community Edition](https://www.visualstudio.com/) (Windows), [Visual Studio Code](https://code.visualstudio.com/) (with the C# plugin installed) or [Jetbrains Rider](https://www.jetbrains.com/rider/) (commercial).
 
 # Objectives


### PR DESCRIPTION
Related to #2009 

Although it seems that only SampleGame and osu.Framework.Tests need .NET Core 2.2.