### PR TITLE
Make GameHost.Exit virtual

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -411,10 +411,15 @@ namespace osu.Framework.Platform
         public ExecutionState ExecutionState { get; private set; }
 
         /// <summary>
+        /// Schedules the game to exit in the next frame.
+        /// </summary>
+        public void Exit() => PerformExit(false);
+
+        /// <summary>
         /// Schedules the game to exit in the next frame (or immediately if <paramref name="immediately"/> is true).
         /// </summary>
         /// <param name="immediately">If true, exits the game immediately.  If false (default), schedules the game to exit in the next frame.</param>
-        public virtual void Exit(bool immediately = false)
+        protected virtual void PerformExit(bool immediately)
         {
             if (immediately)
                 exit();
@@ -511,7 +516,7 @@ namespace osu.Framework.Platform
             finally
             {
                 // Close the window and stop all threads
-                Exit(true);
+                PerformExit(true);
             }
         }
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -411,12 +411,18 @@ namespace osu.Framework.Platform
         public ExecutionState ExecutionState { get; private set; }
 
         /// <summary>
-        /// Schedules the game to exit in the next frame.
+        /// Schedules the game to exit in the next frame (or immediately if <paramref name="immediately"/> is true).
         /// </summary>
-        public void Exit()
+        /// <param name="immediately">If true, exits the game immediately.  If false (default), schedules the game to exit in the next frame.</param>
+        public virtual void Exit(bool immediately = false)
         {
-            ExecutionState = ExecutionState.Stopping;
-            InputThread.Scheduler.Add(exit, false);
+            if (immediately)
+                exit();
+            else
+            {
+                ExecutionState = ExecutionState.Stopping;
+                InputThread.Scheduler.Add(exit, false);
+            }
         }
 
         /// <summary>
@@ -505,7 +511,7 @@ namespace osu.Framework.Platform
             finally
             {
                 // Close the window and stop all threads
-                exit();
+                Exit(true);
             }
         }
 


### PR DESCRIPTION
Allows `Exit` to be no-opped by host implementations (useful for mobile platforms).

The public `Exit` was made virtual rather than the private `exit` implementation, to prevent the game from becoming stuck in a `Stopping` state if `Exit` is called.