### PR TITLE
Use UIImage for iOS image loading

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseTextures.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextures.cs
@@ -15,10 +15,10 @@ namespace osu.Framework.Tests.Visual
     public class TestCaseTextures : TestCase
     {
         [Cached]
-        private TextureStore normalStore = new TextureStore(new TextureLoaderStore(new OnlineStore()));
+        private TextureStore normalStore;
 
         [Cached]
-        private LargeTextureStore largeStore = new LargeTextureStore(new TextureLoaderStore(new OnlineStore()));
+        private LargeTextureStore largeStore;
 
         protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
         {

--- a/osu.Framework.Tests/Visual/TestCaseTextures.cs
+++ b/osu.Framework.Tests/Visual/TestCaseTextures.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
+using osu.Framework.Platform;
 using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual
@@ -14,10 +15,20 @@ namespace osu.Framework.Tests.Visual
     public class TestCaseTextures : TestCase
     {
         [Cached]
-        private readonly TextureStore normalStore = new TextureStore(new TextureLoaderStore(new OnlineStore()));
+        private TextureStore normalStore = new TextureStore(new TextureLoaderStore(new OnlineStore()));
 
         [Cached]
-        private readonly LargeTextureStore largeStore = new LargeTextureStore(new TextureLoaderStore(new OnlineStore()));
+        private LargeTextureStore largeStore = new LargeTextureStore(new TextureLoaderStore(new OnlineStore()));
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+        {
+            var host = parent.Get<GameHost>();
+
+            normalStore = new TextureStore(host.CreateTextureLoaderStore(new OnlineStore()));
+            largeStore = new LargeTextureStore(host.CreateTextureLoaderStore(new OnlineStore()));
+
+            return base.CreateChildDependencies(parent);
+        }
 
         /// <summary>
         /// Tests that a ref-counted texture is disposed when all references are lost.

--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -9,7 +9,6 @@ using Foundation;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 using UIKit;
 
 namespace osu.Framework.iOS.Graphics.Textures
@@ -21,25 +20,7 @@ namespace osu.Framework.iOS.Graphics.Textures
         {
         }
 
-        public override TextureUpload Get(string name)
-        {
-            try
-            {
-                using (var stream = Store.GetStream(name))
-                {
-                    if (stream != null)
-                        return new TextureUpload(imageFromStream<Rgba32>(stream));
-                }
-            }
-            catch
-            {
-            }
-
-            return null;
-        }
-
-        private Image<TPixel> imageFromStream<TPixel>(Stream stream)
-            where TPixel : struct, IPixel<TPixel>
+        protected override Image<TPixel> ImageFromStream<TPixel>(Stream stream)
         {
             var uiImage = UIImage.LoadFromData(NSData.FromStream(stream));
             int width = (int)uiImage.Size.Width;

--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -1,11 +1,16 @@
 // Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using CoreGraphics;
+using Foundation;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
+using UIKit;
 
 namespace osu.Framework.iOS.Graphics.Textures
 {
@@ -20,7 +25,7 @@ namespace osu.Framework.iOS.Graphics.Textures
         {
             try
             {
-                using (var stream = store.GetStream(name))
+                using (var stream = Store.GetStream(name))
                 {
                     if (stream != null)
                         return new TextureUpload(imageFromStream<Rgba32>(stream));

--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -1,0 +1,55 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using osu.Framework.Graphics.Textures;
+using osu.Framework.IO.Stores;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace osu.Framework.iOS.Graphics.Textures
+{
+    public class IOSTextureLoaderStore : TextureLoaderStore
+    {
+        public IOSTextureLoaderStore(IResourceStore<byte[]> store)
+            : base(store)
+        {
+        }
+
+        public override TextureUpload Get(string name)
+        {
+            try
+            {
+                using (var stream = store.GetStream(name))
+                {
+                    if (stream != null)
+                        return new TextureUpload(imageFromStream<Rgba32>(stream));
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        private Image<TPixel> imageFromStream<TPixel>(Stream stream)
+            where TPixel : struct, IPixel<TPixel>
+        {
+            var uiImage = UIImage.LoadFromData(NSData.FromStream(stream));
+            int width = (int)uiImage.Size.Width;
+            int height = (int)uiImage.Size.Height;
+            IntPtr data = Marshal.AllocHGlobal(width * height * 4);
+
+            using (CGBitmapContext textureContext = new CGBitmapContext(data, width, height, 8, width * 4, uiImage.CGImage.ColorSpace, CGImageAlphaInfo.PremultipliedLast))
+                textureContext.DrawImage(new CGRect(0, 0, width, height), uiImage.CGImage);
+
+            var pixels = new byte[width * height * 4];
+            Marshal.Copy(data, pixels, 0, pixels.Length);
+            Marshal.FreeHGlobal(data);
+
+            // NOTE: this will probably only be correct for Rgba32, will need to look into other pixel formats
+            return Image.LoadPixelData<TPixel>(pixels, width, height);
+        }
+    }
+}

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -9,6 +9,7 @@ using osu.Framework.Input;
 using osu.Framework.Input.Handlers;
 using osu.Framework.IO.Stores;
 using osu.Framework.iOS.Audio;
+using osu.Framework.iOS.Graphics.Textures;
 using osu.Framework.iOS.Input;
 using osu.Framework.Platform;
 using osu.Framework.Platform.MacOS;
@@ -43,7 +44,7 @@ namespace osu.Framework.iOS
 
         public override void OpenUrlExternally(string url) => throw new NotImplementedException();
 
-        public override IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore underlyingStore)
+        public override IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore)
             => new IOSTextureLoaderStore(underlyingStore);
 
         public override AudioManager CreateAudioManager(ResourceStore<byte[]> trackStore, ResourceStore<byte[]> sampleStore, Scheduler eventScheduler) =>

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Audio;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
 using osu.Framework.Input.Handlers;
 using osu.Framework.IO.Stores;
@@ -41,6 +42,9 @@ namespace osu.Framework.iOS
         public override void OpenFileExternally(string filename) => throw new NotImplementedException();
 
         public override void OpenUrlExternally(string url) => throw new NotImplementedException();
+
+        public override IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore underlyingStore)
+            => new IOSTextureLoaderStore(underlyingStore);
 
         public override AudioManager CreateAudioManager(ResourceStore<byte[]> trackStore, ResourceStore<byte[]> sampleStore, Scheduler eventScheduler) =>
             new IOSAudioManager(trackStore, sampleStore) { EventScheduler = eventScheduler };

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras/1.6.55">
+﻿<Project Sdk="MSBuild.Sdk.Extras/1.6.55">
   <PropertyGroup Label="Project">
     <TargetFramework>xamarinios10</TargetFramework>
     <OutputType>Library</OutputType>
@@ -42,5 +42,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osuTK.iOS" Version="1.0.50" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0005" />
   </ItemGroup>
 </Project>

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -102,8 +102,8 @@ namespace osu.Framework
             Resources = new ResourceStore<byte[]>();
             Resources.AddStore(new NamespacedResourceStore<byte[]>(new DllResourceStore(@"osu.Framework.dll"), @"Resources"));
 
-            Textures = new TextureStore(new TextureLoaderStore(new NamespacedResourceStore<byte[]>(Resources, @"Textures")));
-            Textures.AddStore(new TextureLoaderStore(new OnlineStore()));
+            Textures = new TextureStore(Host.CreateTextureLoaderStore(new NamespacedResourceStore<byte[]>(Resources, @"Textures")));
+            Textures.AddStore(Host.CreateTextureLoaderStore(new OnlineStore()));
             dependencies.Cache(Textures);
 
             var tracks = new ResourceStore<byte[]>(Resources);

--- a/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
@@ -1,18 +1,21 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System.IO;
 using System.Threading.Tasks;
 using osu.Framework.IO.Stores;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Textures
 {
     public class TextureLoaderStore : ResourceStore<TextureUpload>
     {
-        protected IResourceStore<byte[]> Store { get; }
+        private IResourceStore<byte[]> store { get; }
 
         public TextureLoaderStore(IResourceStore<byte[]> store)
         {
-            Store = store;
+            this.store = store;
             (store as ResourceStore<byte[]>)?.AddExtension(@"png");
             (store as ResourceStore<byte[]>)?.AddExtension(@"jpg");
         }
@@ -23,10 +26,10 @@ namespace osu.Framework.Graphics.Textures
         {
             try
             {
-                using (var stream = Store.GetStream(name))
+                using (var stream = store.GetStream(name))
                 {
                     if (stream != null)
-                        return new TextureUpload(stream);
+                        return new TextureUpload(ImageFromStream<Rgba32>(stream));
                 }
             }
             catch
@@ -35,5 +38,8 @@ namespace osu.Framework.Graphics.Textures
 
             return null;
         }
+
+        protected virtual Image<TPixel> ImageFromStream<TPixel>(Stream stream) where TPixel : struct, IPixel<TPixel>
+            => Image.Load<TPixel>(stream);
     }
 }

--- a/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
@@ -8,11 +8,11 @@ namespace osu.Framework.Graphics.Textures
 {
     public class TextureLoaderStore : ResourceStore<TextureUpload>
     {
-        private IResourceStore<byte[]> store { get; }
+        protected IResourceStore<byte[]> Store { get; }
 
         public TextureLoaderStore(IResourceStore<byte[]> store)
         {
-            this.store = store;
+            Store = store;
             (store as ResourceStore<byte[]>)?.AddExtension(@"png");
             (store as ResourceStore<byte[]>)?.AddExtension(@"jpg");
         }
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics.Textures
         {
             try
             {
-                using (var stream = store.GetStream(name))
+                using (var stream = Store.GetStream(name))
                 {
                     if (stream != null)
                         return new TextureUpload(stream);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -37,6 +37,7 @@ using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using osu.Framework.Audio;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 
 namespace osu.Framework.Platform
@@ -790,6 +791,14 @@ namespace osu.Framework.Platform
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Tab }), new PlatformAction(PlatformActionType.DocumentNext)),
             new KeyBinding(new KeyCombination(new[] { InputKey.Control, InputKey.Shift, InputKey.Tab }), new PlatformAction(PlatformActionType.DocumentPrevious)),
         };
+
+        /// <summary>
+        /// Create a texture loader store based on an underlying data store.
+        /// </summary>
+        /// <param name="underlyingStore">The underlying provider of texture data (in arbitrary image formats).</param>
+        /// <returns>A texture loader store.</returns>
+        public virtual IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore)
+            => new TextureLoaderStore(underlyingStore);
     }
 
     /// <summary>


### PR DESCRIPTION
Alternative to #2037 which avoids using a static loader class.

Untested (still can't compile xamarin on this PC).