### PR TITLE
Make bindable bindings thread-safe

### DIFF
--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -105,7 +105,7 @@ namespace osu.Framework.Configuration
 
         public static implicit operator T(Bindable<T> value) => value.Value;
 
-        protected WeakList<Bindable<T>> Bindings { get; private set; }
+        protected LockedWeakList<Bindable<T>> Bindings { get; private set; }
 
         void IBindable.BindTo(IBindable them)
         {
@@ -163,7 +163,7 @@ namespace osu.Framework.Configuration
         private void addWeakReference(WeakReference<Bindable<T>> weakReference)
         {
             if (Bindings == null)
-                Bindings = new WeakList<Bindable<T>>();
+                Bindings = new LockedWeakList<Bindable<T>>();
 
             Bindings.Add(weakReference);
         }

--- a/osu.Framework/Configuration/BindableCollection.cs
+++ b/osu.Framework/Configuration/BindableCollection.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Configuration
 
         private readonly WeakReference<BindableCollection<T>> weakReference;
 
-        private WeakList<BindableCollection<T>> bindings;
+        private LockedWeakList<BindableCollection<T>> bindings;
 
         /// <summary>
         /// An event which is raised when any items are added to this <see cref="BindableCollection{T}"/>.
@@ -335,7 +335,7 @@ namespace osu.Framework.Configuration
         private void addWeakReference(WeakReference<BindableCollection<T>> weakReference)
         {
             if (bindings == null)
-                bindings = new WeakList<BindableCollection<T>>();
+                bindings = new LockedWeakList<BindableCollection<T>>();
 
             bindings.Add(weakReference);
         }

--- a/osu.Framework/Lists/IWeakList.cs
+++ b/osu.Framework/Lists/IWeakList.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Lists
+{
+    /// <summary>
+    /// A slim interface for a list which stores weak references of objects.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IWeakList<T>
+        where T : class
+    {
+        /// <summary>
+        /// Adds an item to this list. The item is added as a weak reference.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        void Add(T item);
+
+        /// <summary>
+        /// Adds a weak reference to this list.
+        /// </summary>
+        /// <param name="weakReference"></param>
+        void Add(WeakReference<T> weakReference);
+
+        /// <summary>
+        /// Removes an item from this list.
+        /// </summary>
+        /// <param name="item"></param>
+        void Remove(T item);
+
+        /// <summary>
+        /// Removes a weak reference from this list.
+        /// </summary>
+        /// <param name="weakReference"></param>
+        bool Remove(WeakReference<T> weakReference);
+
+        /// <summary>
+        /// Searches for an item in the list.
+        /// </summary>
+        /// <param name="item">The item to search for.</param>
+        /// <returns>Whether the item is alive and in this list.</returns>
+        bool Contains(T item);
+
+        /// <summary>
+        /// Searches for a weak reference in the list.
+        /// </summary>
+        /// <param name="weakReference">The weak reference to search for.</param>
+        /// <returns>Whether the weak reference is in the list.</returns>
+        bool Contains(WeakReference<T> weakReference);
+
+        /// <summary>
+        /// Clears all items from this list.
+        /// </summary>
+        void Clear();
+
+        /// <summary>
+        /// Performs an action for each alive reference in this list.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        void ForEachAlive(Action<T> action);
+    }
+}

--- a/osu.Framework/Lists/LockedWeakList.cs
+++ b/osu.Framework/Lists/LockedWeakList.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Lists
+{
+    /// <summary>
+    /// A <see cref="IWeakList{T}"/> which locks all operations.
+    /// </summary>
+    public class LockedWeakList<T> : IWeakList<T>
+        where T : class
+    {
+        private readonly WeakList<T> list = new WeakList<T>();
+
+        public void Add(T item)
+        {
+            lock (list)
+                list.Add(item);
+        }
+
+        public void Add(WeakReference<T> weakReference)
+        {
+            lock (list)
+                list.Add(weakReference);
+        }
+
+        public void Remove(T item)
+        {
+            lock (list)
+                list.Remove(item);
+        }
+
+        public bool Remove(WeakReference<T> weakReference)
+        {
+            lock (list)
+                return list.Remove(weakReference);
+        }
+
+        public bool Contains(T item)
+        {
+            lock (list)
+                return list.Contains(item);
+        }
+
+        public bool Contains(WeakReference<T> weakReference)
+        {
+            lock (list)
+                return list.Contains(weakReference);
+        }
+
+        public void Clear()
+        {
+            lock (list)
+                list.Clear();
+        }
+
+        public void ForEachAlive(Action<T> action)
+        {
+            lock (list)
+                list.ForEachAlive(action);
+        }
+    }
+}

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace osu.Framework.Lists
 {
@@ -10,26 +11,37 @@ namespace osu.Framework.Lists
     /// A list maintaining weak reference of objects.
     /// </summary>
     /// <typeparam name="T">Type of items tracked by weak reference.</typeparam>
-    public class WeakList<T> : List<WeakReference<T>>
+    public class WeakList<T> : IWeakList<T>
         where T : class
     {
+        private readonly List<WeakReference<T>> list = new List<WeakReference<T>>();
+
         public void Add(T obj) => Add(new WeakReference<T>(obj));
 
-        /// <summary>
-        /// Iterate on alive items, and remove non-alive references.
-        /// </summary>
+        public void Add(WeakReference<T> weakReference) => list.Add(weakReference);
+
+        public void Remove(T item) => list.RemoveAll(t => t.TryGetTarget(out var obj) && obj == item);
+
+        public bool Remove(WeakReference<T> weakReference) => list.Remove(weakReference);
+
+        public bool Contains(T item) => list.Any(t => t.TryGetTarget(out var obj) && obj == item);
+
+        public bool Contains(WeakReference<T> weakReference) => list.Contains(weakReference);
+
+        public void Clear() => list.Clear();
+
         public void ForEachAlive(Action<T> action)
         {
             int index = 0;
-            while (index < Count)
+            while (index < list.Count)
             {
-                if (this[index].TryGetTarget(out T obj))
+                if (list[index].TryGetTarget(out T obj))
                 {
                     action(obj);
                     index++;
                 }
                 else
-                    RemoveAt(index);
+                    list.RemoveAt(index);
             }
         }
     }


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/2047

1. I didn't want to make `WeakList<T>` thread-safe, since it's currently used in GLWrapper where performance is a must.
2. Putting the locking inside `Bindable<T>` looked like a mess, it'd have to be locked at derived levels too (e.g. `BindableNumber<T>`). On top of that the code would be duped to `BindableCollection<T>`.
3. `LockedWeakList<T>` is my alternative, so that it's explicitly known that the list is locked.

`IWeakList` is a very slim implementation because the full functionality of `IList` is not used/needed anywhere in current use cases.