### PR TITLE
De-virtualize equality comparer

### DIFF
--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -207,7 +207,7 @@ namespace osu.Framework.Configuration
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = value;
             if (propagateToBindings) Bindings?.ForEachAlive(b => b.Value = value);
-            if (Equals(beforePropagation, value))
+            if (EqualityComparer<T>.Default.Equals(beforePropagation, value))
                 ValueChanged?.Invoke(value);
         }
 


### PR DESCRIPTION
| Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
| ----------------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
| Before           | 217.9 us |  2.234 us |  1.866 us |    152.3438 |           - |           - |           468.75 KB |
| After            | 69.00 us | 0.6921 us | 0.6135 us |           - |           - |           - |                   - |

Testing by calling `bindable.Value = x` 10000 times, with a different value of `x` every time.