### PR TITLE
Remove letterboxing settings from framework

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -29,9 +29,6 @@ namespace osu.Framework.Configuration
             Set(FrameworkSetting.VolumeMusic, 1.0, 0.0, 1.0, 0.01);
             Set(FrameworkSetting.VolumeEffect, 1.0, 0.0, 1.0, 0.01);
             Set(FrameworkSetting.SizeFullscreen, new Size(9999, 9999), new Size(320, 240));
-            Set(FrameworkSetting.Letterboxing, true);
-            Set(FrameworkSetting.LetterboxPositionX, 0.0, -1.0, 1.0, 0.01);
-            Set(FrameworkSetting.LetterboxPositionY, 0.0, -1.0, 1.0, 0.01);
             Set(FrameworkSetting.FrameSync, FrameSync.Limit2x);
             Set(FrameworkSetting.WindowMode, WindowMode.Windowed);
             Set(FrameworkSetting.ShowUnicode, false);
@@ -80,9 +77,6 @@ namespace osu.Framework.Configuration
 
         WindowMode,
         ConfineMouseMode,
-        Letterboxing,
-        LetterboxPositionX,
-        LetterboxPositionY,
         FrameSync,
 
         ShowUnicode,


### PR DESCRIPTION
Due to how simple it is to implement this on a per-game level, and the fact that different games may want to handle this in different ways, there's no need to have it here.