### PR TITLE
Fix JIT errors on iOS in Waveform

### DIFF
--- a/osu.Framework.iOS/Audio/IOSTrackManager.cs
+++ b/osu.Framework.iOS/Audio/IOSTrackManager.cs
@@ -14,5 +14,7 @@ namespace osu.Framework.iOS.Audio
         }
 
         public override Track CreateTrack(Stream data, bool quick) => new IOSTrackBass(data, quick);
+
+        public override Waveform CreateWaveform(Stream data = null) => new IOSWaveform(data);
     }
 }

--- a/osu.Framework.iOS/Audio/IOSTrackManager.cs
+++ b/osu.Framework.iOS/Audio/IOSTrackManager.cs
@@ -13,8 +13,8 @@ namespace osu.Framework.iOS.Audio
         {
         }
 
-        public override Track CreateTrack(Stream data, bool quick) => new IOSTrackBass(data, quick);
+        public override Track CreateTrack(Stream data, bool quick = false) => new IOSTrackBass(data, quick);
 
-        public override Waveform CreateWaveform(Stream data = null) => new IOSWaveform(data);
+        public override Waveform CreateWaveform(Stream data) => new IOSWaveform(data);
     }
 }

--- a/osu.Framework.iOS/Audio/IOSWaveform.cs
+++ b/osu.Framework.iOS/Audio/IOSWaveform.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.IO;
+using osu.Framework.Audio.Track;
+
+namespace osu.Framework.iOS.Audio
+{
+    public class IOSWaveform : Waveform
+    {
+        public IOSWaveform(Stream data) : base(data)
+        {
+        }
+
+        protected override DataStreamFileProcedures CreateDataStreamFileProcedures(Stream dataStream) => new IOSDataStreamFileProcedures(dataStream);
+    }
+}

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -45,6 +45,11 @@ namespace osu.Framework.Audio.Track
 
         public override bool IsLoaded => isLoaded;
 
+        /// <summary>
+        /// Constructs a new <see cref="TrackBass"/> from provided audio data.
+        /// </summary>
+        /// <param name="data">The sample data stream.</param>
+        /// <param name="quick">If true, the track will not be fully loaded, and should only be used for preview purposes.  Defaults to false.</param>
         public TrackBass(Stream data, bool quick = false)
         {
             EnqueueAction(() =>

--- a/osu.Framework/Audio/Track/TrackManager.cs
+++ b/osu.Framework/Audio/Track/TrackManager.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Audio.Track
         {
             if (string.IsNullOrEmpty(name)) return null;
 
-            Track track = CreateTrack(store.GetStream(name), false);
+            Track track = CreateTrack(store.GetStream(name));
             AddItem(track);
             return track;
         }

--- a/osu.Framework/Audio/Track/TrackManager.cs
+++ b/osu.Framework/Audio/Track/TrackManager.cs
@@ -12,6 +12,8 @@ namespace osu.Framework.Audio.Track
 
         public virtual Track CreateTrack(Stream data, bool quick) => new TrackBass(data, quick);
 
+        public virtual Waveform CreateWaveform(Stream data = null) => new Waveform(data);
+
         public TrackManager(IResourceStore<byte[]> store)
         {
             this.store = store;

--- a/osu.Framework/Audio/Track/TrackManager.cs
+++ b/osu.Framework/Audio/Track/TrackManager.cs
@@ -10,9 +10,18 @@ namespace osu.Framework.Audio.Track
     {
         private readonly IResourceStore<byte[]> store;
 
-        public virtual Track CreateTrack(Stream data, bool quick) => new TrackBass(data, quick);
+        /// <summary>
+        /// Constructs a new <see cref="Track"/> from provided audio data.
+        /// </summary>
+        /// <param name="data">The sample data stream.</param>
+        /// <param name="quick">If true, the <see cref="Track"/> will not be fully loaded, and should only be used for preview purposes.  Defaults to false.</param>
+        public virtual Track CreateTrack(Stream data, bool quick = false) => new TrackBass(data, quick);
 
-        public virtual Waveform CreateWaveform(Stream data = null) => new Waveform(data);
+        /// <summary>
+        /// Constructs a new <see cref="Waveform"/> from provided audio data.
+        /// </summary>
+        /// <param name="data">The sample data stream. If null, an empty waveform is constructed.</param>
+        public virtual Waveform CreateWaveform(Stream data) => new Waveform(data);
 
         public TrackManager(IResourceStore<byte[]> store)
         {

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -72,7 +72,7 @@ namespace osu.Framework.Audio.Track
         /// Constructs a new <see cref="Waveform"/> from provided audio data.
         /// </summary>
         /// <param name="data">The sample data stream. If null, an empty waveform is constructed.</param>
-        public Waveform(Stream data = null)
+        public Waveform(Stream data)
         {
             if (data == null) return;
 
@@ -190,7 +190,7 @@ namespace osu.Framework.Audio.Track
             if (pointCount < 0) throw new ArgumentOutOfRangeException(nameof(pointCount));
 
             if (readTask == null)
-                return new Waveform();
+                return new Waveform(null);
 
             await readTask;
 
@@ -245,7 +245,7 @@ namespace osu.Framework.Audio.Track
                     generatedPoints.Add(point);
                 }
 
-                return new Waveform
+                return new Waveform(null)
                 {
                     points = generatedPoints,
                     channels = channels

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using ManagedBass;
 using osuTK;
 using osu.Framework.MathUtils;
+using System.Runtime.InteropServices;
 
 namespace osu.Framework.Audio.Track
 {
@@ -64,6 +65,9 @@ namespace osu.Framework.Audio.Track
         private readonly CancellationTokenSource cancelSource = new CancellationTokenSource();
         private readonly Task readTask;
 
+        private DataStreamFileProcedures procedures;
+        private GCHandle pinnedProcedures;
+
         /// <summary>
         /// Constructs a new <see cref="Waveform"/> from provided audio data.
         /// </summary>
@@ -78,9 +82,13 @@ namespace osu.Framework.Audio.Track
                 if (Bass.CurrentDevice <= 0)
                     return;
 
-                var procs = new DataStreamFileProcedures(data);
+                procedures = CreateDataStreamFileProcedures(data);
 
-                int decodeStream = Bass.CreateStream(StreamSystem.NoBuffer, BassFlags.Decode | BassFlags.Float, procs.BassProcedures, IntPtr.Zero);
+                if (!RuntimeInfo.SupportsIL)
+                    pinnedProcedures = GCHandle.Alloc(procedures, GCHandleType.Pinned);
+
+                int decodeStream = Bass.CreateStream(StreamSystem.NoBuffer, BassFlags.Decode | BassFlags.Float, procedures.BassProcedures,
+                    RuntimeInfo.SupportsIL ? IntPtr.Zero : GCHandle.ToIntPtr(pinnedProcedures));
 
                 Bass.ChannelGetInfo(decodeStream, out ChannelInfo info);
 
@@ -154,6 +162,8 @@ namespace osu.Framework.Audio.Track
                 channels = info.Channels;
             }, cancelSource.Token);
         }
+
+        protected virtual DataStreamFileProcedures CreateDataStreamFileProcedures(Stream dataStream) => new DataStreamFileProcedures(dataStream);
 
         private double computeIntensity(ChannelInfo info, float[] bins, double startFrequency, double endFrequency)
         {
@@ -301,6 +311,11 @@ namespace osu.Framework.Audio.Track
             cancelSource?.Cancel();
             cancelSource?.Dispose();
             points = null;
+
+            if (pinnedProcedures.IsAllocated)
+                pinnedProcedures.Free();
+
+            procedures = null;
         }
 
         #endregion


### PR DESCRIPTION
Changes `Waveform` to use JIT workarounds similar to `TrackBass`.

Note: Will require some minor changes in osu!, can't really make a PR for them until osu! is at least up to date with other recent framework changes.

---

Fix JIT errors creating Waveforms, which would cause the osu! editor to immediately crash on iOS.