### PR TITLE
Implement IBindableNumber<T> and more BindableNumber<T> methods

### DIFF
--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -281,7 +281,7 @@ namespace osu.Framework.Configuration
         /// <summary>
         /// Create an unbound clone of this bindable.
         /// </summary>
-        public IBindable<T> GetUnboundCopy()
+        public Bindable<T> GetUnboundCopy()
         {
             var clone = GetBoundCopy();
             clone.UnbindAll();

--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Configuration
     /// A generic implementation of a <see cref="IBindable"/>
     /// </summary>
     /// <typeparam name="T">The type of our stored <see cref="Value"/>.</typeparam>
-    public class Bindable<T> : IBindable<T>, IBindable, ISerializableBindable
+    public class Bindable<T> : IBindable<T>, ISerializableBindable
     {
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed (or manually via <see cref="TriggerValueChange"/>).

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 
 namespace osu.Framework.Configuration
 {
-    public abstract class BindableNumber<T> : Bindable<T>
+    public abstract class BindableNumber<T> : Bindable<T>, IBindableNumber<T>
         where T : struct, IComparable, IConvertible
     {
         static BindableNumber()
@@ -32,19 +32,10 @@ namespace osu.Framework.Configuration
                     $"{nameof(BindableNumber<T>)} only accepts the primitive numeric types (except for {typeof(decimal).FullName}) as type arguments. You provided {typeof(T).FullName}.");
         }
 
-        /// <summary>
-        /// An event which is raised when <see cref="Precision"/> has changed (or manually via <see cref="TriggerPrecisionChange"/>).
-        /// </summary>
         public event Action<T> PrecisionChanged;
 
-        /// <summary>
-        /// An event which is raised when <see cref="MinValue"/> has changed (or manually via <see cref="TriggerMinValueChange"/>).
-        /// </summary>
         public event Action<T> MinValueChanged;
 
-        /// <summary>
-        /// An event which is raised when <see cref="MaxValue"/> has changed (or manually via <see cref="TriggerMaxValueChange"/>).
-        /// </summary>
         public event Action<T> MaxValueChanged;
 
         protected BindableNumber(T value = default)
@@ -58,9 +49,6 @@ namespace osu.Framework.Configuration
 
         private T precision;
 
-        /// <summary>
-        /// The precision up to which the value of this bindable should be rounded.
-        /// </summary>
         public T Precision
         {
             get => precision;
@@ -97,9 +85,6 @@ namespace osu.Framework.Configuration
 
         private T minValue;
 
-        /// <summary>
-        /// The minimum value of this bindable. <see cref="Bindable{T}.Value"/> will never go below this value.
-        /// </summary>
         public T MinValue
         {
             get => minValue;
@@ -116,9 +101,6 @@ namespace osu.Framework.Configuration
 
         private T maxValue;
 
-        /// <summary>
-        /// The maximum value of this bindable. <see cref="Bindable{T}.Value"/> will never go above this value.
-        /// </summary>
         public T MaxValue
         {
             get => maxValue;

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -369,6 +369,10 @@ namespace osu.Framework.Configuration
             Set(value);
         }
 
+        IBindableNumber<T> IBindableNumber<T>.GetBoundCopy() => GetBoundCopy();
+
+        public new BindableNumber<T> GetBoundCopy() => (BindableNumber<T>)base.GetBoundCopy();
+
         public new BindableNumber<T> GetUnboundCopy() => (BindableNumber<T>)base.GetUnboundCopy();
 
         private static T max(T value1, T value2)

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -369,6 +369,8 @@ namespace osu.Framework.Configuration
             Set(value);
         }
 
+        public new BindableNumber<T> GetUnboundCopy() => (BindableNumber<T>)base.GetUnboundCopy();
+
         private static T max(T value1, T value2)
         {
             var comparison = value1.CompareTo(value2);

--- a/osu.Framework/Configuration/IBindable.cs
+++ b/osu.Framework/Configuration/IBindable.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Configuration
     /// An interface which can be bound to other <see cref="IBindable{T}"/>s in order to watch for (and react to) <see cref="IBindable{T}.Disabled"/> and <see cref="IBindable{T}.Value"/> changes.
     /// </summary>
     /// <typeparam name="T">The type of value encapsulated by this <see cref="IBindable{T}"/>.</typeparam>
-    public interface IBindable<T> : IParseable, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
+    public interface IBindable<T> : IBindable
     {
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed.
@@ -65,6 +65,6 @@ namespace osu.Framework.Configuration
         /// a local reference.
         /// </summary>
         /// <returns>A weakly bound copy of the specified bindable.</returns>
-        IBindable<T> GetBoundCopy();
+        new IBindable<T> GetBoundCopy();
     }
 }

--- a/osu.Framework/Configuration/IBindableNumber.cs
+++ b/osu.Framework/Configuration/IBindableNumber.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+
+namespace osu.Framework.Configuration
+{
+    public interface IBindableNumber<T> : IBindable<T>
+    {
+        /// <summary>
+        /// An event which is raised when <see cref="Precision"/> has changed.
+        /// </summary>
+        event Action<T> PrecisionChanged;
+
+        /// <summary>
+        /// An event which is raised when <see cref="MinValue"/> has changed.
+        /// </summary>
+        event Action<T> MinValueChanged;
+
+        /// <summary>
+        /// An event which is raised when <see cref="MaxValue"/> has changed.
+        /// </summary>
+        event Action<T> MaxValueChanged;
+
+        /// <summary>
+        /// The precision up to which the value of this bindable should be rounded.
+        /// </summary>
+        T Precision { get; }
+
+        /// <summary>
+        /// The minimum value of this bindable. <see cref="IBindableNumber{T}.Value"/> will never go below this value.
+        /// </summary>
+        T MinValue { get; }
+
+        /// <summary>
+        /// The maximum value of this bindable. <see cref="IBindableNumber{T}"/> will never go above this value.
+        /// </summary>
+        T MaxValue { get; }
+    }
+}

--- a/osu.Framework/Configuration/IBindableNumber.cs
+++ b/osu.Framework/Configuration/IBindableNumber.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;

--- a/osu.Framework/Configuration/IBindableNumber.cs
+++ b/osu.Framework/Configuration/IBindableNumber.cs
@@ -36,5 +36,10 @@ namespace osu.Framework.Configuration
         /// The maximum value of this bindable. <see cref="IBindableNumber{T}"/> will never go above this value.
         /// </summary>
         T MaxValue { get; }
+
+        /// <summary>
+        /// Whether <typeparamref name="T"/> is an integer.
+        /// </summary>
+        bool IsInteger { get; }
     }
 }

--- a/osu.Framework/Configuration/IBindableNumber.cs
+++ b/osu.Framework/Configuration/IBindableNumber.cs
@@ -41,5 +41,13 @@ namespace osu.Framework.Configuration
         /// Whether <typeparamref name="T"/> is an integer.
         /// </summary>
         bool IsInteger { get; }
+
+        /// <summary>
+        /// Retrieve a new bindable instance weakly bound to the configuration backing.
+        /// If you are further binding to events of a bindable retrieved using this method, ensure to hold
+        /// a local reference.
+        /// </summary>
+        /// <returns>A weakly bound copy of the specified bindable.</returns>
+        new IBindableNumber<T> GetBoundCopy();
     }
 }

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (CurrentNumber == null)
                 throw new NotSupportedException($"We don't support the generic type of {nameof(BindableNumber<T>)}.");
 
-            currentNumberInstantaneous = (BindableNumber<T>)CurrentNumber.GetUnboundCopy();
+            currentNumberInstantaneous = CurrentNumber.GetUnboundCopy();
 
             CurrentNumber.ValueChanged += v => currentNumberInstantaneous.Value = v;
             CurrentNumber.MinValueChanged += v => currentNumberInstantaneous.MinValue = v;


### PR DESCRIPTION
New `BindableNumber<T>` methods:

```diff
+ BindableNumber<T> GetBoundCopy()
+ BindableNumber<T> GetUnboundCopy()
```

`BindableNumber<T>` now implements `IBindableNumber<T>` providing similar functionality to `IBindable<T>`.

`IBindable<T>` now implements `IBindable`.