### PR TITLE
Fix nunit DI errors not propagating correctly

### DIFF
--- a/osu.Framework/Testing/TestCaseTestRunner.cs
+++ b/osu.Framework/Testing/TestCaseTestRunner.cs
@@ -94,7 +94,10 @@ namespace osu.Framework.Testing
                         Scheduler.AddDelayed(complete, time_between_tests);
                     }, e =>
                     {
-                        exception = ExceptionDispatchInfo.Capture(e);
+                        if (e is DependencyInjectionException die)
+                            exception = die.DispatchInfo;
+                        else
+                            exception = ExceptionDispatchInfo.Capture(e);
                         complete();
                     });
                 });


### PR DESCRIPTION
Would incorrectly re-capture the exception.