### PR TITLE
Implement a container to automatically cache values from models

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBindingContainer.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestCaseBindingContainer : TestCase
+    {
+        [Test]
+        public void TestCacheModel()
+        {
+            var model = new TestModel();
+            BindingContainer<TestModel> container = null;
+
+            TestResolver resolver = null;
+
+            AddStep("initialise", () =>
+            {
+                Child = container = new BindingContainer<TestModel>
+                {
+                    Model = model,
+                    Child = resolver = new TestResolver()
+                };
+            });
+
+            AddAssert("bindable resolved", () => resolver.Cached.Value == model.Cached.Value);
+
+            AddStep("change model", () => container.Model = model = new TestModel { Cached = { Value = 2 } });
+
+            AddAssert("bindable resolved", () => resolver.Cached.Value == model.Cached.Value);
+        }
+
+        private class TestModel
+        {
+            [Cached]
+            public readonly Bindable<int> Cached = new Bindable<int>(1);
+        }
+
+        private class TestResolver : CompositeDrawable
+        {
+            [Resolved(Parent = typeof(TestModel))]
+            public Bindable<int> Cached { get; private set; }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/TestCaseBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBindingContainer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using NUnit.Framework;

--- a/osu.Framework.Tests/Visual/TestCaseBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseBindingContainer.cs
@@ -48,7 +48,10 @@ namespace osu.Framework.Tests.Visual
             AddAssert("bindable changed", () => resolver.Cached.Value == model2.Cached.Value);
 
             AddStep("change first model", () => model1.Cached.Value = 3);
-            AddAssert("bindable didn't change", () => resolver.Cached.Value != model1.Cached.Value);
+            AddAssert("bindable didn't change", () => resolver.Cached.Value != 3);
+
+            AddStep("change second model", () => model2.Cached.Value = 3);
+            AddAssert("bindable did change", () => resolver.Cached.Value == 3);
         }
 
         [Test]

--- a/osu.Framework/Graphics/Containers/BindingContainer.cs
+++ b/osu.Framework/Graphics/Containers/BindingContainer.cs
@@ -1,0 +1,66 @@
+// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+
+namespace osu.Framework.Graphics.Containers
+{
+    public class BindingContainer<TModel> : Container
+        where TModel : new()
+    {
+        private readonly TModel shadowModel;
+
+        public BindingContainer()
+        {
+            shadowModel = new TModel();
+        }
+
+        protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
+            => DependencyActivator.MergeDependencies(shadowModel, base.CreateChildDependencies(parent), new CacheInfo(parent: typeof(TModel)));
+
+        private TModel model;
+
+        public TModel Model
+        {
+            get => model;
+            set
+            {
+                if (EqualityComparer<TModel>.Default.Equals(model, value))
+                    return;
+
+                var lastModel = model;
+
+                model = value;
+
+                updateShadowBindings(lastModel, model);
+            }
+        }
+
+        private void updateShadowBindings(TModel lastModel, TModel newModel)
+        {
+            foreach (var field in typeof(TModel).GetFields(CachedAttribute.ACTIVATOR_FLAGS).Where(f => f.GetCustomAttributes<CachedAttribute>().Any()))
+            {
+                var shadowField = field.GetValue(shadowModel);
+                var lastModelField = lastModel == null ? null : field.GetValue(lastModel);
+                var modelField = field.GetValue(model);
+
+                // Todo: This will fail if shadowField is null
+
+                if (shadowField is IBindable bindableShadowField)
+                {
+                    // Unbind from the last model
+                    if (lastModelField is IBindable bindableLastModelField)
+                        bindableShadowField.UnbindFrom(bindableLastModelField);
+
+                    // Bind to the new model
+                    if (modelField is IBindable bindableModelField)
+                        bindableShadowField.BindTo(bindableModelField);
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/BindingContainer.cs
+++ b/osu.Framework/Graphics/Containers/BindingContainer.cs
@@ -43,22 +43,42 @@ namespace osu.Framework.Graphics.Containers
         private void updateShadowBindings(TModel lastModel, TModel newModel)
         {
             foreach (var field in typeof(TModel).GetFields(CachedAttribute.ACTIVATOR_FLAGS).Where(f => f.GetCustomAttributes<CachedAttribute>().Any()))
+                rebind(field);
+
+            foreach (var property in typeof(TModel).GetProperties(CachedAttribute.ACTIVATOR_FLAGS).Where(f => f.GetCustomAttributes<CachedAttribute>().Any()))
+                rebind(property);
+
+            void rebind(MemberInfo member)
             {
-                var shadowField = field.GetValue(shadowModel);
-                var lastModelField = lastModel == null ? null : field.GetValue(lastModel);
-                var modelField = field.GetValue(model);
+                object shadowValue = null;
+                object lastModelValue = null;
+                object newModelValue = null;
+
+                switch (member)
+                {
+                    case PropertyInfo pi:
+                        shadowValue = pi.GetValue(shadowModel);
+                        lastModelValue = lastModel == null ? null : pi.GetValue(lastModel);
+                        newModelValue = pi.GetValue(newModel);
+                        break;
+                    case FieldInfo fi:
+                        shadowValue = fi.GetValue(shadowModel);
+                        lastModelValue = lastModel == null ? null : fi.GetValue(lastModel);
+                        newModelValue = fi.GetValue(newModel);
+                        break;
+                }
 
                 // Todo: This will fail if shadowField is null
 
-                if (shadowField is IBindable bindableShadowField)
+                if (shadowValue is IBindable shadowBindable)
                 {
                     // Unbind from the last model
-                    if (lastModelField is IBindable bindableLastModelField)
-                        bindableShadowField.UnbindFrom(bindableLastModelField);
+                    if (lastModelValue is IBindable lastModelBindable)
+                        shadowBindable.UnbindFrom(lastModelBindable);
 
                     // Bind to the new model
-                    if (modelField is IBindable bindableModelField)
-                        bindableShadowField.BindTo(bindableModelField);
+                    if (newModelValue is IBindable newModelBindable)
+                        shadowBindable.BindTo(newModelBindable);
                 }
             }
         }

--- a/osu.Framework/Graphics/Containers/BindingContainer.cs
+++ b/osu.Framework/Graphics/Containers/BindingContainer.cs
@@ -10,7 +10,7 @@ using osu.Framework.Configuration;
 namespace osu.Framework.Graphics.Containers
 {
     /// <summary>
-    /// A <see cref="Container"/> which caches the members of a model for usage by its children.
+    /// A <see cref="Container"/> which caches all cacheable members of a model for usage by its children.
     /// </summary>
     /// <typeparam name="TModel">The type of model.</typeparam>
     public class BindingContainer<TModel> : Container

--- a/osu.Framework/Graphics/Containers/BindingContainer.cs
+++ b/osu.Framework/Graphics/Containers/BindingContainer.cs
@@ -9,6 +9,10 @@ using osu.Framework.Configuration;
 
 namespace osu.Framework.Graphics.Containers
 {
+    /// <summary>
+    /// A <see cref="Container"/> which caches the members of a model for usage by its children.
+    /// </summary>
+    /// <typeparam name="TModel">The type of model.</typeparam>
     public class BindingContainer<TModel> : Container
         where TModel : new()
     {
@@ -24,6 +28,10 @@ namespace osu.Framework.Graphics.Containers
 
         private TModel model;
 
+        /// <summary>
+        /// The model to cache.
+        /// Children of this <see cref="BindingContainer{TModel}"/> can resolve the cached members by using <see cref="ResolvedAttribute.Parent"/> = typeof(<see cref="TModel"/>).
+        /// </summary>
         public TModel Model
         {
             get => model;

--- a/osu.Framework/Graphics/Containers/BindingContainer.cs
+++ b/osu.Framework/Graphics/Containers/BindingContainer.cs
@@ -59,12 +59,12 @@ namespace osu.Framework.Graphics.Containers
                     case PropertyInfo pi:
                         shadowValue = pi.GetValue(shadowModel);
                         lastModelValue = lastModel == null ? null : pi.GetValue(lastModel);
-                        newModelValue = pi.GetValue(newModel);
+                        newModelValue = newModel == null ? null : pi.GetValue(newModel);
                         break;
                     case FieldInfo fi:
                         shadowValue = fi.GetValue(shadowModel);
                         lastModelValue = lastModel == null ? null : fi.GetValue(lastModel);
-                        newModelValue = fi.GetValue(newModel);
+                        newModelValue = newModel == null ? null : fi.GetValue(newModel);
                         break;
                 }
 

--- a/osu.Framework/Graphics/Containers/BindingContainer.cs
+++ b/osu.Framework/Graphics/Containers/BindingContainer.cs
@@ -68,8 +68,6 @@ namespace osu.Framework.Graphics.Containers
                         break;
                 }
 
-                // Todo: This will fail if shadowField is null
-
                 if (shadowValue is IBindable shadowBindable)
                 {
                     // Unbind from the last model

--- a/osu.Framework/Graphics/Containers/BindingContainer.cs
+++ b/osu.Framework/Graphics/Containers/BindingContainer.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System.Collections.Generic;


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/2079

It's becoming more common for us to have:
1. Giant stacks of bindables in a model class.
2. A super custom way of handling binding + re-binding to the model's bindables.

This provides a way to perform the functions of the `MyCachingComponent` mentioned in #2079 automatically, so bindables don't:
1. Need to be passed down and bound manually.
2. Create a helper class to handle binding + re-biding as https://github.com/ppy/osu/blob/master/osu.Game/Screens/Multi/RoomBindings.cs does.