### PR TITLE
Fix undersaturated textures on OpenGL ES

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -514,6 +514,8 @@ namespace osu.Framework.Graphics.OpenGL
                 FlushCurrentBatch();
                 GL.BindFramebuffer(FramebufferTarget.Framebuffer, frameBuffer);
             }
+
+            GlobalPropertyManager.Set(GlobalProperty.GammaCorrection, UsingBackbuffer);
         }
 
         /// <summary>
@@ -531,6 +533,8 @@ namespace osu.Framework.Graphics.OpenGL
 
             FlushCurrentBatch();
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, frame_buffer_stack.Peek());
+
+            GlobalPropertyManager.Set(GlobalProperty.GammaCorrection, UsingBackbuffer);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Shaders/GlobalProperty.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalProperty.cs
@@ -19,5 +19,6 @@ namespace osu.Framework.Graphics.Shaders
         EdgeOffset,
         DiscardInner,
         InnerCornerRadius,
+        GammaCorrection,
     }
 }

--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -30,6 +30,7 @@ namespace osu.Framework.Graphics.Shaders
             global_properties[(int)GlobalProperty.EdgeOffset] = new UniformMapping<Vector2>("g_EdgeOffset");
             global_properties[(int)GlobalProperty.DiscardInner] = new UniformMapping<bool>("g_DiscardInner");
             global_properties[(int)GlobalProperty.InnerCornerRadius] = new UniformMapping<float>("g_InnerCornerRadius");
+            global_properties[(int)GlobalProperty.GammaCorrection] = new UniformMapping<bool>("g_GammaCorrection");
         }
 
         /// <summary>

--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -1,5 +1,7 @@
 ﻿#define GAMMA 2.4
 
+uniform bool g_GammaCorrection;
+
 float toLinear(float color)
 {
 	return color <= 0.04045 ? (color / 12.92) : pow((color + 0.055) / 1.055, GAMMA);
@@ -17,8 +19,11 @@ float toSRGB(float color)
 
 vec4 toSRGB(vec4 colour)
 {
+#ifdef GL_ES
+ 	return g_GammaCorrection ? vec4(toSRGB(colour.r), toSRGB(colour.g), toSRGB(colour.b), colour.a) : colour;
+#else
 	return vec4(toSRGB(colour.r), toSRGB(colour.g), toSRGB(colour.b), colour.a);
-
+#endif
 	// The following implementation using mix and step may be faster, but stackoverflow indicates it is in fact a lot slower on some GPUs.
 	//return vec4(mix(colour.rgb * 12.92, 1.055 * pow(colour.rgb, vec3(1.0 / GAMMA)) - vec3(0.055), step(0.0031308, colour.rgb)), colour.a);
 }


### PR DESCRIPTION
Attempt at fixing undersaturated textures on OpenGL ES by disabling our manual `toSRGB` function via a global uniform if we aren't drawing to the back buffer.  Note that this check is removed on desktop with a `#ifdef GL_ES` directive.

OpenGL ES automatically gamma corrects shader output to sRGB textures, and the extension that allows for it to be disabled does not seem to be available (in OpenTK on iOS at least).
https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_sRGB_write_control.txt

I would prefer to find a better way to do this, but changing `TexImage2D` to use `RGBA` format rather than `SRGB8_ALPHA8` seems to do nothing.

Note the blur looks much nicer now:
![img_0053](https://user-images.githubusercontent.com/2331297/51069495-1eceb900-1680-11e9-84d1-cc7720917786.png)