### PR TITLE
Reenable Sourcelink support by fixing the condition.

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -21,7 +21,7 @@
     <copyright>Copyright (c) 2007-2018 ppy Pty Ltd contact@ppy.sh</copyright>
     <PackageTags>osu game framework</PackageTags>
   </PropertyGroup>
-  <PropertyGroup Label="Sourcelink3" Condition=" '($EnableSourceLink)' == 'true' ">
+  <PropertyGroup Label="Sourcelink3" Condition=" '$(EnableSourceLink)' == 'true' ">
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>


### PR DESCRIPTION
This reenables the sourcelink support by fixing the condition on the itemgroup that enables the sourcelink functionality.

if the value of EnableSourceLink is `true` then:

`'$(EnableSourceLink)' == 'true'` evaluates to `'true' = 'true'` evaluates to `true`


`'($EnableSourceLink)' == 'true'` evaluates to `'($EnableSourceLink)' = 'true'` evaluates to `false`


- This error was regressed by https://github.com/ppy/osu-framework/pull/2005
- Closes https://github.com/ppy/osu/issues/4039

---
Reenable SourceLink3 Support