### PR TITLE
Fix Color4 interpolation crashing on iOS

### DIFF
--- a/osu-framework.iOS.sln.DotSettings
+++ b/osu-framework.iOS.sln.DotSettings
@@ -198,10 +198,10 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=3D/@EntryIndexedValue">3D</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HID/@EntryIndexedValue">HID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IL/@EntryIndexedValue">IL</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IOS/@EntryIndexedValue">IL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IOS/@EntryIndexedValue">IOS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IPC/@EntryIndexedValue">IPC</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=JIT/@EntryIndexedValue">JIT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LTRB/@EntryIndexedValue">LTRB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MD/@EntryIndexedValue">MD5</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NS/@EntryIndexedValue">NS</s:String>

--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -198,10 +198,10 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=3D/@EntryIndexedValue">3D</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=HID/@EntryIndexedValue">HID</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=ID/@EntryIndexedValue">ID</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IL/@EntryIndexedValue">IL</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IOS/@EntryIndexedValue">IL</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IOS/@EntryIndexedValue">IOS</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IP/@EntryIndexedValue">IP</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=IPC/@EntryIndexedValue">IPC</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=JIT/@EntryIndexedValue">JIT</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=LTRB/@EntryIndexedValue">LTRB</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=MD/@EntryIndexedValue">MD5</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=NS/@EntryIndexedValue">NS</s:String>

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -63,11 +63,11 @@ namespace osu.Framework.Audio.Track
 
                 procedures = CreateDataStreamFileProcedures(dataStream);
 
-                if (!RuntimeInfo.SupportsIL)
+                if (!RuntimeInfo.SupportsJIT)
                     pinnedProcedures = GCHandle.Alloc(procedures, GCHandleType.Pinned);
 
                 BassFlags flags = Preview ? 0 : BassFlags.Decode | BassFlags.Prescan | BassFlags.Float;
-                activeStream = Bass.CreateStream(StreamSystem.NoBuffer, flags, procedures.BassProcedures, RuntimeInfo.SupportsIL ? IntPtr.Zero : GCHandle.ToIntPtr(pinnedProcedures));
+                activeStream = Bass.CreateStream(StreamSystem.NoBuffer, flags, procedures.BassProcedures, RuntimeInfo.SupportsJIT ? IntPtr.Zero : GCHandle.ToIntPtr(pinnedProcedures));
 
                 if (!Preview)
                 {

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -84,11 +84,11 @@ namespace osu.Framework.Audio.Track
 
                 procedures = CreateDataStreamFileProcedures(data);
 
-                if (!RuntimeInfo.SupportsIL)
+                if (!RuntimeInfo.SupportsJIT)
                     pinnedProcedures = GCHandle.Alloc(procedures, GCHandleType.Pinned);
 
                 int decodeStream = Bass.CreateStream(StreamSystem.NoBuffer, BassFlags.Decode | BassFlags.Float, procedures.BassProcedures,
-                    RuntimeInfo.SupportsIL ? IntPtr.Zero : GCHandle.ToIntPtr(pinnedProcedures));
+                    RuntimeInfo.SupportsJIT ? IntPtr.Zero : GCHandle.ToIntPtr(pinnedProcedures));
 
                 Bass.ChannelGetInfo(decodeStream, out ChannelInfo info);
 

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Transforms
 
         private static ReadFunc createFieldGetter(FieldInfo field)
         {
-            if (!RuntimeInfo.SupportsIL) return transformable => (TValue)field.GetValue(transformable);
+            if (!RuntimeInfo.SupportsJIT) return transformable => (TValue)field.GetValue(transformable);
 
             string methodName = $"{typeof(T).ReadableName()}.{field.Name}.get_{Guid.NewGuid():N}";
             DynamicMethod setterMethod = new DynamicMethod(methodName, typeof(TValue), new[] { typeof(T) }, true);
@@ -45,7 +45,7 @@ namespace osu.Framework.Graphics.Transforms
 
         private static WriteFunc createFieldSetter(FieldInfo field)
         {
-            if (!RuntimeInfo.SupportsIL) return (transformable, value) => field.SetValue(transformable, value);
+            if (!RuntimeInfo.SupportsJIT) return (transformable, value) => field.SetValue(transformable, value);
 
             string methodName = $"{typeof(T).ReadableName()}.{field.Name}.set_{Guid.NewGuid():N}";
             DynamicMethod setterMethod = new DynamicMethod(methodName, null, new[] { typeof(T), typeof(TValue) }, true);
@@ -59,13 +59,13 @@ namespace osu.Framework.Graphics.Transforms
 
         private static ReadFunc createPropertyGetter(MethodInfo getter)
         {
-            if (!RuntimeInfo.SupportsIL) return transformable => (TValue)getter.Invoke(transformable, new object[0]);
+            if (!RuntimeInfo.SupportsJIT) return transformable => (TValue)getter.Invoke(transformable, new object[0]);
             return (ReadFunc)getter.CreateDelegate(typeof(ReadFunc));
         }
 
         private static WriteFunc createPropertySetter(MethodInfo setter)
         {
-            if (!RuntimeInfo.SupportsIL) return (transformable, value) => setter.Invoke(transformable, new object[]{ value });
+            if (!RuntimeInfo.SupportsJIT) return (transformable, value) => setter.Invoke(transformable, new object[]{ value });
             return (WriteFunc)setter.CreateDelegate(typeof(WriteFunc));
         }
 

--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -25,7 +25,7 @@ namespace osu.Framework
         public static Platform OS { get; }
         public static bool IsUnix => OS == Platform.Linux || OS == Platform.MacOsx || OS == Platform.iOS;
         public static bool IsWine { get; }
-        public static bool SupportsIL => OS != Platform.iOS;
+        public static bool SupportsJIT => OS != Platform.iOS;
 
         static RuntimeInfo()
         {

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -205,7 +205,7 @@ namespace osu.Framework.Testing
 
             searchTextBox.Current.ValueChanged += newValue => leftFlowContainer.SearchTerm = newValue;
 
-            if (RuntimeInfo.SupportsIL)
+            if (RuntimeInfo.SupportsJIT)
             {
                 backgroundCompiler = new DynamicClassCompiler<TestCase>
                 {


### PR DESCRIPTION
Xamarin.iOS cannot AoT the calls to `Interpolation<Color4>.ValueAt` when created via reflection.
This PR calls it manually with explicit casts if JIT is not supported on the platform.

Spinners and drum rolls in osu! use `FadeAccent`, which is the only transform we currently use on a `Color4`.

---

Workaround for Color4 interpolation on Xamarin.iOS.  Fixes spinners/drum rolls crashing on osu! iOS.