### PR TITLE
Reduce constructor overhead of bindables

### DIFF
--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
+using osu.Framework.Caching;
 using osu.Framework.IO.Serialization;
 using osu.Framework.Lists;
 
@@ -81,7 +82,9 @@ namespace osu.Framework.Configuration
             }
         }
 
-        private readonly WeakReference<Bindable<T>> weakReference;
+        private Cached<WeakReference<Bindable<T>>> weakReferenceCache;
+
+        private WeakReference<Bindable<T>> weakReference => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<Bindable<T>>(this);
 
         /// <summary>
         /// Creates a new bindable instance. This is used for deserialization of bindables.
@@ -99,8 +102,6 @@ namespace osu.Framework.Configuration
         public Bindable(T value = default)
         {
             this.value = value;
-
-            weakReference = new WeakReference<Bindable<T>>(this);
         }
 
         public static implicit operator T(Bindable<T> value) => value.Value;

--- a/osu.Framework/Configuration/BindableList.cs
+++ b/osu.Framework/Configuration/BindableList.cs
@@ -5,18 +5,13 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Caching;
 using osu.Framework.Lists;
 
 namespace osu.Framework.Configuration
 {
     public class BindableList<T> : IBindableList<T>, IList<T>, IList, IParseable, IHasDescription
     {
-        private readonly List<T> collection = new List<T>();
-
-        private readonly WeakReference<BindableList<T>> weakReference;
-
-        private LockedWeakList<BindableList<T>> bindings;
-
         /// <summary>
         /// An event which is raised when any items are added to this <see cref="BindableList{T}"/>.
         /// </summary>
@@ -32,6 +27,14 @@ namespace osu.Framework.Configuration
         /// </summary>
         public event Action<bool> DisabledChanged;
 
+        private readonly List<T> collection = new List<T>();
+
+        private Cached<WeakReference<BindableList<T>>> weakReferenceCache;
+
+        private WeakReference<BindableList<T>> weakReference => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<BindableList<T>>(this);
+
+        private LockedWeakList<BindableList<T>> bindings;
+
         /// <summary>
         /// Creates a new <see cref="BindableList{T}"/>, optionally adding the items of the given collection.
         /// </summary>
@@ -40,9 +43,6 @@ namespace osu.Framework.Configuration
         {
             if (items != null)
                 collection.AddRange(items);
-
-            // we can not initialize this directly at the property due to the this capture.
-            weakReference = new WeakReference<BindableList<T>>(this);
         }
 
         #region IList<T>


### PR DESCRIPTION
Turns out that allocating `WeakReference` is pretty expensive. I'm on a quest to leanify HitObjects where bindables are used as data stores, and ctor was the top profiled method.

| Method |     Mean |     Error |    StdDev | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
| ----------------------- |---------:|----------:|----------:|------------:|------------:|------------:|--------------------:|
| HitCircleAllocationOld | 6.526 ms | 0.1289 ms | 0.1076 ms |   1445.3125 |           - |           - |             4.35 MB |
| HitCircleAllocationNew | 471.0 us |  6.980 us |  6.188 us |   1296.8750 |           - |           - |             3.89 MB |
|    SliderAllocationOld | 9.279 ms | 0.1532 ms | 0.1358 ms |   2515.6250 |           - |           - |             7.55 MB |
|    SliderAllocationNew | 934.9 us |  9.639 us |  9.016 us |   2313.4766 |           - |           - |             6.94 MB |
|   SpinnerAllocationOld | 6.257 ms | 0.1249 ms | 0.1336 ms |   1468.7500 |           - |           - |             4.43 MB |
|   SpinnerAllocationNew | 481.2 us |  6.546 us |  5.466 us |   1322.2656 |           - |           - |             3.97 MB |

Tested by allocating 10000 of each hitobject (consider this in the context of us needing to allocate _billions_ of hitobjects all-up).