### PR TITLE
Make appveyor artifacts use nuget nativelibs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ build:
 after_build:
   - cmd: inspectcode /o="inspectcodereport.xml" /caches-home="inspectcode" osu-framework.sln
   - cmd: NVika parsereport "inspectcodereport.xml" --treatwarningsaserrors
+  - cmd: set APPVEYOR_DEPLOY=1
   - cmd: dotnet pack osu.Framework /p:Version=0.0.%APPVEYOR_BUILD_VERSION%
   - cmd: msbuild /t:pack osu.Framework.iOS /p:Configuration=Debug /p:Version=0.0.%APPVEYOR_BUILD_VERSION%
 artifacts:


### PR DESCRIPTION
Otherwise trying to reference an appveyor build will give errors such as:

```
ppy.osu.Framework 0.0.8003 depends on ppy.osu.Framework.NativeLibs (>= 0.0.8003) but ppy.osu.Framework.NativeLibs 0.0.8003 was not found. An approximate best match of ppy.osu.Framework.NativeLibs 1.0.0 was resolved.
```

Don't merge until I've tested plz thx