### PR TITLE
Remove tag build rule for native deploy

### DIFF
--- a/appveyor_native_deploy.yml
+++ b/appveyor_native_deploy.yml
@@ -1,6 +1,5 @@
 clone_depth: 1
 version: '{build}'
-skip_non_tags: true
 image: Visual Studio 2017
 configuration: Release
 platform: Any CPU

--- a/appveyor_native_deploy.yml
+++ b/appveyor_native_deploy.yml
@@ -1,5 +1,6 @@
 clone_depth: 1
 version: '{build}'
+skip_non_tags: true
 image: Visual Studio 2017
 configuration: Release
 platform: Any CPU
@@ -9,6 +10,3 @@ build_script:
   - cmd: dotnet pack osu.Framework.NativeLibs /p:Version=%APPVEYOR_BUILD_VERSION%
 artifacts:
   - path: osu.Framework.NativeLibs/bin/Any CPU/Release/*.nupkg
-deploy:
-  - provider: Environment
-    name: nuget


### PR DESCRIPTION
This overrides anything I can do to stop it automatically deploying.