### PR TITLE
Handle input on Screen only when its content propagates input

### DIFF
--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -59,10 +59,8 @@ namespace osu.Framework.Screens
         }
 
         // in the case we don't have a parent screen, we still want to handle input as we are also responsible for
-        // children inside childScreenContainer.
-        // this means the root screen always received input.
-        // Also, Avoid the case that this receives input but content and children don't receive input.
-        // Which causes a problem if an input blocking is expected.
+        // children inside childScreenContainer. this means the root screen always receive input.
+        // Also only propagate when content is present, else we may incorrectly block/handle events at a screen level.
         private bool propagateInputSubtree => (IsCurrentScreen || !hasExited && ParentScreen == null) && Content.IsPresent;
 
         public override bool PropagateNonPositionalInputSubTree => base.PropagateNonPositionalInputSubTree && propagateInputSubtree;

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -61,7 +61,9 @@ namespace osu.Framework.Screens
         // in the case we don't have a parent screen, we still want to handle input as we are also responsible for
         // children inside childScreenContainer.
         // this means the root screen always received input.
-        private bool propagateInputSubtree => IsCurrentScreen || !hasExited && ParentScreen == null;
+        // Also, Avoid the case that this receives input but content and children don't receive input.
+        // Which causes a problem if an input blocking is expected.
+        private bool propagateInputSubtree => (IsCurrentScreen || !hasExited && ParentScreen == null) && Content.IsPresent;
 
         public override bool PropagateNonPositionalInputSubTree => base.PropagateNonPositionalInputSubTree && propagateInputSubtree;
         public override bool PropagatePositionalInputSubTree => base.PropagatePositionalInputSubTree && propagateInputSubtree;


### PR DESCRIPTION
- Closes ppy/osu#3050
  `MainMenu` expects its child `ExitConfirmOverlay` to block exit input but when screen content is not yet visible `MainMenu.Content.IsPresent` being `false` and input is not blocked yet `MainMenu` receives input.