### PR TITLE
Implement missing IEquatable<> in structs

### DIFF
--- a/osu.Framework/Graphics/BlendingInfo.cs
+++ b/osu.Framework/Graphics/BlendingInfo.cs
@@ -1,11 +1,12 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics
 {
-    public struct BlendingInfo
+    public struct BlendingInfo : IEquatable<BlendingInfo>
     {
         public BlendingFactorSrc Source;
         public BlendingFactorDest Destination;

--- a/osu.Framework/Graphics/BlendingParameters.cs
+++ b/osu.Framework/Graphics/BlendingParameters.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
+using System;
+
 namespace osu.Framework.Graphics
 {
     /// <summary>
     /// Contains information about how an <see cref="IDrawable"/> should be blended into its destination.
     /// </summary>
-    public struct BlendingParameters
+    public struct BlendingParameters : IEquatable<BlendingParameters>
     {
         /// <summary>
         /// Gets or sets <see cref="BlendingMode"/> to use.

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.Colour
     /// ColourInfo contains information about the colours of all 4 vertices of a quad.
     /// These colours are always stored in linear space.
     /// </summary>
-    public struct ColourInfo : IEquatable<ColourInfo>
+    public struct ColourInfo : IEquatable<ColourInfo>, IEquatable<SRGBColour>
     {
         public SRGBColour TopLeft;
         public SRGBColour BottomLeft;


### PR DESCRIPTION
a few structs had Equals(T) defined but did not implement IEquatable<T> so their equality test failed.