### PR TITLE
Fix SliderBar blocking KeyUp

### DIFF
--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -168,7 +168,12 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        protected override bool OnKeyUp(KeyUpEvent e) => commit();
+        protected override bool OnKeyUp(KeyUpEvent e)
+        {
+            if (e.Key == Key.Left || e.Key == Key.Right)
+                return commit();
+            return false;
+        }
 
         private bool uncommittedChanges;
 


### PR DESCRIPTION
`SliderBar` was blocking all `KeyUp` event from `GlobalActionContainer`. An assertion at `KeyBindingContainer.handleNewReleased` failed.
- Fixes ppy/osu#4098, closes ppy/osu#4100.

---
