### PR TITLE
Fix screenshot for OpenGL ES

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -395,22 +395,7 @@ namespace osu.Framework.Platform
                 if (GraphicsContext.CurrentContext == null)
                     throw new GraphicsContextMissingException();
 
-                string version = GL.GetString(StringName.Version);
-
-                if (version.Contains("OpenGL ES"))
-                {
-                    GL.ReadPixels(0, 0, image.Width, image.Height,
-                        PixelFormat.Rgba,
-                        PixelType.UnsignedByte,
-                        ref MemoryMarshal.GetReference(image.GetPixelSpan()));
-                }
-                else
-                {
-                    osuTK.Graphics.OpenGL.GL.ReadPixels(0, 0, image.Width, image.Height,
-                        osuTK.Graphics.OpenGL.PixelFormat.Rgba,
-                        osuTK.Graphics.OpenGL.PixelType.UnsignedByte,
-                        ref MemoryMarshal.GetReference(image.GetPixelSpan()));
-                }
+                GL.ReadPixels(0, 0, image.Width, image.Height, PixelFormat.Rgba, PixelType.UnsignedByte, ref MemoryMarshal.GetReference(image.GetPixelSpan()));
 
                 complete = true;
             });

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -395,10 +395,22 @@ namespace osu.Framework.Platform
                 if (GraphicsContext.CurrentContext == null)
                     throw new GraphicsContextMissingException();
 
-                osuTK.Graphics.OpenGL.GL.ReadPixels(0, 0, image.Width, image.Height,
-                    osuTK.Graphics.OpenGL.PixelFormat.Rgba,
-                    osuTK.Graphics.OpenGL.PixelType.UnsignedByte,
-                    ref MemoryMarshal.GetReference(image.GetPixelSpan()));
+                string version = GL.GetString(StringName.Version);
+
+                if (version.Contains("OpenGL ES"))
+                {
+                    GL.ReadPixels(0, 0, image.Width, image.Height,
+                        PixelFormat.Rgba,
+                        PixelType.UnsignedByte,
+                        ref MemoryMarshal.GetReference(image.GetPixelSpan()));
+                }
+                else
+                {
+                    osuTK.Graphics.OpenGL.GL.ReadPixels(0, 0, image.Width, image.Height,
+                        osuTK.Graphics.OpenGL.PixelFormat.Rgba,
+                        osuTK.Graphics.OpenGL.PixelType.UnsignedByte,
+                        ref MemoryMarshal.GetReference(image.GetPixelSpan()));
+                }
 
                 complete = true;
             });


### PR DESCRIPTION
This pull request simply adds a check for OpenGL ES when taking a screenshot. Without it, devices on GL ES will crash with SIGSEGV errors (iOS and Android devices, for instance).

* Tested on Windows 10 and Android. Got no errors.