### PR TITLE
Allow loading assemblies from non-local DLL files via DllResourceStore

### DIFF
--- a/osu.Framework/IO/Stores/DllResourceStore.cs
+++ b/osu.Framework/IO/Stores/DllResourceStore.cs
@@ -11,16 +11,16 @@ namespace osu.Framework.IO.Stores
     public class DllResourceStore : IResourceStore<byte[]>
     {
         private readonly Assembly assembly;
-        private readonly string space;
+        private readonly string prefix;
 
         public DllResourceStore(string dllName)
         {
-            // prefer the local file if it exists, else load from assembly cache.
-            assembly = System.IO.File.Exists(dllName) ?
-                Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(Assembly.GetCallingAssembly().Location), dllName)) :
-                Assembly.Load(Path.GetFileNameWithoutExtension(dllName));
+            string filePath = Path.Combine(Path.GetDirectoryName(Assembly.GetCallingAssembly().Location), dllName);
 
-            space = Path.GetFileNameWithoutExtension(dllName);
+            // prefer the local file if it exists, else load from assembly cache.
+            assembly = System.IO.File.Exists(filePath) ? Assembly.LoadFrom(filePath) : Assembly.Load(Path.GetFileNameWithoutExtension(dllName));
+
+            prefix = Path.GetFileNameWithoutExtension(dllName);
         }
 
         public byte[] Get(string name)
@@ -55,7 +55,7 @@ namespace osu.Framework.IO.Stores
             for (int i = 0; i < split.Length - 1; i++)
                 split[i] = split[i].Replace('-', '_');
 
-            return assembly?.GetManifestResourceStream($@"{space}.{string.Join(".", split)}");
+            return assembly?.GetManifestResourceStream($@"{prefix}.{string.Join(".", split)}");
         }
 
         #region IDisposable Support

--- a/osu.Framework/IO/Stores/DllResourceStore.cs
+++ b/osu.Framework/IO/Stores/DllResourceStore.cs
@@ -15,7 +15,11 @@ namespace osu.Framework.IO.Stores
 
         public DllResourceStore(string dllName)
         {
-            assembly = Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(Assembly.GetCallingAssembly().Location), dllName));
+            // prefer the local file if it exists, else load from assembly cache.
+            assembly = System.IO.File.Exists(dllName) ?
+                Assembly.LoadFrom(Path.Combine(Path.GetDirectoryName(Assembly.GetCallingAssembly().Location), dllName)) :
+                Assembly.Load(Path.GetFileNameWithoutExtension(dllName));
+
             space = Path.GetFileNameWithoutExtension(dllName);
         }
 


### PR DESCRIPTION
Adds support for nuget based resource projects, as an example.