### PR TITLE
Extract Screen logic into the IScreen interface

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseScreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScreen.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.Tests.Visual
             AddAssert("screen1 entered from baseScreen", () => screen1.EnteredFrom == baseScreen);
 
             // we don't support pushing a screen that has been entered
-            AddStep("bad push", () => Assert.Throws(typeof(Screen.ScreenAlreadyEnteredException), () => screen1.Push(screen1)));
+            AddStep("bad push", () => Assert.Throws(typeof(ScreenStack.ScreenAlreadyEnteredException), () => screen1.Push(screen1)));
 
             pushAndEnsureCurrent(() => screen2 = new TestScreen(), () => screen1);
 
@@ -76,7 +76,7 @@ namespace osu.Framework.Tests.Visual
             pushAndEnsureCurrent(() => screen2 = new TestScreen { ValidForResume = false }, () => screen1);
             pushAndEnsureCurrent(() => screen3 = new TestScreen(), () => screen2);
 
-            AddStep("bad exit", () => Assert.Throws(typeof(Screen.ScreenHasChildException), () => screen1.Exit()));
+            AddStep("bad exit", () => Assert.Throws(typeof(ScreenStack.ScreenHasChildException), () => screen1.Exit()));
             AddStep("exit", () => screen3.Exit());
 
             AddAssert("screen3 exited to screen2", () => screen3.ExitedTo == screen2);

--- a/osu.Framework.Tests/Visual/TestCaseScreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScreen.cs
@@ -6,7 +6,6 @@ using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
@@ -124,7 +123,7 @@ namespace osu.Framework.Tests.Visual
             }
         }
 
-        private class TestScreen : CompositeDrawable, IScreen
+        private class TestScreen : Screen
         {
             public static int Sequence;
             private Button popButton;
@@ -133,41 +132,9 @@ namespace osu.Framework.Tests.Visual
 
             public override bool RemoveWhenNotAlive => false;
 
-            public bool ValidForResume { get; set; } = true;
-
-            public bool ValidForPush { get; set; } = true;
-
             public TestScreen()
             {
                 RelativeSizeAxes = Axes.Both;
-            }
-
-            public void OnEntering(IScreen last)
-            {
-                if (last != null)
-                {
-                    //only show the pop button if we are entered form another screen.
-                    popButton.Alpha = 1;
-                }
-
-                this.MoveTo(new Vector2(0, -DrawSize.Y));
-                this.MoveTo(Vector2.Zero, transition_time, Easing.OutQuint);
-            }
-
-            public bool OnExiting(IScreen next)
-            {
-                this.MoveTo(new Vector2(0, -DrawSize.Y), transition_time, Easing.OutQuint);
-                return false;
-            }
-
-            public void OnSuspending(IScreen next)
-            {
-                this.MoveTo(new Vector2(0, DrawSize.Y), transition_time, Easing.OutQuint);
-            }
-
-            public void OnResuming(IScreen last)
-            {
-                this.MoveTo(Vector2.Zero, transition_time, Easing.OutQuint);
             }
 
             [BackgroundDependencyLoader]
@@ -223,6 +190,38 @@ namespace osu.Framework.Tests.Visual
                         }
                     }
                 };
+            }
+
+            public override void OnEntering(IScreen last)
+            {
+                base.OnEntering(last);
+
+                if (last != null)
+                {
+                    //only show the pop button if we are entered form another screen.
+                    popButton.Alpha = 1;
+                }
+
+                this.MoveTo(new Vector2(0, -DrawSize.Y));
+                this.MoveTo(Vector2.Zero, transition_time, Easing.OutQuint);
+            }
+
+            public override bool OnExiting(IScreen next)
+            {
+                this.MoveTo(new Vector2(0, -DrawSize.Y), transition_time, Easing.OutQuint);
+                return base.OnExiting(next);
+            }
+
+            public override void OnSuspending(IScreen next)
+            {
+                base.OnSuspending(next);
+                this.MoveTo(new Vector2(0, DrawSize.Y), transition_time, Easing.OutQuint);
+            }
+
+            public override void OnResuming(IScreen last)
+            {
+                base.OnResuming(last);
+                this.MoveTo(Vector2.Zero, transition_time, Easing.OutQuint);
             }
         }
     }

--- a/osu.Framework.Tests/Visual/TestCaseScreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseScreen.cs
@@ -130,13 +130,6 @@ namespace osu.Framework.Tests.Visual
 
             private const int transition_time = 500;
 
-            public override bool RemoveWhenNotAlive => false;
-
-            public TestScreen()
-            {
-                RelativeSizeAxes = Axes.Both;
-            }
-
             [BackgroundDependencyLoader]
             private void load()
             {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -91,7 +91,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="cancellation">An optional cancellation token.</param>
         /// <param name="scheduler">The scheduler for <paramref name="onLoaded"/> to be invoked on. If null, the local scheduler will be used.</param>
         /// <returns>The task which is used for loading and callbacks.</returns>
-        protected Task LoadComponentAsync<TLoadable>(TLoadable component, Action<TLoadable> onLoaded = null, CancellationToken cancellation = default, Scheduler scheduler = null)
+        protected internal Task LoadComponentAsync<TLoadable>(TLoadable component, Action<TLoadable> onLoaded = null, CancellationToken cancellation = default, Scheduler scheduler = null)
             where TLoadable : Drawable
             => LoadComponentsAsync(component.Yield(), l => onLoaded?.Invoke(l.Single()), cancellation, scheduler);
 
@@ -108,7 +108,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="cancellation">An optional cancellation token.</param>
         /// <param name="scheduler">The scheduler for <paramref name="onLoaded"/> to be invoked on. If null, the local scheduler will be used.</param>
         /// <returns>The task which is used for loading and callbacks.</returns>
-        protected Task LoadComponentsAsync<TLoadable>(IEnumerable<TLoadable> components, Action<IEnumerable<TLoadable>> onLoaded = null, CancellationToken cancellation = default, Scheduler scheduler = null)
+        protected internal Task LoadComponentsAsync<TLoadable>(IEnumerable<TLoadable> components, Action<IEnumerable<TLoadable>> onLoaded = null, CancellationToken cancellation = default, Scheduler scheduler = null)
             where TLoadable : Drawable
         {
             if (game == null)

--- a/osu.Framework/Graphics/Containers/TabbableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContainer.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Allows for tabbing between multiple levels within the TabbableContentContainer.
         /// </summary>
-        public Container<Drawable> TabbableContentContainer { private get; set; }
+        public CompositeDrawable TabbableContentContainer { private get; set; }
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
@@ -46,7 +46,7 @@ namespace osu.Framework.Graphics.Containers
             return true;
         }
 
-        private Drawable nextTabStop(Container<Drawable> target, bool reverse)
+        private Drawable nextTabStop(CompositeDrawable target, bool reverse)
         {
             Stack<Drawable> stack = new Stack<Drawable>();
             stack.Push(target); // Extra push for circular tabbing

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -194,6 +194,9 @@ namespace osu.Framework.Screens
         /// <param name="source">The <see cref="IScreen"/> which exited. May or may not be the current screen in the stack.</param>
         private void resume(IScreen source)
         {
+            if (CurrentScreen == null)
+                return;
+
             if (CurrentScreen.ValidForResume)
             {
                 CurrentScreen.OnResuming(source);

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -68,6 +68,9 @@ namespace osu.Framework.Screens
             var last = screens.Peek();
             var next = new ScreenDescriptor { Screen = newScreen };
 
+            if (next.ScreenDrawable.RemoveWhenNotAlive)
+                throw new Screen.ScreenWillBeRemovedOnPushException(newScreen.GetType());
+
             // Suspend the current screen
             last.Screen.OnSuspending(newScreen);
             last.ScreenDrawable.Expire();

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -130,7 +130,7 @@ namespace osu.Framework.Screens
             => source == screens.Peek().Screen;
 
         internal IScreen GetChildScreen(IScreen source)
-            => screens.TakeWhile(d => d.Screen != source).Skip(1).First().Screen;
+            => screens.TakeWhile(d => d.Screen != source).LastOrDefault()?.Screen;
 
         /// <summary>
         /// Exits the current <see cref="IScreen"/>.

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -157,7 +157,7 @@ namespace osu.Framework.Screens
             if (!screens.Contains(source))
                 return;
 
-            foreach (var child in screens)
+            foreach (var child in screens.Skip(1))
             {
                 if (child == source)
                     break;

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -101,8 +101,11 @@ namespace osu.Framework.Screens
 
         internal void Exit(IScreen source)
         {
-            if (source != screens.First().Screen)
+            if (screens.All(d => d.Screen != source))
                 throw new Screen.ScreenNotCurrentException(nameof(Exit));
+            
+            if (source != screens.First().Screen)
+                throw new Screen.ScreenHasChildException(nameof(Exit), $"Use {nameof(ScreenExtensions.MakeCurrent)} instead.");
 
             exitFrom(source);
         }

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -2,11 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using JetBrains.Annotations;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Screens
 {
@@ -23,228 +19,69 @@ namespace osu.Framework.Screens
         bool ValidForPush { get; set; }
 
         /// <summary>
-        /// Called when this Screen is being entered. Only happens once, ever.
+        /// Invoked when this <see cref="IScreen"/> is entering from a parent <see cref="IScreen"/>.
         /// </summary>
-        /// <param name="last">The next Screen.</param>
+        /// <param name="last">The <see cref="IScreen"/> which has suspended.</param>
         void OnEntering(IScreen last);
 
         /// <summary>
-        /// Called when this Screen is exiting. Only happens once, ever.
+        /// Invoked when this <see cref="IScreen"/> is exiting to a parent <see cref="IScreen"/>.
         /// </summary>
-        /// <param name="next">The next Screen.</param>
-        /// <returns>Return true to cancel the exit process.</returns>
+        /// <param name="next">The <see cref="IScreen"/> that will be resumed next.</param>
+        /// <returns>True to cancel the exit process.</returns>
         bool OnExiting(IScreen next);
 
         /// <summary>
-        /// Called when this Screen is being returned to from a child exiting.
+        /// Invoked when this <see cref="IScreen"/> is entered from a child <see cref="IScreen"/>.
         /// </summary>
         /// <param name="last">The next Screen.</param>
         void OnResuming(IScreen last);
 
         /// <summary>
-        /// Called when this Screen is being left to a new child.
+        /// Invoked when this <see cref="IScreen"/> is exited to a child <see cref="IScreen"/>.
         /// </summary>
         /// <param name="next">The new Screen</param>
         void OnSuspending(IScreen next);
     }
 
-    public delegate void ScreenChangedDelegate(IScreen lastScreen, IScreen newScreen);
-
-    public class ScreenStack : CompositeDrawable
-    {
-        public event ScreenChangedDelegate ScreenPushed;
-        public event ScreenChangedDelegate ScreenExited;
-
-        public IScreen CurrentScreen => stack.FirstOrDefault();
-
-        private readonly Stack<IScreen> stack = new Stack<IScreen>();
-
-        public ScreenStack()
-        {
-        }
-
-        public ScreenStack(IScreen baseScreen)
-        {
-            Push(baseScreen);
-        }
-
-        /// <summary>
-        /// Pushes a <see cref="IScreen"/> to the current screen.
-        /// </summary>
-        /// <param name="screen"></param>
-        public void Push(IScreen screen)
-        {
-            Push(null, screen);
-        }
-
-        /// <summary>
-        /// Exits from the current <see cref="IScreen"/>.
-        /// </summary>
-        public void Exit()
-        {
-            Exit(CurrentScreen);
-        }
-
-        internal void Push(IScreen source, IScreen newScreen)
-        {
-            if (stack.Contains(newScreen))
-                throw new Screen.ScreenAlreadyEnteredException();
-
-            if (newScreen.AsDrawable().RemoveWhenNotAlive)
-                throw new Screen.ScreenWillBeRemovedOnPushException(newScreen.GetType());
-
-            // Suspend the current screen, if there is one
-            if (source != null)
-            {
-                if (source != stack.Peek())
-                    throw new Screen.ScreenNotCurrentException(nameof(Push));
-
-                source.OnSuspending(newScreen);
-                source.AsDrawable().Expire();
-            }
-
-            // Screens are expired when they are exited - lifetime needs to be reset when entered
-            newScreen.AsDrawable().LifetimeEnd = double.MaxValue;
-
-            // Push the new screen
-            stack.Push(newScreen);
-            ScreenPushed?.Invoke(source, newScreen);
-
-            void finishLoad()
-            {
-                if (!newScreen.ValidForPush)
-                {
-                    exitFrom(null);
-                    return;
-                }
-
-                AddInternal(newScreen.AsDrawable());
-                newScreen.OnEntering(source);
-            }
-
-            if (source != null)
-                LoadScreen((CompositeDrawable)source, newScreen.AsDrawable(), finishLoad);
-            else if (LoadState >= LoadState.Ready)
-                LoadScreen(this, newScreen.AsDrawable(), finishLoad);
-            else
-                finishLoad();
-        }
-
-        protected virtual void LoadScreen(CompositeDrawable loader, Drawable toLoad, Action continuation)
-        {
-            if (toLoad.LoadState >= LoadState.Ready)
-                continuation?.Invoke();
-            else
-                loader.LoadComponentAsync(toLoad, _ => continuation?.Invoke(), scheduler: Scheduler);
-        }
-
-        internal void Exit(IScreen source)
-        {
-            if (!stack.Contains(source))
-                throw new Screen.ScreenNotCurrentException(nameof(Exit));
-
-            if (CurrentScreen != source)
-                throw new Screen.ScreenHasChildException(nameof(Exit), $"Use {nameof(ScreenExtensions.MakeCurrent)} instead.");
-
-            exitFrom(null);
-        }
-
-        internal void MakeCurrent(IScreen source)
-        {
-            if (CurrentScreen == source)
-                return;
-
-            // Todo: This should throw an exception instead?
-            if (!stack.Contains(source))
-                return;
-
-            exitFrom(null, () =>
-            {
-                foreach (var child in stack)
-                {
-                    if (child == source)
-                        break;
-                    child.ValidForResume = false;
-                }
-            });
-        }
-
-        internal bool IsCurrentScreen(IScreen source) => source == CurrentScreen;
-
-        internal IScreen GetChildScreen(IScreen source)
-            => stack.TakeWhile(s => s != source).LastOrDefault();
-
-        /// <summary>
-        /// Exits the current <see cref="IScreen"/>.
-        /// </summary>
-        /// <param name="source">The <see cref="IScreen"/> which last exited.</param>
-        /// <param name="onExiting">An action that is invoked when the current screen allows the exit to continue.</param>
-        private void exitFrom([CanBeNull] IScreen source, Action onExiting = null)
-        {
-            // The current screen is at the top of the stack, it will be the one that is exited
-            var toExit = stack.Pop();
-
-            // The next current screen will be resumed
-            if (toExit.OnExiting(CurrentScreen))
-            {
-                stack.Push(toExit);
-                return;
-            }
-
-            onExiting?.Invoke();
-
-            if (source == null)
-            {
-                // This is the first screen that exited
-                toExit.AsDrawable().Expire();
-            }
-            else
-            {
-                // This screen exited via a recursive-exit chain. Lifetime is propagated from the parent.
-                toExit.AsDrawable().LifetimeEnd = ((Drawable)source).LifetimeEnd;
-            }
-
-            ScreenExited?.Invoke(toExit, CurrentScreen);
-
-            // Resume the next current screen from the exited one
-            resumeFrom(toExit);
-        }
-
-        /// <summary>
-        /// Resumes the current <see cref="IScreen"/>.
-        /// </summary>
-        /// <param name="source">The <see cref="IScreen"/> which exited.</param>
-        private void resumeFrom([NotNull] IScreen source)
-        {
-            if (CurrentScreen == null)
-                return;
-
-            if (CurrentScreen.ValidForResume)
-            {
-                CurrentScreen.OnResuming(source);
-
-                // Screens are expired when they are suspended - lifetime needs to be reset when resumed
-                CurrentScreen.AsDrawable().LifetimeEnd = double.MaxValue;
-            }
-            else
-                exitFrom(source);
-        }
-    }
-
     public static class ScreenExtensions
     {
+        /// <summary>
+        /// Pushes an <see cref="IScreen"/> to another.
+        /// </summary>
+        /// <param name="screen">The <see cref="IScreen"/> to push to.</param>
+        /// <param name="newScreen">The <see cref="IScreen"/> to push.</param>
         public static void Push(this IScreen screen, IScreen newScreen)
             => runOnRoot(screen, stack => stack.Push(screen, newScreen));
 
+        /// <summary>
+        /// Exits from an <see cref="IScreen"/>.
+        /// </summary>
+        /// <param name="screen">The <see cref="IScreen"/> to exit from.</param>
         public static void Exit(this IScreen screen)
             => runOnRoot(screen, stack => stack.Exit(screen), () => screen.ValidForPush = false);
 
+        /// <summary>
+        /// Makes an <see cref="IScreen"/> the current screen, exiting all child <see cref="IScreen"/>s along the way.
+        /// </summary>
+        /// <param name="screen">The <see cref="IScreen"/> to make current.</param>
         public static void MakeCurrent(this IScreen screen)
             => runOnRoot(screen, stack => stack.MakeCurrent(screen));
 
+        /// <summary>
+        /// Retrieves whether an <see cref="IScreen"/> is the current screen.
+        /// This will return false on all <see cref="IScreen"/>s while a child <see cref="IScreen"/> is loading.
+        /// </summary>
+        /// <param name="screen">The <see cref="IScreen"/> to check.</param>
+        /// <returns>True if <paramref name="screen"/> is the current screen.</returns>
         public static bool IsCurrentScreen(this IScreen screen)
             => runOnRoot(screen, stack => stack.IsCurrentScreen(screen), () => false);
 
+        /// <summary>
+        /// Retrieves the child <see cref="IScreen"/> of an <see cref="IScreen"/>.
+        /// </summary>
+        /// <param name="screen">The <see cref="IScreen"/> to retrieve the child of.</param>
+        /// <returns>The child <see cref="IScreen"/> of <paramref name="screen"/>, or <paramref name="screen"/> has no child.</returns>
         public static IScreen GetChildScreen(this IScreen screen)
             => runOnRoot(screen, stack => stack.GetChildScreen(screen), () => null);
 

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -109,7 +109,7 @@ namespace osu.Framework.Screens
             if (next.LoadState >= LoadState.Ready)
                 continuation?.Invoke();
             else
-                last.LoadComponentAsync(next, _ => continuation?.Invoke());
+                last.LoadComponentAsync(next, _ => continuation?.Invoke(), scheduler: Scheduler);
         }
 
         internal void Exit(IScreen source)

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -1,0 +1,212 @@
+// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Screens
+{
+    public interface IScreen : IDrawable
+    {
+        bool ValidForResume { get; set; }
+
+        /// <summary>
+        /// Called when this Screen is being entered. Only happens once, ever.
+        /// </summary>
+        /// <param name="last">The next Screen.</param>
+        void OnEntering(IScreen last);
+
+        /// <summary>
+        /// Called when this Screen is exiting. Only happens once, ever.
+        /// </summary>
+        /// <param name="next">The next Screen.</param>
+        /// <returns>Return true to cancel the exit process.</returns>
+        bool OnExiting(IScreen next);
+
+        /// <summary>
+        /// Called when this Screen is being returned to from a child exiting.
+        /// </summary>
+        /// <param name="last">The next Screen.</param>
+        void OnResuming(IScreen last);
+
+        /// <summary>
+        /// Called when this Screen is being left to a new child.
+        /// </summary>
+        /// <param name="next">The new Screen</param>
+        void OnSuspending(IScreen next);
+    }
+
+    public class ScreenStack : CompositeDrawable
+    {
+        public event Action<IScreen> ScreenPushed;
+        public event Action<IScreen> ScreenExited;
+
+        private readonly Stack<ScreenDescriptor> screens = new Stack<ScreenDescriptor>();
+
+        public ScreenStack(IScreen baseScreen)
+        {
+            var descriptor = new ScreenDescriptor { Screen = baseScreen };
+
+            screens.Push(descriptor);
+
+            AddInternal(descriptor.ScreenDrawable);
+
+            baseScreen.OnEntering(null);
+        }
+
+        internal void Push(IScreen source, IScreen newScreen)
+        {
+            if (source != screens.Peek().Screen)
+                throw new Screen.ScreenNotCurrentException(nameof(Push));
+
+            if (screens.Any(d => d.Screen == newScreen))
+                throw new Screen.ScreenAlreadyEnteredException();
+
+            var last = screens.Peek();
+            var next = new ScreenDescriptor { Screen = newScreen };
+
+            // Suspend the current screen
+            last.Screen.OnSuspending(newScreen);
+            last.ScreenDrawable.Expire();
+
+            // Push the new screen
+            screens.Push(next);
+            ScreenPushed?.Invoke(newScreen);
+
+            void finishLoad()
+            {
+                if (!screens.Contains(last) || !screens.Contains(next))
+                    return;
+
+                AddInternal(next.ScreenDrawable);
+                next.Screen.OnEntering(last.Screen);
+            }
+
+            LoadScreen(last.ScreenDrawable, next.ScreenDrawable, finishLoad);
+        }
+
+        protected virtual void LoadScreen(CompositeDrawable last, CompositeDrawable next, Action continuation)
+        {
+            if (next.LoadState >= LoadState.Ready)
+                continuation?.Invoke();
+            else
+                last.LoadComponentAsync(next, _ => continuation?.Invoke());
+        }
+
+        internal void Exit(IScreen source)
+        {
+            if (source != screens.First().Screen)
+                throw new Screen.ScreenNotCurrentException(nameof(Exit));
+
+            exitFrom(source);
+        }
+
+        internal void MakeCurrent(IScreen source)
+        {
+            if (source == screens.Peek().Screen)
+                return;
+
+            // Todo: This should throw an exception instead?
+            if (screens.All(d => d.Screen != source))
+                return;
+
+            foreach (var child in screens)
+            {
+                if (child.Screen == source)
+                    break;
+                child.Screen.ValidForResume = false;
+            }
+
+            Exit(screens.Peek().Screen);
+        }
+
+        internal bool IsCurrentScreen(IScreen source)
+            => source == screens.Peek().Screen;
+
+        internal IScreen GetChildScreen(IScreen source)
+            => screens.TakeWhile(d => d.Screen != source).Skip(1).First().Screen;
+
+        /// <summary>
+        /// Exits the current <see cref="IScreen"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="IScreen"/> which exited. May or may not be the current screen in the stack.</param>
+        private void exitFrom(IScreen source)
+        {
+            var last = screens.Pop();
+            var next = screens.Peek();
+
+            if (last.Screen.OnExiting(next.Screen))
+            {
+                screens.Push(last);
+                return;
+            }
+
+            // Propagate the lifetime end from the exiting screen
+            last.ScreenDrawable.Expire();
+            last.ScreenDrawable.LifetimeEnd = ((Drawable)source).LifetimeEnd;
+
+            ScreenExited?.Invoke(last.Screen);
+
+            resume(source);
+        }
+
+        /// <summary>
+        /// Resumes the current <see cref="IScreen"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="IScreen"/> which exited. May or may not be the current screen in the stack.</param>
+        private void resume(IScreen source)
+        {
+            var next = screens.Peek();
+
+            if (next.Screen.ValidForResume)
+            {
+                next.Screen.OnResuming(source);
+                next.ScreenDrawable.LifetimeEnd = double.MaxValue;
+            }
+            else
+                exitFrom(source);
+        }
+
+        private class ScreenDescriptor
+        {
+            public IScreen Screen;
+            public CompositeDrawable ScreenDrawable => (CompositeDrawable)Screen;
+        }
+    }
+
+    public static class ScreenExtensions
+    {
+        public static void Push(this IScreen screen, IScreen newScreen)
+            => runOnRoot(screen, stack => stack.Push(screen, newScreen));
+
+        public static void Exit(this IScreen screen)
+            => runOnRoot(screen, stack => stack.Exit(screen));
+
+        public static void MakeCurrent(this IScreen screen)
+            => runOnRoot(screen, stack => stack.MakeCurrent(screen));
+
+        public static bool IsCurrentScreen(this IScreen screen)
+            => runOnRoot(screen, stack => stack.IsCurrentScreen(screen));
+
+        internal static IScreen GetChildScreen(this IScreen screen)
+            => runOnRoot(screen, stack => stack.GetChildScreen(screen));
+
+        private static void runOnRoot(IDrawable current, Action<ScreenStack> action)
+        {
+            if (current is ScreenStack stack)
+                action(stack);
+            else
+                runOnRoot(current.Parent, action);
+        }
+
+        private static T runOnRoot<T>(IDrawable current, Func<ScreenStack, T> action)
+        {
+            if (current is ScreenStack stack)
+                return action(stack);
+            return runOnRoot(current.Parent, action);
+        }
+    }
+}

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -210,7 +210,7 @@ namespace osu.Framework.Screens
         public static bool IsCurrentScreen(this IScreen screen)
             => runOnRoot(screen, stack => stack.IsCurrentScreen(screen), () => false);
 
-        internal static IScreen GetChildScreen(this IScreen screen)
+        public static IScreen GetChildScreen(this IScreen screen)
             => runOnRoot(screen, stack => stack.GetChildScreen(screen), () => null);
 
         private static void runOnRoot(IDrawable current, Action<ScreenStack> onRoot, Action onFail = null)

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -76,6 +76,14 @@ namespace osu.Framework.Screens
             Push(null, screen);
         }
 
+        /// <summary>
+        /// Exits from the current <see cref="IScreen"/>.
+        /// </summary>
+        public void Exit()
+        {
+            Exit(CurrentScreen);
+        }
+
         internal void Push(IScreen source, IScreen newScreen)
         {
             if (screens.Contains(newScreen))

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -75,6 +75,8 @@ namespace osu.Framework.Screens
             last.Screen.OnSuspending(newScreen);
             last.ScreenDrawable.Expire();
 
+            next.ScreenDrawable.LifetimeEnd = double.MaxValue;
+
             // Push the new screen
             screens.Push(next);
             ScreenPushed?.Invoke(newScreen);

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -2,265 +2,29 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
-using osu.Framework.Allocation;
 using osu.Framework.Extensions.TypeExtensions;
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Screens
 {
-    public class Screen : Container
+    public class Screen : CompositeDrawable, IScreen
     {
-        protected Screen ParentScreen;
-        public Screen ChildScreen;
+        public bool ValidForResume { get; set; } = true;
 
-        public bool IsCurrentScreen => !hasExited && hasEntered && ChildScreen == null;
+        public bool ValidForPush { get; set; } = true;
 
-        private readonly Container content;
-        private Container childModeContainer;
-
-        [Resolved]
-        protected Game Game { get; private set; }
-
-        protected override Container<Drawable> Content => content;
-
-        public event Action<Screen> ModePushed;
-
-        public event Action<Screen> Exited;
-
-        private bool hasExited;
-        private bool hasEntered;
-
-        /// <summary>
-        /// Make this Screen directly exited when resuming from a child.
-        /// </summary>
-        public bool ValidForResume = true;
-
-        public Screen()
-        {
-            RelativeSizeAxes = Axes.Both;
-            Anchor = Anchor.Centre;
-            Origin = Anchor.Centre;
-
-            AddRangeInternal(new[]
-            {
-                content = new ContentContainer
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre
-                },
-            });
-        }
-
-        public override void Add(Drawable drawable)
-        {
-            if (drawable is Screen)
-                throw new InvalidOperationException("Use Push to add nested Screens.");
-            base.Add(drawable);
-        }
-
-        // in the case we don't have a parent screen, we still want to handle input as we are also responsible for
-        // children inside childScreenContainer. this means the root screen always receive input.
-        // Also only propagate when content is present, else we may incorrectly block/handle events at a screen level.
-        private bool propagateInputSubtree => IsCurrentScreen && Content.IsPresent || !hasExited && ParentScreen == null;
-
-        public override bool PropagateNonPositionalInputSubTree => base.PropagateNonPositionalInputSubTree && propagateInputSubtree;
-        public override bool PropagatePositionalInputSubTree => base.PropagatePositionalInputSubTree && propagateInputSubtree;
-
-        /// <summary>
-        /// Called when this Screen is being entered. Only happens once, ever.
-        /// </summary>
-        /// <param name="last">The next Screen.</param>
-        protected virtual void OnEntering(Screen last)
+        public virtual void OnEntering(IScreen last)
         {
         }
 
-        /// <summary>
-        /// Called when this Screen is exiting. Only happens once, ever.
-        /// </summary>
-        /// <param name="next">The next Screen.</param>
-        /// <returns>Return true to cancel the exit process.</returns>
-        protected virtual bool OnExiting(Screen next) => false;
+        public virtual bool OnExiting(IScreen next) => false;
 
-        /// <summary>
-        /// Called when this Screen is being returned to from a child exiting.
-        /// </summary>
-        /// <param name="last">The next Screen.</param>
-        protected virtual void OnResuming(Screen last)
+        public virtual void OnResuming(IScreen last)
         {
         }
 
-        /// <summary>
-        /// Called when this Screen is being left to a new child.
-        /// </summary>
-        /// <param name="next">The new Screen</param>
-        protected virtual void OnSuspending(Screen next)
+        public virtual void OnSuspending(IScreen next)
         {
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            //for the case where we are at the top of the mode stack, we still want to run our OnEntering method.
-            if (ParentScreen == null)
-            {
-                enter(null);
-
-                AddInternal(childModeContainer = new Container
-                {
-                    Anchor = Anchor.Centre,
-                    Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
-                });
-            }
-            else
-            {
-                childModeContainer = ParentScreen.childModeContainer;
-            }
-        }
-
-        /// <summary>
-        /// Changes to a new Screen.
-        /// This will trigger an async load if the screen is not already loaded, during which the current screen will no longer be current (or accept user input).
-        /// </summary>
-        /// <param name="screen">The new Screen.</param>
-        public virtual void Push(Screen screen)
-        {
-            if (hasExited)
-                throw new TargetAlreadyExitedException();
-
-            if (!IsCurrentScreen)
-                throw new ScreenNotCurrentException(nameof(Push));
-
-            if (ChildScreen != null)
-                throw new ScreenHasChildException(nameof(Push), "Exit the existing child screen first.");
-
-            if (screen.hasExited)
-                throw new ScreenAlreadyExitedException();
-
-            if (screen.hasEntered)
-                throw new ScreenAlreadyEnteredException();
-
-            screen.ParentScreen = this;
-            startSuspend(screen);
-            ModePushed?.Invoke(screen);
-
-            void finishLoad()
-            {
-                if (hasExited || screen.hasExited)
-                    return;
-
-                childModeContainer.Add(screen);
-
-                screen.enter(this);
-
-                Content.Expire();
-            }
-
-            if (screen.LoadState >= LoadState.Ready)
-                finishLoad();
-            else
-                LoadComponentAsync(screen, _ => finishLoad());
-        }
-
-        private void startSuspend(Screen next)
-        {
-            OnSuspending(next);
-            Content.Expire();
-
-            ChildScreen = next;
-        }
-
-        /// <summary>
-        /// Exits this Screen.
-        /// </summary>
-        public void Exit()
-        {
-            if (ChildScreen != null)
-                throw new ScreenHasChildException(nameof(Exit), $"Use {nameof(MakeCurrent)} instead.");
-
-            ExitFrom(this);
-        }
-
-        private void enter(Screen source)
-        {
-            hasEntered = true;
-            OnEntering(source);
-        }
-
-        /// <summary>
-        /// Exits this Screen.
-        /// </summary>
-        /// <param name="source">Provides an exit source (used when skipping no-longer-valid modes upwards in stack).</param>
-        protected void ExitFrom(Screen source)
-        {
-            if (hasExited)
-                return;
-
-            if (OnExiting(ParentScreen))
-                return;
-
-            hasExited = true;
-
-            if (ValidForResume || source == this)
-                Content.Expire();
-
-            //propagate down the LifetimeEnd from the exit source.
-            LifetimeEnd = source.Content.LifetimeEnd;
-
-            Exited?.Invoke(ParentScreen);
-            ParentScreen?.startResume(source);
-            ParentScreen = null;
-
-            Exited = null;
-            ModePushed = null;
-        }
-
-        private void startResume(Screen source)
-        {
-            ChildScreen = null;
-
-            if (ValidForResume)
-            {
-                OnResuming(source);
-                Content.LifetimeEnd = double.MaxValue;
-            }
-            else
-            {
-                ExitFrom(source);
-            }
-        }
-
-
-        public void MakeCurrent()
-        {
-            if (IsCurrentScreen || ChildScreen == null) return;
-
-            Screen c;
-            for (c = ChildScreen; c.ChildScreen != null; c = c.ChildScreen)
-                c.ValidForResume = false;
-
-            //all the expired ones will exit
-            c.Exit();
-        }
-
-        protected class ContentContainer : Container
-        {
-            public override bool RemoveWhenNotAlive => false;
-
-            public ContentContainer()
-            {
-                RelativeSizeAxes = Axes.Both;
-            }
-        }
-
-        public class TargetAlreadyExitedException : InvalidOperationException
-        {
-            public TargetAlreadyExitedException()
-                : base("Cannot push to an already exited screen.")
-            {
-            }
         }
 
         public class ScreenNotCurrentException : InvalidOperationException
@@ -275,14 +39,6 @@ namespace osu.Framework.Screens
         {
             public ScreenHasChildException(string action, string description)
                 : base($"Cannot perform {action} when a child is already present. {description}")
-            {
-            }
-        }
-
-        public class ScreenAlreadyExitedException : InvalidOperationException
-        {
-            public ScreenAlreadyExitedException()
-                : base("Cannot push a screen in an exited state.")
             {
             }
         }

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
 using System;
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Containers;
 
@@ -12,6 +13,9 @@ namespace osu.Framework.Screens
         public bool ValidForResume { get; set; } = true;
 
         public bool ValidForPush { get; set; } = true;
+        
+        [Resolved]
+        protected Game Game { get; private set; }
 
         public virtual void OnEntering(IScreen last)
         {

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
 // Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
 
-using System;
 using osu.Framework.Allocation;
-using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
@@ -37,39 +35,6 @@ namespace osu.Framework.Screens
 
         public virtual void OnSuspending(IScreen next)
         {
-        }
-
-        public class ScreenNotCurrentException : InvalidOperationException
-        {
-            public ScreenNotCurrentException(string action)
-                : base($"Cannot perform {action} on a non-current screen.")
-            {
-            }
-        }
-
-        public class ScreenHasChildException : InvalidOperationException
-        {
-            public ScreenHasChildException(string action, string description)
-                : base($"Cannot perform {action} when a child is already present. {description}")
-            {
-            }
-        }
-
-        public class ScreenAlreadyEnteredException : InvalidOperationException
-        {
-            public ScreenAlreadyEnteredException()
-                : base("Cannot push a screen in an entered state.")
-            {
-            }
-        }
-
-        public class ScreenWillBeRemovedOnPushException : InvalidOperationException
-        {
-            public ScreenWillBeRemovedOnPushException(Type type)
-                : base($"The pushed ({type.ReadableName()}) has {nameof(RemoveWhenNotAlive)} = true and will be removed when a child screen is pushed. "
-                       + $"Screens must set {nameof(RemoveWhenNotAlive)} to false.")
-            {
-            }
         }
     }
 }

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Screens
@@ -13,9 +14,16 @@ namespace osu.Framework.Screens
         public bool ValidForResume { get; set; } = true;
 
         public bool ValidForPush { get; set; } = true;
-        
+
+        public override bool RemoveWhenNotAlive => false;
+
         [Resolved]
         protected Game Game { get; private set; }
+
+        public Screen()
+        {
+            RelativeSizeAxes = Axes.Both;
+        }
 
         public virtual void OnEntering(IScreen last)
         {

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
@@ -290,6 +291,15 @@ namespace osu.Framework.Screens
         {
             public ScreenAlreadyEnteredException()
                 : base("Cannot push a screen in an entered state.")
+            {
+            }
+        }
+
+        public class ScreenWillBeRemovedOnPushException : InvalidOperationException
+        {
+            public ScreenWillBeRemovedOnPushException(Type type)
+                : base($"The pushed ({type.ReadableName()}) has {nameof(RemoveWhenNotAlive)} = true and will be removed when a child screen is pushed. "
+                       + $"Screens must set {nameof(RemoveWhenNotAlive)} to false.")
             {
             }
         }

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -1,0 +1,258 @@
+// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using JetBrains.Annotations;
+using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Screens
+{
+    /// <summary>
+    /// A component which provides functionality for displaying and handling transitions between multiple <see cref="IScreen"/>s.
+    /// </summary>
+    public class ScreenStack : CompositeDrawable
+    {
+        /// <summary>
+        /// Invoked when <see cref="ScreenExtensions.Push"/> is called on a <see cref="IScreen"/>.
+        /// </summary>
+        public event ScreenChangedDelegate ScreenPushed;
+
+        /// <summary>
+        /// Invoked when <see cref="ScreenExtensions.Exit"/> is called on a <see cref="IScreen"/>.
+        /// </summary>
+        public event ScreenChangedDelegate ScreenExited;
+
+        /// <summary>
+        /// The currently-active <see cref="IScreen"/>.
+        /// </summary>
+        public IScreen CurrentScreen => stack.FirstOrDefault();
+
+        private readonly Stack<IScreen> stack = new Stack<IScreen>();
+
+        /// <summary>
+        /// Creates a new <see cref="ScreenStack"/> with no active <see cref="IScreen"/>.
+        /// </summary>
+        public ScreenStack()
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="ScreenStack"/>, and immediately pushes a <see cref="IScreen"/>.
+        /// </summary>
+        /// <param name="baseScreen"></param>
+        public ScreenStack(IScreen baseScreen)
+        {
+            Push(baseScreen);
+        }
+
+        /// <summary>
+        /// Pushes a <see cref="IScreen"/> to this <see cref="ScreenStack"/>.
+        /// </summary>
+        /// <param name="screen">The <see cref="IScreen"/> to push.</param>
+        public void Push(IScreen screen)
+        {
+            Push(null, screen);
+        }
+
+        /// <summary>
+        /// Exits the current <see cref="IScreen"/>.
+        /// </summary>
+        public void Exit()
+        {
+            Exit(CurrentScreen);
+        }
+
+        internal void Push(IScreen source, IScreen newScreen)
+        {
+            if (stack.Contains(newScreen))
+                throw new ScreenAlreadyEnteredException();
+
+            if (newScreen.AsDrawable().RemoveWhenNotAlive)
+                throw new ScreenWillBeRemovedOnPushException(newScreen.GetType());
+
+            // Suspend the current screen, if there is one
+            if (source != null)
+            {
+                if (source != stack.Peek())
+                    throw new ScreenNotCurrentException(nameof(Push));
+
+                source.OnSuspending(newScreen);
+                source.AsDrawable().Expire();
+            }
+
+            // Screens are expired when they are exited - lifetime needs to be reset when entered
+            newScreen.AsDrawable().LifetimeEnd = double.MaxValue;
+
+            // Push the new screen
+            stack.Push(newScreen);
+            ScreenPushed?.Invoke(source, newScreen);
+
+            void finishLoad()
+            {
+                if (!newScreen.ValidForPush)
+                {
+                    exitFrom(null);
+                    return;
+                }
+
+                AddInternal(newScreen.AsDrawable());
+                newScreen.OnEntering(source);
+            }
+
+            if (source != null)
+                LoadScreen((CompositeDrawable)source, newScreen.AsDrawable(), finishLoad);
+            else if (LoadState >= LoadState.Ready)
+                LoadScreen(this, newScreen.AsDrawable(), finishLoad);
+            else
+                finishLoad();
+        }
+
+        /// <summary>
+        /// Loads a <see cref="IScreen"/> through a <see cref="CompositeDrawable"/>.
+        /// </summary>
+        /// <param name="loader">The <see cref="CompositeDrawable"/> to load <paramref name="toLoad"/> with.</param>
+        /// <param name="toLoad">The <see cref="IScreen"/> to load.</param>
+        /// <param name="continuation">The <see cref="Action"/> to invoke after <paramref name="toLoad"/> has finished loading.</param>
+        protected virtual void LoadScreen(CompositeDrawable loader, Drawable toLoad, Action continuation)
+        {
+            if (toLoad.LoadState >= LoadState.Ready)
+                continuation?.Invoke();
+            else
+                loader.LoadComponentAsync(toLoad, _ => continuation?.Invoke(), scheduler: Scheduler);
+        }
+
+        internal void Exit(IScreen source)
+        {
+            if (!stack.Contains(source))
+                throw new ScreenNotCurrentException(nameof(Exit));
+
+            if (CurrentScreen != source)
+                throw new ScreenHasChildException(nameof(Exit), $"Use {nameof(ScreenExtensions.MakeCurrent)} instead.");
+
+            exitFrom(null);
+        }
+
+        internal void MakeCurrent(IScreen source)
+        {
+            if (CurrentScreen == source)
+                return;
+
+            // Todo: This should throw an exception instead?
+            if (!stack.Contains(source))
+                return;
+
+            exitFrom(null, () =>
+            {
+                foreach (var child in stack)
+                {
+                    if (child == source)
+                        break;
+                    child.ValidForResume = false;
+                }
+            });
+        }
+
+        internal bool IsCurrentScreen(IScreen source) => source == CurrentScreen;
+
+        internal IScreen GetChildScreen(IScreen source)
+            => stack.TakeWhile(s => s != source).LastOrDefault();
+
+        /// <summary>
+        /// Exits the current <see cref="IScreen"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="IScreen"/> which last exited.</param>
+        /// <param name="onExiting">An action that is invoked when the current screen allows the exit to continue.</param>
+        private void exitFrom([CanBeNull] IScreen source, Action onExiting = null)
+        {
+            // The current screen is at the top of the stack, it will be the one that is exited
+            var toExit = stack.Pop();
+
+            // The next current screen will be resumed
+            if (toExit.OnExiting(CurrentScreen))
+            {
+                stack.Push(toExit);
+                return;
+            }
+
+            onExiting?.Invoke();
+
+            if (source == null)
+            {
+                // This is the first screen that exited
+                toExit.AsDrawable().Expire();
+            }
+            else
+            {
+                // This screen exited via a recursive-exit chain. Lifetime is propagated from the parent.
+                toExit.AsDrawable().LifetimeEnd = ((Drawable)source).LifetimeEnd;
+            }
+
+            ScreenExited?.Invoke(toExit, CurrentScreen);
+
+            // Resume the next current screen from the exited one
+            resumeFrom(toExit);
+        }
+
+        /// <summary>
+        /// Resumes the current <see cref="IScreen"/>.
+        /// </summary>
+        /// <param name="source">The <see cref="IScreen"/> which exited.</param>
+        private void resumeFrom([NotNull] IScreen source)
+        {
+            if (CurrentScreen == null)
+                return;
+
+            if (CurrentScreen.ValidForResume)
+            {
+                CurrentScreen.OnResuming(source);
+
+                // Screens are expired when they are suspended - lifetime needs to be reset when resumed
+                CurrentScreen.AsDrawable().LifetimeEnd = double.MaxValue;
+            }
+            else
+                exitFrom(source);
+        }
+
+
+        public class ScreenNotCurrentException : InvalidOperationException
+        {
+            public ScreenNotCurrentException(string action)
+                : base($"Cannot perform {action} on a non-current screen.")
+            {
+            }
+        }
+
+        public class ScreenHasChildException : InvalidOperationException
+        {
+            public ScreenHasChildException(string action, string description)
+                : base($"Cannot perform {action} when a child is already present. {description}")
+            {
+            }
+        }
+
+        public class ScreenAlreadyEnteredException : InvalidOperationException
+        {
+            public ScreenAlreadyEnteredException()
+                : base("Cannot push a screen in an entered state.")
+            {
+            }
+        }
+
+        public class ScreenWillBeRemovedOnPushException : InvalidOperationException
+        {
+            public ScreenWillBeRemovedOnPushException(Type type)
+                : base($"The pushed ({type.ReadableName()}) has {nameof(RemoveWhenNotAlive)} = true and will be removed when a child screen is pushed. "
+                       + $"Screens must set {nameof(RemoveWhenNotAlive)} to false.")
+            {
+            }
+        }
+    }
+
+    /// <param name="lastScreen">The <see cref="IScreen"/> that was exited or suspended.</param>
+    /// <param name="newScreen">The <see cref="IScreen"/> that was pushed or resumed.</param>
+    public delegate void ScreenChangedDelegate(IScreen lastScreen, IScreen newScreen);
+}

--- a/osu.Framework/Testing/TestCaseTestRunner.cs
+++ b/osu.Framework/Testing/TestCaseTestRunner.cs
@@ -76,13 +76,13 @@ namespace osu.Framework.Testing
                     // We want to remove the TestCase from the hierarchy on completion as under nUnit, it may have operations run on it from a different thread.
                     // This is because nUnit will reuse the same class multiple times, running a different [Test] method each time, while the GameHost
                     // is run from its own asynchronous thread.
-                    Remove(test);
+                    RemoveInternal(test);
                     completed = true;
                 }
 
                 Schedule(() =>
                 {
-                    Add(test);
+                    AddInternal(test);
 
                     Console.WriteLine($@"{(int)Time.Current}: Running {test} visual test cases...");
 


### PR DESCRIPTION
The issue I'm currently trying to solve is two-fold:

1. You can't derive from Screen or OsuScreen and something else like CachedModelContainer simultaneously.
2. You can't adjust forward the dependencies of pushed screens because they're pushed to some stack higher up the hierarchy - the child screen is not in the hierarchy of the parent screen.

To solve this I'm moving everything to an IScreen interface, which allows us to at least derive CachedModelContainer, which provides the dependencies for child screens.