### PR TITLE
Drop Float flag from audio stream creation

### DIFF
--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Audio.Track
 
                 fileCallbacks = new FileCallbacks(new DataStreamFileProcedures(dataStream));
 
-                BassFlags flags = Preview ? 0 : BassFlags.Decode | BassFlags.Prescan | BassFlags.Float;
+                BassFlags flags = Preview ? 0 : BassFlags.Decode | BassFlags.Prescan;
                 activeStream = Bass.CreateStream(StreamSystem.NoBuffer, flags, fileCallbacks.Callbacks, fileCallbacks.Handle);
 
                 if (!Preview)


### PR DESCRIPTION
This was causing pops for me, and I'm hoping that this will help with ppy/osu#3648 (if it does we should follow up with un4seen).
It would be great to keep this here, but we don't use this flag in stable so it's safe to assume we won't get any audio degradation in comparison for now.