### PR TITLE
Fix VSCode Restore task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -39,7 +39,8 @@
             "type": "shell",
             "command": "dotnet",
             "args": [
-                "restore"
+                "restore",
+                "osu-framework.sln"
             ],
             "problemMatcher": []
         }


### PR DESCRIPTION
A regression caused by the addition of `osu-framework.iOS.sln`.