### PR TITLE
 Add bindable for 'safe area' padding

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableMarginPaddingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableMarginPaddingTest.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableMarginPaddingTest
+    {
+        [TestCase(0, 0, 0, 0)]
+        [TestCase(0, 1, 2, 3)]
+        [TestCase(1, -1, 2, -2)]
+        [TestCase(float.MinValue, float.MinValue, float.MinValue, float.MinValue)]
+        [TestCase(float.MaxValue, float.MaxValue, float.MaxValue, float.MaxValue)]
+        [TestCase(float.MinValue, 0, 0, 0)]
+        public void TestSet(float top, float left, float bottom, float right)
+        {
+            var value = new MarginPadding { Top = top, Left = left, Bottom = bottom, Right = right };
+
+            var bindable = new BindableMarginPadding { Value = value };
+            Assert.AreEqual(value, bindable.Value);
+        }
+
+        [TestCase("(0, 0, 0, 0)", 0, 0, 0, 0)]
+        [TestCase("(-0, -0, -0, -0)", 0, 0, 0, 0)]
+        [TestCase("(1, 2, 3, 4)", 1, 2, 3, 4)]
+        [TestCase("(1.5, 2.5, 3.5, 4.5)", 1.5f, 2.5f, 3.5f, 4.5f)]
+        public void TestParsingString(string value, float expectedTop, float expectedLeft, float expectedBottom, float expectedRight)
+        {
+            var bindable = new BindableMarginPadding();
+            bindable.Parse(value);
+
+            Assert.AreEqual(new MarginPadding { Top = expectedTop, Left = expectedLeft, Bottom = expectedBottom, Right = expectedRight }, bindable.Value);
+        }
+
+        [TestCase("(0, 0, 0, 0)", -10, -10, -10, -10, 10, 10, 10, 10, 0, 0, 0, 0)]
+        [TestCase("(5, -5, 5, -5)", -10, -10, -10, -10, 10, 10, 10, 10, 5, -5, 5, -5)]
+        [TestCase("(-100, -100, -100, -100)", -10, -10, -10, -10, 10, 10, 10, 10, -10, -10, -10, -10)]
+        [TestCase("(100, 100, 100, 100)", -10, -10, -10, -10, 10, 10, 10, 10, 10, 10, 10, 10)]
+        public void TestParsingStringWithRange(string value,
+            float minValueTop, float minValueLeft, float minValueBottom, float minValueRight,
+            float maxValueTop, float maxValueLeft, float maxValueBottom, float maxValueRight,
+            float expectedTop, float expectedLeft, float expectedBottom, float expectedRight
+        )
+        {
+            var minValue = new MarginPadding { Top = minValueTop, Left = minValueLeft, Bottom = minValueBottom, Right = minValueRight };
+            var maxValue = new MarginPadding { Top = maxValueTop, Left = maxValueLeft, Bottom = maxValueBottom, Right = maxValueRight };
+            var expected = new MarginPadding { Top = expectedTop, Left = expectedLeft, Bottom = expectedBottom, Right = expectedRight };
+
+            var bindable = new BindableMarginPadding { MinValue = minValue, MaxValue = maxValue };
+            bindable.Parse(value);
+
+            Assert.AreEqual(expected, bindable.Value);
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/TestCaseContainer/TestCaseSafeArea.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContainer/TestCaseSafeArea.cs
@@ -1,0 +1,87 @@
+﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Drawing;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Graphics;
+using GameWindow = osu.Framework.Platform.GameWindow;
+
+namespace osu.Framework.Tests.Visual.TestCaseContainer
+{
+    public class TestCaseSafeArea : TestCase
+    {
+        private readonly BindableMarginPadding safeAreaPadding = new BindableMarginPadding();
+        private readonly Container container;
+        private readonly Box box;
+        private readonly SpriteText textbox;
+
+        private GameWindow window;
+
+        public TestCaseSafeArea()
+        {
+            Child = new FillFlowContainer
+            {
+                Padding = new MarginPadding(10),
+                Direction = FillDirection.Vertical,
+                Spacing = new Vector2(5f),
+                Children = new Drawable[]
+                {
+                    textbox = new SpriteText { Text = "SafeAreaPadding:" },
+                    new Container
+                    {
+                        Children = new Drawable[]
+                        {
+                            box = new Box
+                            {
+                                Colour = Color4.Red,
+                                Size = new Vector2(100, 100)
+                            },
+                            container = new Container
+                            {
+                                Size = new Vector2(100, 100),
+                                Child = new Box
+                                {
+                                    Colour = Color4.Blue,
+                                    RelativeSizeAxes = Axes.Both
+                                }
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            window = host.Window;
+            safeAreaPadding.ValueChanged += updatePadding;
+            safeAreaPadding.BindTo(window.SafeAreaPadding);
+            updatePadding(window.SafeAreaPadding.Value);
+        }
+
+        private void updatePadding(MarginPadding padding)
+        {
+            container.Padding = padding;
+            textbox.Text = $"SafeAreaPadding: {padding}";
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            var size = new Vector2(window.Width, window.Height);
+            var scale = Vector2.Divide(Content.DrawSize, size);
+            container.Size = box.Size = size;
+            container.Scale = box.Scale = new Vector2(Math.Min(scale.X, scale.Y) * 0.9f);
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/TestCaseContainer/TestCaseSafeArea.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContainer/TestCaseSafeArea.cs
@@ -1,8 +1,7 @@
-﻿// Copyright (c) 2007-2018 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Drawing;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;

--- a/osu.Framework.Tests/Visual/TestCaseContainer/TestCaseSafeArea.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContainer/TestCaseSafeArea.cs
@@ -63,6 +63,9 @@ namespace osu.Framework.Tests.Visual.TestCaseContainer
         private void load(GameHost host)
         {
             window = host.Window;
+
+            if (window == null) return;
+
             safeAreaPadding.ValueChanged += updatePadding;
             safeAreaPadding.BindTo(window.SafeAreaPadding);
             updatePadding(window.SafeAreaPadding.Value);
@@ -77,6 +80,9 @@ namespace osu.Framework.Tests.Visual.TestCaseContainer
         protected override void Update()
         {
             base.Update();
+
+            if (window == null) return;
+
             var size = new Vector2(window.Width, window.Height);
             var scale = Vector2.Divide(Content.DrawSize, size);
             container.Size = box.Size = size;

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.iOS
 
         // SafeAreaInsets is cached to prevent access outside the main thread
         private UIEdgeInsets safeArea = UIEdgeInsets.Zero;
-        public UIEdgeInsets SafeArea
+        internal UIEdgeInsets SafeArea
         {
             get => safeArea;
             set

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -73,7 +73,6 @@ namespace osu.Framework.iOS
         private bool needsResizeFrameBuffer;
         public void RequestResizeFrameBuffer() => needsResizeFrameBuffer = true;
 
-
         public override void LayoutSubviews()
         {
             base.LayoutSubviews();

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -45,6 +45,20 @@ namespace osu.Framework.iOS
 
         public float Scale { get; private set; }
 
+        // SafeAreaInsets is cached to prevent access outside the main thread
+        private UIEdgeInsets safeArea = UIEdgeInsets.Zero;
+        public UIEdgeInsets SafeArea
+        {
+            get => safeArea;
+            set
+            {
+                if (value.Equals(safeArea))
+                    return;
+                safeArea = value;
+                OnResize(EventArgs.Empty);
+            }
+        }
+
         public override void TouchesBegan(NSSet touches, UIEvent evt) => HandleTouches?.Invoke(touches);
         public override void TouchesCancelled(NSSet touches, UIEvent evt) => HandleTouches?.Invoke(touches);
         public override void TouchesEnded(NSSet touches, UIEvent evt) => HandleTouches?.Invoke(touches);
@@ -58,6 +72,13 @@ namespace osu.Framework.iOS
 
         private bool needsResizeFrameBuffer;
         public void RequestResizeFrameBuffer() => needsResizeFrameBuffer = true;
+
+
+        public override void LayoutSubviews()
+        {
+            base.LayoutSubviews();
+            SafeArea = SafeAreaInsets;
+        }
 
         public override void SwapBuffers()
         {

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -4,6 +4,8 @@
 using osuTK.Graphics;
 using osu.Framework.Configuration;
 using osu.Framework.Platform;
+using osu.Framework.Graphics;
+using System;
 
 namespace osu.Framework.iOS
 {
@@ -17,8 +19,7 @@ namespace osu.Framework.iOS
 
         public override void SetupWindow(FrameworkConfigManager config)
         {
-            // TODO
-
+            Resize += onResize;
             // for now, let's just say the cursor is always in the window.
             CursorInWindow = true;
         }
@@ -37,6 +38,17 @@ namespace osu.Framework.iOS
         public override void Run(double updateRate)
         {
             // do nothing for iOS
+        }
+
+        private void onResize(object sender, EventArgs e)
+        {
+            SafeAreaPadding.Value = new MarginPadding
+            {
+                Top = (float)GameView.SafeArea.Top * GameView.Scale,
+                Left = (float)GameView.SafeArea.Left * GameView.Scale,
+                Bottom = (float)GameView.SafeArea.Bottom * GameView.Scale,
+                Right = (float)GameView.SafeArea.Right * GameView.Scale
+            };
         }
     }
 }

--- a/osu.Framework/Configuration/BindableMarginPadding.cs
+++ b/osu.Framework/Configuration/BindableMarginPadding.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Text.RegularExpressions;
 using osu.Framework.Graphics;
 
 namespace osu.Framework.Configuration

--- a/osu.Framework/Configuration/BindableMarginPadding.cs
+++ b/osu.Framework/Configuration/BindableMarginPadding.cs
@@ -1,4 +1,8 @@
-﻿using System;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Text.RegularExpressions;
 using osu.Framework.Graphics;
 
 namespace osu.Framework.Configuration
@@ -62,21 +66,26 @@ namespace osu.Framework.Configuration
 
         public override void Parse(object input)
         {
-            // TODO
-            //switch (input)
-            //{
-            //    case string str:
-            //        string[] split = str.Split('x');
+            switch (input)
+            {
+                case string str:
+                    string[] split = str.Trim("() ".ToCharArray()).Split(',');
 
-            //        if (split.Length != 2)
-            //            throw new ArgumentException($"Input string was in wrong format! (expected: '<width>x<height>', actual: '{str}')");
+                    if (split.Length != 4)
+                        throw new ArgumentException($"Input string was in wrong format! (expected: '(<top>, <left>, <bottom>, <right>)', actual: '{str}')");
 
-            //        Value = new MarginPadding(int.Parse(split[0]), int.Parse(split[1]));
-            //        break;
-            //    default:
-            //        base.Parse(input);
-            //        break;
-            //}
+                    Value = new MarginPadding
+                    {
+                        Top = float.Parse(split[0]),
+                        Left = float.Parse(split[1]),
+                        Bottom = float.Parse(split[2]),
+                        Right = float.Parse(split[3]),
+                    };
+                    break;
+                default:
+                    base.Parse(input);
+                    break;
+            }
         }
         
         private static MarginPadding clamp(MarginPadding value, MarginPadding minValue, MarginPadding maxValue) =>

--- a/osu.Framework/Configuration/BindableMarginPadding.cs
+++ b/osu.Framework/Configuration/BindableMarginPadding.cs
@@ -87,7 +87,7 @@ namespace osu.Framework.Configuration
                     break;
             }
         }
-        
+
         private static MarginPadding clamp(MarginPadding value, MarginPadding minValue, MarginPadding maxValue) =>
             new MarginPadding
             {

--- a/osu.Framework/Configuration/BindableMarginPadding.cs
+++ b/osu.Framework/Configuration/BindableMarginPadding.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using osu.Framework.Graphics;
+
+namespace osu.Framework.Configuration
+{
+    public class BindableMarginPadding : Bindable<MarginPadding>
+    {
+        public BindableMarginPadding(MarginPadding value = default)
+            : base(value)
+        {
+            MinValue = DefaultMinValue;
+            MaxValue = DefaultMaxValue;
+        }
+
+        public MarginPadding MinValue { get; set; }
+        public MarginPadding MaxValue { get; set; }
+
+        protected MarginPadding DefaultMinValue => new MarginPadding(float.MinValue);
+        protected MarginPadding DefaultMaxValue => new MarginPadding(float.MaxValue);
+
+        public override MarginPadding Value
+        {
+            get => base.Value;
+            set => base.Value = clamp(value, MinValue, MaxValue);
+        }
+
+        public override void BindTo(Bindable<MarginPadding> them)
+        {
+            if (them is BindableMarginPadding other)
+            {
+                MinValue = new MarginPadding
+                {
+                    Top = Math.Max(MinValue.Top, other.MinValue.Top),
+                    Left = Math.Max(MinValue.Left, other.MinValue.Left),
+                    Bottom = Math.Max(MinValue.Bottom, other.MinValue.Bottom),
+                    Right = Math.Max(MinValue.Right, other.MinValue.Right)
+                };
+
+                MaxValue = new MarginPadding
+                {
+                    Top = Math.Min(MaxValue.Top, other.MaxValue.Top),
+                    Left = Math.Min(MaxValue.Left, other.MaxValue.Left),
+                    Bottom = Math.Min(MaxValue.Bottom, other.MaxValue.Bottom),
+                    Right = Math.Min(MaxValue.Right, other.MaxValue.Right)
+                };
+
+                if (MinValue.Top > MaxValue.Top || MinValue.Left > MaxValue.Left || MinValue.Bottom > MaxValue.Bottom || MinValue.Right > MaxValue.Right)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(them),
+                        $"Can not weld BindableMarginPaddings with non-overlapping min/max-ranges. The ranges were [{MinValue} - {MaxValue}] and [{other.MinValue} - {other.MaxValue}]."
+                    );
+                }
+            }
+
+            base.BindTo(them);
+        }
+
+        public static implicit operator MarginPadding(BindableMarginPadding value) => value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableMarginPadding)} to a {nameof(MarginPadding)} is likely a mistake");
+
+        public override string ToString() => Value.ToString();
+
+        public override void Parse(object input)
+        {
+            // TODO
+            //switch (input)
+            //{
+            //    case string str:
+            //        string[] split = str.Split('x');
+
+            //        if (split.Length != 2)
+            //            throw new ArgumentException($"Input string was in wrong format! (expected: '<width>x<height>', actual: '{str}')");
+
+            //        Value = new MarginPadding(int.Parse(split[0]), int.Parse(split[1]));
+            //        break;
+            //    default:
+            //        base.Parse(input);
+            //        break;
+            //}
+        }
+        
+        private static MarginPadding clamp(MarginPadding value, MarginPadding minValue, MarginPadding maxValue) =>
+            new MarginPadding
+            {
+                Top = Math.Max(minValue.Top, Math.Min(maxValue.Top, value.Top)),
+                Left = Math.Max(minValue.Left, Math.Min(maxValue.Left, value.Left)),
+                Bottom = Math.Max(minValue.Bottom, Math.Min(maxValue.Bottom, value.Bottom)),
+                Right = Math.Max(minValue.Right, Math.Min(maxValue.Right, value.Right))
+            };
+    }
+}

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -189,6 +189,8 @@ namespace osu.Framework.Platform
 
         protected virtual void OnKeyDown(object sender, KeyboardKeyEventArgs e) => KeyDown?.Invoke(sender, e);
 
+        public readonly BindableMarginPadding SafeAreaPadding = new BindableMarginPadding();
+
         public virtual VSyncMode VSync { get; set; }
 
         public virtual void CycleMode()

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -189,6 +189,11 @@ namespace osu.Framework.Platform
 
         protected virtual void OnKeyDown(object sender, KeyboardKeyEventArgs e) => KeyDown?.Invoke(sender, e);
 
+        /// <summary>
+        /// Provides a <see cref="BindableMarginPadding"/> that can be used to keep track of the "safe area" insets on mobile
+        /// devices.  This usually corresponds to areas of the screen hidden under notches and rounded corners.
+        /// The safe area insets are provided by the operating system and dynamically change as the user rotates the device.
+        /// </summary>
         public readonly BindableMarginPadding SafeAreaPadding = new BindableMarginPadding();
 
         public virtual VSyncMode VSync { get; set; }


### PR DESCRIPTION
Newer phones and tablets often have notches and rounded corners.  This PR exposes these as a bindable, since they dynamically change when the device is rotated.  Framework consumers can use this to layout UI elements so that they are always visible.

Includes tests, but the results are only evident when running on a device.  Can't really add any asserts either, so it's mostly for visual verification.

Will need to implement this in Android too.

- Closes #2075

---

Add support for 'safe area' padding on mobile devices.
