### PR TITLE
Fix incorrect order of unbind/rebind of shadow model

### DIFF
--- a/osu.Framework.Tests/Dependencies/CachedModelDependenciesTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedModelDependenciesTest.cs
@@ -83,11 +83,14 @@ namespace osu.Framework.Tests.Dependencies
             var resolver = new DerivedFieldModelResolver();
             var dependencies = new CachedModelDependencyContainer<DerivedFieldModel>(null)
             {
-                Model = { Value = new DerivedFieldModel
+                Model =
                 {
-                    Bindable = { Value = 2 },
-                    BindableString = { Value = "2" }
-                } }
+                    Value = new DerivedFieldModel
+                    {
+                        Bindable = { Value = 2 },
+                        BindableString = { Value = "2" }
+                    }
+                }
             };
 
             dependencies.Inject(resolver);
@@ -100,6 +103,46 @@ namespace osu.Framework.Tests.Dependencies
 
             Assert.AreEqual(3, resolver.Model.Bindable.Value);
             Assert.AreEqual("3", resolver.Model.BindableString.Value);
+        }
+
+        [Test]
+        public void TestCrossDependentBindsDoNotPollute()
+        {
+            var model1 = new CrossDependentFieldModel { Bindable = { Value = 2 } };
+            var model2 = new CrossDependentFieldModel { Bindable = { Value = 3 } };
+
+            var dependencies = new CachedModelDependencyContainer<CrossDependentFieldModel>(null)
+            {
+                Model = { Value = model1 }
+            };
+
+            Assert.AreEqual(2, model1.Bindable.Value);
+            Assert.AreEqual(2, model1.BindableTwo.Value);
+
+            Assert.AreEqual(3, model2.Bindable.Value);
+            Assert.AreEqual(3, model2.BindableTwo.Value);
+
+            dependencies.Model.Value = model2;
+
+            Assert.AreEqual(2, model1.Bindable.Value);
+            Assert.AreEqual(2, model1.BindableTwo.Value);
+
+            Assert.AreEqual(3, model2.Bindable.Value);
+            Assert.AreEqual(3, model2.BindableTwo.Value);
+        }
+
+        private class CrossDependentFieldModel
+        {
+            [Cached]
+            public readonly Bindable<int> Bindable = new Bindable<int>(1);
+
+            [Cached]
+            public readonly Bindable<int> BindableTwo = new Bindable<int>();
+
+            public CrossDependentFieldModel()
+            {
+                Bindable.BindValueChanged(v => BindableTwo.Value = v);
+            }
         }
 
         [Test]

--- a/osu.Framework/Allocation/CachedModelDependencyContainer.cs
+++ b/osu.Framework/Allocation/CachedModelDependencyContainer.cs
@@ -93,28 +93,28 @@ namespace osu.Framework.Allocation
                 Debug.Assert(type != null);
 
                 foreach (var field in type.GetFields(activator_flags))
+                    unbind(field);
+
+                foreach (var field in type.GetFields(activator_flags))
                     rebind(field);
 
                 type = type.BaseType;
             }
 
-            void rebind(MemberInfo member)
+            void unbind(MemberInfo member)
             {
                 object shadowValue = null;
                 object lastModelValue = null;
-                object newModelValue = null;
 
                 switch (member)
                 {
                     case PropertyInfo pi:
                         shadowValue = pi.GetValue(shadowModel);
                         lastModelValue = lastModel == null ? null : pi.GetValue(lastModel);
-                        newModelValue = newModel == null ? null : pi.GetValue(newModel);
                         break;
                     case FieldInfo fi:
                         shadowValue = fi.GetValue(shadowModel);
                         lastModelValue = lastModel == null ? null : fi.GetValue(lastModel);
-                        newModelValue = newModel == null ? null : fi.GetValue(newModel);
                         break;
                 }
 
@@ -123,7 +123,28 @@ namespace osu.Framework.Allocation
                     // Unbind from the last model
                     if (lastModelValue is IBindable lastModelBindable)
                         shadowBindable.UnbindFrom(lastModelBindable);
+                }
+            }
 
+            void rebind(MemberInfo member)
+            {
+                object shadowValue = null;
+                object newModelValue = null;
+
+                switch (member)
+                {
+                    case PropertyInfo pi:
+                        shadowValue = pi.GetValue(shadowModel);
+                        newModelValue = newModel == null ? null : pi.GetValue(newModel);
+                        break;
+                    case FieldInfo fi:
+                        shadowValue = fi.GetValue(shadowModel);
+                        newModelValue = newModel == null ? null : fi.GetValue(newModel);
+                        break;
+                }
+
+                if (shadowValue is IBindable shadowBindable)
+                {
                     // Bind to the new model
                     if (newModelValue is IBindable newModelBindable)
                         shadowBindable.BindTo(newModelBindable);

--- a/osu.Framework/Allocation/CachedModelDependencyContainer.cs
+++ b/osu.Framework/Allocation/CachedModelDependencyContainer.cs
@@ -101,22 +101,17 @@ namespace osu.Framework.Allocation
         /// </summary>
         private void perform(TModel targetShadowModel, MemberInfo member, TModel target, Action<(IBindable shadowProp, IBindable modelProp)> action)
         {
-            IBindable shadowProp = null;
-            IBindable modelProp = null;
+            if (target == null) return;
 
             switch (member)
             {
                 case PropertyInfo pi:
-                    shadowProp = (IBindable)pi.GetValue(targetShadowModel);
-                    modelProp = target == null ? null : (IBindable)pi.GetValue(target);
+                    action(((IBindable)pi.GetValue(targetShadowModel), (IBindable)pi.GetValue(target)));
                     break;
                 case FieldInfo fi:
-                    shadowProp = (IBindable)fi.GetValue(targetShadowModel);
-                    modelProp = target == null ? null : (IBindable)fi.GetValue(target);
+                    action(((IBindable)fi.GetValue(targetShadowModel), (IBindable)fi.GetValue(target)));
                     break;
             }
-
-            action((shadowProp, modelProp));
         }
 
         static CachedModelDependencyContainer()

--- a/osu.Framework/Allocation/CachedModelDependencyContainer.cs
+++ b/osu.Framework/Allocation/CachedModelDependencyContainer.cs
@@ -116,18 +116,12 @@ namespace osu.Framework.Allocation
 
         static CachedModelDependencyContainer()
         {
-            var type = typeof(TModel);
-
-            while (type != null && type != typeof(object))
+            foreach (var type in typeof(TModel).EnumerateBaseTypes())
+            foreach (var field in type.GetFields(activator_flags))
             {
-                foreach (var field in type.GetFields(activator_flags))
-                {
-                    if (!typeof(IBindable).IsAssignableFrom(field.FieldType))
-                        throw new InvalidOperationException($"The field \"{field.Name}\" does not subclass {nameof(IBindable)}. "
-                                                            + $"All fields or auto-properties of a cached model container's model must subclass {nameof(IBindable)}");
-                }
-
-                type = type.BaseType;
+                if (!typeof(IBindable).IsAssignableFrom(field.FieldType))
+                    throw new InvalidOperationException($"The field \"{field.Name}\" does not subclass {nameof(IBindable)}. "
+                                                        + $"All fields or auto-properties of a cached model container's model must subclass {nameof(IBindable)}");
             }
         }
     }

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
@@ -33,6 +34,21 @@ namespace osu.Framework.Extensions.TypeExtensions
             }
 
             return result;
+        }
+
+        /// <summary>
+        /// Return every base type until (and excluding) <see cref="object"/>
+        /// </summary>
+        /// <param name="t"></param>
+        /// <returns></returns>
+        public static IEnumerable<Type> EnumerateBaseTypes(this Type t)
+        {
+            while (t != typeof(object))
+            {
+                Debug.Assert(t != null);
+                yield return t;
+                t = t.BaseType;
+            }
         }
 
         public static string ReadableName(this Type t) => readableName(t, new HashSet<Type>());

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 
@@ -43,9 +42,8 @@ namespace osu.Framework.Extensions.TypeExtensions
         /// <returns></returns>
         public static IEnumerable<Type> EnumerateBaseTypes(this Type t)
         {
-            while (t != typeof(object))
+            while (t != null && t != typeof(object))
             {
-                Debug.Assert(t != null);
                 yield return t;
                 t = t.BaseType;
             }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -128,13 +128,13 @@ namespace osu.Framework.Graphics
 
                 // Generate delegates to unbind fields
                 actions.AddRange(type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                                           .Where(f => typeof(IUnbindable).IsAssignableFrom(f.FieldType))
-                                           .Select(f => new Action<object>(target => ((IUnbindable)f.GetValue(target))?.UnbindAll())));
+                                     .Where(f => typeof(IUnbindable).IsAssignableFrom(f.FieldType))
+                                     .Select(f => new Action<object>(target => ((IUnbindable)f.GetValue(target))?.UnbindAll())));
 
                 // Generate delegates to unbind properties
                 actions.AddRange(type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                                           .Where(p => typeof(IUnbindable).IsAssignableFrom(p.PropertyType))
-                                           .Select(p => new Action<object>(target => ((IUnbindable)p.GetValue(target))?.UnbindAll())));
+                                     .Where(p => typeof(IUnbindable).IsAssignableFrom(p.PropertyType))
+                                     .Select(p => new Action<object>(target => ((IUnbindable)p.GetValue(target))?.UnbindAll())));
 
                 unbind_action_cache[type] = target =>
                 {
@@ -163,15 +163,9 @@ namespace osu.Framework.Graphics
             if (unbindComplete) return;
             unbindComplete = true;
 
-            Type type = GetType();
-
-            do
-            {
+            foreach (var type in GetType().EnumerateBaseTypes())
                 if (unbind_action_cache.TryGetValue(type, out var existing))
                     existing?.Invoke(this);
-
-                type = type.BaseType;
-            } while (type != null && type != typeof(object));
         }
 
         #endregion

--- a/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
@@ -53,15 +53,10 @@ namespace osu.Framework.Graphics.Visualisation
 
             var allMembers = new HashSet<MemberInfo>(new MemberInfoComparer());
 
-            Type type = source.GetType();
-            while (type != null && type != typeof(object))
-            {
+            foreach (var type in source.GetType().EnumerateBaseTypes())
                 type.GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
                     .Where(m => m is FieldInfo || m is PropertyInfo pi && pi.GetMethod != null && !pi.GetIndexParameters().Any())
                     .ForEach(m => allMembers.Add(m));
-
-                type = type.BaseType;
-            }
 
             // Order by upper then lower-case, and exclude auto-generated backing fields of properties
             AddRange(allMembers.OrderBy(m => m.Name[0]).ThenBy(m => m.Name)


### PR DESCRIPTION
If two bindables had cross-dependencies in their `ValueChanged` (ie. one sets another's value) the rebind process could cause changes from one model on the previous model.

Just a proof-of-concept fix. Tests should be added before merge.

