### PR TITLE
Remove unused ctor parameters and update inspections

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -146,8 +146,9 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMethodReturnValue_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMethodReturnValue_002ELocal/@EntryIndexedValue">HINT</s:String>
 
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002EGlobal/@EntryIndexedValue">HINT</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002ELocal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002EGlobal/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002ELocal/@EntryIndexedValue"></s:String>
+	<s:Boolean x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002ELocal/@EntryIndexRemoved">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseCollectionCountProperty/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseFormatSpecifierInFormatString/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseFormatSpecifierInInterpolation/@EntryIndexedValue">WARNING</s:String>

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -190,7 +190,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         /// <param name="level">The level in the document of <paramref name="paragraphBlock"/>.
         /// 0 for the root level, 1 for first-level items in a list, 2 for second-level items in a list, etc.</param>
         /// <returns>The visualiser.</returns>
-        protected virtual MarkdownParagraph CreateParagraph(ParagraphBlock paragraphBlock, int level) => new MarkdownParagraph(paragraphBlock, level);
+        protected virtual MarkdownParagraph CreateParagraph(ParagraphBlock paragraphBlock, int level) => new MarkdownParagraph(paragraphBlock);
 
         /// <summary>
         /// Creates the visualiser for a <see cref="QuoteBlock"/>.
@@ -217,13 +217,13 @@ namespace osu.Framework.Graphics.Containers.Markdown
         /// Creates the visualiser for a <see cref="ListBlock"/>.
         /// </summary>
         /// <returns>The visualiser.</returns>
-        protected virtual MarkdownList CreateList(ListBlock listBlock) => new MarkdownList(listBlock);
+        protected virtual MarkdownList CreateList(ListBlock listBlock) => new MarkdownList();
 
         /// <summary>
         /// Creates the visualiser for a horizontal separator.
         /// </summary>
         /// <returns>The visualiser.</returns>
-        protected virtual MarkdownSeparator CreateSeparator(ThematicBreakBlock thematicBlock) => new MarkdownSeparator(thematicBlock);
+        protected virtual MarkdownSeparator CreateSeparator(ThematicBreakBlock thematicBlock) => new MarkdownSeparator();
 
         /// <summary>
         /// Creates the visualiser for an element that isn't implemented.

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownList.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownList.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using Markdig.Syntax;
 using osuTK;
 
 namespace osu.Framework.Graphics.Containers.Markdown
@@ -15,7 +14,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
     /// </code>
     public class MarkdownList : FillFlowContainer
     {
-        public MarkdownList(ListBlock listBlock)
+        public MarkdownList()
         {
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownParagraph.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownParagraph.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         [Resolved]
         private IMarkdownTextFlowComponent parentFlowComponent { get; set; }
 
-        public MarkdownParagraph(ParagraphBlock paragraphBlock, int level)
+        public MarkdownParagraph(ParagraphBlock paragraphBlock)
         {
             this.paragraphBlock = paragraphBlock;
 

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownSeparator.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownSeparator.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using Markdig.Syntax;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shapes;
 using osuTK.Graphics;
@@ -16,7 +15,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
     /// </code>
     public class MarkdownSeparator : CompositeDrawable
     {
-        public MarkdownSeparator(ThematicBreakBlock thematicBlock)
+        public MarkdownSeparator()
         {
             AutoSizeAxes = Axes.Y;
             RelativeSizeAxes = Axes.X;

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTable.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTable.cs
@@ -146,7 +146,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
 
         protected virtual MarkdownTableCell CreateTableCell(TableCell cell, TableColumnDefinition definition, bool isHeading)
         {
-            return new MarkdownTableCell(cell, definition, isHeading);
+            return new MarkdownTableCell(cell, definition);
         }
 
         private class TableContainer : GridContainer

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTableCell.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTableCell.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         [Resolved]
         private IMarkdownTextFlowComponent parentFlowComponent { get; set; }
 
-        public MarkdownTableCell(TableCell cell, TableColumnDefinition definition, bool isHeading)
+        public MarkdownTableCell(TableCell cell, TableColumnDefinition definition)
         {
             this.cell = cell;
             this.definition = definition;


### PR DESCRIPTION
Matches with osu! inspections, so we don't get warnings while using a local framework.