### PR TITLE
Remove implicit operator from bindables

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseContainerExtensions/TestCaseFillFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContainerExtensions/TestCaseFillFlowContainer.cs
@@ -112,16 +112,16 @@ namespace osu.Framework.Tests.Visual.TestCaseContainerExtensions
         {
             base.Update();
 
-            if (childAnchor != anchorDropdown.Current)
+            if (childAnchor != anchorDropdown.Current.Value)
             {
-                childAnchor = anchorDropdown.Current;
+                childAnchor = anchorDropdown.Current.Value;
                 foreach (var child in fillContainer.Children)
                     child.Anchor = childAnchor;
             }
 
-            if (childOrigin != originDropdown.Current)
+            if (childOrigin != originDropdown.Current.Value)
             {
-                childOrigin = originDropdown.Current;
+                childOrigin = originDropdown.Current.Value;
                 foreach (var child in fillContainer.Children)
                     child.Origin = childOrigin;
             }
@@ -278,7 +278,7 @@ namespace osu.Framework.Tests.Visual.TestCaseContainerExtensions
                 else
                 {
                     foreach (var child in fillContainer.Children)
-                        child.Origin = originDropdown.Current;
+                        child.Origin = originDropdown.Current.Value;
                 }
             });
 

--- a/osu.Framework.Tests/Visual/TestCaseDrawable/TestCaseBlending.cs
+++ b/osu.Framework.Tests/Visual/TestCaseDrawable/TestCaseBlending.cs
@@ -153,9 +153,9 @@ namespace osu.Framework.Tests.Visual.TestCaseDrawable
         {
             foregroundContainer.Blending = new BlendingParameters
             {
-                Mode = colourModeDropdown.Current,
-                RGBEquation = colourEquation.Current,
-                AlphaEquation = alphaEquation.Current
+                Mode = colourModeDropdown.Current.Value,
+                RGBEquation = colourEquation.Current.Value,
+                AlphaEquation = alphaEquation.Current.Value
             };
         }
 

--- a/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseDropdownBox.cs
+++ b/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseDropdownBox.cs
@@ -67,10 +67,10 @@ namespace osu.Framework.Tests.Visual.TestCaseUserInterface
             AddStep("click item 13", () => styledDropdown.SelectItem(styledDropdown.Menu.Items[13]));
 
             AddAssert("dropdown1 is closed", () => styledDropdown.Menu.State == MenuState.Closed);
-            AddAssert("item 13 is selected", () => styledDropdown.Current == styledDropdown.Items.ElementAt(13));
+            AddAssert("item 13 is selected", () => styledDropdown.Current.Value == styledDropdown.Items.ElementAt(13));
 
             AddStep("select item 15", () => styledDropdown.Current.Value = styledDropdown.Items.ElementAt(15));
-            AddAssert("item 15 is selected", () => styledDropdown.Current == styledDropdown.Items.ElementAt(15));
+            AddAssert("item 15 is selected", () => styledDropdown.Current.Value == styledDropdown.Items.ElementAt(15));
 
             AddStep("click dropdown1", () => toggleDropdownViaClick(styledDropdown));
             AddAssert("dropdown1 is open", () => styledDropdown.Menu.State == MenuState.Open);
@@ -82,11 +82,11 @@ namespace osu.Framework.Tests.Visual.TestCaseUserInterface
 
             AddStep("select 'invalid'", () => styledDropdown.Current.Value = "invalid");
 
-            AddAssert("'invalid' is selected", () => styledDropdown.Current == "invalid");
+            AddAssert("'invalid' is selected", () => styledDropdown.Current.Value == "invalid");
             AddAssert("label shows 'invalid'", () => styledDropdown.Header.Label == "invalid");
 
             AddStep("select item 2", () => styledDropdown.Current.Value = styledDropdown.Items.ElementAt(2));
-            AddAssert("item 2 is selected", () => styledDropdown.Current == styledDropdown.Items.ElementAt(2));
+            AddAssert("item 2 is selected", () => styledDropdown.Current.Value == styledDropdown.Items.ElementAt(2));
         }
 
         private void toggleDropdownViaClick(StyledDropdown dropdown)

--- a/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseSliderbar.cs
+++ b/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseSliderbar.cs
@@ -85,7 +85,7 @@ namespace osu.Framework.Tests.Visual.TestCaseUserInterface
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("Value == -6,25", () => sliderBarValue == -6.25);
+            AddAssert("Value == -6,25", () => sliderBarValue.Value == -6.25);
 
             AddStep("Press left arrow key", () =>
             {
@@ -96,7 +96,7 @@ namespace osu.Framework.Tests.Visual.TestCaseUserInterface
                 sliderBar.IsHovered = before;
             });
 
-            AddAssert("Value == -7,25", () => sliderBarValue == -7.25);
+            AddAssert("Value == -7,25", () => sliderBarValue.Value == -7.25);
 
             AddStep("Click at x = 150 with shift", () =>
             {
@@ -108,7 +108,7 @@ namespace osu.Framework.Tests.Visual.TestCaseUserInterface
                 InputManager.ReleaseKey(Key.LShift);
             });
 
-            AddAssert("Value == 6", () => sliderBarValue == 6);
+            AddAssert("Value == 6", () => sliderBarValue.Value == 6);
         }
 
         private void sliderBarValueChanged(double newValue)

--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -62,9 +62,9 @@ namespace osu.Framework.Audio
 
         internal virtual void OnStateChanged()
         {
-            VolumeCalculated.Value = volumeAdjustments.Aggregate(Volume.Value, (current, adj) => current * adj);
-            BalanceCalculated.Value = balanceAdjustments.Aggregate(Balance.Value, (current, adj) => current + adj);
-            FrequencyCalculated.Value = frequencyAdjustments.Aggregate(Frequency.Value, (current, adj) => current * adj);
+            VolumeCalculated.Value = volumeAdjustments.Aggregate(Volume.Value, (current, adj) => current * adj.Value);
+            BalanceCalculated.Value = balanceAdjustments.Aggregate(Balance.Value, (current, adj) => current + adj.Value);
+            FrequencyCalculated.Value = frequencyAdjustments.Aggregate(Frequency.Value, (current, adj) => current * adj.Value);
         }
 
         public void AddAdjustmentDependency(AdjustableAudioComponent component)

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -35,9 +35,9 @@ namespace osu.Framework.Audio.Sample
 
             if (channel != 0)
             {
-                Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, VolumeCalculated);
-                Bass.ChannelSetAttribute(channel, ChannelAttribute.Pan, BalanceCalculated);
-                Bass.ChannelSetAttribute(channel, ChannelAttribute.Frequency, initialFrequency * FrequencyCalculated);
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, VolumeCalculated.Value);
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.Pan, BalanceCalculated.Value);
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.Frequency, initialFrequency * FrequencyCalculated.Value);
             }
         }
 

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         public virtual double Rate
         {
-            get => Frequency * Tempo;
+            get => Frequency.Value * Tempo.Value;
             set => Tempo.Value = value;
         }
 

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -252,15 +252,15 @@ namespace osu.Framework.Audio.Track
 
             setDirection(FrequencyCalculated.Value < 0);
 
-            Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Volume, VolumeCalculated);
-            Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Pan, BalanceCalculated);
+            Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Volume, VolumeCalculated.Value);
+            Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Pan, BalanceCalculated.Value);
             Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Frequency, bassFreq);
-            Bass.ChannelSetAttribute(tempoAdjustStream, ChannelAttribute.Tempo, (Math.Abs(Tempo) - 1) * 100);
+            Bass.ChannelSetAttribute(tempoAdjustStream, ChannelAttribute.Tempo, (Math.Abs(Tempo.Value) - 1) * 100);
         }
 
         private volatile float initialFrequency;
 
-        private int bassFreq => (int)MathHelper.Clamp(Math.Abs(initialFrequency * FrequencyCalculated), 100, 100000);
+        private int bassFreq => (int)MathHelper.Clamp(Math.Abs(initialFrequency * FrequencyCalculated.Value), 100, 100000);
 
         private volatile int bitrate;
 

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Audio.Track
             base.OnStateChanged();
 
             lock (clock)
-                clock.Rate = Tempo;
+                clock.Rate = Tempo.Value;
         }
     }
 }

--- a/osu.Framework/Configuration/Bindable.cs
+++ b/osu.Framework/Configuration/Bindable.cs
@@ -121,8 +121,6 @@ namespace osu.Framework.Configuration
             this.value = value;
         }
 
-        public static implicit operator T(Bindable<T> value) => value.Value;
-
         protected LockedWeakList<Bindable<T>> Bindings { get; private set; }
 
         void IBindable.BindTo(IBindable them)

--- a/osu.Framework/Configuration/BindableBool.cs
+++ b/osu.Framework/Configuration/BindableBool.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-
 namespace osu.Framework.Configuration
 {
     public class BindableBool : Bindable<bool>
@@ -11,8 +9,6 @@ namespace osu.Framework.Configuration
             : base(value)
         {
         }
-
-        public static implicit operator bool(BindableBool value) => value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableBool)} to a bool is likely a mistake");
 
         public override string ToString() => Value.ToString();
 

--- a/osu.Framework/Configuration/BindableMarginPadding.cs
+++ b/osu.Framework/Configuration/BindableMarginPadding.cs
@@ -59,8 +59,6 @@ namespace osu.Framework.Configuration
             base.BindTo(them);
         }
 
-        public static implicit operator MarginPadding(BindableMarginPadding value) => value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableMarginPadding)} to a {nameof(MarginPadding)} is likely a mistake");
-
         public override string ToString() => Value.ToString();
 
         public override void Parse(object input)

--- a/osu.Framework/Configuration/BindableNumber.cs
+++ b/osu.Framework/Configuration/BindableNumber.cs
@@ -214,9 +214,6 @@ namespace osu.Framework.Configuration
         /// </summary>
         public bool HasDefinedRange => !MinValue.Equals(DefaultMinValue) || !MaxValue.Equals(DefaultMaxValue);
 
-        public static implicit operator T(BindableNumber<T> value) =>
-            value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableNumber<T>)} to a {nameof(T)} is likely a mistake");
-
         public bool IsInteger
         {
             get

--- a/osu.Framework/Configuration/BindableSize.cs
+++ b/osu.Framework/Configuration/BindableSize.cs
@@ -46,8 +46,6 @@ namespace osu.Framework.Configuration
             base.BindTo(them);
         }
 
-        public static implicit operator Size(BindableSize value) => value?.Value ?? throw new InvalidCastException($"Casting a null {nameof(BindableSize)} to a {nameof(Size)} is likely a mistake");
-
         public override string ToString() => $"{Value.Width}x{Value.Height}";
 
         public override void Parse(object input)

--- a/osu.Framework/Graphics/UserInterface/Checkbox.cs
+++ b/osu.Framework/Graphics/UserInterface/Checkbox.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected override bool OnClick(ClickEvent e)
         {
             if (!Current.Disabled)
-                Current.Value = !Current;
+                Current.Value = !Current.Value;
 
             base.OnClick(e);
             return true;

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -108,7 +108,7 @@ namespace osu.Framework.Graphics.UserInterface
             switch (item)
             {
                 case MenuItem i:
-                    return i.Text;
+                    return i.Text.Value;
                 case IHasText t:
                     return t.Text;
                 case Enum e:
@@ -184,7 +184,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
 
             Menu.SelectItem(selectedItem);
-            Header.Label = selectedItem.Text;
+            Header.Label = selectedItem.Text.Value;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -589,7 +589,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 if (Content is IHasText textContent)
                 {
-                    textContent.Text = item.Text;
+                    textContent.Text = item.Text.Value;
                     Item.Text.ValueChanged += newText => textContent.Text = newText;
                 }
             }

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -590,7 +590,6 @@ namespace osu.Framework.Graphics.UserInterface
                 if (Content is IHasText textContent)
                 {
                     textContent.Text = item.Text.Value;
-                    textContent.Text = item.Text;
                     Item.Text.ValueChanged += args => textContent.Text = args.NewValue;
                 }
             }

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -157,11 +157,11 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 case Key.Right:
                     currentNumberInstantaneous.Add(step);
-                    OnUserChange(currentNumberInstantaneous);
+                    OnUserChange(currentNumberInstantaneous.Value);
                     return true;
                 case Key.Left:
                     currentNumberInstantaneous.Add(-step);
-                    OnUserChange(currentNumberInstantaneous);
+                    OnUserChange(currentNumberInstantaneous.Value);
                     return true;
                 default:
                     return false;
@@ -194,7 +194,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (!currentNumberInstantaneous.Disabled)
                 currentNumberInstantaneous.SetProportional(xPosition / UsableWidth, e.ShiftPressed ? KeyboardStep : 0);
 
-            OnUserChange(currentNumberInstantaneous);
+            OnUserChange(currentNumberInstantaneous.Value);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -123,10 +123,10 @@ namespace osu.Framework.Graphics.UserInterface
             Current.ValueChanged += newSelection =>
             {
                 if (IsLoaded)
-                    SelectTab(tabMap[Current]);
+                    SelectTab(tabMap[Current.Value]);
                 else
                     //will be handled in LoadComplete
-                    SelectedTab = tabMap[Current];
+                    SelectedTab = tabMap[Current.Value];
             };
         }
 

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
@@ -122,7 +122,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             {
                 const int raw_input_resolution = 65536;
 
-                if (mapAbsoluteInputToWindow)
+                if (mapAbsoluteInputToWindow.Value)
                 {
                     // map directly to local window
                     currentPosition.X = ((float)((state.X - raw_input_resolution / 2f) * sensitivity.Value) + raw_input_resolution / 2f) / raw_input_resolution * Host.Window.Width;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -453,7 +453,7 @@ namespace osu.Framework.Input
             var mouse = state.Mouse;
 
             foreach (var h in InputHandlers)
-                if (h.Enabled && h is INeedsMousePositionFeedback handler)
+                if (h.Enabled.Value && h is INeedsMousePositionFeedback handler)
                     handler.FeedbackMousePositionChange(mouse.Position);
 
             handleMouseMove(state, e.LastPosition);

--- a/osu.Framework/Platform/DesktopGameWindow.cs
+++ b/osu.Framework/Platform/DesktopGameWindow.cs
@@ -196,7 +196,7 @@ namespace osu.Framework.Platform
                 switch (newMode)
                 {
                     case Configuration.WindowMode.Fullscreen:
-                        ChangeResolution(currentDisplay, sizeFullscreen);
+                        ChangeResolution(currentDisplay, sizeFullscreen.Value);
                         lastFullscreenDisplay = currentDisplay;
 
                         WindowState = WindowState.Fullscreen;
@@ -224,7 +224,7 @@ namespace osu.Framework.Platform
                         WindowBorder = WindowBorder.Resizable;
 
                         ClientSize = newSize;
-                        Position = new Vector2((float)windowPositionX, (float)windowPositionY);
+                        Position = new Vector2((float)windowPositionX.Value, (float)windowPositionY.Value);
                         break;
                 }
             }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -127,7 +127,7 @@ namespace osu.Framework.Platform
         {
             threads.Add(t);
             t.UnhandledException = unhandledExceptionHandler;
-            t.Monitor.EnablePerformanceProfiling = performanceLogging;
+            t.Monitor.EnablePerformanceProfiling = performanceLogging.Value;
         }
 
         public GameThread DrawThread;
@@ -684,7 +684,7 @@ namespace osu.Framework.Platform
                 if (restoreDefaults)
                 {
                     resetInputHandlers();
-                    ignoredInputHandlers.Value = string.Join(" ", AvailableInputHandlers.Where(h => !h.Enabled).Select(h => h.ToString()));
+                    ignoredInputHandlers.Value = string.Join(" ", AvailableInputHandlers.Where(h => !h.Enabled.Value).Select(h => h.ToString()));
                 }
                 else
                 {
@@ -706,7 +706,7 @@ namespace osu.Framework.Platform
         {
             if (Window == null) return;
 
-            DrawThread.Scheduler.Add(() => Window.VSync = frameSyncMode == FrameSync.VSync ? VSyncMode.On : VSyncMode.Off);
+            DrawThread.Scheduler.Add(() => Window.VSync = frameSyncMode.Value == FrameSync.VSync ? VSyncMode.On : VSyncMode.Off);
         }
 
         protected abstract IEnumerable<InputHandler> CreateAvailableInputHandlers();

--- a/osu.Framework/Testing/Drawables/Sections/ToolbarRecordSection.cs
+++ b/osu.Framework/Testing/Drawables/Sections/ToolbarRecordSection.cs
@@ -92,7 +92,7 @@ namespace osu.Framework.Testing.Drawables.Sections
 
         private void changeState()
         {
-            if (browser.RecordState == RecordState.Stopped)
+            if (browser.RecordState.Value == RecordState.Stopped)
                 browser.RecordState.Value = RecordState.Normal;
             else
                 browser.RecordState.Value = browser.RecordState.Value + 1;


### PR DESCRIPTION
resolves #2150 

In order to avoid accidental misuse / misunderstandings, `.Value` must always be added to `Bindable` when requesting its value. One such case which used to be confusing:

```csharp
Bindable<Drawable> bindableDrawable = new Bindable<Drawable>();

if (bindableDrawable != null)
{
    // true
}

if (bindableDrawable.Value != null)
{
    // false
}

Drawable drawable = null;

if (bindableDrawable == drawable)
{
    // ???
}
```