### PR TITLE
Disallow screens from being added to hierarchy without stack parent

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseScreen.cs
+++ b/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseScreen.cs
@@ -34,6 +34,12 @@ namespace osu.Framework.Tests.Visual.TestCaseUserInterface
         });
 
         [Test]
+        public void TestAddScreenWithoutStackFails()
+        {
+            AddStep("ensure throws", () => Assert.Throws<InvalidOperationException>(() => Add(new TestScreen())));
+        }
+
+        [Test]
         public void TestPushPop()
         {
             TestScreen screen1 = null, screen2 = null;

--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -1,9 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
 
 namespace osu.Framework.Screens
 {
@@ -21,6 +23,13 @@ namespace osu.Framework.Screens
         public Screen()
         {
             RelativeSizeAxes = Axes.Both;
+        }
+
+        internal override void UpdateClock(IFrameBasedClock clock)
+        {
+            base.UpdateClock(clock);
+            if (Parent != null && !(Parent is ScreenStack))
+                throw new InvalidOperationException($"Screens must always be added to a {nameof(ScreenStack)} (attempted to add {GetType()} to {Parent.GetType()})");
         }
 
         public virtual void OnEntering(IScreen last)

--- a/osu.Framework/Testing/TestCaseTestRunner.cs
+++ b/osu.Framework/Testing/TestCaseTestRunner.cs
@@ -7,8 +7,9 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
-using osu.Framework.Screens;
 
 namespace osu.Framework.Testing
 {
@@ -27,7 +28,7 @@ namespace osu.Framework.Testing
         /// <param name="test">The <see cref="TestCase"/> to run.</param>
         public void RunTestBlocking(TestCase test) => runner.RunTestBlocking(test);
 
-        public class TestRunner : Screen
+        public class TestRunner : CompositeDrawable
         {
             private const double time_between_tests = 200;
 
@@ -36,6 +37,11 @@ namespace osu.Framework.Testing
 
             [Resolved]
             private GameHost host { get; set; }
+
+            public TestRunner()
+            {
+                RelativeSizeAxes = Axes.Both;
+            }
 
             [BackgroundDependencyLoader]
             private void load(FrameworkConfigManager config)


### PR DESCRIPTION
This should not be allowed so now throws an exception.