### PR TITLE
Make the float parses culture invariant.

### DIFF
--- a/osu.Framework/Configuration/BindableMarginPadding.cs
+++ b/osu.Framework/Configuration/BindableMarginPadding.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Globalization;
 using osu.Framework.Graphics;
 
 namespace osu.Framework.Configuration
@@ -75,10 +76,10 @@ namespace osu.Framework.Configuration
 
                     Value = new MarginPadding
                     {
-                        Top = float.Parse(split[0]),
-                        Left = float.Parse(split[1]),
-                        Bottom = float.Parse(split[2]),
-                        Right = float.Parse(split[3]),
+                        Top = float.Parse(split[0], CultureInfo.InvariantCulture),
+                        Left = float.Parse(split[1], CultureInfo.InvariantCulture),
+                        Bottom = float.Parse(split[2], CultureInfo.InvariantCulture),
+                        Right = float.Parse(split[3], CultureInfo.InvariantCulture),
                     };
                     break;
                 default:


### PR DESCRIPTION
This allows the tests to pass on my machine (I have the german lang pack installed. That results in `,` and `.` beeing swapped when it comes to decimals.)

------------------

Make the float.Parse calls culture invariant.