### PR TITLE
Rework GameHost/GameWindow IsActive state

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -31,7 +31,12 @@ namespace osu.Framework
 
         protected GameHost Host { get; private set; }
 
-        private bool isActive;
+        private readonly Bindable<bool> isActive = new Bindable<bool>(true);
+
+        /// <summary>
+        /// Whether the Game environment is active (in the foreground).
+        /// </summary>
+        public IBindable<bool> IsActive => isActive;
 
         public AudioManager Audio;
 
@@ -87,8 +92,8 @@ namespace osu.Framework
         {
             Host = host;
             host.Exiting += OnExiting;
-            host.Activated += () => IsActive = true;
-            host.Deactivated += () => IsActive = false;
+            host.Activated += () => isActive.Value = true;
+            host.Deactivated += () => isActive.Value = false;
         }
 
         private DependencyContainer dependencies;
@@ -157,25 +162,6 @@ namespace osu.Framework
             addDebugTools();
         }
 
-        /// <summary>
-        /// Whether the Game environment is active (in the foreground).
-        /// </summary>
-        public bool IsActive
-        {
-            get => isActive;
-            private set
-            {
-                if (value == isActive)
-                    return;
-                isActive = value;
-
-                if (isActive)
-                    OnActivated();
-                else
-                    OnDeactivated();
-            }
-        }
-
         protected FrameStatisticsMode FrameStatisticsMode
         {
             get => performanceContainer.State;
@@ -219,14 +205,6 @@ namespace osu.Framework
         public void Exit()
         {
             Host.Exit();
-        }
-
-        protected virtual void OnActivated()
-        {
-        }
-
-        protected virtual void OnDeactivated()
-        {
         }
 
         protected virtual bool OnExiting()

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -34,7 +34,7 @@ namespace osu.Framework
         private readonly Bindable<bool> isActive = new Bindable<bool>(true);
 
         /// <summary>
-        /// Whether the Game environment is active (in the foreground).
+        /// Whether the game is active (in the foreground).
         /// </summary>
         public IBindable<bool> IsActive => isActive;
 

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKMouseHandler.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Input.Handlers.Mouse
 
                         var mapped = host.Window.PointToClient(new Point(cursorState.X, cursorState.Y));
 
-                        var newState = new OsuTKPollMouseState(cursorState, host.IsActive, new Vector2(mapped.X, mapped.Y));
+                        var newState = new OsuTKPollMouseState(cursorState, host.IsActive.Value, new Vector2(mapped.X, mapped.Y));
                         HandleState(newState, lastPollState, true);
                         lastPollState = newState;
                     }, 0, 1000.0 / 60));
@@ -75,7 +75,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                 // on windows when crossing centre screen boundaries (width/2 or height/2).
                 return;
 
-            var newState = new OsuTKEventMouseState(e.Mouse, Host.IsActive, null);
+            var newState = new OsuTKEventMouseState(e.Mouse, Host.IsActive.Value, null);
             HandleState(newState, lastEventState, true);
             lastEventState = newState;
         }

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
@@ -71,7 +71,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                                 if (lastState != null && rawState.Equals(lastState.RawState))
                                     continue;
 
-                                var newState = new OsuTKPollMouseState(rawState, host.IsActive, getUpdatedPosition(rawState, lastState));
+                                var newState = new OsuTKPollMouseState(rawState, host.IsActive.Value, getUpdatedPosition(rawState, lastState));
 
                                 HandleState(newState, lastState, rawState.Flags.HasFlag(MouseStateFlags.MoveAbsolute));
 
@@ -84,7 +84,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                             var state = osuTK.Input.Mouse.GetCursorState();
                             var screenPoint = host.Window.PointToClient(new Point(state.X, state.Y));
 
-                            var newState = new UnfocusedMouseState(new MouseState(), host.IsActive, new Vector2(screenPoint.X, screenPoint.Y));
+                            var newState = new UnfocusedMouseState(new MouseState(), host.IsActive.Value, new Vector2(screenPoint.X, screenPoint.Y));
 
                             HandleState(newState, lastUnfocusedState, true);
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -487,22 +487,14 @@ namespace osu.Framework.Platform
 
                         Window.ExitRequested += OnExitRequested;
                         Window.Exited += OnExited;
-                        Window.FocusedChanged += delegate { setActive(Window.Focused); };
-
-                        bool initialized = false;
 
                         Window.UpdateFrame += delegate
                         {
-                            if (!initialized)
-                            {
-                                setActive(Window.Focused);
-                                initialized = true;
-                            }
-
                             inputPerformanceCollectionPeriod?.Dispose();
                             InputThread.RunUpdate();
                             inputPerformanceCollectionPeriod = inputMonitor.BeginCollecting(PerformanceCollectionType.WndProc);
                         };
+
                         Window.Closed += delegate
                         {
                             //we need to ensure all threads have stopped before the window is closed (mainly the draw thread

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -618,7 +618,7 @@ namespace osu.Framework.Platform
         private Bindable<string> ignoredInputHandlers;
 
         private Bindable<double> cursorSensitivity;
-        private Bindable<bool> performanceLogging;
+        private readonly Bindable<bool> performanceLogging = new Bindable<bool>();
 
         private void setupConfig()
         {
@@ -694,7 +694,7 @@ namespace osu.Framework.Platform
 
             cursorSensitivity = config.GetBindable<double>(FrameworkSetting.CursorSensitivity);
 
-            performanceLogging = config.GetBindable<bool>(FrameworkSetting.PerformanceLogging);
+            config.BindWith(FrameworkSetting.PerformanceLogging, performanceLogging);
             performanceLogging.BindValueChanged(enabled => threads.ForEach(t => t.Monitor.EnablePerformanceProfiling = enabled), true);
         }
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -476,11 +476,11 @@ namespace osu.Framework.Platform
                 frameSyncMode.TriggerChange();
                 ignoredInputHandlers.TriggerChange();
 
-                IsActive.BindValueChanged(v =>
+                IsActive.BindValueChanged(active =>
                 {
                     activeGCMode.TriggerChange();
 
-                    if (v)
+                    if (active)
                         OnActivated();
                     else
                         OnDeactivated();

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -514,6 +514,8 @@ namespace osu.Framework.Platform
                     }
                     else
                     {
+                        setActive(true);
+
                         while (ExecutionState != ExecutionState.Stopped)
                             InputThread.RunUpdate();
                     }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -51,6 +51,9 @@ namespace osu.Framework.Platform
 
         private FrameworkConfigManager config;
 
+        /// <summary>
+        /// Whether the <see cref="GameWindow"/> is active (in the foreground).
+        /// </summary>
         public readonly IBindable<bool> IsActive = new Bindable<bool>(true);
 
         public bool IsPrimaryInstance { get; protected set; } = true;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -115,7 +115,7 @@ namespace osu.Framework.Platform
         /// </summary>
         public virtual bool CapsLockEnabled => false;
 
-        private readonly List<GameThread> threads;
+        private readonly List<GameThread> threads = new List<GameThread>();
 
         public IEnumerable<GameThread> Threads => threads;
 
@@ -202,24 +202,19 @@ namespace osu.Framework.Platform
             Logger.GameIdentifier = gameName;
             Logger.VersionIdentifier = assembly.GetName().Version.ToString();
 
-            threads = new List<GameThread>
+            RegisterThread(DrawThread = new DrawThread(DrawFrame)
             {
-                (DrawThread = new DrawThread(DrawFrame)
-                {
-                    OnThreadStart = DrawInitialize,
-                    UnhandledException = unhandledExceptionHandler
-                }),
-                (UpdateThread = new UpdateThread(UpdateFrame)
-                {
-                    OnThreadStart = UpdateInitialize,
-                    Monitor = { HandleGC = true },
-                    UnhandledException = unhandledExceptionHandler,
-                }),
-                (InputThread = new InputThread(null)
-                {
-                    UnhandledException = unhandledExceptionHandler
-                }), //never gets started.
-            };
+                OnThreadStart = DrawInitialize,
+            });
+
+            RegisterThread(UpdateThread = new UpdateThread(UpdateFrame)
+            {
+                OnThreadStart = UpdateInitialize,
+                Monitor = { HandleGC = true },
+            });
+
+            //never gets started.
+            RegisterThread(InputThread = new InputThread(null));
 
             if (assemblyPath != null)
                 Environment.CurrentDirectory = assemblyPath;

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -61,6 +61,9 @@ namespace osu.Framework.Platform
 
         private readonly Bindable<bool> isActive = new Bindable<bool>();
 
+        /// <summary>
+        /// Whether this <see cref="GameWindow"/> is active (in the foreground).
+        /// </summary>
         public IBindable<bool> IsActive => isActive;
 
         /// <summary>

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -59,6 +59,10 @@ namespace osu.Framework.Platform
         /// </summary>
         public virtual IEnumerable<DisplayResolution> AvailableResolutions => Enumerable.Empty<DisplayResolution>();
 
+        private readonly Bindable<bool> isActive = new Bindable<bool>();
+
+        public IBindable<bool> IsActive => isActive;
+
         /// <summary>
         /// Creates a <see cref="GameWindow"/> with a given <see cref="IGameWindow"/> implementation.
         /// </summary>
@@ -72,6 +76,20 @@ namespace osu.Framework.Platform
 
             MouseEnter += (sender, args) => CursorInWindow = true;
             MouseLeave += (sender, args) => CursorInWindow = false;
+
+            FocusedChanged += (o, e) => isActive.Value = Focused;
+
+            bool firstUpdate = true;
+            UpdateFrame += (o, e) =>
+            {
+                if (firstUpdate)
+                {
+                    isActive.Value = Focused;
+                    firstUpdate = false;
+                }
+            };
+
+            WindowStateChanged += (o, e) => isActive.Value = WindowState != WindowState.Minimized;
 
             MakeCurrent();
 

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -13,13 +13,7 @@ namespace osu.Framework.Platform.Linux
             : base(gameName, bindIPC, toolkitOptions)
         {
             Window = new LinuxGameWindow();
-            Window.WindowStateChanged += (sender, e) =>
-            {
-                if (Window.WindowState != WindowState.Minimized)
-                    OnActivated();
-                else
-                    OnDeactivated();
-            };
+
             // required for the time being to address libbass_fx.so load failures (see https://github.com/ppy/osu/issues/2852)
             Library.Load("libbass.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
         }

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -14,13 +14,6 @@ namespace osu.Framework.Platform.MacOS
             : base(gameName, bindIPC, toolkitOptions)
         {
             Window = new MacOSGameWindow();
-            Window.WindowStateChanged += (sender, e) =>
-            {
-                if (Window.WindowState != WindowState.Minimized)
-                    OnActivated();
-                else
-                    OnDeactivated();
-            };
         }
 
         protected override Storage GetStorage(string baseName) => new MacOSStorage(baseName, this);

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -26,21 +26,10 @@ namespace osu.Framework.Platform.Windows
             timePeriod = new TimePeriod(1) { Active = true };
 
             Window = new WindowsGameWindow();
-            Window.WindowStateChanged += onWindowOnWindowStateChanged;
-        }
-
-        private void onWindowOnWindowStateChanged(object sender, EventArgs e)
-        {
-            if (Window.WindowState != WindowState.Minimized)
-                OnActivated();
-            else
-                OnDeactivated();
         }
 
         protected override void Dispose(bool isDisposing)
         {
-            Window.WindowStateChanged -= onWindowOnWindowStateChanged;
-
             timePeriod?.Dispose();
             base.Dispose(isDisposing);
         }

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -28,6 +28,9 @@ namespace osu.Framework.Threading
 
         private readonly Action onNewFrame;
 
+        /// <summary>
+        /// Whether the game is active (in the foreground).
+        /// </summary>
         public readonly IBindable<bool> IsActive = new Bindable<bool>(true);
 
         private double activeHz = DEFAULT_ACTIVE_HZ;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -38,8 +38,7 @@ namespace osu.Framework.Threading
             set
             {
                 activeHz = value;
-                if (IsActive.Value)
-                    Clock.MaximumUpdateHz = activeHz;
+                updateMaximumHz();
             }
         }
 
@@ -51,8 +50,7 @@ namespace osu.Framework.Threading
             set
             {
                 inactiveHz = value;
-                if (!IsActive.Value)
-                    Clock.MaximumUpdateHz = inactiveHz;
+                updateMaximumHz();
             }
         }
 
@@ -84,13 +82,15 @@ namespace osu.Framework.Threading
                 Monitor = new PerformanceMonitor(Clock, Thread, StatisticsCounters);
             Scheduler = new Scheduler(null, Clock);
 
-            IsActive.BindValueChanged(v => Scheduler.Add(() => Clock.MaximumUpdateHz = v ? activeHz : inactiveHz), true);
+            IsActive.BindValueChanged(_ => updateMaximumHz(), true);
         }
 
         public void WaitUntilInitialized()
         {
             initializedEvent.WaitOne();
         }
+
+        private void updateMaximumHz() => Scheduler.Add(() => Clock.MaximumUpdateHz = IsActive.Value ? activeHz : inactiveHz);
 
         private void runWork()
         {


### PR DESCRIPTION
- Fixes Game being `IsActive = false` during headless tests. (default `true`)
- `IsActive`'s state is now handled in one location - `GameWindow`.
- Removes the `OnActivated()`/`OnDeactivated()` methods in-favor of binding to the bindables.