### PR TITLE
Build input queue using Visitor pattern

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using osu.Framework.Development;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Input.InputQueue;
 using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Containers
@@ -1149,6 +1150,10 @@ namespace osu.Framework.Graphics.Containers
 
         #region Interaction / Input
 
+        public override bool Accept(INonPositionalInputVisitor visitor, bool allowBlocking = true) => visitor.Visit(this, allowBlocking);
+
+        public override bool Accept(IPositionalInputVisitor visitor, Vector2 screenSpacePos) => visitor.Visit(screenSpacePos, this);
+
         public override bool Contains(Vector2 screenSpacePos)
         {
             float cRadius = CornerRadius;
@@ -1157,31 +1162,6 @@ namespace osu.Framework.Graphics.Containers
             if (cRadius == 0.0f)
                 return base.Contains(screenSpacePos);
             return DrawRectangle.Shrink(cRadius).DistanceSquared(ToLocalSpace(screenSpacePos)) <= cRadius * cRadius;
-        }
-
-        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
-        {
-            if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))
-                return false;
-
-            for (int i = 0; i < aliveInternalChildren.Count; ++i)
-                aliveInternalChildren[i].BuildNonPositionalInputQueue(queue, allowBlocking);
-
-            return true;
-        }
-
-        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
-        {
-            if (!base.BuildPositionalInputQueue(screenSpacePos, queue))
-                return false;
-
-            if (Masking && !ReceivePositionalInputAt(screenSpacePos))
-                return false;
-
-            for (int i = 0; i < aliveInternalChildren.Count; ++i)
-                aliveInternalChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
-
-            return true;
         }
 
         #endregion

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -1,8 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
-using osu.Framework.Input;
+using osu.Framework.Input.InputQueue;
 using osuTK;
 
 namespace osu.Framework.Graphics.Containers
@@ -15,35 +14,15 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Whether we should block any positional input from interacting with things behind us.
         /// </summary>
-        protected virtual bool BlockPositionalInput => true;
+        protected internal virtual bool BlockPositionalInput => true;
 
         /// <summary>
         /// Whether we should block any non-positional input from interacting with things behind us.
         /// </summary>
-        protected virtual bool BlockNonPositionalInput => false;
+        protected internal virtual bool BlockNonPositionalInput => false;
 
-        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
-        {
-            if (PropagateNonPositionalInputSubTree && HandleNonPositionalInput && BlockNonPositionalInput)
-            {
-                // when blocking non-positional input behind us, we still want to make sure the global handlers receive events
-                // but we don't want other drawables behind us handling them.
-                queue.RemoveAll(d => !(d is IHandleGlobalInput));
-            }
+        public override bool Accept(INonPositionalInputVisitor visitor, bool allowBlocking = true) => visitor.Visit(this, allowBlocking);
 
-            return base.BuildNonPositionalInputQueue(queue, allowBlocking);
-        }
-
-        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
-        {
-            if (PropagatePositionalInputSubTree && HandlePositionalInput && BlockPositionalInput && ReceivePositionalInputAt(screenSpacePos))
-            {
-                // when blocking positional input behind us, we still want to make sure the global handlers receive events
-                // but we don't want other drawables behind us handling them.
-                queue.RemoveAll(d => !(d is IHandleGlobalInput));
-            }
-
-            return base.BuildPositionalInputQueue(screenSpacePos, queue);
-        }
+        public override bool Accept(IPositionalInputVisitor visitor, Vector2 screenSpacePos) => visitor.Visit(screenSpacePos, this);
     }
 }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -28,6 +28,7 @@ using osu.Framework.Development;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
+using osu.Framework.Input.InputQueue;
 using osu.Framework.Input.States;
 using osu.Framework.MathUtils;
 using osuTK.Input;
@@ -46,7 +47,7 @@ namespace osu.Framework.Graphics
     /// Drawables are always rectangular in shape in their local coordinate system,
     /// which makes them quad-shaped in arbitrary (linearly transformed) coordinate systems.
     /// </summary>
-    public abstract partial class Drawable : Transformable, IDisposable, IDrawable
+    public abstract partial class Drawable : Transformable, IDisposable, IDrawable, IInputQueueElement
     {
         #region Construction and disposal
 
@@ -2105,39 +2106,9 @@ namespace osu.Framework.Graphics
         /// </summary>
         public virtual bool PropagatePositionalInputSubTree => IsPresent && RequestsPositionalInputSubTree && !IsMaskedAway;
 
-        /// <summary>
-        /// This method is responsible for building a queue of Drawables to receive non-positional input in reverse order.
-        /// </summary>
-        /// <param name="queue">The input queue to be built.</param>
-        /// <param name="allowBlocking">Whether blocking at <see cref="PassThroughInputManager"/>s should be allowed.</param>
-        /// <returns>Returns false if we should skip this sub-tree.</returns>
-        internal virtual bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
-        {
-            if (!PropagateNonPositionalInputSubTree)
-                return false;
+        public virtual bool Accept(INonPositionalInputVisitor visitor, bool allowBlocking = true) => visitor.Visit(this, allowBlocking);
 
-            if (HandleNonPositionalInput)
-                queue.Add(this);
-
-            return true;
-        }
-
-        /// <summary>
-        /// This method is responsible for building a queue of Drawables to receive positional input in reverse order.
-        /// </summary>
-        /// <param name="screenSpacePos">The screen space position of the positional input.</param>
-        /// <param name="queue">The input queue to be built.</param>
-        /// <returns>Returns false if we should skip this sub-tree.</returns>
-        internal virtual bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
-        {
-            if (!PropagatePositionalInputSubTree)
-                return false;
-
-            if (HandlePositionalInput && ReceivePositionalInputAt(screenSpacePos))
-                queue.Add(this);
-
-            return true;
-        }
+        public virtual bool Accept(IPositionalInputVisitor visitor, Vector2 screenSpacePos) => visitor.Visit(screenSpacePos, this);
 
         #endregion
 

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -99,7 +99,7 @@ namespace osu.Framework.Graphics.Visualisation
             inputManager = GetContainingInputManager();
         }
 
-        protected override bool BlockPositionalInput => false;
+        protected internal override bool BlockPositionalInput => false;
 
         protected override void PopIn()
         {

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Graphics.Visualisation
     {
         private readonly FillFlowContainer flow;
 
-        protected override bool BlockPositionalInput => false;
+        protected internal override bool BlockPositionalInput => false;
 
         private Bindable<bool> enabled;
 

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Input
             new KeyBinding(new[] { InputKey.Alt, InputKey.Enter }, FrameworkAction.ToggleFullscreen),
         };
 
-        protected override bool Prioritised => true;
+        protected internal override bool Prioritised => true;
 
         protected override IEnumerable<Drawable> KeyBindingInputQueue => base.KeyBindingInputQueue.Prepend(Children.First());
     }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.Handlers;
+using osu.Framework.Input.InputQueue;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
@@ -210,16 +211,6 @@ namespace osu.Framework.Input
             return true;
         }
 
-        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
-        {
-            if (!allowBlocking)
-                base.BuildNonPositionalInputQueue(queue, false);
-
-            return false;
-        }
-
-        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue) => false;
-
         private bool hoverEventsUpdated;
 
         protected override void Update()
@@ -279,7 +270,11 @@ namespace osu.Framework.Input
             return inputs;
         }
 
-        private readonly List<Drawable> inputQueue = new List<Drawable>();
+        public override bool Accept(INonPositionalInputVisitor visitor, bool allowBlocking = true) => visitor.Visit(this, allowBlocking);
+
+        public override bool Accept(IPositionalInputVisitor visitor, Vector2 screenSpacePos) => visitor.Visit(screenSpacePos, this);
+
+        private readonly NonPositionalInputQueue inputQueue = new NonPositionalInputQueue();
 
         private IEnumerable<Drawable> buildNonPositionalInputQueue()
         {
@@ -290,7 +285,7 @@ namespace osu.Framework.Input
 
             var children = AliveInternalChildren;
             for (int i = 0; i < children.Count; i++)
-                children[i].BuildNonPositionalInputQueue(inputQueue);
+                (children[i] as IInputQueueElement).Accept(inputQueue);
 
             if (!unfocusIfNoLongerValid())
             {
@@ -306,7 +301,7 @@ namespace osu.Framework.Input
             return inputQueue;
         }
 
-        private readonly List<Drawable> positionalInputQueue = new List<Drawable>();
+        private readonly PositionalInputQueue positionalInputQueue = new PositionalInputQueue();
 
         private IEnumerable<Drawable> buildPositionalInputQueue(InputState state)
         {
@@ -317,7 +312,7 @@ namespace osu.Framework.Input
 
             var children = AliveInternalChildren;
             for (int i = 0; i < children.Count; i++)
-                children[i].BuildPositionalInputQueue(state.Mouse.Position, positionalInputQueue);
+                (children[i] as IInputQueueElement).Accept(positionalInputQueue, state.Mouse.Position);
 
             positionalInputQueue.Reverse();
             return positionalInputQueue;

--- a/osu.Framework/Input/InputQueue/IInputQueueElement.cs
+++ b/osu.Framework/Input/InputQueue/IInputQueueElement.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osuTK;
+
+namespace osu.Framework.Input.InputQueue
+{
+    interface IInputQueueElement
+    {
+        bool Accept(INonPositionalInputVisitor visitor, bool allowBlocking = true);
+        bool Accept(IPositionalInputVisitor visitor, Vector2 screenSpacePos);
+    }
+}

--- a/osu.Framework/Input/InputQueue/IInputQueueElement.cs
+++ b/osu.Framework/Input/InputQueue/IInputQueueElement.cs
@@ -5,7 +5,7 @@ using osuTK;
 
 namespace osu.Framework.Input.InputQueue
 {
-    interface IInputQueueElement
+    public interface IInputQueueElement
     {
         bool Accept(INonPositionalInputVisitor visitor, bool allowBlocking = true);
         bool Accept(IPositionalInputVisitor visitor, Vector2 screenSpacePos);

--- a/osu.Framework/Input/InputQueue/INonPositionalInputVisitor.cs
+++ b/osu.Framework/Input/InputQueue/INonPositionalInputVisitor.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Framework.Input.InputQueue
+{
+    public interface INonPositionalInputVisitor
+    {
+        bool Visit(Drawable drawable, bool allowBlocking = true);
+        bool Visit(CompositeDrawable compositeDrawable, bool allowBlocking = true);
+        bool Visit(OverlayContainer overlayContainer, bool allowBlocking = true);
+        bool Visit(KeyBindingContainer keyBindingContainer, bool allowBlocking = true);
+        bool Visit(InputManager inputManager, bool allowBlocking = true);
+        bool Visit(PassThroughInputManager passThroughInputManager, bool allowBlocking = true);
+    }
+}

--- a/osu.Framework/Input/InputQueue/IPositionalInputVisitor.cs
+++ b/osu.Framework/Input/InputQueue/IPositionalInputVisitor.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK;
+
+namespace osu.Framework.Input.InputQueue
+{
+    public interface IPositionalInputVisitor
+    {
+        bool Visit(Vector2 screenSpacePos, Drawable drawable);
+        bool Visit(Vector2 screenSpacePos, CompositeDrawable compositeDrawable);
+        bool Visit(Vector2 screenSpacePos, OverlayContainer overlayContainer);
+        bool Visit(Vector2 screenSpacePos, InputManager inputManager);
+        bool Visit(Vector2 screenSpacePos, PassThroughInputManager passThroughInputManager);
+    }
+}

--- a/osu.Framework/Input/InputQueue/NonPositionalInputQueue.cs
+++ b/osu.Framework/Input/InputQueue/NonPositionalInputQueue.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Framework.Input.InputQueue
+{
+    public class NonPositionalInputQueue : List<Drawable>, INonPositionalInputVisitor
+    {
+        public bool Visit(Drawable drawable, bool allowBlocking = true)
+        {
+            if (!drawable.PropagateNonPositionalInputSubTree)
+                return false;
+
+            if (drawable.HandleNonPositionalInput)
+                Add(drawable);
+
+            return true;
+        }
+
+        public bool Visit(CompositeDrawable compositeDrawable, bool allowBlocking = true)
+        {
+            if (!Visit(compositeDrawable as Drawable, allowBlocking))
+                return false;
+
+            for (int i = 0; i < compositeDrawable.AliveInternalChildren.Count; ++i)
+                (compositeDrawable.AliveInternalChildren[i] as IInputQueueElement).Accept(this, allowBlocking);
+
+            return true;
+        }
+
+        public bool Visit(OverlayContainer overlayContainer, bool allowBlocking = true)
+        {
+            if (overlayContainer.PropagateNonPositionalInputSubTree && overlayContainer.HandleNonPositionalInput && overlayContainer.BlockNonPositionalInput)
+            {
+                // when blocking non-positional input behind us, we still want to make sure the global handlers receive events
+                // but we don't want other drawables behind us handling them.
+                RemoveAll(d => !(d is IHandleGlobalInput));
+            }
+
+            return Visit(overlayContainer as CompositeDrawable, allowBlocking);
+        }
+
+        public bool Visit(KeyBindingContainer keyBindingContainer, bool allowBlocking = true)
+        {
+            if (!Visit(keyBindingContainer as CompositeDrawable, allowBlocking))
+                return false;
+
+            if (keyBindingContainer.Prioritised)
+            {
+                Remove(keyBindingContainer);
+                Add(keyBindingContainer);
+            }
+
+            return true;
+        }
+
+        public bool Visit(InputManager inputManager, bool allowBlocking = true)
+        {
+            if (!allowBlocking)
+                Visit(inputManager as CompositeDrawable, false);
+
+            return false;
+        }
+
+        public bool Visit(PassThroughInputManager passThroughInputManager, bool allowBlocking = true)
+        {
+            if (!passThroughInputManager.PropagateNonPositionalInputSubTree) return false;
+
+            if (!allowBlocking)
+            {
+                Visit(passThroughInputManager as InputManager, false);
+                return false;
+            }
+
+            if (passThroughInputManager.UseParentInput)
+                Add(passThroughInputManager);
+            return false;
+        }
+    }
+}

--- a/osu.Framework/Input/InputQueue/PositionalInputQueue.cs
+++ b/osu.Framework/Input/InputQueue/PositionalInputQueue.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK;
+
+namespace osu.Framework.Input.InputQueue
+{
+    public class PositionalInputQueue : List<Drawable>, IPositionalInputVisitor
+    {
+        public bool Visit(Vector2 screenSpacePos, Drawable drawable)
+        {
+            if (!drawable.PropagatePositionalInputSubTree)
+                return false;
+
+            if (drawable.HandlePositionalInput && drawable.ReceivePositionalInputAt(screenSpacePos))
+                Add(drawable);
+
+            return true;
+        }
+
+        public bool Visit(Vector2 screenSpacePos, CompositeDrawable compositeDrawable)
+        {
+            if (!Visit(screenSpacePos, compositeDrawable as Drawable))
+                return false;
+
+            if (compositeDrawable.Masking && !compositeDrawable.ReceivePositionalInputAt(screenSpacePos))
+                return false;
+
+            for (int i = 0; i < compositeDrawable.AliveInternalChildren.Count; ++i)
+                (compositeDrawable.AliveInternalChildren[i] as IInputQueueElement).Accept(this, screenSpacePos);
+
+            return true;
+        }
+
+        public bool Visit(Vector2 screenSpacePos, OverlayContainer overlayContainer)
+        {
+            if (overlayContainer.PropagatePositionalInputSubTree && overlayContainer.HandlePositionalInput && overlayContainer.BlockPositionalInput && overlayContainer.ReceivePositionalInputAt(screenSpacePos))
+            {
+                // when blocking positional input behind us, we still want to make sure the global handlers receive events
+                // but we don't want other drawables behind us handling them.
+                RemoveAll(d => !(d is IHandleGlobalInput));
+            }
+
+            return Visit(screenSpacePos, overlayContainer as CompositeDrawable);
+        }
+
+        public bool Visit(Vector2 screenSpacePos, InputManager inputManager)
+        {
+            return false;
+        }
+
+        public bool Visit(Vector2 screenSpacePos, PassThroughInputManager passThroughInputManager)
+        {
+            if (!passThroughInputManager.PropagatePositionalInputSubTree) return false;
+
+            if (passThroughInputManager.UseParentInput)
+                Add(passThroughInputManager);
+            return false;
+        }
+    }
+}

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -3,8 +3,8 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
+using osu.Framework.Input.InputQueue;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.States;
 using osuTK;
@@ -42,30 +42,6 @@ namespace osu.Framework.Input
         }
 
         private bool useParentInput = true;
-
-        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
-        {
-            if (!PropagateNonPositionalInputSubTree) return false;
-
-            if (!allowBlocking)
-            {
-                base.BuildNonPositionalInputQueue(queue, false);
-                return false;
-            }
-
-            if (UseParentInput)
-                queue.Add(this);
-            return false;
-        }
-
-        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
-        {
-            if (!PropagatePositionalInputSubTree) return false;
-
-            if (UseParentInput)
-                queue.Add(this);
-            return false;
-        }
 
         protected override List<IInput> GetPendingInputs()
         {
@@ -130,6 +106,10 @@ namespace osu.Framework.Input
             // Some non-positional events are blocked. Sync every frame.
             if (UseParentInput) Sync(true);
         }
+
+        public override bool Accept(INonPositionalInputVisitor visitor, bool allowBlocking = true) => visitor.Visit(this, allowBlocking);
+
+        public override bool Accept(IPositionalInputVisitor visitor, Vector2 screenSpacePos) => visitor.Visit(screenSpacePos, this);
 
         /// <summary>
         /// Sync input state to parent <see cref="InputManager"/>'s <see cref="InputState"/>.

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Input
 
         public override IEnumerable<KeyBinding> DefaultKeyBindings => host.PlatformKeyBindings;
 
-        protected override bool Prioritised => true;
+        protected internal override bool Prioritised => true;
 
         protected override bool SendRepeats => true;
     }


### PR DESCRIPTION
It allows us not to pollute classes with input queue related logic.

### GoF Definition
Represent an operation to be performed on the elements of an object structure. Visitor
lets you define a new operation without changing the classes of the elements on which it
operates.

### Concept
With this pattern, you separate an algorithm from an object structure. So, you can add
new operations without modifying the existing architecture. This pattern supports the
open/close principle (which says extension is allowed but modification is disallowed for
entities such as class, function, modules, and so on).