### PR TITLE
Audio thread and GameThread improvements

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -92,19 +92,21 @@ namespace osu.Framework.Audio
         /// <summary>
         /// Constructs an AudioManager given a track resource store, and a sample resource store.
         /// </summary>
+        /// <param name="audioThread">The host's audio thread.</param>
         /// <param name="trackStore">The resource store containing all audio tracks to be used in the future.</param>
         /// <param name="sampleStore">The sample store containing all audio samples to be used in the future.</param>
-        public AudioManager(ResourceStore<byte[]> trackStore, ResourceStore<byte[]> sampleStore)
+        public AudioManager(AudioThread audioThread, ResourceStore<byte[]> trackStore, ResourceStore<byte[]> sampleStore)
         {
+            Thread = audioThread;
+
+            Thread.RegisterManager(this);
+
             AudioDevice.ValueChanged += onDeviceChanged;
 
             trackStore.AddExtension(@"mp3");
 
             sampleStore.AddExtension(@"wav");
             sampleStore.AddExtension(@"mp3");
-
-            Thread = new AudioThread(Update);
-            Thread.Start();
 
             globalTrackManager = new Lazy<TrackManager>(() => GetTrackManager(trackStore));
             globalSampleManager = new Lazy<SampleManager>(() => GetSampleManager(sampleStore));
@@ -129,6 +131,8 @@ namespace osu.Framework.Audio
 
         protected override void Dispose(bool disposing)
         {
+            Thread.UnregisterManager(this);
+
             OnNewDevice = null;
             OnLostDevice = null;
 

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -120,10 +120,8 @@ namespace osu.Framework
             samples.AddStore(new NamespacedResourceStore<byte[]>(Resources, @"Samples"));
             samples.AddStore(new OnlineStore());
 
-            Audio = new AudioManager(tracks, samples) { EventScheduler = Scheduler };
+            Audio = new AudioManager(Host.AudioThread, tracks, samples) { EventScheduler = Scheduler };
             dependencies.Cache(Audio);
-
-            Host.RegisterThread(Audio.Thread);
 
             //attach our bindables to the audio subsystem.
             config.BindWith(FrameworkSetting.AudioDevice, Audio.AudioDevice);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -134,6 +134,7 @@ namespace osu.Framework.Platform
         public GameThread DrawThread;
         public GameThread UpdateThread;
         public InputThread InputThread;
+        public AudioThread AudioThread;
 
         private double maximumUpdateHz;
 
@@ -217,8 +218,8 @@ namespace osu.Framework.Platform
                 Monitor = { HandleGC = true },
             });
 
-            //never gets started.
-            RegisterThread(InputThread = new InputThread(null));
+            RegisterThread(InputThread = new InputThread());
+            RegisterThread(AudioThread = new AudioThread());
 
             if (assemblyPath != null)
                 Environment.CurrentDirectory = assemblyPath;
@@ -470,6 +471,7 @@ namespace osu.Framework.Platform
 
                 DrawThread.Start();
                 UpdateThread.Start();
+                AudioThread.Start();
 
                 DrawThread.WaitUntilInitialized();
                 bootstrapSceneGraph(game);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -115,7 +115,7 @@ namespace osu.Framework.Platform
         public Storage Storage { get; protected set; }
 
         /// <summary>
-        /// If capslock is enabled on the system, false if not overwritten by a subclass
+        /// If caps-lock is enabled on the system, false if not overwritten by a subclass
         /// </summary>
         public virtual bool CapsLockEnabled => false;
 
@@ -123,12 +123,29 @@ namespace osu.Framework.Platform
 
         public IEnumerable<GameThread> Threads => threads;
 
-        public void RegisterThread(GameThread t)
+        /// <summary>
+        /// Register a thread to be monitored and tracked by this <see cref="GameHost"/>
+        /// </summary>
+        /// <param name="thread">The thread.</param>
+        public void RegisterThread(GameThread thread)
         {
-            threads.Add(t);
-            t.IsActive.BindTo(IsActive);
-            t.UnhandledException = unhandledExceptionHandler;
-            t.Monitor.EnablePerformanceProfiling = performanceLogging.Value;
+            threads.Add(thread);
+            thread.IsActive.BindTo(IsActive);
+            thread.UnhandledException = unhandledExceptionHandler;
+            thread.Monitor.EnablePerformanceProfiling = performanceLogging.Value;
+        }
+
+        /// <summary>
+        /// Unregister a previously registered thread.<see cref="GameHost"/>
+        /// </summary>
+        /// <param name="thread">The thread.</param>
+        public void UnregisterThread(GameThread thread)
+        {
+            if (!threads.Remove(thread))
+                return;
+
+            IsActive.UnbindFrom(thread.IsActive);
+            thread.UnhandledException = null;
         }
 
         public GameThread DrawThread;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -469,9 +469,8 @@ namespace osu.Framework.Platform
 
                 resetInputHandlers();
 
-                DrawThread.Start();
-                UpdateThread.Start();
-                AudioThread.Start();
+                foreach (var t in threads)
+                    t.Start();
 
                 DrawThread.WaitUntilInitialized();
                 bootstrapSceneGraph(game);

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -30,8 +30,13 @@ namespace osu.Framework.Threading
         private void onNewFrame()
         {
             lock (managers)
-            foreach (var m in managers)
-                m.Update();
+            {
+                for (var i = 0; i < managers.Count; i++)
+                {
+                    var m = managers[i];
+                    m.Update();
+                }
+            }
         }
 
         public void RegisterManager(AudioManager manager)

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Threading
         /// </summary>
         public EventHandler<UnhandledExceptionEventArgs> UnhandledException;
 
-        private readonly Action onNewFrame;
+        protected Action OnNewFrame;
 
         /// <summary>
         /// Whether the game is active (in the foreground).
@@ -69,9 +69,9 @@ namespace osu.Framework.Threading
 
         public readonly string Name;
 
-        internal GameThread(Action onNewFrame, string name, bool monitorPerformance = true)
+        internal GameThread(Action onNewFrame = null, string name = "unknown", bool monitorPerformance = true)
         {
-            this.onNewFrame = onNewFrame;
+            OnNewFrame = onNewFrame;
 
             Thread = new Thread(runWork)
             {
@@ -137,7 +137,7 @@ namespace osu.Framework.Threading
                 Scheduler.Update();
 
             using (Monitor?.BeginCollecting(PerformanceCollectionType.Work))
-                onNewFrame?.Invoke();
+                OnNewFrame?.Invoke();
 
             using (Monitor?.BeginCollecting(PerformanceCollectionType.Sleep))
                 Clock.ProcessFrame();
@@ -149,7 +149,7 @@ namespace osu.Framework.Threading
         public bool Exited => exitCompleted;
 
         public void Exit() => exitRequested = true;
-        public void Start() => Thread?.Start();
+        public virtual void Start() => Thread?.Start();
 
         protected virtual void PerformExit()
         {

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -2,15 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Statistics;
-using System;
 using System.Collections.Generic;
 
 namespace osu.Framework.Threading
 {
     public class InputThread : GameThread
     {
-        public InputThread(Action onNewFrame)
-            : base(onNewFrame, "Input")
+        public InputThread()
+            : base(name: "Input")
         {
         }
 
@@ -20,6 +19,11 @@ namespace osu.Framework.Threading
             StatisticsCounterType.KeyEvents,
             StatisticsCounterType.JoystickEvents,
         };
+
+        public override void Start()
+        {
+            // InputThread does not get started. it is run manually by GameHost.
+        }
 
         public void RunUpdate() => ProcessFrame();
     }


### PR DESCRIPTION
- Allows potentially running more than one game in the lifetime of a host.
- Adds a method to unregister threads. Since this was allowing public usage of this interface, this seems logical. Note that `PerformanceOverlay` likely needs to have a bindable reference to GameThreads for completely fixing this.