### PR TITLE
Add IsDesktop and IsMobile to RuntimeInfo

### DIFF
--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -26,6 +26,8 @@ namespace osu.Framework
         public static bool IsUnix => OS == Platform.Linux || OS == Platform.MacOsx || OS == Platform.iOS;
         public static bool IsWine { get; }
         public static bool SupportsJIT => OS != Platform.iOS;
+        public static bool IsDesktop => OS == Platform.Linux || OS == Platform.MacOsx || OS == Platform.Windows;
+        public static bool IsMobile => OS == Platform.iOS || OS == Platform.Android;
 
         static RuntimeInfo()
         {


### PR DESCRIPTION
Avoids framework consumers having to check individual operating systems when showing or hiding features in their app.

The grouping is somewhat arbitrary, but in the majority of cases this is going to be what the developer expects (Windows/macOS/Linux = desktop, iOS/Android = mobile).
