### PR TITLE
Fix ScreenStack.Push behaving incorrectly when screen already present

### DIFF
--- a/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseScreenStack.cs
@@ -77,7 +77,6 @@ namespace osu.Framework.Tests.Visual.TestCaseUserInterface
             AddStep("ensure internal throws", () => Assert.Throws<InvalidOperationException>(() => stack.Push(null, new TestScreen())));
         }
 
-
         [Test]
         public void TestAddScreenWithoutStackFails()
         {

--- a/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/TestCaseUserInterface/TestCaseScreenStack.cs
@@ -68,6 +68,17 @@ namespace osu.Framework.Tests.Visual.TestCaseUserInterface
         }
 
         [Test]
+        public void TestPushStackTwice()
+        {
+            TestScreen testScreen = null;
+
+            AddStep("public push", () => stack.Push(testScreen = new TestScreen()));
+            AddStep("ensure succeeds", () => Assert.IsTrue(stack.CurrentScreen == testScreen));
+            AddStep("ensure internal throws", () => Assert.Throws<InvalidOperationException>(() => stack.Push(null, new TestScreen())));
+        }
+
+
+        [Test]
         public void TestAddScreenWithoutStackFails()
         {
             AddStep("ensure throws", () => Assert.Throws<InvalidOperationException>(() => Add(new TestScreen())));

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Screens
         /// <param name="screen">The <see cref="IScreen"/> to push.</param>
         public void Push(IScreen screen)
         {
-            Push(null, screen);
+            Push(CurrentScreen, screen);
         }
 
         /// <summary>
@@ -76,6 +76,9 @@ namespace osu.Framework.Screens
         {
             if (stack.Contains(newScreen))
                 throw new ScreenAlreadyEnteredException();
+
+            if (source == null && stack.Count > 0)
+                throw new InvalidOperationException($"A source must be provided when pushing to a non-empty {nameof(ScreenStack)}");
 
             if (newScreen.AsDrawable().RemoveWhenNotAlive)
                 throw new ScreenWillBeRemovedOnPushException(newScreen.GetType());


### PR DESCRIPTION
stack.Push(new Screen()); // works correctly
stack.Push(new Screen()); // would not correctly suspend last screen