### PR TITLE
Stop RaiseCompleted being called multiple times for the same VirtualTrack

### DIFF
--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -81,10 +81,14 @@ namespace osu.Framework.Audio.Track
 
             lock (clock)
             {
-                if (!(CurrentTime >= Length) || hasRaisedCompleted || Looping)
+                if (!(CurrentTime >= Length))
                     return;
 
                 Stop();
+
+                if (!Looping && hasRaisedCompleted)
+                    return;
+
                 RaiseCompleted();
                 hasRaisedCompleted = true;
             }

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -81,14 +81,10 @@ namespace osu.Framework.Audio.Track
 
             lock (clock)
             {
-                if (!(CurrentTime >= Length))
+                if (!Looping && hasRaisedCompleted || !(CurrentTime >= Length))
                     return;
 
                 Stop();
-
-                if (!Looping && hasRaisedCompleted)
-                    return;
-
                 RaiseCompleted();
                 hasRaisedCompleted = true;
             }

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -12,6 +12,11 @@ namespace osu.Framework.Audio.Track
 
         private double seekOffset;
 
+        /// <summary>
+        /// Has <see cref="Track.RaiseCompleted"/> been invoked by TrackVirtual at least once?
+        /// </summary>
+        private bool hasRaisedCompleted;
+
         public TrackVirtual()
         {
             Length = double.PositiveInfinity;
@@ -76,11 +81,12 @@ namespace osu.Framework.Audio.Track
 
             lock (clock)
             {
-                if (CurrentTime >= Length)
-                {
-                    Stop();
-                    RaiseCompleted();
-                }
+                if (!(CurrentTime >= Length) || hasRaisedCompleted || Looping)
+                    return;
+
+                Stop();
+                RaiseCompleted();
+                hasRaisedCompleted = true;
             }
         }
 

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -81,7 +81,7 @@ namespace osu.Framework.Audio.Track
 
             lock (clock)
             {
-                if (!Looping && hasRaisedCompleted || !(CurrentTime >= Length))
+                if ((!Looping && hasRaisedCompleted) || !(CurrentTime >= Length))
                     return;
 
                 Stop();

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -12,11 +12,6 @@ namespace osu.Framework.Audio.Track
 
         private double seekOffset;
 
-        /// <summary>
-        /// Has <see cref="Track.RaiseCompleted"/> been invoked by TrackVirtual at least once?
-        /// </summary>
-        private bool hasRaisedCompleted;
-
         public TrackVirtual()
         {
             Length = double.PositiveInfinity;
@@ -81,12 +76,11 @@ namespace osu.Framework.Audio.Track
 
             lock (clock)
             {
-                if (!Looping && hasRaisedCompleted || !(CurrentTime >= Length))
-                    return;
-
-                Stop();
-                RaiseCompleted();
-                hasRaisedCompleted = true;
+                if (clock.IsRunning && CurrentTime >= Length)
+                {
+                    Stop();
+                    RaiseCompleted();
+                }
             }
         }
 

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -81,7 +81,7 @@ namespace osu.Framework.Audio.Track
 
             lock (clock)
             {
-                if ((!Looping && hasRaisedCompleted) || !(CurrentTime >= Length))
+                if (!Looping && hasRaisedCompleted || !(CurrentTime >= Length))
                     return;
 
                 Stop();


### PR DESCRIPTION
This fixes some potential issues that can occur where RaiseCompleted can be called many times until next() has properly finished executing.

Tested locally against osu! and seems to work fine.