### PR TITLE
Ensure vertex buffers initialise on the draw thread

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
@@ -24,10 +24,18 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     public class LinearVertexBuffer<T> : VertexBuffer<T>
         where T : struct, IEquatable<T>, IVertex
     {
+        private readonly int amountVertices;
+
         public LinearVertexBuffer(int amountVertices, PrimitiveType type, BufferUsageHint usage)
             : base(amountVertices, usage)
         {
+            this.amountVertices = amountVertices;
             Type = type;
+        }
+
+        protected override void Initialise()
+        {
+            base.Initialise();
 
             if (amountVertices > LinearIndexData.MaxAmountIndices)
             {

--- a/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
@@ -21,9 +21,18 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     public class QuadVertexBuffer<T> : VertexBuffer<T>
         where T : struct, IEquatable<T>, IVertex
     {
+        private readonly int amountQuads;
+
         public QuadVertexBuffer(int amountQuads, BufferUsageHint usage)
             : base(amountQuads * 4, usage)
         {
+            this.amountQuads = amountQuads;
+        }
+
+        protected override void Initialise()
+        {
+            base.Initialise();
+
             int amountIndices = amountQuads * 6;
             if (amountIndices > QuadIndexData.MaxAmountIndices)
             {

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -61,9 +61,11 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             if (IsDisposed)
                 return;
 
-            Unbind();
-
-            GLWrapper.DeleteBuffer(vboId);
+            if (isInitialised)
+            {
+                Unbind();
+                GLWrapper.DeleteBuffer(vboId);
+            }
 
             IsDisposed = true;
         }

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osuTK.Graphics.ES30;
 using osu.Framework.Statistics;
+using osu.Framework.Development;
 
 namespace osu.Framework.Graphics.OpenGL.Buffers
 {
@@ -27,8 +28,13 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             Vertices = new T[amountVertices];
         }
 
+        /// <summary>
+        /// Initialises this <see cref="VertexBuffer"/>. Guaranteed to be run on the draw thread.
+        /// </summary>
         protected virtual void Initialise()
         {
+            ThreadSafety.EnsureDrawThread();
+
             GL.GenBuffers(1, out vboId);
 
             if (GLWrapper.BindBuffer(BufferTarget.ArrayBuffer, vboId))

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         }
 
         /// <summary>
-        /// Initialises this <see cref="VertexBuffer"/>. Guaranteed to be run on the draw thread.
+        /// Initialises this <see cref="VertexBuffer{T}"/>. Guaranteed to be run on the draw thread.
         /// </summary>
         protected virtual void Initialise()
         {


### PR DESCRIPTION
Currently, `VertexBuffer` is initialised at the point of construction. Going forward we'll want to assure it's only initialised on the draw thread.