### PR TITLE
Defer system gestures on screen edges on iOS

### DIFF
--- a/osu.Framework.iOS/GameViewController.cs
+++ b/osu.Framework.iOS/GameViewController.cs
@@ -10,6 +10,8 @@ namespace osu.Framework.iOS
     {
         public override bool PrefersStatusBarHidden() => true;
 
+        public override UIRectEdge PreferredScreenEdgesDeferringSystemGestures => UIRectEdge.All;
+
         public override void ViewWillTransitionToSize(CGSize toSize, IUIViewControllerTransitionCoordinator coordinator)
         {
             coordinator.AnimateAlongsideTransition(_ => { }, _ => UIView.AnimationsEnabled = true);


### PR DESCRIPTION
Requires users to swipe up twice to access the home bar or control centre, and down twice to access notifications.

Prevents accidental home bar usage on edge-to-edge iOS devices.