### PR TITLE
Fix buffered containers causing GL errors

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainerDrawNode.cs
@@ -148,13 +148,7 @@ namespace osu.Framework.Graphics.Containers
             FrameBuffer source = currentFrameBuffer;
             FrameBuffer target = advanceFrameBuffer();
 
-            GLWrapper.SetBlend(new BlendingInfo
-            {
-                Source = BlendingFactorSrc.One,
-                Destination = BlendingFactorDest.Zero,
-                SourceAlpha = BlendingFactorSrc.One,
-                DestinationAlpha = BlendingFactorDest.Zero,
-            });
+            GLWrapper.SetBlend(new BlendingInfo(BlendingMode.None));
 
             using (bindFrameBuffer(target, source.Size))
             {

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -242,7 +242,7 @@ namespace osu.Framework.Graphics.OpenGL
         /// <summary>
         /// Sets the blending function to draw with.
         /// </summary>
-        /// <param name="blendingInfo">The infor we should use to update the active state.</param>
+        /// <param name="blendingInfo">The info we should use to update the active state.</param>
         public static void SetBlend(BlendingInfo blendingInfo)
         {
             if (lastBlendingInfo.Equals(blendingInfo))


### PR DESCRIPTION
Because the ctor of BlendingInfo wasn't being called, `0` (literally) was being passed to `GL.BlendEquationSeparate` in `GLWrapper`.