### PR TITLE
Make BlendingInfo readonly

### DIFF
--- a/osu.Framework/Graphics/BlendingInfo.cs
+++ b/osu.Framework/Graphics/BlendingInfo.cs
@@ -6,15 +6,15 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics
 {
-    public struct BlendingInfo : IEquatable<BlendingInfo>
+    public readonly struct BlendingInfo : IEquatable<BlendingInfo>
     {
-        public BlendingFactorSrc Source;
-        public BlendingFactorDest Destination;
-        public BlendingFactorSrc SourceAlpha;
-        public BlendingFactorDest DestinationAlpha;
+        public readonly BlendingFactorSrc Source;
+        public readonly BlendingFactorDest Destination;
+        public readonly BlendingFactorSrc SourceAlpha;
+        public readonly BlendingFactorDest DestinationAlpha;
 
-        public BlendEquationMode RGBEquation;
-        public BlendEquationMode AlphaEquation;
+        public readonly BlendEquationMode RGBEquation;
+        public readonly BlendEquationMode AlphaEquation;
 
         public BlendingInfo(BlendingParameters parameters)
         {


### PR DESCRIPTION
I was thinking about how to make sure cases like https://github.com/ppy/osu-framework/pull/2208 never happen again, had a bit of a brain-fart but realized this is the way to go (making sure BlendingInfo can't be instantiated the way it was being).