### PR TITLE
Return any lease when calling UnbindAll on the lease source

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableLeasingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableLeasingTest.cs
@@ -36,6 +36,24 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(original.Value, revert ? 1 : 2);
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestLeaseReturnedOnUnbindAll(bool revert)
+        {
+            var leased = original.BeginLease(revert);
+
+            Assert.AreEqual(original.Value, leased.Value);
+
+            leased.Value = 2;
+
+            Assert.AreEqual(original.Value, 2);
+            Assert.AreEqual(original.Value, leased.Value);
+
+            original.UnbindAll();
+
+            Assert.AreEqual(original.Value, revert ? 1 : 2);
+        }
+
         [Test]
         public void TestConsecutiveLeases()
         {

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -276,10 +276,14 @@ namespace osu.Framework.Bindables
         protected void Unbind(Bindable<T> binding) => Bindings.Remove(binding.weakReference);
 
         /// <summary>
-        /// Calls <see cref="UnbindEvents"/> and <see cref="UnbindBindings"/>
+        /// Calls <see cref="UnbindEvents"/> and <see cref="UnbindBindings"/>.
+        /// Also returns any active lease.
         /// </summary>
         public virtual void UnbindAll()
         {
+            if (isLeased)
+                leasedBindable.Return();
+
             UnbindEvents();
             UnbindBindings();
         }


### PR DESCRIPTION
Fixes a potential case where storing both the source and leased copy to fields and relying on `UnbindAllBindables` could potentially leave outward bound bindables in an incorrect state.