### PR TITLE
Ensure root UserInputManager is alive

### DIFF
--- a/osu.Framework.Tests/Platform/UserInputManagerTest.cs
+++ b/osu.Framework.Tests/Platform/UserInputManagerTest.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Platform
+{
+    [TestFixture]
+    public class UserInputManagerTest : TestCase
+    {
+        [Test]
+        public void IsAliveTest()
+        {
+            AddAssert("UserInputManager is alive", () =>
+            {
+                using (var client = new TestHeadlessGameHost(@"client", true))
+                {
+                    return client.CurrentRoot.IsAlive;
+                }
+            });
+        }
+
+        private class TestHeadlessGameHost : HeadlessGameHost
+            public Drawable CurrentRoot => Root;
+
+            public TestHeadlessGameHost(string hostname, bool bindIPC)
+                : base(hostname, bindIPC)
+            {
+                using (var game = new TestGame())
+                {
+                    Root = game.CreateUserInputManager();
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Platform/UserInputManagerTest.cs
+++ b/osu.Framework.Tests/Platform/UserInputManagerTest.cs
@@ -24,6 +24,7 @@ namespace osu.Framework.Tests.Platform
         }
 
         private class TestHeadlessGameHost : HeadlessGameHost
+        {
             public Drawable CurrentRoot => Root;
 
             public TestHeadlessGameHost(string hostname, bool bindIPC)

--- a/osu.Framework.Tests/Platform/UserInputManagerTest.cs
+++ b/osu.Framework.Tests/Platform/UserInputManagerTest.cs
@@ -2,8 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Graphics;
-using osu.Framework.Platform;
+using osu.Framework.Input;
 using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Platform
@@ -14,27 +13,7 @@ namespace osu.Framework.Tests.Platform
         [Test]
         public void IsAliveTest()
         {
-            AddAssert("UserInputManager is alive", () =>
-            {
-                using (var client = new TestHeadlessGameHost(@"client", true))
-                {
-                    return client.CurrentRoot.IsAlive;
-                }
-            });
-        }
-
-        private class TestHeadlessGameHost : HeadlessGameHost
-        {
-            public Drawable CurrentRoot => Root;
-
-            public TestHeadlessGameHost(string hostname, bool bindIPC)
-                : base(hostname, bindIPC)
-            {
-                using (var game = new TestGame())
-                {
-                    Root = game.CreateUserInputManager();
-                }
-            }
+            AddAssert("UserInputManager is alive", () => new UserInputManager().IsAlive);
         }
     }
 }

--- a/osu.Framework.Tests/Platform/UserInputManagerTest.cs
+++ b/osu.Framework.Tests/Platform/UserInputManagerTest.cs
@@ -2,18 +2,45 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
-using osu.Framework.Input;
-using osu.Framework.Testing;
+using osu.Framework.Graphics;
+using osu.Framework.Platform;
 
 namespace osu.Framework.Tests.Platform
 {
     [TestFixture]
-    public class UserInputManagerTest : TestCase
+    public class UserInputManagerTest
     {
         [Test]
         public void IsAliveTest()
         {
-            AddAssert("UserInputManager is alive", () => new UserInputManager().IsAlive);
+            using (var client = new TestHeadlessGameHost(@"client", true))
+            {
+                var testGame = new TestTestGame();
+                client.Run(testGame);
+                Assert.IsTrue(testGame.IsRootAlive);
+            }
+
+        }
+
+        private class TestHeadlessGameHost : HeadlessGameHost
+        {
+            public Drawable CurrentRoot => Root;
+
+            public TestHeadlessGameHost(string hostname, bool bindIPC)
+                : base(hostname, bindIPC)
+            {
+            }
+        }
+
+        private class TestTestGame : TestGame
+        {
+            public bool IsRootAlive;
+
+            protected override void LoadComplete()
+            {
+                IsRootAlive = ((TestHeadlessGameHost)Host).CurrentRoot.IsAlive;
+                Exit();
+            }
         }
     }
 }

--- a/osu.Framework.Tests/Platform/UserInputManagerTest.cs
+++ b/osu.Framework.Tests/Platform/UserInputManagerTest.cs
@@ -19,7 +19,6 @@ namespace osu.Framework.Tests.Platform
                 client.Run(testGame);
                 Assert.IsTrue(testGame.IsRootAlive);
             }
-
         }
 
         private class TestHeadlessGameHost : HeadlessGameHost

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -17,6 +17,7 @@ namespace osu.Framework.Input
 
         public UserInputManager()
         {
+            IsAlive = true;
             UseParentInput = false;
         }
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -15,11 +15,12 @@ namespace osu.Framework.Input
 
         protected override bool HandleHoverEvents => Host.Window?.CursorInWindow ?? true;
 
-        // IsAlive is being forced to true here as UserInputManager is at the very top of the Draw Hierarchy, which means it never becomes alive normally.
         protected internal override bool ShouldBeAlive => true;
 
         protected internal UserInputManager()
         {
+            // IsAlive is being forced to true here as UserInputManager is at the very top of the Draw Hierarchy, which means it never becomes alive normally.
+            IsAlive = true;
             UseParentInput = false;
         }
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -15,10 +15,11 @@ namespace osu.Framework.Input
 
         protected override bool HandleHoverEvents => Host.Window?.CursorInWindow ?? true;
 
+        // IsAlive is being forced to true here as UserInputManager is at the very top of the Draw Hierarchy, which means it never becomes alive normally.
+        protected internal override bool ShouldBeAlive => true;
+
         protected internal UserInputManager()
         {
-            // IsAlive is being forced to true here as UserInputManager is at the very top of the Draw Hierarchy, which means it never becomes alive normally.
-            IsAlive = true;
             UseParentInput = false;
         }
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -15,8 +15,9 @@ namespace osu.Framework.Input
 
         protected override bool HandleHoverEvents => Host.Window?.CursorInWindow ?? true;
 
-        public UserInputManager()
+        protected internal UserInputManager()
         {
+            // IsAlive is being forced to true here as UserInputManager is at the very top of the Draw Hierarchy, which means it never becomes alive normally.
             IsAlive = true;
             UseParentInput = false;
         }

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Input
 
         protected internal UserInputManager()
         {
-            // IsAlive is being forced to true here as UserInputManager is at the very top of the Draw Hierarchy, which means it never becomes alive normally.
+            // UserInputManager is at the very top of the draw hierarchy, so it has no parnt updating its IsAlive state
             IsAlive = true;
             UseParentInput = false;
         }


### PR DESCRIPTION
Currently, the very top level of the draw hierarchy never becomes alive. We need to make sure UserInputManager is always alive because checks dependent on parent life will always fail as a result.