### PR TITLE
Fix premature disposal of ResponseStream

### DIFF
--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -459,7 +459,7 @@ namespace osu.Framework.IO.Network
                 {
                     // in the case we fail a request, spitting out the response in the log is quite helpful.
                     ResponseStream.Seek(0, SeekOrigin.Begin);
-                    using (StreamReader r = new StreamReader(ResponseStream, new UTF8Encoding(false, true)))
+                    using (StreamReader r = new StreamReader(ResponseStream, new UTF8Encoding(false, true), true, 1024, true))
                     {
                         try
                         {


### PR DESCRIPTION
This fixes being unable to read returned json errors from the api when the server response code isn't in the 2xx range.

Defaults for the parameters taken from [here](https://source.dot.net/#System.Private.CoreLib/shared/System/IO/StreamReader.cs,802d803734748de8,references).

fixes ppy/osu#4271