### PR TITLE
Refactor GridContainer to remove code duplication

### DIFF
--- a/osu.Framework.Tests/Lists/TestArrayExtensions.cs
+++ b/osu.Framework.Tests/Lists/TestArrayExtensions.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions;

--- a/osu.Framework.Tests/Lists/TestArrayExtensions.cs
+++ b/osu.Framework.Tests/Lists/TestArrayExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions;
 
@@ -135,6 +137,76 @@ namespace osu.Framework.Tests.Lists
 
             for (int i = 0; i < 10; i++)
                 Assert.AreEqual(0, result[i, 0]);
+        }
+
+        [Test]
+        public void TestInvertRectangular()
+        {
+            var original = new int?[,]
+            {
+                { 1, 2, null },
+                { null, 3, 4 },
+                { 5, 6, null }
+            };
+
+            var result = original.Invert();
+
+            Assert.AreEqual(1, result[0, 0]);
+            Assert.AreEqual(2, result[1, 0]);
+            Assert.AreEqual(null, result[2, 0]);
+            Assert.AreEqual(null, result[0, 1]);
+            Assert.AreEqual(3, result[1, 1]);
+            Assert.AreEqual(4, result[2, 1]);
+            Assert.AreEqual(5, result[0, 2]);
+            Assert.AreEqual(6, result[1, 2]);
+            Assert.AreEqual(null, result[2, 2]);
+        }
+
+        [Test]
+        public void TestInvertJagged()
+        {
+            // 4x5 array
+            var original = new[]
+            {
+                new int?[] { 1, 2, null },
+                new int?[] { 3, 4 },
+                null,
+                new int?[] { null, 5, 6, 7, 8}
+            };
+
+            var result = original.Invert();
+
+            // Ensure 5x4 array
+            Assert.AreEqual(5, result.Length);
+            Assert.AreEqual(4, result.Max(r => r.Length));
+
+            // Column 1
+            Assert.AreEqual(1, result[0][0]);
+            Assert.AreEqual(2, result[1][0]);
+            Assert.AreEqual(null, result[2][0]);
+            Assert.AreEqual(null, result[3][0]);
+            Assert.AreEqual(null, result[4][0]);
+
+            // Column 2
+            Assert.AreEqual(3, result[0][1]);
+            Assert.AreEqual(4, result[1][1]);
+            Assert.AreEqual(null, result[2][1]);
+            Assert.AreEqual(null, result[3][1]);
+            Assert.AreEqual(null, result[4][1]);
+
+            // Column 3
+            Assert.AreEqual(null, result[0][2]);
+            Assert.AreEqual(null, result[1][2]);
+            Assert.AreEqual(null, result[2][2]);
+            Assert.AreEqual(null, result[3][2]);
+            Assert.AreEqual(null, result[4][2]);
+
+            // Column 4
+            Assert.AreEqual(null, result[0][3]);
+            Assert.AreEqual(5, result[1][3]);
+            Assert.AreEqual(6, result[2][3]);
+            Assert.AreEqual(7, result[3][3]);
+            Assert.AreEqual(8, result[4][3]);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/TestCaseContainerExtensions/TestCaseGridContainer.cs
+++ b/osu.Framework.Tests/Visual/TestCaseContainerExtensions/TestCaseGridContainer.cs
@@ -1,6 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -13,11 +17,12 @@ namespace osu.Framework.Tests.Visual.TestCaseContainerExtensions
 {
     public class TestCaseGridContainer : TestCase
     {
-        private readonly GridContainer grid;
+        private GridContainer grid;
 
-        public TestCaseGridContainer()
+        [SetUp]
+        public void Setup() => Schedule(() =>
         {
-            Add(new Container
+            Child = new Container
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
@@ -36,259 +41,378 @@ namespace osu.Framework.Tests.Visual.TestCaseContainerExtensions
                     },
                     grid = new GridContainer { RelativeSizeAxes = Axes.Both }
                 }
+            };
+        });
+
+        [Test]
+        public void TestBlankGrid()
+        {
+        }
+
+        [Test]
+        public void TestSingleCellDistributedXy()
+        {
+            FillBox box = null;
+            AddStep("set content", () => grid.Content = new[] { new Drawable[] { box = new FillBox() }, });
+            AddAssert("box is same size as grid", () => Precision.AlmostEquals(box.DrawSize, grid.DrawSize));
+        }
+
+        [Test]
+        public void TestSingleCellAbsoluteXy()
+        {
+            const float size = 100;
+
+            FillBox box = null;
+            AddStep("set content", () =>
+            {
+                grid.Content = new[] { new Drawable[] { box = new FillBox() }, };
+                grid.RowDimensions = grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.Absolute, size) };
             });
 
-            AddStep("Blank grid", reset);
-            AddStep("1-cell (auto)", () =>
+            AddAssert("box has expected size", () => Precision.AlmostEquals(box.DrawSize, new Vector2(size)));
+        }
+
+        [Test]
+        public void TestSingleCellRelativeXy()
+        {
+            const float size = 0.5f;
+
+            FillBox box = null;
+            AddStep("set content", () =>
             {
-                reset();
-                grid.Content = new[] { new Drawable[] { new FillBox() } };
+                grid.Content = new[] { new Drawable[] { box = new FillBox() }, };
+                grid.RowDimensions = grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.Relative, size) };
             });
 
-            AddStep("1-cell (absolute)", () =>
+            AddAssert("box has expected size", () => Precision.AlmostEquals(box.DrawSize, grid.DrawSize * new Vector2(size)));
+        }
+
+        [Test]
+        public void TestSingleCellRelativeXAbsoluteY()
+        {
+            const float absolute_height = 100;
+            const float relative_width = 0.5f;
+
+            FillBox box = null;
+            AddStep("set content", () =>
             {
-                reset();
-                grid.Content = new[] { new Drawable[] { new FillBox() } };
-                grid.RowDimensions = grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.Absolute, 100) };
+                grid.Content = new[] { new Drawable[] { box = new FillBox() }, };
+                grid.RowDimensions = new[] { new Dimension(GridSizeMode.Absolute, absolute_height) };
+                grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.Relative, relative_width) };
             });
 
-            AddStep("1-cell (relative)", () =>
+            AddAssert("box has expected width", () => Precision.AlmostEquals(box.DrawWidth, grid.DrawWidth * relative_width));
+            AddAssert("box has expected height", () => Precision.AlmostEquals(box.DrawHeight, absolute_height));
+        }
+
+        [Test]
+        public void TestSingleCellDistributedXRelativeY()
+        {
+            const float height = 0.5f;
+
+            FillBox box = null;
+            AddStep("set content", () =>
             {
-                reset();
-                grid.Content = new [] { new Drawable[] { new FillBox() } };
-                grid.RowDimensions = grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.Relative, 0.5f) };
+                grid.Content = new[] { new Drawable[] { box = new FillBox() }, };
+                grid.RowDimensions = new[] { new Dimension(GridSizeMode.Relative, height) };
             });
 
-            AddStep("1-cell (mixed)", () =>
-            {
-                reset();
-                grid.Content = new [] { new Drawable[] { new FillBox() } };
-                grid.RowDimensions = new[] { new Dimension(GridSizeMode.Absolute, 100) };
-                grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.Relative, 0.5f) };
-            });
+            AddAssert("box has expected width", () => Precision.AlmostEquals(box.DrawWidth, grid.DrawWidth));
+            AddAssert("box has expected height", () => Precision.AlmostEquals(box.DrawHeight, grid.DrawHeight * height));
+        }
 
-            AddStep("1-cell (mixed) 2", () =>
-            {
-                reset();
-                grid.Content = new [] { new Drawable[] { new FillBox() } };
-                grid.RowDimensions = new [] { new Dimension(GridSizeMode.Relative, 0.5f) };
-            });
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Test3CellRowOrColumnDistributedXy(bool row)
+        {
+            FillBox[] boxes = new FillBox[3];
 
-            AddStep("3-cell row (auto)", () =>
+            setSingleDimensionContent(() => new[]
             {
-                reset();
-                grid.Content = new [] { new Drawable[] { new FillBox(), new FillBox(), new FillBox() } };
-            });
+                new Drawable[] { boxes[0] = new FillBox(), boxes[1] = new FillBox(), boxes[2] = new FillBox() }
+            }, row: row);
 
-            AddStep("3-cell row (absolute)", () =>
+            for (int i = 0; i < 3; i++)
             {
-                reset();
-                grid.Content = new [] { new Drawable[] { new FillBox(), new FillBox(), new FillBox() } };
-                grid.RowDimensions = grid.ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Absolute, 50),
-                    new Dimension(GridSizeMode.Absolute, 100),
-                    new Dimension(GridSizeMode.Absolute, 150)
-                };
-            });
+                int local = i;
 
-            AddStep("3-cell row (relative)", () =>
-            {
-                reset();
-                grid.Content = new [] { new Drawable[] { new FillBox(), new FillBox(), new FillBox() } };
-                grid.RowDimensions = grid.ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Relative, 0.1f),
-                    new Dimension(GridSizeMode.Relative, 0.2f),
-                    new Dimension(GridSizeMode.Relative, 0.3f)
-                };
-            });
+                if (row)
+                    AddAssert($"box {local} has correct size", () => Precision.AlmostEquals(boxes[local].DrawSize, new Vector2(grid.DrawWidth / 3f, grid.DrawHeight)));
+                else
+                    AddAssert($"box {local} has correct size", () => Precision.AlmostEquals(boxes[local].DrawSize, new Vector2(grid.DrawWidth, grid.DrawHeight / 3f)));
+            }
+        }
 
-            AddStep("3-cell row (mixed)", () =>
-            {
-                reset();
-                grid.Content = new [] { new Drawable[] { new FillBox(), new FillBox(), new FillBox() } };
-                grid.RowDimensions = grid.ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Absolute, 50),
-                    new Dimension(GridSizeMode.Relative, 0.2f)
-                };
-            });
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Test3CellRowOrColumnDistributedXyAbsoluteYx(bool row)
+        {
+            var sizes = new[] { 50f, 100f, 75f };
+            var boxes = new FillBox[3];
 
-            AddStep("3-cell column (auto)", () =>
+            setSingleDimensionContent(() => new[]
             {
-                reset();
+                new Drawable[] { boxes[0] = new FillBox() },
+                new Drawable[] { boxes[1] = new FillBox() },
+                new Drawable[] { boxes[2] = new FillBox() },
+            }, new[]
+            {
+                new Dimension(GridSizeMode.Absolute, sizes[0]),
+                new Dimension(GridSizeMode.Absolute, sizes[1]),
+                new Dimension(GridSizeMode.Absolute, sizes[2])
+            }, row);
+
+            for (int i = 0; i < 3; i++)
+            {
+                int local = i;
+
+                if (row)
+                    AddAssert($"box {local} has correct size", () => Precision.AlmostEquals(boxes[local].DrawSize, new Vector2(grid.DrawWidth, sizes[local])));
+                else
+                    AddAssert($"box {local} has correct size", () => Precision.AlmostEquals(boxes[local].DrawSize, new Vector2(sizes[local], grid.DrawHeight)));
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Test3CellRowOrColumnDistributedXyRelativeYx(bool row)
+        {
+            var sizes = new[] { 0.2f, 0.4f, 0.2f };
+            var boxes = new FillBox[3];
+
+            setSingleDimensionContent(() => new[]
+            {
+                new Drawable[] { boxes[0] = new FillBox() },
+                new Drawable[] { boxes[1] = new FillBox() },
+                new Drawable[] { boxes[2] = new FillBox() },
+            }, new[]
+            {
+                new Dimension(GridSizeMode.Relative, sizes[0]),
+                new Dimension(GridSizeMode.Relative, sizes[1]),
+                new Dimension(GridSizeMode.Relative, sizes[2])
+            }, row);
+
+            for (int i = 0; i < 3; i++)
+            {
+                int local = i;
+
+                if (row)
+                    AddAssert($"box {local} has correct size", () => Precision.AlmostEquals(boxes[local].DrawSize, new Vector2(grid.DrawWidth, sizes[local] * grid.DrawHeight)));
+                else
+                    AddAssert($"box {local} has correct size", () => Precision.AlmostEquals(boxes[local].DrawSize, new Vector2(sizes[local] * grid.DrawWidth, grid.DrawHeight)));
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void Test3CellRowOrColumnDistributedXyMixedYx(bool row)
+        {
+            var sizes = new[] { 0.2f, 75f };
+            var boxes = new FillBox[3];
+
+            setSingleDimensionContent(() => new[]
+            {
+                new Drawable[] { boxes[0] = new FillBox() },
+                new Drawable[] { boxes[1] = new FillBox() },
+                new Drawable[] { boxes[2] = new FillBox() },
+            }, new[]
+            {
+                new Dimension(GridSizeMode.Relative, sizes[0]),
+                new Dimension(GridSizeMode.Absolute, sizes[1]),
+                new Dimension(GridSizeMode.Distributed),
+            }, row);
+
+            if (row)
+            {
+                AddAssert("box 0 has correct size", () => Precision.AlmostEquals(boxes[0].DrawSize, new Vector2(grid.DrawWidth, sizes[0] * grid.DrawHeight)));
+                AddAssert("box 1 has correct size", () => Precision.AlmostEquals(boxes[1].DrawSize, new Vector2(grid.DrawWidth, sizes[1])));
+                AddAssert("box 2 has correct size", () => Precision.AlmostEquals(boxes[2].DrawSize, new Vector2(grid.DrawWidth, grid.DrawHeight - boxes[0].DrawHeight - boxes[1].DrawHeight)));
+            }
+            else
+            {
+                AddAssert("box 0 has correct size", () => Precision.AlmostEquals(boxes[0].DrawSize, new Vector2(sizes[0] * grid.DrawWidth, grid.DrawHeight)));
+                AddAssert("box 1 has correct size", () => Precision.AlmostEquals(boxes[1].DrawSize, new Vector2(sizes[1], grid.DrawHeight)));
+                AddAssert("box 2 has correct size", () => Precision.AlmostEquals(boxes[2].DrawSize, new Vector2(grid.DrawWidth - boxes[0].DrawWidth - boxes[1].DrawWidth, grid.DrawHeight)));
+            }
+        }
+
+        [Test]
+        public void Test3X3GridDistributedXy()
+        {
+            var boxes = new FillBox[9];
+
+            AddStep("set content", () =>
+            {
                 grid.Content = new[]
                 {
-                    new Drawable[] { new FillBox() },
-                    new Drawable[] { new FillBox() },
-                    new Drawable[] { new FillBox() }
+                    new Drawable[] { boxes[0] = new FillBox(), boxes[1] = new FillBox(), boxes[2] = new FillBox() },
+                    new Drawable[] { boxes[3] = new FillBox(), boxes[4] = new FillBox(), boxes[5] = new FillBox() },
+                    new Drawable[] { boxes[6] = new FillBox(), boxes[7] = new FillBox(), boxes[8] = new FillBox() }
                 };
             });
 
-            AddStep("3-cell column (absolute)", () =>
+            for (int i = 0; i < 9; i++)
             {
-                reset();
+                int local = i;
+                AddAssert($"box {local} has correct size", () => Precision.AlmostEquals(grid.DrawSize / 3f, boxes[local].DrawSize));
+            }
+        }
+
+        [Test]
+        public void Test3X3GridAbsoluteXy()
+        {
+            var boxes = new FillBox[9];
+
+            var dimensions = new[]
+            {
+                new Dimension(GridSizeMode.Absolute, 50),
+                new Dimension(GridSizeMode.Absolute, 100),
+                new Dimension(GridSizeMode.Absolute, 75)
+            };
+
+            AddStep("set content", () =>
+            {
                 grid.Content = new[]
                 {
-                    new Drawable[] { new FillBox() },
-                    new Drawable[] { new FillBox() },
-                    new Drawable[] { new FillBox() }
+                    new Drawable[] { boxes[0] = new FillBox(), boxes[1] = new FillBox(), boxes[2] = new FillBox() },
+                    new Drawable[] { boxes[3] = new FillBox(), boxes[4] = new FillBox(), boxes[5] = new FillBox() },
+                    new Drawable[] { boxes[6] = new FillBox(), boxes[7] = new FillBox(), boxes[8] = new FillBox() }
                 };
 
-                grid.RowDimensions = grid.ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Absolute, 50),
-                    new Dimension(GridSizeMode.Absolute, 100),
-                    new Dimension(GridSizeMode.Absolute, 150)
-                };
+                grid.RowDimensions = grid.ColumnDimensions = dimensions;
             });
 
-            AddStep("3-cell column (relative)", () =>
+            for (int i = 0; i < 9; i++)
             {
-                reset();
+                int local = i;
+                AddAssert($"box {local} has correct size", () => Precision.AlmostEquals(new Vector2(dimensions[local % 3].Size, dimensions[local / 3].Size), boxes[local].DrawSize));
+            }
+        }
+
+        [Test]
+        public void Test3X3GridRelativeXy()
+        {
+            var boxes = new FillBox[9];
+
+            var dimensions = new[]
+            {
+                new Dimension(GridSizeMode.Relative, 0.2f),
+                new Dimension(GridSizeMode.Relative, 0.4f),
+                new Dimension(GridSizeMode.Relative, 0.2f)
+            };
+
+            AddStep("set content", () =>
+            {
                 grid.Content = new[]
                 {
-                    new Drawable[] { new FillBox() },
-                    new Drawable[] { new FillBox() },
-                    new Drawable[] { new FillBox() }
+                    new Drawable[] { boxes[0] = new FillBox(), boxes[1] = new FillBox(), boxes[2] = new FillBox() },
+                    new Drawable[] { boxes[3] = new FillBox(), boxes[4] = new FillBox(), boxes[5] = new FillBox() },
+                    new Drawable[] { boxes[6] = new FillBox(), boxes[7] = new FillBox(), boxes[8] = new FillBox() }
                 };
 
-                grid.RowDimensions = grid.ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Relative, 0.1f),
-                    new Dimension(GridSizeMode.Relative, 0.2f),
-                    new Dimension(GridSizeMode.Relative, 0.3f)
-                };
+                grid.RowDimensions = grid.ColumnDimensions = dimensions;
             });
 
-            AddStep("3-cell column (mixed)", () =>
+            for (int i = 0; i < 9; i++)
             {
-                reset();
+                int local = i;
+                AddAssert($"box {local} has correct size",
+                    () => Precision.AlmostEquals(new Vector2(dimensions[local % 3].Size * grid.DrawWidth, dimensions[local / 3].Size * grid.DrawHeight), boxes[local].DrawSize));
+            }
+        }
+
+        [Test]
+        public void Test3X3GridMixedXy()
+        {
+            var boxes = new FillBox[9];
+
+            var dimensions = new[]
+            {
+                new Dimension(GridSizeMode.Absolute, 50),
+                new Dimension(GridSizeMode.Relative, 0.2f)
+            };
+
+            AddStep("set content", () =>
+            {
                 grid.Content = new[]
                 {
-                    new Drawable[] { new FillBox() },
-                    new Drawable[] { new FillBox() },
-                    new Drawable[] { new FillBox() }
+                    new Drawable[] { boxes[0] = new FillBox(), boxes[1] = new FillBox(), boxes[2] = new FillBox() },
+                    new Drawable[] { boxes[3] = new FillBox(), boxes[4] = new FillBox(), boxes[5] = new FillBox() },
+                    new Drawable[] { boxes[6] = new FillBox(), boxes[7] = new FillBox(), boxes[8] = new FillBox() }
                 };
 
-                grid.RowDimensions = grid.ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Absolute, 50),
-                    new Dimension(GridSizeMode.Relative, 0.2f)
-                };
+                grid.RowDimensions = grid.ColumnDimensions = dimensions;
             });
 
-            AddStep("3x3-cell (auto)", () =>
+            // Row 1
+            AddAssert("box 0 has correct size", () => Precision.AlmostEquals(boxes[0].DrawSize, new Vector2(dimensions[0].Size, dimensions[0].Size)));
+            AddAssert("box 1 has correct size", () => Precision.AlmostEquals(boxes[1].DrawSize, new Vector2(grid.DrawWidth * dimensions[1].Size, dimensions[0].Size)));
+            AddAssert("box 2 has correct size", () => Precision.AlmostEquals(boxes[2].DrawSize, new Vector2(grid.DrawWidth - boxes[0].DrawWidth - boxes[1].DrawWidth, dimensions[0].Size)));
+
+            // Row 2
+            AddAssert("box 3 has correct size", () => Precision.AlmostEquals(boxes[3].DrawSize, new Vector2(dimensions[0].Size, grid.DrawHeight * dimensions[1].Size)));
+            AddAssert("box 4 has correct size", () => Precision.AlmostEquals(boxes[4].DrawSize, new Vector2(grid.DrawWidth * dimensions[1].Size, grid.DrawHeight * dimensions[1].Size)));
+            AddAssert("box 5 has correct size",
+                () => Precision.AlmostEquals(boxes[5].DrawSize, new Vector2(grid.DrawWidth - boxes[0].DrawWidth - boxes[1].DrawWidth, grid.DrawHeight * dimensions[1].Size)));
+
+            // Row 3
+            AddAssert("box 6 has correct size", () => Precision.AlmostEquals(boxes[6].DrawSize, new Vector2(dimensions[0].Size, grid.DrawHeight - boxes[3].DrawHeight - boxes[0].DrawHeight)));
+            AddAssert("box 7 has correct size",
+                () => Precision.AlmostEquals(boxes[7].DrawSize, new Vector2(grid.DrawWidth * dimensions[1].Size, grid.DrawHeight - boxes[4].DrawHeight - boxes[1].DrawHeight)));
+            AddAssert("box 8 has correct size",
+                () => Precision.AlmostEquals(boxes[8].DrawSize, new Vector2(grid.DrawWidth - boxes[0].DrawWidth - boxes[1].DrawWidth, grid.DrawHeight - boxes[5].DrawHeight - boxes[2].DrawHeight)));
+        }
+
+        [Test]
+        public void TestGridWithNullRowsAndColumns()
+        {
+            var boxes = new FillBox[4];
+
+            AddStep("set content", () =>
             {
-                reset();
                 grid.Content = new[]
                 {
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
-                };
-            });
-
-            AddStep("3x3-cell (absolute)", () =>
-            {
-                reset();
-                grid.Content = new[]
-                {
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
-                };
-
-                grid.RowDimensions = grid.ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Absolute, 50),
-                    new Dimension(GridSizeMode.Absolute, 100),
-                    new Dimension(GridSizeMode.Absolute, 150)
-                };
-            });
-
-            AddStep("3x3-cell (relative)", () =>
-            {
-                reset();
-                grid.Content = new[]
-                {
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
-                };
-
-                grid.RowDimensions = grid.ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Relative, 0.1f),
-                    new Dimension(GridSizeMode.Relative, 0.2f),
-                    new Dimension(GridSizeMode.Relative, 0.3f)
-                };
-            });
-
-            AddStep("3x3-cell (mixed)", () =>
-            {
-                reset();
-                grid.Content = new[]
-                {
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
-                };
-
-                grid.RowDimensions = grid.ColumnDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Absolute, 50),
-                    new Dimension(GridSizeMode.Relative, 0.2f)
-                };
-            });
-
-            AddStep("Larger sides", () =>
-            {
-                reset();
-                grid.Content = new[]
-                {
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
-                };
-
-                grid.ColumnDimensions = grid.RowDimensions = new[]
-                {
-                    new Dimension(GridSizeMode.Relative, 0.4f),
-                    new Dimension(),
-                    new Dimension(GridSizeMode.Relative, 0.4f)
-                };
-            });
-
-            AddStep("Separated", () =>
-            {
-                reset();
-                grid.Content = new[]
-                {
-                    new Drawable[] { new FillBox(), null, new FillBox() },
+                    new Drawable[] { boxes[0] = new FillBox(), null, boxes[1] = new FillBox(), null },
                     null,
-                    new Drawable[] { new FillBox(), null, new FillBox() }
-                };
-            });
-
-            AddStep("Separated 2", () =>
-            {
-                reset();
-                grid.Content = new[]
-                {
-                    new Drawable[] { new FillBox(), null, new FillBox(), null },
-                    null,
-                    new Drawable[] { new FillBox(), null, new FillBox(), null },
+                    new Drawable[] { boxes[2] = new FillBox(), null, boxes[3] = new FillBox(), null },
                     null
                 };
             });
 
-            AddStep("Nested grids", () =>
+            AddAssert("two extra rows and columns", () =>
             {
-                reset();
+                for (int i = 0; i < 4; i++)
+                {
+                    if (!Precision.AlmostEquals(boxes[i].DrawSize, grid.DrawSize / 4))
+                        return false;
+                }
+
+                return true;
+            });
+        }
+
+        [Test]
+        public void TestNestedGrids()
+        {
+            var boxes = new FillBox[4];
+
+            AddStep("set content", () =>
+            {
                 grid.Content = new[]
                 {
+                    new Drawable[]
+                    {
+                        new GridContainer
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Content = new[]
+                            {
+                                new Drawable[] { boxes[0] = new FillBox(), new FillBox(), },
+                                new Drawable[] { new FillBox(), boxes[1] = new FillBox(), },
+                            }
+                        },
+                        new FillBox(),
+                    },
                     new Drawable[]
                     {
                         new FillBox(),
@@ -297,71 +421,51 @@ namespace osu.Framework.Tests.Visual.TestCaseContainerExtensions
                             RelativeSizeAxes = Axes.Both,
                             Content = new[]
                             {
-                                new Drawable[] { new FillBox(), new FillBox() },
-                                new Drawable[]
-                                {
-                                    new FillBox(),
-                                    new GridContainer
-                                    {
-                                        RelativeSizeAxes = Axes.Both,
-                                        Content = new[]
-                                        {
-                                            new Drawable[] { new FillBox(), new FillBox() },
-                                            new Drawable[] { new FillBox(), new FillBox() }
-                                        }
-                                    }
-                                }
+                                new Drawable[] { boxes[2] = new FillBox(), new FillBox(), },
+                                new Drawable[] { new FillBox(), boxes[3] = new FillBox(), },
                             }
-                        },
-                        new FillBox()
-                    }
+                        }
+                    },
                 };
             });
 
-            AddStep("Auto size", () =>
+            for (int i = 0; i < 4; i++)
             {
-                reset();
-                grid.Content = new[]
-                {
-                    new Drawable[] { new Box { Size = new Vector2(30) }, new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() },
-                    new Drawable[] { new FillBox(), new FillBox(), new FillBox() }
-                };
+                int local = i;
+                AddAssert($"box {local} has correct size", () => Precision.AlmostEquals(boxes[local].DrawSize, grid.DrawSize / 4));
+            }
+        }
 
-                grid.RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize), new Dimension(GridSizeMode.Relative, 0.5f) };
-                grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.AutoSize), new Dimension(GridSizeMode.Relative, 0.5f) };
-            });
+        [Test]
+        public void TestGridWithAutoSizingCells()
+        {
+            FillBox fillBox = null;
+            var autoSizingChildren = new Drawable[2];
 
-            AddStep("Autosizing child", () =>
+            AddStep("set content", () =>
             {
-                reset();
-
-                Drawable child1, child2;
-
                 grid.Content = new[]
                 {
                     new[]
                     {
-                        child1 = new Container
+                        autoSizingChildren[0] = new Box
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            AutoSizeAxes = Axes.Both,
-                            Child = new Box { Size = new Vector2(100, 50) }
+                            Size = new Vector2(50, 10)
                         },
-                        new FillBox()
+                        fillBox = new FillBox(),
                     },
                     new[]
                     {
                         null,
-                        child2 = new Container
+                        autoSizingChildren[1] = new Box
                         {
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
-                            AutoSizeAxes = Axes.Both,
-                            Child = new Box { Size = new Vector2(100, 50) }
+                            Size = new Vector2(50, 10)
                         },
-                    }
+                    },
                 };
 
                 grid.ColumnDimensions = new[] { new Dimension(GridSizeMode.AutoSize) };
@@ -370,20 +474,30 @@ namespace osu.Framework.Tests.Visual.TestCaseContainerExtensions
                     new Dimension(),
                     new Dimension(GridSizeMode.AutoSize),
                 };
-
-                SchedulerAfterChildren.Add(() =>
-                {
-                    child1.Spin(3000, RotationDirection.Clockwise);
-                    child2.Spin(3000, RotationDirection.Clockwise);
-                });
             });
+
+            AddAssert("fill box has correct size", () => Precision.AlmostEquals(fillBox.DrawSize, new Vector2(grid.DrawWidth - 50, grid.DrawHeight - 10)));
+            AddStep("rotate boxes", () => autoSizingChildren.ForEach(c => c.RotateTo(90)));
+            AddAssert("fill box has resized correctly", () => Precision.AlmostEquals(fillBox.DrawSize, new Vector2(grid.DrawWidth - 10, grid.DrawHeight - 50)));
         }
 
-        private void reset()
+        private void setSingleDimensionContent(Func<Drawable[][]> contentFunc, Dimension[] dimensions = null, bool row = false) => AddStep("set content", () =>
         {
-            grid.ClearInternal();
-            grid.RowDimensions = grid.ColumnDimensions = new Dimension[] { };
-        }
+            var content = contentFunc();
+
+            if (!row)
+                content = content.Invert();
+
+            grid.Content = content;
+
+            if (dimensions == null)
+                return;
+
+            if (row)
+                grid.RowDimensions = dimensions;
+            else
+                grid.ColumnDimensions = dimensions;
+        });
 
         private class FillBox : Box
         {

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -151,6 +151,35 @@ namespace osu.Framework.Extensions
             return rectangular;
         }
 
+        /// <summary>
+        /// Inverts the rows and columns of a rectangular array.
+        /// </summary>
+        /// <param name="array">The array to invert.</param>
+        /// <returns>The inverted array.</returns>
+        public static T[,] Invert<T>(this T[,] array)
+        {
+            if (array == null)
+                return null;
+
+            int rows = array.GetLength(0);
+            int cols = array.GetLength(1);
+
+            var result = new T[cols, rows];
+
+            for (int r = 0; r < rows; r++)
+            for (int c = 0; c < cols; c++)
+                result[c, r] = array[r, c];
+
+            return result;
+        }
+
+        /// <summary>
+        /// Inverts the rows and columns of a jagged array.
+        /// </summary>
+        /// <param name="array">The array to invert.</param>
+        /// <returns>The inverted array. This is always a square array.</returns>
+        public static T[][] Invert<T>(this T[][] array) => array.ToRectangular().Invert().ToJagged();
+
         public static string ToResolutionString(this Size size)
         {
             return size.Width.ToString() + 'x' + size.Height;

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -91,7 +91,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
         {
-            if ((invalidation & Invalidation.RequiredParentSizeToFit | Invalidation.Presence) > 0)
+            if ((invalidation & (Invalidation.RequiredParentSizeToFit | Invalidation.Presence)) > 0)
                 cellLayout.Invalidate();
 
             base.InvalidateFromChild(invalidation, source);

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -15,6 +15,7 @@ namespace osu.Framework.Graphics.Containers
     public class GridContainer : CompositeDrawable
     {
         private Drawable[][] content;
+
         /// <summary>
         /// The content of this <see cref="GridContainer"/>, arranged in a 2D grid array, where each array
         /// of <see cref="Drawable"/>s represents a row and each element of that array represents a column.
@@ -29,6 +30,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 if (content == value)
                     return;
+
                 content = value;
 
                 cellContent.Invalidate();
@@ -36,6 +38,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         private Dimension[] rowDimensions;
+
         /// <summary>
         /// Explicit dimensions for rows. Each index of this array applies to the respective row index inside <see cref="Content"/>.
         /// </summary>
@@ -45,6 +48,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 if (rowDimensions == value)
                     return;
+
                 rowDimensions = value;
 
                 cellLayout.Invalidate();
@@ -52,6 +56,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         private Dimension[] columnDimensions;
+
         /// <summary>
         /// Explicit dimensions for columns. Each index of this array applies to the respective column index inside <see cref="Content"/>.
         /// </summary>
@@ -61,6 +66,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 if (columnDimensions == value)
                     return;
+
                 columnDimensions = value;
 
                 cellLayout.Invalidate();
@@ -127,29 +133,29 @@ namespace osu.Framework.Graphics.Containers
             // Create the new cell containers and add content
             cells = new CellContainer[requiredRows, requiredColumns];
             for (int r = 0; r < cellRows; r++)
-                for (int c = 0; c < cellColumns; c++)
-                {
-                    // Add cell
-                    cells[r, c] = new CellContainer();
+            for (int c = 0; c < cellColumns; c++)
+            {
+                // Add cell
+                cells[r, c] = new CellContainer();
 
-                    // Allow empty rows
-                    if (Content[r] == null)
-                        continue;
+                // Allow empty rows
+                if (Content[r] == null)
+                    continue;
 
-                    // Allow non-square grids
-                    if (c >= Content[r].Length)
-                        continue;
+                // Allow non-square grids
+                if (c >= Content[r].Length)
+                    continue;
 
-                    // Allow empty cells
-                    if (Content[r][c] == null)
-                        continue;
+                // Allow empty cells
+                if (Content[r][c] == null)
+                    continue;
 
-                    // Add content
-                    cells[r, c].Add(Content[r][c]);
-                    cells[r, c].Depth = Content[r][c].Depth;
+                // Add content
+                cells[r, c].Add(Content[r][c]);
+                cells[r, c].Depth = Content[r][c].Depth;
 
-                    AddInternal(cells[r, c]);
-                }
+                AddInternal(cells[r, c]);
+            }
 
             cellContent.Validate();
         }
@@ -259,18 +265,18 @@ namespace osu.Framework.Graphics.Containers
 
             // Add size to distributed columns/rows and add adjust cell positions
             for (int r = 0; r < cellRows; r++)
-                for (int c = 0; c < cellColumns; c++)
-                {
-                    if (cells[r, c].DistributedWidth)
-                        cells[r, c].Width = distributedSize.X;
-                    if (cells[r, c].DistributedHeight)
-                        cells[r, c].Height = distributedSize.Y;
+            for (int c = 0; c < cellColumns; c++)
+            {
+                if (cells[r, c].DistributedWidth)
+                    cells[r, c].Width = distributedSize.X;
+                if (cells[r, c].DistributedHeight)
+                    cells[r, c].Height = distributedSize.Y;
 
-                    if (c > 0)
-                        cells[r, c].X = cells[r, c - 1].X + cells[r, c - 1].Width;
-                    if (r > 0)
-                        cells[r, c].Y = cells[r - 1, c].Y + cells[r - 1, c].Height;
-                }
+                if (c > 0)
+                    cells[r, c].X = cells[r, c - 1].X + cells[r, c - 1].Width;
+                if (r > 0)
+                    cells[r, c].Y = cells[r - 1, c].Y + cells[r - 1, c].Height;
+            }
 
             cellLayout.Validate();
         }
@@ -334,14 +340,17 @@ namespace osu.Framework.Graphics.Containers
         /// other elements which use <see cref="GridSizeMode.Distributed"/>.
         /// </summary>
         Distributed,
+
         /// <summary>
         /// This element should be sized relative to the dimensions of the <see cref="GridContainer"/>.
         /// </summary>
         Relative,
+
         /// <summary>
         /// This element has a size independent of the <see cref="GridContainer"/>.
         /// </summary>
         Absolute,
+
         /// <summary>
         /// This element will be sized to the maximum size along its span.
         /// </summary>

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Dimension[] rowDimensions;
+        private Dimension[] rowDimensions = Array.Empty<Dimension>();
 
         /// <summary>
         /// Explicit dimensions for rows. Each index of this array applies to the respective row index inside <see cref="Content"/>.
@@ -46,6 +46,9 @@ namespace osu.Framework.Graphics.Containers
         {
             set
             {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(RowDimensions));
+
                 if (rowDimensions == value)
                     return;
 
@@ -55,7 +58,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Dimension[] columnDimensions;
+        private Dimension[] columnDimensions = Array.Empty<Dimension>();
 
         /// <summary>
         /// Explicit dimensions for columns. Each index of this array applies to the respective column index inside <see cref="Content"/>.
@@ -64,6 +67,9 @@ namespace osu.Framework.Graphics.Containers
         {
             set
             {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(ColumnDimensions));
+
                 if (columnDimensions == value)
                     return;
 


### PR DESCRIPTION
A lot of GridContainer layout code was duplicated for the x and y dimensions, leading to difficulties when extra logic is required.

I've refactored it so that the only places where code is duplicated is when properties are written to drawables, which is axis-dependent.

Alongside that, I've rewritten `TestCaseGridContainer` to be automated.