### PR TITLE
Fix `GameWindow.IsActive` and on-screen keyboard for Android

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -24,6 +24,8 @@ namespace osu.Framework.Android
             Window = new AndroidGameWindow();
         }
 
+        public override bool OnScreenKeyboardOverlapsGameWindow => true;
+
         public override ITextInputSource GetTextInput()
             => new AndroidTextInput(gameView);
 

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -32,6 +32,8 @@ namespace osu.Framework.Android
         {
             // Let's just say the cursor is always in the window.
             CursorInWindow = true;
+            // And the window is always active.
+            SetActive(true);
         }
 
         protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new WindowMode[]

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -70,6 +70,11 @@ namespace osu.Framework.Platform
         public IBindable<bool> IsActive => isActive;
 
         /// <summary>
+        /// Set the value of IsActive property.
+        /// </summary>
+        protected void SetActive(bool val) => isActive.Value = val;
+
+        /// <summary>
         /// Creates a <see cref="GameWindow"/> with a given <see cref="IGameWindow"/> implementation.
         /// </summary>
         protected GameWindow([NotNull] IGameWindow implementation)


### PR DESCRIPTION
`GameWindow.IsActive` is always `false` on Android when `AndroidGameWindow` overrided `Focused` to be `true`.

https://github.com/ppy/osu-framework/blob/dd8d1136cb386aea8b7a6fe5db5af6dfd3458fb9/osu.Framework.Android/AndroidGameWindow.cs#L19

Overriding `Focused` property doesn't work for Android but do work for iOS:

https://github.com/ppy/osu-framework/blob/dd8d1136cb386aea8b7a6fe5db5af6dfd3458fb9/osu.Framework.iOS/IOSGameWindow.cs#L30

I guess it's because some events (used to update `IsActive`) never get raised on Android, like this one:

https://github.com/ppy/osu-framework/blob/dd8d1136cb386aea8b7a6fe5db5af6dfd3458fb9/osu.Framework/Platform/GameWindow.cs#L86

So I just make `IsActive` default to true on Android.