### PR TITLE
Fix TextFlowContainer not laying out correctly

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestCaseTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestCaseTextFlowContainer.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
 using NUnit.Framework;

--- a/osu.Framework.Tests/Visual/Containers/TestCaseTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestCaseTextFlowContainer.cs
@@ -65,5 +65,13 @@ namespace osu.Framework.Tests.Visual.Containers
                 return result == default_text;
             });
         }
+
+        [Test]
+        public void TestAddTextWithTextAnchor()
+        {
+            AddStep("change text anchor", () => textContainer.TextAnchor = Anchor.TopCentre);
+            AddStep("add text", () => textContainer.AddText("added text"));
+            AddAssert("children have correct anchors", () => textContainer.Children.All(c => c.Anchor == Anchor.TopCentre && c.Origin == Anchor.TopCentre));
+        }
     }
 }

--- a/osu.Framework.Tests/Visual/Containers/TestCaseTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestCaseTextFlowContainer.cs
@@ -1,0 +1,69 @@
+// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    public class TestCaseTextFlowContainer : TestCase
+    {
+        private const string default_text = "Default text";
+
+        private TextFlowContainer textContainer;
+
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            Child = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Width = 300,
+                AutoSizeAxes = Axes.Y,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.White.Opacity(0.1f)
+                    },
+                    textContainer = new TextFlowContainer
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Text = default_text
+                    }
+                }
+            };
+        });
+
+        [TestCase(Anchor.TopLeft)]
+        [TestCase(Anchor.TopCentre)]
+        [TestCase(Anchor.TopRight)]
+        [TestCase(Anchor.BottomLeft)]
+        [TestCase(Anchor.BottomCentre)]
+        [TestCase(Anchor.BottomRight)]
+        public void TestChangeTextAnchor(Anchor anchor)
+        {
+            AddStep("change text anchor", () => textContainer.TextAnchor = anchor);
+            AddAssert("children have correct anchors", () => textContainer.Children.All(c => c.Anchor == anchor && c.Origin == anchor));
+            AddAssert("children are in correct order", () =>
+            {
+                var children = textContainer.FlowingChildren.OfType<SpriteText>().Select(c => c.Text);
+
+                if ((anchor & Anchor.x2) > 0)
+                    children = children.Reverse();
+
+                return children.Aggregate((cur, next) => cur + next) == default_text;
+            });
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Containers/TestCaseTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestCaseTextFlowContainer.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Tests.Visual.Containers
 {
     public class TestCaseTextFlowContainer : TestCase
     {
-        private const string default_text = "Default text";
+        private const string default_text = "Default text\n\nnewline";
 
         private TextFlowContainer textContainer;
 
@@ -55,14 +55,14 @@ namespace osu.Framework.Tests.Visual.Containers
         {
             AddStep("change text anchor", () => textContainer.TextAnchor = anchor);
             AddAssert("children have correct anchors", () => textContainer.Children.All(c => c.Anchor == anchor && c.Origin == anchor));
-            AddAssert("children are in correct order", () =>
+            AddAssert("children are positioned correctly", () =>
             {
-                var children = textContainer.FlowingChildren.OfType<SpriteText>().Select(c => c.Text);
+                var result = textContainer.Children
+                                          .OrderBy(c => c.ScreenSpaceDrawQuad.TopLeft.Y).ThenBy(c => c is TextFlowContainer.NewLineContainer ? 0 : c.ScreenSpaceDrawQuad.TopLeft.X)
+                                          .Select(c => (c as SpriteText)?.Text.ToString() ?? "\n")
+                                          .Aggregate((cur, next) => cur + next);
 
-                if ((anchor & Anchor.x2) > 0)
-                    children = children.Reverse();
-
-                return children.Aggregate((cur, next) => cur + next) == default_text;
+                return result == default_text;
             });
         }
     }

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -41,10 +41,6 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Cached layout = new Cached();
-
-        protected void InvalidateLayout() => layout.Invalidate();
-
         private Vector2 maximumSize;
 
         /// <summary>
@@ -63,7 +59,14 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        private Cached layout = new Cached();
+
         protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate || !layout.IsValid;
+
+        /// <summary>
+        /// Invoked when layout should be invalidated.
+        /// </summary>
+        protected virtual void InvalidateLayout() => layout.Invalidate();
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -87,6 +87,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         private Anchor textAnchor = Anchor.TopLeft;
+
         /// <summary>
         /// The <see cref="Anchor"/> which text should flow from.
         /// </summary>
@@ -99,9 +100,8 @@ namespace osu.Framework.Graphics.Containers
                     return;
                 textAnchor = value;
 
-                // Todo: This is temporary for now because we don't have an easy way to re-flow the container...
-                if (IsLoaded)
-                    throw new InvalidOperationException($"{nameof(TextAnchor)} may not change after the {nameof(TextFlowContainer)} is loaded.");
+                layout.Invalidate();
+                InvalidateLayout();
             }
         }
 

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -127,13 +127,13 @@ namespace osu.Framework.Graphics.Containers
 
         protected override void UpdateAfterChildren()
         {
-            base.UpdateAfterChildren();
-
             if (!layout.IsValid)
             {
                 computeLayout();
                 layout.Validate();
             }
+
+            base.UpdateAfterChildren();
         }
 
         protected override int Compare(Drawable x, Drawable y)

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -106,7 +106,6 @@ namespace osu.Framework.Graphics.Containers
                 textAnchor = value;
 
                 layout.Invalidate();
-                InvalidateLayout();
             }
         }
 
@@ -123,11 +122,10 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
+        protected override void InvalidateLayout()
         {
-            if ((invalidation & Invalidation.DrawSize) > 0)
-                layout.Invalidate();
-            return base.Invalidate(invalidation, source, shallPropagate);
+            base.InvalidateLayout();
+            layout.Invalidate();
         }
 
         public override IEnumerable<Drawable> FlowingChildren

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -18,6 +18,11 @@ namespace osu.Framework.Graphics.Containers
         private float firstLineIndent;
         private readonly Action<SpriteText> defaultCreationParameters;
 
+        public TextFlowContainer(Action<SpriteText> defaultCreationParameters = null)
+        {
+            this.defaultCreationParameters = defaultCreationParameters;
+        }
+
         /// <summary>
         /// An indent value for the first (header) line of a paragraph.
         /// </summary>
@@ -125,6 +130,11 @@ namespace osu.Framework.Graphics.Containers
             return base.Invalidate(invalidation, source, shallPropagate);
         }
 
+        public override IEnumerable<Drawable> FlowingChildren
+            => (TextAnchor & Anchor.x2) > 0
+                ? base.FlowingChildren.Reverse() // When displaying backwards, children order needs to be reversed
+                : base.FlowingChildren;
+
         protected override void UpdateAfterChildren()
         {
             if (!layout.IsValid)
@@ -184,11 +194,6 @@ namespace osu.Framework.Graphics.Containers
         /// End current paragraph and start a new one.
         /// </summary>
         public void NewParagraph() => base.Add(new NewLineContainer(true));
-
-        public TextFlowContainer(Action<SpriteText> defaultCreationParameters = null)
-        {
-            this.defaultCreationParameters = defaultCreationParameters;
-        }
 
         protected virtual SpriteText CreateSpriteText() => new SpriteText();
 


### PR DESCRIPTION
1. Fixes using x2/y2 anchors inverting the displayed words (e.g. `SOME TEXT` -> `TEXTSOME `).
2. Makes `TextAnchor` changeable post-load.
3. Fixes layout not being invalidated when children are added/removed/cleared/expired/etc.

Fixes issues presented in https://github.com/ppy/osu/pull/4467