### PR TITLE
Add non-immediate suspend support and fix many sanity issues with screens

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -258,6 +258,29 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddAssert("screen1 registered suspend", () => screen1.SuspendedTo == screen2);
             AddAssert("screen2 registered entered", () => screen2.EnteredFrom == screen1);
+        }
+
+        [Test]
+        public void TestAsyncPushWithNonImmediateSuspend()
+        {
+            AddStep("override stack", () =>
+            {
+                // we can't use the [SetUp] screen stack as we need to change the ctor parameters.
+                Clear();
+                Add(stack = new ScreenStack(baseScreen = new TestScreen(), suspendImmediately: false)
+                {
+                    RelativeSizeAxes = Axes.Both
+                });
+            });
+
+            TestScreenSlow screen1 = null;
+
+            AddStep("push slow", () => baseScreen.Push(screen1 = new TestScreenSlow()));
+            AddAssert("base screen not yet registered suspend", () => baseScreen.SuspendedTo == null);
+            AddAssert("ensure notcurrent", () => !screen1.IsCurrentScreen());
+            AddStep("allow load", () => screen1.AllowLoad = true);
+            AddUntilStep(() => screen1.IsCurrentScreen(), "ensure current");
+            AddAssert("base screen registered suspend", () => baseScreen.SuspendedTo == screen1);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -219,19 +219,19 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestEventOrder()
         {
-            int order = 0;
+            List<int> order = new List<int>();
 
             var screen1 = new TestScreen
             {
-                Entered = () => Assert.AreEqual(1, Interlocked.Increment(ref order)),
-                Suspended = () => Assert.AreEqual(2, Interlocked.Increment(ref order)),
-                Exited = () => Assert.AreEqual(5, Interlocked.Increment(ref order)),
+                Entered = () => order.Add(1),
+                Suspended = () => order.Add(2),
+                Resumed = () => order.Add(5),
             };
 
             var screen2 = new TestScreen
             {
-                Entered = () => Assert.AreEqual(3, Interlocked.Increment(ref order)),
-                Exited = () => Assert.AreEqual(4, Interlocked.Increment(ref order)),
+                Entered = () => order.Add(3),
+                Exited = () => order.Add(4),
             };
 
             AddStep("push screen1", () => stack.Push(screen1));
@@ -248,6 +248,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep("push screen2", () => screen1.Exit());
             AddUntilStep(() => !screen1.IsCurrentScreen(), "ensure exited");
+
+            AddAssert("order is correct", () => order.SequenceEqual(order.OrderBy(i => i)));
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -208,6 +208,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestPushToNonLoadedScreenFails()
+        {
+            TestScreenSlow screen1 = null;
+
+            AddStep("push slow", () => stack.Push(screen1 = new TestScreenSlow()));
+            AddStep("push second slow", () => Assert.Throws<InvalidOperationException>(() => screen1.Push(new TestScreenSlow())));
+        }
+
+        [Test]
         public void TestMakeCurrent()
         {
             TestScreen screen1 = null;

--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Screens
         /// <param name="screen">The <see cref="IScreen"/> to push to.</param>
         /// <param name="newScreen">The <see cref="IScreen"/> to push.</param>
         public static void Push(this IScreen screen, IScreen newScreen)
-            => runOnRoot(screen, stack => stack.Push(screen, newScreen));
+            => runOnRoot(screen, stack => stack.Push(screen, newScreen), () => throw new InvalidOperationException($"Cannot {nameof(Push)} to a non-loaded {nameof(IScreen)} directly. Consider using {nameof(ScreenStack.Push)} instead."));
 
         /// <summary>
         /// Exits from an <see cref="IScreen"/>.

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -139,7 +139,7 @@ namespace osu.Framework.Screens
                 else
                 {
                     // Screens only receive OnEntering() upon load completion, so OnSuspending() should be delayed until after that
-                    sourceDrawable.OnLoadComplete = _ => performSuspend();
+                    sourceDrawable.OnLoadComplete += _ => performSuspend();
                 }
 
                 void performSuspend()

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -128,8 +128,13 @@ namespace osu.Framework.Screens
 
             void suspend()
             {
-                source?.OnSuspending(newScreen);
-                source?.AsDrawable().Expire();
+                var sourceDrawable = source?.AsDrawable();
+
+                sourceDrawable?.Schedule(() =>
+                {
+                    source.OnSuspending(newScreen);
+                    sourceDrawable.Expire();
+                });
             }
         }
 

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -144,7 +144,12 @@ namespace osu.Framework.Screens
             if (toLoad.LoadState >= LoadState.Ready)
                 continuation?.Invoke();
             else
-                loader.LoadComponentAsync(toLoad, _ => continuation?.Invoke(), scheduler: Scheduler);
+            {
+                if (loader.LoadState >= LoadState.Loaded)
+                    loader.LoadComponentAsync(toLoad, _ => continuation?.Invoke(), scheduler: Scheduler);
+                else
+                    Schedule(() => LoadScreen(loader, toLoad, continuation));
+            }
         }
 
         internal void Exit(IScreen source)

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -104,10 +104,12 @@ namespace osu.Framework.Screens
             stack.Push(newScreen);
             ScreenPushed?.Invoke(source, newScreen);
 
+            var newScreenDrawable = newScreen.AsDrawable();
+
             if (source != null)
-                LoadScreen((CompositeDrawable)source, newScreen.AsDrawable(), finishLoad);
+                LoadScreen((CompositeDrawable)source, newScreenDrawable, finishLoad);
             else if (LoadState >= LoadState.Ready)
-                LoadScreen(this, newScreen.AsDrawable(), finishLoad);
+                LoadScreen(this, newScreenDrawable, finishLoad);
             else
                 Schedule(finishLoad);
 
@@ -122,8 +124,8 @@ namespace osu.Framework.Screens
                     return;
                 }
 
-                AddInternal(newScreen.AsDrawable());
-                newScreen.OnEntering(source);
+                newScreenDrawable.OnLoadComplete = _ => newScreen.OnEntering(source);
+                AddInternal(newScreenDrawable);
             }
 
             void suspend()
@@ -150,7 +152,7 @@ namespace osu.Framework.Screens
                 continuation?.Invoke();
             else
             {
-                if (loader.LoadState >= LoadState.Loaded)
+                if (loader.LoadState >= LoadState.Ready)
                     loader.LoadComponentAsync(toLoad, _ => continuation?.Invoke(), scheduler: Scheduler);
                 else
                     Schedule(() => LoadScreen(loader, toLoad, continuation));

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Screens
 
                 if (!newScreen.ValidForPush)
                 {
-                    exitFrom(null);
+                    exitFrom(null, shouldFireEvent: false);
                     return;
                 }
 
@@ -197,7 +197,8 @@ namespace osu.Framework.Screens
         /// </summary>
         /// <param name="source">The <see cref="IScreen"/> which last exited.</param>
         /// <param name="onExiting">An action that is invoked when the current screen allows the exit to continue.</param>
-        private void exitFrom([CanBeNull] IScreen source, Action onExiting = null)
+        /// <param name="shouldFireEvent">Whether <see cref="IScreen.OnExiting"/> should be fired on the exiting screen.</param>
+        private void exitFrom([CanBeNull] IScreen source, Action onExiting = null, bool shouldFireEvent = true)
         {
             if (stack.Count == 0)
                 return;
@@ -206,7 +207,7 @@ namespace osu.Framework.Screens
             var toExit = stack.Pop();
 
             // The next current screen will be resumed
-            if (toExit.OnExiting(CurrentScreen))
+            if (shouldFireEvent && toExit.OnExiting(CurrentScreen))
             {
                 stack.Push(toExit);
                 return;

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -124,19 +124,29 @@ namespace osu.Framework.Screens
                     return;
                 }
 
-                newScreenDrawable.OnLoadComplete = _ => newScreen.OnEntering(source);
                 AddInternal(newScreenDrawable);
+                newScreen.OnEntering(source);
             }
 
             void suspend()
             {
                 var sourceDrawable = source?.AsDrawable();
+                if (sourceDrawable == null)
+                    return;
 
-                sourceDrawable?.Schedule(() =>
+                if (sourceDrawable.IsLoaded)
+                    performSuspend();
+                else
+                {
+                    // Screens only receive OnEntering() upon load completion, so OnSuspending() should be delayed until after that
+                    sourceDrawable.OnLoadComplete = _ => performSuspend();
+                }
+
+                void performSuspend()
                 {
                     source.OnSuspending(newScreen);
                     sourceDrawable.Expire();
-                });
+                }
             }
         }
 


### PR DESCRIPTION
Basic purpose here was to allow a `ScreenStack` to not fire `OnSuspend` until the next screen is ready to call `OnEntering`. This may be preferred for certain scenarios to create fluid transitions.

Required for https://github.com/ppy/osu/pull/4455.

Going forward we may want to add a new event for the beginning of a push occurring (`OnNextScreenLoading` or something like that) to allow for loading screens/states.

This also fixes quite a few issues with `Screen`/`ScreenStack`, and adds extensive testing. I tried to split these out into individual PRs but the logic is too intertwined. If necessary I'll give it another go.

Fixed:
- `TestScreenSlow` now uses a flag rather than `Thread.Sleep` to load "slow".
- Pushing to a non-loaded screen now throws an exception. This was undefined behaviour previously and could lead to many weird scenarios.
- Fixes a possible case where `OnSuspending` could be fired before `OnResuming`.
- Fixes `OnExiting` being fired on screens which never received `OnEntering` (due to exiting during load, for example).
- Fixes crashes when pushing a screen to the stack when the previously pushed screen is still in a loading state. Now it will queue the next screen ahead of the previous one.