### PR TITLE
Ensure public actions specify the event keyword

### DIFF
--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownImage.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownImage.cs
@@ -30,10 +30,12 @@ namespace osu.Framework.Graphics.Containers.Markdown
             InternalChild = new DelayedLoadWrapper(CreateImageContainer(url));
         }
 
-        protected virtual ImageContainer CreateImageContainer(string url) => new ImageContainer(url)
+        protected virtual ImageContainer CreateImageContainer(string url)
         {
-            OnLoadComplete = d => d.FadeInFromZero(300, Easing.OutQuint)
-        };
+            var converter = new ImageContainer(url);
+            converter.OnLoadComplete += d => d.FadeInFromZero(300, Easing.OutQuint);
+            return converter;
+        }
 
         protected class ImageContainer : CompositeDrawable
         {

--- a/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
+++ b/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
@@ -121,7 +121,7 @@ namespace osu.Framework.Graphics.Containers
                 replaceDrawable(DisplayedDrawable, placeholder, true);
             }
 
-            nextDrawable.OnLoadComplete = loadedDrawable =>
+            nextDrawable.OnLoadComplete += loadedDrawable =>
             {
                 if (loadedDrawable != nextDrawable)
                 {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -358,14 +358,15 @@ namespace osu.Framework.Graphics
         /// <see cref="UpdateSubTree"/>. It should be used when a simple action should be performed
         /// at the end of every update call which does not warrant overriding the Drawable.
         /// </summary>
-        public Action<Drawable> OnUpdate;
+        public event Action<Drawable> OnUpdate;
 
         /// <summary>
         /// This event is fired after the <see cref="LoadComplete"/> method is called.
         /// It should be used when a simple action should be performed
         /// when the Drawable is loaded which does not warrant overriding the Drawable.
+        /// This event is automatically cleared after being invoked.
         /// </summary>
-        public Action<Drawable> OnLoadComplete;
+        public event Action<Drawable> OnLoadComplete;
 
         /// <summary>.
         /// Fired after the <see cref="Invalidate(Invalidation, Drawable, bool)"/> method is called.

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -404,7 +404,7 @@ namespace osu.Framework.Testing
                 OnCaughtError = compileFailed
             });
 
-            newTest.OnLoadComplete = d => Schedule(() =>
+            newTest.OnLoadComplete += d => Schedule(() =>
             {
                 if (lastTest?.Parent != null)
                 {


### PR DESCRIPTION
This protects against bindings being overwritten.

Note that there are many other places we should be doing this, but I didn't want to break too much at once. On a quick check, these drawable ones are the important cases where a user could potentially overwrite framework-internal bindings. If/when we get object-initializer-inline event bindings, we should efinitely switch all remaining cases across (https://github.com/dotnet/csharplang/issues/307).

Closes #2250.