### PR TITLE
Fix various Scheduler failure cases

### DIFF
--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -1,5 +1,5 @@
-// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
-// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
 
 using System;
 using System.Threading;

--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -1,0 +1,237 @@
+// Copyright (c) 2007-2019 ppy Pty Ltd <contact@ppy.sh>.
+// Licensed under the MIT Licence - https://raw.githubusercontent.com/ppy/osu-framework/master/LICENCE
+
+using System;
+using System.Threading;
+using NUnit.Framework;
+using osu.Framework.Threading;
+using osu.Framework.Timing;
+
+namespace osu.Framework.Tests.Threading
+{
+    [TestFixture]
+    public class SchedulerTest
+    {
+        private Scheduler scheduler;
+
+        [SetUp]
+        public void Setup()
+        {
+            scheduler = new Scheduler(new Thread(() => { }));
+        }
+
+        [Test]
+        public void TestScheduleOnce([Values(false, true)] bool fromMainThread, [Values(false, true)] bool forceScheduled)
+        {
+            if (fromMainThread)
+                scheduler.SetCurrentThread(Thread.CurrentThread);
+
+            int invocations = 0;
+
+            scheduler.Add(() => invocations++, forceScheduled);
+
+            if (fromMainThread && !forceScheduled)
+                Assert.AreEqual(1, invocations);
+            else
+                Assert.AreEqual(0, invocations);
+
+            scheduler.Update();
+            Assert.AreEqual(1, invocations);
+
+            // Ensures that the delegate runs only once in the scheduled/not on main thread branch
+            scheduler.Update();
+            Assert.AreEqual(1, invocations);
+        }
+
+        [Test]
+        public void TestCancelScheduledDelegate()
+        {
+            int invocations = 0;
+
+            ScheduledDelegate del;
+            scheduler.Add(del = new ScheduledDelegate(() => invocations++));
+
+            del.Cancel();
+
+            scheduler.Update();
+            Assert.AreEqual(0, invocations);
+        }
+
+        [Test]
+        public void TestAddCancelledDelegate()
+        {
+            int invocations = 0;
+
+            ScheduledDelegate del = new ScheduledDelegate(() => invocations++);
+            del.Cancel();
+
+            scheduler.Add(del);
+
+            scheduler.Update();
+            Assert.AreEqual(0, invocations);
+        }
+
+        [Test]
+        public void TestCustomScheduledDelegateRunsOnce()
+        {
+            int invocations = 0;
+
+            scheduler.Add(new ScheduledDelegate(() => invocations++));
+
+            scheduler.Update();
+            Assert.AreEqual(1, invocations);
+
+            scheduler.Update();
+            Assert.AreEqual(1, invocations);
+        }
+
+        [Test]
+        public void TestDelayedDelegatesAreScheduledWithCorrectTime()
+        {
+            var clock = new StopwatchClock();
+            scheduler.UpdateClock(clock);
+
+            ScheduledDelegate del = scheduler.AddDelayed(() => { }, 1000);
+
+            Assert.AreEqual(1000, del.ExecutionTime);
+
+            clock.Seek(500);
+            del = scheduler.AddDelayed(() => { }, 1000);
+
+            Assert.AreEqual(1500, del.ExecutionTime);
+        }
+
+        [Test]
+        public void TestDelayedDelegateDoesNotRunUntilExpectedTime()
+        {
+            var clock = new StopwatchClock();
+            scheduler.UpdateClock(clock);
+
+            int invocations = 0;
+
+            scheduler.AddDelayed(() => invocations++, 1000);
+
+            clock.Seek(1000);
+            scheduler.AddDelayed(() => invocations++, 1000);
+
+            for (double d = 0; d <= 2500; d += 100)
+            {
+                clock.Seek(d);
+                scheduler.Update();
+
+                int expectedInvocations = 0;
+
+                if (d >= 1000)
+                    expectedInvocations++;
+                if (d >= 2000)
+                    expectedInvocations++;
+
+                Assert.AreEqual(expectedInvocations, invocations);
+            }
+        }
+
+        [Test]
+        public void TestCancelDelayedDelegate()
+        {
+            var clock = new StopwatchClock();
+            scheduler.UpdateClock(clock);
+
+            int invocations = 0;
+
+            ScheduledDelegate del;
+            scheduler.Add(del = new ScheduledDelegate(() => invocations++, 1000));
+            del.Cancel();
+
+            clock.Seek(1500);
+            scheduler.Update();
+            Assert.AreEqual(0, invocations);
+        }
+
+        [Test]
+        public void TestRepeatingDelayedDelegate()
+        {
+            var clock = new StopwatchClock();
+            scheduler.UpdateClock(clock);
+
+            int invocations = 0;
+
+            scheduler.Add(new ScheduledDelegate(() => invocations++, 500, 500));
+            scheduler.Add(new ScheduledDelegate(() => invocations++, 1000, 500));
+
+            for (double d = 0; d <= 2500; d += 100)
+            {
+                clock.Seek(d);
+                scheduler.Update();
+
+                int expectedInvocations = 0;
+
+                if (d >= 500)
+                    expectedInvocations += 1 + (int)((d - 500) / 500);
+                if (d >= 1000)
+                    expectedInvocations += 1 + (int)((d - 1000) / 500);
+
+                Assert.AreEqual(expectedInvocations, invocations);
+            }
+        }
+
+        [Test]
+        public void TestCancelAfterRepeatReschedule()
+        {
+            var clock = new StopwatchClock();
+            scheduler.UpdateClock(clock);
+
+            int invocations = 0;
+
+            ScheduledDelegate del;
+            scheduler.Add(del = new ScheduledDelegate(() => invocations++, 500, 500));
+
+            clock.Seek(750);
+            scheduler.Update();
+            Assert.AreEqual(1, invocations);
+
+            del.Cancel();
+            clock.Seek(1250);
+            scheduler.Update();
+            Assert.AreEqual(1, invocations);
+        }
+
+        [Test]
+        public void TestAddOnce()
+        {
+            int invocations = 0;
+
+            Action action = () => { invocations++; };
+
+            scheduler.AddOnce(action);
+            scheduler.AddOnce(action);
+
+            scheduler.Update();
+            Assert.AreEqual(1, invocations);
+        }
+
+        [Test]
+        public void TestScheduleFromInsideDelegate()
+        {
+            const int max_reschedules = 3;
+
+            int reschedules = 0;
+
+            scheduleTask();
+
+            for (int i = 0; i <= max_reschedules; i++)
+            {
+                scheduler.Update();
+                Assert.AreEqual(Math.Min(max_reschedules, i + 1), reschedules);
+            }
+
+            void scheduleTask() => scheduler.Add(() =>
+            {
+                if (reschedules == max_reschedules)
+                    return;
+
+                scheduleTask();
+                reschedules++;
+            });
+        }
+    }
+}

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -143,15 +143,19 @@ namespace osu.Framework.Threading
                 runQueue.Enqueue(task);
             }
 
+            int countToRun = runQueue.Count;
             int countRun = 0;
 
             while (runQueue.TryDequeue(out ScheduledDelegate sd))
             {
-                if (sd.Cancelled) continue;
+                if (sd.Cancelled)
+                    continue;
 
                 //todo: error handling
                 sd.RunTask();
-                countRun++;
+
+                if (++countRun == countToRun)
+                    break;
             }
 
             return countRun;

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -235,7 +235,7 @@ namespace osu.Framework.Threading
         /// <returns>Whether this is the first queue attempt of this work.</returns>
         public bool AddOnce(Action task)
         {
-            if (runQueue.Any(sd => sd.RunTask == task))
+            if (runQueue.Any(sd => sd.Task == task))
                 return false;
 
             runQueue.Enqueue(new ScheduledDelegate(task));
@@ -246,17 +246,18 @@ namespace osu.Framework.Threading
 
     public class ScheduledDelegate : IComparable<ScheduledDelegate>
     {
-        public ScheduledDelegate(Action task, double executionTime = 0, double repeatInterval = -1)
-        {
-            ExecutionTime = executionTime;
-            RepeatInterval = repeatInterval;
-            this.task = task;
-        }
-
         /// <summary>
         /// The work task.
         /// </summary>
-        private readonly Action task;
+        internal readonly Action Task;
+
+        public ScheduledDelegate(Action task, double executionTime = 0, double repeatInterval = -1)
+        {
+            Task = task;
+
+            ExecutionTime = executionTime;
+            RepeatInterval = repeatInterval;
+        }
 
         /// <summary>
         /// Set to true to skip scheduled executions until we are ready.
@@ -279,7 +280,7 @@ namespace osu.Framework.Threading
                 throw new InvalidOperationException($"Can not run a {nameof(ScheduledDelegate)} that has been {nameof(Cancelled)}");
 
             if (!Waiting)
-                task();
+                Task();
             Completed = true;
         }
 

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -259,28 +259,12 @@ namespace osu.Framework.Threading
             RepeatInterval = repeatInterval;
         }
 
-        /// <summary>
-        /// Set to true to skip scheduled executions until we are ready.
-        /// </summary>
-        internal bool Waiting;
-
-        public void Wait()
-        {
-            Waiting = true;
-        }
-
-        public void Continue()
-        {
-            Waiting = false;
-        }
-
         public void RunTask()
         {
             if (Cancelled)
                 throw new InvalidOperationException($"Can not run a {nameof(ScheduledDelegate)} that has been {nameof(Cancelled)}");
 
-            if (!Waiting)
-                Task();
+            Task();
             Completed = true;
         }
 

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -247,6 +247,26 @@ namespace osu.Framework.Threading
     public class ScheduledDelegate : IComparable<ScheduledDelegate>
     {
         /// <summary>
+        /// The earliest ElapsedTime value at which we can be executed.
+        /// </summary>
+        public double ExecutionTime { get; internal set; }
+
+        /// <summary>
+        /// Time in milliseconds between repeats of this task. -1 means no repeats.
+        /// </summary>
+        public readonly double RepeatInterval;
+
+        /// <summary>
+        /// Whether this task has finished running.
+        /// </summary>
+        public bool Completed { get; private set; }
+
+        /// <summary>
+        /// Whether this task has been cancelled.
+        /// </summary>
+        public bool Cancelled { get; private set; }
+
+        /// <summary>
         /// The work task.
         /// </summary>
         internal readonly Action Task;
@@ -268,28 +288,8 @@ namespace osu.Framework.Threading
             Completed = true;
         }
 
-        public bool Completed;
+        public void Cancel() => Cancelled = true;
 
-        public bool Cancelled { get; private set; }
-
-        public void Cancel()
-        {
-            Cancelled = true;
-        }
-
-        /// <summary>
-        /// The earliest ElapsedTime value at which we can be executed.
-        /// </summary>
-        public double ExecutionTime;
-
-        /// <summary>
-        /// Time in milliseconds between repeats of this task. -1 means no repeats.
-        /// </summary>
-        public double RepeatInterval;
-
-        public int CompareTo(ScheduledDelegate other)
-        {
-            return ExecutionTime == other.ExecutionTime ? -1 : ExecutionTime.CompareTo(other.ExecutionTime);
-        }
+        public int CompareTo(ScheduledDelegate other) => ExecutionTime == other.ExecutionTime ? -1 : ExecutionTime.CompareTo(other.ExecutionTime);
     }
 }


### PR DESCRIPTION
1. When scheduling from inside a `Schedule()`, the inner scheduled delegate would run instantaneously, even with `forceScheduled = true`.
2. `AddOnce()` would fail the equality comparison.

It's likely that this caused https://github.com/ppy/osu-framework/issues/2239 due to the inner re-schedule in `GLWrapper.ScheduleDisposal()`.