### PR TITLE
Fix possible DrawVisualiser property display nullref

### DIFF
--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -111,6 +111,8 @@ namespace osu.Framework.Graphics.Visualisation
         {
             this.FadeOut(100);
 
+            propertyDisplay.Hide();
+
             recycleVisualisers();
         }
 
@@ -301,6 +303,8 @@ namespace osu.Framework.Graphics.Visualisation
 
         private void recycleVisualisers()
         {
+            setHighlight(null);
+
             // May come from the disposal thread, in which case they won't ever be reused anyway
             Schedule(() => treeContainer.Clear());
 

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -111,6 +111,7 @@ namespace osu.Framework.Graphics.Visualisation
         {
             this.FadeOut(100);
 
+            setHighlight(null);
             propertyDisplay.Hide();
 
             recycleVisualisers();
@@ -303,8 +304,6 @@ namespace osu.Framework.Graphics.Visualisation
 
         private void recycleVisualisers()
         {
-            setHighlight(null);
-
             // May come from the disposal thread, in which case they won't ever be reused anyway
             Schedule(() => treeContainer.Clear());
 


### PR DESCRIPTION
When closed, the draw visualiser is cleared and reset to a clean slate, but the property display was not.