### PR TITLE
Ensure [SetUp] is run at least once when defined by a user test

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         };
 
         [SetUp]
-        public new void SetupTest() => Schedule(() =>
+        public void SetupTest() => Schedule(() =>
         {
             Clear();
             Add(stack = new ScreenStack(baseScreen = new TestScreen())

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -80,12 +80,8 @@ namespace osu.Framework.Testing
             }
         }
 
-        /// <summary>
-        /// Runs prior to all tests except <see cref="TestConstructor"/> to ensure that the <see cref="TestCase"/>
-        /// is reverted to a clean state for all tests.
-        /// </summary>
         [SetUp]
-        public void SetupTest()
+        public void SetUpTestForNUnit()
         {
             if (isNUnitRunning && TestContext.CurrentContext.Test.MethodName != nameof(TestConstructor))
                 Schedule(() => StepsContainer.Clear());


### PR DESCRIPTION
Previously the test browser would not perform `[SetUp]` unless at least one `[Test]` was defined, which is outright incorrect.