### PR TITLE
Allow draw visualisers to be targetted by each other

### DIFF
--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -212,7 +212,7 @@ namespace osu.Framework.Graphics.Visualisation
 
             bool isValidTarget(Drawable drawable)
             {
-                if (drawable is DrawVisualiser || drawable is CursorContainer || drawable is PropertyDisplay)
+                if (drawable == this || drawable is CursorContainer)
                     return false;
 
                 if (!drawable.IsPresent)


### PR DESCRIPTION
Allows targetting to work on `TestCaseDrawVisualiser`.