### PR TITLE
Add obsolete methods to avoid breaking test API change

### DIFF
--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -302,6 +302,10 @@ namespace osu.Framework.Testing
             });
         });
 
+        [Obsolete("Parameter order didn't match other methods – switch order to fix")]
+        protected void AddUntilStep(Func<bool> waitUntilTrueDelegate, string description = null)
+            => AddUntilStep(description, waitUntilTrueDelegate);
+
         protected void AddUntilStep(string description, Func<bool> waitUntilTrueDelegate) => Schedule(() =>
         {
             StepsContainer.Add(new UntilStepButton(waitUntilTrueDelegate)
@@ -309,6 +313,10 @@ namespace osu.Framework.Testing
                 Text = description ?? @"Until",
             });
         });
+
+        [Obsolete("Parameter order didn't match other methods – switch order to fix")]
+        protected void AddWaitStep(int waitCount, string description = null)
+            => AddWaitStep(description, waitCount);
 
         protected void AddWaitStep(string description, int waitCount) => Schedule(() =>
         {


### PR DESCRIPTION
Ensures framework consumers won't outright break from #2256.