### PR TITLE
Add attribute [SetUpSteps]

### DIFF
--- a/osu.Framework.Tests/Visual/Testing/TestCaseTest.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestCaseTest.cs
@@ -26,24 +26,30 @@ namespace osu.Framework.Tests.Visual.Testing
 
         public TestCaseTest()
         {
-            // run before setup
-            testRunCount++;
+            Schedule(() =>
+            {
+                // [SetUp} gets run via TestConstructor() when we are running under nUnit.
+                // note that in TestBrowser's case, this does not invoke SetUp methods, so we skip this increment.
+                // schedule is required to ensure that IsNUnitRunning is initialised.
+                if (IsNUnitRunning)
+                    testRunCount++;
+            });
         }
 
         [Test]
         public void Test1()
         {
-            testRunCount++;
-            Assert.AreEqual(testRunCount, setupRun);
-            Assert.AreEqual(testRunCount, setupStepsRun);
+            AddStep("increment run count", () => testRunCount++);
+            AddAssert("correct setup run count", () => testRunCount == setupRun);
+            AddAssert("correct setup steps run count", () => (IsNUnitRunning ? testRunCount : 2) == setupStepsRun);
         }
 
         [Test]
         public void Test2()
         {
-            testRunCount++;
-            Assert.AreEqual(testRunCount, setupRun);
-            Assert.AreEqual(testRunCount, setupStepsRun);
+            AddStep("increment run count", () => testRunCount++);
+            AddAssert("correct setup run count", () => testRunCount == setupRun);
+            AddAssert("correct setup steps run count", () => (IsNUnitRunning ? testRunCount : 2) == setupStepsRun);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Testing/TestCaseTest.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestCaseTest.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Tests.Visual.Testing
         {
             Schedule(() =>
             {
-                // [SetUp} gets run via TestConstructor() when we are running under nUnit.
+                // [SetUp] gets run via TestConstructor() when we are running under nUnit.
                 // note that in TestBrowser's case, this does not invoke SetUp methods, so we skip this increment.
                 // schedule is required to ensure that IsNUnitRunning is initialised.
                 if (IsNUnitRunning)

--- a/osu.Framework.Tests/Visual/Testing/TestCaseTest.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestCaseTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual.Testing
+{
+    public class TestCaseTest : TestCase
+    {
+        private int setupRun;
+        private int setupStepsRun;
+        private int testRunCount;
+
+        [SetUp]
+        public void SetUp()
+        {
+            setupRun++;
+        }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            setupStepsRun++;
+        }
+
+        public TestCaseTest()
+        {
+            // run before setup
+            testRunCount++;
+        }
+
+        [Test]
+        public void Test1()
+        {
+            testRunCount++;
+            Assert.AreEqual(testRunCount, setupRun);
+            Assert.AreEqual(testRunCount, setupStepsRun);
+        }
+
+        [Test]
+        public void Test2()
+        {
+            testRunCount++;
+            Assert.AreEqual(testRunCount, setupRun);
+            Assert.AreEqual(testRunCount, setupStepsRun);
+        }
+    }
+}

--- a/osu.Framework/Testing/SetUpStepsAttribute.cs
+++ b/osu.Framework/Testing/SetUpStepsAttribute.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 
 namespace osu.Framework.Testing
 {
@@ -10,6 +11,7 @@ namespace osu.Framework.Testing
     /// Invoked via <see cref="TestCase.RunSetUpSteps"/> (which is called from nUnit's [SetUp] or <see cref="TestBrowser.LoadTest"/>).
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
+    [MeansImplicitUse]
     public class SetUpStepsAttribute : Attribute
     {
     }

--- a/osu.Framework/Testing/SetUpStepsAttribute.cs
+++ b/osu.Framework/Testing/SetUpStepsAttribute.cs
@@ -1,0 +1,15 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Testing
+{
+    /// <summary>
+    /// Denotes a method which adds <see cref="TestCase"/> steps.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class SetUpStepsAttribute : Attribute
+    {
+    }
+}

--- a/osu.Framework/Testing/SetUpStepsAttribute.cs
+++ b/osu.Framework/Testing/SetUpStepsAttribute.cs
@@ -7,6 +7,7 @@ namespace osu.Framework.Testing
 {
     /// <summary>
     /// Denotes a method which adds <see cref="TestCase"/> steps.
+    /// Invoked via <see cref="TestCase.RunSetUpSteps"/> (which is called from nUnit's [SetUp] or <see cref="TestBrowser.LoadTest"/>).
     /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class SetUpStepsAttribute : Attribute

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -428,8 +428,6 @@ namespace osu.Framework.Testing
 
             var methods = newTest.GetType().GetMethods();
 
-            var setUpMethods = methods.Where(m => m.Name != nameof(TestCase.SetUpTestForNUnit) && m.GetCustomAttributes(typeof(SetUpAttribute), false).Length > 0);
-
             bool hadTestAttributeTest = false;
 
             foreach (var m in methods.Where(m => m.Name != nameof(TestCase.TestConstructor)))
@@ -465,6 +463,8 @@ namespace osu.Framework.Testing
 
             void addSetUpSteps()
             {
+                var setUpMethods = methods.Where(m => m.Name != nameof(TestCase.SetUpTestForNUnit) && m.GetCustomAttributes(typeof(SetUpAttribute), false).Length > 0).ToArray();
+
                 if (setUpMethods.Any())
                 {
                     CurrentTest.AddStep(new SetUpStep
@@ -472,6 +472,9 @@ namespace osu.Framework.Testing
                         Action = () => setUpMethods.ForEach(s => s.Invoke(CurrentTest, null))
                     });
                 }
+
+                foreach (var method in methods.Where(m => m.GetCustomAttributes(typeof(SetUpStepsAttribute), false).Length > 0))
+                    method.Invoke(CurrentTest, null);
             }
         }
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -473,8 +473,7 @@ namespace osu.Framework.Testing
                     });
                 }
 
-                foreach (var method in methods.Where(m => m.GetCustomAttributes(typeof(SetUpStepsAttribute), false).Length > 0))
-                    method.Invoke(CurrentTest, null);
+                CurrentTest.RunSetUpSteps();
             }
         }
 

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -85,6 +85,8 @@ namespace osu.Framework.Testing
         {
             if (isNUnitRunning && TestContext.CurrentContext.Test.MethodName != nameof(TestConstructor))
                 Schedule(() => StepsContainer.Clear());
+
+            RunSetUpSteps();
         }
 
         [TearDown]
@@ -342,5 +344,11 @@ namespace osu.Framework.Testing
         });
 
         public virtual IReadOnlyList<Type> RequiredTypes => new Type[] { };
+
+        internal void RunSetUpSteps()
+        {
+            foreach (var method in GetType().GetMethods().Where(m => m.GetCustomAttributes(typeof(SetUpStepsAttribute), false).Length > 0))
+                method.Invoke(this, null);
+        }
     }
 }

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -33,12 +33,13 @@ namespace osu.Framework.Testing
         private GameHost host;
         private Task runTask;
         private ITestCaseTestRunner runner;
-        private bool isNUnitRunning;
+
+        internal bool IsNUnitRunning;
 
         [OneTimeSetUp]
         public void SetupGameHost()
         {
-            isNUnitRunning = true;
+            IsNUnitRunning = true;
 
             host = new HeadlessGameHost($"{GetType().Name}-{Guid.NewGuid()}", realtime: false);
             runner = CreateRunner();
@@ -83,7 +84,7 @@ namespace osu.Framework.Testing
         [SetUp]
         public void SetUpTestForNUnit()
         {
-            if (isNUnitRunning && TestContext.CurrentContext.Test.MethodName != nameof(TestConstructor))
+            if (IsNUnitRunning && TestContext.CurrentContext.Test.MethodName != nameof(TestConstructor))
                 Schedule(() => StepsContainer.Clear());
 
             RunSetUpSteps();
@@ -191,7 +192,7 @@ namespace osu.Framework.Testing
             Schedule(() =>
             {
                 stepRunner?.Cancel();
-                foreach (var step in StepsContainer.OfType<StepButton>())
+                foreach (var step in StepsContainer.FlowingChildren.OfType<StepButton>())
                     step.Reset();
 
                 actionIndex = -1;

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -343,13 +343,4 @@ namespace osu.Framework.Testing
 
         public virtual IReadOnlyList<Type> RequiredTypes => new Type[] { };
     }
-
-    /// <summary>
-    /// Denotes a method which adds <see cref="TestCase"/> steps.
-    /// </summary>
-    [AttributeUsage(AttributeTargets.Method)]
-    public class SetUpStepsAttribute : Attribute
-    {
-
-    }
 }

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -343,4 +343,13 @@ namespace osu.Framework.Testing
 
         public virtual IReadOnlyList<Type> RequiredTypes => new Type[] { };
     }
+
+    /// <summary>
+    /// Denotes a method which adds <see cref="TestCase"/> steps.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class SetUpStepsAttribute : Attribute
+    {
+
+    }
 }


### PR DESCRIPTION
Allows adding steps global to all `[Test]`. Previously not possible due to `[SetUp]` discrepancies between nUnit and visual tests.