### PR TITLE
Make Screen.RemoveWhenNotAlive sealed

### DIFF
--- a/osu.Framework/Screens/Screen.cs
+++ b/osu.Framework/Screens/Screen.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Screens
 
         public bool ValidForPush { get; set; } = true;
 
-        public override bool RemoveWhenNotAlive => false;
+        public sealed override bool RemoveWhenNotAlive => false;
 
         [Resolved]
         protected Game Game { get; private set; }

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -87,6 +87,9 @@ namespace osu.Framework.Screens
             if (source == null && stack.Count > 0)
                 throw new InvalidOperationException($"A source must be provided when pushing to a non-empty {nameof(ScreenStack)}");
 
+            if (newScreen.AsDrawable().RemoveWhenNotAlive)
+                throw new ScreenWillBeRemovedOnPushException(newScreen.GetType());
+
             // Suspend the current screen, if there is one
             if (source != null && source != stack.Peek()) throw new ScreenNotCurrentException(nameof(Push));
 
@@ -321,6 +324,15 @@ namespace osu.Framework.Screens
         {
             public ScreenAlreadyEnteredException()
                 : base("Cannot push a screen in an entered state.")
+            {
+            }
+        }
+
+        public class ScreenWillBeRemovedOnPushException : InvalidOperationException
+        {
+            public ScreenWillBeRemovedOnPushException(Type type)
+                : base($"The pushed ({type.ReadableName()}) has {nameof(RemoveWhenNotAlive)} = true and will be removed when a child screen is pushed. "
+                       + $"Screens must set {nameof(RemoveWhenNotAlive)} to false.")
             {
             }
         }

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -87,9 +87,6 @@ namespace osu.Framework.Screens
             if (source == null && stack.Count > 0)
                 throw new InvalidOperationException($"A source must be provided when pushing to a non-empty {nameof(ScreenStack)}");
 
-            if (newScreen.AsDrawable().RemoveWhenNotAlive)
-                throw new ScreenWillBeRemovedOnPushException(newScreen.GetType());
-
             // Suspend the current screen, if there is one
             if (source != null && source != stack.Peek()) throw new ScreenNotCurrentException(nameof(Push));
 
@@ -324,15 +321,6 @@ namespace osu.Framework.Screens
         {
             public ScreenAlreadyEnteredException()
                 : base("Cannot push a screen in an entered state.")
-            {
-            }
-        }
-
-        public class ScreenWillBeRemovedOnPushException : InvalidOperationException
-        {
-            public ScreenWillBeRemovedOnPushException(Type type)
-                : base($"The pushed ({type.ReadableName()}) has {nameof(RemoveWhenNotAlive)} = true and will be removed when a child screen is pushed. "
-                       + $"Screens must set {nameof(RemoveWhenNotAlive)} to false.")
             {
             }
         }


### PR DESCRIPTION
This prevents subclasses from overriding the property, making checking
for its truthiness and the associated ScreenWillBeRemovedOnPushException
superfluous

Since doing anything with RemoveWhenNotAlive that isn't setting it always to false it feels wrong to expose it as an overridable property on Screen. There are obscure scenarios this prevents (for example logging whenever the property gets read in a subclass or causing other side effects) but I do not think they are important concerns.