### PR TITLE
Remove potentially expensive iteration over all vertex batches

### DIFF
--- a/osu.Framework/Graphics/Batches/VertexBatch.cs
+++ b/osu.Framework/Graphics/Batches/VertexBatch.cs
@@ -41,8 +41,6 @@ namespace osu.Framework.Graphics.Batches
             this.maxBuffers = maxBuffers;
 
             AddAction = Add;
-
-            GLWrapper.RegisterVertexBatch(this);
         }
 
         #region Disposal


### PR DESCRIPTION
Stops potentially resetting many more batches than are actually used within a frame.