### PR TITLE
Improve performance of ForEachAlive

### DIFF
--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -32,16 +32,12 @@ namespace osu.Framework.Lists
 
         public void ForEachAlive(Action<T> action)
         {
-            int index = 0;
-            while (index < list.Count)
+            list.RemoveAll(item => item.TryGetTarget(out _));
+
+            foreach (var item in list)
             {
-                if (list[index].TryGetTarget(out T obj))
-                {
+                if (item.TryGetTarget(out T obj))
                     action(obj);
-                    index++;
-                }
-                else
-                    list.RemoveAt(index);
             }
         }
     }

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Lists
 
         public void ForEachAlive(Action<T> action)
         {
-            list.RemoveAll(item => item.TryGetTarget(out _));
+            list.RemoveAll(item => !item.TryGetTarget(out _));
 
             foreach (var item in list)
             {


### PR DESCRIPTION
`RemoveAll()` is internally optimised to avoid O(n^2) operations.

Tested using the following code: https://hastebin.com/yanokamoze.cs

|                         Method |       Mean |     Error |     StdDev |     Median | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
|------------------------------- |-----------:|----------:|-----------:|-----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
|           ForEachAliveNoRemove |   8.689 us | 0.5134 us |  1.4225 us |   8.449 us |  1.00 |    0.00 |           - |           - |           - |                88 B |
|        ForEachAliveNoRemoveNew |   6.988 us | 0.2016 us |  0.5753 us |   6.933 us |  0.82 |    0.13 |           - |           - |           - |                88 B |
|    ForEachAliveRemoveAllSparse |  11.796 us | 0.2919 us |  0.7942 us |  11.719 us |  1.39 |    0.23 |           - |           - |           - |                88 B |
| ForEachAliveRemoveAllSparseNew |  17.750 us | 0.4373 us |  1.1747 us |  17.778 us |  2.09 |    0.33 |           - |           - |           - |                88 B |
|     ForEachAliveRemoveAllDense | 128.297 us | 4.4506 us | 12.6979 us | 120.961 us | 15.16 |    2.56 |           - |           - |           - |                88 B |
|  ForEachAliveRemoveAllDenseNew |   8.089 us | 0.6347 us |  1.8211 us |   7.604 us |  0.95 |    0.25 |           - |           - |           - |                88 B |
