### PR TITLE
Increase usability of WithChild/WithChildren

### DIFF
--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -30,11 +30,11 @@ namespace osu.Framework.Graphics.Containers
     /// Additionally, containers support various effects, such as masking, edge effect,
     /// padding, and automatic sizing depending on their children.
     /// </summary>
-    public class Container<T> : CompositeDrawable, IContainer<T>, IContainerEnumerable<T>, IContainerCollection<T>, ICollection<T>, IReadOnlyList<T>
+    public class Container<T> : CompositeDrawable, IContainerEnumerable<T>, IContainerCollection<T>, ICollection<T>, IReadOnlyList<T>
         where T : Drawable
     {
         /// <summary>
-        /// Contructs a <see cref="Container"/> that stores children.
+        /// Constructs a <see cref="Container"/> that stores children.
         /// </summary>
         public Container()
         {

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Graphics.Containers
     /// Additionally, containers support various effects, such as masking, edge effect,
     /// padding, and automatic sizing depending on their children.
     /// </summary>
-    public class Container<T> : CompositeDrawable, IContainerEnumerable<T>, IContainerCollection<T>, ICollection<T>, IReadOnlyList<T>
+    public class Container<T> : CompositeDrawable, IContainer<T>, IContainerEnumerable<T>, IContainerCollection<T>, ICollection<T>, IReadOnlyList<T>
         where T : Drawable
     {
         /// <summary>

--- a/osu.Framework/Graphics/Containers/ContainerExtensions.cs
+++ b/osu.Framework/Graphics/Containers/ContainerExtensions.cs
@@ -63,12 +63,14 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Set a specified <paramref name="child"/> on <paramref name="container"/>.
         /// </summary>
-        /// <typeparam name="T">The type of the children of <paramref name="container"/>.</typeparam>
+        /// <typeparam name="T">The container type.</typeparam>
+        /// <typeparam name="U">The type of children contained by <paramref name="container"/>.</typeparam>
         /// <param name="container">The <paramref name="container"/> that will have a child set.</param>
         /// <param name="child">The <paramref name="child"/> that should be set to the <paramref name="container"/>.</param>
         /// <returns>The given <paramref name="container"/>.</returns>
-        public static Container<T> WithChild<T>(this Container<T> container, T child)
-            where T : Drawable
+        public static T WithChild<T, U>(this T container, U child)
+            where T : IContainer<U>
+            where U : Drawable
         {
             container.Child = child;
 
@@ -78,12 +80,14 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Set specified <paramref name="children"/> on <paramref name="container"/>.
         /// </summary>
-        /// <typeparam name="T">The type of the children of <paramref name="container"/>.</typeparam>
+        /// <typeparam name="T">The container type.</typeparam>
+        /// <typeparam name="U">The type of children contained by <paramref name="container"/>.</typeparam>
         /// <param name="container">The <paramref name="container"/> that will have children set.</param>
         /// <param name="children">The <paramref name="children"/> that should be set to the <paramref name="container"/>.</param>
         /// <returns>The given <paramref name="container"/>.</returns>
-        public static Container<T> WithChildren<T>(this Container<T> container, IEnumerable<T> children)
-            where T : Drawable
+        public static T WithChildren<T, U>(this T container, IEnumerable<U> children)
+            where T : IContainer<U>
+            where U : Drawable
         {
             container.ChildrenEnumerable = children;
 

--- a/osu.Framework/Graphics/Containers/ContainerExtensions.cs
+++ b/osu.Framework/Graphics/Containers/ContainerExtensions.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="child">The <paramref name="child"/> that should be set to the <paramref name="container"/>.</param>
         /// <returns>The given <paramref name="container"/>.</returns>
         public static T WithChild<T, U>(this T container, U child)
-            where T : IContainer<U>
+            where T : IContainerCollection<U>
             where U : Drawable
         {
             container.Child = child;
@@ -86,7 +86,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="children">The <paramref name="children"/> that should be set to the <paramref name="container"/>.</param>
         /// <returns>The given <paramref name="container"/>.</returns>
         public static T WithChildren<T, U>(this T container, IEnumerable<U> children)
-            where T : IContainer<U>
+            where T : IContainerCollection<U>
             where U : Drawable
         {
             container.ChildrenEnumerable = children;

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -16,6 +16,13 @@ namespace osu.Framework.Graphics.Containers
         Vector2 RelativeChildOffset { get; set; }
     }
 
+    public interface IContainer<in T>
+    {
+        T Child { set; }
+
+        IEnumerable<T> ChildrenEnumerable { set; }
+    }
+
     public interface IContainerEnumerable<out T> : IContainer
         where T : IDrawable
     {

--- a/osu.Framework/Graphics/Containers/IContainer.cs
+++ b/osu.Framework/Graphics/Containers/IContainer.cs
@@ -16,13 +16,6 @@ namespace osu.Framework.Graphics.Containers
         Vector2 RelativeChildOffset { get; set; }
     }
 
-    public interface IContainer<in T>
-    {
-        T Child { set; }
-
-        IEnumerable<T> ChildrenEnumerable { set; }
-    }
-
     public interface IContainerEnumerable<out T> : IContainer
         where T : IDrawable
     {
@@ -35,6 +28,10 @@ namespace osu.Framework.Graphics.Containers
         where T : IDrawable
     {
         IReadOnlyList<T> Children { set; }
+
+        T Child { set; }
+
+        IEnumerable<T> ChildrenEnumerable { set; }
 
         void Add(T drawable);
         void AddRange(IEnumerable<T> collection);


### PR DESCRIPTION
Previously, `WithChild()`/`WithChildren()` would return the incorrect type:

<img width="399" alt="Screen Shot 2019-03-26 at 12 48 08 pm" src="https://user-images.githubusercontent.com/1329837/54970472-96e12580-4fc5-11e9-82b6-08ee3f6638fc.png">

This now uses contravariance to retain the original container type:

<img width="403" alt="Screen Shot 2019-03-26 at 12 48 32 pm" src="https://user-images.githubusercontent.com/1329837/54970474-99437f80-4fc5-11e9-982e-519de76e8894.png">

With...

```
public class DerivedContainer : Container<Box>
{
}

public class DerivedContainer<T> : Container
{
}
```