### PR TITLE
Add config manager default overrides

### DIFF
--- a/osu.Framework.Tests/Configuration/FrameworkConfigManagerTest.cs
+++ b/osu.Framework.Tests/Configuration/FrameworkConfigManagerTest.cs
@@ -1,0 +1,99 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Configuration;
+
+namespace osu.Framework.Tests.Configuration
+{
+    [TestFixture]
+    public class FrameworkConfigManagerTest
+    {
+        [Test]
+        public void TestDefault()
+        {
+            using (var storage = new TemporaryNativeStorage(new Guid().ToString()))
+            {
+                using (var configManager = new FrameworkConfigManager(storage))
+                {
+                    var bindable = configManager.GetBindable<string>(FrameworkSetting.Locale);
+
+                    Assert.AreEqual(string.Empty, bindable.Value);
+                    Assert.AreEqual(string.Empty, bindable.Default);
+                    Assert.IsTrue(bindable.IsDefault);
+                }
+            }
+        }
+
+        [Test]
+        public void TestSaveLoad()
+        {
+            const double test_volume = 0.65;
+
+            using (var storage = new TemporaryNativeStorage(new Guid().ToString()))
+            {
+                using (var configManager = new FrameworkConfigManager(storage))
+                {
+                    var bindable = configManager.GetBindable<double>(FrameworkSetting.VolumeMusic);
+
+                    Assert.AreEqual(bindable.Default, bindable.Value);
+                    Assert.IsTrue(bindable.IsDefault);
+
+                    bindable.Value = test_volume;
+                    Assert.AreEqual(test_volume, bindable.Value);
+                }
+
+                using (var configManager = new FrameworkConfigManager(storage))
+                {
+                    var bindable = configManager.GetBindable<double>(FrameworkSetting.VolumeMusic);
+
+                    Assert.IsFalse(bindable.IsDefault);
+                    Assert.AreEqual(test_volume, bindable.Value);
+                }
+            }
+        }
+
+        [Test]
+        public void TestDefaultOverrides()
+        {
+            const string test_locale = "override test";
+
+            using (var storage = new TemporaryNativeStorage(new Guid().ToString()))
+            {
+                using (var configManager = new FrameworkConfigManager(storage, new Dictionary<FrameworkSetting, object> { { FrameworkSetting.Locale, test_locale } }))
+                {
+                    var bindable = configManager.GetBindable<string>(FrameworkSetting.Locale);
+                    Assert.AreEqual(test_locale, bindable.Value);
+                    Assert.AreEqual(test_locale, bindable.Default);
+                    Assert.IsTrue(bindable.IsDefault);
+
+                    bindable.Value = string.Empty;
+                    Assert.IsFalse(bindable.IsDefault);
+                }
+
+                // ensure correct after save
+                using (var configManager = new FrameworkConfigManager(storage, new Dictionary<FrameworkSetting, object> { { FrameworkSetting.Locale, test_locale } }))
+                {
+                    var bindable = configManager.GetBindable<string>(FrameworkSetting.Locale);
+                    Assert.AreEqual(test_locale, bindable.Default);
+                    Assert.AreEqual(string.Empty, bindable.Value);
+                    Assert.IsFalse(bindable.IsDefault);
+
+                    bindable.Value = test_locale;
+                    Assert.IsTrue(bindable.IsDefault);
+                }
+
+                // ensure correct after save with default
+                using (var configManager = new FrameworkConfigManager(storage, new Dictionary<FrameworkSetting, object> { { FrameworkSetting.Locale, test_locale } }))
+                {
+                    var bindable = configManager.GetBindable<string>(FrameworkSetting.Locale);
+                    Assert.AreEqual(test_locale, bindable.Value);
+                    Assert.AreEqual(test_locale, bindable.Default);
+                    Assert.IsTrue(bindable.IsDefault);
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/IO/TestDesktopStorage.cs
+++ b/osu.Framework.Tests/IO/TestDesktopStorage.cs
@@ -4,7 +4,6 @@
 using System;
 using System.IO;
 using NUnit.Framework;
-using osu.Framework.Platform;
 
 namespace osu.Framework.Tests.IO
 {
@@ -15,20 +14,19 @@ namespace osu.Framework.Tests.IO
         public void TestRelativePaths()
         {
             var guid = new Guid().ToString();
-            var storage = new NativeStorage(guid);
+            using (var storage = new TemporaryNativeStorage(guid))
+            {
+                var basePath = storage.GetFullPath(string.Empty);
 
-            var basePath = storage.GetFullPath(string.Empty);
+                Assert.IsTrue(basePath.EndsWith(guid));
 
-            Assert.IsTrue(basePath.EndsWith(guid));
+                Assert.Throws<ArgumentException>(() => storage.GetFullPath("../"));
+                Assert.Throws<ArgumentException>(() => storage.GetFullPath(".."));
+                Assert.Throws<ArgumentException>(() => storage.GetFullPath("./../"));
 
-            Assert.Throws<ArgumentException>(() => storage.GetFullPath("../"));
-            Assert.Throws<ArgumentException>(() => storage.GetFullPath(".."));
-            Assert.Throws<ArgumentException>(() => storage.GetFullPath("./../"));
-
-            Assert.AreEqual(Path.GetFullPath(Path.Combine(basePath, "sub", "test")) + Path.DirectorySeparatorChar, storage.GetFullPath("sub/test/"));
-            Assert.AreEqual(Path.GetFullPath(Path.Combine(basePath, "sub", "test")), storage.GetFullPath("sub/test"));
-
-            storage.DeleteDirectory(string.Empty);
+                Assert.AreEqual(Path.GetFullPath(Path.Combine(basePath, "sub", "test")) + Path.DirectorySeparatorChar, storage.GetFullPath("sub/test/"));
+                Assert.AreEqual(Path.GetFullPath(Path.Combine(basePath, "sub", "test")), storage.GetFullPath("sub/test"));
+            }
         }
     }
 }

--- a/osu.Framework.Tests/TemporaryNativeStorage.cs
+++ b/osu.Framework.Tests/TemporaryNativeStorage.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Tests
+{
+    public class TemporaryNativeStorage : NativeStorage, IDisposable
+    {
+        public TemporaryNativeStorage(string name, GameHost host = null)
+            : base(name, host)
+        {
+        }
+
+        public void Dispose()
+        {
+            DeleteDirectory(string.Empty);
+        }
+    }
+}

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -175,7 +175,6 @@ namespace osu.Framework.Configuration
             return fallback;
         }
 
-
         private Bindable<U> set<U>(T lookup, U value)
         {
             Bindable<U> bindable = new Bindable<U>(value);

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -42,6 +42,8 @@ namespace osu.Framework.Configuration
 
         public BindableDouble Set(T lookup, double value, double? min = null, double? max = null, double? precision = null)
         {
+            value = getDefault(lookup, value);
+
             if (!(GetOriginalBindable<double>(lookup) is BindableDouble bindable))
             {
                 bindable = new BindableDouble(value);
@@ -52,7 +54,7 @@ namespace osu.Framework.Configuration
                 bindable.Value = value;
             }
 
-            bindable.Default = getDefault(lookup, value);
+            bindable.Default = value;
             if (min.HasValue) bindable.MinValue = min.Value;
             if (max.HasValue) bindable.MaxValue = max.Value;
             if (precision.HasValue) bindable.Precision = precision.Value;
@@ -62,6 +64,8 @@ namespace osu.Framework.Configuration
 
         public BindableFloat Set(T lookup, float value, float? min = null, float? max = null, float? precision = null)
         {
+            value = getDefault(lookup, value);
+
             if (!(GetOriginalBindable<float>(lookup) is BindableFloat bindable))
             {
                 bindable = new BindableFloat(value);
@@ -72,7 +76,7 @@ namespace osu.Framework.Configuration
                 bindable.Value = value;
             }
 
-            bindable.Default = getDefault(lookup, value);
+            bindable.Default = value;
             if (min.HasValue) bindable.MinValue = min.Value;
             if (max.HasValue) bindable.MaxValue = max.Value;
             if (precision.HasValue) bindable.Precision = precision.Value;
@@ -82,6 +86,8 @@ namespace osu.Framework.Configuration
 
         public BindableInt Set(T lookup, int value, int? min = null, int? max = null)
         {
+            value = getDefault(lookup, value);
+
             if (!(GetOriginalBindable<int>(lookup) is BindableInt bindable))
             {
                 bindable = new BindableInt(value);
@@ -92,7 +98,7 @@ namespace osu.Framework.Configuration
                 bindable.Value = value;
             }
 
-            bindable.Default = getDefault(lookup, value);
+            bindable.Default = value;
             if (min.HasValue) bindable.MinValue = min.Value;
             if (max.HasValue) bindable.MaxValue = max.Value;
 
@@ -101,6 +107,8 @@ namespace osu.Framework.Configuration
 
         public BindableBool Set(T lookup, bool value)
         {
+            value = getDefault(lookup, value);
+
             if (!(GetOriginalBindable<bool>(lookup) is BindableBool bindable))
             {
                 bindable = new BindableBool(value);
@@ -111,13 +119,15 @@ namespace osu.Framework.Configuration
                 bindable.Value = value;
             }
 
-            bindable.Default = getDefault(lookup, value);
+            bindable.Default = value;
 
             return bindable;
         }
 
         public BindableSize Set(T lookup, Size value, Size? min = null, Size? max = null)
         {
+            value = getDefault(lookup, value);
+
             if (!(GetOriginalBindable<Size>(lookup) is BindableSize bindable))
             {
                 bindable = new BindableSize(value);
@@ -128,11 +138,33 @@ namespace osu.Framework.Configuration
                 bindable.Value = value;
             }
 
-            bindable.Default = getDefault(lookup, value);
+            bindable.Default = value;
             if (min.HasValue) bindable.MinValue = min.Value;
             if (max.HasValue) bindable.MaxValue = max.Value;
 
             return bindable;
+        }
+
+        public Bindable<U> Set<U>(T lookup, U value)
+        {
+            value = getDefault(lookup, value);
+
+            Bindable<U> bindable = GetOriginalBindable<U>(lookup);
+
+            if (bindable == null)
+                bindable = set(lookup, value);
+            else
+                bindable.Value = value;
+
+            bindable.Default = value;
+
+            return bindable;
+        }
+
+        protected virtual void AddBindable<TBindable>(T lookup, Bindable<TBindable> bindable)
+        {
+            ConfigStore[lookup] = bindable;
+            bindable.ValueChanged += _ => backgroundSave();
         }
 
         private TType getDefault<TType>(T lookup, TType fallback)
@@ -143,25 +175,6 @@ namespace osu.Framework.Configuration
             return fallback;
         }
 
-        public Bindable<U> Set<U>(T lookup, U value)
-        {
-            Bindable<U> bindable = GetOriginalBindable<U>(lookup);
-
-            if (bindable == null)
-                bindable = set(lookup, value);
-            else
-                bindable.Value = value;
-
-            bindable.Default = getDefault(lookup, value);
-
-            return bindable;
-        }
-
-        protected virtual void AddBindable<TBindable>(T lookup, Bindable<TBindable> bindable)
-        {
-            ConfigStore[lookup] = bindable;
-            bindable.ValueChanged += _ => backgroundSave();
-        }
 
         private Bindable<U> set<U>(T lookup, U value)
         {

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Drawing;
 using osu.Framework.Configuration.Tracking;
 using osu.Framework.Extensions;
@@ -40,8 +41,8 @@ namespace osu.Framework.Configuration
             Set(FrameworkSetting.PerformanceLogging, false);
         }
 
-        public FrameworkConfigManager(Storage storage)
-            : base(storage)
+        public FrameworkConfigManager(Storage storage, IDictionary<FrameworkSetting, object> defaultOverrides = null)
+            : base(storage, defaultOverrides)
         {
         }
 

--- a/osu.Framework/Configuration/IniConfigManager.cs
+++ b/osu.Framework/Configuration/IniConfigManager.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using osu.Framework.Bindables;
 using osu.Framework.Logging;
@@ -19,7 +20,8 @@ namespace osu.Framework.Configuration
 
         private readonly Storage storage;
 
-        public IniConfigManager(Storage storage)
+        public IniConfigManager(Storage storage, IDictionary<T, object> defaultOverrides = null)
+            : base(defaultOverrides)
         {
             this.storage = storage;
 

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -63,6 +63,14 @@ namespace osu.Framework
 
         protected internal virtual UserInputManager CreateUserInputManager() => new UserInputManager();
 
+        /// <summary>
+        /// Provide <see cref="FrameworkSetting"/> defaults which should override those provided by osu-framework.
+        /// <remarks>
+        /// Please check https://github.com/ppy/osu-framework/blob/master/osu.Framework/Configuration/FrameworkConfigManager.cs for expected types.
+        /// </remarks>
+        /// </summary>
+        protected internal virtual IDictionary<FrameworkSetting, object> GetFrameworkConfigDefaults() => null;
+
         protected Game()
         {
             RelativeSizeAxes = Axes.Both;
@@ -252,7 +260,5 @@ namespace osu.Framework
             Audio?.Dispose();
             Audio = null;
         }
-
-        protected internal virtual IDictionary<FrameworkSetting, object> GetFrameworkConfigDefaults() => null;
     }
 }

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using osuTK;
 using osu.Framework.Allocation;
@@ -251,5 +252,7 @@ namespace osu.Framework
             Audio?.Dispose();
             Audio = null;
         }
+
+        protected internal virtual IDictionary<FrameworkSetting, object> GetFrameworkConfigDefaults() => null;
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -480,7 +480,7 @@ namespace osu.Framework.Platform
 
                 ExecutionState = ExecutionState.Running;
 
-                setupConfig();
+                setupConfig(game.GetFrameworkConfigDefaults());
 
                 if (Window != null)
                 {
@@ -660,12 +660,25 @@ namespace osu.Framework.Platform
 
         private Bindable<WindowMode> windowMode;
 
-        private void setupConfig()
+        private void setupConfig(IDictionary<FrameworkSetting, object> gameDefaults)
         {
+            var hostDefaults = new Dictionary<FrameworkSetting, object>
+            {
+                { FrameworkSetting.WindowMode, Window?.DefaultWindowMode ?? WindowMode.Windowed }
+            };
+
+            // merge defaults provided by game into host defaults.
+            if (gameDefaults != null)
+            {
+                foreach (var d in gameDefaults)
+                    hostDefaults[d.Key] = d.Value;
+            }
+
             Dependencies.Cache(debugConfig = new FrameworkDebugConfigManager());
-            Dependencies.Cache(config = new FrameworkConfigManager(Storage));
+            Dependencies.Cache(config = new FrameworkConfigManager(Storage, hostDefaults));
 
             windowMode = config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
+
             windowMode.BindValueChanged(mode =>
             {
                 if (Window == null)


### PR DESCRIPTION
Allows games to provide framework setting defaults.

- Closes #2203.
- Adds tests for `ConfigManager`.