### PR TITLE
Remove extra GL clears

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -305,7 +305,6 @@ namespace osu.Framework.Platform
             setVSyncMode();
 
             GLWrapper.Reset(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height));
-            GLWrapper.Clear(ClearInfo.Default);
         }
 
         private long lastDrawFrameId;
@@ -327,10 +326,7 @@ namespace osu.Framework.Platform
                     }
 
                     using (drawMonitor.BeginCollecting(PerformanceCollectionType.GLReset))
-                    {
                         GLWrapper.Reset(new Vector2(Window.ClientSize.Width, Window.ClientSize.Height));
-                        GLWrapper.Clear(ClearInfo.Default);
-                    }
 
                     buffer.Object.Draw(null);
                     lastDrawFrameId = buffer.FrameId;


### PR DESCRIPTION
Since this is being done in `GLWrapper.Reset()` now.