### PR TITLE
Add OpenGL query for number of fragments drawn

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Queries/Query.cs
+++ b/osu.Framework/Graphics/OpenGL/Queries/Query.cs
@@ -1,0 +1,66 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osuTK.Graphics.ES30;
+
+namespace osu.Framework.Graphics.OpenGL.Queries
+{
+    internal class Query : IDisposable
+    {
+        public int Result => result;
+        private int result;
+
+        private readonly QueryTarget target;
+
+        private int queryObject = -1;
+
+        public Query(QueryTarget target)
+        {
+            this.target = target;
+        }
+
+        public InvokeOnDisposal Begin()
+        {
+            bool queryActive = false;
+
+            if (queryObject == -1)
+                queryObject = GL.GenQuery();
+            else
+            {
+                GL.GetQueryObject(queryObject, GetQueryObjectParam.QueryResultAvailable, out int resultAvailable);
+                queryActive = resultAvailable == 0;
+            }
+
+            bool queryStarted = false;
+
+            if (!queryActive)
+            {
+                GL.GetQueryObject(queryObject, GetQueryObjectParam.QueryResult, out result);
+                GL.BeginQuery(target, queryObject);
+
+                queryStarted = true;
+            }
+
+            return queryStarted ? new InvokeOnDisposal(() => GL.EndQuery(target)) : null;
+        }
+
+        ~Query()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool isDisposing) => GLWrapper.ScheduleDisposal(() =>
+        {
+            if (queryObject != -1)
+                GL.DeleteQuery(queryObject);
+        });
+    }
+}

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -25,6 +25,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.OpenGL;
+using osu.Framework.Graphics.OpenGL.Queries;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
@@ -310,6 +311,8 @@ namespace osu.Framework.Platform
 
         private long lastDrawFrameId;
 
+        private readonly Query samplesPassedQuery = new Query(QueryTarget.SamplesPassed);
+
         protected virtual void DrawFrame()
         {
             if (Root == null)
@@ -332,7 +335,11 @@ namespace osu.Framework.Platform
                         GLWrapper.ClearColour(Color4.Black);
                     }
 
-                    buffer.Object.Draw(null);
+                    using (samplesPassedQuery.Begin())
+                        buffer.Object.Draw(null);
+
+                    FrameStatistics.Add(StatisticsCounterType.Fragments, samplesPassedQuery.Result);
+
                     lastDrawFrameId = buffer.FrameId;
                     break;
                 }

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -64,6 +64,7 @@ namespace osu.Framework.Statistics
         VerticesDraw,
         VerticesUpl,
         Pixels,
+        Fragments,
 
         TasksRun,
         Tracks,

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -24,6 +24,7 @@ namespace osu.Framework.Threading
             StatisticsCounterType.VerticesDraw,
             StatisticsCounterType.VerticesUpl,
             StatisticsCounterType.Pixels,
+            StatisticsCounterType.Fragments,
         };
     }
 }


### PR DESCRIPTION
Open to opinion on whether this is actually useful/worth the effort, since I already had code ready for this. I've made it asynchronous so as to not stall the GPU, via querying for result availability.

As such, `Result` may not be up-to-date instantly, therefore this isn't really nice to use in a general sense - ideally it'd have a callback and schedule on `GLWrapper.Reset()`. I've made it `internal` for this reason.

Just provides some interesting statistics with front-to-back rendering, that's all.