### PR TITLE
Allow GridContainer to be autosized

### DIFF
--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -15,6 +15,12 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public class GridContainer : CompositeDrawable
     {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            layoutContent();
+        }
+
         private Drawable[][] content;
 
         /// <summary>
@@ -80,10 +86,18 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        [BackgroundDependencyLoader]
-        private void load()
+        /// <summary>
+        /// Controls which <see cref="Axes"/> are automatically sized w.r.t. <see cref="CompositeDrawable.InternalChildren"/>.
+        /// Children's <see cref="Drawable.BypassAutoSizeAxes"/> are ignored for automatic sizing.
+        /// Most notably, <see cref="Drawable.RelativePositionAxes"/> and <see cref="Drawable.RelativeSizeAxes"/> of children
+        /// do not affect automatic sizing to avoid circular size dependencies.
+        /// It is not allowed to manually set <see cref="Drawable.Size"/> (or <see cref="Drawable.Width"/> / <see cref="Drawable.Height"/>)
+        /// on any <see cref="Axes"/> which are automatically sized.
+        /// </summary>
+        public new Axes AutoSizeAxes
         {
-            layoutContent();
+            get => base.AutoSizeAxes;
+            set => base.AutoSizeAxes = value;
         }
 
         protected override void Update()

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTable.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTable.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
     /// </code>
     public class MarkdownTable : CompositeDrawable
     {
-        private TableContainer tableContainer;
+        private GridContainer tableContainer;
 
         private readonly Table table;
 
@@ -55,7 +55,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
                 rows.Add(row);
             }
 
-            InternalChild = tableContainer = new TableContainer
+            InternalChild = tableContainer = new GridContainer
             {
                 AutoSizeAxes = Axes.Y,
                 RelativeSizeAxes = Axes.X,
@@ -145,13 +145,5 @@ namespace osu.Framework.Graphics.Containers.Markdown
         }
 
         protected virtual MarkdownTableCell CreateTableCell(TableCell cell, TableColumnDefinition definition, bool isHeading) => new MarkdownTableCell(cell, definition);
-
-        private class TableContainer : GridContainer
-        {
-            public new Axes AutoSizeAxes
-            {
-                set => base.AutoSizeAxes = value;
-            }
-        }
     }
 }


### PR DESCRIPTION
There's an increasing number of situations in which autosized grids are required.