### PR TITLE
Add TableContainer as an extension of GridContainer

### DIFF
--- a/osu.Framework.Tests/Visual/Layout/TestCaseTableContainer.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestCaseTableContainer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.MathUtils;
 using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
@@ -211,6 +212,41 @@ namespace osu.Framework.Tests.Visual.Layout
         }
 
         [Test]
+        public void TestRowSize()
+        {
+            AddStep("set content", () =>
+            {
+                table.Content = createContent(2, 2);
+                table.RowSize = new Dimension(GridSizeMode.Absolute, 30f);
+            });
+
+            AddAssert("all row size = 30", () => testRows(30));
+            AddStep("add headers", () => table.Columns = new[]
+            {
+                new TableColumn("Header 1"),
+                new TableColumn("Header 2"),
+                new TableColumn("Header 3"),
+            });
+
+            AddAssert("all row size = 30", () => testRows(30));
+            AddStep("change row size", () => table.RowSize = new Dimension(GridSizeMode.Absolute, 50));
+            AddAssert("all row size = 50", () => testRows(50));
+            AddStep("change content", () => table.Content = createContent(4, 4));
+            AddAssert("all row size = 50", () => testRows(50));
+            AddStep("remove custom row size", () => table.RowSize = null);
+            AddAssert("all row size = distributed", () => testRows(table.DrawHeight / 5f));
+
+            bool testRows(float expectedHeight)
+            {
+                for (int row = 0; row < getGrid().Content.Length; row++)
+                    if (!Precision.AlmostEquals(expectedHeight, getGrid().Content[row][0].Parent.DrawHeight))
+                        return false;
+
+                return true;
+            }
+        }
+
+        [Test]
         public void TestClearGrid()
         {
             AddStep("set content", () =>
@@ -224,7 +260,11 @@ namespace osu.Framework.Tests.Visual.Layout
                 };
             });
 
-            AddStep("clear grid", () => table.Content = null);
+            AddStep("clear grid", () =>
+            {
+                table.Columns = null;
+                table.Content = null;
+            });
         }
 
         private Drawable[,] createContent(int rows, int columns)

--- a/osu.Framework.Tests/Visual/Layout/TestCaseTableContainer.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestCaseTableContainer.cs
@@ -1,0 +1,253 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Layout
+{
+    public class TestCaseTableContainer : TestCase
+    {
+        private TableContainer table;
+
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            Child = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(300),
+                Children = new Drawable[]
+                {
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Masking = true,
+                        BorderColour = Color4.White,
+                        BorderThickness = 2,
+                        Child = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Alpha = 0,
+                            AlwaysPresent = true
+                        }
+                    },
+                    table = new TableContainer { RelativeSizeAxes = Axes.Both }
+                }
+            };
+        });
+
+        [Test]
+        public void TestBlankTable()
+        {
+        }
+
+        [Test]
+        public void TestOnlyContent()
+        {
+            AddStep("set content", () => table.Content = createContent(2, 2));
+            AddAssert("headers not displayed", () => getGrid().Content.Length == 2);
+        }
+
+        [Test]
+        public void TestOnlyHeaders()
+        {
+            AddStep("set columns", () => table.Columns = new[]
+            {
+                new TableColumn("Col 1"),
+                new TableColumn("Col 2"),
+            });
+        }
+
+        [Test]
+        public void TestContentAndHeaders()
+        {
+            AddStep("set cells", () =>
+            {
+                table.Content = createContent(3, 3);
+                table.Columns = new[]
+                {
+                    new TableColumn("Header 1"),
+                    new TableColumn("Header 2"),
+                    new TableColumn("Header 3"),
+                };
+            });
+
+            AddAssert("4 rows", () => getGrid().Content.Length == 4);
+            AddStep("disable headers", () => table.ShowHeaders = false);
+            AddAssert("3 rows", () => getGrid().Content.Length == 3);
+        }
+
+        [Test]
+        public void TestHeaderLongerThanContent()
+        {
+            AddStep("set cells", () =>
+            {
+                table.Content = createContent(2, 2);
+                table.Columns = new[]
+                {
+                    new TableColumn("Header 1"),
+                    new TableColumn("Header 2"),
+                    new TableColumn("Header 3"),
+                };
+            });
+
+            AddAssert("3 columns", () => getGrid().Content.Max(r => r.Length) == 3);
+            AddStep("disable headers", () => table.ShowHeaders = false);
+            AddAssert("2 columns", () => getGrid().Content.Max(r => r.Length) == 2);
+        }
+
+        [Test]
+        public void TestContentLongerThanHeader()
+        {
+            AddStep("set cells", () =>
+            {
+                table.Content = createContent(3, 3);
+                table.Columns = new[]
+                {
+                    new TableColumn("Header 1"),
+                    new TableColumn("Header 2"),
+                };
+            });
+
+            AddAssert("3 columns", () => getGrid().Content.Max(r => r.Length) == 3);
+            AddStep("disable headers", () => table.ShowHeaders = false);
+            AddAssert("2 columns", () => getGrid().Content.Max(r => r.Length) == 3);
+        }
+
+        [Test]
+        public void TestColumnsWithAnchors()
+        {
+            AddStep("set content", () =>
+            {
+                table.Content = createContent(3, 3);
+                table.Columns = new[]
+                {
+                    new TableColumn("Left", Anchor.CentreLeft),
+                    new TableColumn("Centre", Anchor.Centre),
+                    new TableColumn("Right", Anchor.CentreRight),
+                };
+            });
+
+            AddAssert("column 0 all left aligned", () => testColumn(0, Anchor.CentreLeft));
+            AddAssert("column 1 all centre aligned", () => testColumn(1, Anchor.Centre));
+            AddAssert("column 2 all right aligned", () => testColumn(2, Anchor.CentreRight));
+
+            AddStep("attempt to change anchor", () =>
+            {
+                var cell = table?.Content?[0, 0];
+                if (cell != null)
+                    cell.Anchor = Anchor.Centre;
+            });
+
+            // This currently fails, but should probably pass, but is particularly hard to fix.
+            // It's open to interpretation for how this should work, though, so it's not critical...
+            // AddAssert("column 0 all left aligned", () => testColumn(0, Anchor.CentreLeft));
+
+            AddStep("change columns", () => table.Columns = new[]
+            {
+                new TableColumn("Left", Anchor.CentreRight),
+                new TableColumn("Centre", Anchor.Centre),
+                new TableColumn("Right", Anchor.CentreLeft),
+            });
+
+            AddAssert("column 0 all right aligned", () => testColumn(0, Anchor.CentreRight));
+            AddAssert("column 1 all centre aligned", () => testColumn(1, Anchor.Centre));
+            AddAssert("column 2 all left aligned", () => testColumn(2, Anchor.CentreLeft));
+
+            AddStep("change content", () => table.Content = createContent(4, 4));
+
+            AddAssert("column 0 all right aligned", () => testColumn(0, Anchor.CentreRight));
+            AddAssert("column 1 all centre aligned", () => testColumn(1, Anchor.Centre));
+            AddAssert("column 2 all left aligned", () => testColumn(2, Anchor.CentreLeft));
+            AddAssert("column 3 all top-left aligned", () => testColumn(3, Anchor.TopLeft));
+
+            bool testColumn(int index, Anchor anchor)
+            {
+                for (int r = 0; r < getGrid().Content.Length; r++)
+                    if (getGrid().Content[r][index].Anchor != anchor)
+                        return false;
+
+                return true;
+            }
+        }
+
+        [Test]
+        public void TestChangeColumns()
+        {
+            AddStep("set content", () =>
+            {
+                table.Content = createContent(2, 2);
+                table.Columns = new[]
+                {
+                    new TableColumn("Header 1"),
+                    new TableColumn("Header 2"),
+                };
+            });
+
+            AddStep("increase columns", () => table.Columns = new[]
+            {
+                new TableColumn("Header 1"),
+                new TableColumn("Header 2"),
+                new TableColumn("Header 3"),
+            });
+
+            AddAssert("3 columns", () => getGrid().Content.Max(r => r.Length) == 3);
+
+            AddStep("decrease columns", () => table.Columns = new[]
+            {
+                new TableColumn("Header 1"),
+            });
+
+            AddAssert("2 columns", () => getGrid().Content.Max(r => r.Length) == 2);
+        }
+
+        [Test]
+        public void TestClearGrid()
+        {
+            AddStep("set content", () =>
+            {
+                table.Content = createContent(3, 3);
+                table.Columns = new[]
+                {
+                    new TableColumn("Header 1"),
+                    new TableColumn("Header 2"),
+                    new TableColumn("Header 3"),
+                };
+            });
+
+            AddStep("clear grid", () => table.Content = null);
+        }
+
+        private Drawable[,] createContent(int rows, int columns)
+        {
+            var content = new Drawable[rows, columns];
+
+            int cellIndex = 0;
+
+            for (int r = 0; r < rows; r++)
+            for (int c = 0; c < columns; c++)
+                content[r, c] = new Cell(cellIndex++);
+
+            return content;
+        }
+
+        private GridContainer getGrid() => (GridContainer)table.InternalChild;
+
+        private class Cell : SpriteText
+        {
+            public Cell(int index)
+            {
+                Text = $"Cell {index}";
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/TableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TableContainer.cs
@@ -131,16 +131,18 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
-        {
-            base.InvalidateFromChild(invalidation, source);
-
-            if ((invalidation & Invalidation.MiscGeometry) > 0)
-                updateAnchors();
-        }
-
         private int totalRows => content.GetLength(0) + (ShowHeaders ? 1 : 0);
-        private int totalColumns => content.GetLength(1);
+
+        private int totalColumns
+        {
+            get
+            {
+                if (columns == null || !showHeaders)
+                    return content.GetLength(1);
+
+                return Math.Max(columns.Length, content.GetLength(1));
+            }
+        }
 
         private void updateContent()
         {
@@ -163,20 +165,20 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>The content, with headers added if required.</returns>
         private Drawable[,] getContentWithHeaders()
         {
-            if (!ShowHeaders)
+            if (!ShowHeaders || Columns == null || Columns.Length == 0)
                 return content;
 
-            int rows = totalRows;
-            int cols = totalColumns;
+            int rowCount = totalRows;
+            int columnCount = totalColumns;
 
-            var result = new Drawable[rows, cols];
+            var result = new Drawable[rowCount, columnCount];
 
-            for (int row = 0; row < rows; row++)
-            for (int col = 0; col < cols; col++)
+            for (int row = 0; row < rowCount; row++)
+            for (int col = 0; col < columnCount; col++)
             {
                 if (row == 0)
-                    result[row, col] = CreateHeader(col, Columns?[col]);
-                else
+                    result[row, col] = CreateHeader(col, col >= Columns?.Length ? null : Columns?[col]);
+                else if (col < content.GetLength(1))
                     result[row, col] = content[row - 1, col];
             }
 
@@ -191,12 +193,12 @@ namespace osu.Framework.Graphics.Containers
             if (grid.Content == null)
                 return;
 
-            int rows = totalRows;
-            int cols = totalColumns;
+            int rowCount = totalRows;
+            int columnCount = totalColumns;
 
-            for (int row = 0; row < rows; row++)
+            for (int row = 0; row < rowCount; row++)
             {
-                for (int col = 0; col < cols; col++)
+                for (int col = 0; col < columnCount; col++)
                 {
                     if (col >= columns.Length)
                         break;

--- a/osu.Framework/Graphics/Containers/TableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TableContainer.cs
@@ -50,10 +50,11 @@ namespace osu.Framework.Graphics.Containers
         /// Describes the columns of this <see cref="TableContainer"/>.
         /// Each index of this array applies to the respective column index inside <see cref="Content"/>.
         /// </summary>
-        [CanBeNull]
         public TableColumn[] Columns
         {
+            [NotNull]
             get => columns;
+            [CanBeNull]
             set
             {
                 value = value ?? Array.Empty<TableColumn>();
@@ -137,7 +138,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The total number of rows in the content, including the header.
         /// </summary>
-        private int totalRows => content.GetLength(0) + (ShowHeaders ? 1 : 0);
+        private int totalRows => (content?.GetLength(0) ?? 0) + (ShowHeaders ? 1 : 0);
 
         /// <summary>
         /// The total number of columns in the content, including the header.
@@ -147,9 +148,9 @@ namespace osu.Framework.Graphics.Containers
             get
             {
                 if (columns == null || !showHeaders)
-                    return content.GetLength(1);
+                    return content?.GetLength(1) ?? 0;
 
-                return Math.Max(columns.Length, content.GetLength(1));
+                return Math.Max(columns.Length, content?.GetLength(1) ?? 0);
             }
         }
 
@@ -158,15 +159,10 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         private void updateContent()
         {
-            if (content == null)
-                grid.Content = null;
-            else
-            {
-                grid.Content = getContentWithHeaders().ToJagged();
+            grid.Content = getContentWithHeaders().ToJagged();
 
-                grid.ColumnDimensions = columns.Select(c => c.Dimension).ToArray();
-                grid.RowDimensions = Enumerable.Repeat(rowSize ?? new Dimension(), totalRows).ToArray();
-            }
+            grid.ColumnDimensions = columns.Select(c => c.Dimension).ToArray();
+            grid.RowDimensions = Enumerable.Repeat(rowSize ?? new Dimension(), totalRows).ToArray();
 
             updateAnchors();
         }

--- a/osu.Framework/Graphics/Containers/TableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TableContainer.cs
@@ -41,19 +41,19 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Column[] columns = Array.Empty<Column>();
+        private TableColumn[] columns = Array.Empty<TableColumn>();
 
         /// <summary>
         /// Describes the columns of this <see cref="TableContainer"/>.
         /// Each index of this array applies to the respective column index inside <see cref="Content"/>.
         /// </summary>
         [CanBeNull]
-        public Column[] Columns
+        public TableColumn[] Columns
         {
             get => columns;
             set
             {
-                value = value ?? Array.Empty<Column>();
+                value = value ?? Array.Empty<TableColumn>();
 
                 if (columns == value)
                     return;
@@ -64,21 +64,21 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Dimension rowDimension;
+        private Dimension rowSize;
 
         /// <summary>
         /// Explicit dimensions for rows. The dimension is applied to every row of this <see cref="TableContainer"/>
         /// </summary>
         [CanBeNull]
-        public Dimension RowDimension
+        public Dimension RowSize
         {
-            get => rowDimension;
+            get => rowSize;
             set
             {
-                if (rowDimension == value)
+                if (rowSize == value)
                     return;
 
-                rowDimension = value;
+                rowSize = value;
 
                 updateContent();
             }
@@ -151,7 +151,7 @@ namespace osu.Framework.Graphics.Containers
                 grid.Content = getContentWithHeaders().ToJagged();
 
                 grid.ColumnDimensions = columns.Select(c => c.Dimension).ToArray();
-                grid.RowDimensions = Enumerable.Repeat(rowDimension ?? new Dimension(), totalRows).ToArray();
+                grid.RowDimensions = Enumerable.Repeat(rowSize ?? new Dimension(), totalRows).ToArray();
             }
 
             updateAnchors();
@@ -231,10 +231,10 @@ namespace osu.Framework.Graphics.Containers
                 grid.AutoSizeAxes |= Axes.Y;
         }
 
-        protected virtual Drawable CreateHeader(int index, [CanBeNull] Column column) => new SpriteText { Text = column?.Header ?? string.Empty };
+        protected virtual Drawable CreateHeader(int index, [CanBeNull] TableColumn column) => new SpriteText { Text = column?.Header ?? string.Empty };
     }
 
-    public class Column
+    public class TableColumn
     {
         public readonly string Header;
 
@@ -242,7 +242,7 @@ namespace osu.Framework.Graphics.Containers
 
         public readonly Dimension Dimension;
 
-        public Column(string header = null, Anchor anchor = Anchor.TopLeft, Dimension dimension = null)
+        public TableColumn(string header = null, Anchor anchor = Anchor.TopLeft, Dimension dimension = null)
         {
             Header = header ?? "";
             Anchor = anchor;

--- a/osu.Framework/Graphics/Containers/TableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TableContainer.cs
@@ -68,17 +68,20 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Dimension rowSize;
+        private Dimension rowSize = new Dimension();
 
         /// <summary>
         /// Explicit dimensions for rows. The dimension is applied to every row of this <see cref="TableContainer"/>
         /// </summary>
-        [CanBeNull]
         public Dimension RowSize
         {
+            [NotNull]
             get => rowSize;
+            [CanBeNull]
             set
             {
+                value = value ?? new Dimension();
+
                 if (rowSize == value)
                     return;
 
@@ -162,7 +165,7 @@ namespace osu.Framework.Graphics.Containers
             grid.Content = getContentWithHeaders().ToJagged();
 
             grid.ColumnDimensions = columns.Select(c => c.Dimension).ToArray();
-            grid.RowDimensions = Enumerable.Repeat(rowSize ?? new Dimension(), totalRows).ToArray();
+            grid.RowDimensions = Enumerable.Repeat(RowSize, totalRows).ToArray();
 
             updateAnchors();
         }

--- a/osu.Framework/Graphics/Containers/TableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TableContainer.cs
@@ -9,6 +9,9 @@ using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Graphics.Containers
 {
+    /// <summary>
+    /// A container which tabulates <see cref="Drawable"/>s.
+    /// </summary>
     public class TableContainer : CompositeDrawable
     {
         private readonly GridContainer grid;
@@ -131,8 +134,14 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        /// <summary>
+        /// The total number of rows in the content, including the header.
+        /// </summary>
         private int totalRows => content.GetLength(0) + (ShowHeaders ? 1 : 0);
 
+        /// <summary>
+        /// The total number of columns in the content, including the header.
+        /// </summary>
         private int totalColumns
         {
             get
@@ -144,6 +153,9 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        /// <summary>
+        /// Adds content to the underlying grid.
+        /// </summary>
         private void updateContent()
         {
             if (content == null)
@@ -233,17 +245,41 @@ namespace osu.Framework.Graphics.Containers
                 grid.AutoSizeAxes |= Axes.Y;
         }
 
+        /// <summary>
+        /// Creates the content for a cell in the header row of the table.
+        /// </summary>
+        /// <param name="index">The column index.</param>
+        /// <param name="column">The column definition.</param>
+        /// <returns>The cell content.</returns>
         protected virtual Drawable CreateHeader(int index, [CanBeNull] TableColumn column) => new SpriteText { Text = column?.Header ?? string.Empty };
     }
 
+    /// <summary>
+    /// Defines a column of the <see cref="TableContainer"/>.
+    /// </summary>
     public class TableColumn
     {
+        /// <summary>
+        /// The text to be displayed in the cell.
+        /// </summary>
         public readonly string Header;
 
+        /// <summary>
+        /// The anchor of all cells in this column of the <see cref="TableContainer"/>.
+        /// </summary>
         public readonly Anchor Anchor;
 
+        /// <summary>
+        /// The dimension of the column in the table.
+        /// </summary>
         public readonly Dimension Dimension;
 
+        /// <summary>
+        /// Constructs a new <see cref="TableColumn"/>.
+        /// </summary>
+        /// <param name="header">The text to be displayed in the cell.</param>
+        /// <param name="anchor">The anchor of all cells in this column of the <see cref="TableContainer"/>.</param>
+        /// <param name="dimension">The dimension of the column in the table.</param>
         public TableColumn(string header = null, Anchor anchor = Anchor.TopLeft, Dimension dimension = null)
         {
             Header = header ?? "";

--- a/osu.Framework/Graphics/Containers/TableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TableContainer.cs
@@ -1,0 +1,252 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using JetBrains.Annotations;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Graphics.Containers
+{
+    public class TableContainer : CompositeDrawable
+    {
+        private readonly GridContainer grid;
+
+        public TableContainer()
+        {
+            InternalChild = grid = new GridContainer { RelativeSizeAxes = Axes.Both };
+        }
+
+        private Drawable[,] content;
+
+        /// <summary>
+        /// The content of this <see cref="TableContainer"/>, arranged in a 2D rectangular array.
+        /// <para>
+        /// Null elements are allowed to represent blank rows/cells.
+        /// </para>
+        /// </summary>
+        [CanBeNull]
+        public Drawable[,] Content
+        {
+            get => content;
+            set
+            {
+                if (content == value)
+                    return;
+
+                content = value;
+
+                updateContent();
+            }
+        }
+
+        private Column[] columns = Array.Empty<Column>();
+
+        /// <summary>
+        /// Describes the columns of this <see cref="TableContainer"/>.
+        /// Each index of this array applies to the respective column index inside <see cref="Content"/>.
+        /// </summary>
+        [CanBeNull]
+        public Column[] Columns
+        {
+            get => columns;
+            set
+            {
+                value = value ?? Array.Empty<Column>();
+
+                if (columns == value)
+                    return;
+
+                columns = value;
+
+                updateContent();
+            }
+        }
+
+        private Dimension rowDimension;
+
+        /// <summary>
+        /// Explicit dimensions for rows. The dimension is applied to every row of this <see cref="TableContainer"/>
+        /// </summary>
+        [CanBeNull]
+        public Dimension RowDimension
+        {
+            get => rowDimension;
+            set
+            {
+                if (rowDimension == value)
+                    return;
+
+                rowDimension = value;
+
+                updateContent();
+            }
+        }
+
+        private bool showHeaders = true;
+
+        /// <summary>
+        /// Whether to display a row with column headers at the top of the table.
+        /// </summary>
+        public bool ShowHeaders
+        {
+            get => showHeaders;
+            set
+            {
+                if (showHeaders == value)
+                    return;
+
+                showHeaders = value;
+
+                updateContent();
+            }
+        }
+
+        public override Axes RelativeSizeAxes
+        {
+            get => base.RelativeSizeAxes;
+            set
+            {
+                base.RelativeSizeAxes = value;
+                updateGridSize();
+            }
+        }
+
+        /// <summary>
+        /// Controls which <see cref="Axes"/> are automatically sized w.r.t. <see cref="CompositeDrawable.InternalChildren"/>.
+        /// Children's <see cref="Drawable.BypassAutoSizeAxes"/> are ignored for automatic sizing.
+        /// Most notably, <see cref="Drawable.RelativePositionAxes"/> and <see cref="Drawable.RelativeSizeAxes"/> of children
+        /// do not affect automatic sizing to avoid circular size dependencies.
+        /// It is not allowed to manually set <see cref="Drawable.Size"/> (or <see cref="Drawable.Width"/> / <see cref="Drawable.Height"/>)
+        /// on any <see cref="Axes"/> which are automatically sized.
+        /// </summary>
+        public new Axes AutoSizeAxes
+        {
+            get => base.AutoSizeAxes;
+            set
+            {
+                base.AutoSizeAxes = value;
+                updateGridSize();
+            }
+        }
+
+        public override void InvalidateFromChild(Invalidation invalidation, Drawable source = null)
+        {
+            base.InvalidateFromChild(invalidation, source);
+
+            if ((invalidation & Invalidation.MiscGeometry) > 0)
+                updateAnchors();
+        }
+
+        private int totalRows => content.GetLength(0) + (ShowHeaders ? 1 : 0);
+        private int totalColumns => content.GetLength(1);
+
+        private void updateContent()
+        {
+            if (content == null)
+                grid.Content = null;
+            else
+            {
+                grid.Content = getContentWithHeaders().ToJagged();
+
+                grid.ColumnDimensions = columns.Select(c => c.Dimension).ToArray();
+                grid.RowDimensions = Enumerable.Repeat(rowDimension ?? new Dimension(), totalRows).ToArray();
+            }
+
+            updateAnchors();
+        }
+
+        /// <summary>
+        /// Adds headers, if required, and returns the resulting content. <see cref="content"/> is not modified in the process.
+        /// </summary>
+        /// <returns>The content, with headers added if required.</returns>
+        private Drawable[,] getContentWithHeaders()
+        {
+            if (!ShowHeaders)
+                return content;
+
+            int rows = totalRows;
+            int cols = totalColumns;
+
+            var result = new Drawable[rows, cols];
+
+            for (int row = 0; row < rows; row++)
+            for (int col = 0; col < cols; col++)
+            {
+                if (row == 0)
+                    result[row, col] = CreateHeader(col, Columns?[col]);
+                else
+                    result[row, col] = content[row - 1, col];
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Ensures that all cells have the correct anchors defined by <see cref="Columns"/>.
+        /// </summary>
+        private void updateAnchors()
+        {
+            if (grid.Content == null)
+                return;
+
+            int rows = totalRows;
+            int cols = totalColumns;
+
+            for (int row = 0; row < rows; row++)
+            {
+                for (int col = 0; col < cols; col++)
+                {
+                    if (col >= columns.Length)
+                        break;
+
+                    Drawable child = grid.Content[row][col];
+
+                    if (child == null)
+                        continue;
+
+                    child.Origin = columns[col].Anchor;
+                    child.Anchor = columns[col].Anchor;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Keeps the grid autosized in our autosized axes, and relative-sized in our non-autosized axes.
+        /// </summary>
+        private void updateGridSize()
+        {
+            grid.RelativeSizeAxes = Axes.None;
+            grid.AutoSizeAxes = Axes.None;
+
+            if ((AutoSizeAxes & Axes.X) == 0)
+                grid.RelativeSizeAxes |= Axes.X;
+            else
+                grid.AutoSizeAxes |= Axes.X;
+
+            if ((AutoSizeAxes & Axes.Y) == 0)
+                grid.RelativeSizeAxes |= Axes.Y;
+            else
+                grid.AutoSizeAxes |= Axes.Y;
+        }
+
+        protected virtual Drawable CreateHeader(int index, [CanBeNull] Column column) => new SpriteText { Text = column?.Header ?? string.Empty };
+    }
+
+    public class Column
+    {
+        public readonly string Header;
+
+        public readonly Anchor Anchor;
+
+        public readonly Dimension Dimension;
+
+        public Column(string header = null, Anchor anchor = Anchor.TopLeft, Dimension dimension = null)
+        {
+            Header = header ?? "";
+            Anchor = anchor;
+            Dimension = dimension ?? new Dimension();
+        }
+    }
+}


### PR DESCRIPTION
Expands on `GridContainer` to allow customization of columns/headers.