### PR TITLE
Optimise IConvexPolygon.Insersects

### DIFF
--- a/osu.Framework/Extensions/PolygonExtensions/ConvexPolygonExtensions.cs
+++ b/osu.Framework/Extensions/PolygonExtensions/ConvexPolygonExtensions.cs
@@ -34,6 +34,13 @@ namespace osu.Framework.Extensions.PolygonExtensions
             return result;
         }
 
+        /// <summary>
+        /// Determines whether two sets of vertices intersect along a set of axes.
+        /// </summary>
+        /// <param name="axes">The axes to check for intersections along.</param>
+        /// <param name="firstVertices">The first set of vertices.</param>
+        /// <param name="secondVertices">The second set of vertices.</param>
+        /// <returns>Whether there is an intersection between <paramref name="firstVertices"/> and <see cref="secondVertices"/> along any of <paramref name="axes"/>.</returns>
         private static bool intersects(ReadOnlySpan<Vector2> axes, ReadOnlySpan<Vector2> firstVertices, ReadOnlySpan<Vector2> secondVertices)
         {
             foreach (Vector2 axis in axes)

--- a/osu.Framework/Extensions/PolygonExtensions/ConvexPolygonExtensions.cs
+++ b/osu.Framework/Extensions/PolygonExtensions/ConvexPolygonExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics.Primitives;
 using osuTK;
 
@@ -18,26 +19,30 @@ namespace osu.Framework.Extensions.PolygonExtensions
         /// <param name="first">The first polygon.</param>
         /// <param name="second">The second polygon.</param>
         /// <returns>Whether the two polygons intersect.</returns>
-        public static bool Intersects(this IConvexPolygon first, IConvexPolygon second)
+        public static bool Intersects<TPolygon1, TPolygon2>(this TPolygon1 first, TPolygon2 second)
+            where TPolygon1 : IConvexPolygon
+            where TPolygon2 : IConvexPolygon
         {
-            Vector2[][] bothAxes = { first.GetAxes(), second.GetAxes() };
-            Vector2[][] bothVertices = { first.Vertices, second.Vertices };
+            var firstVertices = first.GetVertices();
+            var secondVertices = second.GetVertices();
 
-            return intersects(bothAxes, bothVertices);
+            Span<Vector2> axisBuffer = stackalloc Vector2[Math.Max(firstVertices.Length, secondVertices.Length)];
+
+            bool result = intersects(first.GetAxes(axisBuffer), firstVertices, secondVertices);
+            result = result && intersects(second.GetAxes(axisBuffer), firstVertices, secondVertices);
+
+            return result;
         }
 
-        private static bool intersects(Vector2[][] bothAxes, Vector2[][] bothVertices)
+        private static bool intersects(ReadOnlySpan<Vector2> axes, ReadOnlySpan<Vector2> firstVertices, ReadOnlySpan<Vector2> secondVertices)
         {
-            foreach (Vector2[] axes in bothAxes)
+            foreach (Vector2 axis in axes)
             {
-                foreach (Vector2 axis in axes)
-                {
-                    ProjectionRange firstRange = new ProjectionRange(axis, bothVertices[0]);
-                    ProjectionRange secondRange = new ProjectionRange(axis, bothVertices[1]);
+                ProjectionRange firstRange = new ProjectionRange(axis, firstVertices);
+                ProjectionRange secondRange = new ProjectionRange(axis, secondVertices);
 
-                    if (!firstRange.Overlaps(secondRange))
-                        return false;
-                }
+                if (!firstRange.Overlaps(secondRange))
+                    return false;
             }
 
             return true;

--- a/osu.Framework/Extensions/PolygonExtensions/PolygonExtensions.cs
+++ b/osu.Framework/Extensions/PolygonExtensions/PolygonExtensions.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Extensions.PolygonExtensions
         /// <param name="buffer">A buffer to be used as storage for the axes. Must have a length of at least the count of vertices in <paramref name="polygon"/>.</param>
         /// <param name="normalize">Whether the normals should be normalized. Allows computation of the exact intersection point.</param>
         /// <returns>The axes of the polygon. Returned as a slice of <paramref name="buffer"/>.</returns>
-        internal static Span<Vector2> GetAxes<TPolygon>(this TPolygon polygon, Span<Vector2> buffer, bool normalize = false)
+        public static Span<Vector2> GetAxes<TPolygon>(this TPolygon polygon, Span<Vector2> buffer, bool normalize = false)
             where TPolygon : IPolygon
             => getAxes(polygon.GetAxisVertices(), buffer, normalize);
 

--- a/osu.Framework/Extensions/PolygonExtensions/PolygonExtensions.cs
+++ b/osu.Framework/Extensions/PolygonExtensions/PolygonExtensions.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics.Primitives;
 using osuTK;
 
@@ -11,18 +12,44 @@ namespace osu.Framework.Extensions.PolygonExtensions
         /// <summary>
         /// Computes the axes for each edge in a polygon.
         /// </summary>
-        /// <param name="polygon">The polygon to return the axes of.</param>
+        /// <param name="polygon">The polygon to compute the axes of.</param>
         /// <param name="normalize">Whether the normals should be normalized. Allows computation of the exact intersection point.</param>
         /// <returns>The axes of the polygon.</returns>
-        public static Vector2[] GetAxes(this IPolygon polygon, bool normalize = false)
+        public static Span<Vector2> GetAxes<TPolygon>(TPolygon polygon, bool normalize = false)
+            where TPolygon : IPolygon
         {
-            Vector2[] axes = new Vector2[polygon.AxisVertices.Length];
+            var axisVertices = polygon.GetAxisVertices();
 
-            for (int i = 0; i < polygon.AxisVertices.Length; i++)
+            var buffer = new Vector2[axisVertices.Length];
+
+            return getAxes(axisVertices, buffer, normalize);
+        }
+
+        /// <summary>
+        /// Computes the axes for each edge in a polygon.
+        /// </summary>
+        /// <param name="polygon">The polygon to compute the axes of.</param>
+        /// <param name="buffer">A buffer to be used as storage for the axes. Must have a length of at least the count of vertices in <paramref name="polygon"/>.</param>
+        /// <param name="normalize">Whether the normals should be normalized. Allows computation of the exact intersection point.</param>
+        /// <returns>The axes of the polygon. Returned as a slice of <paramref name="buffer"/>.</returns>
+        internal static Span<Vector2> GetAxes<TPolygon>(this TPolygon polygon, Span<Vector2> buffer, bool normalize = false)
+            where TPolygon : IPolygon
+            => getAxes(polygon.GetAxisVertices(), buffer, normalize);
+
+        /// <summary>
+        /// Computes the axes for a set of vertices.
+        /// </summary>
+        /// <param name="vertices">The vertices to compute the axes for.</param>
+        /// <param name="buffer">A buffer to be used as storage for the axes. Must have a length of at least the count of <paramref name="vertices"/>.</param>
+        /// <param name="normalize">Whether the normals should be normalized. Allows computation of the exact intersection point.</param>
+        /// <returns>The axes represented by <paramref name="vertices"/>. Returned as a slice of <paramref name="buffer"/>.</returns>
+        private static Span<Vector2> getAxes(ReadOnlySpan<Vector2> vertices, Span<Vector2> buffer, bool normalize = false)
+        {
+            for (int i = 0; i < vertices.Length; i++)
             {
                 // Construct an edge between two sequential points
-                Vector2 v1 = polygon.AxisVertices[i];
-                Vector2 v2 = polygon.AxisVertices[i == polygon.AxisVertices.Length - 1 ? 0 : i + 1];
+                Vector2 v1 = vertices[i];
+                Vector2 v2 = vertices[i == vertices.Length - 1 ? 0 : i + 1];
                 Vector2 edge = v2 - v1;
 
                 // Find the normal to the edge
@@ -31,10 +58,10 @@ namespace osu.Framework.Extensions.PolygonExtensions
                 if (normalize)
                     normal = Vector2.Normalize(normal);
 
-                axes[i] = normal;
+                buffer[i] = normal;
             }
 
-            return axes;
+            return buffer.Slice(0, vertices.Length);
         }
     }
 }

--- a/osu.Framework/Extensions/PolygonExtensions/PolygonExtensions.cs
+++ b/osu.Framework/Extensions/PolygonExtensions/PolygonExtensions.cs
@@ -42,6 +42,9 @@ namespace osu.Framework.Extensions.PolygonExtensions
         /// <returns>The axes represented by <paramref name="vertices"/>. Returned as a slice of <paramref name="buffer"/>.</returns>
         private static Span<Vector2> getAxes(ReadOnlySpan<Vector2> vertices, Span<Vector2> buffer, bool normalize = false)
         {
+            if (buffer.Length < vertices.Length)
+                throw new ArgumentException($"Axis buffer must have a length of {vertices.Length}, but was {buffer.Length}.", nameof(buffer));
+
             for (int i = 0; i < vertices.Length; i++)
             {
                 // Construct an edge between two sequential points

--- a/osu.Framework/Extensions/PolygonExtensions/PolygonExtensions.cs
+++ b/osu.Framework/Extensions/PolygonExtensions/PolygonExtensions.cs
@@ -19,10 +19,7 @@ namespace osu.Framework.Extensions.PolygonExtensions
             where TPolygon : IPolygon
         {
             var axisVertices = polygon.GetAxisVertices();
-
-            var buffer = new Vector2[axisVertices.Length];
-
-            return getAxes(axisVertices, buffer, normalize);
+            return getAxes(axisVertices, new Vector2[axisVertices.Length], normalize);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading.Tasks;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.PolygonExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Threading;
 

--- a/osu.Framework/Graphics/Primitives/IPolygon.cs
+++ b/osu.Framework/Graphics/Primitives/IPolygon.cs
@@ -10,8 +10,6 @@ namespace osu.Framework.Graphics.Primitives
     {
         /// <summary>
         /// The vertices for this polygon that define the axes spanned by the polygon.
-        /// <para>
-        /// </para>
         /// </summary>
         /// <remarks>
         /// Must be returned in a clockwise orientation. For best performance, colinear edges should not be included.

--- a/osu.Framework/Graphics/Primitives/IPolygon.cs
+++ b/osu.Framework/Graphics/Primitives/IPolygon.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osuTK;
 
 namespace osu.Framework.Graphics.Primitives
@@ -8,17 +9,22 @@ namespace osu.Framework.Graphics.Primitives
     public interface IPolygon
     {
         /// <summary>
-        /// The vertices for this polygon.
-        /// </summary>
-        Vector2[] Vertices { get; }
-
-        /// <summary>
-        /// The vertices for this polygon that are used to compute the axes of the polygon.
+        /// The vertices for this polygon that define the axes spanned by the polygon.
         /// <para>
-        /// Optimisation: Edges that would form duplicate normals as other edges
-        /// in the polygon do not need their vertices added to this array.
         /// </para>
         /// </summary>
-        Vector2[] AxisVertices { get; }
+        /// <remarks>
+        /// Must be returned in a clockwise orientation. For best performance, colinear edges should not be included.
+        /// </remarks>
+        ReadOnlySpan<Vector2> GetAxisVertices();
+
+        /// <summary>
+        /// Retrieves the vertices of this polygon.
+        /// </summary>
+        /// <remarks>
+        /// Must be returned in a clockwise orientation.
+        /// </remarks>
+        /// <returns>The vertices of this polygon.</returns>
+        ReadOnlySpan<Vector2> GetVertices();
     }
 }

--- a/osu.Framework/Graphics/Primitives/IPolygon.cs
+++ b/osu.Framework/Graphics/Primitives/IPolygon.cs
@@ -9,11 +9,14 @@ namespace osu.Framework.Graphics.Primitives
     public interface IPolygon
     {
         /// <summary>
-        /// The vertices for this polygon that define the axes spanned by the polygon.
+        /// The vertices that define the axes spanned by this polygon.
         /// </summary>
         /// <remarks>
-        /// Must be returned in a clockwise orientation. For best performance, colinear edges should not be included.
+        /// Must be returned in a clockwise orientation. For best performance, vertices that form colinear edges should not be included.
         /// </remarks>
+        /// <returns>
+        /// The vertices that define the axes spanned by this polygon.
+        /// </returns>
         ReadOnlySpan<Vector2> GetAxisVertices();
 
         /// <summary>

--- a/osu.Framework/Graphics/Primitives/ProjectionRange.cs
+++ b/osu.Framework/Graphics/Primitives/ProjectionRange.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osuTK;
 
 namespace osu.Framework.Graphics.Primitives
@@ -21,7 +22,7 @@ namespace osu.Framework.Graphics.Primitives
         /// </summary>
         public float Max { get; }
 
-        public ProjectionRange(Vector2 axis, Vector2[] vertices)
+        public ProjectionRange(Vector2 axis, ReadOnlySpan<Vector2> vertices)
         {
             Min = 0;
             Max = 0;

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -3,15 +3,16 @@
 
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using osuTK;
 using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Primitives
 {
+    [StructLayout(LayoutKind.Sequential)]
     public struct Quad : IConvexPolygon, IEquatable<Quad>
     {
-        // Note: Vertices are clockwise-ordered
-
+        // Note: Do not change the order of vertices.
         public Vector2 TopLeft;
         public Vector2 TopRight;
         public Vector2 BottomRight;
@@ -107,7 +108,7 @@ namespace osu.Framework.Graphics.Primitives
         {
             unsafe
             {
-                return new Span<Vector2>(Unsafe.AsPointer(ref this), 4);
+                return new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref this), 4);
             }
         }
 

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Extensions.PolygonExtensions;
+using System.Runtime.CompilerServices;
 using osuTK;
 using osu.Framework.MathUtils;
 
@@ -10,10 +10,12 @@ namespace osu.Framework.Graphics.Primitives
 {
     public struct Quad : IConvexPolygon, IEquatable<Quad>
     {
+        // Note: Vertices are clockwise-ordered
+
         public Vector2 TopLeft;
         public Vector2 TopRight;
-        public Vector2 BottomLeft;
         public Vector2 BottomRight;
+        public Vector2 BottomLeft;
 
         public Quad(Vector2 topLeft, Vector2 topRight, Vector2 bottomLeft, Vector2 bottomRight)
         {
@@ -99,8 +101,15 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public Vector2[] Vertices => new[] { TopLeft, TopRight, BottomRight, BottomLeft };
-        public Vector2[] AxisVertices => Vertices;
+        public ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
+
+        public ReadOnlySpan<Vector2> GetVertices()
+        {
+            unsafe
+            {
+                return new Span<Vector2>(Unsafe.AsPointer(ref this), 4);
+            }
+        }
 
         public bool Contains(Vector2 pos) =>
             new Triangle(BottomRight, BottomLeft, TopRight).Contains(pos) ||
@@ -127,8 +136,6 @@ namespace osu.Framework.Graphics.Primitives
                 return (float)Math.Sqrt(lsq1 * lsq2);
             }
         }
-
-        public bool Intersects(IConvexPolygon other) => (this as IConvexPolygon).Intersects(other);
 
         public bool Equals(Quad other) =>
             TopLeft == other.TopLeft &&


### PR DESCRIPTION
Originally I just wanted to get `ReadOnlySpan<Vector2> GetVertices()` in, but decided to take the time and optimise the existing intersection code since this code sometimes runs per-frame (see: `DelayedLoadWrapper`).

In this PR:

1. `Quad` vertices are made to be clockwise. This is now required for correct implementations of `IPolygon`.
2. Generics are used to avoid boxing of `IConvexPolygon` and `IPolygon`.
3. All allocations of vertex arrays have been removed, either through unsafe or use of stackalloc. Use of stack space should be fine for now since there's little vertices in all cases. In the future we may want to add a heuristic or a global buffer.

```diff
  | Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
  |------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
- |  Quads | 1.251 us | 0.0077 us | 0.0068 us | 0.7668 |     - |     - |   2.36 KB |
+ |  Quads | 472.0 ns |  1.697 ns |  1.587 ns |      - |     - |     - |         - |
```

(This is KBs allocated per intersection. with 0.76 gen0 collections per 1000 intersections)