### PR TITLE
Prevent non-current screens from handling input

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -525,7 +525,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 inputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("screen 2 is clicked", () => screen2.IsCurrentScreen() && screen2.Clicked);
+            AddAssert("screen 2 is clicked and screen 1 is not clicked", () => screen2.IsCurrentScreen() && screen2.Clicked && !screen1.Clicked);
         }
 
         private ManualInputManager createManualInputManager()

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -482,6 +482,54 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestNonCurrentScreenDoesNotAcceptInput()
         {
+            ManualInputManager inputManager = createManualInputManager();
+
+            TestScreen screen1 = null;
+            TestScreen screen2 = null;
+
+            pushAndEnsureCurrent(() => screen1 = new TestScreen());
+            AddStep("push slow", () => screen1.Push(screen2 = new TestScreenSlow()));
+            AddStep("click centre of screen", () =>
+            {
+                inputManager.MoveMouseTo(screen1);
+                inputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("screen 1 not clicked", () => !screen1.Clicked);
+            AddAssert("Screen 2 not clicked", () => !screen2.Clicked && !screen2.IsLoaded);
+        }
+
+        /// <summary>
+        /// Push two screens and check that both screens accept input when they are respectively current.
+        /// </summary>
+        [Test]
+        public void TestCurrentScreenAcceptsInput()
+        {
+            ManualInputManager inputManager = createManualInputManager();
+
+            TestScreen screen1 = null;
+            TestScreen screen2 = null;
+
+            pushAndEnsureCurrent(() => screen1 = new TestScreen());
+            AddStep("click centre of screen", () =>
+            {
+                inputManager.MoveMouseTo(screen1);
+                inputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("screen 1 is clicked", () => screen1.IsCurrentScreen() && screen1.Clicked);
+            pushAndEnsureCurrent(() => screen2 = new TestScreen());
+            AddStep("click centre of screen", () =>
+            {
+                inputManager.MoveMouseTo(screen2);
+                inputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("screen 2 is clicked", () => screen2.IsCurrentScreen() && screen2.Clicked);
+        }
+
+        private ManualInputManager createManualInputManager()
+        {
             ManualInputManager inputManager = null;
 
             AddStep("override stack", () =>
@@ -498,19 +546,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 });
             });
 
-            TestScreen screen1 = null;
-            TestScreen screen2 = null;
-
-            pushAndEnsureCurrent(() => screen1 = new TestScreen());
-            AddStep("push slow", () => screen1.Push(screen2 = new TestScreenSlow()));
-            AddStep("click centre of screen", () =>
-            {
-                inputManager.MoveMouseTo(screen1);
-                inputManager.Click(MouseButton.Left);
-            });
-
-            AddAssert("screen 1 not clicked", () => !screen1.Clicked);
-            AddAssert("Screen 2 not clicked", () => !screen2.Clicked && !screen2.IsLoaded);
+            return inputManager;
         }
 
         private void pushAndEnsureCurrent(Func<IScreen> screenCtor, Func<IScreen> target = null)

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -477,8 +477,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         /// <summary>
-        /// Click after pushing a slow loading screen to a base screen.
-        /// Check that neither screens handle input while the pushed screen is still loading.
+        /// Push two screens and check that neither screens handle input while the pushed screen is still loading.
         /// </summary>
         [Test]
         public void TestNonCurrentScreenDoesNotAcceptInput()

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -476,6 +476,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("Bindables have been returned by new screen", () => !screen2.DummyBindable.Disabled && !screen2.LeasedCopy.Disabled);
         }
 
+        /// <summary>
+        /// Click after pushing a slow loading screen to a base screen.
+        /// Check that neither screens handle input while the pushed screen is still loading.
+        /// </summary>
         [Test]
         public void TestNonCurrentScreenDoesNotAcceptInput()
         {
@@ -496,9 +500,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
 
             TestScreen screen1 = null;
+            TestScreen screen2 = null;
 
             pushAndEnsureCurrent(() => screen1 = new TestScreen());
-            AddStep("push", () => screen1.Push(new TestScreenSlow()));
+            AddStep("push slow", () => screen1.Push(screen2 = new TestScreenSlow()));
             AddStep("click centre of screen", () =>
             {
                 inputManager.MoveMouseTo(screen1);
@@ -506,6 +511,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
 
             AddAssert("screen 1 not clicked", () => !screen1.Clicked);
+            AddAssert("Screen 2 not clicked", () => !screen2.Clicked && !screen2.IsLoaded);
         }
 
         private void pushAndEnsureCurrent(Func<IScreen> screenCtor, Func<IScreen> target = null)

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -506,7 +506,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("screen 1 clicked", () => screen1.ClickCount == 1);
 
             AddStep("push slow", () => screen1.Push(screen2 = new TestScreenSlow()));
-            AddStep("Click center of screen", () => clickScreen(inputManager, screen2));
+            AddStep("Click center of screen", () => inputManager.Click(MouseButton.Left));
             AddAssert("screen 1 not clicked", () => screen1.ClickCount == 1);
             AddAssert("Screen 2 not clicked", () => screen2.ClickCount == 0 && !screen2.IsLoaded);
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -482,54 +482,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestNonCurrentScreenDoesNotAcceptInput()
         {
-            ManualInputManager inputManager = createManualInputManager();
-
-            TestScreen screen1 = null;
-            TestScreen screen2 = null;
-
-            pushAndEnsureCurrent(() => screen1 = new TestScreen());
-            AddStep("push slow", () => screen1.Push(screen2 = new TestScreenSlow()));
-            AddStep("click centre of screen", () =>
-            {
-                inputManager.MoveMouseTo(screen1);
-                inputManager.Click(MouseButton.Left);
-            });
-
-            AddAssert("screen 1 not clicked", () => !screen1.Clicked);
-            AddAssert("Screen 2 not clicked", () => !screen2.Clicked && !screen2.IsLoaded);
-        }
-
-        /// <summary>
-        /// Push two screens and check that both screens accept input when they are respectively current.
-        /// </summary>
-        [Test]
-        public void TestCurrentScreenAcceptsInput()
-        {
-            ManualInputManager inputManager = createManualInputManager();
-
-            TestScreen screen1 = null;
-            TestScreen screen2 = null;
-
-            pushAndEnsureCurrent(() => screen1 = new TestScreen());
-            AddStep("click centre of screen", () =>
-            {
-                inputManager.MoveMouseTo(screen1);
-                inputManager.Click(MouseButton.Left);
-            });
-
-            AddAssert("screen 1 is clicked", () => screen1.IsCurrentScreen() && screen1.Clicked);
-            pushAndEnsureCurrent(() => screen2 = new TestScreen());
-            AddStep("click centre of screen", () =>
-            {
-                inputManager.MoveMouseTo(screen2);
-                inputManager.Click(MouseButton.Left);
-            });
-
-            AddAssert("screen 2 is clicked and screen 1 is not clicked", () => screen2.IsCurrentScreen() && screen2.Clicked && !screen1.Clicked);
-        }
-
-        private ManualInputManager createManualInputManager()
-        {
             ManualInputManager inputManager = null;
 
             AddStep("override stack", () =>
@@ -546,7 +498,19 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 });
             });
 
-            return inputManager;
+            TestScreen screen1 = null;
+            TestScreen screen2 = null;
+
+            pushAndEnsureCurrent(() => screen1 = new TestScreen());
+            AddStep("push slow", () => screen1.Push(screen2 = new TestScreenSlow()));
+            AddStep("click centre of screen", () =>
+            {
+                inputManager.MoveMouseTo(screen1);
+                inputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("screen 1 not clicked", () => !screen1.Clicked);
+            AddAssert("Screen 2 not clicked", () => !screen2.Clicked && !screen2.IsLoaded);
         }
 
         private void pushAndEnsureCurrent(Func<IScreen> screenCtor, Func<IScreen> target = null)

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using osu.Framework.Development;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Input;
 using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Containers
@@ -120,7 +121,8 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="cancellation">An optional cancellation token.</param>
         /// <param name="scheduler">The scheduler for <paramref name="onLoaded"/> to be invoked on. If null, the local scheduler will be used.</param>
         /// <returns>The task which is used for loading and callbacks.</returns>
-        protected internal Task LoadComponentsAsync<TLoadable>(IEnumerable<TLoadable> components, Action<IEnumerable<TLoadable>> onLoaded = null, CancellationToken cancellation = default, Scheduler scheduler = null)
+        protected internal Task LoadComponentsAsync<TLoadable>(IEnumerable<TLoadable> components, Action<IEnumerable<TLoadable>> onLoaded = null, CancellationToken cancellation = default,
+                                                               Scheduler scheduler = null)
             where TLoadable : Drawable
         {
             if (game == null)
@@ -1222,8 +1224,7 @@ namespace osu.Framework.Graphics.Containers
             if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))
                 return false;
 
-            for (int i = 0; i < aliveInternalChildren.Count; ++i)
-                aliveInternalChildren[i].BuildNonPositionalInputQueue(queue, allowBlocking);
+            BuildInternalNonPositionalInputQueue(queue, allowBlocking);
 
             return true;
         }
@@ -1236,10 +1237,31 @@ namespace osu.Framework.Graphics.Containers
             if (Masking && !ReceivePositionalInputAt(screenSpacePos))
                 return false;
 
-            for (int i = 0; i < aliveInternalChildren.Count; ++i)
-                aliveInternalChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
+            BuildInternalPositionalInputQueue(screenSpacePos, queue);
 
             return true;
+        }
+
+        /// <summary>
+        /// Calls <see cref="Drawable.BuildPositionalInputQueue"/> for the internal children of this composite drawable.
+        /// </summary>
+        /// <param name="screenSpacePos">The screen space position of the positional input.</param>
+        /// <param name="queue">The input queue to be built.</param>
+        protected virtual void BuildInternalPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        {
+            for (int i = 0; i < aliveInternalChildren.Count; ++i)
+                aliveInternalChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
+        }
+
+        /// <summary>
+        /// Calls <see cref="Drawable.BuildNonPositionalInputQueue"/> for the internal children of this composite drawable.
+        /// </summary>
+        /// <param name="queue">The input queue to be built.</param>
+        /// <param name="allowBlocking">Whether blocking at <see cref="PassThroughInputManager"/>s should be allowed.</param>
+        protected virtual void BuildInternalNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        {
+            for (int i = 0; i < aliveInternalChildren.Count; ++i)
+                aliveInternalChildren[i].BuildNonPositionalInputQueue(queue, allowBlocking);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1219,9 +1219,9 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Evaluate a child for whether or not it should be considered when building input queues.
+        /// Check whether a child should be considered for inclusion in <see cref="BuildNonPositionalInputQueue"/> and <see cref="BuildPositionalInputQueue"/>
         /// </summary>
-        /// <param name="child">The drawable to be evaluated</param>
+        /// <param name="child">The drawable to be evaluated.</param>
         /// <returns>Whether or not the specified drawable should be considered when building input queues.</returns>
         protected virtual bool ShouldBeConsideredForInput(Drawable child) => true;
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1224,7 +1224,7 @@ namespace osu.Framework.Graphics.Containers
             if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))
                 return false;
 
-            BuildInternalNonPositionalInputQueue(queue, allowBlocking);
+            BuildNonPositionalInputQueueChildren(aliveInternalChildren, queue, allowBlocking);
 
             return true;
         }
@@ -1237,31 +1237,33 @@ namespace osu.Framework.Graphics.Containers
             if (Masking && !ReceivePositionalInputAt(screenSpacePos))
                 return false;
 
-            BuildInternalPositionalInputQueue(screenSpacePos, queue);
+            BuildPositionalInputQueueChildren(aliveInternalChildren, screenSpacePos, queue);
 
             return true;
         }
 
         /// <summary>
-        /// Calls <see cref="Drawable.BuildPositionalInputQueue"/> for the internal children of this composite drawable.
+        /// Calls <see cref="Drawable.BuildPositionalInputQueue"/> for a provided list of children.
         /// </summary>
+        /// <param name="aliveChildren">The list of children that should be added to the queue.</param>
         /// <param name="screenSpacePos">The screen space position of the positional input.</param>
         /// <param name="queue">The input queue to be built.</param>
-        protected virtual void BuildInternalPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        protected virtual void BuildPositionalInputQueueChildren(SortedList<Drawable> aliveChildren, Vector2 screenSpacePos, List<Drawable> queue)
         {
-            for (int i = 0; i < aliveInternalChildren.Count; ++i)
-                aliveInternalChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
+            for (int i = 0; i < aliveChildren.Count; ++i)
+                aliveChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
         }
 
         /// <summary>
-        /// Calls <see cref="Drawable.BuildNonPositionalInputQueue"/> for the internal children of this composite drawable.
+        /// Calls <see cref="Drawable.BuildNonPositionalInputQueue"/> for a provided list of children.
         /// </summary>
+        /// <param name="aliveChildren">The list of children that should be added to the queue.</param>
         /// <param name="queue">The input queue to be built.</param>
         /// <param name="allowBlocking">Whether blocking at <see cref="PassThroughInputManager"/>s should be allowed.</param>
-        protected virtual void BuildInternalNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        protected virtual void BuildNonPositionalInputQueueChildren(SortedList<Drawable> aliveChildren, List<Drawable> queue, bool allowBlocking = true)
         {
-            for (int i = 0; i < aliveInternalChildren.Count; ++i)
-                aliveInternalChildren[i].BuildNonPositionalInputQueue(queue, allowBlocking);
+            for (int i = 0; i < aliveChildren.Count; ++i)
+                aliveChildren[i].BuildNonPositionalInputQueue(queue, allowBlocking);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1230,9 +1230,10 @@ namespace osu.Framework.Graphics.Containers
             if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))
                 return false;
 
-            foreach (Drawable d in aliveInternalChildren.Where(ShouldBeConsideredForInput))
+            for (int i = 0; i < aliveInternalChildren.Count; ++i)
             {
-                d.BuildNonPositionalInputQueue(queue, allowBlocking);
+                if (ShouldBeConsideredForInput(aliveInternalChildren[i]))
+                    aliveInternalChildren[i].BuildNonPositionalInputQueue(queue, allowBlocking);
             }
 
             return true;
@@ -1246,9 +1247,10 @@ namespace osu.Framework.Graphics.Containers
             if (Masking && !ReceivePositionalInputAt(screenSpacePos))
                 return false;
 
-            foreach (Drawable d in aliveInternalChildren.Where(ShouldBeConsideredForInput))
+            for (int i = 0; i < aliveInternalChildren.Count; ++i)
             {
-                d.BuildPositionalInputQueue(screenSpacePos, queue);
+                if (ShouldBeConsideredForInput(aliveInternalChildren[i]))
+                    aliveInternalChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
             }
 
             return true;

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -308,13 +308,9 @@ namespace osu.Framework.Screens
 
         internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
-            // Avoids the use of CompositeDrawable.BuildNonPositionalInputQueue as any number of screens may be alive while loading/suspending.
-            // This method otherwise matches the implementation of Drawable.BuildNonPositionalInputQueue.
+            // Avoids the use of CompositeDrawable.BuildNonPositionalInputQueue as only the current screen should be allowed to handle input.
             if (!PropagateNonPositionalInputSubTree)
                 return false;
-
-            if (HandleNonPositionalInput)
-                queue.Add(this);
 
             CurrentScreen?.AsDrawable().BuildNonPositionalInputQueue(queue, allowBlocking);
 
@@ -323,13 +319,9 @@ namespace osu.Framework.Screens
 
         internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
-            // Avoids the use of CompositeDrawable.BuildPositionalInputQueue as any number of screens may be alive while loading/suspending.
-            // This method otherwise matches the implementation of Drawable.BuildPositionalInputQueue.
+            // Avoids the use of CompositeDrawable.BuildPositionalInputQueue as only the current screen should be allowed to handle input.
             if (!PropagatePositionalInputSubTree)
                 return false;
-
-            if (HandlePositionalInput && ReceivePositionalInputAt(screenSpacePos))
-                queue.Add(this);
 
             CurrentScreen?.AsDrawable().BuildPositionalInputQueue(screenSpacePos, queue);
 

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -9,8 +9,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Lists;
-using osuTK;
 
 namespace osu.Framework.Screens
 {
@@ -287,6 +285,8 @@ namespace osu.Framework.Screens
                 exitFrom(source);
         }
 
+        protected override bool ShouldBeConsideredForInput(Drawable child) => !(child is IScreen screen) || screen.IsCurrentScreen();
+
         protected override bool UpdateChildrenLife()
         {
             if (!base.UpdateChildrenLife()) return false;
@@ -305,26 +305,6 @@ namespace osu.Framework.Screens
             }
 
             return true;
-        }
-
-        protected override void BuildPositionalInputQueueChildren(SortedList<Drawable> aliveChildren, Vector2 screenSpacePos, List<Drawable> queue)
-        {
-            // Only allow the current screen and non-IScreen drawables to handle positional input.
-            for (int i = 0; i < aliveChildren.Count; ++i)
-            {
-                if (!(aliveChildren[i] is IScreen screen) || screen.IsCurrentScreen())
-                    aliveChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
-            }
-        }
-
-        protected override void BuildNonPositionalInputQueueChildren(SortedList<Drawable> aliveChildren, List<Drawable> queue, bool allowBlocking = true)
-        {
-            // Only allow the current screen and non-IScreen drawables to handle non-positional input.
-            for (int i = 0; i < aliveChildren.Count; ++i)
-            {
-                if (!(aliveChildren[i] is IScreen screen) || screen.IsCurrentScreen())
-                    aliveChildren[i].BuildNonPositionalInputQueue(queue, allowBlocking);
-            }
         }
 
         public class ScreenNotCurrentException : InvalidOperationException

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -6,10 +6,10 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Lists;
 using osuTK;
 
 namespace osu.Framework.Screens
@@ -307,24 +307,24 @@ namespace osu.Framework.Screens
             return true;
         }
 
-        protected override void BuildInternalPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        protected override void BuildPositionalInputQueueChildren(SortedList<Drawable> aliveChildren, Vector2 screenSpacePos, List<Drawable> queue)
         {
             // Only allow the current screen and non-IScreen drawables to handle positional input.
-            AliveInternalChildren.ForEach(c =>
+            for (int i = 0; i < aliveChildren.Count; ++i)
             {
-                if (!(c is IScreen screen) || screen.IsCurrentScreen())
-                    c.BuildPositionalInputQueue(screenSpacePos, queue);
-            });
+                if (!(aliveChildren[i] is IScreen screen) || screen.IsCurrentScreen())
+                    aliveChildren[i].BuildPositionalInputQueue(screenSpacePos, queue);
+            }
         }
 
-        protected override void BuildInternalNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        protected override void BuildNonPositionalInputQueueChildren(SortedList<Drawable> aliveChildren, List<Drawable> queue, bool allowBlocking = true)
         {
             // Only allow the current screen and non-IScreen drawables to handle non-positional input.
-            AliveInternalChildren.ForEach(c =>
+            for (int i = 0; i < aliveChildren.Count; ++i)
             {
-                if (!(c is IScreen screen) || screen.IsCurrentScreen())
-                    c.BuildNonPositionalInputQueue(queue, allowBlocking);
-            });
+                if (!(aliveChildren[i] is IScreen screen) || screen.IsCurrentScreen())
+                    aliveChildren[i].BuildNonPositionalInputQueue(queue, allowBlocking);
+            }
         }
 
         public class ScreenNotCurrentException : InvalidOperationException

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -9,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osuTK;
 
 namespace osu.Framework.Screens
 {
@@ -301,6 +302,32 @@ namespace osu.Framework.Screens
 
                 exited.Clear();
             }
+
+            return true;
+        }
+
+        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        {
+            if (!PropagateNonPositionalInputSubTree)
+                return false;
+
+            if (HandleNonPositionalInput)
+                queue.Add(this);
+
+            CurrentScreen?.AsDrawable().BuildNonPositionalInputQueue(queue, allowBlocking);
+
+            return true;
+        }
+
+        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        {
+            if (!PropagatePositionalInputSubTree)
+                return false;
+
+            if (HandlePositionalInput && ReceivePositionalInputAt(screenSpacePos))
+                queue.Add(this);
+
+            CurrentScreen?.AsDrawable().BuildPositionalInputQueue(screenSpacePos, queue);
 
             return true;
         }

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -306,26 +307,24 @@ namespace osu.Framework.Screens
             return true;
         }
 
-        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        protected override void BuildInternalPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
-            // Avoids the use of CompositeDrawable.BuildNonPositionalInputQueue as only the current screen should be allowed to handle input.
-            if (!PropagateNonPositionalInputSubTree)
-                return false;
-
-            CurrentScreen?.AsDrawable().BuildNonPositionalInputQueue(queue, allowBlocking);
-
-            return true;
+            // Only allow the current screen and non-IScreen drawables to handle positional input.
+            AliveInternalChildren.ForEach(c =>
+            {
+                if (!(c is IScreen screen) || screen.IsCurrentScreen())
+                    c.BuildPositionalInputQueue(screenSpacePos, queue);
+            });
         }
 
-        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        protected override void BuildInternalNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
-            // Avoids the use of CompositeDrawable.BuildPositionalInputQueue as only the current screen should be allowed to handle input.
-            if (!PropagatePositionalInputSubTree)
-                return false;
-
-            CurrentScreen?.AsDrawable().BuildPositionalInputQueue(screenSpacePos, queue);
-
-            return true;
+            // Only allow the current screen and non-IScreen drawables to handle non-positional input.
+            AliveInternalChildren.ForEach(c =>
+            {
+                if (!(c is IScreen screen) || screen.IsCurrentScreen())
+                    c.BuildNonPositionalInputQueue(queue, allowBlocking);
+            });
         }
 
         public class ScreenNotCurrentException : InvalidOperationException

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -308,6 +308,8 @@ namespace osu.Framework.Screens
 
         internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
+            // Avoids the use of CompositeDrawable.BuildNonPositionalInputQueue as any number of screens may be alive while loading/suspending.
+            // This method otherwise matches the implementation of Drawable.BuildNonPositionalInputQueue.
             if (!PropagateNonPositionalInputSubTree)
                 return false;
 
@@ -321,6 +323,8 @@ namespace osu.Framework.Screens
 
         internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
+            // Avoids the use of CompositeDrawable.BuildPositionalInputQueue as any number of screens may be alive while loading/suspending.
+            // This method otherwise matches the implementation of Drawable.BuildPositionalInputQueue.
             if (!PropagatePositionalInputSubTree)
                 return false;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/2277
Fixes ppy/osu#4530

Keep in mind that as a result of https://github.com/ppy/osu-framework/issues/2345, running tests in the test browser sequentially will not reach the test added in this branch as it will fail before then. 