### PR TITLE
Prevent OnUnbind from being invoked twice in TestScreens

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -541,7 +541,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             {
                 base.UnbindAllBindables();
 
-                // Don't fire for a second unbind since the second one gets blocked in Drawable.
+                // As a second unbind event would incorrectly cause TestMakeCurrentUnbindOrder check to fail, block it.
                 if (!hasUnbound)
                     OnUnbind?.Invoke();
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -437,23 +437,31 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestMakeCurrentUnbindOrder()
         {
-            List<TestScreen> screens = new List<TestScreen>();
+            List<TestScreen> screens = null;
+
+            AddStep("Setup screens", () =>
+            {
+                screens = new List<TestScreen>();
+                for (int i = 0; i < 5; i++)
+                {
+                    var screen = new TestScreen();
+
+                    screen.OnUnbind += () =>
+                    {
+                        if (screens.Last() != screen)
+                            throw new InvalidOperationException("Disposal order was wrong");
+
+                        screens.Remove(screen);
+                    };
+
+                    screens.Add(screen);
+                }
+            });
 
             for (int i = 0; i < 5; i++)
             {
-                var screen = new TestScreen();
-                var target = screens.LastOrDefault();
-
-                screen.OnUnbind += () =>
-                {
-                    if (screens.Last() != screen)
-                        throw new InvalidOperationException("Disposal order was wrong");
-
-                    screens.Remove(screen);
-                };
-
-                pushAndEnsureCurrent(() => screen, target != null ? () => target : (Func<IScreen>)null);
-                screens.Add(screen);
+                var local = i; // needed to store the correct value for our delegate
+                pushAndEnsureCurrent(() => screens[local], () => local > 0 ? screens[local - 1] : null);
             }
 
             AddStep("make first screen current", () => screens.First().MakeCurrent());
@@ -527,11 +535,17 @@ namespace osu.Framework.Tests.Visual.UserInterface
             public readonly Bindable<bool> DummyBindable = new Bindable<bool>();
 
             private readonly bool shouldTakeOutLease;
+            private bool hasUnbound;
 
             internal override void UnbindAllBindables()
             {
                 base.UnbindAllBindables();
-                OnUnbind?.Invoke();
+
+                // Don't fire for a second unbind since the second one gets blocked in Drawable.
+                if (!hasUnbound)
+                    OnUnbind?.Invoke();
+
+                hasUnbound = true;
             }
 
             public TestScreen(bool shouldTakeOutLease = false)


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/2345

Since DisposeChildAsync unbinds bindables after it has already been unbound OnExiting, the OnUnbind check will fail. The actual second unbind gets blocked at the Drawable level, so correcting the test should be enough.

Also fixes TestMakeCurrentUnbindOrder to be resettable.