### PR TITLE
Add generalized Annulus alongside CircularProgress

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseAnnulus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseAnnulus.cs
@@ -85,16 +85,16 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 },
             };
 
-            AddStep("Horizontal Gradient Texture", delegate { setTexture(1); });
-            AddStep("Vertical Gradient Texture", delegate { setTexture(2); });
-            AddStep("2D Gradient Texture", delegate { setTexture(3); });
-            AddStep("White Texture", delegate { setTexture(0); });
+            AddStep("Horizontal Gradient Texture", () => setTexture(1));
+            AddStep("Vertical Gradient Texture", () => setTexture(2));
+            AddStep("2D Gradient Texture", () => setTexture(3));
+            AddStep("White Texture", () => setTexture(0));
 
-            AddStep("Red Colour", delegate { setColour(1); });
-            AddStep("Horzontal Gradient Colour", delegate { setColour(2); });
-            AddStep("Vertical Gradient Colour", delegate { setColour(3); });
-            AddStep("2D Gradient Colour", delegate { setColour(4); });
-            AddStep("White Colour", delegate { setColour(0); });
+            AddStep("Red Colour", () => setColour(1));
+            AddStep("Horzontal Gradient Colour", () => setColour(2));
+            AddStep("Vertical Gradient Colour", () => setColour(3));
+            AddStep("2D Gradient Colour", () => setColour(4));
+            AddStep("White Colour", () => setColour(0));
 
             AddSliderStep("Start angle", 0d, 2d, 0d, angle => annulus.StartAngle.Value = MathHelper.TwoPi * angle);
             AddSliderStep("End angle", 0d, 2d, 1d, angle => annulus.EndAngle.Value = MathHelper.TwoPi * angle);

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseAnnulus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseAnnulus.cs
@@ -84,7 +84,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     Origin = Anchor.Centre,
                 },
             };
-            
+
             AddStep("Horizontal Gradient Texture", delegate { setTexture(1); });
             AddStep("Vertical Gradient Texture", delegate { setTexture(2); });
             AddStep("2D Gradient Texture", delegate { setTexture(3); });

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseAnnulus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseAnnulus.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Graphics;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace osu.Framework.Tests.Visual.UserInterface
+{
+    public class TestCaseAnnulus : TestCase
+    {
+        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(Annulus), typeof(AnnularDrawNode) };
+
+        private readonly Annulus annulus;
+
+        private const double period = 4000;
+        private const double transition_period = 2000;
+
+        private readonly Texture gradientTextureHorizontal;
+        private readonly Texture gradientTextureVertical;
+        private readonly Texture gradientTextureBoth;
+
+        public TestCaseAnnulus()
+        {
+            const int width = 128;
+
+            var image = new Image<Rgba32>(width, 1);
+
+            gradientTextureHorizontal = new Texture(width, 1, true);
+            for (int i = 0; i < width; ++i)
+            {
+                float brightness = (float)i / (width - 1);
+                image[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
+            }
+
+            gradientTextureHorizontal.SetData(new TextureUpload(image));
+
+            image = new Image<Rgba32>(width, 1);
+
+            gradientTextureVertical = new Texture(1, width, true);
+            for (int i = 0; i < width; ++i)
+            {
+                float brightness = (float)i / (width - 1);
+                image[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
+            }
+
+            gradientTextureVertical.SetData(new TextureUpload(image));
+
+            image = new Image<Rgba32>(width, width);
+
+            gradientTextureBoth = new Texture(width, width, true);
+            for (int i = 0; i < width; ++i)
+            {
+                for (int j = 0; j < width; ++j)
+                {
+                    float brightness = (float)i / (width - 1);
+                    float brightness2 = (float)j / (width - 1);
+                    image[i, j] = new Rgba32(
+                        (byte)(128 + (1 + brightness - brightness2) / 2 * 127),
+                        (byte)(128 + (1 + brightness2 - brightness) / 2 * 127),
+                        (byte)(128 + (brightness + brightness2) / 2 * 127),
+                        255);
+                }
+            }
+
+            gradientTextureBoth.SetData(new TextureUpload(image));
+
+            Children = new Drawable[]
+            {
+                annulus = new Annulus
+                {
+                    Width = 0.8f,
+                    Height = 0.8f,
+                    RelativeSizeAxes = Axes.Both,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                },
+            };
+            
+            AddStep("Horizontal Gradient Texture", delegate { setTexture(1); });
+            AddStep("Vertical Gradient Texture", delegate { setTexture(2); });
+            AddStep("2D Gradient Texture", delegate { setTexture(3); });
+            AddStep("White Texture", delegate { setTexture(0); });
+
+            AddStep("Red Colour", delegate { setColour(1); });
+            AddStep("Horzontal Gradient Colour", delegate { setColour(2); });
+            AddStep("Vertical Gradient Colour", delegate { setColour(3); });
+            AddStep("2D Gradient Colour", delegate { setColour(4); });
+            AddStep("White Colour", delegate { setColour(0); });
+
+            AddSliderStep("Start angle", 0d, 2d, 0d, angle => annulus.StartAngle.Value = MathHelper.TwoPi * angle);
+            AddSliderStep("End angle", 0d, 2d, 1d, angle => annulus.EndAngle.Value = MathHelper.TwoPi * angle);
+            AddSliderStep("Fill", 0, 10, 10, fill => annulus.InnerRadius = fill / 10f);
+        }
+
+        private void setTexture(int textureMode)
+        {
+            switch (textureMode)
+            {
+                case 0:
+                    annulus.Texture = Texture.WhitePixel;
+                    break;
+                case 1:
+                    annulus.Texture = gradientTextureHorizontal;
+                    break;
+                case 2:
+                    annulus.Texture = gradientTextureVertical;
+                    break;
+                case 3:
+                    annulus.Texture = gradientTextureBoth;
+                    break;
+            }
+        }
+
+        private void setColour(int colourMode)
+        {
+            switch (colourMode)
+            {
+                case 0:
+                    annulus.Colour = new Color4(255, 255, 255, 255);
+                    break;
+                case 1:
+                    annulus.Colour = new Color4(255, 128, 128, 255);
+                    break;
+                case 2:
+                    annulus.Colour = new ColourInfo
+                    {
+                        TopLeft = new Color4(255, 128, 128, 255),
+                        TopRight = new Color4(128, 255, 128, 255),
+                        BottomLeft = new Color4(255, 128, 128, 255),
+                        BottomRight = new Color4(128, 255, 128, 255),
+                    };
+                    break;
+                case 3:
+                    annulus.Colour = new ColourInfo
+                    {
+                        TopLeft = new Color4(255, 128, 128, 255),
+                        TopRight = new Color4(255, 128, 128, 255),
+                        BottomLeft = new Color4(128, 255, 128, 255),
+                        BottomRight = new Color4(128, 255, 128, 255),
+                    };
+                    break;
+                case 4:
+                    annulus.Colour = new ColourInfo
+                    {
+                        TopLeft = new Color4(255, 128, 128, 255),
+                        TopRight = new Color4(128, 255, 128, 255),
+                        BottomLeft = new Color4(128, 128, 255, 255),
+                        BottomRight = new Color4(255, 255, 255, 255),
+                    };
+                    break;
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseCircularProgress.cs
@@ -4,14 +4,9 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Colour;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using osuTK;
-using osuTK.Graphics;
-using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseCircularProgress.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestCaseCircularProgress : TestCase
     {
-        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(CircularProgress), typeof(CircularProgressDrawNode) };
+        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(CircularProgress), typeof(AnnularDrawNode) };
 
         private readonly CircularProgress clock;
 
@@ -24,55 +24,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         private const double period = 4000;
         private const double transition_period = 2000;
 
-        private readonly Texture gradientTextureHorizontal;
-        private readonly Texture gradientTextureVertical;
-        private readonly Texture gradientTextureBoth;
-
         public TestCaseCircularProgress()
         {
-            const int width = 128;
-
-            var image = new Image<Rgba32>(width, 1);
-
-            gradientTextureHorizontal = new Texture(width, 1, true);
-            for (int i = 0; i < width; ++i)
-            {
-                float brightness = (float)i / (width - 1);
-                image[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
-            }
-
-            gradientTextureHorizontal.SetData(new TextureUpload(image));
-
-            image = new Image<Rgba32>(width, 1);
-
-            gradientTextureVertical = new Texture(1, width, true);
-            for (int i = 0; i < width; ++i)
-            {
-                float brightness = (float)i / (width - 1);
-                image[i, 0] = new Rgba32((byte)(128 + (1 - brightness) * 127), (byte)(128 + brightness * 127), 128, 255);
-            }
-
-            gradientTextureVertical.SetData(new TextureUpload(image));
-
-            image = new Image<Rgba32>(width, width);
-
-            gradientTextureBoth = new Texture(width, width, true);
-            for (int i = 0; i < width; ++i)
-            {
-                for (int j = 0; j < width; ++j)
-                {
-                    float brightness = (float)i / (width - 1);
-                    float brightness2 = (float)j / (width - 1);
-                    image[i, j] = new Rgba32(
-                        (byte)(128 + (1 + brightness - brightness2) / 2 * 127),
-                        (byte)(128 + (1 + brightness2 - brightness) / 2 * 127),
-                        (byte)(128 + (brightness + brightness2) / 2 * 127),
-                        255);
-                }
-            }
-
-            gradientTextureBoth.SetData(new TextureUpload(image));
-
             Children = new Drawable[]
             {
                 clock = new CircularProgress
@@ -90,17 +43,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Transition Focus", delegate { rotateMode = 3; });
             AddStep("Transition Focus 2", delegate { rotateMode = 4; });
             AddStep("Forward/Backward", delegate { rotateMode = 0; });
-
-            AddStep("Horizontal Gradient Texture", delegate { setTexture(1); });
-            AddStep("Vertical Gradient Texture", delegate { setTexture(2); });
-            AddStep("2D Graident Texture", delegate { setTexture(3); });
-            AddStep("White Texture", delegate { setTexture(0); });
-
-            AddStep("Red Colour", delegate { setColour(1); });
-            AddStep("Horzontal Gradient Colour", delegate { setColour(2); });
-            AddStep("Vertical Gradient Colour", delegate { setColour(3); });
-            AddStep("2D Gradient Colour", delegate { setColour(4); });
-            AddStep("White Colour", delegate { setColour(0); });
 
             AddSliderStep("Fill", 0, 10, 10, fill => clock.InnerRadius = fill / 10f);
         }
@@ -124,65 +66,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     break;
                 case 4:
                     clock.Current.Value = (Time.Current % transition_period / transition_period / 5 - 0.1f + 2) % 2 - 1;
-                    break;
-            }
-        }
-
-        private void setTexture(int textureMode)
-        {
-            switch (textureMode)
-            {
-                case 0:
-                    clock.Texture = Texture.WhitePixel;
-                    break;
-                case 1:
-                    clock.Texture = gradientTextureHorizontal;
-                    break;
-                case 2:
-                    clock.Texture = gradientTextureVertical;
-                    break;
-                case 3:
-                    clock.Texture = gradientTextureBoth;
-                    break;
-            }
-        }
-
-        private void setColour(int colourMode)
-        {
-            switch (colourMode)
-            {
-                case 0:
-                    clock.Colour = new Color4(255, 255, 255, 255);
-                    break;
-                case 1:
-                    clock.Colour = new Color4(255, 128, 128, 255);
-                    break;
-                case 2:
-                    clock.Colour = new ColourInfo
-                    {
-                        TopLeft = new Color4(255, 128, 128, 255),
-                        TopRight = new Color4(128, 255, 128, 255),
-                        BottomLeft = new Color4(255, 128, 128, 255),
-                        BottomRight = new Color4(128, 255, 128, 255),
-                    };
-                    break;
-                case 3:
-                    clock.Colour = new ColourInfo
-                    {
-                        TopLeft = new Color4(255, 128, 128, 255),
-                        TopRight = new Color4(255, 128, 128, 255),
-                        BottomLeft = new Color4(128, 255, 128, 255),
-                        BottomRight = new Color4(128, 255, 128, 255),
-                    };
-                    break;
-                case 4:
-                    clock.Colour = new ColourInfo
-                    {
-                        TopLeft = new Color4(255, 128, 128, 255),
-                        TopRight = new Color4(128, 255, 128, 255),
-                        BottomLeft = new Color4(128, 128, 255, 255),
-                        BottomRight = new Color4(255, 255, 255, 255),
-                    };
                     break;
             }
         }

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseCircularProgress.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
+using osuTK;
 using osuTK.Graphics;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -44,6 +45,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Transition Focus 2", delegate { rotateMode = 4; });
             AddStep("Forward/Backward", delegate { rotateMode = 0; });
 
+            AddSliderStep("Start angle", 0d, 2d, 0d, angle => clock.StartAngle.Value = MathHelper.TwoPi * angle);
+            AddSliderStep("End angle", 0d, 2d, 1d, angle => clock.EndAngle.Value = MathHelper.TwoPi * angle);
             AddSliderStep("Fill", 0, 10, 10, fill => clock.InnerRadius = fill / 10f);
         }
 

--- a/osu.Framework/Graphics/UserInterface/AnnularDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/AnnularDrawNode.cs
@@ -15,10 +15,11 @@ using osu.Framework.Graphics.OpenGL.Vertices;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    public class CircularProgressDrawNode : DrawNode
+    public class AnnularDrawNode : DrawNode
     {
         public const int MAXRES = 24;
-        public float Angle;
+        public float StartAngle;
+        public float EndAngle;
         public float InnerRadius = 1;
 
         public Vector2 DrawSize;
@@ -46,17 +47,18 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void updateVertexBuffer()
         {
-            const float start_angle = 0;
             const float step = MathHelper.Pi / MAXRES;
 
-            float dir = Math.Sign(Angle);
+            float deltaAngle = EndAngle - StartAngle;
 
-            int amountPoints = (int)Math.Ceiling(Math.Abs(Angle) / step);
+            float dir = Math.Sign(deltaAngle);
+
+            int amountPoints = (int)Math.Ceiling(Math.Abs(deltaAngle) / step);
 
             Matrix3 transformationMatrix = DrawInfo.Matrix;
             MatrixExtensions.ScaleFromLeft(ref transformationMatrix, DrawSize);
 
-            Vector2 current = origin + pointOnCircle(start_angle) * 0.5f;
+            Vector2 current = origin + pointOnCircle(StartAngle) * 0.5f;
             Color4 currentColour = colourAt(current);
             current = Vector2Extensions.Transform(current, transformationMatrix);
 
@@ -68,27 +70,11 @@ namespace osu.Framework.Graphics.UserInterface
 
             float prevOffset = dir >= 0 ? 0 : 1;
 
-            // First center point
-            halfCircleBatch.Add(new TexturedVertex2D
-            {
-                Position = Vector2.Lerp(current, screenOrigin, InnerRadius),
-                TexturePosition = new Vector2(dir >= 0 ? texRect.Left : texRect.Right, texRect.Top),
-                Colour = originColour
-            });
-
-            // First outer point.
-            halfCircleBatch.Add(new TexturedVertex2D
-            {
-                Position = new Vector2(current.X, current.Y),
-                TexturePosition = new Vector2(dir >= 0 ? texRect.Left : texRect.Right, texRect.Bottom),
-                Colour = currentColour
-            });
-
-            for (int i = 1; i <= amountPoints; i++)
+            for (int i = 0; i <= amountPoints; i++)
             {
                 // Clamps the angle so we don't overshoot.
                 // dir is used so negative angles result in negative angularOffset.
-                float angularOffset = dir * Math.Min(i * step, dir * Angle);
+                float angularOffset = dir * Math.Min(i * step, dir * deltaAngle);
                 float normalisedOffset = angularOffset / MathHelper.TwoPi;
                 if (dir < 0)
                 {
@@ -96,7 +82,7 @@ namespace osu.Framework.Graphics.UserInterface
                 }
 
                 // Update `current`
-                current = origin + pointOnCircle(start_angle + angularOffset) * 0.5f;
+                current = origin + pointOnCircle(StartAngle + angularOffset) * 0.5f;
                 currentColour = colourAt(current);
                 current = Vector2Extensions.Transform(current, transformationMatrix);
 

--- a/osu.Framework/Graphics/UserInterface/AnnularDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/AnnularDrawNode.cs
@@ -58,10 +58,6 @@ namespace osu.Framework.Graphics.UserInterface
             Matrix3 transformationMatrix = DrawInfo.Matrix;
             MatrixExtensions.ScaleFromLeft(ref transformationMatrix, DrawSize);
 
-            Vector2 current = origin + pointOnCircle(StartAngle) * 0.5f;
-            Color4 currentColour = colourAt(current);
-            current = Vector2Extensions.Transform(current, transformationMatrix);
-
             Vector2 screenOrigin = Vector2Extensions.Transform(origin, transformationMatrix);
             Color4 originColour = colourAt(origin);
 
@@ -82,8 +78,8 @@ namespace osu.Framework.Graphics.UserInterface
                 }
 
                 // Update `current`
-                current = origin + pointOnCircle(StartAngle + angularOffset) * 0.5f;
-                currentColour = colourAt(current);
+                Vector2 current = origin + pointOnCircle(StartAngle + angularOffset) * 0.5f;
+                Color4 currentColour = colourAt(current);
                 current = Vector2Extensions.Transform(current, transformationMatrix);
 
                 // current center point

--- a/osu.Framework/Graphics/UserInterface/Annulus.cs
+++ b/osu.Framework/Graphics/UserInterface/Annulus.cs
@@ -27,6 +27,7 @@ namespace osu.Framework.Graphics.UserInterface
                 startAngle.BindTo(value);
             }
         }
+
         public Bindable<double> EndAngle
         {
             get => endAngle;

--- a/osu.Framework/Graphics/UserInterface/Annulus.cs
+++ b/osu.Framework/Graphics/UserInterface/Annulus.cs
@@ -6,16 +6,14 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.MathUtils;
 using osuTK;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    public class CircularProgress : Drawable, IHasCurrentValue<double>
+    public class Annulus : Drawable
     {
         private readonly Bindable<double> startAngle = new Bindable<double>();
-        private readonly Bindable<double> endAngle = new Bindable<double>(MathHelper.TwoPi);
-        private readonly Bindable<double> current = new Bindable<double>();
+        private readonly Bindable<double> endAngle = new Bindable<double>();
 
         public Bindable<double> StartAngle
         {
@@ -41,24 +39,11 @@ namespace osu.Framework.Graphics.UserInterface
                 endAngle.BindTo(value);
             }
         }
-        public Bindable<double> Current
-        {
-            get => current;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
 
-                current.UnbindBindings();
-                current.BindTo(value);
-            }
-        }
-
-        public CircularProgress()
+        public Annulus()
         {
             StartAngle.ValueChanged += newValue => Invalidate(Invalidation.DrawNode);
             EndAngle.ValueChanged += newValue => Invalidate(Invalidation.DrawNode);
-            Current.ValueChanged += newValue => Invalidate(Invalidation.DrawNode);
         }
 
         private IShader roundedTextureShader;
@@ -87,7 +72,7 @@ namespace osu.Framework.Graphics.UserInterface
             n.RoundedTextureShader = roundedTextureShader;
             n.DrawSize = DrawSize;
             n.StartAngle = (float)StartAngle.Value;
-            n.EndAngle = (float)Interpolation.Lerp(StartAngle.Value, EndAngle.Value, Current.Value);
+            n.EndAngle = (float)EndAngle.Value;
             n.InnerRadius = innerRadius;
 
             base.ApplyDrawNode(node);

--- a/osu.Framework/Graphics/UserInterface/Annulus.cs
+++ b/osu.Framework/Graphics/UserInterface/Annulus.cs
@@ -43,8 +43,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         public Annulus()
         {
-            StartAngle.ValueChanged += newValue => Invalidate(Invalidation.DrawNode);
-            EndAngle.ValueChanged += newValue => Invalidate(Invalidation.DrawNode);
+            StartAngle.ValueChanged += _ => Invalidate(Invalidation.DrawNode);
+            EndAngle.ValueChanged += _ => Invalidate(Invalidation.DrawNode);
         }
 
         private IShader roundedTextureShader;

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -29,6 +29,7 @@ namespace osu.Framework.Graphics.UserInterface
                 startAngle.BindTo(value);
             }
         }
+
         public Bindable<double> EndAngle
         {
             get => endAngle;
@@ -41,6 +42,7 @@ namespace osu.Framework.Graphics.UserInterface
                 endAngle.BindTo(value);
             }
         }
+
         public Bindable<double> Current
         {
             get => current;


### PR DESCRIPTION
- Refactors CircularProgressDrawNode into AnnularDrawNode, allowing changes to be made to both the start and end positions of the ring.
- Adds generic Annulus class for use in fun stuff, while CircularProgress retains previous functionality with the additional ability to have an adjustable start and end position.

For consideration:
- Currently, an annulus samples its texture starting from its StartAngle and ending at StartAngle + 2π (i.e. no scaling to EndAngle).