### PR TITLE
Clamp scrollTo target to ClampExtension

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestCaseScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestCaseScrollContainer.cs
@@ -14,6 +14,9 @@ namespace osu.Framework.Tests.Visual.Containers
 {
     public class TestCaseScrollContainer : ManualInputManagerTestCase
     {
+        private float clampExtension = 50;
+        private ScrollContainer scrollContainer;
+
         public TestCaseScrollContainer()
         {
             AddSliderStep("Clamp extension", 0, 100, 50, c =>
@@ -24,10 +27,6 @@ namespace osu.Framework.Tests.Visual.Containers
                 clampExtension = c;
             });
         }
-
-        private float clampExtension = 50;
-
-        private ScrollContainer scrollContainer;
 
         /// <summary>
         /// Create a scroll container, attempt to scroll past its <see cref="ScrollContainer.ClampExtension"/>, and check that it does not.

--- a/osu.Framework.Tests/Visual/Containers/TestCaseScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestCaseScrollContainer.cs
@@ -1,0 +1,92 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    public class TestCaseScrollContainer : ManualInputManagerTestCase
+    {
+        public TestCaseScrollContainer()
+        {
+            AddSliderStep("Clamp extension", 0, 100, 50, c =>
+            {
+                if (scrollContainer != null)
+                    scrollContainer.ClampExtension = c;
+
+                clampExtension = c;
+            });
+        }
+
+        private float clampExtension = 50;
+
+        private ScrollContainer scrollContainer;
+
+        /// <summary>
+        /// Create a scroll container, attempt to scroll past its <see cref="ScrollContainer.ClampExtension"/>, and check that it does not.
+        /// </summary>
+        [Test]
+        public void ScrollToTest()
+        {
+            AddStep("Create scroll container with specified clamp extension", () => createScrollContainer(clampExtension));
+            AddStep("Scroll past extent", () => scrollContainer.ScrollTo(200));
+            checkScrollWithinBounds();
+            AddStep("Scroll past negative", () => scrollContainer.ScrollTo(-200));
+            checkScrollWithinBounds();
+        }
+
+        /// <summary>
+        /// Attempt to drag a scrollcontainer past its <see cref="ScrollContainer.ClampExtension"/> and check that it does not.
+        /// </summary>
+        [Test]
+        public void DraggingScrollTest()
+        {
+            AddStep("Create scroll container with specified clamp extension", () => createScrollContainer(clampExtension));
+            AddStep("Click and drag scrollcontainer", () =>
+            {
+                InputManager.MoveMouseTo(scrollContainer);
+                InputManager.PressButton(MouseButton.Left);
+                // Required for the dragging state to be set correctly.
+                InputManager.MoveMouseTo(scrollContainer.ToScreenSpace(scrollContainer.LayoutRectangle.Centre + new Vector2(10f)));
+            });
+            AddStep("Move mouse up", () => InputManager.MoveMouseTo(scrollContainer.ToScreenSpace(scrollContainer.LayoutRectangle.Centre + new Vector2(-300f))));
+            checkScrollWithinBounds();
+            AddStep("Move mouse down", () => InputManager.MoveMouseTo(scrollContainer.ToScreenSpace(scrollContainer.LayoutRectangle.Centre + new Vector2(300f))));
+            checkScrollWithinBounds();
+            AddStep("Release mouse button", () => InputManager.ReleaseButton(MouseButton.Left));
+            checkScrollWithinBounds();
+        }
+
+        private void checkScrollWithinBounds()
+        {
+            AddAssert("Scroll amount is within ClampExtension bounds", () => Math.Abs(scrollContainer.Current) <= scrollContainer.ClampExtension);
+        }
+
+        private void createScrollContainer(float clampExtension = 0)
+        {
+            if (scrollContainer != null)
+                InputManager.Remove(scrollContainer);
+
+            InputManager.Add(scrollContainer = new ScrollContainer
+            {
+                ClampExtension = clampExtension,
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        Height = 50,
+                        RelativeSizeAxes = Axes.X
+                    }
+                }
+            });
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -318,7 +318,9 @@ namespace osu.Framework.Graphics.Containers
             // such that the user can feel it.
             scrollOffset = clampedScrollOffset + (scrollOffset - clampedScrollOffset) / 2;
 
-            offset(scrollOffset, false);
+            // We can't use the offset function here, as clamping calculations done in updatePosition ignores dragging.
+            // As a result, we need to manually clamp our target within the limits set by ClampExtension.
+            scrollTo(Clamp(target + scrollOffset, ClampExtension), false);
             return true;
         }
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -318,9 +318,7 @@ namespace osu.Framework.Graphics.Containers
             // such that the user can feel it.
             scrollOffset = clampedScrollOffset + (scrollOffset - clampedScrollOffset) / 2;
 
-            // We can't use the offset function here, as clamping calculations done in updatePosition ignores dragging.
-            // As a result, we need to manually clamp our target within the limits set by ClampExtension.
-            scrollTo(Clamp(target + scrollOffset, ClampExtension), false);
+            offset(scrollOffset, false);
             return true;
         }
 
@@ -416,7 +414,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void scrollTo(float value, bool animated, double distanceDecay = float.PositiveInfinity)
         {
-            target = value;
+            target = Clamp(value, ClampExtension);
 
             if (animated)
                 this.distanceDecay = distanceDecay;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/2306

Preview: https://streamable.com/20kg8

~~I've decided to only apply the clamp in OnDrag, as it seems to be the only case where clamping isn't applied via updatePosition (it looks bad if you clamp it that way when dragging).~~ Done so at scrollTo instead to resolve the jitter issue. I've tested the code paths into osu and it works fine, so it should be okay.
