### PR TITLE
Fix visual unit tests never running

### DIFF
--- a/osu.Framework.Tests/Visual/Testing/TestCaseTest.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestCaseTest.cs
@@ -34,6 +34,8 @@ namespace osu.Framework.Tests.Visual.Testing
                 if (IsNUnitRunning)
                     testRunCount++;
             });
+
+            AddStep("dummy step", () => { });
         }
 
         [Test]
@@ -50,6 +52,19 @@ namespace osu.Framework.Tests.Visual.Testing
             AddStep("increment run count", () => testRunCount++);
             AddAssert("correct setup run count", () => testRunCount == setupRun);
             AddAssert("correct setup steps run count", () => (IsNUnitRunning ? testRunCount : 2) == setupStepsRun);
+        }
+
+        protected override ITestCaseTestRunner CreateRunner() => new TestRunner();
+
+        private class TestRunner : TestCaseTestRunner
+        {
+            public override void RunTestBlocking(TestCase test)
+            {
+                base.RunTestBlocking(test);
+
+                // This will only ever trigger via NUnit
+                Assert.That(test.StepsContainer, Has.Count.GreaterThan(0));
+            }
         }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -85,6 +85,8 @@ namespace osu.Framework.Graphics.OpenGL
 
             if (host != null && host.TryGetTarget(out GameHost h))
                 h.UpdateThread.Scheduler.Add(scheduleNextDisposal);
+            else
+                disposalAction.Invoke();
 
             void scheduleNextDisposal() => reset_scheduler.Add(() =>
             {

--- a/osu.Framework/Testing/TestCase.cs
+++ b/osu.Framework/Testing/TestCase.cs
@@ -106,7 +106,7 @@ namespace osu.Framework.Testing
                 }
 
                 if (TestContext.CurrentContext.Test.MethodName != nameof(TestConstructor))
-                    Schedule(() => StepsContainer.Clear());
+                    schedule(() => StepsContainer.Clear());
             }
 
             RunSetUpSteps();

--- a/osu.Framework/Testing/TestCaseTestRunner.cs
+++ b/osu.Framework/Testing/TestCaseTestRunner.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Testing
         /// Blocks execution until a provided <see cref="TestCase"/> runs to completion.
         /// </summary>
         /// <param name="test">The <see cref="TestCase"/> to run.</param>
-        public void RunTestBlocking(TestCase test) => runner.RunTestBlocking(test);
+        public virtual void RunTestBlocking(TestCase test) => runner.RunTestBlocking(test);
 
         public class TestRunner : CompositeDrawable
         {


### PR DESCRIPTION
The `AddSteps()` ones aren't forced to be scheduled, but the clear was.