### PR TITLE
Add basic variant of menu and context menu

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseContextMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseContextMenu.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -18,6 +20,14 @@ namespace osu.Framework.Tests.Visual.UserInterface
         private const int duration = 1000;
 
         private readonly ContextMenuBox movingBox;
+
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(Menu),
+            typeof(BasicMenu),
+            typeof(ContextMenuContainer),
+            typeof(BasicContextMenuContainer)
+        };
 
         private ContextMenuBox makeBox(Anchor anchor) =>
             new ContextMenuBox
@@ -37,7 +47,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         public TestCaseContextMenu()
         {
-            Add(new ContextMenuContainer
+            Add(new BasicContextMenuContainer
             {
                 RelativeSizeAxes = Axes.Both,
                 Children = new[]

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseNestedMenus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseNestedMenus.cs
@@ -19,7 +19,11 @@ namespace osu.Framework.Tests.Visual.UserInterface
         private const int max_depth = 5;
         private const int max_count = 5;
 
-        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(Menu) };
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(Menu),
+            typeof(BasicMenu)
+        };
 
         private Random rng;
 
@@ -58,7 +62,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             }
         };
 
-        private class ClickOpenMenu : Menu
+        private class ClickOpenMenu : BasicMenu
         {
             protected override Menu CreateSubMenu() => new ClickOpenMenu(HoverOpenDelay, false);
 

--- a/osu.Framework/Graphics/Cursor/BasicContextMenuContainer.cs
+++ b/osu.Framework/Graphics/Cursor/BasicContextMenuContainer.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.UserInterface;
+
+namespace osu.Framework.Graphics.Cursor
+{
+    public class BasicContextMenuContainer : ContextMenuContainer
+    {
+        protected override Menu CreateMenu() => new BasicMenu(Direction.Vertical);
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/BasicMenu.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicMenu.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Graphics.UserInterface
+{
+    public class BasicMenu : Menu
+    {
+        public BasicMenu(Direction direction, bool topLevelMenu = false)
+            : base(direction, topLevelMenu)
+        {
+            BackgroundColour = FrameworkColour.Blue;
+        }
+
+        protected override Menu CreateSubMenu() => new BasicMenu(Direction.Vertical)
+        {
+            Anchor = Direction == Direction.Horizontal ? Anchor.BottomLeft : Anchor.TopRight
+        };
+
+        protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new BasicDrawableMenuItem(item);
+
+        public class BasicDrawableMenuItem : DrawableMenuItem
+        {
+            public BasicDrawableMenuItem(MenuItem item)
+                : base(item)
+            {
+                BackgroundColour = FrameworkColour.BlueGreen;
+                BackgroundColourHover = FrameworkColour.Green;
+            }
+
+            protected override Drawable CreateContent() => new SpriteText
+            {
+                Anchor = Anchor.CentreLeft,
+                Origin = Anchor.CentreLeft,
+                Padding = new MarginPadding(2),
+                Font = new FontUsage("RobotoCondensed", weight: "Regular"),
+            };
+        }
+    }
+}


### PR DESCRIPTION
The variants try to *follow* the new design, because the design in #2135 didn't show them.

I'm also unsure if ``BasicContextMenuContainer`` should be in the ``UserInterface`` or the ``Cursor`` namespace