### PR TITLE
Fix incorrectness of composite clearing

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -605,9 +605,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
             private readonly bool shouldTakeOutLease;
             private bool hasUnbound;
 
-            internal override void UnbindAllBindables()
+            internal override void UnbindAllBindablesSubTree()
             {
-                base.UnbindAllBindables();
+                base.UnbindAllBindablesSubTree();
 
                 // As a second unbind event would incorrectly cause TestMakeCurrentUnbindOrder check to fail, block it.
                 if (!hasUnbound)

--- a/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestCaseScreenStack.cs
@@ -448,7 +448,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 {
                     var screen = new TestScreen();
 
-                    screen.OnUnbind += () =>
+                    screen.OnUnbindAllBindables += () =>
                     {
                         if (screens.Last() != screen)
                             throw new InvalidOperationException("Disposal order was wrong");
@@ -596,25 +596,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
             public override bool AcceptsFocus => EagerFocus;
 
             public override bool HandleNonPositionalInput => true;
-            public Action OnUnbind;
 
             public LeasedBindable<bool> LeasedCopy;
 
             public readonly Bindable<bool> DummyBindable = new Bindable<bool>();
 
             private readonly bool shouldTakeOutLease;
-            private bool hasUnbound;
-
-            internal override void UnbindAllBindablesSubTree()
-            {
-                base.UnbindAllBindablesSubTree();
-
-                // As a second unbind event would incorrectly cause TestMakeCurrentUnbindOrder check to fail, block it.
-                if (!hasUnbound)
-                    OnUnbind?.Invoke();
-
-                hasUnbound = true;
-            }
 
             public TestScreen(bool shouldTakeOutLease = false)
             {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -746,11 +746,12 @@ namespace osu.Framework.Graphics.Containers
                 DisposeChildAsync(child);
         }
 
-        internal override void UnbindAllBindables()
+        internal override void UnbindAllBindablesSubTree()
         {
-            base.UnbindAllBindables();
+            base.UnbindAllBindablesSubTree();
+
             foreach (Drawable child in internalChildren)
-                child.UnbindAllBindables();
+                child.UnbindAllBindablesSubTree();
         }
 
         /// <summary>
@@ -759,7 +760,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="drawable">The child to dispose.</param>
         internal void DisposeChildAsync(Drawable drawable)
         {
-            drawable.UnbindAllBindables();
+            drawable.UnbindAllBindablesSubTree();
             Task.Run(drawable.Dispose);
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -455,15 +455,10 @@ namespace osu.Framework.Graphics.Containers
                     ChildDied?.Invoke(t);
 
                 t.IsAlive = false;
+                t.Parent = null;
 
                 if (disposeChildren)
-                {
-                    //cascade disposal
-                    (t as CompositeDrawable)?.ClearInternal();
-                    t.Dispose();
-                }
-                else
-                    t.Parent = null;
+                    DisposeChildAsync(t);
 
                 Trace.Assert(t.Parent == null);
             }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Graphics
 
                 Dispose(isDisposing);
 
-                unbindAllBindables();
+                UnbindAllBindables();
 
                 Parent = null;
 
@@ -118,7 +118,10 @@ namespace osu.Framework.Graphics
 
         private static readonly ConcurrentDictionary<Type, Action<object>> unbind_action_cache = new ConcurrentDictionary<Type, Action<object>>();
 
-        internal virtual void UnbindAllBindablesSubTree() => unbindAllBindables();
+        /// <summary>
+        /// Recursively invokes <see cref="UnbindAllBindables"/> on this <see cref="Drawable"/> and all <see cref="Drawable"/>s further down the scene graph.
+        /// </summary>
+        internal virtual void UnbindAllBindablesSubTree() => UnbindAllBindables();
 
         private void cacheUnbindActions()
         {
@@ -162,9 +165,10 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Unbinds all <see cref="Bindable{T}"/>s stored as fields or properties in this <see cref="Drawable"/>.
         /// </summary>
-        private void unbindAllBindables()
+        internal virtual void UnbindAllBindables()
         {
-            if (unbindComplete) return;
+            if (unbindComplete)
+                return;
 
             unbindComplete = true;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Graphics
 
         private static readonly ConcurrentDictionary<Type, Action<object>> unbind_action_cache = new ConcurrentDictionary<Type, Action<object>>();
 
-        internal virtual void UnbindAllBindables() => unbindAllBindables();
+        internal virtual void UnbindAllBindablesSubTree() => unbindAllBindables();
 
         private void cacheUnbindActions()
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -171,6 +171,8 @@ namespace osu.Framework.Graphics
             foreach (var type in GetType().EnumerateBaseTypes())
                 if (unbind_action_cache.TryGetValue(type, out var existing))
                     existing?.Invoke(this);
+
+            OnUnbindAllBindables?.Invoke();
         }
 
         #endregion
@@ -378,6 +380,11 @@ namespace osu.Framework.Graphics
         /// Fired after the <see cref="dispose(bool)"/> method is called.
         /// </summary>
         internal event Action OnDispose;
+
+        /// <summary>
+        /// Fired after the <see cref="UnbindAllBindables"/> method is called.
+        /// </summary>
+        internal event Action OnUnbindAllBindables;
 
         private readonly Lazy<Scheduler> scheduler;
 

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -263,7 +263,7 @@ namespace osu.Framework.Screens
         /// leases could potentially be in a leased state during exiting transitions.
         /// This method should be called after exiting is confirmed to ensure a correct leased state before <see cref="IScreen.OnResuming"/>.
         /// </remarks>
-        private void onExited(IScreen prev, IScreen next) => (prev as CompositeDrawable)?.UnbindAllBindables();
+        private void onExited(IScreen prev, IScreen next) => (prev as CompositeDrawable)?.UnbindAllBindablesSubTree();
 
         /// <summary>
         /// Resumes the current <see cref="IScreen"/>.


### PR DESCRIPTION
I believe this is a more correct process for `ClearInternal()`:

1. Cleared containers will dispose children asynchronously.
2. Children aren't themselves cleared, so the hierarchy can be preserved.
3. The clearing process now calls `UnbindAllBindables` (now renamed `UnbindAllBindablesSubTree`) which can be overridden by `ScreenStack`.

Children removed without `disposeChildren = true` aren't unbound.