### PR TITLE
Fix method hiding warning in FontAwesome

### DIFF
--- a/osu.Framework/Graphics/Sprites/FontAwesome.cs
+++ b/osu.Framework/Graphics/Sprites/FontAwesome.cs
@@ -4337,7 +4337,7 @@ namespace osu.Framework.Graphics.Sprites
             /// <summary>
             /// Equals
             /// </summary>
-            public static IconUsage Equals => Get(0xf52c);
+            public static new IconUsage Equals => Get(0xf52c);
 
             /// <summary>
             /// eraser

--- a/osu.Framework/Graphics/Sprites/FontAwesome.cs
+++ b/osu.Framework/Graphics/Sprites/FontAwesome.cs
@@ -4337,7 +4337,9 @@ namespace osu.Framework.Graphics.Sprites
             /// <summary>
             /// Equals
             /// </summary>
-            public static new IconUsage Equals => Get(0xf52c);
+#pragma warning disable 109
+            public new static IconUsage Equals => Get(0xf52c);
+#pragma warning restore 109
 
             /// <summary>
             /// eraser


### PR DESCRIPTION
Fixes `FontAwesome.cs(4340, 37): [CS0108] 'FontAwesome.Solid.Equals' hides inherited member 'object.Equals(object)'. Use the new keyword if hiding was intended.`