### PR TITLE
Fix interpolating clock seek

### DIFF
--- a/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
+++ b/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Threading;
 using NUnit.Framework;
-using osu.Framework.Logging;
 using osu.Framework.MathUtils;
 using osu.Framework.Timing;
 

--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -83,8 +83,9 @@ namespace osu.Framework.Timing
 
             if (!allowInterpolation || Math.Abs(FramedSourceClock.CurrentTime - CurrentInterpolatedTime) > AllowableErrorMilliseconds)
             {
-                //if we've exceeded the allowable error, we should use the source clock's time value.
-                CurrentInterpolatedTime = FramedSourceClock.CurrentTime;
+                // if we've exceeded the allowable error, we should use the source clock's time value.
+                // seeking backwards should only be allowed if the source is explicitly doing that.
+                CurrentInterpolatedTime = FramedSourceClock.ElapsedFrameTime < 0 ? FramedSourceClock.CurrentTime : Math.Max(LastInterpolatedTime, FramedSourceClock.CurrentTime);
 
                 // once interpolation fails, we don't want to resume interpolating until the source clock starts to move again.
                 allowInterpolation = false;


### PR DESCRIPTION
Fix interpolating clock seeking backwards on a failed interpolation. Now it will only seek backwards on an actual seek (as determined by `ElapsedFrameTime`).