### PR TITLE
Fix DrawVisualiser crashing on popout

### DIFF
--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -305,8 +305,7 @@ namespace osu.Framework.Graphics.Visualisation
 
         private void recycleVisualisers()
         {
-            // May come from the disposal thread, in which case they won't ever be reused anyway
-            Schedule(() => treeContainer.Clear());
+            treeContainer.Clear();
 
             // We don't really know where the visualised drawables are, so we have to dispose them manually
             // This is done as an optimisation so that events aren't handled while the visualiser is hidden
@@ -316,12 +315,6 @@ namespace osu.Framework.Graphics.Visualisation
 
             target = null;
             targetVisualiser = null;
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-            recycleVisualisers();
         }
     }
 }


### PR DESCRIPTION
Because `.Clear()` sets parent, which would happen after the disposal due to the schedule.

Also removed the recycle from `Dispose()` because it's unnecessary - this component is never disposed for the lifetime of the game. It causes cross thread operations otherwise with this change.