### PR TITLE
Don't dispose drawnodes while being recorded

### DIFF
--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -4,6 +4,8 @@
 using osu.Framework.Graphics.OpenGL;
 using System;
 using osu.Framework.Graphics.OpenGL.Vertices;
+using osu.Framework.Logging;
+using osu.Framework.Threading;
 
 namespace osu.Framework.Graphics
 {
@@ -35,6 +37,8 @@ namespace osu.Framework.Graphics
         /// </summary>
         protected readonly IDrawable Source;
 
+        private readonly AtomicCounter referenceCount = new AtomicCounter();
+
         /// <summary>
         /// Creates a new <see cref="DrawNode"/>.
         /// </summary>
@@ -42,6 +46,8 @@ namespace osu.Framework.Graphics
         public DrawNode(IDrawable source)
         {
             Source = source;
+
+            Reference();
         }
 
         /// <summary>
@@ -66,6 +72,15 @@ namespace osu.Framework.Graphics
             GLWrapper.SetBlend(DrawColourInfo.Blending);
         }
 
+        /// <summary>
+        /// Increments the reference count of this <see cref="DrawNode"/>, blocking <see cref="Dispose"/> until the count reaches 0.
+        /// Invoke <see cref="Dispose"/> to remove the reference.
+        /// </summary>
+        /// <remarks>
+        /// All <see cref="DrawNode"/>s start with a reference count of 1.
+        /// </remarks>
+        internal void Reference() => referenceCount.Increment();
+
         ~DrawNode()
         {
             Dispose(false);
@@ -73,6 +88,9 @@ namespace osu.Framework.Graphics
 
         public void Dispose()
         {
+            if (referenceCount.Decrement() != 0)
+                return;
+
             Dispose(true);
             GC.SuppressFinalize(this);
         }

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Graphics.OpenGL;
 using System;
 using osu.Framework.Graphics.OpenGL.Vertices;
-using osu.Framework.Logging;
 using osu.Framework.Threading;
 
 namespace osu.Framework.Graphics

--- a/osu.Framework/Testing/DrawFrameRecordingContainer.cs
+++ b/osu.Framework/Testing/DrawFrameRecordingContainer.cs
@@ -35,12 +35,16 @@ namespace osu.Framework.Testing
             {
                 default:
                 case RecordState.Normal:
+                    recordedFrames.ForEach(disposeRecursively);
                     recordedFrames.Clear();
+
                     currentFrame.Value = currentFrame.MaxValue = 0;
 
                     return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
                 case RecordState.Recording:
                     var node = base.GenerateDrawNodeSubtree(frame, treeIndex, true);
+
+                    referenceRecursively(node);
 
                     recordedFrames.Add(node);
                     currentFrame.Value = currentFrame.MaxValue = recordedFrames.Count - 1;
@@ -49,6 +53,28 @@ namespace osu.Framework.Testing
                 case RecordState.Stopped:
                     return recordedFrames[currentFrame.Value];
             }
+        }
+
+        private void referenceRecursively(DrawNode drawNode)
+        {
+            drawNode.Reference();
+
+            if (!(drawNode is ICompositeDrawNode composite))
+                return;
+
+            foreach (var child in composite.Children)
+                referenceRecursively(child);
+        }
+
+        private void disposeRecursively(DrawNode drawNode)
+        {
+            drawNode.Dispose();
+
+            if (!(drawNode is ICompositeDrawNode composite))
+                return;
+
+            foreach (var child in composite.Children)
+                disposeRecursively(child);
         }
     }
 }

--- a/osu.Framework/Threading/AtomicCounter.cs
+++ b/osu.Framework/Threading/AtomicCounter.cs
@@ -11,6 +11,8 @@ namespace osu.Framework.Threading
 
         public long Increment() => Interlocked.Increment(ref count);
 
+        public long Decrement() => Interlocked.Decrement(ref count);
+
         public long Add(long value) => Interlocked.Add(ref count, value);
 
         public long Reset() => Interlocked.Exchange(ref count, 0);


### PR DESCRIPTION
Haven't really been able to replicate in framework, the hierarchies we have are just not complex enough, but very easy to replicate in osu-side player testcases.