### PR TITLE
Fix android volume keys

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -63,8 +63,18 @@ namespace osu.Framework.Android
 
         public override bool OnKeyDown([GeneratedEnum] Keycode keyCode, KeyEvent e)
         {
-            KeyDown?.Invoke(keyCode, e);
-            return true;
+            switch(keyCode) {
+                /// Do not consume Volume keys, so the system can handle them
+                /// No need to handle in the other methods?
+                case Keycode.VolumeDown:
+                case Keycode.VolumeUp:
+                case Keycode.VolumeMute:
+                    return false;
+
+                default:
+                    KeyDown?.Invoke(keyCode, e);
+                    return true;
+            }
         }
 
         public override bool OnKeyLongPress([GeneratedEnum] Keycode keyCode, KeyEvent e)

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -63,9 +63,9 @@ namespace osu.Framework.Android
 
         public override bool OnKeyDown([GeneratedEnum] Keycode keyCode, KeyEvent e)
         {
-            switch(keyCode) {
-                /// Do not consume Volume keys, so the system can handle them
-                /// No need to handle in the other methods?
+            switch (keyCode)
+            {
+                // Do not consume Volume keys, so the system can handle them
                 case Keycode.VolumeDown:
                 case Keycode.VolumeUp:
                 case Keycode.VolumeMute:


### PR DESCRIPTION
Excludes the Android Volume keys from being consumed, and allows the device volume to be changed while playing the game.

Resolves #2383 
