### PR TITLE
Fix android window focus

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -13,8 +13,19 @@ namespace osu.Framework.Android
         protected override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
-
             SetContentView(new AndroidGameView(this, CreateGame()));
+        }
+
+        protected override void OnResume() {
+            base.OnResume();
+            AndroidGameWindow.View?.Resume();
+            System.Console.WriteLine("AGA:OnResume called");
+        }
+
+        protected override void OnPause() {
+            base.OnPause();
+            AndroidGameWindow.View?.Pause();
+            System.Console.WriteLine("AGA:OnPause called");
         }
     }
 }

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -16,16 +16,16 @@ namespace osu.Framework.Android
             SetContentView(new AndroidGameView(this, CreateGame()));
         }
 
-        protected override void OnResume() {
+        protected override void OnResume()
+        {
             base.OnResume();
             AndroidGameWindow.View?.Resume();
-            System.Console.WriteLine("AGA:OnResume called");
         }
 
-        protected override void OnPause() {
+        protected override void OnPause()
+        {
             base.OnPause();
             AndroidGameWindow.View?.Pause();
-            System.Console.WriteLine("AGA:OnPause called");
         }
     }
 }

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -93,13 +93,19 @@ namespace osu.Framework.Android
             host.Run(game);
         }
 
-        public override void Pause() {
-            (host.Window as AndroidGameWindow).ActivityInForeground = false;
+        public override void Pause()
+        {
+            if (host.Window is AndroidGameWindow androidWindow)
+                androidWindow.ActivityInForeground = false;
+
             base.Pause();
         }
 
-        public override void Resume() {
-            (host.Window as AndroidGameWindow).ActivityInForeground = true;
+        public override void Resume()
+        {
+            if (host.Window is AndroidGameWindow androidWindow)
+                androidWindow.ActivityInForeground = true;
+
             base.Resume();
         }
     }

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -92,5 +92,15 @@ namespace osu.Framework.Android
             host = new AndroidGameHost(this);
             host.Run(game);
         }
+
+        public override void Pause() {
+            (host.Window as AndroidGameWindow).ActivityInForeground = false;
+            base.Pause();
+        }
+
+        public override void Resume() {
+            (host.Window as AndroidGameWindow).ActivityInForeground = true;
+            base.Resume();
+        }
     }
 }

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -16,8 +16,9 @@ namespace osu.Framework.Android
 
         internal static AndroidGameView View;
 
-        protected bool activityInForeground = true;
-        public bool ActivityInForeground {
+        private bool activityInForeground = true;
+        public bool ActivityInForeground
+        {
             get => activityInForeground;
             set {
                 activityInForeground = value;

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -16,8 +16,17 @@ namespace osu.Framework.Android
 
         internal static AndroidGameView View;
 
+        protected bool activityInForeground = true;
+        public bool ActivityInForeground {
+            get => activityInForeground;
+            set {
+                activityInForeground = value;
+                OnFocusedChanged(this, EventArgs.Empty);
+            }
+        }
+
         public override bool Focused
-            => true;
+            => ActivityInForeground;
 
         public override osuTK.WindowState WindowState {
             get => osuTK.WindowState.Normal;
@@ -32,6 +41,7 @@ namespace osu.Framework.Android
         {
             // Let's just say the cursor is always in the window.
             CursorInWindow = true;
+            OnFocusedChanged(this, EventArgs.Empty); // Ensures that the isActive is set correctly on initial setup
         }
 
         protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new WindowMode[]

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -139,7 +139,7 @@ namespace osu.Framework.Platform
 
         protected void OnFocusedChanged(object sender, EventArgs e)
         {
-             isActive.Value = Focused;
+            isActive.Value = Focused;
         }
 
         /// <summary>

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -84,7 +84,7 @@ namespace osu.Framework.Platform
             MouseEnter += (sender, args) => CursorInWindow = true;
             MouseLeave += (sender, args) => CursorInWindow = false;
 
-            FocusedChanged += (o, e) => isActive.Value = Focused;
+            FocusedChanged += OnFocusedChanged;
 
             SupportedWindowModes.AddRange(DefaultSupportedWindowModes);
 
@@ -135,6 +135,10 @@ namespace osu.Framework.Platform
                         GL Extensions:              {GL.GetString(StringName.Extensions)}");
 
             Context.MakeCurrent(null);
+        }
+
+        protected void OnFocusedChanged(object sender, EventArgs e) {
+             isActive.Value = Focused;
         }
 
         /// <summary>

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -137,7 +137,8 @@ namespace osu.Framework.Platform
             Context.MakeCurrent(null);
         }
 
-        protected void OnFocusedChanged(object sender, EventArgs e) {
+        protected void OnFocusedChanged(object sender, EventArgs e)
+        {
              isActive.Value = Focused;
         }
 


### PR DESCRIPTION
Ensures that the window focus is updated when app moves into foreground and background. This should also trigger the Pause menu in the main osu! game when required. 

Resolves #2385