### PR TITLE
Fix AoT crashes on iOS when rapidly creating callbacks

### DIFF
--- a/osu.Framework/Allocation/ObjectHandle.cs
+++ b/osu.Framework/Allocation/ObjectHandle.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Allocation
 
         /// <summary>
         /// Gets the object being referenced.
-        /// Returns true if successful and populates <paramref name="value"/> with the referenced object.
+        /// Returns true if successful and populates <paramref name="target"/> with the referenced object.
         /// Returns false If the handle is not allocated or the target is not of type <typeparamref name="T"/>.
         /// </summary>
         /// <param name="target">Populates this parameter with the targeted object.</param>

--- a/osu.Framework/Allocation/ObjectHandle.cs
+++ b/osu.Framework/Allocation/ObjectHandle.cs
@@ -12,12 +12,6 @@ namespace osu.Framework.Allocation
     public struct ObjectHandle<T> : IDisposable
     {
         /// <summary>
-        /// The object being referenced.  Returns the default value for <see cref="T" /> if the handle is not allocated
-        /// or if the handle points to an object that cannot be cast to <see cref="T" />.
-        /// </summary>
-        public T Target => handle.IsAllocated && handle.Target is T ? (T)handle.Target : default;
-
-        /// <summary>
         /// The pointer from the <see cref="GCHandle" />, if it is allocated.  Otherwise <see cref="IntPtr.Zero" />.
         /// </summary>
         public IntPtr Handle => handle.IsAllocated ? GCHandle.ToIntPtr(handle) : IntPtr.Zero;
@@ -54,6 +48,37 @@ namespace osu.Framework.Allocation
         {
             this.handle = GCHandle.FromIntPtr(handle);
             fromPointer = true;
+        }
+
+        /// <summary>
+        /// Gets the object being referenced.
+        /// Returns true if successful and populates <paramref name="value"/> with the referenced object.
+        /// Returns false If the handle is not allocated or the target is not of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="target">Populates this parameter with the targeted object.</param>
+        public bool GetTarget(out T target)
+        {
+            if (!handle.IsAllocated)
+            {
+                target = default;
+                return false;
+            }
+
+            try
+            {
+                var value = handle.Target;
+                if (value is T)
+                {
+                    target = (T)value;
+                    return true;
+                }
+            }
+            catch (InvalidOperationException)
+            {
+            }
+
+            target = default;
+            return false;
         }
 
         #region IDisposable Support

--- a/osu.Framework/Audio/Callbacks/FileCallbacks.cs
+++ b/osu.Framework/Audio/Callbacks/FileCallbacks.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Audio.Callbacks
     /// </summary>
     public class FileCallbacks : BassCallback
     {
-        public FileProcedures Callbacks => RuntimeInfo.SupportsJIT ? instanceProcedures : staticProcedures;
+        public FileProcedures Callbacks { get; private set; }
 
         private FileProcedures instanceProcedures => new FileProcedures
         {
@@ -24,7 +24,7 @@ namespace osu.Framework.Audio.Callbacks
             Seek = Seek
         };
 
-        private FileProcedures staticProcedures => new FileProcedures
+        private static FileProcedures staticProcedures = new FileProcedures
         {
             Read = readCallback,
             Close = closeCallback,
@@ -38,12 +38,14 @@ namespace osu.Framework.Audio.Callbacks
 
         public FileCallbacks(IFileProcedures implementation)
         {
+            Callbacks = RuntimeInfo.SupportsJIT ? instanceProcedures : staticProcedures;
             this.implementation = implementation;
             procedures = null;
         }
 
         public FileCallbacks(FileProcedures procedures)
         {
+            Callbacks = RuntimeInfo.SupportsJIT ? instanceProcedures : staticProcedures;
             this.procedures = procedures;
             implementation = null;
         }
@@ -66,28 +68,35 @@ namespace osu.Framework.Audio.Callbacks
         private static int readCallback(IntPtr buffer, int length, IntPtr user)
         {
             var ptr = new ObjectHandle<FileCallbacks>(user);
-            return ptr.Target.Read(buffer, length, user);
+            if (ptr.GetTarget(out FileCallbacks target))
+                return target.Read(buffer, length, user);
+            return 0;
         }
 
         [MonoPInvokeCallback(typeof(FileCloseProcedure))]
         private static void closeCallback(IntPtr user)
         {
             var ptr = new ObjectHandle<FileCallbacks>(user);
-            ptr.Target.Close(user);
+            if (ptr.GetTarget(out FileCallbacks target))
+                target.Close(user);
         }
 
         [MonoPInvokeCallback(typeof(FileLengthProcedure))]
         private static long lengthCallback(IntPtr user)
         {
             var ptr = new ObjectHandle<FileCallbacks>(user);
-            return ptr.Target.Length(user);
+            if (ptr.GetTarget(out FileCallbacks target))
+                return target.Length(user);
+            return 0;
         }
 
         [MonoPInvokeCallback(typeof(FileSeekProcedure))]
         private static bool seekCallback(long offset, IntPtr user)
         {
             var ptr = new ObjectHandle<FileCallbacks>(user);
-            return ptr.Target.Seek(offset, user);
+            if (ptr.GetTarget(out FileCallbacks target))
+                return target.Seek(offset, user);
+            return false;
         }
     }
 }

--- a/osu.Framework/Audio/Callbacks/FileCallbacks.cs
+++ b/osu.Framework/Audio/Callbacks/FileCallbacks.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Audio.Callbacks
             Seek = Seek
         };
 
-        private static readonly FileProcedures staticProcedures = new FileProcedures
+        private static readonly FileProcedures static_procedures = new FileProcedures
         {
             Read = readCallback,
             Close = closeCallback,
@@ -38,14 +38,14 @@ namespace osu.Framework.Audio.Callbacks
 
         public FileCallbacks(IFileProcedures implementation)
         {
-            Callbacks = RuntimeInfo.SupportsJIT ? instanceProcedures : staticProcedures;
+            Callbacks = RuntimeInfo.SupportsJIT ? instanceProcedures : static_procedures;
             this.implementation = implementation;
             procedures = null;
         }
 
         public FileCallbacks(FileProcedures procedures)
         {
-            Callbacks = RuntimeInfo.SupportsJIT ? instanceProcedures : staticProcedures;
+            Callbacks = RuntimeInfo.SupportsJIT ? instanceProcedures : static_procedures;
             this.procedures = procedures;
             implementation = null;
         }

--- a/osu.Framework/Audio/Callbacks/FileCallbacks.cs
+++ b/osu.Framework/Audio/Callbacks/FileCallbacks.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Audio.Callbacks
             Seek = Seek
         };
 
-        private static FileProcedures staticProcedures = new FileProcedures
+        private static readonly FileProcedures staticProcedures = new FileProcedures
         {
             Read = readCallback,
             Close = closeCallback,
@@ -70,6 +70,7 @@ namespace osu.Framework.Audio.Callbacks
             var ptr = new ObjectHandle<FileCallbacks>(user);
             if (ptr.GetTarget(out FileCallbacks target))
                 return target.Read(buffer, length, user);
+
             return 0;
         }
 
@@ -87,6 +88,7 @@ namespace osu.Framework.Audio.Callbacks
             var ptr = new ObjectHandle<FileCallbacks>(user);
             if (ptr.GetTarget(out FileCallbacks target))
                 return target.Length(user);
+
             return 0;
         }
 
@@ -96,6 +98,7 @@ namespace osu.Framework.Audio.Callbacks
             var ptr = new ObjectHandle<FileCallbacks>(user);
             if (ptr.GetTarget(out FileCallbacks target))
                 return target.Seek(offset, user);
+
             return false;
         }
     }

--- a/osu.Framework/Audio/Callbacks/SyncCallback.cs
+++ b/osu.Framework/Audio/Callbacks/SyncCallback.cs
@@ -26,7 +26,8 @@ namespace osu.Framework.Audio.Callbacks
         private static void syncCallback(int handle, int channel, int data, IntPtr user)
         {
             var ptr = new ObjectHandle<SyncCallback>(user);
-            ptr.Target.Sync(handle, channel, data, user);
+            if (ptr.GetTarget(out SyncCallback target))
+                target.Sync(handle, channel, data, user);
         }
     }
 }


### PR DESCRIPTION
The main issue was that `FileCallbacks.staticProcedures` would create a new callback structure every time it was called, and was not being retained anywhere.  Changed to be a private static var that only gets set once.

As part of the change I also put in some safety to ensure we never try to work with a freed target.

Resolves #2200 

Will probably also resolve https://github.com/ppy/osu/issues/4384
