### PR TITLE
Implement initial OML support

### DIFF
--- a/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
@@ -7,6 +7,8 @@ using System.IO;
 using NUnit.Framework;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Framework.MarkupLanguage;
 using osu.Framework.Testing;
 
@@ -28,6 +30,46 @@ Layout:
       Colour: '#00F7'
 ";
 
+        private const string event_layout = @"
+Layout:
+  Children:
+    - Extends: HoverBox
+      Width: 100
+      Height: 100
+      Position: 50, 50
+      Colour: HotPink
+
+      Events:
+        - Name: BoxHover
+          AliasOf: OnBoxHover
+        - Name: BoxUnHover
+          AliasOf: OnBoxUnHover
+      Transitions:
+        - Name: BoxHover
+          State:
+            Colour: Orange
+        - Name: BoxUnHover
+          State:
+            Colour: HotPink
+
+    - Extends: Button
+      Width: 100
+      Height: 25
+      Text: Test button
+      Position: 50, 175
+      BackgroundColour: Purple
+
+      Events:
+        - Name: ButtonClick
+          AliasOf: Action
+          Transitions:
+            -
+              State:
+                Alpha: 0.5
+              Duration: 500
+              Easing: EasingTypes.Out
+";
+
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(OmlReader), typeof(OmlObject) };
         private OmlReader reader;
 
@@ -43,6 +85,37 @@ Layout:
             }));
 
             AddStep("Load layout", () => Child = reader.Load("Layout", new StringReader(simple_layout)));
+        }
+
+        [TestCase]
+        public void LoadEventLayout()
+        {
+            AddStep("Create OmlReader", () => reader = new OmlReader(new Dictionary<string, Type>
+            {
+                { "Box", typeof(Box) },
+                { "HoverBox", typeof(HoverBox) },
+                { "Button", typeof(Button) },
+            }));
+
+            AddStep("Load layout", () => Child = reader.Load("Layout", new StringReader(event_layout)));
+        }
+
+        private class HoverBox : Box
+        {
+            public event Action<HoverEvent> OnBoxHover;
+            public event Action<HoverLostEvent> OnBoxUnHover;
+
+            protected override bool OnHover(HoverEvent e)
+            {
+                OnBoxHover?.Invoke(e);
+                return base.OnHover(e);
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                OnBoxUnHover?.Invoke(e);
+                base.OnHoverLost(e);
+            }
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.MarkupLanguage;
 using osu.Framework.Testing;
@@ -28,17 +29,20 @@ Layout:
 ";
 
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(OmlReader), typeof(OmlObject) };
+        private OmlReader reader;
+
+        [SetUp]
+        public void SetUp() => Schedule(() => Child = new Container());
 
         [TestCase]
         public void LoadSimpleLayout()
         {
-            var reader = new OmlReader(new Dictionary<string, Type>
+            AddStep("Create OmlReader", () => reader = new OmlReader(new Dictionary<string, Type>
             {
                 { "Box", typeof(Box) },
-            });
+            }));
 
-            var obj = reader.Load("Layout", new StringReader(simple_layout));
-            Child = obj;
+            AddStep("Load layout", () => Child = reader.Load("Layout", new StringReader(simple_layout)));
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.MarkupLanguage;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual.Layout
+{
+    [System.ComponentModel.Description("Loads a layout using osu! markup language")]
+    public class TestCaseOmlLayout : TestCase
+    {
+        private const string simple_layout = @"
+Layout:
+  Extends: Box
+  Width: 200
+  Height: 100
+  Colour: Red";
+
+        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(OmlReader), typeof(OmlObject) };
+
+        [TestCase]
+        public void LoadSimpleLayout()
+        {
+            var reader = new OmlReader(new Dictionary<string, Type>
+            {
+                { "Box", typeof(Box) },
+            });
+
+            var obj = reader.Load("Layout", new StringReader(simple_layout));
+            Child = obj;
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
@@ -16,10 +16,16 @@ namespace osu.Framework.Tests.Visual.Layout
     {
         private const string simple_layout = @"
 Layout:
-  Extends: Box
-  Width: 200
-  Height: 100
-  Colour: Red";
+  Children:
+    - Extends: Box
+      Width: 200
+      Height: 100
+      Colour: Red
+    - Extends: Box
+      Width: 100
+      Height: 200
+      Colour: '#00F7'
+";
 
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(OmlReader), typeof(OmlObject) };
 

--- a/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
@@ -37,8 +37,13 @@ Layout:
       Width: 100
       Height: 100
       Position: 50, 50
-      Colour: HotPink
+      Colour: UnHoverColor
 
+      Properties:
+        - Name: HoverColor
+          Value: Orange
+        - Name: UnHoverColor
+          Value: HotPink
       Events:
         - Name: BoxHover
           AliasFor: OnBoxHover
@@ -47,10 +52,10 @@ Layout:
       Transitions:
         - Name: BoxHover
           State:
-            Colour: Orange
+            Colour: HoverColor
         - Name: BoxUnHover
           State:
-            Colour: HotPink
+            Colour: UnHoverColor
 
     - Extends: Button
       Width: 100

--- a/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestCaseOmlLayout.cs
@@ -41,9 +41,9 @@ Layout:
 
       Events:
         - Name: BoxHover
-          AliasOf: OnBoxHover
+          AliasFor: OnBoxHover
         - Name: BoxUnHover
-          AliasOf: OnBoxUnHover
+          AliasFor: OnBoxUnHover
       Transitions:
         - Name: BoxHover
           State:
@@ -61,7 +61,7 @@ Layout:
 
       Events:
         - Name: ButtonClick
-          AliasOf: Action
+          AliasFor: Action
           Transitions:
             -
               State:
@@ -91,11 +91,17 @@ Layout:
         public void LoadEventLayout()
         {
             AddStep("Create OmlReader", () => reader = new OmlReader(new Dictionary<string, Type>
-            {
-                { "Box", typeof(Box) },
-                { "HoverBox", typeof(HoverBox) },
-                { "Button", typeof(Button) },
-            }));
+                {
+                    { "Box", typeof(Box) },
+                    { "HoverBox", typeof(HoverBox) },
+                    { "Button", typeof(Button) },
+                },
+                new Dictionary<string, Delegate>
+                {
+                    { "ButtonClick", new Action(() => { Console.WriteLine("Button click"); }) },
+                    { "BoxHover", new Action<HoverEvent>(x => { Console.WriteLine("Hover"); }) },
+                    { "BoxUnHover", new Action<HoverLostEvent>(x => { Console.WriteLine("UnHover"); }) },
+                }));
 
             AddStep("Load layout", () => Child = reader.Load("Layout", new StringReader(event_layout)));
         }

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -93,6 +93,17 @@ namespace osu.Framework.Extensions.TypeExtensions
         /// </summary>
         /// <remarks>See: https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/nullable-types/how-to-identify-a-nullable-type</remarks>
         public static bool IsNullable(this Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+
+        /// <summary>
+        /// Checks if the object extends the given type (directly or indirectly). Also checks for generic types.
+        /// </summary>
+        public static bool ExtendsClass(this object obj, Type t)
+        {
+            bool isGeneric = t.IsGenericType;
+            return obj.GetType().EnumerateBaseTypes()
+                      .Where(x => x.IsGenericType == isGeneric)
+                      .Any(x => (isGeneric ? x.GetGenericTypeDefinition() : x) == t);
+        }
     }
 
     [Flags]

--- a/osu.Framework/MarkupLanguage/OmlObject.cs
+++ b/osu.Framework/MarkupLanguage/OmlObject.cs
@@ -116,7 +116,7 @@ namespace osu.Framework.MarkupLanguage
             /// <summary>
             /// A unique alias for this event
             /// </summary>
-            public string Alias;
+            public string AliasFor;
 
             /// <summary>
             /// Transitions to be ran when this event gets triggered.

--- a/osu.Framework/MarkupLanguage/OmlObject.cs
+++ b/osu.Framework/MarkupLanguage/OmlObject.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.MarkupLanguage
     /// </summary>
     public class OmlObject
     {
-        public static readonly string[] SPECIAL_PROPERTIES = { "Extends", "States", "Transitions", "Events", "Properties", "Children" };
+        internal static readonly string[] SPECIAL_PROPERTIES = { "Extends", "States", "Transitions", "Events", "Properties", "Children" };
 
         /// <summary>
         /// Contains general properties such as Width, Height and Colour. These are set when the <seealso cref="Drawable"/> is constructed.
@@ -108,11 +108,6 @@ namespace osu.Framework.MarkupLanguage
         /// </summary>
         public class OmlEvent
         {
-            /// <summary>
-            /// An event that propagates the trigger of the underlying even
-            /// </summary>
-            public event Action<object[]> OnTrigger;
-
             /// <summary>
             /// A unique alias for this event
             /// </summary>

--- a/osu.Framework/MarkupLanguage/OmlObject.cs
+++ b/osu.Framework/MarkupLanguage/OmlObject.cs
@@ -1,0 +1,127 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using YamlDotNet.Serialization;
+
+namespace osu.Framework.MarkupLanguage
+{
+    /// <summary>
+    /// An object holding the contents of an OML yaml file. This defines the properties and layout of <seealso cref="Drawable"/>s.
+    /// </summary>
+    public class OmlObject
+    {
+        public static readonly string[] SPECIAL_PROPERTIES = { "Extends", "States", "Transitions", "Events", "Properties", "Children" };
+
+        /// <summary>
+        /// Contains general properties such as Width, Height and Colour. These are set when the <seealso cref="Drawable"/> is constructed.
+        /// </summary>
+        [YamlIgnore]
+        public Dictionary<string, string> GeneralProperties = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Objects are <seealso cref="Drawable"/>s by default and inherit all of <seealso cref="Drawable"/>'s properties. It is possible to change
+        /// this by specifying the Extends property of the object.
+        /// </summary>
+        public Type Extends;
+
+        /// <summary>
+        /// A list of pre-defined properties to be used by <seealso cref="States"/>
+        /// </summary>
+        public Dictionary<string, OmlProperty> Properties;
+
+        /// <summary>
+        /// A state defines modifications to the value of the general properties of the object. This may be used to define named states which may be
+        /// referred to in further code.
+        ///
+        /// The property named "Default" is optional but will be applied when the object is first constructed.
+        /// </summary>
+        public Dictionary<string, OmlState> States;
+
+        /// <summary>
+        /// A transition defines how an object should transition towards a state. This may be used to define named transitions which may be referred
+        /// to in further code. These can transition to named or anonymous states.
+        /// </summary>
+        public Dictionary<string, OmlTransition> Transitions;
+
+        /// <summary>
+        /// An event defines the transitions applied to an object when the event is called. Events are exposed in the generated C# code. These can be
+        /// used to apply named or anonymous transitions.
+        /// </summary>
+        public Dictionary<string, OmlEvent> Events;
+
+        /// <summary>
+        /// An object may be composited by several children that are directly affected by the containing object. In this way it is possible to
+        /// transition an object and all of its children together by applying the transition to the containing object. (Read: transition applies to
+        /// children)
+        ///
+        /// Children may be either named - allowing them to be referenced as private members from generated code, or anonymous.
+        /// </summary>
+        public OmlObject[] Children;
+
+        /// <summary>
+        /// A type with an optional default value
+        /// </summary>
+        public class OmlProperty
+        {
+            /// <summary>
+            /// The type of this property
+            /// </summary>
+            public Type Type;    // TODO: is this needed?
+
+            /// <summary>
+            /// The default value of this property. Can be null.
+            /// </summary>
+            public string Value;
+        }
+
+        /// <summary>
+        /// A collection of key-value pairs containing property names and their value.
+        /// </summary>
+        public class OmlState : Dictionary<string, object> { }
+
+        /// <summary>
+        /// A transition to an <seealso cref="OmlState"/>.
+        /// </summary>
+        public class OmlTransition
+        {
+            /// <summary>
+            /// The end state of this transition
+            /// </summary>
+            public OmlState State;
+
+            /// <summary>
+            /// The duration of this transition. Defaults to 0 (instant)
+            /// </summary>
+            public float Duration = 0;
+
+            /// <summary>
+            /// The easing of this transition. Defaults to none (linear)
+            /// </summary>
+            public Easing Easing = Easing.None;
+        }
+
+        /// <summary>
+        /// An event which may start some <seealso cref="OmlTransition"/>s.
+        /// </summary>
+        public class OmlEvent
+        {
+            /// <summary>
+            /// An event that propagates the trigger of the underlying even
+            /// </summary>
+            public event Action<object[]> OnTrigger;
+
+            /// <summary>
+            /// A unique alias for this event
+            /// </summary>
+            public string Alias;
+
+            /// <summary>
+            /// Transitions to be ran when this event gets triggered.
+            /// </summary>
+            public OmlTransition[] Transitions;
+        }
+    }
+}

--- a/osu.Framework/MarkupLanguage/OmlReader.cs
+++ b/osu.Framework/MarkupLanguage/OmlReader.cs
@@ -1,0 +1,247 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using osu.Framework.Graphics;
+using YamlDotNet.Serialization;
+
+namespace osu.Framework.MarkupLanguage
+{
+    public class OmlReader
+    {
+        // TODO: accept a dictionary of types for Extends (ctor or dep inj)
+        public Drawable Load(string objectName, TextReader text)
+        {
+            var obj = Parse(objectName, text);
+
+            // TODO
+            return null;
+        }
+
+        public OmlObject Parse(string objectName, TextReader text) => ParseAll(text)[objectName];
+
+        public Dictionary<string, OmlObject> ParseAll(TextReader text)
+        {
+            var deserializer = new Deserializer();
+            var bla = deserializer.Deserialize<Dictionary<string, object>>(text);
+            return parseChildren(bla);
+        }
+
+        private Dictionary<string, OmlObject> parseChildren(Dictionary<string, object> bla)
+        {
+            var ret = new Dictionary<string, OmlObject>();
+
+            foreach (var pair in bla)
+                ret.Add(pair.Key, parseChild((Dictionary<object, object>)pair.Value));
+
+            return ret;
+        }
+
+        private OmlObject[] parseChildren(List<object> bla)
+        {
+            var ret = new OmlObject[bla.Count];
+
+            for (int i = 0; i < bla.Count; i++)
+                ret[i] = parseChild((Dictionary<object, object>)bla[i]);
+
+            return ret;
+        }
+
+        private OmlObject parseChild(Dictionary<object, object> values)
+        {
+            var obj = new OmlObject();
+
+            // TODO: actually use these!
+            if (values.ContainsKey("Properties"))
+                obj.Properties = parseProperties(values["Properties"]);
+
+            if (values.ContainsKey("Extends"))
+                obj.Extends = resolveType(values["Extends"]);
+
+            if (values.ContainsKey("States"))
+                obj.States = parseStates(values["States"]);
+
+            if (values.ContainsKey("Transitions"))
+                obj.Transitions = parseTransitions(values["Transitions"], in obj);
+
+            if (values.ContainsKey("Events"))
+                obj.Events = parseEvents(values["Events"], in obj);
+
+            if (values.ContainsKey("Children"))
+                obj.Children = parseChildren((List<object>)values["Children"]);
+
+            // add all others
+            obj.GeneralProperties = new Dictionary<string, string>();
+            foreach (KeyValuePair<object, object> pair in values.Where(x => !OmlObject.SPECIAL_PROPERTIES.Contains(x.Key)))
+                obj.GeneralProperties.Add((string)pair.Key, (string)pair.Value);
+
+            return obj;
+        }
+
+        private Type resolveType(object s)
+        {
+            return typeof(object);    // TODO
+        }
+
+        private Dictionary<string, OmlObject.OmlState> parseStates(object value)
+        {
+            var ret = new Dictionary<string, OmlObject.OmlState>();
+            foreach (Dictionary<object, object> o in (List<object>)value) {
+                var s = parseState(o, out string name);
+
+                if (name == null)
+                    throw new Exception("State had no name");
+
+                ret[name] = s;
+            }
+
+            return ret;
+        }
+
+        private OmlObject.OmlState parseState(Dictionary<object, object> o, out string name)
+        {
+            var s = new OmlObject.OmlState();
+            name = null;
+            foreach ((string key1, string value1) in o.Select(x => ((string)x.Key, (string)x.Value))) {
+                if (key1 != "Name")
+                    s.Add(key1, value1);
+                else
+                    name = value1;
+            }
+
+            return s;
+        }
+
+        private Dictionary<string, OmlObject.OmlTransition> parseTransitions(object value, in OmlObject obj)
+        {
+            var ret = new Dictionary<string, OmlObject.OmlTransition>();
+
+            foreach (Dictionary<object, object> o in (List<object>)value) {
+                var t = parseTransition(o, in obj, out string name);
+
+                if (name == null)
+                    throw new Exception("Transition had no name");
+
+                ret[name] = t;
+            }
+
+            return ret;
+        }
+
+        private OmlObject.OmlTransition parseTransition(Dictionary<object, object> o, in OmlObject obj, out string name)
+        {
+            var transition = new OmlObject.OmlTransition();
+            name = null;
+
+            foreach ((string key1, object value1) in o.Select(x => ((string)x.Key, x.Value))) {
+                string valString = value1 as string;
+                switch (key1) {
+                    case "Name":
+                        name = valString;
+                        break;
+                    case "Duration":
+                        transition.Duration = float.Parse(valString, CultureInfo.InvariantCulture);
+                        break;
+                    case "Easing":
+                        transition.Easing = (Easing)Enum.Parse(typeof(Easing), valString.Split('.').Last());
+                        break;
+                    case "State":
+                        transition.State = valString != null
+                            ? obj.States[valString]
+                            : parseState((Dictionary<object, object>)value1, out _);
+                        break;
+                }
+            }
+
+            return transition;
+        }
+
+        private Dictionary<string, OmlObject.OmlEvent> parseEvents(object value, in OmlObject obj)
+        {
+            var ret = new Dictionary<string, OmlObject.OmlEvent>();
+
+            foreach (Dictionary<object, object> o in (List<object>)value) {
+                var t = parseEvent(o, in obj, out string name);
+
+                if (name == null)
+                    throw new Exception("Event had no name");
+
+                ret[name] = t;
+            }
+
+            return ret;
+        }
+
+        private OmlObject.OmlEvent parseEvent(Dictionary<object, object> o, in OmlObject obj, out string name)
+        {
+            var e = new OmlObject.OmlEvent();
+            name = null;
+
+            foreach ((string key1, object value1) in o.Select(x => ((string)x.Key, x.Value))) {
+                string valString = value1 as string;
+                switch (key1) {
+                    case "Name":
+                        name = valString;
+                        break;
+                    case "Transitions":
+                        var objs = (List<object>)value1;
+                        e.Transitions = new OmlObject.OmlTransition[objs.Count];
+
+                        for (int i = 0; i < objs.Count; i++) {
+                            if (objs[i] is string s)
+                                e.Transitions[i] = obj.Transitions[s];
+                            else
+                                e.Transitions[i] = parseTransition((Dictionary<object, object>)objs[i], in obj, out _);
+                        }
+
+                        break;
+                }
+            }
+
+            return e;
+        }
+
+        private Dictionary<string, OmlObject.OmlProperty> parseProperties(object value)
+        {
+            var ret = new Dictionary<string, OmlObject.OmlProperty>();
+
+            foreach (Dictionary<object, object> o in (List<object>)value) {
+                var t = parseProperty(o, out string name);
+
+                if (name == null)
+                    throw new Exception("Property had no name");
+
+                ret[name] = t;
+            }
+
+            return ret;
+        }
+
+        private OmlObject.OmlProperty parseProperty(Dictionary<object, object> o, out string name)
+        {
+            var p = new OmlObject.OmlProperty();
+            name = null;
+
+            foreach ((string key1, object value1) in o.Select(x => ((string)x.Key, x.Value))) {
+                string valString = value1 as string;
+                switch (key1) {
+                    case "Name":
+                        name = valString;
+                        break;
+                    case "Type":
+                        p.Type = typeof(object);    // TODO
+                        break;
+                    case "Value":
+                        p.Value = valString;
+                        break;
+                }
+            }
+
+            return p;
+        }
+    }
+}

--- a/osu.Framework/MarkupLanguage/OmlReader.cs
+++ b/osu.Framework/MarkupLanguage/OmlReader.cs
@@ -332,49 +332,55 @@ namespace osu.Framework.MarkupLanguage
                 return new Vector2(float.Parse(split[0], CultureInfo.InvariantCulture), float.Parse(split[1], CultureInfo.InvariantCulture));
             }
 
-            if (type == typeof(ColourInfo)) {
-                // try color code
-                if (val.StartsWith("#")) {
-                    val = val.Substring(1);
+            if (type == typeof(ColourInfo))
+                return (ColourInfo)textToColor(val);
 
-                    switch (val.Length) {
-                        case 6:
-                            return (ColourInfo)new Color4(
-                                Convert.ToByte(val.Substring(0, 2), 16),
-                                Convert.ToByte(val.Substring(2, 2), 16),
-                                Convert.ToByte(val.Substring(4, 2), 16),
-                                0xFF);
-                        case 3:
-                            return (ColourInfo)new Color4(
-                                (byte)(Convert.ToByte(val.Substring(0, 1), 16) * 0x11),
-                                (byte)(Convert.ToByte(val.Substring(1, 1), 16) * 0x11),
-                                (byte)(Convert.ToByte(val.Substring(2, 1), 16) * 0x11),
-                                0xFF);
-                        case 8:
-                            return (ColourInfo)new Color4(
-                                Convert.ToByte(val.Substring(0, 2), 16),
-                                Convert.ToByte(val.Substring(2, 2), 16),
-                                Convert.ToByte(val.Substring(4, 2), 16),
-                                Convert.ToByte(val.Substring(6, 2), 16));
-                        case 4:
-                            return (ColourInfo)new Color4(
-                                (byte)(Convert.ToByte(val.Substring(0, 1), 16) * 0x11),
-                                (byte)(Convert.ToByte(val.Substring(1, 1), 16) * 0x11),
-                                (byte)(Convert.ToByte(val.Substring(2, 1), 16) * 0x11),
-                                (byte)(Convert.ToByte(val.Substring(3, 1), 16) * 0x11));
-                    }
-                }
-
-                // try pre-defined code
-                var c = typeof(Color4).GetProperty(val, BindingFlags.Static | BindingFlags.Public);
-                if (c != null)
-                    return (ColourInfo)(Color4)c.GetValue(null);
-
-                // perhaps try osucolours in the future
-                throw new Exception("Unrecognized color: " + val);
-            }
+            if (type == typeof(Color4))
+                return textToColor(val);
 
             return null;
+        }
+
+        private static Color4 textToColor(string val)
+        {
+            // try color code
+            if (val.StartsWith("#")) {
+                val = val.Substring(1);
+
+                switch (val.Length) {
+                    case 6:
+                        return new Color4(
+                            Convert.ToByte(val.Substring(0, 2), 16),
+                            Convert.ToByte(val.Substring(2, 2), 16),
+                            Convert.ToByte(val.Substring(4, 2), 16),
+                            0xFF);
+                    case 3:
+                        return new Color4(
+                            (byte)(Convert.ToByte(val.Substring(0, 1), 16) * 0x11),
+                            (byte)(Convert.ToByte(val.Substring(1, 1), 16) * 0x11),
+                            (byte)(Convert.ToByte(val.Substring(2, 1), 16) * 0x11),
+                            0xFF);
+                    case 8:
+                        return new Color4(
+                            Convert.ToByte(val.Substring(0, 2), 16),
+                            Convert.ToByte(val.Substring(2, 2), 16),
+                            Convert.ToByte(val.Substring(4, 2), 16),
+                            Convert.ToByte(val.Substring(6, 2), 16));
+                    case 4:
+                        return new Color4(
+                            (byte)(Convert.ToByte(val.Substring(0, 1), 16) * 0x11),
+                            (byte)(Convert.ToByte(val.Substring(1, 1), 16) * 0x11),
+                            (byte)(Convert.ToByte(val.Substring(2, 1), 16) * 0x11),
+                            (byte)(Convert.ToByte(val.Substring(3, 1), 16) * 0x11));
+                }
+            }
+
+            // try pre-defined code
+            var c = typeof(Color4).GetProperty(val, BindingFlags.Static | BindingFlags.Public);
+            if (c != null)
+                return (Color4)c.GetValue(null);
+
+            throw new Exception("Unrecognized color: " + val);
         }
 
         private static Type findContainerGenericParam(object o)

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -54,6 +54,7 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
+    <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\Fonts\FontAwesome" />


### PR DESCRIPTION
Add an initial implementation for osu! markup language, which reads yaml files and creates Drawables from them.

---

Adds a partial implementation for the osu! markup language as described in #30. It deviates from the spec in the following ways:
- Transitions are not implemented. I've been thinking about how to implement it for a few days and I can't come up with a way to combine an Action with an arbitrary Delegate. Any help would be greatly appreciated.
- The Type field in Properties is not used, since it's derived from the found field/property.
- The Default state is not yet applied.

OmlReader's constructor accepts a Dictionary<string,Type> for resolving Drawable types and Dictionary<string,Delegate> which can be assigned to events. The only properties that can be set are the types supported by TypeConverter (primitives, Enums), Color4/ColourInfo (in RGB/RGBA hex format or as static field of Color4) and Vector2.

This probably isn't ready for merging yet, I've opened this PR to get some feedback. This implementation may throw a bit eagerly and there are no unit tests yet.