### PR TITLE
Seek by decoupledClock.CurrentTime when decoupled on Start()

### DIFF
--- a/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
@@ -250,6 +250,26 @@ namespace osu.Framework.Tests.Clocks
             Assert.AreEqual(source.CurrentTime, decoupleable.CurrentTime, "Coupled time should match source time.");
         }
 
+        [Test]
+        public void TestDecoupledSourceSeeksDecoupledTimeOnStart()
+        {
+            decoupleable.IsCoupled = false;
+            source.Stop();
+            decoupleable.Start();
+
+            Assert.AreEqual(source.CurrentTime, decoupleable.DecoupledTime);
+        }
+
+        [Test]
+        public void TestCoupledSourceSeeksCoupledTimeOnStart()
+        {
+            decoupleable.IsCoupled = true;
+            source.Stop();
+            decoupleable.Start();
+
+            Assert.AreEqual(source.CurrentTime, decoupleable.CurrentTime);
+        }
+
         /// <summary>
         /// Tests that the source clock is seeked when the decoupled clock is seeked.
         /// </summary>

--- a/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Timing
         {
             if (adjustableSource?.IsRunning == false)
             {
-                if (adjustableSource.Seek(CurrentTime))
+                if (adjustableSource.Seek(IsCoupled ? CurrentTime : decoupledClock.CurrentTime))
                     //only start the source clock if our time values match.
                     //this handles the case where we seeked to an unsupported value and the source clock is out of sync.
                     adjustableSource.Start();

--- a/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
@@ -35,6 +35,8 @@ namespace osu.Framework.Timing
         /// </summary>
         private IAdjustableClock adjustableSource => Source as IAdjustableClock;
 
+        internal double DecoupledTime => decoupledClock.CurrentTime;
+
         public override double CurrentTime => currentTime;
 
         private double currentTime;
@@ -120,7 +122,7 @@ namespace osu.Framework.Timing
         {
             if (adjustableSource?.IsRunning == false)
             {
-                if (adjustableSource.Seek(IsCoupled ? CurrentTime : decoupledClock.CurrentTime))
+                if (adjustableSource.Seek(IsCoupled ? CurrentTime : DecoupledTime))
                     //only start the source clock if our time values match.
                     //this handles the case where we seeked to an unsupported value and the source clock is out of sync.
                     adjustableSource.Start();


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/4705

The issue was caused by a very tiny difference between the interpolated `CurrentTime` of the `DecoupleableInterpolatingFramedClock` and the real frame time. A check was supposed to block the source clock from restarting if `CurrentTime` would exceed that of the track length, but because of this difference the check would incorrectly pass.

Performing this check on the decoupled clock instead when we are actually decoupled resolves this issue.

Note: I exposed the decoupled clock time as internal for use in tests. Not sure if it should be otherwise.
