### PR TITLE
Implement an async disposal queue

### DIFF
--- a/osu.Framework.Tests/Threading/AsyncDisposalQueueTest.cs
+++ b/osu.Framework.Tests/Threading/AsyncDisposalQueueTest.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Logging;
+
+namespace osu.Framework.Tests.Threading
+{
+    [TestFixture]
+    public class AsyncDisposalQueueTest
+    {
+        [Test]
+        public void TestManyAsyncDisposal()
+        {
+            var objects = new List<DisposableObject>();
+            for (int i = 0; i < 10000; i++)
+                objects.Add(new DisposableObject());
+
+            objects.ForEach(AsyncDisposalQueue.Enqueue);
+
+            int attempts = 1000;
+            while (!objects.All(o => o.IsDisposed))
+            {
+                if (attempts-- == 0)
+                    Assert.Fail("Expected all objects to dispose.");
+                Thread.Sleep(10);
+            }
+
+            Logger.Log(objects.Select(d => d.TaskId).Distinct().Count().ToString());
+
+            // It's very unlikely for this to fail by chance due to the number of objects being disposed and computational time requirement of task scheduling
+            Assert.That(objects.Select(d => d.TaskId).Distinct().Count(), Is.LessThan(objects.Count));
+        }
+
+        private class DisposableObject : IDisposable
+        {
+            public int? TaskId { get; private set; }
+
+            public bool IsDisposed { get; private set; }
+
+            public void Dispose()
+            {
+                TaskId = Task.CurrentId;
+                IsDisposed = true;
+            }
+        }
+    }
+}

--- a/osu.Framework/Allocation/AsyncDisposalQueue.cs
+++ b/osu.Framework/Allocation/AsyncDisposalQueue.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Allocation
+{
+    /// <summary>
+    /// A queue which batches object disposal on threadpool threads.
+    /// </summary>
+    internal static class AsyncDisposalQueue
+    {
+        private static readonly ConcurrentQueue<IDisposable> disposal_queue = new ConcurrentQueue<IDisposable>();
+        private static readonly object task_lock = new object();
+
+        private static Task runTask;
+
+        public static void Enqueue(IDisposable disposable)
+        {
+            disposal_queue.Enqueue(disposable);
+
+            lock (task_lock)
+            {
+                if (runTask != null
+                    && (runTask.Status == TaskStatus.WaitingForActivation
+                        || runTask.Status == TaskStatus.WaitingToRun
+                        || runTask.Status == TaskStatus.Created))
+                {
+                    return;
+                }
+
+                runTask = Task.Run(() =>
+                {
+                    while (disposal_queue.TryDequeue(out var toDispose))
+                        toDispose.Dispose();
+                });
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -756,7 +756,7 @@ namespace osu.Framework.Graphics.Containers
         internal void DisposeChildAsync(Drawable drawable)
         {
             drawable.UnbindAllBindablesSubTree();
-            Task.Run(drawable.Dispose);
+            AsyncDisposalQueue.Enqueue(drawable);
         }
 
         internal override void UpdateClock(IFrameBasedClock clock)


### PR DESCRIPTION
This tackles two issues.

1. Calling `Task.Run(drawable.Dispose)` incurs a delegate allocation due to the capture of `drawable`.
2. There are potentially many calls happening to `Task.Run` here.

For this purpose, I've added a new component which allows us to both remove delegate allocation and batch multiple `.Dispose()` calls.

In a little test I made with `CompositeDrawable`, 10000 tasks were previously scheduled, and now only ~7 are. This further reduces as expected when the threadpool load is increased.