### PR TITLE
Avoid concurrent queue overhead in Scheduler.AddDelayed usage

### DIFF
--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -130,18 +130,19 @@ namespace osu.Framework.Threading
 
                     tasksToSchedule.Clear();
                 }
-            }
 
-            for (int i = 0; i < perUpdateTasks.Count; i++)
-            {
-                ScheduledDelegate task = perUpdateTasks[i];
-                if (task.Cancelled)
+                for (int i = 0; i < perUpdateTasks.Count; i++)
                 {
-                    perUpdateTasks.RemoveAt(i--);
-                    continue;
-                }
+                    ScheduledDelegate task = perUpdateTasks[i];
 
-                runQueue.Enqueue(task);
+                    if (task.Cancelled)
+                    {
+                        perUpdateTasks.RemoveAt(i--);
+                        continue;
+                    }
+
+                    runQueue.Enqueue(task);
+                }
             }
 
             int countToRun = runQueue.Count;

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -166,11 +166,13 @@ namespace osu.Framework.Threading
         private bool getNextTask(out ScheduledDelegate task)
         {
             lock (queueLock)
+            {
                 if (runQueue.Count > 0)
                 {
                     task = runQueue.Dequeue();
                     return true;
                 }
+            }
 
             task = null;
             return false;

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -16,7 +15,7 @@ namespace osu.Framework.Threading
     /// </summary>
     public class Scheduler
     {
-        private readonly ConcurrentQueue<ScheduledDelegate> runQueue = new ConcurrentQueue<ScheduledDelegate>();
+        private readonly Queue<ScheduledDelegate> runQueue = new Queue<ScheduledDelegate>();
         private readonly List<ScheduledDelegate> timedTasks = new List<ScheduledDelegate>();
         private readonly List<ScheduledDelegate> perUpdateTasks = new List<ScheduledDelegate>();
         private int mainThreadId;
@@ -24,10 +23,12 @@ namespace osu.Framework.Threading
         private IClock clock;
         private double currentTime => clock?.CurrentTime ?? 0;
 
+        private readonly object queueLock = new object();
+
         /// <summary>
         /// Whether there are any tasks queued to run (including delayed tasks in the future).
         /// </summary>
-        public bool HasPendingTasks => !runQueue.IsEmpty || timedTasks.Count > 0 || perUpdateTasks.Count > 0;
+        public bool HasPendingTasks => runQueue.Count > 0 || timedTasks.Count > 0 || perUpdateTasks.Count > 0;
 
         /// <summary>
         /// The base thread is assumed to be the the thread on which the constructor is run.
@@ -64,7 +65,7 @@ namespace osu.Framework.Threading
             if (newClock == clock)
                 return;
 
-            lock (timedTasks)
+            lock (queueLock)
             {
                 if (clock == null)
                 {
@@ -92,7 +93,7 @@ namespace osu.Framework.Threading
         /// <returns>true if any tasks were run.</returns>
         public virtual int Update()
         {
-            lock (timedTasks)
+            lock (queueLock)
             {
                 double currentTimeLocal = currentTime;
 
@@ -146,7 +147,7 @@ namespace osu.Framework.Threading
             int countToRun = runQueue.Count;
             int countRun = 0;
 
-            while (runQueue.TryDequeue(out ScheduledDelegate sd))
+            while (getNextTask(out ScheduledDelegate sd))
             {
                 if (sd.Cancelled)
                     continue;
@@ -161,12 +162,25 @@ namespace osu.Framework.Threading
             return countRun;
         }
 
+        private bool getNextTask(out ScheduledDelegate task)
+        {
+            lock (queueLock)
+                if (runQueue.Count > 0)
+                {
+                    task = runQueue.Dequeue();
+                    return true;
+                }
+
+            task = null;
+            return false;
+        }
+
         /// <summary>
         /// Cancel any pending work tasks.
         /// </summary>
         public void CancelDelayedTasks()
         {
-            lock (timedTasks)
+            lock (queueLock)
             {
                 foreach (var t in timedTasks)
                     t.Cancel();
@@ -199,14 +213,15 @@ namespace osu.Framework.Threading
                 return true;
             }
 
-            runQueue.Enqueue(new ScheduledDelegate(task));
+            lock (queueLock)
+                runQueue.Enqueue(new ScheduledDelegate(task));
 
             return false;
         }
 
         public void Add(ScheduledDelegate task)
         {
-            lock (timedTasks)
+            lock (queueLock)
             {
                 if (task.RepeatInterval == 0)
                     perUpdateTasks.Add(task);
@@ -224,7 +239,7 @@ namespace osu.Framework.Threading
         public ScheduledDelegate AddDelayed(Action task, double timeUntilRun, bool repeat = false)
         {
             // We are locking here already to make sure we have no concurrent access to currentTime
-            lock (timedTasks)
+            lock (queueLock)
             {
                 ScheduledDelegate del = new ScheduledDelegate(task, currentTime + timeUntilRun, repeat ? timeUntilRun : -1);
                 Add(del);
@@ -239,10 +254,13 @@ namespace osu.Framework.Threading
         /// <returns>Whether this is the first queue attempt of this work.</returns>
         public bool AddOnce(Action task)
         {
-            if (runQueue.Any(sd => sd.Task == task))
-                return false;
+            lock (queueLock)
+            {
+                if (runQueue.Any(sd => sd.Task == task))
+                    return false;
 
-            runQueue.Enqueue(new ScheduledDelegate(task));
+                runQueue.Enqueue(new ScheduledDelegate(task));
+            }
 
             return true;
         }


### PR DESCRIPTION
`TestCaseDelayLoad` Previously:

![image](https://user-images.githubusercontent.com/191335/57863883-d3970380-7835-11e9-9f26-8babd2b7accd.png)
