### PR TITLE
Fix looping tracks not restarting

### DIFF
--- a/osu.Framework.Tests/Platform/TrackBassTest.cs
+++ b/osu.Framework.Tests/Platform/TrackBassTest.cs
@@ -69,21 +69,6 @@ namespace osu.Framework.Tests.Platform
         }
 
         [Test]
-        public void TestStopAtEnd()
-        {
-            startPlaybackAt(track.Length - 1);
-
-            Thread.Sleep(50);
-
-            track.Update();
-            track.StopAsync();
-            track.Update();
-
-            Assert.IsFalse(track.IsRunning);
-            Assert.AreEqual(track.Length, track.CurrentTime);
-        }
-
-        [Test]
         public void TestSeek()
         {
             track.SeekAsync(1000);
@@ -159,20 +144,6 @@ namespace osu.Framework.Tests.Platform
 
             Assert.IsTrue(track.IsRunning);
             Assert.Less(track.CurrentTime, 1000);
-        }
-
-        [Test]
-        public void TestRestartAtEnd()
-        {
-            startPlaybackAt(track.Length - 1);
-
-            Thread.Sleep(50);
-
-            track.Update();
-            restartTrack();
-
-            Assert.IsTrue(track.IsRunning);
-            Assert.LessOrEqual(track.CurrentTime, 1000);
         }
 
         [Test]

--- a/osu.Framework.Tests/Platform/TrackBassTest.cs
+++ b/osu.Framework.Tests/Platform/TrackBassTest.cs
@@ -143,7 +143,7 @@ namespace osu.Framework.Tests.Platform
             restartTrack();
 
             Assert.IsTrue(track.IsRunning);
-            Assert.AreEqual(0, track.CurrentTime);
+            Assert.Less(track.CurrentTime, 1000);
         }
 
         [Test]
@@ -157,7 +157,7 @@ namespace osu.Framework.Tests.Platform
             restartTrack();
 
             Assert.IsTrue(track.IsRunning);
-            Assert.AreEqual(0, track.CurrentTime);
+            Assert.LessOrEqual(track.CurrentTime, 1000);
         }
 
         [Test]
@@ -165,10 +165,12 @@ namespace osu.Framework.Tests.Platform
         {
             track.RestartPoint = 1000;
 
+            startPlaybackAt(3000);
             restartTrack();
 
             Assert.IsTrue(track.IsRunning);
-            Assert.AreEqual(1000, track.CurrentTime);
+            Assert.GreaterOrEqual(track.CurrentTime, 1000);
+            Assert.Less(track.CurrentTime, 3000);
         }
 
         [Test]
@@ -198,7 +200,7 @@ namespace osu.Framework.Tests.Platform
             track.Update();
 
             Assert.IsTrue(track.IsRunning);
-            Assert.Less(track.CurrentTime, 2000);
+            Assert.LessOrEqual(track.CurrentTime, 1000);
         }
 
         private void startPlaybackAt(double time)
@@ -215,6 +217,7 @@ namespace osu.Framework.Tests.Platform
             Task.Run(() =>
             {
                 track.Restart();
+                track.Update();
                 resetEvent.Set();
             });
 

--- a/osu.Framework.Tests/Platform/TrackBassTest.cs
+++ b/osu.Framework.Tests/Platform/TrackBassTest.cs
@@ -1,19 +1,26 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Threading;
+using System.Threading.Tasks;
 using ManagedBass;
 using NUnit.Framework;
 using osu.Framework.Audio.Track;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
+using osu.Framework.Threading;
+
+#pragma warning disable 4014
 
 namespace osu.Framework.Tests.Platform
 {
     [TestFixture]
     public class TrackBassTest
     {
-        private readonly TrackBass track;
+        private readonly DllResourceStore resources;
+
+        private TrackBass track;
 
         public TrackBassTest()
         {
@@ -22,32 +29,89 @@ namespace osu.Framework.Tests.Platform
             // Initialize bass with no audio to make sure the test remains consistent even if there is no audio device.
             Bass.Init(0);
 
-            var resources = new DllResourceStore("osu.Framework.Tests.dll");
-            var fileStream = resources.GetStream("Resources.Tracks.sample-track.mp3");
-            track = new TrackBass(fileStream);
+            resources = new DllResourceStore("osu.Framework.Tests.dll");
         }
 
         [SetUp]
         public void Setup()
         {
-#pragma warning disable 4014
-            track.SeekAsync(1000);
-#pragma warning restore 4014
+            track = new TrackBass(resources.GetStream("Resources.Tracks.sample-track.mp3"));
             track.Update();
+        }
+
+        [Test]
+        public void TestStart()
+        {
+            track.StartAsync();
+            track.Update();
+
+            Thread.Sleep(50);
+
+            track.Update();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.Greater(track.CurrentTime, 0);
+        }
+
+        [Test]
+        public void TestStop()
+        {
+            track.StartAsync();
+            track.StopAsync();
+            track.Update();
+
+            Assert.IsFalse(track.IsRunning);
+
+            double expectedTime = track.CurrentTime;
+            Thread.Sleep(50);
+
+            Assert.AreEqual(expectedTime, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestSeek()
+        {
+            track.SeekAsync(1000);
+            track.Update();
+
+            Assert.IsFalse(track.IsRunning);
             Assert.AreEqual(1000, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestSeekWhileRunning()
+        {
+            track.StartAsync();
+            track.SeekAsync(1000);
+            track.Update();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.GreaterOrEqual(track.CurrentTime, 1000);
         }
 
         /// <summary>
         /// Bass does not allow seeking to the end of the track. It should fail and the current time should not change.
         /// </summary>
         [Test]
-        public void TestTrackSeekingToEndFails()
+        public void TestSeekToEndFails()
         {
-#pragma warning disable 4014
             track.SeekAsync(track.Length);
-#pragma warning restore 4014
             track.Update();
-            Assert.AreEqual(1000, track.CurrentTime);
+
+            Assert.AreEqual(0, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestPlaybackToEnd()
+        {
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            track.Update();
+
+            Assert.IsFalse(track.IsRunning);
+            Assert.AreEqual(track.Length, track.CurrentTime);
         }
 
         /// <summary>
@@ -55,20 +119,109 @@ namespace osu.Framework.Tests.Platform
         /// This is blocked locally in <see cref="TrackBass"/>, so this test expects the track to not restart.
         /// </summary>
         [Test]
-        public void TestTrackPlaybackBlocksAtTrackEnd()
+        public void TestStartFromEndDoesNotRestart()
         {
-#pragma warning disable 4014
-            track.SeekAsync(track.Length - 1);
-#pragma warning restore 4014
-            track.StartAsync();
-            track.Update();
+            startPlaybackAt(track.Length - 1);
+
             Thread.Sleep(50);
+
             track.Update();
-            Assert.IsFalse(track.IsRunning);
-            Assert.AreEqual(track.Length, track.CurrentTime);
             track.StartAsync();
             track.Update();
+
             Assert.AreEqual(track.Length, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestRestart()
+        {
+            startPlaybackAt(1000);
+
+            Thread.Sleep(50);
+
+            track.Update();
+            restartTrack();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.AreEqual(0, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestRestartAtEnd()
+        {
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            track.Update();
+            restartTrack();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.AreEqual(0, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestRestartFromRestartPoint()
+        {
+            track.RestartPoint = 1000;
+
+            restartTrack();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.AreEqual(1000, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestLoopingRestart()
+        {
+            track.Looping = true;
+
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            var resetEvent = new ManualResetEvent(false);
+
+            Task.Run(() =>
+            {
+                // The restart action is invoked during the update and will block if not invoked on the audio thread.
+                // The update is always run on the audio thread in normal operation such that the restart action is always inlined.
+                // The audio thread is faked here to simulate this operation and avoid a deadlock.
+                Thread.CurrentThread.Name = GameThread.PrefixedThreadNameFor("Audio");
+
+                track.Update();
+                resetEvent.Set();
+            });
+
+            resetEvent.WaitOne(TimeSpan.FromSeconds(10));
+
+            track.Update();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.Less(track.CurrentTime, 2000);
+        }
+
+        private void startPlaybackAt(double time)
+        {
+            track.SeekAsync(time);
+            track.StartAsync();
+            track.Update();
+        }
+
+        private void restartTrack()
+        {
+            var resetEvent = new ManualResetEventSlim(false);
+
+            Task.Run(() =>
+            {
+                track.Restart();
+                resetEvent.Set();
+            });
+
+            while (!resetEvent.IsSet)
+                track.Update();
         }
     }
 }
+
+#pragma warning restore 4014

--- a/osu.Framework.Tests/Platform/TrackBassTest.cs
+++ b/osu.Framework.Tests/Platform/TrackBassTest.cs
@@ -69,6 +69,21 @@ namespace osu.Framework.Tests.Platform
         }
 
         [Test]
+        public void TestStopAtEnd()
+        {
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            track.Update();
+            track.StopAsync();
+            track.Update();
+
+            Assert.IsFalse(track.IsRunning);
+            Assert.AreEqual(track.Length, track.CurrentTime);
+        }
+
+        [Test]
         public void TestSeek()
         {
             track.SeekAsync(1000);

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -127,7 +127,8 @@ namespace osu.Framework.Audio.Track
         {
             isRunning = Bass.ChannelIsActive(activeStream) == PlaybackState.Playing;
 
-            Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetPosition(activeStream)) * 1000);
+            double currentTimeLocal = Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetPosition(activeStream)) * 1000;
+            Interlocked.Exchange(ref currentTime, currentTimeLocal == Length && !isPlayed ? 0 : currentTimeLocal);
 
             var leftChannel = isPlayed ? Bass.ChannelGetLevelLeft(activeStream) / 32768f : -1;
             var rightChannel = isPlayed ? Bass.ChannelGetLevelRight(activeStream) / 32768f : -1;

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -38,6 +38,8 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         private bool isPlayed;
 
+        private long byteLength;
+
         private FileCallbacks fileCallbacks;
         private SyncCallback stopCallback;
         private SyncCallback endCallback;
@@ -86,7 +88,7 @@ namespace osu.Framework.Audio.Track
                 }
 
                 // will be -1 in case of an error
-                double seconds = Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetLength(activeStream));
+                double seconds = Bass.ChannelBytes2Seconds(activeStream, byteLength = Bass.ChannelGetLength(activeStream));
 
                 bool success = seconds >= 0;
 
@@ -125,8 +127,7 @@ namespace osu.Framework.Audio.Track
         {
             isRunning = Bass.ChannelIsActive(activeStream) == PlaybackState.Playing;
 
-            double currentTimeLocal = Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetPosition(activeStream)) * 1000;
-            Interlocked.Exchange(ref currentTime, currentTimeLocal == Length && !isPlayed ? 0 : currentTimeLocal);
+            Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetPosition(activeStream)) * 1000);
 
             var leftChannel = isPlayed ? Bass.ChannelGetLevelLeft(activeStream) / 32768f : -1;
             var rightChannel = isPlayed ? Bass.ChannelGetLevelRight(activeStream) / 32768f : -1;
@@ -210,7 +211,7 @@ namespace osu.Framework.Audio.Track
         public Task StartAsync() => EnqueueAction(() =>
         {
             // Bass will restart the track if it has reached its end. This behavior isn't desirable so block locally.
-            if (CurrentTime == Length)
+            if (Bass.ChannelGetPosition(activeStream) == byteLength)
                 return;
 
             if (Bass.ChannelPlay(activeStream))


### PR DESCRIPTION
Adds more comprehensive testing in general. crossing my fingers for no random CI failures - I've run tests in a loop over 50 times and haven't had a local failure, but threading is hard here >_>.

`Restart()`, when called from the audio thread, inlines the Seek() and Start() calls into the current method. Because of this, `UpdateState()` doesn't get called before `Start()`, and `Start()` would early-return due to `CurrentTime` being out of date.

To resolve this, Start() now uses bass' raw position to figure out whether it should early-return.