### PR TITLE
Fix TrackBass.Seek() potentially incorrectly returning early

### DIFF
--- a/osu.Framework.Tests/Platform/TrackBassTest.cs
+++ b/osu.Framework.Tests/Platform/TrackBassTest.cs
@@ -102,6 +102,21 @@ namespace osu.Framework.Tests.Platform
         }
 
         [Test]
+        public void TestSeekBackToSamePosition()
+        {
+            track.SeekAsync(1000);
+            track.SeekAsync(0);
+            track.Update();
+
+            Thread.Sleep(50);
+
+            track.Update();
+
+            Assert.GreaterOrEqual(track.CurrentTime, 0);
+            Assert.Less(track.CurrentTime, 1000);
+        }
+
+        [Test]
         public void TestPlaybackToEnd()
         {
             startPlaybackAt(track.Length - 1);

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -234,11 +234,10 @@ namespace osu.Framework.Audio.Track
             {
                 double clamped = MathHelper.Clamp(seek, 0, Length);
 
-                if (clamped != CurrentTime)
-                {
-                    long pos = Bass.ChannelSeconds2Bytes(activeStream, clamped / 1000d);
+                long pos = Bass.ChannelSeconds2Bytes(activeStream, clamped / 1000d);
+
+                if (pos != Bass.ChannelGetPosition(activeStream))
                     Bass.ChannelSetPosition(activeStream, pos);
-                }
             });
 
             return conservativeClamped == seek;


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/2415

Similar to the prereq PR - using bass' raw position to determine whether to early-return. I didn't notice a performance change with this from scrubbing in the music player.