### PR TITLE
Don't reset current time to 0 when track is stopped upon completion

### DIFF
--- a/osu.Framework.Tests/Platform/TrackBassTest.cs
+++ b/osu.Framework.Tests/Platform/TrackBassTest.cs
@@ -69,6 +69,21 @@ namespace osu.Framework.Tests.Platform
         }
 
         [Test]
+        public void TestStopAtEnd()
+        {
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            track.Update();
+            track.StopAsync();
+            track.Update();
+
+            Assert.IsFalse(track.IsRunning);
+            Assert.AreEqual(track.Length, track.CurrentTime);
+        }
+
+        [Test]
         public void TestSeek()
         {
             track.SeekAsync(1000);
@@ -144,6 +159,20 @@ namespace osu.Framework.Tests.Platform
 
             Assert.IsTrue(track.IsRunning);
             Assert.Less(track.CurrentTime, 1000);
+        }
+
+        [Test]
+        public void TestRestartAtEnd()
+        {
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            track.Update();
+            restartTrack();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.LessOrEqual(track.CurrentTime, 1000);
         }
 
         [Test]

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -127,8 +127,7 @@ namespace osu.Framework.Audio.Track
         {
             isRunning = Bass.ChannelIsActive(activeStream) == PlaybackState.Playing;
 
-            double currentTimeLocal = Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetPosition(activeStream)) * 1000;
-            Interlocked.Exchange(ref currentTime, currentTimeLocal == Length && !isPlayed ? 0 : currentTimeLocal);
+            Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetPosition(activeStream)) * 1000);
 
             var leftChannel = isPlayed ? Bass.ChannelGetLevelLeft(activeStream) / 32768f : -1;
             var rightChannel = isPlayed ? Bass.ChannelGetLevelRight(activeStream) / 32768f : -1;


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/2415

Although the issue this caused is also resolved by https://github.com/ppy/osu-framework/pull/2416, I think this seems more correct? It's also what `TrackVirtual` does. Doesn't make sense to have `CurrentTime = 0` because `.Start()` would fail.