### PR TITLE
Optimise DependencyContainer lookups

### DIFF
--- a/osu.Framework/Allocation/CacheInfo.cs
+++ b/osu.Framework/Allocation/CacheInfo.cs
@@ -6,7 +6,7 @@ using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Allocation
 {
-    public struct CacheInfo
+    public readonly struct CacheInfo
     {
         /// <summary>
         /// The name of the cached member.
@@ -21,14 +21,21 @@ namespace osu.Framework.Allocation
         /// <summary>
         /// The type of the cached member.
         /// </summary>
-        internal Type Type;
+        internal readonly Type Type;
 
         public CacheInfo(string name = null, Type parent = null)
+            : this(null, name, parent)
         {
-            Type = null;
+        }
+
+        private CacheInfo(Type type, string name, Type parent)
+        {
+            Type = type;
             Name = name;
             Parent = parent;
         }
+
+        internal CacheInfo WithType(Type type) => new CacheInfo(type, Name, Parent);
 
         public override string ToString() => $"{nameof(Type)} = {Type?.ReadableName()}, {nameof(Name)} = {Name}, {nameof(Parent)} = {Parent?.ReadableName()}";
     }

--- a/osu.Framework/Allocation/CacheInfo.cs
+++ b/osu.Framework/Allocation/CacheInfo.cs
@@ -6,7 +6,7 @@ using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Allocation
 {
-    public readonly struct CacheInfo
+    public readonly struct CacheInfo : IEquatable<CacheInfo>
     {
         /// <summary>
         /// The name of the cached member.
@@ -38,5 +38,20 @@ namespace osu.Framework.Allocation
         internal CacheInfo WithType(Type type) => new CacheInfo(type, Name, Parent);
 
         public override string ToString() => $"{nameof(Type)} = {Type?.ReadableName()}, {nameof(Name)} = {Name}, {nameof(Parent)} = {Parent?.ReadableName()}";
+
+        public override bool Equals(object obj) => obj is CacheInfo cacheInfo && Equals(cacheInfo);
+
+        public bool Equals(CacheInfo other) => Name == other.Name && Parent == other.Parent && Type == other.Type;
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (Name != null ? Name.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Parent != null ? Parent.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Type != null ? Type.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
     }
 }

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -143,7 +143,7 @@ namespace osu.Framework.Allocation
                 throw new ArgumentNullException(nameof(instance));
             }
 
-            info.Type = Nullable.GetUnderlyingType(type) ?? type;
+            info = info.WithType(Nullable.GetUnderlyingType(type) ?? type);
 
             var instanceType = instance.GetType();
             instanceType = Nullable.GetUnderlyingType(instanceType) ?? instanceType;
@@ -167,7 +167,7 @@ namespace osu.Framework.Allocation
 
         public object Get(Type type, CacheInfo info)
         {
-            info.Type = Nullable.GetUnderlyingType(type) ?? type;
+            info = info.WithType(Nullable.GetUnderlyingType(type) ?? type);
 
             if (cache.TryGetValue(info, out var existing))
                 return existing;


### PR DESCRIPTION
I noticed the memory usage of this (was somewhere in the top 5 on world.execute(me)), but turns out to have a significant impact on time as well:

```diff
  | Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
  |------- |---------:|---------:|---------:|------:|------:|------:|----------:|
- |    Get | 21.34 us | 1.099 us | 3.136 us |     - |     - |     - |     936 B |
+ |    Get | 870.2 ns | 48.47 ns | 134.3 ns |     - |     - |     - |         - |
```

(per `.Get()` call)