### PR TITLE
Change TabItem.IsRemovable default to true

### DIFF
--- a/osu.Framework/Graphics/UserInterface/BasicTabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicTabControl.cs
@@ -18,8 +18,6 @@ namespace osu.Framework.Graphics.UserInterface
         {
             private readonly SpriteText text;
 
-            public override bool IsRemovable => true;
-
             public BasicTabItem(T value)
                 : base(value)
             {

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -237,7 +237,8 @@ namespace osu.Framework.Graphics.UserInterface
         /// <param name="removeFromDropdown">Whether the tab should be removed from the Dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
         protected virtual void RemoveTabItem(TabItem<T> tab, bool removeFromDropdown = true)
         {
-            if (!tab.IsRemovable) return;
+            if (!tab.IsRemovable)
+                throw new InvalidOperationException($"Cannot remove non-removable tab {tab}. Ensure {nameof(TabItem.IsRemovable)} is set appropriately.");
 
             if (tab == SelectedTab)
                 SelectedTab = null;

--- a/osu.Framework/Graphics/UserInterface/TabItem.cs
+++ b/osu.Framework/Graphics/UserInterface/TabItem.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public override bool IsPresent => base.IsPresent && Y == 0;
 
-        public override bool IsRemovable => false;
+        public override bool IsRemovable => true;
 
         /// <summary>
         /// When true, this tab can be switched to using PlatformAction.DocumentPrevious and PlatformAction.DocumentNext. Otherwise, it will be skipped.


### PR DESCRIPTION
The previous default value felt unintuitive. This is a minor breaking change.

Also throw an exception when trying to remove a tab that should not be removed.

