### PR TITLE
Interpolation<T> searches for interpolation method inside the generic class

### DIFF
--- a/osu.Framework.Tests/MathUtils/TestInterpolation.cs
+++ b/osu.Framework.Tests/MathUtils/TestInterpolation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using NUnit.Framework;
+using osu.Framework.Graphics;
 using osu.Framework.MathUtils;
 using osuTK;
 
@@ -46,6 +47,41 @@ namespace osu.Framework.Tests.MathUtils
             Assert.AreEqual(2, weights[0]);
             Assert.AreEqual(-4, weights[1]);
             Assert.AreEqual(2, weights[2]);
+        }
+
+        [Test]
+        public void TestGenericInterpolation()
+        {
+            // Implementations from Interpolation
+            Assert.AreEqual(10, Interpolation<int>.ValueAt(0.1, 0, 100, 0, 1));
+            Assert.IsTrue(Precision.AlmostEquals(0.01, Interpolation<double>.ValueAt(0.1, 0, 0.1, 0, 1)));
+
+            // Implementations inside struct
+            Assert.AreEqual(new MarginPadding(10), Interpolation<MarginPadding>.ValueAt(0.1, new MarginPadding(0), new MarginPadding(100), 0, 1));
+            Assert.AreEqual(new TestClassWithValueAt(50), Interpolation<TestClassWithValueAt>.ValueAt(10, new TestClassWithValueAt(0), new TestClassWithValueAt(100), 0, 20));
+
+            // Without implementations
+            Assert.Throws<TypeInitializationException>(() => Interpolation<TestClassWithoutValueAt>.ValueAt(0, new TestClassWithoutValueAt(), new TestClassWithoutValueAt(), 0, 0));
+        }
+
+        private struct TestClassWithoutValueAt
+        {
+        }
+
+        private struct TestClassWithValueAt
+        {
+            private readonly int i;
+
+            public TestClassWithValueAt(int i)
+            {
+                this.i = i;
+            }
+
+            public bool Equals(TestClassWithValueAt other) => i == other.i;
+
+            public static TestClassWithValueAt ValueAt(double time, TestClassWithValueAt startValue, TestClassWithValueAt endValue, double startTime, double endTime, Easing easingType) => new TestClassWithValueAt(Interpolation.ValueAt(time, startValue.i, endValue.i, startTime, endTime, easingType));
+
+            public override string ToString() => $"{nameof(i)}: {i}";
         }
     }
 }

--- a/osu.Framework/Graphics/MarginPadding.cs
+++ b/osu.Framework/Graphics/MarginPadding.cs
@@ -3,6 +3,8 @@
 
 using osuTK;
 using System;
+using JetBrains.Annotations;
+using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics
 {
@@ -92,5 +94,17 @@ namespace osu.Framework.Graphics
                 Right = -mp.Right,
                 Bottom = -mp.Bottom,
             };
+
+        [UsedImplicitly]
+        public static MarginPadding ValueAt(double time, MarginPadding startValue, MarginPadding endValue, double startTime, double endTime, Easing easingType = Easing.None)
+        {
+            return new MarginPadding
+            {
+                Left = Interpolation.ValueAt(time, startValue.Left, endValue.Left, startTime, endTime, easingType),
+                Top = Interpolation.ValueAt(time, startValue.Top, endValue.Top, startTime, endTime, easingType),
+                Right = Interpolation.ValueAt(time, startValue.Right, endValue.Right, startTime, endTime, easingType),
+                Bottom = Interpolation.ValueAt(time, startValue.Bottom, endValue.Bottom, startTime, endTime, easingType),
+            };
+        }
     }
 }

--- a/osu.Framework/Testing/Drawables/TestSceneHeaderButton.cs
+++ b/osu.Framework/Testing/Drawables/TestSceneHeaderButton.cs
@@ -73,28 +73,16 @@ namespace osu.Framework.Testing.Drawables
                 if (value)
                 {
                     leftBoxContainer.ResizeWidthTo(1, TRANSITION_DURATION);
-                    this.TransformTo(nameof(leftBoxContainerPadding), left_box_width, TRANSITION_DURATION);
-                    this.TransformTo(nameof(contentPadding), 0f, TRANSITION_DURATION);
+                    leftBoxContainer.TransformTo(nameof(Padding), new MarginPadding { Right = left_box_width }, TRANSITION_DURATION);
+                    Content.TransformTo(nameof(Padding), new MarginPadding { Right = 0f }, TRANSITION_DURATION);
                 }
                 else
                 {
                     leftBoxContainer.ResizeWidthTo(0, TRANSITION_DURATION);
-                    this.TransformTo(nameof(leftBoxContainerPadding), -left_box_width, TRANSITION_DURATION);
-                    this.TransformTo(nameof(contentPadding), LEFT_TEXT_PADDING, TRANSITION_DURATION);
+                    leftBoxContainer.TransformTo(nameof(Padding), new MarginPadding { Right = -left_box_width }, TRANSITION_DURATION);
+                    Content.TransformTo(nameof(Padding), new MarginPadding { Right = LEFT_TEXT_PADDING }, TRANSITION_DURATION);
                 }
             }
-        }
-
-        private float leftBoxContainerPadding
-        {
-            get => leftBoxContainer.Padding.Right;
-            set => leftBoxContainer.Padding = new MarginPadding { Right = value };
-        }
-
-        private float contentPadding
-        {
-            get => Content.Padding.Right;
-            set => Content.Padding = new MarginPadding { Right = value };
         }
 
         public override bool Collapsed


### PR DESCRIPTION
Fixes #2284

The method has to be called `ValueAt`, must be static and have the same parameters as `InterpolationFunc<TValue>`

Already existing ``ValueAt`` methods inside ``Interpolation`` can also be moved to their own classes (e.g. ``ColourInfo``)