### PR TITLE
Fix potential disposal race condition

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -213,11 +213,11 @@ namespace osu.Framework.Graphics
         /// <param name="dependencies">The dependency tree we will inherit by default. May be extended via <see cref="CompositeDrawable.CreateChildDependencies"/></param>
         internal void Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies)
         {
-            if (IsDisposed)
-                throw new ObjectDisposedException(ToString(), "Attempting to load an already disposed drawable.");
-
             lock (loadLock)
             {
+                if (IsDisposed)
+                    throw new ObjectDisposedException(ToString(), "Attempting to load an already disposed drawable.");
+
                 if (loadState == LoadState.NotLoaded)
                 {
                     Trace.Assert(loadState == LoadState.NotLoaded);


### PR DESCRIPTION
We haven't experienced this yet, and this is hard to test without manual thread blocking, but it could happen via natural suspension of threads.

In the following test, the following exception gets thrown (aggregated into a parent):
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateClock(IFrameBasedClock clock) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 771
   at osu.Framework.Graphics.Drawable.load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Drawable.cs:line 248
   at osu.Framework.Graphics.Drawable.Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Drawable.cs:line 231
   at osu.Framework.Graphics.Containers.CompositeDrawable.loadComponents[TLoadable](IEnumerable`1 components, IReadOnlyDependencyContainer dependencies) in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 192
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c__DisplayClass15_0`1.<LoadComponentsAsync>b__0() in /Users/smoogipoo/Repos/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 141
   at System.Threading.Tasks.Task.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__275_1(Object obj)
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location where exception was thrown ---
   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot)
```

Which shows that load() is called after already being disposed, at which point `CompositeDrawable.schedulerAfterChildren` is null.

```diff
diff --git a/osu.Framework/Graphics/Drawable.cs b/osu.Framework/Graphics/Drawable.cs
index 9cf40e1ec1642129cb948cd220f8ecf77a8e18e3..dc8149f93615d41f441d1ad99e49f019f26c0a05 100644
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -206,6 +206,8 @@ internal virtual void UnbindAllBindables()
         private static readonly StopwatchClock perf = new StopwatchClock(true);
         private static double getPerfTime() => perf.CurrentTime;
 
+        public readonly ManualResetEventSlim AllowLoad = new ManualResetEventSlim(true);
+
         /// <summary>
         /// Loads this drawable, including the gathering of dependencies and initialisation of required resources.
         /// </summary>
@@ -216,6 +218,8 @@ internal void Load(IFrameBasedClock clock, IReadOnlyDependencyContainer dependen
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Attempting to load an already disposed drawable.");
 
+            AllowLoad.Wait();
+
             lock (loadLock)
             {
                 if (loadState == LoadState.NotLoaded)
diff --git a/osu.Framework.Tests/Visual/TestSceneScratch.cs b/osu.Framework.Tests/Visual/TestSceneScratch.cs
new file mode 100644
index 0000000000000000000000000000000000000000..3f8fa3f464edaee723e18de097cbd0cf70d9fab1
--- /dev/null
+++ b/osu.Framework.Tests/Visual/TestSceneScratch.cs
@@ -0,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestSceneScratch : TestScene
+    {
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            var loadableChild = new Container();
+            loadableChild.AllowLoad.Reset();
+
+            // Begin loading the child
+            LoadComponentAsync(loadableChild);
+
+            // Wait for the Load() method to get hit
+            Thread.Sleep(2000);
+
+            // Dispose the child
+            loadableChild.Dispose();
+
+            // Allow loading of child to continue
+            loadableChild.AllowLoad.Set();
+
+            // Wait for child's BDL to get invoked
+            Thread.Sleep(2000);
+        }
+    }
+}
```