### PR TITLE
Fix caps lock on macOS

### DIFF
--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -17,28 +17,7 @@ namespace osu.Framework.Input
             this.window = window;
         }
 
-        private void window_KeyPress(object sender, osuTK.KeyPressEventArgs e)
-        {
-            // Drop any keypresses if the control, alt, or windows/command key are being held.
-            // This is a workaround for an issue on macOS where osuTK will fire KeyPress events even
-            // if modifier keys are held.  This can be reverted when it is fixed on osuTK's side.
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.MacOsx)
-            {
-                var state = osuTK.Input.Keyboard.GetState();
-                if (state.IsKeyDown(osuTK.Input.Key.LControl)
-                    || state.IsKeyDown(osuTK.Input.Key.RControl)
-                    || state.IsKeyDown(osuTK.Input.Key.LAlt)
-                    || state.IsKeyDown(osuTK.Input.Key.RAlt)
-                    || state.IsKeyDown(osuTK.Input.Key.LWin)
-                    || state.IsKeyDown(osuTK.Input.Key.RWin))
-                    return;
-                // arbitrary choice here, but it caters for any non-printable keys on an A1243 Apple Keyboard
-                if (e.KeyChar > 63000)
-                    return;
-            }
-
-            pending += e.KeyChar;
-        }
+        protected virtual void HandleKeyPress(object sender, osuTK.KeyPressEventArgs e) => pending += e.KeyChar;
 
         public bool ImeActive => false;
 
@@ -56,12 +35,12 @@ namespace osu.Framework.Input
 
         public void Deactivate(object sender)
         {
-            window.KeyPress -= window_KeyPress;
+            window.KeyPress -= HandleKeyPress;
         }
 
         public void Activate(object sender)
         {
-            window.KeyPress += window_KeyPress;
+            window.KeyPress += HandleKeyPress;
         }
 
         private void imeCompose()

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -23,6 +23,8 @@ namespace osu.Framework.Platform.MacOS
 
         protected override Storage GetStorage(string baseName) => new MacOSStorage(baseName, this);
 
+        public override ITextInputSource GetTextInput() => Window == null ? null : new MacOSTextInput(Window);
+
         public override Clipboard GetClipboard() => new MacOSClipboard();
 
         public override IEnumerable<KeyBinding> PlatformKeyBindings => new[]

--- a/osu.Framework/Platform/MacOS/MacOSTextInput.cs
+++ b/osu.Framework/Platform/MacOS/MacOSTextInput.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.Platform.MacOS
             // capslock is not correctly handled by osuTK, so force uppercase if capslock is on
             if (isCapsLockOn)
                 e = new osuTK.KeyPressEventArgs(char.ToUpper(e.KeyChar));
-            
+
             base.HandleKeyPress(sender, e);
         }
     }

--- a/osu.Framework/Platform/MacOS/MacOSTextInput.cs
+++ b/osu.Framework/Platform/MacOS/MacOSTextInput.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input;
+using osu.Framework.Platform.MacOS.Native;
+
+namespace osu.Framework.Platform.MacOS
+{
+    internal class MacOSTextInput : GameWindowTextInput
+    {
+        // Defined as kCGEventFlagMaskAlphaShift in CoreGraphics
+        private const ulong event_flag_mask_alpha_shift = 65536;
+
+        // Defined as kCGEventSourceStateHIDSystemState in CoreGraphics
+        private const int event_source_state_hid_system_state = 1;
+
+        private static bool isCapsLockOn => (Cocoa.CGEventSourceFlagsState(event_source_state_hid_system_state) & event_flag_mask_alpha_shift) != 0;
+
+        public MacOSTextInput(GameWindow window)
+            : base(window)
+        {
+        }
+
+        protected override void HandleKeyPress(object sender, osuTK.KeyPressEventArgs e)
+        {
+            // Drop any keypresses if the control, alt, or windows/command key are being held.
+            // This is a workaround for an issue on macOS where osuTK will fire KeyPress events even
+            // if modifier keys are held.  This can be reverted when it is fixed on osuTK's side.
+            var state = osuTK.Input.Keyboard.GetState();
+            if (state.IsKeyDown(osuTK.Input.Key.LControl)
+                || state.IsKeyDown(osuTK.Input.Key.RControl)
+                || state.IsKeyDown(osuTK.Input.Key.LAlt)
+                || state.IsKeyDown(osuTK.Input.Key.RAlt)
+                || state.IsKeyDown(osuTK.Input.Key.LWin)
+                || state.IsKeyDown(osuTK.Input.Key.RWin))
+                return;
+
+            // arbitrary choice here, but it caters for any non-printable keys on an A1243 Apple Keyboard
+            if (e.KeyChar > 63000)
+                return;
+
+            // capslock is not correctly handled by osuTK, so force uppercase if capslock is on
+            if (isCapsLockOn)
+                e = new osuTK.KeyPressEventArgs(char.ToUpper(e.KeyChar));
+            
+            base.HandleKeyPress(sender, e);
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -72,6 +72,9 @@ namespace osu.Framework.Platform.MacOS.Native
         [DllImport(LIB_CORE_GRAPHICS, EntryPoint = "CGCursorIsVisible")]
         public static extern bool CGCursorIsVisible();
 
+        [DllImport(LIB_CORE_GRAPHICS, EntryPoint = "CGEventSourceFlagsState")]
+        public static extern ulong CGEventSourceFlagsState(int stateID);
+
         static Cocoa()
         {
             AppKitLibrary = (IntPtr)type_cocoa.GetField("AppKitLibrary").GetValue(null);


### PR DESCRIPTION
Resolves #2392

Refactored the platform check in `GameWindowTextInput` into a separate class, instantiated from `MacOSGameHost`.