### PR TITLE
Add AggregateBindable implementation

### DIFF
--- a/osu.Framework.Tests/Bindables/AggregateBindableTest.cs
+++ b/osu.Framework.Tests/Bindables/AggregateBindableTest.cs
@@ -27,6 +27,27 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
+        public void TestResultBounds()
+        {
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, new BindableDouble(1)
+            {
+                Default = 1,
+                MinValue = 0,
+                MaxValue = 2
+            });
+
+            Assert.AreEqual(1, aggregate.Result.Value);
+
+            var bindable1 = new BindableDouble(-1);
+            aggregate.AddSource(bindable1);
+            Assert.AreEqual(0, aggregate.Result.Value);
+
+            var bindable2 = new BindableDouble(-4);
+            aggregate.AddSource(bindable2);
+            Assert.AreEqual(2, aggregate.Result.Value);
+        }
+
+        [Test]
         public void TestClassAggregate()
         {
             var aggregate = new AggregateBindable<BoxedInt>((a, b) => new BoxedInt((a?.Value ?? 0) + (b?.Value ?? 0)));

--- a/osu.Framework.Tests/Bindables/AggregateBindableTest.cs
+++ b/osu.Framework.Tests/Bindables/AggregateBindableTest.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestMultiplicationAggregate()
         {
-            var aggregate = new AggregateBindable<double>((a, b) => a * b, 1);
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1) { Default = 1 });
 
             Assert.AreEqual(1, aggregate.Result.Value);
 
@@ -55,7 +55,7 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestSourceChanged()
         {
-            var aggregate = new AggregateBindable<double>((a, b) => a * b, 1);
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1) { Default = 1 });
 
             var bindable1 = new BindableDouble(0.5);
             aggregate.AddSource(bindable1);
@@ -75,7 +75,7 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestSourceRemoved()
         {
-            var aggregate = new AggregateBindable<double>((a, b) => a * b, 1);
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1) { Default = 1 });
 
             var bindable1 = new BindableDouble(0.5);
             aggregate.AddSource(bindable1);
@@ -97,7 +97,7 @@ namespace osu.Framework.Tests.Bindables
         {
             int aggregateResultFireCount = 0, bindable1FireCount = 0, bindable2FireCount = 0;
 
-            var aggregate = new AggregateBindable<double>((a, b) => a * b, 1);
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1) { Default = 1 });
             aggregate.Result.BindValueChanged(_ => Interlocked.Increment(ref aggregateResultFireCount));
 
             Assert.AreEqual(0, aggregateResultFireCount);

--- a/osu.Framework.Tests/Bindables/AggregateBindableTest.cs
+++ b/osu.Framework.Tests/Bindables/AggregateBindableTest.cs
@@ -1,0 +1,142 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class AggregateBindableTest
+    {
+        [Test]
+        public void TestMultiplicationAggregate()
+        {
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, 1);
+
+            Assert.AreEqual(1, aggregate.Result.Value);
+
+            var bindable1 = new BindableDouble(0.5);
+            aggregate.AddSource(bindable1);
+            Assert.AreEqual(0.5, aggregate.Result.Value);
+
+            var bindable2 = new BindableDouble(0.25);
+            aggregate.AddSource(bindable2);
+            Assert.AreEqual(0.125, aggregate.Result.Value);
+        }
+
+        [Test]
+        public void TestClassAggregate()
+        {
+            var aggregate = new AggregateBindable<BoxedInt>((a, b) => new BoxedInt((a?.Value ?? 0) + (b?.Value ?? 0)));
+
+            Assert.AreEqual(null, aggregate.Result.Value);
+
+            var bindable1 = new Bindable<BoxedInt>(new BoxedInt(1));
+            aggregate.AddSource(bindable1);
+            Assert.AreEqual(1, aggregate.Result.Value.Value);
+
+            var bindable2 = new Bindable<BoxedInt>(new BoxedInt(2));
+            aggregate.AddSource(bindable2);
+            Assert.AreEqual(3, aggregate.Result.Value.Value);
+        }
+
+        private class BoxedInt
+        {
+            public readonly int Value;
+
+            public BoxedInt(int value)
+            {
+                Value = value;
+            }
+        }
+
+        [Test]
+        public void TestSourceChanged()
+        {
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, 1);
+
+            var bindable1 = new BindableDouble(0.5);
+            aggregate.AddSource(bindable1);
+
+            var bindable2 = new BindableDouble(0.5);
+            aggregate.AddSource(bindable2);
+
+            Assert.AreEqual(0.25, aggregate.Result.Value);
+
+            bindable1.Value = 0.25;
+            Assert.AreEqual(0.125, aggregate.Result.Value);
+
+            bindable2.Value = 0.25;
+            Assert.AreEqual(0.0625, aggregate.Result.Value);
+        }
+
+        [Test]
+        public void TestSourceRemoved()
+        {
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, 1);
+
+            var bindable1 = new BindableDouble(0.5);
+            aggregate.AddSource(bindable1);
+
+            var bindable2 = new BindableDouble(0.5);
+            aggregate.AddSource(bindable2);
+
+            Assert.AreEqual(0.25, aggregate.Result.Value);
+
+            aggregate.RemoveSource(bindable1);
+            Assert.AreEqual(0.5, aggregate.Result.Value);
+
+            aggregate.RemoveSource(bindable2);
+            Assert.AreEqual(1, aggregate.Result.Value);
+        }
+
+        [Test]
+        public void TestValueChangedFirings()
+        {
+            int aggregateResultFireCount = 0, bindable1FireCount = 0, bindable2FireCount = 0;
+
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, 1);
+            aggregate.Result.BindValueChanged(_ => Interlocked.Increment(ref aggregateResultFireCount));
+
+            Assert.AreEqual(0, aggregateResultFireCount);
+
+            var bindable1 = new BindableDouble(0.5);
+            bindable1.BindValueChanged(_ => Interlocked.Increment(ref bindable1FireCount));
+            aggregate.AddSource(bindable1);
+
+            Assert.AreEqual(1, aggregateResultFireCount);
+
+            var bindable2 = new BindableDouble(0.5);
+            bindable2.BindValueChanged(_ => Interlocked.Increment(ref bindable2FireCount));
+            aggregate.AddSource(bindable2);
+
+            Assert.AreEqual(2, aggregateResultFireCount);
+
+            bindable1.Value = 0.25;
+
+            Assert.AreEqual(3, aggregateResultFireCount);
+            Assert.AreEqual(1, bindable1FireCount);
+            Assert.AreEqual(0, bindable2FireCount);
+
+            bindable2.Value = 0.25;
+
+            Assert.AreEqual(4, aggregateResultFireCount);
+            Assert.AreEqual(1, bindable1FireCount);
+            Assert.AreEqual(1, bindable2FireCount);
+
+            aggregate.RemoveSource(bindable2);
+
+            Assert.AreEqual(5, aggregateResultFireCount);
+            Assert.AreEqual(1, bindable1FireCount);
+            Assert.AreEqual(1, bindable2FireCount);
+
+            bindable2.Value = 0.5;
+
+            Assert.AreEqual(5, aggregateResultFireCount);
+            Assert.AreEqual(1, bindable1FireCount);
+            Assert.AreEqual(2, bindable2FireCount);
+        }
+    }
+}

--- a/osu.Framework.Tests/Bindables/AggregateBindableTest.cs
+++ b/osu.Framework.Tests/Bindables/AggregateBindableTest.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestMultiplicationAggregate()
         {
-            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1) { Default = 1 });
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1));
 
             Assert.AreEqual(1, aggregate.Result.Value);
 
@@ -76,7 +76,7 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestSourceChanged()
         {
-            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1) { Default = 1 });
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1));
 
             var bindable1 = new BindableDouble(0.5);
             aggregate.AddSource(bindable1);
@@ -96,7 +96,7 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestSourceRemoved()
         {
-            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1) { Default = 1 });
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1));
 
             var bindable1 = new BindableDouble(0.5);
             aggregate.AddSource(bindable1);
@@ -118,7 +118,7 @@ namespace osu.Framework.Tests.Bindables
         {
             int aggregateResultFireCount = 0, bindable1FireCount = 0, bindable2FireCount = 0;
 
-            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1) { Default = 1 });
+            var aggregate = new AggregateBindable<double>((a, b) => a * b, new Bindable<double>(1));
             aggregate.Result.BindValueChanged(_ => Interlocked.Increment(ref aggregateResultFireCount));
 
             Assert.AreEqual(0, aggregateResultFireCount);

--- a/osu.Framework/Bindables/AggregateBindable.cs
+++ b/osu.Framework/Bindables/AggregateBindable.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Framework.Bindables
+{
+    /// <summary>
+    /// Combine multiple bindables into one aggregate bindable result.
+    /// </summary>
+    /// <typeparam name="T">The type of values.</typeparam>
+    public class AggregateBindable<T>
+    {
+        private readonly Func<T, T, T> aggregateFunction;
+
+        /// <summary>
+        /// THe final result after aggregating all added sources..
+        /// </summary>
+        public IBindable<T> Result => result;
+
+        private readonly Bindable<T> result;
+
+        /// <summary>
+        /// Create a new aggregate bindable.
+        /// </summary>
+        /// <param name="aggregateFunction">The function to be used for aggregation, taking two input <see cref="T"/> values and returning one output.</param>
+        /// <param name="defaultValue">The value used for the initial <see cref="Result"/> and for the first step of aggregation.</param>
+        public AggregateBindable(Func<T, T, T> aggregateFunction, T defaultValue = default)
+        {
+            this.aggregateFunction = aggregateFunction;
+            result = new Bindable<T>(defaultValue) { Default = defaultValue };
+        }
+
+        private readonly Dictionary<WeakReference, IBindable<T>> sourceMapping = new Dictionary<WeakReference, IBindable<T>>();
+
+        public void AddSource(IBindable<T> bindable)
+        {
+            if (findExistingWeak(bindable) != null)
+                return;
+
+            var boundCopy = bindable.GetBoundCopy();
+            sourceMapping.Add(new WeakReference(bindable), boundCopy);
+            boundCopy.BindValueChanged(recalculateAggregate, true);
+        }
+
+        public void RemoveSource(IBindable<T> bindable)
+        {
+            var weak = findExistingWeak(bindable);
+            if (weak != null)
+            {
+                sourceMapping[weak].UnbindAll();
+                sourceMapping.Remove(weak);
+            }
+
+            recalculateAggregate();
+        }
+
+        private WeakReference findExistingWeak(IBindable<T> bindable) => sourceMapping.Keys.FirstOrDefault(k => k.Target == bindable);
+
+        private void recalculateAggregate(ValueChangedEvent<T> obj = null)
+        {
+            T calculated = result.Default;
+
+            foreach (var dead in sourceMapping.Keys.Where(k => !k.IsAlive).ToArray())
+                sourceMapping.Remove(dead);
+
+            foreach (var s in sourceMapping.Values)
+                calculated = aggregateFunction(calculated, s.Value);
+
+            result.Value = calculated;
+        }
+    }
+}

--- a/osu.Framework/Bindables/AggregateBindable.cs
+++ b/osu.Framework/Bindables/AggregateBindable.cs
@@ -26,11 +26,11 @@ namespace osu.Framework.Bindables
         /// Create a new aggregate bindable.
         /// </summary>
         /// <param name="aggregateFunction">The function to be used for aggregation, taking two input <see cref="T"/> values and returning one output.</param>
-        /// <param name="defaultValue">The value used for the initial <see cref="Result"/> and for the first step of aggregation.</param>
-        public AggregateBindable(Func<T, T, T> aggregateFunction, T defaultValue = default)
+        /// <param name="resultBindable">An optional newly constructed bindable type to use for <see cref="Result"/> aggregation.</param>
+        public AggregateBindable(Func<T, T, T> aggregateFunction, Bindable<T> resultBindable = null)
         {
             this.aggregateFunction = aggregateFunction;
-            result = new Bindable<T>(defaultValue) { Default = defaultValue };
+            result = resultBindable ?? new Bindable<T>();
         }
 
         private readonly Dictionary<WeakReference, IBindable<T>> sourceMapping = new Dictionary<WeakReference, IBindable<T>>();

--- a/osu.Framework/Bindables/AggregateBindable.cs
+++ b/osu.Framework/Bindables/AggregateBindable.cs
@@ -8,7 +8,7 @@ using System.Linq;
 namespace osu.Framework.Bindables
 {
     /// <summary>
-    /// Combine multiple bindables into one aggregate bindable result.
+    /// Combines multiple bindables into one aggregate bindable result.
     /// </summary>
     /// <typeparam name="T">The type of values.</typeparam>
     public class AggregateBindable<T>
@@ -16,7 +16,7 @@ namespace osu.Framework.Bindables
         private readonly Func<T, T, T> aggregateFunction;
 
         /// <summary>
-        /// THe final result after aggregating all added sources..
+        /// The final result after aggregating all added sources.
         /// </summary>
         public IBindable<T> Result => result;
 
@@ -28,7 +28,7 @@ namespace osu.Framework.Bindables
         /// Create a new aggregate bindable.
         /// </summary>
         /// <param name="aggregateFunction">The function to be used for aggregation, taking two input <see cref="T"/> values and returning one output.</param>
-        /// <param name="resultBindable">An optional newly constructed bindable type to use for <see cref="Result"/> aggregation. The initial value of this bindable is used as the first value for aggregation logic.</param>
+        /// <param name="resultBindable">An optional newly constructed bindable to use for <see cref="Result"/>. The initial value of this bindable is used as the initial value for the aggregate.</param>
         public AggregateBindable(Func<T, T, T> aggregateFunction, Bindable<T> resultBindable = null)
         {
             this.aggregateFunction = aggregateFunction;

--- a/osu.Framework/Bindables/AggregateBindable.cs
+++ b/osu.Framework/Bindables/AggregateBindable.cs
@@ -22,15 +22,18 @@ namespace osu.Framework.Bindables
 
         private readonly Bindable<T> result;
 
+        private readonly T initialValue;
+
         /// <summary>
         /// Create a new aggregate bindable.
         /// </summary>
         /// <param name="aggregateFunction">The function to be used for aggregation, taking two input <see cref="T"/> values and returning one output.</param>
-        /// <param name="resultBindable">An optional newly constructed bindable type to use for <see cref="Result"/> aggregation.</param>
+        /// <param name="resultBindable">An optional newly constructed bindable type to use for <see cref="Result"/> aggregation. The initial value of this bindable is used as the first value for aggregation logic.</param>
         public AggregateBindable(Func<T, T, T> aggregateFunction, Bindable<T> resultBindable = null)
         {
             this.aggregateFunction = aggregateFunction;
             result = resultBindable ?? new Bindable<T>();
+            initialValue = result.Value;
         }
 
         private readonly Dictionary<WeakReference, IBindable<T>> sourceMapping = new Dictionary<WeakReference, IBindable<T>>();
@@ -61,7 +64,7 @@ namespace osu.Framework.Bindables
 
         private void recalculateAggregate(ValueChangedEvent<T> obj = null)
         {
-            T calculated = result.Default;
+            T calculated = initialValue;
 
             foreach (var dead in sourceMapping.Keys.Where(k => !k.IsAlive).ToArray())
                 sourceMapping.Remove(dead);


### PR DESCRIPTION
Takes multiple bindables and offers an aggregated (and bindable) result.

To be used to tidy up the existing audio subsystem (PR coming soon – feel free to wait for that to see this in action).