### PR TITLE
Improve performance of various Line operations

### DIFF
--- a/osu.Framework/Graphics/Primitives/Line.cs
+++ b/osu.Framework/Graphics/Primitives/Line.cs
@@ -10,17 +10,17 @@ namespace osu.Framework.Graphics.Primitives
     /// <summary>
     /// Represents a single line segment.
     /// </summary>
-    public struct Line
+    public readonly struct Line
     {
         /// <summary>
         /// Begin point of the line.
         /// </summary>
-        public Vector2 StartPoint;
+        public readonly Vector2 StartPoint;
 
         /// <summary>
         /// End point of the line.
         /// </summary>
-        public Vector2 EndPoint;
+        public readonly Vector2 EndPoint;
 
         /// <summary>
         /// The length of the line.


### PR DESCRIPTION
1. `Line` is now readonly, to avoid unintentional struct copies.
2. `.At()` and `.IntersectWith()` now use raw coordinate operations to trigger JIT intrinsics and remove `Vector2` allocations. The `Vector2` allocations aren't _super_ expensive, but they add up here - around 300-400ns on a quad-quad convex polygon intersection.
3. `.IntersectWith()` / `.At()` are now inlined. I have measured ~40ns decrease from this in a simple quad-quad intersection.

I've also added a few more `.IntersectWith()` methods to drill down into more optimal cases but kept the remaining ones to ease usability for consumers that aren't as strict on perf.
