### PR TITLE
Move audio adjustment logic to separate class

### DIFF
--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -8,85 +8,37 @@ namespace osu.Framework.Audio
     /// <summary>
     /// An audio component which allows for basic bindable adjustments to be applied.
     /// </summary>
-    public class AdjustableAudioComponent : AudioComponent
+    public class AdjustableAudioComponent : AudioComponent, IAggregateAudioAdjustment
     {
+        private readonly AudioAdjustments adjustments = new AudioAdjustments();
+
         /// <summary>
         /// The volume of this component.
         /// </summary>
-        public readonly BindableDouble Volume = new BindableDouble(1)
-        {
-            MinValue = 0,
-            MaxValue = 1
-        };
+        public BindableDouble Volume => adjustments.Volume;
 
         /// <summary>
         /// The playback balance of this sample (-1 .. 1 where 0 is centered)
         /// </summary>
-        public readonly BindableDouble Balance = new BindableDouble
-        {
-            MinValue = -1,
-            MaxValue = 1
-        };
+        public BindableDouble Balance => adjustments.Balance;
 
         /// <summary>
         /// Rate at which the component is played back (affects pitch). 1 is 100% playback speed, or default frequency.
         /// </summary>
-        public readonly BindableDouble Frequency = new BindableDouble(1);
-
-        protected readonly AggregateBindable<double> VolumeAggregate;
-        protected readonly AggregateBindable<double> BalanceAggregate;
-        protected readonly AggregateBindable<double> FrequencyAggregate;
+        public BindableDouble Frequency => adjustments.Frequency;
 
         protected AdjustableAudioComponent()
         {
-            VolumeAggregate = new AggregateBindable<double>((a, b) => a * b, Volume.GetUnboundCopy());
-            VolumeAggregate.AddSource(Volume);
-            VolumeAggregate.Result.ValueChanged += InvalidateState;
-
-            BalanceAggregate = new AggregateBindable<double>((a, b) => a + b, Balance.GetUnboundCopy());
-            BalanceAggregate.AddSource(Balance);
-            BalanceAggregate.Result.ValueChanged += InvalidateState;
-
-            FrequencyAggregate = new AggregateBindable<double>((a, b) => a * b, Frequency.GetUnboundCopy());
-            FrequencyAggregate.AddSource(Frequency);
-            FrequencyAggregate.Result.ValueChanged += InvalidateState;
+            AggregateVolume.ValueChanged += InvalidateState;
+            AggregateBalance.ValueChanged += InvalidateState;
+            AggregateFrequency.ValueChanged += InvalidateState;
         }
 
-        public void AddAdjustment(AdjustableProperty type, BindableDouble adjustBindable) => EnqueueAction(() =>
-        {
-            switch (type)
-            {
-                case AdjustableProperty.Balance:
-                    BalanceAggregate.AddSource(adjustBindable);
-                    break;
+        public void AddAdjustment(AdjustableProperty type, BindableDouble adjustBindable) =>
+            adjustments.AddAdjustment(type, adjustBindable);
 
-                case AdjustableProperty.Frequency:
-                    FrequencyAggregate.AddSource(adjustBindable);
-                    break;
-
-                case AdjustableProperty.Volume:
-                    VolumeAggregate.AddSource(adjustBindable);
-                    break;
-            }
-        });
-
-        public void RemoveAdjustment(AdjustableProperty type, BindableDouble adjustBindable) => EnqueueAction(() =>
-        {
-            switch (type)
-            {
-                case AdjustableProperty.Balance:
-                    BalanceAggregate.RemoveSource(adjustBindable);
-                    break;
-
-                case AdjustableProperty.Frequency:
-                    FrequencyAggregate.RemoveSource(adjustBindable);
-                    break;
-
-                case AdjustableProperty.Volume:
-                    VolumeAggregate.RemoveSource(adjustBindable);
-                    break;
-            }
-        });
+        public void RemoveAdjustment(AdjustableProperty type, BindableDouble adjustBindable) =>
+            adjustments.RemoveAdjustment(type, adjustBindable);
 
         internal void InvalidateState(ValueChangedEvent<double> valueChangedEvent = null) => EnqueueAction(OnStateChanged);
 
@@ -98,23 +50,19 @@ namespace osu.Framework.Audio
         /// Bind all adjustments to another component's aggregated results.
         /// </summary>
         /// <param name="component">The other component (generally a direct parent).</param>
-        internal void BindAdjustments(AdjustableAudioComponent component)
-        {
-            VolumeAggregate.AddSource(component.VolumeAggregate.Result);
-            BalanceAggregate.AddSource(component.BalanceAggregate.Result);
-            FrequencyAggregate.AddSource(component.FrequencyAggregate.Result);
-        }
+        internal void BindAdjustments(AdjustableAudioComponent component) => adjustments.BindAdjustments(component);
 
         /// <summary>
         /// Unbind all adjustments from another component's aggregated results.
         /// </summary>
         /// <param name="component">The other component (generally a direct parent).</param>
-        internal void UnbindAdjustments(AdjustableAudioComponent component)
-        {
-            VolumeAggregate.RemoveSource(component.VolumeAggregate.Result);
-            BalanceAggregate.RemoveSource(component.BalanceAggregate.Result);
-            FrequencyAggregate.RemoveSource(component.FrequencyAggregate.Result);
-        }
+        internal void UnbindAdjustments(AdjustableAudioComponent component) => adjustments.UnbindAdjustments(component);
+
+        public IBindable<double> AggregateVolume => adjustments.AggregateVolume;
+
+        public IBindable<double> AggregateBalance => adjustments.AggregateBalance;
+
+        public IBindable<double> AggregateFrequency => adjustments.AggregateFrequency;
     }
 
     public enum AdjustableProperty

--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -50,13 +50,13 @@ namespace osu.Framework.Audio
         /// Bind all adjustments to another component's aggregated results.
         /// </summary>
         /// <param name="component">The other component (generally a direct parent).</param>
-        internal void BindAdjustments(AdjustableAudioComponent component) => adjustments.BindAdjustments(component);
+        internal void BindAdjustments(IAggregateAudioAdjustment component) => adjustments.BindAdjustments(component);
 
         /// <summary>
         /// Unbind all adjustments from another component's aggregated results.
         /// </summary>
         /// <param name="component">The other component (generally a direct parent).</param>
-        internal void UnbindAdjustments(AdjustableAudioComponent component) => adjustments.UnbindAdjustments(component);
+        internal void UnbindAdjustments(IAggregateAudioAdjustment component) => adjustments.UnbindAdjustments(component);
 
         public IBindable<double> AggregateVolume => adjustments.AggregateVolume;
 

--- a/osu.Framework/Audio/AudioAdjustments.cs
+++ b/osu.Framework/Audio/AudioAdjustments.cs
@@ -1,0 +1,115 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Audio
+{
+    /// <summary>
+    /// Provides adjustable and bindable attributes for an audio component.
+    /// Aggregates results as a <see cref="IAggregateAudioAdjustment"/>.
+    /// </summary>
+    public class AudioAdjustments : IAggregateAudioAdjustment
+    {
+        /// <summary>
+        /// The volume of this component.
+        /// </summary>
+        public readonly BindableDouble Volume = new BindableDouble(1)
+        {
+            MinValue = 0,
+            MaxValue = 1
+        };
+
+        /// <summary>
+        /// The playback balance of this sample (-1 .. 1 where 0 is centered)
+        /// </summary>
+        public readonly BindableDouble Balance = new BindableDouble
+        {
+            MinValue = -1,
+            MaxValue = 1
+        };
+
+        /// <summary>
+        /// Rate at which the component is played back (affects pitch). 1 is 100% playback speed, or default frequency.
+        /// </summary>
+        public readonly BindableDouble Frequency = new BindableDouble(1);
+
+        public IBindable<double> AggregateVolume => volumeAggregate.Result;
+        public IBindable<double> AggregateBalance => balanceAggregate.Result;
+        public IBindable<double> AggregateFrequency => frequencyAggregate.Result;
+
+        private readonly AggregateBindable<double> volumeAggregate;
+        private readonly AggregateBindable<double> balanceAggregate;
+        private readonly AggregateBindable<double> frequencyAggregate;
+
+        public AudioAdjustments()
+        {
+            volumeAggregate = new AggregateBindable<double>((a, b) => a * b, Volume.GetUnboundCopy());
+            volumeAggregate.AddSource(Volume);
+
+            balanceAggregate = new AggregateBindable<double>((a, b) => a + b, Balance.GetUnboundCopy());
+            balanceAggregate.AddSource(Balance);
+
+            frequencyAggregate = new AggregateBindable<double>((a, b) => a * b, Frequency.GetUnboundCopy());
+            frequencyAggregate.AddSource(Frequency);
+        }
+
+        public void AddAdjustment(AdjustableProperty type, BindableDouble adjustBindable)
+        {
+            switch (type)
+            {
+                case AdjustableProperty.Balance:
+                    balanceAggregate.AddSource(adjustBindable);
+                    break;
+
+                case AdjustableProperty.Frequency:
+                    frequencyAggregate.AddSource(adjustBindable);
+                    break;
+
+                case AdjustableProperty.Volume:
+                    volumeAggregate.AddSource(adjustBindable);
+                    break;
+            }
+        }
+
+        public void RemoveAdjustment(AdjustableProperty type, BindableDouble adjustBindable)
+        {
+            switch (type)
+            {
+                case AdjustableProperty.Balance:
+                    balanceAggregate.RemoveSource(adjustBindable);
+                    break;
+
+                case AdjustableProperty.Frequency:
+                    frequencyAggregate.RemoveSource(adjustBindable);
+                    break;
+
+                case AdjustableProperty.Volume:
+                    volumeAggregate.RemoveSource(adjustBindable);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Bind all adjustments from an <see cref="IAggregateAudioAdjustment"/>.
+        /// </summary>
+        /// <param name="component">The adjustment source.</param>
+        internal void BindAdjustments(IAggregateAudioAdjustment component)
+        {
+            volumeAggregate.AddSource(component.AggregateVolume);
+            balanceAggregate.AddSource(component.AggregateBalance);
+            frequencyAggregate.AddSource(component.AggregateFrequency);
+        }
+
+        /// <summary>
+        /// Unbind all adjustments from an <see cref="IAggregateAudioAdjustment"/>.
+        /// </summary>
+        /// <param name="component">The adjustment source.</param>
+        internal void UnbindAdjustments(IAggregateAudioAdjustment component)
+        {
+            volumeAggregate.RemoveSource(component.AggregateVolume);
+            balanceAggregate.RemoveSource(component.AggregateBalance);
+            frequencyAggregate.RemoveSource(component.AggregateFrequency);
+        }
+    }
+}

--- a/osu.Framework/Audio/IAggregateAudioAdjustment.cs
+++ b/osu.Framework/Audio/IAggregateAudioAdjustment.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Audio
+{
+    /// <summary>
+    /// Provides aggregated adjustments for an audio component.
+    /// </summary>
+    public interface IAggregateAudioAdjustment
+    {
+        /// <summary>
+        /// The aggregate volume of this component (0..1).
+        /// </summary>
+        IBindable<double> AggregateVolume { get; }
+
+        /// <summary>
+        /// The aggregate playback balance of this sample (-1 .. 1 where 0 is centered)
+        /// </summary>
+        IBindable<double> AggregateBalance { get; }
+
+        /// <summary>
+        /// The aggregate rate at which the component is played back (affects pitch). 1 is 100% playback speed, or default frequency.
+        /// </summary>
+        IBindable<double> AggregateFrequency { get; }
+    }
+}

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -35,9 +35,9 @@ namespace osu.Framework.Audio.Sample
 
             if (channel != 0)
             {
-                Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, VolumeAggregate.Result.Value);
-                Bass.ChannelSetAttribute(channel, ChannelAttribute.Pan, BalanceAggregate.Result.Value);
-                Bass.ChannelSetAttribute(channel, ChannelAttribute.Frequency, initialFrequency * FrequencyAggregate.Result.Value);
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, ((IAggregateAudioAdjustment)this).AggregateVolume.Value);
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.Pan, ((IAggregateAudioAdjustment)this).AggregateBalance.Value);
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.Frequency, initialFrequency * ((IAggregateAudioAdjustment)this).AggregateFrequency.Value);
             }
         }
 

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -35,9 +35,9 @@ namespace osu.Framework.Audio.Sample
 
             if (channel != 0)
             {
-                Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, ((IAggregateAudioAdjustment)this).AggregateVolume.Value);
-                Bass.ChannelSetAttribute(channel, ChannelAttribute.Pan, ((IAggregateAudioAdjustment)this).AggregateBalance.Value);
-                Bass.ChannelSetAttribute(channel, ChannelAttribute.Frequency, initialFrequency * ((IAggregateAudioAdjustment)this).AggregateFrequency.Value);
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, AggregateVolume.Value);
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.Pan, AggregateBalance.Value);
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.Frequency, initialFrequency * AggregateFrequency.Value);
             }
         }
 

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -255,17 +255,17 @@ namespace osu.Framework.Audio.Track
         {
             base.OnStateChanged();
 
-            setDirection(FrequencyAggregate.Result.Value < 0);
+            setDirection(AggregateFrequency.Value < 0);
 
-            Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Volume, VolumeAggregate.Result.Value);
-            Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Pan, BalanceAggregate.Result.Value);
+            Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Volume, AggregateVolume.Value);
+            Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Pan, AggregateBalance.Value);
             Bass.ChannelSetAttribute(activeStream, ChannelAttribute.Frequency, bassFreq);
             Bass.ChannelSetAttribute(tempoAdjustStream, ChannelAttribute.Tempo, (Math.Abs(Tempo.Value) - 1) * 100);
         }
 
         private volatile float initialFrequency;
 
-        private int bassFreq => (int)MathHelper.Clamp(Math.Abs(initialFrequency * FrequencyAggregate.Result.Value), 100, 100000);
+        private int bassFreq => (int)MathHelper.Clamp(Math.Abs(initialFrequency * AggregateFrequency.Value), 100, 100000);
 
         private volatile int bitrate;
 


### PR DESCRIPTION
In preparation for being used in `DrawableAudioWrapper` (#2396).

- [x] Depends on #2447
