### PR TITLE
Rename sample/track managers to stores

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         private void load(Game game, AudioManager audio)
         {
             track = new TrackBass(game.Resources.GetStream("Tracks/sample-track.mp3"));
-            audio.Track.AddItem(track);
+            audio.Tracks.AddItem(track);
 
             waveform = new Waveform(game.Resources.GetStream("Tracks/sample-track.mp3"));
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         };
 
         private Button button;
-        private TrackBass track;
+        private Track track;
         private Waveform waveform;
         private Container<Drawable> waveformContainer;
         private readonly Bindable<float> zoom = new BindableFloat(1) { MinValue = 0.1f, MaxValue = 20 };
@@ -39,10 +39,12 @@ namespace osu.Framework.Tests.Visual.Drawables
         [BackgroundDependencyLoader]
         private void load(Game game, AudioManager audio)
         {
-            track = new TrackBass(game.Resources.GetStream("Tracks/sample-track.mp3"));
-            audio.Tracks.AddItem(track);
+            var store = audio.GetTrackStore(game.Resources);
 
-            waveform = new Waveform(game.Resources.GetStream("Tracks/sample-track.mp3"));
+            const string track_name = "Tracks/sample-track.mp3";
+
+            track = store.Get(track_name);
+            waveform = new Waveform(store.GetStream(track_name));
 
             const float track_width = 1366; // required because RelativeSizeAxes.X doesn't seem to work with horizontal scroll
 

--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Audio
     /// <summary>
     /// An audio component which allows for basic bindable adjustments to be applied.
     /// </summary>
-    public class AdjustableAudioComponent : AudioComponent, IAggregateAudioAdjustment
+    public class AdjustableAudioComponent : AudioComponent, IAggregateAudioAdjustment, IAdjustableAudioComponent
     {
         private readonly AudioAdjustments adjustments = new AudioAdjustments();
 

--- a/osu.Framework/Audio/AudioCollectionManager.cs
+++ b/osu.Framework/Audio/AudioCollectionManager.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Audio
     /// <summary>
     /// A collection of audio components which need central property control.
     /// </summary>
-    public class AudioCollectionManager<T> : AdjustableAudioComponent
+    public class AudioCollectionManager<T> : AdjustableAudioComponent, IBassAudio
         where T : AdjustableAudioComponent
     {
         protected List<T> Items = new List<T>();
@@ -40,7 +40,7 @@ namespace osu.Framework.Audio
             EnqueueAction(() => item.UnbindAdjustments(this));
         }
 
-        internal virtual void UpdateDevice(int deviceIndex)
+        public virtual void UpdateDevice(int deviceIndex)
         {
             foreach (var item in Items.OfType<IBassAudio>())
                 item.UpdateDevice(deviceIndex);

--- a/osu.Framework/Audio/AudioCollectionManager.cs
+++ b/osu.Framework/Audio/AudioCollectionManager.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Audio
                 item.OnStateChanged();
         }
 
-        public virtual void UpdateDevice(int deviceIndex)
+        internal virtual void UpdateDevice(int deviceIndex)
         {
             foreach (var item in Items.OfType<IBassAudio>())
                 item.UpdateDevice(deviceIndex);

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -289,7 +289,7 @@ namespace osu.Framework.Audio
             return true;
         }
 
-        public override void UpdateDevice(int deviceIndex)
+        internal override void UpdateDevice(int deviceIndex)
         {
             Samples.UpdateDevice(deviceIndex);
             Tracks.UpdateDevice(deviceIndex);

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -21,12 +21,12 @@ namespace osu.Framework.Audio
         /// <summary>
         /// The manager component responsible for audio tracks (e.g. songs).
         /// </summary>
-        public TrackManager Track => GetTrackManager();
+        public TrackStore Tracks => GetTrackStore();
 
         /// <summary>
         /// The manager component responsible for audio samples (e.g. sound effects).
         /// </summary>
-        public SampleManager Sample => GetSampleManager();
+        public SampleStore Samples => GetSampleStore();
 
         /// <summary>
         /// The thread audio operations (mainly Bass calls) are ran on.
@@ -86,8 +86,8 @@ namespace osu.Framework.Audio
         /// </summary>
         public Scheduler EventScheduler;
 
-        private readonly Lazy<TrackManager> globalTrackManager;
-        private readonly Lazy<SampleManager> globalSampleManager;
+        private readonly Lazy<TrackStore> globalTrackManager;
+        private readonly Lazy<SampleStore> globalSampleManager;
 
         /// <summary>
         /// Constructs an AudioManager given a track resource store, and a sample resource store.
@@ -108,8 +108,8 @@ namespace osu.Framework.Audio
             sampleStore.AddExtension(@"wav");
             sampleStore.AddExtension(@"mp3");
 
-            globalTrackManager = new Lazy<TrackManager>(() => GetTrackManager(trackStore));
-            globalSampleManager = new Lazy<SampleManager>(() => GetSampleManager(sampleStore));
+            globalTrackManager = new Lazy<TrackStore>(() => GetTrackStore(trackStore));
+            globalSampleManager = new Lazy<SampleStore>(() => GetSampleStore(sampleStore));
 
             scheduler.Add(() =>
             {
@@ -155,15 +155,15 @@ namespace osu.Framework.Audio
         private IEnumerable<string> getDeviceNames(List<DeviceInfo> devices) => devices.Skip(1).Select(d => d.Name);
 
         /// <summary>
-        /// Obtains the <see cref="TrackManager"/> corresponding to a given resource store.
-        /// Returns the global <see cref="TrackManager"/> if no resource store is passed.
+        /// Obtains the <see cref="TrackStore"/> corresponding to a given resource store.
+        /// Returns the global <see cref="TrackStore"/> if no resource store is passed.
         /// </summary>
-        /// <param name="store">The <see cref="IResourceStore{T}"/> of which to retrieve the <see cref="TrackManager"/>.</param>
-        public TrackManager GetTrackManager(IResourceStore<byte[]> store = null)
+        /// <param name="store">The <see cref="IResourceStore{T}"/> of which to retrieve the <see cref="TrackStore"/>.</param>
+        public TrackStore GetTrackStore(IResourceStore<byte[]> store = null)
         {
             if (store == null) return globalTrackManager.Value;
 
-            TrackManager tm = new TrackManager(store);
+            TrackStore tm = new TrackStore(store);
             AddItem(tm);
             tm.AddAdjustment(AdjustableProperty.Volume, VolumeTrack);
             VolumeTrack.ValueChanged += e => tm.InvalidateState(e.NewValue);
@@ -172,15 +172,15 @@ namespace osu.Framework.Audio
         }
 
         /// <summary>
-        /// Obtains the <see cref="SampleManager"/> corresponding to a given resource store.
-        /// Returns the global <see cref="SampleManager"/> if no resource store is passed.
+        /// Obtains the <see cref="SampleStore"/> corresponding to a given resource store.
+        /// Returns the global <see cref="SampleStore"/> if no resource store is passed.
         /// </summary>
-        /// <param name="store">The <see cref="IResourceStore{T}"/> of which to retrieve the <see cref="SampleManager"/>.</param>
-        public SampleManager GetSampleManager(IResourceStore<byte[]> store = null)
+        /// <param name="store">The <see cref="IResourceStore{T}"/> of which to retrieve the <see cref="SampleStore"/>.</param>
+        public SampleStore GetSampleStore(IResourceStore<byte[]> store = null)
         {
             if (store == null) return globalSampleManager.Value;
 
-            SampleManager sm = new SampleManager(store);
+            SampleStore sm = new SampleStore(store);
             AddItem(sm);
             sm.AddAdjustment(AdjustableProperty.Volume, VolumeSample);
             VolumeSample.ValueChanged += e => sm.InvalidateState(e.NewValue);
@@ -291,8 +291,8 @@ namespace osu.Framework.Audio
 
         public override void UpdateDevice(int deviceIndex)
         {
-            Sample.UpdateDevice(deviceIndex);
-            Track.UpdateDevice(deviceIndex);
+            Samples.UpdateDevice(deviceIndex);
+            Tracks.UpdateDevice(deviceIndex);
         }
 
         private void updateAvailableAudioDevices()

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -86,8 +86,8 @@ namespace osu.Framework.Audio
         /// </summary>
         public Scheduler EventScheduler;
 
-        private readonly Lazy<IResourceStore<Track.Track>> globalTrackManager;
-        private readonly Lazy<IResourceStore<SampleChannel>> globalSampleManager;
+        private readonly Lazy<IAdjustableResourceStore<Track.Track>> globalTrackManager;
+        private readonly Lazy<IAdjustableResourceStore<SampleChannel>> globalSampleManager;
 
         /// <summary>
         /// Constructs an AudioManager given a track resource store, and a sample resource store.
@@ -108,8 +108,8 @@ namespace osu.Framework.Audio
             sampleStore.AddExtension(@"wav");
             sampleStore.AddExtension(@"mp3");
 
-            globalTrackManager = new Lazy<IResourceStore<Track.Track>>(() => GetTrackStore(trackStore));
-            globalSampleManager = new Lazy<IResourceStore<SampleChannel>>(() => GetSampleStore(sampleStore));
+            globalTrackManager = new Lazy<IAdjustableResourceStore<Track.Track>>(() => GetTrackStore(trackStore));
+            globalSampleManager = new Lazy<IAdjustableResourceStore<SampleChannel>>(() => GetSampleStore(sampleStore));
 
             scheduler.Add(() =>
             {
@@ -159,7 +159,7 @@ namespace osu.Framework.Audio
         /// Returns the global <see cref="TrackStore"/> if no resource store is passed.
         /// </summary>
         /// <param name="store">The <see cref="IResourceStore{T}"/> of which to retrieve the <see cref="TrackStore"/>.</param>
-        public IResourceStore<Track.Track> GetTrackStore(IResourceStore<byte[]> store = null)
+        public IAdjustableResourceStore<Track.Track> GetTrackStore(IResourceStore<byte[]> store = null)
         {
             if (store == null) return globalTrackManager.Value;
 
@@ -175,7 +175,7 @@ namespace osu.Framework.Audio
         /// Returns the global <see cref="SampleStore"/> if no resource store is passed.
         /// </summary>
         /// <param name="store">The <see cref="IResourceStore{T}"/> of which to retrieve the <see cref="SampleStore"/>.</param>
-        public IResourceStore<SampleChannel> GetSampleStore(IResourceStore<byte[]> store = null)
+        public IAdjustableResourceStore<SampleChannel> GetSampleStore(IResourceStore<byte[]> store = null)
         {
             if (store == null) return globalSampleManager.Value;
 

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -21,12 +21,12 @@ namespace osu.Framework.Audio
         /// <summary>
         /// The manager component responsible for audio tracks (e.g. songs).
         /// </summary>
-        public TrackStore Tracks => GetTrackStore();
+        public IResourceStore<Track.Track> Tracks => GetTrackStore();
 
         /// <summary>
         /// The manager component responsible for audio samples (e.g. sound effects).
         /// </summary>
-        public SampleStore Samples => GetSampleStore();
+        public IResourceStore<SampleChannel> Samples => GetSampleStore();
 
         /// <summary>
         /// The thread audio operations (mainly Bass calls) are ran on.
@@ -86,8 +86,8 @@ namespace osu.Framework.Audio
         /// </summary>
         public Scheduler EventScheduler;
 
-        private readonly Lazy<TrackStore> globalTrackManager;
-        private readonly Lazy<SampleStore> globalSampleManager;
+        private readonly Lazy<IResourceStore<Track.Track>> globalTrackManager;
+        private readonly Lazy<IResourceStore<SampleChannel>> globalSampleManager;
 
         /// <summary>
         /// Constructs an AudioManager given a track resource store, and a sample resource store.
@@ -108,8 +108,8 @@ namespace osu.Framework.Audio
             sampleStore.AddExtension(@"wav");
             sampleStore.AddExtension(@"mp3");
 
-            globalTrackManager = new Lazy<TrackStore>(() => GetTrackStore(trackStore));
-            globalSampleManager = new Lazy<SampleStore>(() => GetSampleStore(sampleStore));
+            globalTrackManager = new Lazy<IResourceStore<Track.Track>>(() => GetTrackStore(trackStore));
+            globalSampleManager = new Lazy<IResourceStore<SampleChannel>>(() => GetSampleStore(sampleStore));
 
             scheduler.Add(() =>
             {
@@ -159,7 +159,7 @@ namespace osu.Framework.Audio
         /// Returns the global <see cref="TrackStore"/> if no resource store is passed.
         /// </summary>
         /// <param name="store">The <see cref="IResourceStore{T}"/> of which to retrieve the <see cref="TrackStore"/>.</param>
-        public TrackStore GetTrackStore(IResourceStore<byte[]> store = null)
+        public IResourceStore<Track.Track> GetTrackStore(IResourceStore<byte[]> store = null)
         {
             if (store == null) return globalTrackManager.Value;
 
@@ -175,7 +175,7 @@ namespace osu.Framework.Audio
         /// Returns the global <see cref="SampleStore"/> if no resource store is passed.
         /// </summary>
         /// <param name="store">The <see cref="IResourceStore{T}"/> of which to retrieve the <see cref="SampleStore"/>.</param>
-        public SampleStore GetSampleStore(IResourceStore<byte[]> store = null)
+        public IResourceStore<SampleChannel> GetSampleStore(IResourceStore<byte[]> store = null)
         {
             if (store == null) return globalSampleManager.Value;
 
@@ -285,12 +285,6 @@ namespace osu.Framework.Audio
             Bass.UpdatePeriod = 5;
 
             return true;
-        }
-
-        internal override void UpdateDevice(int deviceIndex)
-        {
-            Samples.UpdateDevice(deviceIndex);
-            Tracks.UpdateDevice(deviceIndex);
         }
 
         private void updateAvailableAudioDevices()

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -21,12 +21,12 @@ namespace osu.Framework.Audio
         /// <summary>
         /// The manager component responsible for audio tracks (e.g. songs).
         /// </summary>
-        public IResourceStore<Track.Track> Tracks => GetTrackStore();
+        public IAdjustableResourceStore<Track.Track> Tracks => GetTrackStore();
 
         /// <summary>
         /// The manager component responsible for audio samples (e.g. sound effects).
         /// </summary>
-        public IResourceStore<SampleChannel> Samples => GetSampleStore();
+        public IAdjustableResourceStore<SampleChannel> Samples => GetSampleStore();
 
         /// <summary>
         /// The thread audio operations (mainly Bass calls) are ran on.

--- a/osu.Framework/Audio/IAdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/IAdjustableAudioComponent.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Audio
+{
+    public interface IAdjustableAudioComponent
+    {
+        /// <summary>
+        /// The volume of this component.
+        /// </summary>
+        BindableDouble Volume { get; }
+
+        /// <summary>
+        /// The playback balance of this sample (-1 .. 1 where 0 is centered)
+        /// </summary>
+        BindableDouble Balance { get; }
+
+        /// <summary>
+        /// Rate at which the component is played back (affects pitch). 1 is 100% playback speed, or default frequency.
+        /// </summary>
+        BindableDouble Frequency { get; }
+
+        /// <summary>
+        /// Add a bindable adjustment source.
+        /// </summary>
+        /// <param name="type">The target type for this adjustment.</param>
+        /// <param name="adjustBindable">The bindable adjustment.</param>
+        void AddAdjustment(AdjustableProperty type, BindableDouble adjustBindable);
+
+        /// <summary>
+        /// Remove a bindable adjustment source.
+        /// </summary>
+        /// <param name="type">The target type for this adjustment.</param>
+        /// <param name="adjustBindable">The bindable adjustment.</param>
+        void RemoveAdjustment(AdjustableProperty type, BindableDouble adjustBindable);
+    }
+}

--- a/osu.Framework/Audio/IAdjustableResourceStore.cs
+++ b/osu.Framework/Audio/IAdjustableResourceStore.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.IO.Stores;
+
+namespace osu.Framework.Audio
+{
+    public interface IAdjustableResourceStore<T> : IResourceStore<T>, IAdjustableAudioComponent
+        where T : AudioComponent
+    {
+    }
+}

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace osu.Framework.Audio.Sample
 {
-    public class SampleStore : AudioCollectionManager<SampleChannel>, IResourceStore<SampleChannel>
+    public class SampleStore : AudioCollectionManager<SampleChannel>, IAdjustableResourceStore<SampleChannel>
     {
         private readonly IResourceStore<byte[]> store;
 

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Audio.Sample
 
         public Task<SampleChannel> GetAsync(string name) => Task.Run(() => Get(name));
 
-        internal override void UpdateDevice(int deviceIndex)
+        public override void UpdateDevice(int deviceIndex)
         {
             foreach (var sample in sampleCache.Values.OfType<IBassAudio>())
                 sample.UpdateDevice(deviceIndex);

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Audio.Sample
         /// </summary>
         public int PlaybackConcurrency { get; set; } = Sample.DEFAULT_CONCURRENCY;
 
-        public SampleStore(IResourceStore<byte[]> store)
+        internal SampleStore(IResourceStore<byte[]> store)
         {
             this.store = store;
         }
@@ -51,7 +51,7 @@ namespace osu.Framework.Audio.Sample
 
         public Task<SampleChannel> GetAsync(string name) => Task.Run(() => Get(name));
 
-        public override void UpdateDevice(int deviceIndex)
+        internal override void UpdateDevice(int deviceIndex)
         {
             foreach (var sample in sampleCache.Values.OfType<IBassAudio>())
                 sample.UpdateDevice(deviceIndex);

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace osu.Framework.Audio.Sample
 {
-    public class SampleManager : AudioCollectionManager<SampleChannel>, IResourceStore<SampleChannel>
+    public class SampleStore : AudioCollectionManager<SampleChannel>, IResourceStore<SampleChannel>
     {
         private readonly IResourceStore<byte[]> store;
 
@@ -21,7 +21,7 @@ namespace osu.Framework.Audio.Sample
         /// </summary>
         public int PlaybackConcurrency { get; set; } = Sample.DEFAULT_CONCURRENCY;
 
-        public SampleManager(IResourceStore<byte[]> store)
+        public SampleStore(IResourceStore<byte[]> store)
         {
             this.store = store;
         }

--- a/osu.Framework/Audio/Track/TrackStore.cs
+++ b/osu.Framework/Audio/Track/TrackStore.cs
@@ -7,11 +7,11 @@ using osu.Framework.IO.Stores;
 
 namespace osu.Framework.Audio.Track
 {
-    public class TrackManager : AudioCollectionManager<Track>, IResourceStore<Track>
+    public class TrackStore : AudioCollectionManager<Track>, IResourceStore<Track>
     {
         private readonly IResourceStore<byte[]> store;
 
-        public TrackManager(IResourceStore<byte[]> store)
+        public TrackStore(IResourceStore<byte[]> store)
         {
             this.store = store;
         }

--- a/osu.Framework/Audio/Track/TrackStore.cs
+++ b/osu.Framework/Audio/Track/TrackStore.cs
@@ -11,7 +11,7 @@ namespace osu.Framework.Audio.Track
     {
         private readonly IResourceStore<byte[]> store;
 
-        public TrackStore(IResourceStore<byte[]> store)
+        internal TrackStore(IResourceStore<byte[]> store)
         {
             this.store = store;
         }

--- a/osu.Framework/Audio/Track/TrackStore.cs
+++ b/osu.Framework/Audio/Track/TrackStore.cs
@@ -7,7 +7,7 @@ using osu.Framework.IO.Stores;
 
 namespace osu.Framework.Audio.Track
 {
-    public class TrackStore : AudioCollectionManager<Track>, IResourceStore<Track>
+    public class TrackStore : AudioCollectionManager<Track>, IAdjustableResourceStore<Track>
     {
         private readonly IResourceStore<byte[]> store;
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -449,7 +449,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             if (oldStart != selectionStart || oldEnd != selectionEnd)
             {
-                audio.Sample.Get(@"Keyboard/key-movement")?.Play();
+                audio.Samples.Get(@"Keyboard/key-movement")?.Play();
                 cursorAndLayout.Invalidate();
             }
         }
@@ -468,7 +468,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (count == 0) return false;
 
             if (sound)
-                audio.Sample.Get(@"Keyboard/key-delete")?.Play();
+                audio.Samples.Get(@"Keyboard/key-delete")?.Play();
 
             foreach (var d in TextFlow.Children.Skip(start).Take(count).ToArray()) //ToArray since we are removing items from the children in this block.
             {
@@ -677,9 +677,9 @@ namespace osu.Framework.Graphics.UserInterface
             if (!string.IsNullOrEmpty(pendingText) && !ReadOnly)
             {
                 if (pendingText.Any(char.IsUpper))
-                    audio.Sample.Get(@"Keyboard/key-caps")?.Play();
+                    audio.Samples.Get(@"Keyboard/key-caps")?.Play();
                 else
-                    audio.Sample.Get($@"Keyboard/key-press-{RNG.Next(1, 5)}")?.Play();
+                    audio.Samples.Get($@"Keyboard/key-press-{RNG.Next(1, 5)}")?.Play();
 
                 insertString(pendingText);
             }
@@ -736,7 +736,7 @@ namespace osu.Framework.Graphics.UserInterface
             Background.ClearTransforms();
             Background.FlashColour(BackgroundCommit, 400);
 
-            audio.Sample.Get(@"Keyboard/key-confirm")?.Play();
+            audio.Samples.Get(@"Keyboard/key-confirm")?.Play();
             OnCommit?.Invoke(this, true);
         }
 
@@ -949,7 +949,7 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 //in the case of backspacing (or a NOP), we can exit early here.
                 if (didDelete)
-                    audio.Sample.Get(@"Keyboard/key-delete")?.Play();
+                    audio.Samples.Get(@"Keyboard/key-delete")?.Play();
                 return;
             }
 
@@ -965,7 +965,7 @@ namespace osu.Framework.Graphics.UserInterface
                 }
             }
 
-            audio.Sample.Get($@"Keyboard/key-press-{RNG.Next(1, 5)}")?.Play();
+            audio.Samples.Get($@"Keyboard/key-press-{RNG.Next(1, 5)}")?.Play();
         }
 
         #endregion


### PR DESCRIPTION
# Breaking Changes

`AudioManager.Track` -> `AudioManager.Tracks`
`AudioManager.Sample` -> `AudioManager.Samples`

`SampleManager` -> `SampleStore`
`TrackManager` -> `TrackStore`

This also tidies up the return types to not expose the underlying collection functionality. This was being used in dangerous ways osu!-side, so this is a step in simplifying the audio subsystem's usage in consumer apps.