### PR TITLE
Nest all user-created sample and track stores in the global stores

### DIFF
--- a/osu.Framework.Tests/Audio/AudioComponentTest.cs
+++ b/osu.Framework.Tests/Audio/AudioComponentTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Audio;
@@ -36,7 +37,7 @@ namespace osu.Framework.Tests.Audio
         {
             thread.Exit();
 
-            Task.Delay(500);
+            Thread.Sleep(500);
 
             Assert.IsFalse(thread.Exited);
         }

--- a/osu.Framework.Tests/Audio/AudioComponentTest.cs
+++ b/osu.Framework.Tests/Audio/AudioComponentTest.cs
@@ -42,6 +42,34 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
+        public void TestNestedStoreAdjustments()
+        {
+            var customStore = manager.GetSampleStore(new ResourceStore<byte[]>());
+
+            checkAggregateVolume(manager.Samples, 1);
+            checkAggregateVolume(customStore, 1);
+
+            manager.Samples.Volume.Value = 0.5;
+
+            waitAudioFrame();
+
+            checkAggregateVolume(manager.Samples, 0.5);
+            checkAggregateVolume(customStore, 0.5);
+
+            customStore.Volume.Value = 0.5;
+
+            waitAudioFrame();
+
+            checkAggregateVolume(manager.Samples, 0.5);
+            checkAggregateVolume(customStore, 0.25);
+        }
+
+        private void checkAggregateVolume(ISampleStore store, double expected)
+        {
+            Assert.AreEqual(expected, ((IAggregateAudioAdjustment)store).AggregateVolume.Value);
+        }
+
+        [Test]
         public void TestVirtualTrack()
         {
             var track = manager.Tracks.GetVirtual();

--- a/osu.Framework.Tests/Audio/AudioComponentTest.cs
+++ b/osu.Framework.Tests/Audio/AudioComponentTest.cs
@@ -35,11 +35,13 @@ namespace osu.Framework.Tests.Audio
         [TearDown]
         public void TearDown()
         {
+            Assert.IsFalse(thread.Exited);
+
             thread.Exit();
 
             Thread.Sleep(500);
 
-            Assert.IsFalse(thread.Exited);
+            Assert.IsTrue(thread.Exited);
         }
 
         [Test]

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -12,7 +12,7 @@ using osu.Framework.Threading;
 
 #pragma warning disable 4014
 
-namespace osu.Framework.Tests.Platform
+namespace osu.Framework.Tests.Audio
 {
     [TestFixture]
     public class TrackBassTest

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -13,7 +13,7 @@ using osu.Framework.Audio.Track;
 
 namespace osu.Framework.Audio.Sample
 {
-    internal class SampleStore : AudioCollectionManager<SampleChannel>, ISampleStore
+    internal class SampleStore : AudioCollectionManager<AdjustableAudioComponent>, ISampleStore
     {
         private readonly IResourceStore<byte[]> store;
 

--- a/osu.Framework/Audio/Track/TrackStore.cs
+++ b/osu.Framework/Audio/Track/TrackStore.cs
@@ -9,7 +9,7 @@ using osu.Framework.IO.Stores;
 
 namespace osu.Framework.Audio.Track
 {
-    internal class TrackStore : AudioCollectionManager<Track>, ITrackStore
+    internal class TrackStore : AudioCollectionManager<AdjustableAudioComponent>, ITrackStore
     {
         private readonly IResourceStore<byte[]> store;
 


### PR DESCRIPTION
This allows for adjustments to be placed on `AudioManager.Samples` and `AudioManager.Tracks` and have them apply to all tracks/samples game-wide, as one would expect.

Previously custom stores would be added at the top level (`AudioManager`) and therefore be immune to non-global adjustments.