### PR TITLE
Use FrameworkTestScene as base class wherever possible

### DIFF
--- a/osu.Framework.Tests/Visual/Bindables/TestSceneBindableAutoUnbinding.cs
+++ b/osu.Framework.Tests/Visual/Bindables/TestSceneBindableAutoUnbinding.cs
@@ -8,13 +8,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Bindables
 {
-    public class TestSceneBindableAutoUnbinding : TestScene
+    public class TestSceneBindableAutoUnbinding : FrameworkTestScene
     {
         [Test]
         public void TestBindableAutoUnbindingAssign()

--- a/osu.Framework.Tests/Visual/Bindables/TestSceneBindableNumbers.cs
+++ b/osu.Framework.Tests/Visual/Bindables/TestSceneBindableNumbers.cs
@@ -7,11 +7,10 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.Bindables
 {
-    public class TestSceneBindableNumbers : TestScene
+    public class TestSceneBindableNumbers : FrameworkTestScene
     {
         private readonly BindableInt bindableInt = new BindableInt();
         private readonly BindableLong bindableLong = new BindableLong();

--- a/osu.Framework.Tests/Visual/Clocks/TestSceneClock.cs
+++ b/osu.Framework.Tests/Visual/Clocks/TestSceneClock.cs
@@ -7,14 +7,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Clocks
 {
-    public abstract class TestSceneClock : TestScene
+    public abstract class TestSceneClock : FrameworkTestScene
     {
         private readonly FillFlowContainer fill;
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCircularContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCircularContainer.cs
@@ -5,13 +5,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.MathUtils;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
     [System.ComponentModel.Description(@"Checking for bugged corner radius")]
-    public class TestSceneCircularContainer : TestScene
+    public class TestSceneCircularContainer : FrameworkTestScene
     {
         private SingleUpdateCircularContainer container;
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCircularContainerSizing.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCircularContainerSizing.cs
@@ -6,12 +6,11 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
-    public class TestSceneCircularContainerSizing : TestScene
+    public class TestSceneCircularContainerSizing : FrameworkTestScene
     {
         [Test]
         public void TestLateSizing() => Schedule(() =>

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCompositeMutability.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCompositeMutability.cs
@@ -8,11 +8,10 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
-    public class TestSceneCompositeMutability : TestScene
+    public class TestSceneCompositeMutability : FrameworkTestScene
     {
         [TestCase(TestThread.External, false)]
         [TestCase(TestThread.Update, false)]

--- a/osu.Framework.Tests/Visual/Containers/TestSceneContainerState.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneContainerState.cs
@@ -8,12 +8,11 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
     [System.ComponentModel.Description("ensure valid container state in various scenarios")]
-    public class TestSceneContainerState : TestScene
+    public class TestSceneContainerState : FrameworkTestScene
     {
         /// <summary>
         /// Tests if a drawable can be added to a container, removed, and then re-added to the same container.

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCoordinateSpaces.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCoordinateSpaces.cs
@@ -6,13 +6,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
-    public class TestSceneCoordinateSpaces : TestScene
+    public class TestSceneCoordinateSpaces : FrameworkTestScene
     {
         public TestSceneCoordinateSpaces()
         {

--- a/osu.Framework.Tests/Visual/Containers/TestSceneDrawSizePreservingFillContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneDrawSizePreservingFillContainer.cs
@@ -4,13 +4,12 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
-    public class TestSceneDrawSizePreservingFillContainer : TestScene
+    public class TestSceneDrawSizePreservingFillContainer : FrameworkTestScene
     {
         public TestSceneDrawSizePreservingFillContainer()
         {

--- a/osu.Framework.Tests/Visual/Containers/TestSceneDynamicDepth.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneDynamicDepth.cs
@@ -5,14 +5,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
     [System.ComponentModel.Description("changing depth of child dynamically")]
-    public class TestSceneDynamicDepth : TestScene
+    public class TestSceneDynamicDepth : FrameworkTestScene
     {
         private void addDepthSteps(DepthBox box, Container container)
         {

--- a/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
@@ -8,12 +8,11 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osu.Framework.Timing;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
-    public class TestSceneLifetimeManagementContainer : TestScene
+    public class TestSceneLifetimeManagementContainer : FrameworkTestScene
     {
         private ManualClock manualClock;
         private TestContainer container;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
@@ -8,13 +8,12 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
-    public class TestSceneMasking : TestScene
+    public class TestSceneMasking : FrameworkTestScene
     {
         protected Container TestContainer;
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
@@ -9,14 +9,13 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
 using osu.Framework.MathUtils;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
     [System.ComponentModel.Description("potentially challenging size calculations")]
-    public class TestSceneSizing : TestScene
+    public class TestSceneSizing : FrameworkTestScene
     {
         private Container testContainer;
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -8,12 +8,11 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Containers
 {
-    public class TestSceneTextFlowContainer : TestScene
+    public class TestSceneTextFlowContainer : FrameworkTestScene
     {
         private const string default_text = "Default text\n\nnewline";
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneBlending.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneBlending.cs
@@ -8,13 +8,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneBlending : TestScene
+    public class TestSceneBlending : FrameworkTestScene
     {
         private readonly Dropdown<BlendingMode> colourModeDropdown;
         private readonly Dropdown<BlendingEquation> colourEquation;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneConcurrentLoad.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneConcurrentLoad.cs
@@ -9,13 +9,12 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneConcurrentLoad : TestScene
+    public class TestSceneConcurrentLoad : FrameworkTestScene
     {
         private const int panel_count = 6;
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoad.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoad.cs
@@ -9,13 +9,12 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneDelayedLoad : TestScene
+    public class TestSceneDelayedLoad : FrameworkTestScene
     {
         private const int panel_count = 2048;
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedUnload.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedUnload.cs
@@ -6,13 +6,12 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneDelayedUnload : TestScene
+    public class TestSceneDelayedUnload : FrameworkTestScene
     {
         private const int panel_count = 1024;
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawableLoadCancellation.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawableLoadCancellation.cs
@@ -13,13 +13,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Logging;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneDrawableLoadCancellation : TestScene
+    public class TestSceneDrawableLoadCancellation : FrameworkTestScene
     {
         private readonly List<SlowLoader> loaders = new List<SlowLoader>();
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneEffects.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneEffects.cs
@@ -7,14 +7,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
     [System.ComponentModel.Description("implementing the IEffect interface")]
-    public class TestSceneEffects : TestScene
+    public class TestSceneEffects : FrameworkTestScene
     {
         private readonly SpriteText changeColourText;
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneIsMaskedAway.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneIsMaskedAway.cs
@@ -5,12 +5,11 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneIsMaskedAway : TestScene
+    public class TestSceneIsMaskedAway : FrameworkTestScene
     {
         /// <summary>
         /// Tests that a box which is within the bounds of a parent is never masked away, regardless of whether the parent is masking or not.

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
@@ -9,13 +9,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneModelBackedDrawable : TestScene
+    public class TestSceneModelBackedDrawable : FrameworkTestScene
     {
         private TestModelBackedDrawable backedDrawable;
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithLoading.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawableWithLoading.cs
@@ -8,13 +8,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneModelBackedDrawableWithLoading : TestScene
+    public class TestSceneModelBackedDrawableWithLoading : FrameworkTestScene
     {
         private TestModelBackedDrawable backedDrawable;
 

--- a/osu.Framework.Tests/Visual/Drawables/TestScenePropertyBoundaries.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestScenePropertyBoundaries.cs
@@ -4,13 +4,12 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
     [System.ComponentModel.Description("ensure validity of drawables when receiving certain values")]
-    public class TestScenePropertyBoundaries : TestScene
+    public class TestScenePropertyBoundaries : FrameworkTestScene
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawables.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawables.cs
@@ -6,13 +6,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneProxyDrawables : TestScene
+    public class TestSceneProxyDrawables : FrameworkTestScene
     {
         public TestSceneProxyDrawables()
         {

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -12,14 +12,13 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Transforms;
 using osu.Framework.MathUtils;
-using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneTransformRewinding : TestScene
+    public class TestSceneTransformRewinding : FrameworkTestScene
     {
         private const double interval = 250;
         private const int interval_count = 4;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneUpdateBeforeDraw.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneUpdateBeforeDraw.cs
@@ -7,14 +7,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
     [Description("Tests whether drawable updates occur before drawing.")]
-    public class TestSceneUpdateBeforeDraw : TestScene
+    public class TestSceneUpdateBeforeDraw : FrameworkTestScene
     {
         /// <summary>
         /// Tests whether a <see cref="Drawable"/> is updated before being drawn when it is added to a parent

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -11,13 +11,12 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.Handlers.Mouse;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Input
 {
-    public class TestSceneInputManager : TestScene
+    public class TestSceneInputManager : FrameworkTestScene
     {
         public TestSceneInputManager()
         {

--- a/osu.Framework.Tests/Visual/Input/TestSceneJoystick.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneJoystick.cs
@@ -7,13 +7,12 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Input
 {
-    public class TestSceneJoystick : TestScene
+    public class TestSceneJoystick : FrameworkTestScene
     {
         public TestSceneJoystick()
         {

--- a/osu.Framework.Tests/Visual/Input/TestSceneNestedHover.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneNestedHover.cs
@@ -5,13 +5,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Input
 {
-    public class TestSceneNestedHover : TestScene
+    public class TestSceneNestedHover : FrameworkTestScene
     {
         public TestSceneNestedHover()
         {

--- a/osu.Framework.Tests/Visual/Input/TestScenePathInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePathInput.cs
@@ -8,13 +8,12 @@ using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input.Events;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Input
 {
-    public class TestScenePathInput : TestScene
+    public class TestScenePathInput : FrameworkTestScene
     {
         private const float path_width = 50;
         private const float path_radius = path_width / 2;

--- a/osu.Framework.Tests/Visual/Layout/TestSceneFillFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneFillFlowContainer.cs
@@ -10,14 +10,13 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.MathUtils;
-using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Layout
 {
-    public class TestSceneFillFlowContainer : TestScene
+    public class TestSceneFillFlowContainer : FrameworkTestScene
     {
         private FillDirectionDropdown selectionDropdown;
 

--- a/osu.Framework.Tests/Visual/Layout/TestSceneFitInsideFlow.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneFitInsideFlow.cs
@@ -5,13 +5,12 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.Layout
 {
     [TestFixture]
-    public class TestSceneFitInsideFlow : TestScene
+    public class TestSceneFitInsideFlow : FrameworkTestScene
     {
         private const float container_width = 60;
 

--- a/osu.Framework.Tests/Visual/Layout/TestSceneGridContainer.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneGridContainer.cs
@@ -10,13 +10,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.MathUtils;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Layout
 {
-    public class TestSceneGridContainer : TestScene
+    public class TestSceneGridContainer : FrameworkTestScene
     {
         private Container gridParent;
         private GridContainer grid;

--- a/osu.Framework.Tests/Visual/Layout/TestSceneLayoutDurations.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneLayoutDurations.cs
@@ -7,14 +7,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osu.Framework.MathUtils;
-using osu.Framework.Testing;
 using osu.Framework.Timing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Layout
 {
-    public class TestSceneLayoutDurations : TestScene
+    public class TestSceneLayoutDurations : FrameworkTestScene
     {
         private ManualClock manualClock;
         private Container autoSizeContainer;

--- a/osu.Framework.Tests/Visual/Layout/TestSceneLayoutTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneLayoutTransformRewinding.cs
@@ -6,13 +6,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.MathUtils;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.Layout
 {
     [System.ComponentModel.Description("Rewinding of transforms that are important to layout.")]
-    public class TestSceneLayoutTransformRewinding : TestScene
+    public class TestSceneLayoutTransformRewinding : FrameworkTestScene
     {
         private readonly ManualUpdateSubTreeContainer manualContainer;
 

--- a/osu.Framework.Tests/Visual/Layout/TestSceneScrollableFlow.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneScrollableFlow.cs
@@ -5,14 +5,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.MathUtils;
-using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Layout
 {
-    public class TestSceneScrollableFlow : TestScene
+    public class TestSceneScrollableFlow : FrameworkTestScene
     {
         private readonly ScheduledDelegate boxCreator;
 

--- a/osu.Framework.Tests/Visual/Layout/TestSceneTableContainer.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneTableContainer.cs
@@ -8,13 +8,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.MathUtils;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Layout
 {
-    public class TestSceneTableContainer : TestScene
+    public class TestSceneTableContainer : FrameworkTestScene
     {
         private TableContainer table;
 

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -12,13 +12,12 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
-    public class TestSceneBorderless : TestScene
+    public class TestSceneBorderless : FrameworkTestScene
     {
         private readonly SpriteText currentActualSize = new SpriteText();
         private readonly SpriteText currentClientSize = new SpriteText();

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -8,11 +8,10 @@ using osu.Framework.Configuration;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
-using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
-    public class TestSceneFullscreen : TestScene
+    public class TestSceneFullscreen : FrameworkTestScene
     {
         private readonly SpriteText currentActualSize = new SpriteText();
         private readonly SpriteText currentWindowMode = new SpriteText();

--- a/osu.Framework.Tests/Visual/Platform/TestSceneSafeArea.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneSafeArea.cs
@@ -9,14 +9,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 using GameWindow = osu.Framework.Platform.GameWindow;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
-    public class TestSceneSafeArea : TestScene
+    public class TestSceneSafeArea : FrameworkTestScene
     {
         private readonly BindableMarginPadding safeAreaPadding = new BindableMarginPadding();
         private readonly Container container;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -7,14 +7,13 @@ using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
     [System.ComponentModel.Description("frame-based animations")]
-    public class TestSceneAnimation : TestScene
+    public class TestSceneAnimation : FrameworkTestScene
     {
         public TestSceneAnimation()
         {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
@@ -7,13 +7,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Platform;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
-    public class TestSceneScreenshot : TestScene
+    public class TestSceneScreenshot : FrameworkTestScene
     {
         [Resolved]
         private GameHost host { get; set; }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
@@ -10,14 +10,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
     [TestFixture]
-    public class TestSceneSpriteIcon : TestScene
+    public class TestSceneSpriteIcon : FrameworkTestScene
     {
         public TestSceneSpriteIcon()
         {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteText.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteText.cs
@@ -4,11 +4,10 @@
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
-    public class TestSceneSpriteText : TestScene
+    public class TestSceneSpriteText : FrameworkTestScene
     {
         public TestSceneSpriteText()
         {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTruncate.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTruncate.cs
@@ -5,13 +5,12 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
-    public class TestSceneSpriteTextTruncate : TestScene
+    public class TestSceneSpriteTextTruncate : FrameworkTestScene
     {
         private readonly FillFlowContainer flow;
 

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextFlow.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextFlow.cs
@@ -6,14 +6,13 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
     [System.ComponentModel.Description("word-wrap and paragraphs")]
-    public class TestSceneTextFlow : TestScene
+    public class TestSceneTextFlow : FrameworkTestScene
     {
         public TestSceneTextFlow()
         {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
@@ -8,11 +8,10 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
-using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
-    public class TestSceneTextures : TestScene
+    public class TestSceneTextures : FrameworkTestScene
     {
         [Cached]
         private TextureStore normalStore;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTriangles.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTriangles.cs
@@ -5,14 +5,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
-using osu.Framework.Testing;
 using osu.Framework.Tests.Visual.Containers;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
-    public class TestSceneTriangles : TestScene
+    public class TestSceneTriangles : FrameworkTestScene
     {
         private readonly Container testContainer;
 

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideoSprite.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideoSprite.cs
@@ -5,12 +5,11 @@ using System;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Video;
 using osu.Framework.IO.Network;
-using osu.Framework.Testing;
 using osu.Framework.Timing;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
-    public class TestSceneVideoSprite : TestScene
+    public class TestSceneVideoSprite : FrameworkTestScene
     {
         private ManualClock clock;
         private VideoSprite videoSprite;

--- a/osu.Framework.Tests/Visual/Testing/TestSceneDrawVisualiser.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDrawVisualiser.cs
@@ -4,13 +4,12 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Visualisation;
-using osu.Framework.Testing;
 using osu.Framework.Tests.Visual.Containers;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.Testing
 {
-    public class TestSceneDrawVisualiser : TestScene
+    public class TestSceneDrawVisualiser : FrameworkTestScene
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTest.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTest.cs
@@ -7,7 +7,7 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.Testing
 {
-    public class TestSceneTest : TestScene
+    public class TestSceneTest : FrameworkTestScene
     {
         private int setupRun;
         private int setupStepsRun;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCheckboxes.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCheckboxes.cs
@@ -6,12 +6,11 @@ using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneCheckboxes : TestScene
+    public class TestSceneCheckboxes : FrameworkTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
@@ -7,14 +7,13 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Testing;
 using osuTK.Graphics;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneCircularProgress : TestScene
+    public class TestSceneCircularProgress : FrameworkTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(CircularProgress), typeof(CircularProgressDrawNode) };
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
@@ -8,13 +8,12 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneContextMenu : TestScene
+    public class TestSceneContextMenu : FrameworkTestScene
     {
         private const int start_time = 0;
         private const int duration = 1000;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCountingText.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCountingText.cs
@@ -7,12 +7,11 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneCountingText : TestScene
+    public class TestSceneCountingText : FrameworkTestScene
     {
         private readonly Bindable<CountType> countType = new Bindable<CountType>();
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdown.cs
@@ -7,12 +7,11 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Containers.Markdown;
 using osu.Framework.IO.Network;
-using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
     [Description("markdown reader")]
-    public class TestSceneMarkdown : TestScene
+    public class TestSceneMarkdown : FrameworkTestScene
     {
         public TestSceneMarkdown()
         {

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneRigidBody.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneRigidBody.cs
@@ -7,13 +7,12 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.MathUtils;
 using osu.Framework.Physics;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneRigidBody : TestScene
+    public class TestSceneRigidBody : FrameworkTestScene
     {
         private readonly TestRigidBodySimulation sim;
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
@@ -15,7 +15,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.MathUtils;
 using osu.Framework.Screens;
-using osu.Framework.Testing;
 using osu.Framework.Testing.Input;
 using osuTK;
 using osuTK.Graphics;
@@ -23,7 +22,7 @@ using osuTK.Input;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneScreenStack : TestScene
+    public class TestSceneScreenStack : FrameworkTestScene
     {
         private TestScreen baseScreen;
         private ScreenStack stack;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -8,12 +8,11 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneSearchContainer : TestScene
+    public class TestSceneSearchContainer : FrameworkTestScene
     {
         private SearchContainer search;
         private BasicTextBox textBox;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -11,12 +11,11 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneTabControl : TestScene
+    public class TestSceneTabControl : FrameworkTestScene
     {
         private readonly IEnumerable<TestEnum> items;
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -6,12 +6,11 @@ using System.Collections.Generic;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Testing;
 using osuTK;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneTextBox : TestScene
+    public class TestSceneTextBox : FrameworkTestScene
     {
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTooltip.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTooltip.cs
@@ -7,13 +7,12 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneTooltip : TestScene
+    public class TestSceneTooltip : FrameworkTestScene
     {
         private readonly Container testContainer;
 


### PR DESCRIPTION
Not *required* as such, but gives more visibility to the existence of this base class which is required in cases resources are sourced from the tests project.