### PR TITLE
Add thread check to SpriteText's character computation method

### DIFF
--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -426,7 +426,8 @@ namespace osu.Framework.Graphics.Sprites
         /// </summary>
         private void computeCharacters()
         {
-            ThreadSafety.EnsureUpdateThread();
+            if (LoadState >= LoadState.Loaded)
+                ThreadSafety.EnsureUpdateThread();
 
             if (store == null)
                 return;

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
+using osu.Framework.Development;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
@@ -425,6 +426,8 @@ namespace osu.Framework.Graphics.Sprites
         /// </summary>
         private void computeCharacters()
         {
+            ThreadSafety.EnsureUpdateThread();
+
             if (store == null)
                 return;
 


### PR DESCRIPTION
Accessing `SpriteText.Size` from a non-update thread can potentially cause a crash on the draw thread due to collection modification. This warns the user when this happens, rather than crashing on a different (untraceable) thread.

Closes #2457 (by providing a more relevant call stack when this happens again).