### PR TITLE
Re-expose TextureGL.Bind() publicly

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -98,7 +98,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// Bind as active texture.
         /// </summary>
         /// <returns>True if bind was successful.</returns>
-        internal abstract bool Bind();
+        public abstract bool Bind();
 
         /// <summary>
         /// Uploads pending texture data to the GPU if it exists.

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlasWhite.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlasWhite.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         {
         }
 
-        internal override bool Bind()
+        public override bool Bind()
         {
             //we can use the special white space from any atlas texture.
             if (GLWrapper.AtlasTextureIsBound)

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -298,7 +298,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
-        internal override bool Bind()
+        public override bool Bind()
         {
             if (!Available)
                 throw new ObjectDisposedException(ToString(), "Can not bind a disposed texture.");

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
@@ -79,7 +79,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         {
         }
 
-        internal override bool Bind()
+        public override bool Bind()
         {
             if (!Available)
                 throw new ObjectDisposedException(ToString(), "Can not bind disposed sub textures.");


### PR DESCRIPTION
It's actually quite useful to have this one when drawing a custom vertex buffer.