### PR TITLE
Fix ProxyDrawables not drawing at the correct depth

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawables.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawables.cs
@@ -44,6 +44,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                         generateProxyBelowParentOriginalIndirectlyMaskedAway(1),
                         generateProxyAboveParentOriginalIndirectlyMaskedAway(6),
                         generateProxyBelowParentOriginalIndirectlyMaskedAway(6),
+                        generateOpaqueProxyAboveOpaqueBox(),
                     }
                 }
             };
@@ -339,6 +340,27 @@ namespace osu.Framework.Tests.Visual.Drawables
             };
         }
 
+        private Drawable generateOpaqueProxyAboveOpaqueBox()
+        {
+            var box = new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(50),
+            };
+
+            var proxy = box.CreateProxy();
+
+            return new Visualiser("proxy above opaque box")
+            {
+                Children = new Drawable[]
+                {
+                    box,
+                    new ProxyVisualiser(proxy, false, 1.0f)
+                }
+            };
+        }
+
         private class NonPresentContainer : Container
         {
             private bool isPresent = true;
@@ -406,7 +428,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             private readonly Drawable original;
             private readonly Drawable overlay;
 
-            public ProxyVisualiser(Drawable proxy, bool proxyIsBelow)
+            public ProxyVisualiser(Drawable proxy, bool proxyIsBelow, float boxAlpha = 0.5f)
             {
                 RelativeSizeAxes = Axes.Both;
 
@@ -427,12 +449,13 @@ namespace osu.Framework.Tests.Visual.Drawables
                         new Box
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Alpha = 0.5f,
+                            Alpha = boxAlpha,
                         },
                         new SpriteText
                         {
                             Anchor = Anchor.BottomCentre,
                             Origin = Anchor.BottomCentre,
+                            Colour = Color4.Black,
                             Text = "proxy"
                         }
                     }

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -132,7 +132,7 @@ namespace osu.Framework.Graphics
         /// Whether this <see cref="DrawNode"/> can draw a opaque interior. <see cref="DrawOpaqueInterior"/> will only be invoked if this value is <code>true</code>.
         /// Should not return <code>true</code> if <see cref="DrawOpaqueInterior"/> will result in a no-op.
         /// </summary>
-        protected virtual bool CanDrawOpaqueInterior => false;
+        protected internal virtual bool CanDrawOpaqueInterior => false;
 
         /// <summary>
         /// Draws a triangle to the screen.

--- a/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
+++ b/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
@@ -76,16 +76,25 @@ namespace osu.Framework.Graphics
                 {
                 }
 
+                protected internal override void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
+                    => getCurrentFrameSource()?.DrawOpaqueInteriorSubTree(depthValue, vertexAction);
+
                 public override void Draw(Action<TexturedVertex2D> vertexAction)
+                    => getCurrentFrameSource()?.Draw(vertexAction);
+
+                protected internal override bool CanDrawOpaqueInterior => getCurrentFrameSource()?.CanDrawOpaqueInterior ?? false;
+
+                private DrawNode getCurrentFrameSource()
                 {
                     var target = Source.originalDrawNodes[DrawNodeIndex];
+
                     if (target == null)
-                        return;
+                        return null;
 
                     if (Source.drawNodeValidationIds[DrawNodeIndex] != FrameCount)
-                        return;
+                        return null;
 
-                    target.Draw(vertexAction);
+                    return target;
                 }
             }
         }

--- a/osu.Framework/Graphics/Shapes/Box.cs
+++ b/osu.Framework/Graphics/Shapes/Box.cs
@@ -73,7 +73,7 @@ namespace osu.Framework.Graphics.Shapes
                 TextureShader.Unbind();
             }
 
-            protected override bool CanDrawOpaqueInterior =>
+            protected internal override bool CanDrawOpaqueInterior =>
                 Texture?.Available == true
                 && DrawColourInfo.Colour.MinAlpha == 1
                 && DrawColourInfo.Blending.RGBEquation == BlendEquationMode.FuncAdd


### PR DESCRIPTION
Because `DrawOpaqueInterior()` wasn't passed through.