### PR TITLE
Fix BufferedContainers being drawn with the wrong depth

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
@@ -119,7 +119,7 @@ namespace osu.Framework.Tests.Visual.Containers
             {
             }
 
-            protected internal override void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
+            internal override void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
             {
                 startQuery();
                 base.DrawOpaqueInteriorSubTree(depthValue, vertexAction);

--- a/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using System;
 using osu.Framework.Graphics.Colour;
-using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.MathUtils;
 
 namespace osu.Framework.Graphics.Containers
@@ -133,11 +132,6 @@ namespace osu.Framework.Graphics.Containers
             {
                 get => Child.Children;
                 set => Child.Children = value;
-            }
-
-            protected internal override void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
-            {
-                // Opaque interiors aren't supported inside buffered containers yet
             }
 
             public bool AddChildDrawNodes => RequiresRedraw;

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -223,7 +223,7 @@ namespace osu.Framework.Graphics.Containers
                     GLWrapper.PopMaskingInfo();
             }
 
-            protected internal override void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
+            internal override void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
             {
                 DrawChildrenOpaqueInteriors(depthValue, vertexAction);
                 base.DrawOpaqueInteriorSubTree(depthValue, vertexAction);

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -99,7 +99,7 @@ namespace osu.Framework.Graphics
         /// </remarks>
         /// <param name="depthValue">The previous depth value.</param>
         /// <param name="vertexAction">The action to be performed on each vertex of the draw node in order to draw it if required. This is primarily used by textured sprites.</param>
-        protected internal virtual void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
+        internal virtual void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
         {
             if (!depthValue.CanIncrement || !CanDrawOpaqueInterior)
             {

--- a/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
+++ b/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
@@ -76,7 +76,7 @@ namespace osu.Framework.Graphics
                 {
                 }
 
-                protected internal override void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
+                internal override void DrawOpaqueInteriorSubTree(DepthValue depthValue, Action<TexturedVertex2D> vertexAction)
                     => getCurrentFrameSource()?.DrawOpaqueInteriorSubTree(depthValue, vertexAction);
 
                 public override void Draw(Action<TexturedVertex2D> vertexAction)


### PR DESCRIPTION
Not sure how to really test this - it's removing an override so that buffered containers are drawn at the correct depth, but:

1. Children still don't get their opaque interiors drawn since `BufferedContainer` never invokes the required methods. It's not a `CompositeDrawable` anymore (it used to be, hence this code), so the base class doesn't handle it.
2. I've made the subtree method internal because it's pretty dangerous to let consumers adjust it as they wish.