### PR TITLE
Only write to depth buffer during FTB prepass

### DIFF
--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -108,6 +108,8 @@ namespace osu.Framework.Graphics
                 return;
             }
 
+            float origDepthValue = depthValue;
+
             // It is crucial to draw with an incremented depth value, consider the case of a box:
             // In the front-to-back pass, the inner conservative area is drawn at depth X
             // In the back-to-front pass, the full area is drawn at depth X, and the depth test function is set to GL_LESS, so the inner conservative area is not redrawn
@@ -115,6 +117,8 @@ namespace osu.Framework.Graphics
             drawDepth = depthValue.Increment();
 
             DrawOpaqueInterior(vertexAction);
+
+            drawDepth = origDepthValue;
         }
 
         /// <summary>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -330,12 +330,12 @@ namespace osu.Framework.Platform
                     {
                         var depthValue = new DepthValue();
 
-                        GLWrapper.PushDepthInfo(DepthInfo.Default);
-
                         // Front pass
+                        GL.ColorMask(false, false, false, false);
+                        GLWrapper.PushDepthInfo(DepthInfo.Default);
                         buffer.Object.DrawOpaqueInteriorSubTree(depthValue, null);
-
                         GLWrapper.PopDepthInfo();
+                        GL.ColorMask(true, true, true, true);
 
                         // The back pass doesn't write depth, but needs to depth test properly
                         GLWrapper.PushDepthInfo(new DepthInfo(true, false));


### PR DESCRIPTION
Curious if this changes anything on iOS. General idea being that maybe iOS's renderer doesn't consider any colour buffer draws for early-z testing.

It would be silly if so, but if that's the case then I guess we'll have to flesh this out.

Doesn't provide quite as much of a performance improvement as the current implementation to me.