### PR TITLE
Seek to one byte before the end of a track when seeking to end

### DIFF
--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -104,7 +104,7 @@ namespace osu.Framework.Tests.Audio
         }
 
         /// <summary>
-        /// Bass does not allow seeking to the end of the track. It should fail and the current time should not change.
+        /// Bass does not allow seeking to the end of the track. Seek is clamped to one byte before the end to account for this.
         /// </summary>
         [Test]
         public void TestSeekToEndFails()
@@ -112,7 +112,7 @@ namespace osu.Framework.Tests.Audio
             track.SeekAsync(track.Length);
             updateTrack();
 
-            Assert.AreEqual(0, track.CurrentTime);
+            Assert.Greater(track.CurrentTime, 0);
         }
 
         [Test]

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -234,7 +234,8 @@ namespace osu.Framework.Audio.Track
             {
                 double clamped = MathHelper.Clamp(seek, 0, Length);
 
-                long pos = Bass.ChannelSeconds2Bytes(activeStream, clamped / 1000d);
+                // If attempting to seek past or at the end of the track, seek one byte before it since bass disallows seeking to the end.
+                long pos = Bass.ChannelSeconds2Bytes(activeStream, clamped / 1000d) - (seek >= Length ? 1 : 0);
 
                 if (pos != Bass.ChannelGetPosition(activeStream))
                     Bass.ChannelSetPosition(activeStream, pos);


### PR DESCRIPTION
Part of https://github.com/ppy/osu-framework/issues/824 (it would still not fire the completed state, but that can be added if necessary)

Before, seeking to the exactly end would silently fail (though attempting to seek past it will return false on the Seek). This change makes it so it would seek to the last seek-able byte instead.

An alternative would be just changing the return of `SeekAsync` to also account for seeking to the length of the track (or simply making it return whether or not bass returned a length error). Depends on whether or not we want this to be possible.