### PR TITLE
Introduce IWindow interface on GameWindow

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Drawing;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
@@ -18,7 +19,7 @@ namespace osu.Framework.Tests.Visual.Platform
         private readonly SpriteText currentDisplay = new SpriteText();
         private readonly SpriteText supportedWindowModes = new SpriteText();
 
-        private GameWindow window;
+        private IWindow window;
         private readonly BindableSize sizeFullscreen = new BindableSize();
         private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
 

--- a/osu.Framework.Tests/Visual/Platform/TestSceneSafeArea.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneSafeArea.cs
@@ -11,18 +11,17 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
-using GameWindow = osu.Framework.Platform.GameWindow;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
     public class TestSceneSafeArea : FrameworkTestScene
     {
-        private readonly BindableMarginPadding safeAreaPadding = new BindableMarginPadding();
+        private readonly IBindable<MarginPadding> safeAreaPadding = new BindableMarginPadding();
         private readonly Container container;
         private readonly Box box;
         private readonly SpriteText textbox;
 
-        private GameWindow window;
+        private IWindow window;
 
         public TestSceneSafeArea()
         {

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -7,12 +7,17 @@ using osu.Framework.Platform;
 using osu.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using osu.Framework.Bindables;
 
 namespace osu.Framework.iOS
 {
     public class IOSGameWindow : GameWindow
     {
         internal static IOSGameView GameView;
+
+        private readonly BindableMarginPadding safeAreaPadding = new BindableMarginPadding();
+
+        public override IBindable<MarginPadding> SafeAreaPadding => safeAreaPadding;
 
         public IOSGameWindow()
             : base(GameView)
@@ -53,7 +58,7 @@ namespace osu.Framework.iOS
 
         private void onResize(object sender, EventArgs e)
         {
-            SafeAreaPadding.Value = new MarginPadding
+            safeAreaPadding.Value = new MarginPadding
             {
                 Top = (float)GameView.SafeArea.Top * GameView.Scale,
                 Left = (float)GameView.SafeArea.Left * GameView.Scale,

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -20,13 +20,12 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.IO.Stores;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
-using GameWindow = osu.Framework.Platform.GameWindow;
 
 namespace osu.Framework
 {
     public abstract class Game : Container, IKeyBindingHandler<FrameworkAction>
     {
-        public GameWindow Window => Host?.Window;
+        public IWindow Window => Host?.Window;
 
         public ResourceStore<byte[]> Resources { get; private set; }
 

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -18,6 +18,7 @@ using osu.Framework.MathUtils;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Platform;
+using GameWindow = osu.Framework.Platform.GameWindow;
 
 namespace osu.Framework.Graphics.OpenGL
 {
@@ -65,7 +66,8 @@ namespace osu.Framework.Graphics.OpenGL
         {
             if (IsInitialized) return;
 
-            isEmbedded = host.Window.IsEmbedded;
+            if (host.Window is GameWindow win)
+                isEmbedded = win.IsEmbedded;
 
             GLWrapper.host = new WeakReference<GameHost>(host);
             reset_scheduler.SetCurrentThread();

--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -8,11 +8,11 @@ namespace osu.Framework.Input
 {
     public class GameWindowTextInput : ITextInputSource
     {
-        private readonly GameWindow window;
+        private readonly IWindow window;
 
         private string pending = string.Empty;
 
-        public GameWindowTextInput(GameWindow window)
+        public GameWindowTextInput(IWindow window)
         {
             this.window = window;
         }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -42,14 +42,14 @@ namespace osu.Framework.Platform
 {
     public abstract class GameHost : IIpcHost, IDisposable
     {
-        public GameWindow Window { get; protected set; }
+        public IWindow Window { get; protected set; }
 
         protected FrameworkDebugConfigManager DebugConfig { get; private set; }
 
         protected FrameworkConfigManager Config { get; private set; }
 
         /// <summary>
-        /// Whether the <see cref="GameWindow"/> is active (in the foreground).
+        /// Whether the <see cref="IWindow"/> is active (in the foreground).
         /// </summary>
         public readonly IBindable<bool> IsActive = new Bindable<bool>(true);
 

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -15,11 +15,12 @@ using System.ComponentModel;
 using System.Drawing;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using Icon = osuTK.Icon;
 
 namespace osu.Framework.Platform
 {
-    public abstract class GameWindow : IGameWindow
+    public abstract class GameWindow : IWindow
     {
         /// <summary>
         /// The <see cref="IGraphicsContext"/> associated with this <see cref="GameWindow"/>.
@@ -86,7 +87,7 @@ namespace osu.Framework.Platform
 
             FocusedChanged += (o, e) => isActive.Value = Focused;
 
-            SupportedWindowModes.AddRange(DefaultSupportedWindowModes);
+            supportedWindowModes.AddRange(DefaultSupportedWindowModes);
 
             bool firstUpdate = true;
             UpdateFrame += (o, e) =>
@@ -223,14 +224,18 @@ namespace osu.Framework.Platform
 
         protected virtual void OnKeyDown(object sender, KeyboardKeyEventArgs e) => KeyDown?.Invoke(sender, e);
 
+        private readonly BindableMarginPadding safeAreaPadding = new BindableMarginPadding();
+
         /// <summary>
         /// Provides a <see cref="BindableMarginPadding"/> that can be used to keep track of the "safe area" insets on mobile
         /// devices.  This usually corresponds to areas of the screen hidden under notches and rounded corners.
         /// The safe area insets are provided by the operating system and dynamically change as the user rotates the device.
         /// </summary>
-        public readonly BindableMarginPadding SafeAreaPadding = new BindableMarginPadding();
+        public IBindable<MarginPadding> SafeAreaPadding => safeAreaPadding;
 
-        public readonly BindableList<WindowMode> SupportedWindowModes = new BindableList<WindowMode>();
+        private readonly BindableList<WindowMode> supportedWindowModes = new BindableList<WindowMode>();
+
+        public IBindableList<WindowMode> SupportedWindowModes => supportedWindowModes;
 
         public virtual WindowMode DefaultWindowMode => SupportedWindowModes.First();
 

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -224,14 +224,12 @@ namespace osu.Framework.Platform
 
         protected virtual void OnKeyDown(object sender, KeyboardKeyEventArgs e) => KeyDown?.Invoke(sender, e);
 
-        private readonly BindableMarginPadding safeAreaPadding = new BindableMarginPadding();
-
         /// <summary>
         /// Provides a <see cref="BindableMarginPadding"/> that can be used to keep track of the "safe area" insets on mobile
         /// devices.  This usually corresponds to areas of the screen hidden under notches and rounded corners.
         /// The safe area insets are provided by the operating system and dynamically change as the user rotates the device.
         /// </summary>
-        public IBindable<MarginPadding> SafeAreaPadding => safeAreaPadding;
+        public virtual IBindable<MarginPadding> SafeAreaPadding { get; } = new BindableMarginPadding();
 
         private readonly BindableList<WindowMode> supportedWindowModes = new BindableList<WindowMode>();
 

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osuTK;
+using osuTK.Platform;
+
+namespace osu.Framework.Platform
+{
+    /// <summary>
+    /// Interface representation of the game window, intended to hide any implementation-specific code.
+    /// Currently inherits from osuTK; this will be removed as part of the <see cref="GameWindow"/> refactor.
+    /// </summary>
+    public interface IWindow : IGameWindow
+    {
+        void CycleMode();
+
+        void SetupWindow(FrameworkConfigManager config);
+
+        event Func<bool> ExitRequested;
+
+        event Action Exited;
+
+        bool CursorInWindow { get; }
+
+        CursorState CursorState { get; set; }
+
+        VSyncMode VSync { get; set; }
+
+        WindowMode DefaultWindowMode { get; }
+
+        DisplayDevice CurrentDisplay { get; }
+
+        IBindable<bool> IsActive { get; }
+
+        IBindable<MarginPadding> SafeAreaPadding { get; }
+
+        IBindableList<WindowMode> SupportedWindowModes { get; }
+    }
+}

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -72,7 +72,7 @@ namespace osu.Framework.Platform
 
         /// <summary>
         /// Provides a <see cref="IBindable{MarginPadding}"/> that can be used to keep track of the "safe area" insets on mobile
-        /// devices.  This usually corresponds to areas of the screen hidden under notches and rounded corners.
+        /// devices. This usually corresponds to areas of the screen hidden under notches and rounded corners.
         /// The safe area insets are provided by the operating system and dynamically change as the user rotates the device.
         /// </summary>
         IBindable<MarginPadding> SafeAreaPadding { get; }

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
@@ -16,28 +17,69 @@ namespace osu.Framework.Platform
     /// </summary>
     public interface IWindow : IGameWindow
     {
+        /// <summary>
+        /// Cycles through the available <see cref="WindowMode"/>s as determined by <see cref="SupportedWindowModes"/>.
+        /// </summary>
         void CycleMode();
 
+        /// <summary>
+        /// Configures the <see cref="IWindow"/> based on the provided <see cref="FrameworkConfigManager"/>.
+        /// </summary>
+        /// <param name="config">The configuration manager to use.</param>
         void SetupWindow(FrameworkConfigManager config);
 
+        /// <summary>
+        /// Return value decides whether we should intercept and cancel this exit (if possible).
+        /// </summary>
+        [CanBeNull]
         event Func<bool> ExitRequested;
 
+        /// <summary>
+        /// Invoked when the <see cref="IWindow"/> has closed.
+        /// </summary>
+        [CanBeNull]
         event Action Exited;
 
+        /// <summary>
+        /// Whether the OS cursor is currently contained within the game window.
+        /// </summary>
         bool CursorInWindow { get; }
 
+        /// <summary>
+        /// Controls the state of the OS cursor.
+        /// </summary>
         CursorState CursorState { get; set; }
 
+        /// <summary>
+        /// Controls the vertical sync mode of the screen.
+        /// </summary>
         VSyncMode VSync { get; set; }
 
+        /// <summary>
+        /// Returns the default <see cref="WindowMode"/> for the implementation.
+        /// </summary>
         WindowMode DefaultWindowMode { get; }
 
+        /// <summary>
+        /// Gets the <see cref="DisplayDevice"/> that this window is currently on.
+        /// </summary>
         DisplayDevice CurrentDisplay { get; }
 
+        /// <summary>
+        /// Whether this <see cref="IWindow"/> is active (in the foreground).
+        /// </summary>
         IBindable<bool> IsActive { get; }
 
+        /// <summary>
+        /// Provides a <see cref="IBindable{MarginPadding}"/> that can be used to keep track of the "safe area" insets on mobile
+        /// devices.  This usually corresponds to areas of the screen hidden under notches and rounded corners.
+        /// The safe area insets are provided by the operating system and dynamically change as the user rotates the device.
+        /// </summary>
         IBindable<MarginPadding> SafeAreaPadding { get; }
 
+        /// <summary>
+        /// The <see cref="WindowMode"/>s supported by this <see cref="IWindow"/> implementation.
+        /// </summary>
         IBindableList<WindowMode> SupportedWindowModes { get; }
     }
 }

--- a/osu.Framework/Platform/MacOS/MacOSTextInput.cs
+++ b/osu.Framework/Platform/MacOS/MacOSTextInput.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Platform.MacOS
 
         private static bool isCapsLockOn => (Cocoa.CGEventSourceFlagsState(event_source_state_hid_system_state) & event_flag_mask_alpha_shift) != 0;
 
-        public MacOSTextInput(GameWindow window)
+        public MacOSTextInput(IWindow window)
             : base(window)
         {
         }


### PR DESCRIPTION
First step in decoupling of `GameWindow` for #2448 

Eventually the `osuTK.IGameWindow` inheritance will go away as we replace many properties and events with bindables.
