### PR TITLE
Allow providing a custom name for ThreadedTaskSchedulers

### DIFF
--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -44,8 +44,6 @@ namespace osu.Framework.iOS
 
         public override bool OnScreenKeyboardOverlapsGameWindow => true;
 
-        
-
         public override bool CanExit => false;
 
         public override ITextInputSource GetTextInput() => new IOSTextInput(gameView);

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -44,6 +44,8 @@ namespace osu.Framework.iOS
 
         public override bool OnScreenKeyboardOverlapsGameWindow => true;
 
+        
+
         public override bool CanExit => false;
 
         public override ITextInputSource GetTextInput() => new IOSTextInput(gameView);

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -76,7 +76,7 @@ namespace osu.Framework.Graphics.Containers
 
         private CancellationTokenSource disposalCancellationSource;
 
-        private static readonly ThreadedTaskScheduler threaded_scheduler = new ThreadedTaskScheduler(4, $"{nameof(LoadComponentsAsync)}");
+        private static readonly ThreadedTaskScheduler threaded_scheduler = new ThreadedTaskScheduler(4, nameof(LoadComponentsAsync));
 
         /// <summary>
         /// Loads a future child or grand-child of this <see cref="CompositeDrawable"/> asynchronously. <see cref="Dependencies"/>

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -76,7 +76,7 @@ namespace osu.Framework.Graphics.Containers
 
         private CancellationTokenSource disposalCancellationSource;
 
-        private static readonly ThreadedTaskScheduler threaded_scheduler = new ThreadedTaskScheduler(4);
+        private static readonly ThreadedTaskScheduler threaded_scheduler = new ThreadedTaskScheduler(4, $"{nameof(LoadComponentsAsync)}");
 
         /// <summary>
         /// Loads a future child or grand-child of this <see cref="CompositeDrawable"/> asynchronously. <see cref="Dependencies"/>

--- a/osu.Framework/Threading/ThreadedTaskScheduler.cs
+++ b/osu.Framework/Threading/ThreadedTaskScheduler.cs
@@ -24,7 +24,8 @@ namespace osu.Framework.Threading
         /// Initializes a new instance of the StaTaskScheduler class with the specified concurrency level.
         /// </summary>
         /// <param name="numberOfThreads">The number of threads that should be created and used by this scheduler.</param>
-        public ThreadedTaskScheduler(int numberOfThreads)
+        /// <param name="name">The thread name to give threads in this pool.</param>
+        public ThreadedTaskScheduler(int numberOfThreads, string name)
         {
             if (numberOfThreads < 1)
                 throw new ArgumentOutOfRangeException(nameof(numberOfThreads));
@@ -35,7 +36,7 @@ namespace osu.Framework.Threading
             {
                 var thread = new Thread(processTasks)
                 {
-                    Name = "LoadComponentThreadPool",
+                    Name = $"ThreadedTaskScheduler ({name})",
                     IsBackground = true
                 };
 


### PR DESCRIPTION
Easier identification of different scheduler pools when debugging.