### PR TITLE
Internalise vertex buffers

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/LinearVertexBuffer.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     {
         private readonly int amountVertices;
 
-        public LinearVertexBuffer(int amountVertices, PrimitiveType type, BufferUsageHint usage)
+        internal LinearVertexBuffer(int amountVertices, PrimitiveType type, BufferUsageHint usage)
             : base(amountVertices, usage)
         {
             this.amountVertices = amountVertices;

--- a/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     {
         private readonly int amountQuads;
 
-        public QuadVertexBuffer(int amountQuads, BufferUsageHint usage)
+        internal QuadVertexBuffer(int amountQuads, BufferUsageHint usage)
             : base(amountQuads * 4, usage)
         {
             this.amountQuads = amountQuads;


### PR DESCRIPTION
They're very unwieldy to use by themselves, requiring custom implementation to check whether updates should/should not occur.
The whole process is functionally equivalent to what `VertexBatch` with numBuffers = 1 already does.

Breaking changes:

# vNext

`LinearVertexBuffer` and `QuadVertexBuffer` can no longer be constructed outside of osu!framework.

For existing code, `LinearBatch(size, 1)` and `QuadBatch(size, 1)` may be used to replace vertex buffer usages. Code must be updated to always invoke `batch.Add(vertex)` with the vertices that should be drawn.

`VertexBuffer` may still be derived for custom implementations.