### PR TITLE
Remove all locking from GlobalPropertyManager

### DIFF
--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -42,40 +42,33 @@ namespace osu.Framework.Graphics.Shaders
         public static void Set<T>(GlobalProperty property, T value)
             where T : struct
         {
-            lock (global_properties)
-                ((UniformMapping<T>)global_properties[(int)property]).UpdateValue(ref value);
+            ((UniformMapping<T>)global_properties[(int)property]).UpdateValue(ref value);
         }
 
         public static void Register(Shader shader)
         {
-            lock (global_properties)
+            // transfer all existing global properties across.
+            foreach (var global in global_properties)
             {
-                // transfer all existing global properties across.
-                foreach (var global in global_properties)
-                {
-                    if (!shader.Uniforms.TryGetValue(global.Name, out IUniform uniform))
-                        continue;
+                if (!shader.Uniforms.TryGetValue(global.Name, out IUniform uniform))
+                    continue;
 
-                    global.LinkShaderUniform(uniform);
-                }
-
-                all_shaders.Add(shader);
+                global.LinkShaderUniform(uniform);
             }
+
+            all_shaders.Add(shader);
         }
 
         public static void Unregister(Shader shader)
         {
-            lock (global_properties)
+            if (!all_shaders.Remove(shader)) return;
+
+            foreach (var global in global_properties)
             {
-                if (!all_shaders.Remove(shader)) return;
+                if (!shader.Uniforms.TryGetValue(global.Name, out IUniform uniform))
+                    continue;
 
-                foreach (var global in global_properties)
-                {
-                    if (!shader.Uniforms.TryGetValue(global.Name, out IUniform uniform))
-                        continue;
-
-                    global.UnlinkShaderUniform(uniform);
-                }
+                global.UnlinkShaderUniform(uniform);
             }
         }
 
@@ -84,12 +77,6 @@ namespace osu.Framework.Graphics.Shaders
         /// </summary>
         /// <param name="name">The name to check</param>
         /// <returns>Whether a global exists.</returns>
-        public static bool CheckGlobalExists(string name)
-        {
-            lock (global_properties)
-            {
-                return global_properties.Any(m => m.Name == name);
-            }
-        }
+        public static bool CheckGlobalExists(string name) => global_properties.Any(m => m.Name == name);
     }
 }


### PR DESCRIPTION
We don't do cross-thread operations anywhere. Even when the lock hasn't been taken it's still not a no-op:

|                 Method |     Mean |     Error |    StdDev |
|------------------ |--------:|--------:|----------:|
| No Lock                 | 310.1 ns |    1.837 ns |  1.628 ns |
| Locked                  | 20.96 us | 0.2716 us | 0.2540 us |

(per 1000 locking operations)