### PR TITLE
Migrate VisibilityContainer to use a bindable for state

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
@@ -1,0 +1,109 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    public class TestSceneVisibilityContainer : FrameworkTestScene
+    {
+        private TestVisibilityContainer testContainer;
+
+        [Test]
+        public void TestShowHide()
+        {
+            AddStep("create container", () => Child = testContainer = new TestVisibilityContainer());
+
+            checkHidden(true);
+
+            AddStep("show", () => testContainer.Show());
+            checkVisible();
+
+            AddStep("hide", () => testContainer.Hide());
+            checkHidden();
+
+            AddAssert("fire count is 2", () => testContainer.FireCount == 2);
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestStartHidden(bool startHidden)
+        {
+            AddStep("create container", () => Child = testContainer =
+                new TestVisibilityContainer(startHidden) { State = { Value = Visibility.Visible } });
+
+            checkVisible(!startHidden);
+
+            AddStep("hide", () => testContainer.Hide());
+            checkHidden();
+
+            AddAssert("fire count is 2", () => testContainer.FireCount == 2);
+        }
+
+        private void checkHidden(bool instant = false)
+        {
+            AddAssert("is hidden", () => testContainer.State.Value == Visibility.Hidden);
+            if (instant)
+                AddAssert("alpha zero", () => testContainer.Alpha == 0);
+            else
+                AddUntilStep("alpha zero", () => testContainer.Alpha == 0);
+        }
+
+        private void checkVisible(bool instant = false)
+        {
+            AddAssert("is visible", () => testContainer.State.Value == Visibility.Visible);
+            if (instant)
+                AddAssert("alpha one", () => testContainer.Alpha == 1);
+            else
+                AddUntilStep("alpha one", () => testContainer.Alpha == 1);
+        }
+
+        private class TestVisibilityContainer : VisibilityContainer
+        {
+            private readonly bool startHidden;
+
+            protected override bool StartHidden => startHidden;
+
+            public TestVisibilityContainer(bool startHidden = true)
+            {
+                this.startHidden = startHidden;
+
+                Size = new Vector2(0.5f);
+                RelativeSizeAxes = Axes.Both;
+
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                Children = new Drawable[]
+                {
+                    new Box
+                    {
+                        Colour = Color4.Cyan,
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                };
+
+                State.ValueChanged += e => FireCount++;
+            }
+
+            public int FireCount { get; private set; }
+
+            protected override void PopIn()
+            {
+                this.FadeIn(1000, Easing.OutQuint);
+                this.ScaleTo(1, 1000, Easing.OutElastic);
+            }
+
+            protected override void PopOut()
+            {
+                this.FadeOut(1000, Easing.OutQuint);
+                this.ScaleTo(0.4f, 1000, Easing.OutQuint);
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         [Test]
         public void FocusedOverlayTakesFocusOnShow()
         {
-            AddAssert("overlay not visible", () => overlay.State == Visibility.Hidden);
+            AddAssert("overlay not visible", () => overlay.State.Value == Visibility.Hidden);
             checkNotFocused(() => overlay);
 
             AddStep("show overlay", () => overlay.Show());
@@ -82,7 +82,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         [Test]
         public void FocusedOverlayLosesFocusOnClickAway()
         {
-            AddAssert("overlay not visible", () => overlay.State == Visibility.Hidden);
+            AddAssert("overlay not visible", () => overlay.State.Value == Visibility.Hidden);
             checkNotFocused(() => overlay);
 
             AddStep("show overlay", () => overlay.Show());
@@ -251,7 +251,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             {
                 if (!box.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
                 {
-                    State = Visibility.Hidden;
+                    Hide();
                     return true;
                 }
 

--- a/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/FocusedOverlayContainer.cs
@@ -8,9 +8,9 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public abstract class FocusedOverlayContainer : OverlayContainer
     {
-        public override bool RequestsFocus => State == Visibility.Visible;
+        public override bool RequestsFocus => State.Value == Visibility.Visible;
 
-        public override bool AcceptsFocus => State == Visibility.Visible;
+        public override bool AcceptsFocus => State.Value == Visibility.Visible;
 
         protected override void PopIn()
         {

--- a/osu.Framework/Graphics/Containers/VisibilityContainer.cs
+++ b/osu.Framework/Graphics/Containers/VisibilityContainer.cs
@@ -1,21 +1,26 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
+using osu.Framework.Bindables;
 
 namespace osu.Framework.Graphics.Containers
 {
     /// <summary>
     /// A container which adds a basic visibility state.
     /// </summary>
-    public abstract class VisibilityContainer : Container, IStateful<Visibility>
+    public abstract class VisibilityContainer : Container
     {
+        /// <summary>
+        /// The current visibility state.
+        /// </summary>
+        public readonly Bindable<Visibility> State = new Bindable<Visibility>();
+
         /// <summary>
         /// Whether we should be in a hidden state when first displayed.
         /// Override this and set to true to *always* perform a <see cref="PopIn"/> animation even when the state is non-hidden at
         /// first display.
         /// </summary>
-        protected virtual bool StartHidden => state == Visibility.Hidden;
+        protected virtual bool StartHidden => State.Value == Visibility.Hidden;
 
         protected override void LoadComplete()
         {
@@ -26,32 +31,43 @@ namespace osu.Framework.Graphics.Containers
                 FinishTransforms(true);
             }
 
-            if (state != Visibility.Hidden)
-                updateState();
+            State.BindValueChanged(updateState, State.Value != Visibility.Hidden);
 
             base.LoadComplete();
         }
 
-        private Visibility state;
+        /// <summary>
+        /// Hide this container by setting its visibility to <see cref="Visibility.Visible"/>.
+        /// </summary>
+        public override void Show() => State.Value = Visibility.Visible;
 
-        public Visibility State
+        /// <summary>
+        /// Hide this container by setting its visibility to <see cref="Visibility.Hidden"/>.
+        /// </summary>
+        public override void Hide() => State.Value = Visibility.Hidden;
+
+        /// <summary>
+        /// Toggle this container's visibility.
+        /// </summary>
+        public void ToggleVisibility() => State.Value = State.Value == Visibility.Visible ? Visibility.Hidden : Visibility.Visible;
+
+        public override bool PropagateNonPositionalInputSubTree => base.PropagateNonPositionalInputSubTree && State.Value == Visibility.Visible;
+        public override bool PropagatePositionalInputSubTree => base.PropagatePositionalInputSubTree && State.Value == Visibility.Visible;
+
+        /// <summary>
+        /// Implement any transition to be played when <see cref="State"/> becomes <see cref="Visibility.Visible"/>.
+        /// </summary>
+        protected abstract void PopIn();
+
+        /// <summary>
+        /// Implement any transition to be played when <see cref="State"/> becomes <see cref="Visibility.Hidden"/>.
+        /// Will be invoked once on <see cref="LoadComplete"/> if <see cref="StartHidden"/> is set.
+        /// </summary>
+        protected abstract void PopOut();
+
+        private void updateState(ValueChangedEvent<Visibility> e)
         {
-            get => state;
-            set
-            {
-                if (value == state) return;
-
-                state = value;
-
-                if (!IsLoaded) return;
-
-                updateState();
-            }
-        }
-
-        private void updateState()
-        {
-            switch (state)
+            switch (e.NewValue)
             {
                 case Visibility.Hidden:
                     PopOut();
@@ -61,24 +77,7 @@ namespace osu.Framework.Graphics.Containers
                     PopIn();
                     break;
             }
-
-            StateChanged?.Invoke(state);
         }
-
-        public override void Hide() => State = Visibility.Hidden;
-
-        public override void Show() => State = Visibility.Visible;
-
-        public override bool PropagateNonPositionalInputSubTree => base.PropagateNonPositionalInputSubTree && State == Visibility.Visible;
-        public override bool PropagatePositionalInputSubTree => base.PropagatePositionalInputSubTree && State == Visibility.Visible;
-
-        public event Action<Visibility> StateChanged;
-
-        protected abstract void PopIn();
-
-        protected abstract void PopOut();
-
-        public void ToggleVisibility() => State = State == Visibility.Visible ? Visibility.Hidden : Visibility.Visible;
     }
 
     public enum Visibility

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.Cursor
             Depth = float.MinValue;
             RelativeSizeAxes = Axes.Both;
 
-            State = Visibility.Visible;
+            State.Value = Visibility.Visible;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -62,7 +62,7 @@ namespace osu.Framework.Graphics.Visualisation
 
                             if (visualised != null)
                             {
-                                propertyDisplay.State = Visibility.Visible;
+                                propertyDisplay.Show();
                                 setHighlight(visualised);
                             }
                         }
@@ -74,7 +74,7 @@ namespace osu.Framework.Graphics.Visualisation
 
                         propertyDisplay.ToggleVisibility();
 
-                        if (propertyDisplay.State == Visibility.Visible)
+                        if (propertyDisplay.State.Value == Visibility.Visible)
                             setHighlight(targetVisualiser);
                     },
                 },
@@ -83,9 +83,9 @@ namespace osu.Framework.Graphics.Visualisation
 
             propertyDisplay = treeContainer.PropertyDisplay;
 
-            propertyDisplay.StateChanged += visibility =>
+            propertyDisplay.State.ValueChanged += v =>
             {
-                switch (visibility)
+                switch (v.NewValue)
                 {
                     case Visibility.Hidden:
                         // Dehighlight everything automatically if property display is closed
@@ -129,7 +129,7 @@ namespace osu.Framework.Graphics.Visualisation
 
             visualiser.HighlightTarget = d =>
             {
-                propertyDisplay.State = Visibility.Visible;
+                propertyDisplay.Show();
 
                 // Either highlight or dehighlight the target, depending on whether
                 // it is currently highlighted
@@ -148,7 +148,7 @@ namespace osu.Framework.Graphics.Visualisation
             treeContainer.Remove(visualiser);
 
             if (Target == null)
-                propertyDisplay.State = Visibility.Hidden;
+                propertyDisplay.Hide();
         }
 
         private VisualisedDrawable targetVisualiser;
@@ -256,7 +256,7 @@ namespace osu.Framework.Graphics.Visualisation
             }
 
             // Only update when property display is visible
-            if (propertyDisplay.State == Visibility.Visible)
+            if (propertyDisplay.State.Value == Visibility.Visible)
             {
                 highlightedTarget = newHighlight;
                 newHighlight.IsHighlighted = true;

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Graphics.Visualisation
         private void load(FrameworkConfigManager config)
         {
             enabled = config.GetBindable<bool>(FrameworkSetting.ShowLogOverlay);
-            enabled.ValueChanged += e => State = e.NewValue ? Visibility.Visible : Visibility.Hidden;
+            enabled.ValueChanged += e => State.Value = e.NewValue ? Visibility.Visible : Visibility.Hidden;
             enabled.TriggerChange();
         }
 

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -165,7 +165,7 @@ namespace osu.Framework.Graphics.Visualisation
                 }
             });
 
-            PropertyDisplay.StateChanged += v => propertyButton.BackgroundColour = v == Visibility.Visible ? buttonBackgroundHighlighted : buttonBackground;
+            PropertyDisplay.State.ValueChanged += v => propertyButton.BackgroundColour = v.NewValue == Visibility.Visible ? buttonBackgroundHighlighted : buttonBackground;
         }
 
         protected override void Update()


### PR DESCRIPTION
Move away from property implementation to allow for more flexibility in usage scenarios. Adds documentation and test coverage.

# vNext

## VisibilityContainer now exposes visibility via a bindable

`VisibilityContainer` no longer implements `IStateful<Visibility>`, instead exposing a single `Bindable<Visibility> State`.