### PR TITLE
Fix g_BackbufferDraw not being set on framebuffer unbinds

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -629,6 +629,7 @@ namespace osu.Framework.Graphics.OpenGL
             FlushCurrentBatch();
             GL.BindFramebuffer(FramebufferTarget.Framebuffer, frame_buffer_stack.Peek());
 
+            GlobalPropertyManager.Set(GlobalProperty.BackbufferDraw, UsingBackbuffer);
             GlobalPropertyManager.Set(GlobalProperty.GammaCorrection, UsingBackbuffer);
         }
 


### PR DESCRIPTION
I didn't notice a specific breaking case, just found this while refactoring. Will remove g_GammaCorrection at a later point.