### PR TITLE
Add null check for debug check and fallback to Calling assembly

### DIFF
--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -32,14 +32,15 @@ namespace osu.Framework.Development
         );
 
         // https://stackoverflow.com/a/2186634
-        private static bool isDebugAssembly(Assembly assembly) => assembly.GetCustomAttributes(false).OfType<DebuggableAttribute>().Any(da => da.IsJITTrackingEnabled);
+        private static bool isDebugAssembly(Assembly assembly) => assembly?.GetCustomAttributes(false).OfType<DebuggableAttribute>().Any(da => da.IsJITTrackingEnabled) ?? false;
 
         /// <summary>
         /// Get the entry assembly, even when running under nUnit.
+        /// Will fall back to calling assembly if there is no Entry assembly.
         /// </summary>
         /// <returns>The entry assembly (usually obtained via <see cref="Assembly.GetEntryAssembly()"/>.</returns>
         public static Assembly GetEntryAssembly() =>
-            HostAssembly ?? Assembly.GetEntryAssembly();
+            HostAssembly ?? Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
 
         /// <summary>
         /// Get the entry path, even when running under nUnit.


### PR DESCRIPTION
This is in cases, such as Android, where the Entry Assembly is NULL due to unmanaged calls.

> The assembly that is the process executable in the default application domain, or the first executable that was executed by ExecuteAssembly(String). Can return null when called from unmanaged code.

https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly?view=netframework-4.8