### PR TITLE
Set OnScreenKeyboardOverlapsGameWindow for Android

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -29,6 +29,8 @@ namespace osu.Framework.Android
             Window = new AndroidGameWindow();
         }
 
+        public override bool OnScreenKeyboardOverlapsGameWindow => true;
+
         public override ITextInputSource GetTextInput()
             => new AndroidTextInput(gameView);
 


### PR DESCRIPTION
Credit to @hex11 for the initial implementation in #2245. This will stop the keyboard constantly getting in the way every time there is a text field