### PR TITLE
Various iOS keyboard fixes

### DIFF
--- a/SampleGame.iOS/Application.cs
+++ b/SampleGame.iOS/Application.cs
@@ -12,7 +12,7 @@ namespace SampleGame.iOS
         {
             // if you want to use a different Application Delegate class from "AppDelegate"
             // you can specify it here.
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, "GameUIApplication", "AppDelegate");
         }
     }
 }

--- a/osu.Framework.Tests.iOS/Application.cs
+++ b/osu.Framework.Tests.iOS/Application.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Tests.iOS
         {
             // if you want to use a different Application Delegate class from "AppDelegate"
             // you can specify it here.
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, "GameUIApplication", "AppDelegate");
         }
     }
 }

--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.iOS.Graphics.Textures
         {
         }
 
-        protected unsafe override Image<TPixel> ImageFromStream<TPixel>(Stream stream)
+        protected override unsafe Image<TPixel> ImageFromStream<TPixel>(Stream stream)
         {
             using (var uiImage = UIImage.LoadFromData(NSData.FromStream(stream)))
             {

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.iOS
             NSValue nsKeyboardFrame = (NSValue)notification.UserInfo[UIKeyboard.FrameEndUserInfoKey];
             RectangleF keyboardFrame = nsKeyboardFrame.RectangleFValue;
 
-            var softwareKeyboard = keyboardFrame.Height > 300;
+            var softwareKeyboard = keyboardFrame.Height > 120;
 
             if (keyboardHandler != null)
                 keyboardHandler.KeyboardActive = softwareKeyboard;

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -26,15 +26,23 @@ namespace osu.Framework.iOS
         public IOSGameHost(IOSGameView gameView)
         {
             this.gameView = gameView;
-            NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillShowNotification, keyboardWillShow);
+            NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillShowNotification, handleKeyboardNotification);
+            NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.DidHideNotification, handleKeyboardNotification);
         }
 
-        private void keyboardWillShow(NSNotification notification)
+        /// <summary>
+        /// If the keyboard visibility changes (including the hardware keyboard helper bar) we select the keyboard
+        /// handler based on the height of the on-screen keyboard at the end of the animation. If the height is above
+        /// an arbitrary value, we decide that the software keyboard handler should be enabled. Otherwise, enable the
+        /// raw keyboard handler.
+        /// This will also cover the case where there is no first responder, in which case the raw handler will still
+        /// successfully catch key events.
+        /// </summary>
+        private void handleKeyboardNotification(NSNotification notification)
         {
             NSValue nsKeyboardFrame = (NSValue)notification.UserInfo[UIKeyboard.FrameEndUserInfoKey];
             RectangleF keyboardFrame = nsKeyboardFrame.RectangleFValue;
 
-            // if the keyboard height is above an arbitrary value, we assume software
             var softwareKeyboard = keyboardFrame.Height > 300;
 
             if (keyboardHandler != null)

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
+using Foundation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
@@ -11,16 +13,35 @@ using osu.Framework.IO.Stores;
 using osu.Framework.iOS.Graphics.Textures;
 using osu.Framework.iOS.Input;
 using osu.Framework.Platform;
+using UIKit;
 
 namespace osu.Framework.iOS
 {
     public class IOSGameHost : GameHost
     {
         private readonly IOSGameView gameView;
+        private IOSKeyboardHandler keyboardHandler;
+        private IOSRawKeyboardHandler rawKeyboardHandler;
 
         public IOSGameHost(IOSGameView gameView)
         {
             this.gameView = gameView;
+            NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillShowNotification, keyboardWillShow);
+        }
+
+        private void keyboardWillShow(NSNotification notification)
+        {
+            NSValue nsKeyboardFrame = (NSValue)notification.UserInfo[UIKeyboard.FrameEndUserInfoKey];
+            RectangleF keyboardFrame = nsKeyboardFrame.RectangleFValue;
+
+            // if the keyboard height is above an arbitrary value, we assume software
+            var softwareKeyboard = keyboardFrame.Height > 300;
+
+            if (keyboardHandler != null)
+                keyboardHandler.KeyboardActive = softwareKeyboard;
+
+            if (rawKeyboardHandler != null)
+                rawKeyboardHandler.KeyboardActive = !softwareKeyboard;
         }
 
         protected override void SetupForRun()
@@ -49,7 +70,7 @@ namespace osu.Framework.iOS
         public override ITextInputSource GetTextInput() => new IOSTextInput(gameView);
 
         protected override IEnumerable<InputHandler> CreateAvailableInputHandlers() =>
-            new InputHandler[] { new IOSTouchHandler(gameView), new IOSKeyboardHandler(gameView), new IOSRawKeyboardHandler() };
+            new InputHandler[] { new IOSTouchHandler(gameView), keyboardHandler = new IOSKeyboardHandler(gameView), rawKeyboardHandler = new IOSRawKeyboardHandler() };
 
         protected override Storage GetStorage(string baseName) => new IOSStorage(baseName, this);
 

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.iOS
     {
         public event Action<NSSet> HandleTouches;
 
-        public HiddenTextField KeyboardTextField { get; private set; }
+        public HiddenTextField KeyboardTextField { get; }
 
         [Export("layerClass")]
         public static Class LayerClass() => GetLayerClass();
@@ -44,7 +44,7 @@ namespace osu.Framework.iOS
             UserInteractionEnabled = true;
         }
 
-        public float Scale { get; private set; }
+        public float Scale { get; }
 
         // SafeAreaInsets is cached to prevent access outside the main thread
         private UIEdgeInsets safeArea = UIEdgeInsets.Zero;
@@ -105,10 +105,10 @@ namespace osu.Framework.iOS
             /// <summary>
             /// Placeholder text that the <see cref="HiddenTextField"/> will be populated with after every keystroke.
             /// </summary>
-            public const string PLACEHOLDER_TEXT = "placeholder placeholder placeholder";
+            private const string placeholder_text = "placeholder placeholder placeholder";
 
             /// <summary>
-            /// The approximate midpoint of <see cref="PLACEHOLDER_TEXT"/> that the cursor will be reset to after every keystroke.
+            /// The approximate midpoint of <see cref="placeholder_text"/> that the cursor will be reset to after every keystroke.
             /// </summary>
             public const int CURSOR_POSITION = 17;
 
@@ -156,7 +156,7 @@ namespace osu.Framework.iOS
             private void resetText()
             {
                 // we put in some dummy text and move the cursor to the middle so that backspace (and potentially delete or cursor keys) will be detected
-                Text = PLACEHOLDER_TEXT;
+                Text = placeholder_text;
                 var newPosition = GetPosition(BeginningOfDocument, CURSOR_POSITION);
                 SelectedTextRange = GetTextRange(newPosition, newPosition);
             }

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.iOS
     {
         public event Action<NSSet> HandleTouches;
 
-        public DummyTextField KeyboardTextField { get; private set; }
+        public HiddenTextField KeyboardTextField { get; private set; }
 
         [Export("layerClass")]
         public static Class LayerClass() => GetLayerClass();
@@ -33,7 +33,7 @@ namespace osu.Framework.iOS
             ContextRenderingApi = EAGLRenderingAPI.OpenGLES3;
             LayerRetainsBacking = false;
 
-            AddSubview(KeyboardTextField = new DummyTextField());
+            AddSubview(KeyboardTextField = new HiddenTextField());
         }
 
         protected override void ConfigureLayer(CAEAGLLayer eaglLayer)
@@ -96,13 +96,21 @@ namespace osu.Framework.iOS
 
         protected override bool ShouldCallOnRender => false;
 
-        public class DummyTextField : UITextField
+        public class HiddenTextField : UITextField
         {
             public event Action<NSRange, string> HandleShouldChangeCharacters;
             public event Action HandleShouldReturn;
             public event Action<UIKeyCommand> HandleKeyCommand;
 
-            public const int CURSOR_POSITION = 5;
+            /// <summary>
+            /// Placeholder text that the <see cref="HiddenTextField"/> will be populated with after every keystroke.
+            /// </summary>
+            public const string PLACEHOLDER_TEXT = "placeholder placeholder placeholder";
+
+            /// <summary>
+            /// The approximate midpoint of <see cref="PLACEHOLDER_TEXT"/> that the cursor will be reset to after every keystroke.
+            /// </summary>
+            public const int CURSOR_POSITION = 17;
 
             private int responderSemaphore;
 
@@ -110,7 +118,7 @@ namespace osu.Framework.iOS
             public override UITextSmartInsertDeleteType SmartInsertDeleteType => UITextSmartInsertDeleteType.No;
             public override UITextSmartQuotesType SmartQuotesType => UITextSmartQuotesType.No;
 
-            public DummyTextField()
+            public HiddenTextField()
             {
                 AutocapitalizationType = UITextAutocapitalizationType.None;
                 AutocorrectionType = UITextAutocorrectionType.No;
@@ -148,7 +156,7 @@ namespace osu.Framework.iOS
             private void resetText()
             {
                 // we put in some dummy text and move the cursor to the middle so that backspace (and potentially delete or cursor keys) will be detected
-                Text = "dummytext";
+                Text = PLACEHOLDER_TEXT;
                 var newPosition = GetPosition(BeginningOfDocument, CURSOR_POSITION);
                 SelectedTextRange = GetTextRange(newPosition, newPosition);
             }

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.iOS
             set { }
         }
 
-        protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new WindowMode[]
+        protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new[]
         {
             Configuration.WindowMode.Fullscreen,
         };

--- a/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
@@ -25,6 +25,9 @@ namespace osu.Framework.iOS.Input
 
         private void handleShouldChangeCharacters(NSRange range, string text)
         {
+            if (!IsActive)
+                return;
+
             if (text.Length == 0)
             {
                 Key key = range.Location < IOSGameView.HiddenTextField.CURSOR_POSITION ? Key.BackSpace : Key.Delete;
@@ -64,12 +67,18 @@ namespace osu.Framework.iOS.Input
 
         private void handleShouldReturn()
         {
+            if (!IsActive)
+                return;
+
             PendingInputs.Enqueue(new KeyboardKeyInput(Key.Enter, true));
             PendingInputs.Enqueue(new KeyboardKeyInput(Key.Enter, false));
         }
 
         private void handleKeyCommand(UIKeyCommand cmd)
         {
+            if (!IsActive)
+                return;
+
             Key? key;
             bool upper = false;
 
@@ -239,7 +248,8 @@ namespace osu.Framework.iOS.Input
             }
         }
 
-        public override bool IsActive => true;
+        internal bool KeyboardActive;
+        public override bool IsActive => KeyboardActive;
 
         public override int Priority => 0;
 

--- a/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
@@ -27,12 +27,20 @@ namespace osu.Framework.iOS.Input
         {
             if (text.Length == 0)
             {
+                Key key = range.Location < IOSGameView.HiddenTextField.CURSOR_POSITION ? Key.BackSpace : Key.Delete;
+
+                // NOTE: this makes the assumption that Key.ControlLeft triggers the WordPrevious platform action
+                if (range.Length > 1)
+                    PendingInputs.Enqueue(new KeyboardKeyInput(Key.ControlLeft, true));
+
                 if (range.Length > 0)
                 {
-                    Key key = range.Location < IOSGameView.DummyTextField.CURSOR_POSITION ? Key.BackSpace : Key.Delete;
                     PendingInputs.Enqueue(new KeyboardKeyInput(key, true));
                     PendingInputs.Enqueue(new KeyboardKeyInput(key, false));
                 }
+
+                if (range.Length > 1)
+                    PendingInputs.Enqueue(new KeyboardKeyInput(Key.ControlLeft, false));
 
                 return;
             }

--- a/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
@@ -108,6 +108,9 @@ namespace osu.Framework.iOS.Input
 
             switch (c)
             {
+                case ' ':
+                    return Key.Space;
+
                 case '\t':
                     return Key.Tab;
 

--- a/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.iOS.Input
             if (!(UIApplication.SharedApplication is GameUIApplication game))
                 return false;
 
-            game.KeyEvent += (int keyCode, bool isDown) =>
+            game.KeyEvent += (keyCode, isDown) =>
             {
                 if (IsActive && keyMap.ContainsKey(keyCode))
                     PendingInputs.Enqueue(new KeyboardKeyInput(keyMap[keyCode], isDown));

--- a/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
@@ -71,6 +71,7 @@ namespace osu.Framework.iOS.Input
             { 39, Key.Number0 },
             { 40, Key.Enter },
             { 41, Key.Escape },
+            { 42, Key.BackSpace },
             { 43, Key.Tab },
             { 44, Key.Space },
             { 45, Key.Minus },

--- a/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.iOS.Input
 {
     public class IOSRawKeyboardHandler : InputHandler
     {
-        internal bool KeyboardActive;
+        internal bool KeyboardActive = true;
         public override bool IsActive => KeyboardActive;
 
         public override int Priority => 0;

--- a/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
@@ -12,7 +12,8 @@ namespace osu.Framework.iOS.Input
 {
     public class IOSRawKeyboardHandler : InputHandler
     {
-        public override bool IsActive => true;
+        internal bool KeyboardActive;
+        public override bool IsActive => KeyboardActive;
 
         public override int Priority => 0;
 
@@ -23,7 +24,7 @@ namespace osu.Framework.iOS.Input
 
             game.KeyEvent += (int keyCode, bool isDown) =>
             {
-                if (keyMap.ContainsKey(keyCode))
+                if (IsActive && keyMap.ContainsKey(keyCode))
                     PendingInputs.Enqueue(new KeyboardKeyInput(keyMap[keyCode], isDown));
             };
 


### PR DESCRIPTION
* Spacebar on software keyboard was not queueing `KeyEvent`s.  Resolves #2526 
* Holding backspace on software keyboard was triggering "delete word" at the iOS level but not in the framework.  This means delete events were being slowed down by the operating system.
* Focusing a text box and connecting a hardware keyboard (including Smart Keyboard) would cause both keyboard handlers to enqueue `KeyEvent`s.
* Visual tests and SampleGame.iOS were not using `GameUIApplication`, which means the raw keyboard handler was never initialised.