### PR TITLE
Fix key repeats sometimes being ignored

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -405,8 +405,11 @@ namespace osu.Framework.Input
             {
                 handleKeyUp(state, key);
 
-                keyboardRepeatKey = null;
-                keyboardRepeatTime = 0;
+                if (key == keyboardRepeatKey)
+                {
+                    keyboardRepeatKey = null;
+                    keyboardRepeatTime = 0;
+                }
             }
         }
 


### PR DESCRIPTION
Ensures that key repeats will be ended only by releasing the currently repeated key.  Previously it was possible to stop a key repeat from triggering by releasing a different key.  Especially noticeable when arrowing through text boxes, but would occur for any key.

Scenario:
1. Left key is pressed.  Key repeat timer starts, key is set to Left.
2. Right key is pressed.  Key repeat timer restarts, key is set to Right.
3. Left key is released.  Key repeat timer stops, key is set to null.
4. Right key is still held, but is not repeating even though it is the most recent key down.

This PR changes step 3, so that the key repeat timer is only stopped if the Right key is released.