### PR TITLE
Add logging for non-background resource retrievals

### DIFF
--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -67,6 +67,8 @@ namespace osu.Framework.Graphics.Textures
         {
             if (string.IsNullOrEmpty(name)) return null;
 
+            this.LogIfNonBackgroundThread(name);
+
             lock (textureCache)
             {
                 // refresh the texture if no longer available (may have been previously disposed).

--- a/osu.Framework/IO/Stores/DllResourceStore.cs
+++ b/osu.Framework/IO/Stores/DllResourceStore.cs
@@ -27,6 +27,8 @@ namespace osu.Framework.IO.Stores
 
         public byte[] Get(string name)
         {
+            this.LogIfNonBackgroundThread(name);
+
             using (Stream input = GetStream(name))
             {
                 if (input == null)
@@ -40,6 +42,8 @@ namespace osu.Framework.IO.Stores
 
         public virtual async Task<byte[]> GetAsync(string name)
         {
+            this.LogIfNonBackgroundThread(name);
+
             using (Stream input = GetStream(name))
             {
                 if (input == null)
@@ -72,6 +76,8 @@ namespace osu.Framework.IO.Stores
 
         public Stream GetStream(string name)
         {
+            this.LogIfNonBackgroundThread(name);
+
             var split = name.Split('/');
             for (int i = 0; i < split.Length - 1; i++)
                 split[i] = split[i].Replace('-', '_');

--- a/osu.Framework/IO/Stores/IResourceStore.cs
+++ b/osu.Framework/IO/Stores/IResourceStore.cs
@@ -3,8 +3,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;
+using osu.Framework.Development;
+using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Logging;
 
 namespace osu.Framework.IO.Stores
 {
@@ -31,5 +35,22 @@ namespace osu.Framework.IO.Stores
         /// </summary>
         /// <returns>String representations of the resources available.</returns>
         IEnumerable<string> GetAvailableResources();
+    }
+
+    internal static class ResourceStoreExtensions
+    {
+        /// <summary>
+        /// Outputs a message to the log if a resource was not retrieved on a non-background thread.
+        /// </summary>
+        /// <param name="store">The store which the resources was retrieved from.</param>
+        /// <param name="resourceName">The resource retrieved.</param>
+        public static void LogIfNonBackgroundThread<T>(this IResourceStore<T> store, string resourceName)
+        {
+            if (ThreadSafety.IsUpdateThread || ThreadSafety.IsDrawThread || ThreadSafety.IsAudioThread)
+            {
+                Logger.Log($"Resource {resourceName} was retrieved from a {store.GetType().ReadableName()} on a non-background thread.", LoggingTarget.Performance);
+                Logger.Log(new StackTrace(1).ToString(), LoggingTarget.Performance, outputToListeners: false);
+            }
+        }
     }
 }

--- a/osu.Framework/IO/Stores/OnlineStore.cs
+++ b/osu.Framework/IO/Stores/OnlineStore.cs
@@ -14,6 +14,8 @@ namespace osu.Framework.IO.Stores
     {
         public async Task<byte[]> GetAsync(string url)
         {
+            this.LogIfNonBackgroundThread(url);
+
             try
             {
                 using (WebRequest req = new WebRequest($@"{url}"))
@@ -32,6 +34,8 @@ namespace osu.Framework.IO.Stores
         {
             if (!url.StartsWith(@"https://", StringComparison.Ordinal))
                 return null;
+
+            this.LogIfNonBackgroundThread(url);
 
             try
             {

--- a/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
+++ b/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
@@ -24,6 +24,8 @@ namespace osu.Framework.IO.Stores
 
         public byte[] Get(string name)
         {
+            this.LogIfNonBackgroundThread(name);
+
             using (Stream stream = storage.GetStream(name))
             {
                 if (stream == null) return null;
@@ -36,6 +38,8 @@ namespace osu.Framework.IO.Stores
 
         public virtual async Task<byte[]> GetAsync(string name)
         {
+            this.LogIfNonBackgroundThread(name);
+
             using (Stream stream = storage.GetStream(name))
             {
                 if (stream == null) return null;
@@ -46,7 +50,12 @@ namespace osu.Framework.IO.Stores
             }
         }
 
-        public Stream GetStream(string name) => storage.GetStream(name);
+        public Stream GetStream(string name)
+        {
+            this.LogIfNonBackgroundThread(name);
+
+            return storage.GetStream(name);
+        }
 
         public IEnumerable<string> GetAvailableResources() =>
             storage.GetDirectories(string.Empty).SelectMany(storage.GetFiles);


### PR DESCRIPTION
Resolves #2529

Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/2543

Example:

Console:
```
[performance:verbose] 2019-06-17 07:20:38: Resource Textures/Grades/A.png was retrieved from a DllResourceStore on a non-background thread.
```
performance.log:
```
2019-06-17 07:20:38: Resource Textures/Grades/A.png was retrieved from a DllResourceStore on a non-background thread.

2019-06-17 07:20:38: at osu.Framework.IO.Stores.DllResourceStore.GetStream(String name)
2019-06-17 07:20:38: at osu.Framework.IO.Stores.ResourceStore`1.GetStream(String name)
2019-06-17 07:20:38: at osu.Framework.IO.Stores.ResourceStore`1.GetStream(String name)
2019-06-17 07:20:38: at osu.Framework.Graphics.Textures.TextureLoaderStore.Get(String name)
2019-06-17 07:20:38: at osu.Framework.IO.Stores.ResourceStore`1.Get(String name)
2019-06-17 07:20:38: at osu.Framework.Graphics.Textures.TextureStore.getTexture(String name)
2019-06-17 07:20:38: at osu.Framework.Graphics.Textures.TextureStore.Get(String name)
2019-06-17 07:20:38: at osu.Game.Online.Leaderboards.DrawableRank.updateTexture()
2019-06-17 07:20:38: at osu.Game.Online.Leaderboards.DrawableRank.load(TextureStore textures)
2019-06-17 07:20:38: at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
2019-06-17 07:20:38: at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
2019-06-17 07:20:38: at osu.Framework.Allocation.BackgroundDependencyLoaderAttribute.<>c__DisplayClass6_1.<CreateActivator>b__4(Object target, IReadOnlyDependencyContainer dc)
2019-06-17 07:20:38: at osu.Framework.Allocation.DependencyActivator.activate(Object obj, IReadOnlyDependencyContainer dependencies)
--snip--
osu.Framework.Graphics.Containers.CompositeDrawable.loadChild(Drawable child)
2019-06-17 07:20:38: at osu.Framework.Graphics.Containers.CompositeDrawable.AddInternal(Drawable drawable)
2019-06-17 07:20:38: at osu.Framework.Graphics.Containers.CompositeDrawable.AddRangeInternal(IEnumerable`1 range)
2019-06-17 07:20:38: at osu.Framework.Graphics.Containers.CompositeDrawable.set_InternalChildrenEnumerable(IEnumerable`1 value)
2019-06-17 07:20:38: at osu.Framework.Graphics.Containers.CompositeDrawable.set_InternalChildren(IReadOnlyList`1 value)
2019-06-17 07:20:38: at osu.Game.Overlays.Profile.Header.DetailHeaderContainer.load(OsuColour colours)
--snip--
2019-06-17 07:20:38: at osu.Framework.Graphics.Containers.Container`1.Add(T drawable)
2019-06-17 07:20:38: at osu.Framework.Graphics.Containers.Container`1.Add(T drawable)
2019-06-17 07:20:38: at osu.Framework.Graphics.Containers.Container`1.Add(T drawable)
2019-06-17 07:20:38: at osu.Game.Overlays.UserProfileOverlay.ShowUser(User user, Boolean fetchOnline)
2019-06-17 07:20:38: at osu.Game.Users.UserPanel.<>c__DisplayClass19_0.<load>b__2()
2019-06-17 07:20:38: at osu.Framework.Graphics.Containers.ClickableContainer.OnClick(ClickEvent e)
2019-06-17 07:20:38: at osu.Framework.Graphics.Drawable.TriggerEvent(UIEvent e)
2019-06-17 07:20:38: at osu.Framework.Input.MouseButtonEventManager.<>c__DisplayClass38_0.<PropagateMouseButtonEvent>b__0(Drawable target)
--snip--
```

It's a little bit spammy, especially with fonts, because even cached texture retrievals are logged. The alternative is to not log cached texture retrievals but that introduces possible uncertainties, opinions appreciated.