### PR TITLE
Fix UI controls implementing IHasCurrentValue in an unsafe way

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCheckboxes.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCheckboxes.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
@@ -12,6 +14,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestSceneCheckboxes : FrameworkTestScene
     {
+        private readonly BasicCheckbox basic;
+
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
             typeof(Checkbox),
@@ -34,7 +38,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     AutoSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
-                        new BasicCheckbox
+                        basic = new BasicCheckbox
                         {
                             LabelText = @"Basic Test"
                         },
@@ -57,6 +61,29 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             swap.Current.ValueChanged += check => swap.RightHandedCheckbox = check.NewValue;
             rotate.Current.ValueChanged += e => rotate.RotateTo(e.NewValue ? 45 : 0, 100);
+        }
+
+        /// <summary>
+        /// Test safety of <see cref="IHasCurrentValue{T}"/> implementation.
+        /// This is shared across all UI elements.
+        /// </summary>
+        [Test]
+        public void TestDirectToggle()
+        {
+            var testBindable = basic.Current.GetBoundCopy();
+
+            AddAssert("is unchecked", () => !basic.Current.Value);
+            AddAssert("bindable unchecked", () => !testBindable.Value);
+
+            AddStep("switch bindable directly", () => basic.Current.Value = true);
+
+            AddAssert("is checked", () => basic.Current.Value);
+            AddAssert("bindable checked", () => testBindable.Value);
+
+            AddStep("change bindable", () => basic.Current = new Bindable<bool>());
+
+            AddAssert("is unchecked", () => !basic.Current.Value);
+            AddAssert("bindable unchecked", () => !testBindable.Value);
         }
     }
 }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -99,6 +99,8 @@ namespace osu.Framework.Graphics.Sprites
 
         private readonly Bindable<string> current = new Bindable<string>(string.Empty);
 
+        private Bindable<string> currentBound;
+
         public Bindable<string> Current
         {
             get => current;
@@ -107,8 +109,8 @@ namespace osu.Framework.Graphics.Sprites
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindBindings();
-                current.BindTo(value);
+                current.UnbindFrom(currentBound);
+                current.BindTo(currentBound = value);
             }
         }
 

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -109,7 +109,7 @@ namespace osu.Framework.Graphics.Sprites
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindFrom(currentBound);
+                if (currentBound != null) current.UnbindFrom(currentBound);
                 current.BindTo(currentBound = value);
             }
         }

--- a/osu.Framework/Graphics/UserInterface/Checkbox.cs
+++ b/osu.Framework/Graphics/UserInterface/Checkbox.cs
@@ -15,6 +15,8 @@ namespace osu.Framework.Graphics.UserInterface
     {
         private readonly Bindable<bool> current = new Bindable<bool>();
 
+        private Bindable<bool> currentBound;
+
         /// <summary>
         /// A bindable that holds the value if the checkbox is checked or not.
         /// </summary>
@@ -26,8 +28,8 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindBindings();
-                current.BindTo(value);
+                current.UnbindFrom(currentBound);
+                current.BindTo(currentBound = value);
             }
         }
 

--- a/osu.Framework/Graphics/UserInterface/Checkbox.cs
+++ b/osu.Framework/Graphics/UserInterface/Checkbox.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindFrom(currentBound);
+                if (currentBound != null) current.UnbindFrom(currentBound);
                 current.BindTo(currentBound = value);
             }
         }

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindFrom(currentBound);
+                if (currentBound != null) current.UnbindFrom(currentBound);
                 current.BindTo(currentBound = value);
             }
         }

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -15,6 +15,8 @@ namespace osu.Framework.Graphics.UserInterface
     {
         private readonly Bindable<double> current = new Bindable<double>();
 
+        private Bindable<double> currentBound;
+
         public Bindable<double> Current
         {
             get => current;
@@ -23,8 +25,8 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindBindings();
-                current.BindTo(value);
+                current.UnbindFrom(currentBound);
+                current.BindTo(currentBound = value);
             }
         }
 

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -169,6 +169,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         private readonly Bindable<T> current = new Bindable<T>();
 
+        private Bindable<T> currentBound;
+
         public Bindable<T> Current
         {
             get => current;
@@ -177,8 +179,8 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindBindings();
-                current.BindTo(value);
+                current.UnbindFrom(currentBound);
+                current.BindTo(currentBound = value);
             }
         }
 

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -179,7 +179,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindFrom(currentBound);
+                if (currentBound != null) current.UnbindFrom(currentBound);
                 current.BindTo(currentBound = value);
             }
         }

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -25,6 +25,8 @@ namespace osu.Framework.Graphics.UserInterface
     {
         private readonly Bindable<T> current = new Bindable<T>();
 
+        private Bindable<T> currentBound;
+
         public Bindable<T> Current
         {
             get => current;
@@ -33,8 +35,8 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindBindings();
-                current.BindTo(value);
+                current.UnbindFrom(currentBound);
+                current.BindTo(currentBound = value);
             }
         }
 

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindFrom(currentBound);
+                if (currentBound != null) current.UnbindFrom(currentBound);
                 current.BindTo(currentBound = value);
             }
         }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -606,7 +606,7 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindFrom(currentBound);
+                if (currentBound != null) current.UnbindFrom(currentBound);
                 current.BindTo(currentBound = value);
             }
         }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -596,6 +596,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         private readonly Bindable<string> current = new Bindable<string>(string.Empty);
 
+        private Bindable<string> currentBound;
+
         public Bindable<string> Current
         {
             get => current;
@@ -604,8 +606,8 @@ namespace osu.Framework.Graphics.UserInterface
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                current.UnbindBindings();
-                current.BindTo(value);
+                current.UnbindFrom(currentBound);
+                current.BindTo(currentBound = value);
             }
         }
 


### PR DESCRIPTION
If an implementation of a UI control was binding to its own `Current` internally, an external change to `Current` via the setter could cause loss of flow of information.