### PR TITLE
 Add generalized Annulus alongside CircularProgress

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneAnnulus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneAnnulus.cs
@@ -13,21 +13,17 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneCircularProgress : FrameworkTestScene
+    public class TestSceneAnnulus : FrameworkTestScene
     {
-        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(CircularProgress), typeof(Annulus), typeof(AnnulusDrawNode) };
+        public override IReadOnlyList<Type> RequiredTypes => new[] { typeof(Annulus), typeof(AnnulusDrawNode) };
 
-        private readonly CircularProgress clock;
-
-        private int rotateMode;
-        private const double period = 4000;
-        private const double transition_period = 2000;
+        private readonly Annulus annulus;
 
         private readonly Texture gradientTextureHorizontal;
         private readonly Texture gradientTextureVertical;
         private readonly Texture gradientTextureBoth;
 
-        public TestSceneCircularProgress()
+        public TestSceneAnnulus()
         {
             const int width = 128;
 
@@ -77,7 +73,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             Children = new Drawable[]
             {
-                clock = new CircularProgress
+                annulus = new Annulus
                 {
                     Width = 0.8f,
                     Height = 0.8f,
@@ -87,15 +83,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 },
             };
 
-            AddStep("Forward", () => rotateMode = 1);
-            AddStep("Backward", () => rotateMode = 2);
-            AddStep("Transition Focus", () => rotateMode = 3);
-            AddStep("Transition Focus 2", () => rotateMode = 4);
-            AddStep("Forward/Backward", () => rotateMode = 0);
-
             AddStep("Horizontal Gradient Texture", () => setTexture(1));
             AddStep("Vertical Gradient Texture", () => setTexture(2));
-            AddStep("2D Gradient Texture", () => setTexture(3));
+            AddStep("2D Graident Texture", () => setTexture(3));
             AddStep("White Texture", () => setTexture(0));
 
             AddStep("Red Colour", () => setColour(1));
@@ -104,37 +94,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("2D Gradient Colour", () => setColour(4));
             AddStep("White Colour", () => setColour(0));
 
-            AddSliderStep("Progress start angle", 0.0, 1.0, 0.0, angle => clock.ProgressStartAngle.Value = angle);
-            AddSliderStep("Progress end angle", 0.0, 1.0, 1.0, angle => clock.ProgressEndAngle.Value = angle);
-            AddSliderStep("Fill", 0, 10, 10, fill => clock.InnerRadius = fill / 10f);
-        }
-
-        protected override void Update()
-        {
-            base.Update();
-
-            switch (rotateMode)
-            {
-                case 0:
-                    clock.Current.Value = Time.Current % (period * 2) / period - 1;
-                    break;
-
-                case 1:
-                    clock.Current.Value = Time.Current % period / period;
-                    break;
-
-                case 2:
-                    clock.Current.Value = Time.Current % period / period - 1;
-                    break;
-
-                case 3:
-                    clock.Current.Value = Time.Current % transition_period / transition_period / 5 - 0.1f;
-                    break;
-
-                case 4:
-                    clock.Current.Value = (Time.Current % transition_period / transition_period / 5 - 0.1f + 2) % 2 - 1;
-                    break;
-            }
+            AddSliderStep("Start angle", 0.0, 1.0, 0.0, angle => annulus.StartAngle.Value = angle);
+            AddSliderStep("End angle", 0.0, 1.0, 1.0, angle => annulus.EndAngle.Value = angle);
+            AddSliderStep("Fill", 0, 10, 10, fill => annulus.InnerRadius = fill / 10f);
         }
 
         private void setTexture(int textureMode)
@@ -142,19 +104,19 @@ namespace osu.Framework.Tests.Visual.UserInterface
             switch (textureMode)
             {
                 case 0:
-                    clock.Texture = Texture.WhitePixel;
+                    annulus.Texture = Texture.WhitePixel;
                     break;
 
                 case 1:
-                    clock.Texture = gradientTextureHorizontal;
+                    annulus.Texture = gradientTextureHorizontal;
                     break;
 
                 case 2:
-                    clock.Texture = gradientTextureVertical;
+                    annulus.Texture = gradientTextureVertical;
                     break;
 
                 case 3:
-                    clock.Texture = gradientTextureBoth;
+                    annulus.Texture = gradientTextureBoth;
                     break;
             }
         }
@@ -164,15 +126,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
             switch (colourMode)
             {
                 case 0:
-                    clock.Colour = new Color4(255, 255, 255, 255);
+                    annulus.Colour = new Color4(255, 255, 255, 255);
                     break;
 
                 case 1:
-                    clock.Colour = new Color4(255, 128, 128, 255);
+                    annulus.Colour = new Color4(255, 128, 128, 255);
                     break;
 
                 case 2:
-                    clock.Colour = new ColourInfo
+                    annulus.Colour = new ColourInfo
                     {
                         TopLeft = new Color4(255, 128, 128, 255),
                         TopRight = new Color4(128, 255, 128, 255),
@@ -182,7 +144,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     break;
 
                 case 3:
-                    clock.Colour = new ColourInfo
+                    annulus.Colour = new ColourInfo
                     {
                         TopLeft = new Color4(255, 128, 128, 255),
                         TopRight = new Color4(255, 128, 128, 255),
@@ -192,7 +154,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     break;
 
                 case 4:
-                    clock.Colour = new ColourInfo
+                    annulus.Colour = new ColourInfo
                     {
                         TopLeft = new Color4(255, 128, 128, 255),
                         TopRight = new Color4(128, 255, 128, 255),

--- a/osu.Framework/Graphics/UserInterface/Annulus.cs
+++ b/osu.Framework/Graphics/UserInterface/Annulus.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Graphics.Transforms;
+using osuTK;
+
+namespace osu.Framework.Graphics.UserInterface
+{
+    public class Annulus : Drawable, ITexturedShaderDrawable
+    {
+        protected readonly Bindable<double> startAngle = new Bindable<double>();
+        protected readonly Bindable<double> endAngle = new Bindable<double>();
+
+        public Bindable<double> StartAngle
+        {
+            get => startAngle;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                startAngle.UnbindBindings();
+                startAngle.BindTo(value);
+            }
+        }
+
+        public Bindable<double> EndAngle
+        {
+            get => endAngle;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                endAngle.UnbindBindings();
+                endAngle.BindTo(value);
+            }
+        }
+
+        public Annulus()
+        {
+            StartAngle.ValueChanged += _ => Invalidate(Invalidation.DrawNode);
+            EndAngle.ValueChanged += _ => Invalidate(Invalidation.DrawNode);
+        }
+
+        public IShader RoundedTextureShader { get; private set; }
+        public IShader TextureShader { get; private set; }
+
+        #region Disposal
+
+        protected override void Dispose(bool isDisposing)
+        {
+            texture?.Dispose();
+            texture = null;
+
+            base.Dispose(isDisposing);
+        }
+
+        #endregion
+
+        protected override DrawNode CreateDrawNode() => new AnnulusDrawNode(this);
+
+        [BackgroundDependencyLoader]
+        private void load(ShaderManager shaders)
+        {
+            RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
+            TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+        }
+
+        private Texture texture = Texture.WhitePixel;
+
+        public Texture Texture
+        {
+            get => texture;
+            set
+            {
+                if (value == texture)
+                    return;
+
+                texture?.Dispose();
+                texture = value;
+
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+
+        private float innerRadius = 1;
+
+        /// <summary>
+        /// The inner fill radius, relative to the <see cref="Drawable.DrawSize"/> of the <see cref="CircularProgress"/>.
+        /// The value range is 0 to 1 where 0 is invisible and 1 is completely filled.
+        /// The entire texture still fills the disk without cropping it.
+        /// </summary>
+        public float InnerRadius
+        {
+            get => innerRadius;
+            set
+            {
+                innerRadius = MathHelper.Clamp(value, 0, 1);
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/Annulus.cs
+++ b/osu.Framework/Graphics/UserInterface/Annulus.cs
@@ -6,15 +6,14 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Graphics.Transforms;
 using osuTK;
 
 namespace osu.Framework.Graphics.UserInterface
 {
     public class Annulus : Drawable, ITexturedShaderDrawable
     {
-        protected readonly Bindable<double> startAngle = new Bindable<double>();
-        protected readonly Bindable<double> endAngle = new Bindable<double>();
+        private readonly Bindable<double> startAngle = new Bindable<double>();
+        private readonly Bindable<double> endAngle = new Bindable<double>();
 
         public Bindable<double> StartAngle
         {

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        public CircularProgress() : base()
+        public CircularProgress()
         {
             ProgressStartAngle.ValueChanged += recalculateAngles;
             ProgressEndAngle.ValueChanged += recalculateAngles;

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -2,18 +2,42 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Graphics.Shaders;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Transforms;
-using osuTK;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    public class CircularProgress : Drawable, ITexturedShaderDrawable, IHasCurrentValue<double>
+    public class CircularProgress : Annulus, IHasCurrentValue<double>
     {
+        private readonly Bindable<double> progressStartAngle = new Bindable<double>();
+        private readonly Bindable<double> progressEndAngle = new Bindable<double>();
         private readonly Bindable<double> current = new Bindable<double>();
+
+        public Bindable<double> ProgressStartAngle
+        {
+            get => progressStartAngle;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                progressStartAngle.UnbindBindings();
+                progressStartAngle.BindTo(value);
+            }
+        }
+
+        public Bindable<double> ProgressEndAngle
+        {
+            get => progressEndAngle;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                progressEndAngle.UnbindBindings();
+                progressEndAngle.BindTo(value);
+            }
+        }
 
         public Bindable<double> Current
         {
@@ -28,71 +52,23 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        public CircularProgress()
+        public CircularProgress() : base()
         {
-            Current.ValueChanged += newValue => Invalidate(Invalidation.DrawNode);
+            ProgressStartAngle.ValueChanged += recalculateAngles;
+            ProgressEndAngle.ValueChanged += recalculateAngles;
+            Current.ValueChanged += recalculateAngles;
         }
 
-        public IShader RoundedTextureShader { get; private set; }
-        public IShader TextureShader { get; private set; }
-
-        #region Disposal
-
-        protected override void Dispose(bool isDisposing)
+        private void recalculateAngles(ValueChangedEvent<double> args)
         {
-            texture?.Dispose();
-            texture = null;
+            StartAngle.Value = ProgressStartAngle.Value;
+            EndAngle.Value = ProgressStartAngle.Value + Current.Value * (ProgressEndAngle.Value - ProgressStartAngle.Value);
 
-            base.Dispose(isDisposing);
+            Invalidate(Invalidation.DrawNode);
         }
-
-        #endregion
-
-        protected override DrawNode CreateDrawNode() => new CircularProgressDrawNode(this);
 
         public TransformSequence<CircularProgress> FillTo(double newValue, double duration = 0, Easing easing = Easing.None)
             => this.TransformBindableTo(Current, newValue, duration, easing);
-
-        [BackgroundDependencyLoader]
-        private void load(ShaderManager shaders)
-        {
-            RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
-            TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
-        }
-
-        private Texture texture = Texture.WhitePixel;
-
-        public Texture Texture
-        {
-            get => texture;
-            set
-            {
-                if (value == texture)
-                    return;
-
-                texture?.Dispose();
-                texture = value;
-
-                Invalidate(Invalidation.DrawNode);
-            }
-        }
-
-        private float innerRadius = 1;
-
-        /// <summary>
-        /// The inner fill radius, relative to the <see cref="Drawable.DrawSize"/> of the <see cref="CircularProgress"/>.
-        /// The value range is 0 to 1 where 0 is invisible and 1 is completely filled.
-        /// The entire texture still fills the disk without cropping it.
-        /// </summary>
-        public float InnerRadius
-        {
-            get => innerRadius;
-            set
-            {
-                innerRadius = MathHelper.Clamp(value, 0, 1);
-                Invalidate(Invalidation.DrawNode);
-            }
-        }
     }
 
     public static class CircularProgressExtensions


### PR DESCRIPTION
Replaces #2349:

> * Refactors CircularProgressDrawNode into AnnularDrawNode, allowing changes to be made to both the start and end positions of the ring.
>* Adds generic Annulus class for use in fun stuff, while CircularProgress retains previous functionality with the additional ability to have an adjustable start and end position.
>
>For consideration:
>
> * Currently, an annulus samples its texture starting from its StartAngle and ending at StartAngle + 2π (i.e. no scaling to EndAngle).