### PR TITLE
Fix backspace on iOS

### DIFF
--- a/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
+++ b/osu.Framework.iOS/Graphics/Textures/IOSTextureLoaderStore.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.iOS.Graphics.Textures
         {
         }
 
-        protected unsafe override Image<TPixel> ImageFromStream<TPixel>(Stream stream)
+        protected override unsafe Image<TPixel> ImageFromStream<TPixel>(Stream stream)
         {
             using (var uiImage = UIImage.LoadFromData(NSData.FromStream(stream)))
             {

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.iOS
     {
         public event Action<NSSet> HandleTouches;
 
-        public HiddenTextField KeyboardTextField { get; private set; }
+        public HiddenTextField KeyboardTextField { get; }
 
         [Export("layerClass")]
         public static Class LayerClass() => GetLayerClass();
@@ -44,7 +44,7 @@ namespace osu.Framework.iOS
             UserInteractionEnabled = true;
         }
 
-        public float Scale { get; private set; }
+        public float Scale { get; }
 
         // SafeAreaInsets is cached to prevent access outside the main thread
         private UIEdgeInsets safeArea = UIEdgeInsets.Zero;
@@ -105,10 +105,10 @@ namespace osu.Framework.iOS
             /// <summary>
             /// Placeholder text that the <see cref="HiddenTextField"/> will be populated with after every keystroke.
             /// </summary>
-            public const string PLACEHOLDER_TEXT = "placeholder placeholder placeholder";
+            private const string placeholder_text = "placeholder placeholder placeholder";
 
             /// <summary>
-            /// The approximate midpoint of <see cref="PLACEHOLDER_TEXT"/> that the cursor will be reset to after every keystroke.
+            /// The approximate midpoint of <see cref="placeholder_text"/> that the cursor will be reset to after every keystroke.
             /// </summary>
             public const int CURSOR_POSITION = 17;
 
@@ -156,7 +156,7 @@ namespace osu.Framework.iOS
             private void resetText()
             {
                 // we put in some dummy text and move the cursor to the middle so that backspace (and potentially delete or cursor keys) will be detected
-                Text = PLACEHOLDER_TEXT;
+                Text = placeholder_text;
                 var newPosition = GetPosition(BeginningOfDocument, CURSOR_POSITION);
                 SelectedTextRange = GetTextRange(newPosition, newPosition);
             }

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -105,12 +105,12 @@ namespace osu.Framework.iOS
             /// <summary>
             /// Placeholder text that the <see cref="HiddenTextField"/> will be populated with after every keystroke.
             /// </summary>
-            private const string placeholder_text = "placeholder placeholder placeholder";
+            private const string placeholder_text = "aaaaaa";
 
             /// <summary>
             /// The approximate midpoint of <see cref="placeholder_text"/> that the cursor will be reset to after every keystroke.
             /// </summary>
-            public const int CURSOR_POSITION = 17;
+            public const int CURSOR_POSITION = 3;
 
             private int responderSemaphore;
 

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.iOS
     {
         public event Action<NSSet> HandleTouches;
 
-        public DummyTextField KeyboardTextField { get; private set; }
+        public HiddenTextField KeyboardTextField { get; private set; }
 
         [Export("layerClass")]
         public static Class LayerClass() => GetLayerClass();
@@ -33,7 +33,7 @@ namespace osu.Framework.iOS
             ContextRenderingApi = EAGLRenderingAPI.OpenGLES3;
             LayerRetainsBacking = false;
 
-            AddSubview(KeyboardTextField = new DummyTextField());
+            AddSubview(KeyboardTextField = new HiddenTextField());
         }
 
         protected override void ConfigureLayer(CAEAGLLayer eaglLayer)
@@ -96,13 +96,21 @@ namespace osu.Framework.iOS
 
         protected override bool ShouldCallOnRender => false;
 
-        public class DummyTextField : UITextField
+        public class HiddenTextField : UITextField
         {
             public event Action<NSRange, string> HandleShouldChangeCharacters;
             public event Action HandleShouldReturn;
             public event Action<UIKeyCommand> HandleKeyCommand;
 
-            public const int CURSOR_POSITION = 5;
+            /// <summary>
+            /// Placeholder text that the <see cref="HiddenTextField"/> will be populated with after every keystroke.
+            /// </summary>
+            public const string PLACEHOLDER_TEXT = "placeholder placeholder placeholder";
+
+            /// <summary>
+            /// The approximate midpoint of <see cref="PLACEHOLDER_TEXT"/> that the cursor will be reset to after every keystroke.
+            /// </summary>
+            public const int CURSOR_POSITION = 17;
 
             private int responderSemaphore;
 
@@ -110,7 +118,7 @@ namespace osu.Framework.iOS
             public override UITextSmartInsertDeleteType SmartInsertDeleteType => UITextSmartInsertDeleteType.No;
             public override UITextSmartQuotesType SmartQuotesType => UITextSmartQuotesType.No;
 
-            public DummyTextField()
+            public HiddenTextField()
             {
                 AutocapitalizationType = UITextAutocapitalizationType.None;
                 AutocorrectionType = UITextAutocorrectionType.No;
@@ -148,7 +156,7 @@ namespace osu.Framework.iOS
             private void resetText()
             {
                 // we put in some dummy text and move the cursor to the middle so that backspace (and potentially delete or cursor keys) will be detected
-                Text = "dummytext";
+                Text = PLACEHOLDER_TEXT;
                 var newPosition = GetPosition(BeginningOfDocument, CURSOR_POSITION);
                 SelectedTextRange = GetTextRange(newPosition, newPosition);
             }

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.iOS
             set { }
         }
 
-        protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new WindowMode[]
+        protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new[]
         {
             Configuration.WindowMode.Fullscreen,
         };

--- a/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
@@ -27,12 +27,20 @@ namespace osu.Framework.iOS.Input
         {
             if (text.Length == 0)
             {
+                Key key = range.Location < IOSGameView.HiddenTextField.CURSOR_POSITION ? Key.BackSpace : Key.Delete;
+
+                // NOTE: this makes the assumption that Key.ControlLeft triggers the WordPrevious platform action
+                if (range.Length > 1)
+                    PendingInputs.Enqueue(new KeyboardKeyInput(Key.ControlLeft, true));
+
                 if (range.Length > 0)
                 {
-                    Key key = range.Location < IOSGameView.DummyTextField.CURSOR_POSITION ? Key.BackSpace : Key.Delete;
                     PendingInputs.Enqueue(new KeyboardKeyInput(key, true));
                     PendingInputs.Enqueue(new KeyboardKeyInput(key, false));
                 }
+
+                if (range.Length > 1)
+                    PendingInputs.Enqueue(new KeyboardKeyInput(Key.ControlLeft, false));
 
                 return;
             }

--- a/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.iOS.Input
             if (!(UIApplication.SharedApplication is GameUIApplication game))
                 return false;
 
-            game.KeyEvent += (int keyCode, bool isDown) =>
+            game.KeyEvent += (keyCode, isDown) =>
             {
                 if (keyMap.ContainsKey(keyCode))
                     PendingInputs.Enqueue(new KeyboardKeyInput(keyMap[keyCode], isDown));

--- a/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
@@ -70,6 +70,7 @@ namespace osu.Framework.iOS.Input
             { 39, Key.Number0 },
             { 40, Key.Enter },
             { 41, Key.Escape },
+            { 42, Key.BackSpace },
             { 43, Key.Tab },
             { 44, Key.Space },
             { 45, Key.Minus },


### PR DESCRIPTION
Holding backspace on software keyboard was triggering "delete word" at the iOS level but not in the framework. This means delete events were being slowed down by the operating system.  Also backspace was not being correctly handled by the hardware keyboard.