### PR TITLE
Ensure iOS only ever uses one keyboard handler at a time

### DIFF
--- a/SampleGame.iOS/Application.cs
+++ b/SampleGame.iOS/Application.cs
@@ -12,7 +12,7 @@ namespace SampleGame.iOS
         {
             // if you want to use a different Application Delegate class from "AppDelegate"
             // you can specify it here.
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, "GameUIApplication", "AppDelegate");
         }
     }
 }

--- a/osu.Framework.Tests.iOS/Application.cs
+++ b/osu.Framework.Tests.iOS/Application.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Tests.iOS
         {
             // if you want to use a different Application Delegate class from "AppDelegate"
             // you can specify it here.
-            UIApplication.Main(args, null, "AppDelegate");
+            UIApplication.Main(args, "GameUIApplication", "AppDelegate");
         }
     }
 }

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -26,15 +26,23 @@ namespace osu.Framework.iOS
         public IOSGameHost(IOSGameView gameView)
         {
             this.gameView = gameView;
-            NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillShowNotification, keyboardWillShow);
+            NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillShowNotification, handleKeyboardNotification);
+            NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.DidHideNotification, handleKeyboardNotification);
         }
 
-        private void keyboardWillShow(NSNotification notification)
+        /// <summary>
+        /// If the keyboard visibility changes (including the hardware keyboard helper bar) we select the keyboard
+        /// handler based on the height of the on-screen keyboard at the end of the animation. If the height is above
+        /// an arbitrary value, we decide that the software keyboard handler should be enabled. Otherwise, enable the
+        /// raw keyboard handler.
+        /// This will also cover the case where there is no first responder, in which case the raw handler will still
+        /// successfully catch key events.
+        /// </summary>
+        private void handleKeyboardNotification(NSNotification notification)
         {
             NSValue nsKeyboardFrame = (NSValue)notification.UserInfo[UIKeyboard.FrameEndUserInfoKey];
             RectangleF keyboardFrame = nsKeyboardFrame.RectangleFValue;
 
-            // if the keyboard height is above an arbitrary value, we assume software
             var softwareKeyboard = keyboardFrame.Height > 300;
 
             if (keyboardHandler != null)

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -43,13 +43,15 @@ namespace osu.Framework.iOS
             NSValue nsKeyboardFrame = (NSValue)notification.UserInfo[UIKeyboard.FrameEndUserInfoKey];
             RectangleF keyboardFrame = nsKeyboardFrame.RectangleFValue;
 
-            var softwareKeyboard = keyboardFrame.Height > 300;
+            var softwareKeyboard = keyboardFrame.Height > 120;
 
             if (keyboardHandler != null)
                 keyboardHandler.KeyboardActive = softwareKeyboard;
 
             if (rawKeyboardHandler != null)
                 rawKeyboardHandler.KeyboardActive = !softwareKeyboard;
+
+            gameView.KeyboardTextField.SoftwareKeyboard = softwareKeyboard;
         }
 
         protected override void SetupForRun()

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
+using Foundation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Input;
@@ -11,16 +13,35 @@ using osu.Framework.IO.Stores;
 using osu.Framework.iOS.Graphics.Textures;
 using osu.Framework.iOS.Input;
 using osu.Framework.Platform;
+using UIKit;
 
 namespace osu.Framework.iOS
 {
     public class IOSGameHost : GameHost
     {
         private readonly IOSGameView gameView;
+        private IOSKeyboardHandler keyboardHandler;
+        private IOSRawKeyboardHandler rawKeyboardHandler;
 
         public IOSGameHost(IOSGameView gameView)
         {
             this.gameView = gameView;
+            NSNotificationCenter.DefaultCenter.AddObserver(UIKeyboard.WillShowNotification, keyboardWillShow);
+        }
+
+        private void keyboardWillShow(NSNotification notification)
+        {
+            NSValue nsKeyboardFrame = (NSValue)notification.UserInfo[UIKeyboard.FrameEndUserInfoKey];
+            RectangleF keyboardFrame = nsKeyboardFrame.RectangleFValue;
+
+            // if the keyboard height is above an arbitrary value, we assume software
+            var softwareKeyboard = keyboardFrame.Height > 300;
+
+            if (keyboardHandler != null)
+                keyboardHandler.KeyboardActive = softwareKeyboard;
+
+            if (rawKeyboardHandler != null)
+                rawKeyboardHandler.KeyboardActive = !softwareKeyboard;
         }
 
         protected override void SetupForRun()
@@ -49,7 +70,7 @@ namespace osu.Framework.iOS
         public override ITextInputSource GetTextInput() => new IOSTextInput(gameView);
 
         protected override IEnumerable<InputHandler> CreateAvailableInputHandlers() =>
-            new InputHandler[] { new IOSTouchHandler(gameView), new IOSKeyboardHandler(gameView), new IOSRawKeyboardHandler() };
+            new InputHandler[] { new IOSTouchHandler(gameView), keyboardHandler = new IOSKeyboardHandler(gameView), rawKeyboardHandler = new IOSRawKeyboardHandler() };
 
         protected override Storage GetStorage(string baseName) => new IOSStorage(baseName, this);
 

--- a/osu.Framework.iOS/IOSGameView.cs
+++ b/osu.Framework.iOS/IOSGameView.cs
@@ -118,6 +118,17 @@ namespace osu.Framework.iOS
             public override UITextSmartInsertDeleteType SmartInsertDeleteType => UITextSmartInsertDeleteType.No;
             public override UITextSmartQuotesType SmartQuotesType => UITextSmartQuotesType.No;
 
+            private bool softwareKeyboard = true;
+            internal bool SoftwareKeyboard
+            {
+                get => softwareKeyboard;
+                set
+                {
+                    softwareKeyboard = value;
+                    resetText();
+                }
+            }
+
             public HiddenTextField()
             {
                 AutocapitalizationType = UITextAutocapitalizationType.None;
@@ -155,10 +166,18 @@ namespace osu.Framework.iOS
 
             private void resetText()
             {
-                // we put in some dummy text and move the cursor to the middle so that backspace (and potentially delete or cursor keys) will be detected
-                Text = placeholder_text;
-                var newPosition = GetPosition(BeginningOfDocument, CURSOR_POSITION);
-                SelectedTextRange = GetTextRange(newPosition, newPosition);
+                if (SoftwareKeyboard)
+                {
+                    // we put in some dummy text and move the cursor to the middle so that backspace (and potentially delete or cursor keys) will be detected
+                    Text = placeholder_text;
+                    var newPosition = GetPosition(BeginningOfDocument, CURSOR_POSITION);
+                    SelectedTextRange = GetTextRange(newPosition, newPosition);
+                }
+                else
+                {
+                    Text = "";
+                    SelectedTextRange = GetTextRange(BeginningOfDocument, BeginningOfDocument);
+                }
             }
 
             public void UpdateFirstResponder(bool become)

--- a/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
@@ -25,6 +25,9 @@ namespace osu.Framework.iOS.Input
 
         private void handleShouldChangeCharacters(NSRange range, string text)
         {
+            if (!IsActive)
+                return;
+
             if (text.Length == 0)
             {
                 Key key = range.Location < IOSGameView.HiddenTextField.CURSOR_POSITION ? Key.BackSpace : Key.Delete;
@@ -64,12 +67,18 @@ namespace osu.Framework.iOS.Input
 
         private void handleShouldReturn()
         {
+            if (!IsActive)
+                return;
+
             PendingInputs.Enqueue(new KeyboardKeyInput(Key.Enter, true));
             PendingInputs.Enqueue(new KeyboardKeyInput(Key.Enter, false));
         }
 
         private void handleKeyCommand(UIKeyCommand cmd)
         {
+            if (!IsActive)
+                return;
+
             Key? key;
             bool upper = false;
 
@@ -239,7 +248,8 @@ namespace osu.Framework.iOS.Input
             }
         }
 
-        public override bool IsActive => true;
+        internal bool KeyboardActive;
+        public override bool IsActive => KeyboardActive;
 
         public override int Priority => 0;
 

--- a/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
@@ -12,7 +12,8 @@ namespace osu.Framework.iOS.Input
 {
     public class IOSRawKeyboardHandler : InputHandler
     {
-        public override bool IsActive => true;
+        internal bool KeyboardActive;
+        public override bool IsActive => KeyboardActive;
 
         public override int Priority => 0;
 
@@ -23,7 +24,7 @@ namespace osu.Framework.iOS.Input
 
             game.KeyEvent += (keyCode, isDown) =>
             {
-                if (keyMap.ContainsKey(keyCode))
+                if (IsActive && keyMap.ContainsKey(keyCode))
                     PendingInputs.Enqueue(new KeyboardKeyInput(keyMap[keyCode], isDown));
             };
 

--- a/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.iOS.Input
 {
     public class IOSRawKeyboardHandler : InputHandler
     {
-        internal bool KeyboardActive;
+        internal bool KeyboardActive = true;
         public override bool IsActive => KeyboardActive;
 
         public override int Priority => 0;


### PR DESCRIPTION
Note that we remove the "placeholder" text if using hardware keyboard, because otherwise it allows the user to select the invisible text with shift+arrow keys, which will display the cut/copy icons in the on-screen command bar.