### PR TITLE
Add NetworkHelper

### DIFF
--- a/osu.Framework/IO/Network/NetworkHelper.cs
+++ b/osu.Framework/IO/Network/NetworkHelper.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Net.NetworkInformation;
+
+namespace osu.Framework.IO.Network
+{
+    public static class NetworkHelper
+    {
+        public static bool NetworkAvailable => NetworkInterface.GetIsNetworkAvailable();
+    }
+}


### PR DESCRIPTION
This PR adds `NetworkHelper` class which is intended to contain various network related helper methods.
I understand that this class is too simple, but having it allows us to change `NetworkHelper.NetworkAvailable` implementation without making changes in concrete games.