### PR TITLE
Reduce overhead of blocking resource store log events

### DIFF
--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -35,6 +35,8 @@ namespace osu.Framework.Audio.Sample
 
             if (string.IsNullOrEmpty(name)) return null;
 
+            this.LogIfNonBackgroundThread(name);
+
             lock (sampleCache)
             {
                 SampleChannel channel = null;

--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using osu.Framework.Configuration;
 
 namespace osu.Framework.Development
 {
@@ -30,6 +31,12 @@ namespace osu.Framework.Development
         private static readonly Lazy<bool> is_debug_build = new Lazy<bool>(() =>
             isDebugAssembly(typeof(DebugUtils).Assembly) || isDebugAssembly(GetEntryAssembly())
         );
+
+        /// <summary>
+        /// Whether the framework is currently logging performance issues via <see cref="FrameworkSetting.PerformanceLogging"/>.
+        /// This should be used only when a configuration is not available via DI or otherwise (ie. in a static context).
+        /// </summary>
+        public static bool LogPerformanceIssues { get; internal set; }
 
         // https://stackoverflow.com/a/2186634
         private static bool isDebugAssembly(Assembly assembly) => assembly?.GetCustomAttributes(false).OfType<DebuggableAttribute>().Any(da => da.IsJITTrackingEnabled) ?? false;

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -67,13 +67,13 @@ namespace osu.Framework.Graphics.Textures
         {
             if (string.IsNullOrEmpty(name)) return null;
 
+            this.LogIfNonBackgroundThread(name);
+
             lock (textureCache)
             {
                 // refresh the texture if no longer available (may have been previously disposed).
                 if (!textureCache.TryGetValue(name, out var tex) || tex?.Available == false)
                 {
-                    this.LogIfNonBackgroundThread(name);
-
                     try
                     {
                         textureCache[name] = tex = getTexture(name);

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -67,13 +67,13 @@ namespace osu.Framework.Graphics.Textures
         {
             if (string.IsNullOrEmpty(name)) return null;
 
-            this.LogIfNonBackgroundThread(name);
-
             lock (textureCache)
             {
                 // refresh the texture if no longer available (may have been previously disposed).
                 if (!textureCache.TryGetValue(name, out var tex) || tex?.Available == false)
                 {
+                    this.LogIfNonBackgroundThread(name);
+
                     try
                     {
                         textureCache[name] = tex = getTexture(name);

--- a/osu.Framework/IO/Stores/IResourceStore.cs
+++ b/osu.Framework/IO/Stores/IResourceStore.cs
@@ -49,7 +49,8 @@ namespace osu.Framework.IO.Stores
             if (ThreadSafety.IsUpdateThread || ThreadSafety.IsDrawThread || ThreadSafety.IsAudioThread)
             {
                 Logger.Log($"Resource {resourceName} was retrieved from a {store.GetType().ReadableName()} on a non-background thread.", LoggingTarget.Performance);
-                Logger.Log(new StackTrace(1).ToString(), LoggingTarget.Performance, outputToListeners: false);
+                if (DebugUtils.IsDebugBuild)
+                    Logger.Log(new StackTrace(1).ToString(), LoggingTarget.Performance, outputToListeners: false);
             }
         }
     }

--- a/osu.Framework/IO/Stores/IResourceStore.cs
+++ b/osu.Framework/IO/Stores/IResourceStore.cs
@@ -46,11 +46,13 @@ namespace osu.Framework.IO.Stores
         /// <param name="resourceName">The resource retrieved.</param>
         public static void LogIfNonBackgroundThread<T>(this IResourceStore<T> store, string resourceName)
         {
+            if (!DebugUtils.LogPerformanceIssues)
+                return;
+
             if (ThreadSafety.IsUpdateThread || ThreadSafety.IsDrawThread || ThreadSafety.IsAudioThread)
             {
                 Logger.Log($"Resource {resourceName} was retrieved from a {store.GetType().ReadableName()} on a non-background thread.", LoggingTarget.Performance);
-                if (DebugUtils.IsDebugBuild)
-                    Logger.Log(new StackTrace(1).ToString(), LoggingTarget.Performance, outputToListeners: false);
+                Logger.Log(new StackTrace(1).ToString(), LoggingTarget.Performance, outputToListeners: false);
             }
         }
     }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -772,7 +772,11 @@ namespace osu.Framework.Platform
             cursorSensitivity = Config.GetBindable<double>(FrameworkSetting.CursorSensitivity);
 
             Config.BindWith(FrameworkSetting.PerformanceLogging, performanceLogging);
-            performanceLogging.BindValueChanged(logging => threads.ForEach(t => t.Monitor.EnablePerformanceProfiling = logging.NewValue), true);
+            performanceLogging.BindValueChanged(logging =>
+            {
+                threads.ForEach(t => t.Monitor.EnablePerformanceProfiling = logging.NewValue);
+                DebugUtils.LogPerformanceIssues = logging.NewValue;
+            }, true);
 
             bypassFrontToBackPass = DebugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass);
         }


### PR DESCRIPTION
- `TextureStore` now only logs on cache misses. On checking, other stores are already doing this (`TrackStore`, `SampleStore` etc.) so I believe this is in line with expectations.
- Stack traces are only output in debug configurations. As an alternative, this could match `FrameworkSetting.PerformanceLogging` to allow for the ability to also log in release builds. I kind of like this idea, but it will likely result in the need of a static bool to track state. Thoughts?
