### PR TITLE
Make menu and related classes abstract

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -198,7 +198,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 Header.Origin = Anchor.TopRight;
             }
 
-            private class StyledDropdownMenu : DropdownMenu
+            private class StyledDropdownMenu : BasicDropdown<TestEnum?>.BasicDropdownMenu
             {
                 public StyledDropdownMenu()
                 {

--- a/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
+++ b/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Cursor
     /// If a right-click happens on a <see cref="Drawable"/> that implements <see cref="IHasContextMenu"/> and exists as a child of the same <see cref="InputManager"/> as this container,
     /// a <see cref="Menu"/> will be displayed with bottom-right origin at the right-clicked position.
     /// </summary>
-    public class ContextMenuContainer : CursorEffectContainer<ContextMenuContainer, IHasContextMenu>
+    public abstract class ContextMenuContainer : CursorEffectContainer<ContextMenuContainer, IHasContextMenu>
     {
         private readonly Menu menu;
 
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.Cursor
         /// <summary>
         /// Creates a new context menu. Can be overridden to supply custom subclass of <see cref="Menu"/>.
         /// </summary>
-        protected virtual Menu CreateMenu() => new Menu(Direction.Vertical);
+        protected abstract Menu CreateMenu();
 
         private readonly Container content;
         protected override Container<Drawable> Content => content;
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.Cursor
         /// <summary>
         /// Creates a new <see cref="ContextMenuContainer"/>.
         /// </summary>
-        public ContextMenuContainer()
+        protected ContextMenuContainer()
         {
             AddInternal(content = new Container
             {

--- a/osu.Framework/Graphics/UserInterface/BasicDropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDropdown.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Graphics.UserInterface
@@ -42,7 +43,11 @@ namespace osu.Framework.Graphics.UserInterface
 
         public class BasicDropdownMenu : DropdownMenu
         {
-            protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new DrawableBasicDropdownMenuItem(item);
+            protected override Menu CreateSubMenu() => new BasicMenu(Direction.Vertical);
+
+            protected override DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item) => new DrawableBasicDropdownMenuItem(item);
+
+            protected override ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new BasicScrollContainer(direction);
 
             private class DrawableBasicDropdownMenuItem : DrawableDropdownMenuItem
             {

--- a/osu.Framework/Graphics/UserInterface/BasicMenu.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicMenu.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Graphics.UserInterface
@@ -19,6 +20,8 @@ namespace osu.Framework.Graphics.UserInterface
         };
 
         protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new BasicDrawableMenuItem(item);
+
+        protected override ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new BasicScrollContainer(direction);
 
         public class BasicDrawableMenuItem : DrawableMenuItem
         {

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -294,13 +294,13 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Creates the menu body.
         /// </summary>
-        protected virtual DropdownMenu CreateMenu() => new DropdownMenu();
+        protected abstract DropdownMenu CreateMenu();
 
         #region DropdownMenu
 
-        public class DropdownMenu : Menu
+        public abstract class DropdownMenu : Menu
         {
-            public DropdownMenu()
+            protected DropdownMenu()
                 : base(Direction.Vertical)
             {
             }
@@ -331,14 +331,16 @@ namespace osu.Framework.Graphics.UserInterface
             /// </summary>
             public bool AnyPresent => Children.Any(c => c.IsPresent);
 
-            protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new DrawableDropdownMenuItem(item);
+            protected sealed override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => CreateDrawableDropdownMenuItem(item);
+
+            protected abstract DrawableDropdownMenuItem CreateDrawableDropdownMenuItem(MenuItem item);
 
             #region DrawableDropdownMenuItem
 
             // must be public due to mono bug(?) https://github.com/ppy/osu/issues/1204
-            public class DrawableDropdownMenuItem : DrawableMenuItem
+            public abstract class DrawableDropdownMenuItem : DrawableMenuItem
             {
-                public DrawableDropdownMenuItem(MenuItem item)
+                protected DrawableDropdownMenuItem(MenuItem item)
                     : base(item)
                 {
                 }

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -18,7 +18,7 @@ using osuTK.Input;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    public class Menu : CompositeDrawable, IStateful<MenuState>
+    public abstract class Menu : CompositeDrawable, IStateful<MenuState>
     {
         /// <summary>
         /// Invoked when this <see cref="Menu"/>'s <see cref="State"/> changes.
@@ -72,7 +72,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         /// <param name="direction">The direction of layout for this menu.</param>
         /// <param name="topLevelMenu">Whether the resultant menu is always displayed in an open state (ie. a menu bar).</param>
-        public Menu(Direction direction, bool topLevelMenu = false)
+        protected Menu(Direction direction, bool topLevelMenu = false)
         {
             Direction = direction;
             TopLevelMenu = topLevelMenu;
@@ -532,29 +532,26 @@ namespace osu.Framework.Graphics.UserInterface
         /// Creates a sub-menu for <see cref="MenuItem.Items"/> of <see cref="MenuItem"/>s added to this <see cref="Menu"/>.
         /// </summary>
         /// <returns></returns>
-        protected virtual Menu CreateSubMenu() => new Menu(Direction.Vertical)
-        {
-            Anchor = Direction == Direction.Horizontal ? Anchor.BottomLeft : Anchor.TopRight
-        };
+        protected abstract Menu CreateSubMenu();
 
         /// <summary>
         /// Creates the visual representation for a <see cref="MenuItem"/>.
         /// </summary>
         /// <param name="item">The <see cref="MenuItem"/> that is to be visualised.</param>
         /// <returns>The visual representation.</returns>
-        protected virtual DrawableMenuItem CreateDrawableMenuItem(MenuItem item) => new DrawableMenuItem(item);
+        protected abstract DrawableMenuItem CreateDrawableMenuItem(MenuItem item);
 
         /// <summary>
         /// Creates the <see cref="ScrollContainer{T}"/> to hold the items of this <see cref="Menu"/>.
         /// </summary>
         /// <param name="direction">The scrolling direction.</param>
         /// <returns>The <see cref="ScrollContainer{T}"/>.</returns>
-        protected virtual ScrollContainer<Drawable> CreateScrollContainer(Direction direction) => new BasicScrollContainer<Drawable>(direction);
+        protected abstract ScrollContainer<Drawable> CreateScrollContainer(Direction direction);
 
         #region DrawableMenuItem
 
         // must be public due to mono bug(?) https://github.com/ppy/osu/issues/1204
-        public class DrawableMenuItem : CompositeDrawable, IStateful<MenuItemState>
+        public abstract class DrawableMenuItem : CompositeDrawable, IStateful<MenuItemState>
         {
             /// <summary>
             /// Invoked when this <see cref="DrawableMenuItem"/>'s <see cref="State"/> changes.
@@ -592,7 +589,7 @@ namespace osu.Framework.Graphics.UserInterface
             /// </summary>
             protected readonly Container Foreground;
 
-            public DrawableMenuItem(MenuItem item)
+            protected DrawableMenuItem(MenuItem item)
             {
                 Item = item;
 
@@ -779,13 +776,7 @@ namespace osu.Framework.Graphics.UserInterface
             /// If the <see cref="Drawable"/> returned implements <see cref="IHasText"/>, the text will be automatically
             /// updated when the <see cref="MenuItem.Text"/> is updated.
             /// </summary>
-            protected virtual Drawable CreateContent() => new SpriteText
-            {
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
-                Padding = new MarginPadding(5),
-                Font = new FontUsage(size: 17),
-            };
+            protected abstract Drawable CreateContent();
         }
 
         #endregion


### PR DESCRIPTION
This is a breaking change for everything that directly created instances of ``Menu`` and/or related classes.