### PR TITLE
Change ReadableString output to not include a joining character

### DIFF
--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -94,7 +94,7 @@ namespace osu.Framework.Input.Bindings
 
         public override string ToString() => Keys.Select(b => ((int)b).ToString()).Aggregate((s1, s2) => $"{s1},{s2}");
 
-        public string ReadableString() => Keys.Select(getReadableKey).Aggregate((s1, s2) => $"{s1}+{s2}");
+        public string ReadableString() => Keys.Select(getReadableKey).Aggregate((s1, s2) => $"{s1} {s2}");
 
         public static bool IsModifierKey(InputKey key) => key == InputKey.Control || key == InputKey.Shift || key == InputKey.Alt || key == InputKey.Super;
 


### PR DESCRIPTION
Aimed to solve ambiguous display.

![image](https://user-images.githubusercontent.com/191335/60019385-b07b3180-96c8-11e9-912a-7505841b08f1.png)
