### PR TITLE
Remove unnecessary hover handling in Dropdown

### DIFF
--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -10,7 +10,6 @@ using osu.Framework.Graphics.Containers;
 using osuTK.Graphics;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Input.Events;
 
 namespace osu.Framework.Graphics.UserInterface
 {
@@ -286,8 +285,6 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         private void updateHeaderVisibility() => Header.Alpha = Menu.AnyPresent ? 1 : 0;
-
-        protected override bool OnHover(HoverEvent e) => true;
 
         /// <summary>
         /// Creates the menu body.


### PR DESCRIPTION
Fixes osu! chat not being draggable when too many channels are joined.