### PR TITLE
Fix potential memory leaks with disposed DrawNodes

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawNodeDisposal.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawNodeDisposal.cs
@@ -1,0 +1,149 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    public class TestSceneDrawNodeDisposal : FrameworkTestScene
+    {
+        /// <summary>
+        /// Tests that all references are lost after a drawable is disposed.
+        /// </summary>
+        [Test]
+        public void TestBasicDrawNodeReferencesRemovedAfterDisposal() => performTest(new Box { RelativeSizeAxes = Axes.Both });
+
+        /// <summary>
+        /// Tests that all references are lost after a composite is disposed.
+        /// </summary>
+        [Test]
+        public void TestCompositeDrawNodeReferencesRemovedAfterDisposal() => performTest(new NonFlattenedContainer
+        {
+            RelativeSizeAxes = Axes.Both,
+            Children = new[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Width = 0.5f,
+                    Colour = Color4.Blue
+                },
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    X = 0.5f,
+                    Width = 0.5f,
+                    Colour = Color4.Blue
+                },
+            }
+        });
+
+        /// <summary>
+        /// Tests that all references are lost after a buffered container is disposed.
+        /// </summary>
+        [Test]
+        public void TestBufferedDrawNodeReferencesRemovedAfterDisposal() => performTest(new BufferedContainer
+        {
+            RelativeSizeAxes = Axes.Both,
+            Children = new[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Width = 0.5f,
+                    Colour = Color4.Blue
+                },
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    X = 0.5f,
+                    Width = 0.5f,
+                    Colour = Color4.Blue
+                },
+            }
+        });
+
+        private void performTest(Drawable child)
+        {
+            Container parentContainer = null;
+
+            var drawableRefs = new List<WeakReference>();
+
+            // Add the children to the hierarchy, and build weak-reference wrappers around them
+            AddStep("create hierarchy", () =>
+            {
+                drawableRefs.Clear();
+                buildReferencesRecursive(child);
+
+                Child = parentContainer = new NonFlattenedContainer
+                {
+                    Size = new Vector2(200),
+                    Child = child
+                };
+
+                void buildReferencesRecursive(Drawable target)
+                {
+                    drawableRefs.Add(new WeakReference(target));
+
+                    if (target is CompositeDrawable compositeTarget)
+                    {
+                        foreach (var c in compositeTarget.InternalChildren)
+                            buildReferencesRecursive(c);
+                    }
+                }
+            });
+
+            AddWaitStep("wait for some draw nodes", GLWrapper.MAX_DRAW_NODES);
+
+            // Clear the parent to ensure no references are held via drawables themselves,
+            // and remove the parent to ensure that the parent maintains references to the child draw nodes
+            AddStep("clear + remove parent container", () =>
+            {
+                parentContainer.Clear();
+                Remove(parentContainer);
+
+                // Lose last hard-reference to the child
+                child = null;
+            });
+
+            // Wait for all drawables to get disposed
+            DisposalMarker disposalMarker = null;
+            AddStep("add disposal marker", () => AsyncDisposalQueue.Enqueue(disposalMarker = new DisposalMarker()));
+            AddUntilStep("wait for drawables to dispose", () => disposalMarker.Disposed);
+
+            // Induce the collection of drawables
+            AddStep("invoke GC", () =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+            });
+
+            AddUntilStep("all drawable references lost", () => !drawableRefs.Any(r => r.IsAlive));
+        }
+
+        private class NonFlattenedContainer : Container
+        {
+            protected override bool CanBeFlattened => false;
+        }
+
+        private class DisposalMarker : IDisposable
+        {
+            public bool Disposed { get; private set; }
+
+            public void Dispose()
+            {
+                Disposed = true;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Batches/VertexBatch.cs
+++ b/osu.Framework/Graphics/Batches/VertexBatch.cs
@@ -56,12 +56,12 @@ namespace osu.Framework.Graphics.Batches
             GC.SuppressFinalize(this);
         }
 
-        protected void Dispose(bool disposing) => GLWrapper.ScheduleDisposal(() =>
+        protected void Dispose(bool disposing)
         {
             if (disposing)
                 foreach (VertexBuffer<T> vbo in VertexBuffers)
                     vbo.Dispose();
-        });
+        }
 
         #endregion
 

--- a/osu.Framework/Graphics/Batches/VertexBatch.cs
+++ b/osu.Framework/Graphics/Batches/VertexBatch.cs
@@ -45,11 +45,6 @@ namespace osu.Framework.Graphics.Batches
 
         #region Disposal
 
-        ~VertexBatch()
-        {
-            Dispose(false);
-        }
-
         public void Dispose()
         {
             Dispose(true);

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -192,7 +192,7 @@ namespace osu.Framework.Graphics
         {
             base.Dispose(isDisposing);
 
-            Child.Dispose();
+            Child?.Dispose();
             Child = null;
         }
     }

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// The child <see cref="DrawNode"/> which is used to populate the <see cref="FrameBuffer"/>s with.
         /// </summary>
-        protected readonly DrawNode Child;
+        protected DrawNode Child { get; private set; }
 
         /// <summary>
         /// Data shared amongst all <see cref="BufferedDrawNode"/>s, providing storage for <see cref="FrameBuffer"/>s.
@@ -186,6 +186,14 @@ namespace osu.Framework.Graphics
         {
             GLWrapper.PopViewport();
             GLWrapper.PopMaskingInfo();
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            Child.Dispose();
+            Child = null;
         }
     }
 }

--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
 
 namespace osu.Framework.Graphics
@@ -89,7 +90,7 @@ namespace osu.Framework.Graphics
 
         public void Dispose()
         {
-            Dispose(true);
+            GLWrapper.ScheduleDisposal(() => Dispose(true));
             GC.SuppressFinalize(this);
         }
 

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -109,7 +109,7 @@ namespace osu.Framework.Graphics.Containers
             get => pixelSnapping;
             set
             {
-                if (sharedData?.MainBuffer.IsInitialized == true)
+                if (sharedData.MainBuffer.IsInitialized)
                     throw new InvalidOperationException("May only set PixelSnapping before FrameBuffers are initialized (i.e. before the first draw).");
 
                 pixelSnapping = value;

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -271,7 +271,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 base.Dispose(isDisposing);
 
-                Children?.ForEach(c => c.Dispose());
+                // Children disposed via their source drawables
                 Children = null;
 
                 quadBatch?.Dispose();

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -271,6 +271,9 @@ namespace osu.Framework.Graphics.Containers
             {
                 base.Dispose(isDisposing);
 
+                Children?.ForEach(c => c.Dispose());
+                Children = null;
+
                 quadBatch?.Dispose();
                 triangleBatch?.Dispose();
             }

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -286,7 +286,7 @@ namespace osu.Framework.Graphics
             if (referenceCount.Decrement() != 0)
                 return;
 
-            Dispose(true);
+            GLWrapper.ScheduleDisposal(() => Dispose(true));
             GC.SuppressFinalize(this);
         }
 

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// The <see cref="Drawable"/> which this <see cref="DrawNode"/> draws.
         /// </summary>
-        protected readonly IDrawable Source;
+        protected IDrawable Source { get; private set; }
 
         private readonly AtomicCounter referenceCount = new AtomicCounter();
 
@@ -292,6 +292,7 @@ namespace osu.Framework.Graphics
 
         protected virtual void Dispose(bool isDisposing)
         {
+            Source = null;
         }
     }
 }

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -188,5 +188,12 @@ namespace osu.Framework.Graphics.Lines
         private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData();
 
         protected override DrawNode CreateDrawNode() => new BufferedDrawNode(this, new PathDrawNode(this), sharedData, new[] { RenderbufferInternalFormat.DepthComponent16 });
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            sharedData.Dispose();
+        }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         ~FrameBuffer()
         {
-            Dispose(false);
+            GLWrapper.ScheduleDisposal(() => Dispose(false));
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         private bool isDisposed;
 
-        protected virtual void Dispose(bool disposing) => GLWrapper.ScheduleDisposal(delegate
+        protected virtual void Dispose(bool disposing)
         {
             if (isDisposed)
                 return;
@@ -42,7 +42,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
             GLWrapper.DeleteFramebuffer(frameBuffer);
             frameBuffer = -1;
-        });
+        }
 
         #endregion
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -77,7 +77,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         protected bool IsDisposed;
 
-        protected virtual void Dispose(bool disposing) => GLWrapper.ScheduleDisposal(() =>
+        protected virtual void Dispose(bool disposing)
         {
             if (IsDisposed)
                 return;
@@ -89,7 +89,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             }
 
             IsDisposed = true;
-        });
+        }
 
         public virtual void Bind(bool forRendering)
         {

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         ~VertexBuffer()
         {
-            Dispose(false);
+            GLWrapper.ScheduleDisposal(() => Dispose(false));
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Text;
 using osu.Framework.Graphics.OpenGL;
@@ -10,7 +9,7 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class Shader : IDisposable, IShader
+    public class Shader : IShader
     {
         internal StringBuilder Log = new StringBuilder();
 
@@ -39,9 +38,6 @@ namespace osu.Framework.Graphics.Shaders
             Uniforms.Clear();
             uniformsArray = null;
             Log.Clear();
-
-            if (programID != -1)
-                Dispose(true);
 
             if (parts.Count == 0)
                 return;
@@ -191,35 +187,5 @@ namespace osu.Framework.Graphics.Shaders
         }
 
         public static implicit operator int(Shader shader) => shader.programID;
-
-        #region Disposal
-
-        ~Shader()
-        {
-            Dispose(false);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing) => GLWrapper.ScheduleDisposal(() =>
-        {
-            if (IsLoaded)
-            {
-                IsLoaded = false;
-
-                Unbind();
-                GL.DeleteProgram(this);
-
-                GlobalPropertyManager.Unregister(this);
-
-                programID = -1;
-            }
-        });
-
-        #endregion
     }
 }

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -11,7 +11,7 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class ShaderManager : IDisposable
+    public class ShaderManager
     {
         private const string shader_prefix = @"sh_";
 
@@ -97,30 +97,6 @@ namespace osu.Framework.Graphics.Shaders
 
             return shader;
         }
-
-        #region Disposal
-
-        ~ShaderManager()
-        {
-            Dispose(false);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            foreach (var kvp in partCache)
-                kvp.Value.Dispose();
-
-            foreach (var kvp in shaderCache)
-                kvp.Value.Dispose();
-        }
-
-        #endregion
     }
 
     public static class VertexShaderDescriptor

--- a/osu.Framework/Graphics/Shaders/ShaderPart.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderPart.cs
@@ -6,12 +6,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Text.RegularExpressions;
-using osu.Framework.Graphics.OpenGL;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    internal class ShaderPart : IDisposable
+    internal class ShaderPart
     {
         internal const string BOUNDARY = @"----------------------{0}";
 
@@ -168,22 +167,5 @@ namespace osu.Framework.Graphics.Shaders
             Compiled = false;
             partID = -1;
         }
-
-        #region Disposal
-
-        ~ShaderPart()
-        {
-            Dispose(false);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected void Dispose(bool disposing) => GLWrapper.ScheduleDisposal(delete);
-
-        #endregion
     }
 }


### PR DESCRIPTION
Several important changes here.

1. `DrawNode.Dispose(bool)` now happens 3-frames into the future.
2. To tighten things as a consequence of (1), all disposed objects (framebuffers, vertexbuffers, vertexbatches) have had their 3-frame delay removed. Their finalisers still have the 3-frame delay, not for the delay but to force them onto the GL thread.
3. `DrawNode` now nulls the source on disposal - fixing the issue.

Also, all shader disposal methods have been removed - shaders should never be disposed with our current structures.

Finally, I've removed the finaliser from vertexbatch, since any time it gets finalised its vertex buffers will also be finalised.