### PR TITLE
Remove custom GC mode changing

### DIFF
--- a/osu.Framework/Configuration/FrameworkDebugConfig.cs
+++ b/osu.Framework/Configuration/FrameworkDebugConfig.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Runtime;
 using osu.Framework.Caching;
 
 namespace osu.Framework.Configuration
@@ -19,7 +18,6 @@ namespace osu.Framework.Configuration
         {
             base.InitialiseDefaults();
 
-            Set(DebugSetting.ActiveGCMode, GCLatencyMode.SustainedLowLatency);
             Set(DebugSetting.BypassCaching, false).ValueChanged += delegate { StaticCached.BypassCache = Get<bool>(DebugSetting.BypassCaching); };
             Set(DebugSetting.BypassFrontToBackPass, false);
         }
@@ -27,7 +25,6 @@ namespace osu.Framework.Configuration
 
     public enum DebugSetting
     {
-        ActiveGCMode,
         BypassCaching,
         BypassFrontToBackPass
     }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
-using System.Runtime;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -509,8 +508,6 @@ namespace osu.Framework.Platform
 
                 IsActive.BindValueChanged(active =>
                 {
-                    activeGCMode.TriggerChange();
-
                     if (active.NewValue)
                         OnActivated();
                     else
@@ -659,8 +656,6 @@ namespace osu.Framework.Platform
 
         private Bindable<bool> bypassFrontToBackPass;
 
-        private Bindable<GCLatencyMode> activeGCMode;
-
         private Bindable<FrameSync> frameSyncMode;
 
         private Bindable<string> ignoredInputHandlers;
@@ -697,9 +692,6 @@ namespace osu.Framework.Platform
                 if (!Window.SupportedWindowModes.Contains(mode.NewValue))
                     windowMode.Value = Window.DefaultWindowMode;
             }, true);
-
-            activeGCMode = DebugConfig.GetBindable<GCLatencyMode>(DebugSetting.ActiveGCMode);
-            activeGCMode.ValueChanged += e => { GCSettings.LatencyMode = IsActive.Value ? e.NewValue : GCLatencyMode.Interactive; };
 
             frameSyncMode = Config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
             frameSyncMode.ValueChanged += e =>


### PR DESCRIPTION
For now we have deemed this counter-productive. It may be added back int eh future as a framework-consumer Begin/EndGameplayExclusiveMode which would automatically optimise the GC (and other) workflows for periods of time when the user is involved exclusively in gameplay.

# Breaking Changes

## `DebugSetting.ActiveGCMode` no longer exists

If you were manually setting this, you can do so via [.NET methods](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/latency?view=netframework-4.8).