### PR TITLE
Load debug overlays on demand rather than on startup

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -83,19 +83,6 @@ namespace osu.Framework
             });
         }
 
-        private void addDebugTools()
-        {
-            LoadComponentAsync(drawVisualiser = new DrawVisualiser
-            {
-                Depth = float.MinValue / 2,
-            }, AddInternal);
-
-            LoadComponentAsync(logOverlay = new LogOverlay
-            {
-                Depth = float.MinValue / 2,
-            }, AddInternal);
-        }
-
         /// <summary>
         /// As Load is run post host creation, you can override this method to alter properties of the host before it makes itself visible to the user.
         /// </summary>
@@ -187,8 +174,6 @@ namespace osu.Framework
             }, AddInternal);
 
             FrameStatistics.BindValueChanged(e => performanceOverlay.State = e.NewValue, true);
-
-            addDebugTools();
         }
 
         protected readonly Bindable<FrameStatisticsMode> FrameStatistics = new Bindable<FrameStatisticsMode>();
@@ -216,10 +201,27 @@ namespace osu.Framework
                     return true;
 
                 case FrameworkAction.ToggleDrawVisualiser:
+
+                    if (drawVisualiser == null)
+                    {
+                        LoadComponentAsync(drawVisualiser = new DrawVisualiser
+                        {
+                            Depth = float.MinValue / 2,
+                        }, AddInternal);
+                    }
+
                     drawVisualiser.ToggleVisibility();
                     return true;
 
                 case FrameworkAction.ToggleLogOverlay:
+                    if (logOverlay == null)
+                    {
+                        LoadComponentAsync(logOverlay = new LogOverlay
+                        {
+                            Depth = float.MinValue / 2,
+                        }, AddInternal);
+                    }
+
                     logOverlay.ToggleVisibility();
                     return true;
 


### PR DESCRIPTION
Avoids potentially initialising a texture atlas that would otherwise never be required. Also reduces startup overhead for normal users.