### PR TITLE
Limit ImageSharp memory usage on memory constrained devices

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -29,6 +29,8 @@ namespace osu.Framework.Android
             Window = new AndroidGameWindow();
         }
 
+        protected override bool LimitedMemoryEnvironment => true;
+
         public override bool OnScreenKeyboardOverlapsGameWindow => true;
 
         public override ITextInputSource GetTextInput()

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -75,6 +75,8 @@ namespace osu.Framework.iOS
 
         public override bool OnScreenKeyboardOverlapsGameWindow => true;
 
+        protected override bool LimitedMemoryEnvironment => true;
+
         public override bool CanExit => false;
 
         public override ITextInputSource GetTextInput() => new IOSTextInput(gameView);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -37,6 +37,7 @@ using SixLabors.ImageSharp.Processing;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.IO.File;
 using osu.Framework.IO.Stores;
+using SixLabors.Memory;
 
 namespace osu.Framework.Platform
 {
@@ -85,6 +86,11 @@ namespace osu.Framework.Platform
         /// Whether this host can exit (mobile platforms, for instance, do not support exiting the app).
         /// </summary>
         public virtual bool CanExit => true;
+
+        /// <summary>
+        /// Whether memory constraints should be considered before performance concerns.
+        /// </summary>
+        protected virtual bool LimitedMemoryEnvironment => false;
 
         protected void OnMessageReceived(IpcMessage message) => MessageReceived?.Invoke(message);
 
@@ -439,6 +445,12 @@ namespace osu.Framework.Platform
 
         public void Run(Game game)
         {
+            if (LimitedMemoryEnvironment)
+            {
+                // recommended middle-ground https://github.com/SixLabors/docs/blob/master/articles/ImageSharp/MemoryManagement.md#working-in-memory-constrained-environments
+                SixLabors.ImageSharp.Configuration.Default.MemoryAllocator = ArrayPoolMemoryAllocator.CreateWithModeratePooling();
+            }
+
             DebugUtils.HostAssembly = game.GetType().Assembly;
 
             if (ExecutionState != ExecutionState.Idle)


### PR DESCRIPTION
On desktop this seems to result in around 50% lower LOH usage in most cases. We do cause some fragmentation along the way which should eventually be addressed, but I believe this should reduce mobile device memory pressure in the mean time.