### PR TITLE
Fix delayed load unload reference retention

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -7,10 +7,8 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Lists;
-using osu.Framework.Tests.Visual.Containers;
 using osu.Framework.Threading;
 using osuTK;
 using osuTK.Graphics;
@@ -98,6 +96,10 @@ namespace osu.Framework.Tests.Visual.Drawables
                 GC.Collect();
                 return !references.Any();
             });
+
+            AddStep("scroll to start", () => scroll.ScrollToStart());
+
+            AddUntilStep("references restored", () => references.Count() == 16);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -11,11 +11,11 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneDelayedUnload : FrameworkTestScene
+    public class TestSceneDelayedLoadUnloadWrapper : FrameworkTestScene
     {
         private const int panel_count = 1024;
 
-        public TestSceneDelayedUnload()
+        public TestSceneDelayedLoadUnloadWrapper()
         {
             FillFlowContainer<Container> flow;
             ScrollContainer<Drawable> scroll;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
@@ -14,7 +14,7 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    public class TestSceneDelayedLoad : FrameworkTestScene
+    public class TestSceneDelayedLoadWrapper : FrameworkTestScene
     {
         private const int panel_count = 2048;
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.Graphics.Containers
 
             if (unloadSchedule != null)
             {
-                unloadSchedule?.Cancel();
+                unloadSchedule.Cancel();
                 unloadSchedule = null;
 
                 loaded_count.Value--;

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -45,7 +45,9 @@ namespace osu.Framework.Graphics.Containers
         protected override void EndDelayedLoad(Drawable content)
         {
             base.EndDelayedLoad(content);
+
             Debug.Assert(unloadSchedule == null);
+
             unloadSchedule = OptimisingContainer?.ScheduleCheckAction(checkForUnload);
             loaded_count.Value++;
         }
@@ -54,8 +56,13 @@ namespace osu.Framework.Graphics.Containers
         {
             base.CancelTasks();
 
-            unloadSchedule?.Cancel();
-            unloadSchedule = null;
+            if (unloadSchedule != null)
+            {
+                unloadSchedule?.Cancel();
+                unloadSchedule = null;
+
+                loaded_count.Value--;
+            }
         }
 
         private void checkForUnload()
@@ -68,7 +75,6 @@ namespace osu.Framework.Graphics.Containers
 
             if (ShouldUnloadContent)
             {
-                loaded_count.Value--;
                 ClearInternal();
                 Content = null;
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Threading;
 
 namespace osu.Framework.Graphics.Containers
@@ -29,13 +30,16 @@ namespace osu.Framework.Graphics.Containers
         protected override void EndDelayedLoad(Drawable content)
         {
             base.EndDelayedLoad(content);
+            Debug.Assert(unloadSchedule == null);
             unloadSchedule = OptimisingContainer?.ScheduleCheckAction(checkForUnload);
         }
 
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
+
             unloadSchedule?.Cancel();
+            unloadSchedule = null;
         }
 
         private void checkForUnload()
@@ -52,7 +56,11 @@ namespace osu.Framework.Graphics.Containers
                 Content = null;
 
                 timeHidden = 0;
+
                 unloadSchedule?.Cancel();
+                unloadSchedule = null;
+
+                Unload();
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -25,6 +25,18 @@ namespace osu.Framework.Graphics.Containers
 
         protected bool ShouldUnloadContent => timeBeforeUnload == 0 || timeHidden > timeBeforeUnload;
 
+        public override double LifetimeStart
+        {
+            get => base.Content?.LifetimeStart ?? double.MinValue;
+            set => throw new NotSupportedException();
+        }
+
+        public override double LifetimeEnd
+        {
+            get => base.Content?.LifetimeEnd ?? double.MaxValue;
+            set => throw new NotSupportedException();
+        }
+
         public override Drawable Content => base.Content ?? (Content = createContentFunction());
 
         protected override void EndDelayedLoad(Drawable content)

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -72,7 +72,7 @@ namespace osu.Framework.Graphics.Containers
                 unloadSchedule?.Cancel();
                 unloadSchedule = null;
 
-                Unload();
+                CancelTasks();
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -46,9 +46,9 @@ namespace osu.Framework.Graphics.Containers
             unloadSchedule = OptimisingContainer?.ScheduleCheckAction(checkForUnload);
         }
 
-        protected override void Dispose(bool isDisposing)
+        protected override void CancelTasks()
         {
-            base.Dispose(isDisposing);
+            base.CancelTasks();
 
             unloadSchedule?.Cancel();
             unloadSchedule = null;
@@ -68,9 +68,6 @@ namespace osu.Framework.Graphics.Containers
                 Content = null;
 
                 timeHidden = 0;
-
-                unloadSchedule?.Cancel();
-                unloadSchedule = null;
 
                 CancelTasks();
             }

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -98,7 +98,7 @@ namespace osu.Framework.Graphics.Containers
             CancelTasks();
         }
 
-        protected void CancelTasks()
+        protected virtual void CancelTasks()
         {
             loadScheduledDelegate?.Cancel();
             loadScheduledDelegate = null;


### PR DESCRIPTION
- Fixes unload not successfully dropping all references.
- Fixes excessive parent traversal when no parent optimising container is available.
- Adds more robust tests.
- [x] Depends on #2603.