### PR TITLE
Fix DelayedLoadUnloadWrapper unnecessarily reloading after removal

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -173,7 +173,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                         {
                             new DelayedLoadUnloadWrapper(() =>
                             {
-                                TestBox testBox = null;
+                                TestBox testBox;
                                 var container = new Container
                                 {
                                     RelativeSizeAxes = Axes.Both,

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -61,10 +61,10 @@ namespace osu.Framework.Graphics.Containers
         {
             base.Update();
 
+            scheduleIsIntersecting();
+
             // This code can be expensive, so only run if we haven't yet loaded.
             if (DelayedLoadCompleted || DelayedLoadTriggered) return;
-
-            scheduleIsIntersecting();
 
             if (!IsIntersecting)
                 timeVisible = 0;


### PR DESCRIPTION
Cache revalidation was being blocked by an already-true condition.