### PR TITLE
Add lifetime support to DelayedLoadUnloadWrapper

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -268,7 +268,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                         RelativeSizeAxes = Axes.Both,
                         Children = new Drawable[]
                         {
-                            new TestNonRemovableBox { RelativeSizeAxes = Axes.Both }
+                            new TestBox { RelativeSizeAxes = Axes.Both }
                         }
                     }, 500, 2000);
 
@@ -297,13 +297,6 @@ namespace osu.Framework.Tests.Visual.Drawables
         public class TestScrollContainer : BasicScrollContainer
         {
             public new Scheduler Scheduler => base.Scheduler;
-        }
-
-        public class TestNonRemovableBox : TestBox
-        {
-            public override bool DisposeOnDeathRemoval => false;
-
-            public override bool RemoveWhenNotAlive => false;
         }
 
         public class TestBox : Container

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -254,9 +254,56 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddUntilStep("wait some unloaded", () => childrenWithAvatarsLoaded() < loadedCountSecondary);
         }
 
+        [Test]
+        public void TestWrapperExpiry()
+        {
+            var wrappers = new List<DelayedLoadUnloadWrapper>();
+
+            AddStep("populate panels", () =>
+            {
+                for (int i = 1; i < 16; i++)
+                {
+                    var wrapper = new DelayedLoadUnloadWrapper(() => new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Children = new Drawable[]
+                        {
+                            new TestNonRemovableBox { RelativeSizeAxes = Axes.Both }
+                        }
+                    }, 500, 2000);
+
+                    wrappers.Add(wrapper);
+
+                    flow.Add(new Container
+                    {
+                        Size = new Vector2(128),
+                        Children = new Drawable[]
+                        {
+                            wrapper,
+                            new SpriteText { Text = i.ToString() },
+                        }
+                    });
+                }
+            });
+
+            Func<int> childrenWithAvatarsLoaded = () =>
+                flow.Children.Count(c => c.Children.OfType<DelayedLoadWrapper>().FirstOrDefault()?.Content?.IsLoaded ?? false);
+
+            AddUntilStep("wait some loaded", () => childrenWithAvatarsLoaded() > 5);
+            AddStep("expire wrappers", () => wrappers.ForEach(w => w.Expire()));
+            AddAssert("all unloaded", () => childrenWithAvatarsLoaded() == 0);
+        }
+
         public class TestScrollContainer : BasicScrollContainer
         {
             public new Scheduler Scheduler => base.Scheduler;
+        }
+
+        public class TestNonRemovableBox : TestBox
+        {
+            public override bool DisposeOnDeathRemoval => false;
+
+            public override bool RemoveWhenNotAlive => false;
         }
 
         public class TestBox : Container

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -28,16 +28,30 @@ namespace osu.Framework.Graphics.Containers
 
         protected bool ShouldUnloadContent => timeBeforeUnload == 0 || timeHidden > timeBeforeUnload;
 
+        private double lifetimeStart = double.MinValue;
+
         public override double LifetimeStart
         {
-            get => base.Content?.LifetimeStart ?? double.MinValue;
-            set => throw new NotSupportedException();
+            get => base.Content?.LifetimeStart ?? lifetimeStart;
+            set
+            {
+                if (base.Content != null)
+                    base.Content.LifetimeStart = value;
+                lifetimeStart = value;
+            }
         }
+
+        private double lifetimeEnd = double.MaxValue;
 
         public override double LifetimeEnd
         {
-            get => base.Content?.LifetimeEnd ?? double.MaxValue;
-            set => throw new NotSupportedException();
+            get => base.Content?.LifetimeEnd ?? lifetimeEnd;
+            set
+            {
+                if (base.Content != null)
+                    base.Content.LifetimeEnd = value;
+                lifetimeEnd = value;
+            }
         }
 
         public override Drawable Content => base.Content ?? (Content = createContentFunction());
@@ -45,6 +59,9 @@ namespace osu.Framework.Graphics.Containers
         protected override void EndDelayedLoad(Drawable content)
         {
             base.EndDelayedLoad(content);
+
+            content.LifetimeStart = lifetimeStart;
+            content.LifetimeEnd = lifetimeEnd;
 
             Debug.Assert(unloadSchedule == null);
 


### PR DESCRIPTION
Resolves #2610

Uses a local variable in the fallback case, passing it into the content when loaded.