### PR TITLE
Fix DelayedLoadUnloadWrapper loaded count being incorrect

### DIFF
--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -65,8 +65,12 @@ namespace osu.Framework.Graphics.Containers
 
             Debug.Assert(unloadSchedule == null);
 
-            unloadSchedule = OptimisingContainer?.ScheduleCheckAction(checkForUnload);
-            loaded_count.Value++;
+            if (OptimisingContainer != null)
+            {
+                unloadSchedule = OptimisingContainer.ScheduleCheckAction(checkForUnload);
+                Debug.Assert(unloadSchedule != null);
+                loaded_count.Value++;
+            }
         }
 
         protected override void CancelTasks()

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -20,7 +20,8 @@ namespace osu.Framework.Graphics.Containers
             this.timeBeforeUnload = timeBeforeUnload;
         }
 
-        private static readonly GlobalStatistic<int> loaded_count = GlobalStatistics.Get<int>("Drawable", $"{nameof(DelayedLoadUnloadWrapper)}s loaded");
+        private static readonly GlobalStatistic<int> loaded_optimised = GlobalStatistics.Get<int>("Drawable", $"{nameof(DelayedLoadUnloadWrapper)}s (optimised)");
+        private static readonly GlobalStatistic<int> loaded_unoptimised = GlobalStatistics.Get<int>("Drawable", $"{nameof(DelayedLoadUnloadWrapper)}s (unoptimised)");
 
         private double timeHidden;
 
@@ -56,6 +57,8 @@ namespace osu.Framework.Graphics.Containers
 
         public override Drawable Content => base.Content ?? (Content = createContentFunction());
 
+        private bool contentLoaded;
+
         protected override void EndDelayedLoad(Drawable content)
         {
             base.EndDelayedLoad(content);
@@ -63,14 +66,19 @@ namespace osu.Framework.Graphics.Containers
             content.LifetimeStart = lifetimeStart;
             content.LifetimeEnd = lifetimeEnd;
 
+            Debug.Assert(!contentLoaded);
             Debug.Assert(unloadSchedule == null);
+
+            contentLoaded = true;
 
             if (OptimisingContainer != null)
             {
                 unloadSchedule = OptimisingContainer.ScheduleCheckAction(checkForUnload);
                 Debug.Assert(unloadSchedule != null);
-                loaded_count.Value++;
+                loaded_optimised.Value++;
             }
+            else
+                loaded_unoptimised.Value++;
         }
 
         protected override void CancelTasks()
@@ -82,8 +90,10 @@ namespace osu.Framework.Graphics.Containers
                 unloadSchedule.Cancel();
                 unloadSchedule = null;
 
-                loaded_count.Value--;
+                loaded_optimised.Value--;
             }
+            else if (contentLoaded)
+                loaded_unoptimised.Value--;
         }
 
         private void checkForUnload()

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -106,12 +106,16 @@ namespace osu.Framework.Graphics.Containers
 
             if (ShouldUnloadContent)
             {
+                Debug.Assert(contentLoaded);
+
                 ClearInternal();
                 Content = null;
 
                 timeHidden = 0;
 
                 CancelTasks();
+
+                contentLoaded = false;
             }
         }
     }


### PR DESCRIPTION
`DelayedLoadUnloadWrapper` with no containing `OpitimisingContainer` would have incorrectly incremented the counter.