### PR TITLE
Fix nullref on using logger without a target specification

### DIFF
--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -64,6 +64,45 @@ namespace osu.Framework.Logging
         }
 
         /// <summary>
+        /// The target for which this logger logs information. This will only be null if the logger has a name.
+        /// </summary>
+        public LoggingTarget? Target { get; }
+
+        /// <summary>
+        /// The name of the logger. This will only have a value if <see cref="Target"/> is null.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// Gets the name of the file that this logger is logging to.
+        /// </summary>
+        public string Filename => $@"{Name}.log";
+
+        private readonly GlobalStatistic<int> logCount;
+
+        private static readonly HashSet<string> reserved_names = new HashSet<string>(Enum.GetNames(typeof(LoggingTarget)).Select(n => n.ToLower()));
+
+        private Logger(LoggingTarget target = LoggingTarget.Runtime)
+            : this(target.ToString(), false)
+        {
+            Target = target;
+        }
+
+        private Logger(string name, bool checkedReserved)
+        {
+            name = name.ToLower();
+
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("The name of a logger must be non-null and may not contain only white space.", nameof(name));
+
+            if (checkedReserved && reserved_names.Contains(name))
+                throw new ArgumentException($"The name \"{name}\" is reserved. Please use the {nameof(LoggingTarget)}-value corresponding to the name instead.");
+
+            Name = name;
+            logCount = GlobalStatistics.Get<int>(nameof(Logger), Name);
+        }
+
+        /// <summary>
         /// Add a plain-text phrase which should always be filtered from logs. The filtered phrase will be replaced with asterisks (*).
         /// Useful for avoiding logging of credentials.
         /// See also <seealso cref="ApplyFilters(string)"/>.
@@ -210,48 +249,12 @@ namespace osu.Framework.Logging
 
                 if (!static_loggers.TryGetValue(nameLower, out Logger l))
                 {
-                    static_loggers[nameLower] = l = Enum.TryParse(name, true, out LoggingTarget target) ? new Logger(target) : new Logger(name);
+                    static_loggers[nameLower] = l = Enum.TryParse(name, true, out LoggingTarget target) ? new Logger(target) : new Logger(name, true);
                     l.clear();
                 }
 
                 return l;
             }
-        }
-
-        /// <summary>
-        /// The target for which this logger logs information. This will only be null if the logger has a name.
-        /// </summary>
-        public LoggingTarget? Target { get; }
-
-        /// <summary>
-        /// The name of the logger. This will only have a value if <see cref="Target"/> is null.
-        /// </summary>
-        public string Name { get; }
-
-        /// <summary>
-        /// Gets the name of the file that this logger is logging to.
-        /// </summary>
-        public string Filename => $@"{(Target?.ToString() ?? Name).ToLower()}.log";
-
-        private readonly GlobalStatistic<int> logCount;
-
-        private Logger(LoggingTarget target = LoggingTarget.Runtime)
-        {
-            Target = target;
-            logCount = GlobalStatistics.Get<int>(nameof(Logger), target.ToString());
-        }
-
-        private static readonly HashSet<string> reserved_names = new HashSet<string>(Enum.GetNames(typeof(LoggingTarget)).Select(n => n.ToLower()));
-
-        private Logger(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name))
-                throw new ArgumentException("The name of a logger must be non-null and may not contain only white space.", nameof(name));
-
-            if (reserved_names.Contains(name.ToLower()))
-                throw new ArgumentException($"The name \"{name}\" is reserved. Please use the {nameof(LoggingTarget)}-value corresponding to the name instead.");
-
-            Name = name;
         }
 
         /// <summary>
@@ -325,7 +328,7 @@ namespace osu.Framework.Logging
                     {
                         if (bypassRateLimit || debugOutputRollingTime.RequestEntry())
                         {
-                            consoleLog($"[{Target?.ToString().ToLower() ?? Name}:{level.ToString().ToLower()}] {line}");
+                            consoleLog($"[{Name}:{level.ToString().ToLower()}] {line}");
 
                             if (!bypassRateLimit && debugOutputRollingTime.IsAtLimit)
                                 consoleLog($"Console output is being limited. Please check {Filename} for full logs.");
@@ -396,7 +399,7 @@ namespace osu.Framework.Logging
             headerAdded = true;
 
             add("----------------------------------------------------------", outputToListeners: false);
-            add($"{Target} Log for {UserIdentifier} (LogLevel: {Level})", outputToListeners: false);
+            add($"{Name} Log for {UserIdentifier} (LogLevel: {Level})", outputToListeners: false);
             add($"{GameIdentifier} {VersionIdentifier}", outputToListeners: false);
             add($"Running on {Environment.OSVersion}, {Environment.ProcessorCount} cores", outputToListeners: false);
             add("----------------------------------------------------------", outputToListeners: false);

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Logging
         public LoggingTarget? Target { get; }
 
         /// <summary>
-        /// The name of the logger. This will only have a value if <see cref="Target"/> is null.
+        /// The name of the logger.
         /// </summary>
         public string Name { get; }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/5228.

Missed a second constructor.