### PR TITLE
Return ValueTask from TakeScreenshotAsync

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
@@ -37,20 +37,19 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddStep("take screenshot", takeScreenshot);
         }
 
-        private void takeScreenshot()
+        private async void takeScreenshot()
         {
             if (host.Window == null)
                 return;
 
-            host.TakeScreenshotAsync().ContinueWith(t => Schedule(() =>
+            var screenshot = await host.TakeScreenshotAsync();
+            Schedule(() =>
             {
-                var image = t.Result;
-
-                var tex = new Texture(image.Width, image.Height);
-                tex.SetData(new TextureUpload(image));
+                var tex = new Texture(screenshot.Width, screenshot.Height);
+                tex.SetData(new TextureUpload(screenshot));
 
                 display.Texture = tex;
-            }));
+            });
         }
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -378,7 +378,7 @@ namespace osu.Framework.Platform
         /// Takes a screenshot of the game. The returned <see cref="Image{TPixel}"/> must be disposed by the caller when applicable.
         /// </summary>
         /// <returns>The screenshot as an <see cref="Image{TPixel}"/>.</returns>
-        public async Task<Image<Rgba32>> TakeScreenshotAsync()
+        public async ValueTask<Image<Rgba32>> TakeScreenshotAsync()
         {
             if (Window == null) throw new NullReferenceException(nameof(Window));
 


### PR DESCRIPTION
As far as I understand, since `image` creation is synchronous, there is no need to allocate a `Task<Image<Rgba32>>` in order to return it.