### PR TITLE
Add failing test showing bass getting incorrect channel position with non-virtual device

### DIFF
--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Tests.Audio
             Architecture.SetIncludePath();
 
             // Initialize bass with no audio to make sure the test remains consistent even if there is no audio device.
-            Bass.Init(0);
+            Bass.Init();
 
             resources = new DllResourceStore("osu.Framework.Tests.dll");
 
@@ -165,6 +165,39 @@ namespace osu.Framework.Tests.Audio
             updateTrack();
 
             Assert.AreEqual(track.Length, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestResetStart()
+        {
+            for (int i = 0; i < 1000; i++)
+            {
+                track.StartAsync();
+
+                const double seek = 100;
+
+                while (track.CurrentTime <= seek)
+                {
+                    track.Update();
+                    Thread.Sleep(10);
+                }
+
+                Assert.Greater(track.CurrentTime, seek);
+
+                runOnAudioThread(() => { track.Reset(); });
+                track.Update();
+                Assert.AreEqual(0, track.CurrentTime);
+
+                track.StartAsync();
+
+                // haven't update the track yet
+                Assert.IsTrue(!track.IsRunning);
+                Assert.AreEqual(0, track.CurrentTime);
+
+                track.Update();
+                Assert.IsTrue(track.IsRunning);
+                Assert.Less(track.CurrentTime, seek);
+            }
         }
 
         [Test]


### PR DESCRIPTION
This is not a fix. It's an issue which I don't yet have a solution for. Current thought are that it has something to do with the fx/reverse channels we are using.