### PR TITLE
Fix DelayedLoadWrapper potentially not cleaning up scheduled tasks

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
@@ -23,13 +23,13 @@ namespace osu.Framework.Tests.Visual.Drawables
         public void TestManyChildren(bool instant)
         {
             FillFlowContainer<Container> flow = null;
-            ScrollContainer<Drawable> scroll = null;
+            TestSceneDelayedLoadUnloadWrapper.TestScrollContainer scroll = null;
 
             AddStep("create children", () =>
             {
                 Children = new Drawable[]
                 {
-                    scroll = new BasicScrollContainer
+                    scroll = new TestSceneDelayedLoadUnloadWrapper.TestScrollContainer
                     {
                         RelativeSizeAxes = Axes.Both,
                         Children = new Drawable[]
@@ -69,6 +69,10 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddWaitStep("wait more", 10);
             AddAssert("some loaded", () => childrenWithAvatarsLoaded().Count() > 5);
             AddAssert("not too many loaded", () => childrenWithAvatarsLoaded().Count() < panel_count / 4);
+
+            AddStep("Remove all panels", () => flow.Clear(false));
+
+            AddUntilStep("repeating schedulers removed", () => !scroll.Scheduler.HasPendingTasks);
         }
 
         public class TestBox : Container

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -182,7 +182,10 @@ namespace osu.Framework.Graphics.Containers
             {
                 OptimisingContainer = null;
                 optimisingContainerCache.Invalidate();
+
+                // Cancel the load task and allow the unload to take place by assuming the intersection is no longer valid
                 cancelLoadScheduledDelegate();
+                IsIntersecting = false;
             }
 
             isIntersectingCache.Invalidate();

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -100,8 +100,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected virtual void CancelTasks()
         {
-            loadScheduledDelegate?.Cancel();
-            loadScheduledDelegate = null;
+            cancelLoadScheduledDelegate();
 
             isIntersectingCache.Invalidate();
             loadTask = null;
@@ -125,7 +124,7 @@ namespace osu.Framework.Graphics.Containers
 
         public bool DelayedLoadCompleted => InternalChildren.Count > 0;
 
-        private Cached findParentCache = new Cached();
+        private Cached optimisingContainerCache = new Cached();
         private Cached isIntersectingCache = new Cached();
 
         private ScheduledDelegate loadScheduledDelegate;
@@ -146,10 +145,10 @@ namespace osu.Framework.Graphics.Containers
 
         private void scheduleIsIntersecting()
         {
-            if (!findParentCache.IsValid)
+            if (!optimisingContainerCache.IsValid)
             {
                 OptimisingContainer = FindParentOptimisingContainer();
-                findParentCache.Validate();
+                optimisingContainerCache.Validate();
             }
 
             if (OptimisingContainer == null)
@@ -162,9 +161,9 @@ namespace osu.Framework.Graphics.Containers
                 if (loadScheduledDelegate == null)
                     loadScheduledDelegate = OptimisingContainer.ScheduleCheckAction(() =>
                     {
-                        // clean up tasks if we have lost sight of the OptimisingContainer that was used to schedule upon.
-                        if (!DelayedLoadCompleted && !findParentCache.IsValid)
-                            CancelTasks();
+                        // clean up this task immediately if we have lost sight of the OptimisingContainer that was used to schedule upon.
+                        if (!optimisingContainerCache.IsValid)
+                            cancelLoadScheduledDelegate();
 
                         if (!isIntersectingCache.IsValid)
                         {
@@ -175,12 +174,18 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        private void cancelLoadScheduledDelegate()
+        {
+            loadScheduledDelegate?.Cancel();
+            loadScheduledDelegate = null;
+        }
+
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
             if (invalidation.HasFlag(Invalidation.Parent))
             {
                 OptimisingContainer = null;
-                findParentCache.Invalidate();
+                optimisingContainerCache.Invalidate();
             }
 
             isIntersectingCache.Invalidate();

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -161,10 +161,6 @@ namespace osu.Framework.Graphics.Containers
                 if (loadScheduledDelegate == null)
                     loadScheduledDelegate = OptimisingContainer.ScheduleCheckAction(() =>
                     {
-                        // clean up this task immediately if we have lost sight of the OptimisingContainer that was used to schedule upon.
-                        if (!optimisingContainerCache.IsValid)
-                            cancelLoadScheduledDelegate();
-
                         if (!isIntersectingCache.IsValid)
                         {
                             IsIntersecting = OptimisingContainer?.ScreenSpaceDrawQuad.Intersects(ScreenSpaceDrawQuad) == true;
@@ -186,6 +182,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 OptimisingContainer = null;
                 optimisingContainerCache.Invalidate();
+                cancelLoadScheduledDelegate();
             }
 
             isIntersectingCache.Invalidate();

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -162,6 +162,10 @@ namespace osu.Framework.Graphics.Containers
                 if (loadScheduledDelegate == null)
                     loadScheduledDelegate = OptimisingContainer.ScheduleCheckAction(() =>
                     {
+                        // clean up tasks if we have lost sight of the OptimisingContainer that was used to schedule upon.
+                        if (!DelayedLoadCompleted && !findParentCache.IsValid)
+                            CancelTasks();
+
                         if (!isIntersectingCache.IsValid)
                         {
                             IsIntersecting = OptimisingContainer?.ScreenSpaceDrawQuad.Intersects(ScreenSpaceDrawQuad) == true;


### PR DESCRIPTION
Not-loaded DelayedLoadWrappers would get in a perpetual state of checking-for-load if they were not explicitly disposed.