### PR TITLE
Fix non-loaded drawables potentially being drawn

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -999,18 +999,16 @@ namespace osu.Framework.Graphics.Containers
                     if (!drawable.IsPresent)
                         continue;
 
+                    if (drawable.IsMaskedAway)
+                        continue;
+
                     CompositeDrawable composite = drawable as CompositeDrawable;
 
                     if (composite?.CanBeFlattened == true)
                     {
-                        if (!composite.IsMaskedAway)
-                            addFromComposite(frame, treeIndex, forceNewDrawNode, ref j, composite, target);
-
+                        addFromComposite(frame, treeIndex, forceNewDrawNode, ref j, composite, target);
                         continue;
                     }
-
-                    if (drawable.IsMaskedAway)
-                        continue;
                 }
 
                 DrawNode next = drawable.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -994,6 +994,9 @@ namespace osu.Framework.Graphics.Containers
             {
                 Drawable drawable = children[i];
 
+                if (!drawable.IsLoaded)
+                    continue;
+
                 if (!drawable.IsProxy)
                 {
                     if (!drawable.IsPresent)


### PR DESCRIPTION
In some cases it may be possible for children to be alive without actually being loaded - e.g. the parent updated its children's life but decided it doesn't need to be updated further due to presence.