### PR TITLE
Use GC SustainedLowLatency again

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
+using System.Runtime;
 using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
@@ -444,6 +445,8 @@ namespace osu.Framework.Platform
 
         public void Run(Game game)
         {
+            GCSettings.LatencyMode = GCLatencyMode.SustainedLowLatency;
+
             if (LimitedMemoryEnvironment)
             {
                 // recommended middle-ground https://github.com/SixLabors/docs/blob/master/articles/ImageSharp/MemoryManagement.md#working-in-memory-constrained-environments


### PR DESCRIPTION
Adding this back as it seems to be better if anything. Leaving it in an always-on state to keep things simple. In the future we could consider exposing this to the game for use specifically during performance-dependent gameplay segments, or toggle it automatically when the window is inactive.

Should hopefully help resolve ppy/osu#5357.