### PR TITLE
Reduce transform allocation overhead of autosize updates

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1681,7 +1681,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void autoSizeResizeTo(Vector2 newSize, double duration = 0, Easing easing = Easing.None)
         {
-            var currentTransform = ((AutoSizeTransform)Transforms.FirstOrDefault(t => t is AutoSizeTransform));
+            var currentTransform = Transforms.Count == 0 ? null : Transforms.OfType<AutoSizeTransform>().FirstOrDefault();
 
             if ((currentTransform?.EndValue ?? Size) != newSize)
             {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1681,9 +1681,19 @@ namespace osu.Framework.Graphics.Containers
 
         private void autoSizeResizeTo(Vector2 newSize, double duration = 0, Easing easing = Easing.None)
         {
-            var currentTargetSize = ((AutoSizeTransform)Transforms.FirstOrDefault(t => t is AutoSizeTransform))?.EndValue ?? Size;
-            if (currentTargetSize != newSize)
-                this.TransformTo(this.PopulateTransform(new AutoSizeTransform { Rewindable = false }, newSize, duration, easing));
+            var currentTransform = ((AutoSizeTransform)Transforms.FirstOrDefault(t => t is AutoSizeTransform));
+
+            if ((currentTransform?.EndValue ?? Size) != newSize)
+            {
+                if (duration == 0)
+                {
+                    if (currentTransform != null)
+                        ClearTransforms(false, nameof(baseSize));
+                    baseSize = newSize;
+                }
+                else
+                    this.TransformTo(this.PopulateTransform(new AutoSizeTransform { Rewindable = false }, newSize, duration, easing));
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/191335/61291153-a7353e80-a808-11e9-8296-7400a80b20e5.png)

The `FirstOrDefault` here is still allocating an enumerator which may be able to be optimised away.