### PR TITLE
Avoid creating joystick states for disconnected devices

### DIFF
--- a/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
@@ -35,11 +35,10 @@ namespace osu.Framework.Input.Handlers.Joystick
                     {
                         foreach (var device in devices)
                         {
-                            if (device.RawState.Equals(device.LastRawState))
+                            if (device.RawState.Equals(device.LastRawState) || !device.RawState.IsConnected)
                                 continue;
 
-                            var newState = new OsuTKJoystickState(device);
-                            handleState(device, newState);
+                            handleState(device, new OsuTKJoystickState(device));
                             FrameStatistics.Increment(StatisticsCounterType.JoystickEvents);
                         }
                     }, 0, 0));

--- a/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
@@ -35,7 +35,8 @@ namespace osu.Framework.Input.Handlers.Joystick
                     {
                         foreach (var device in devices)
                         {
-                            if (device.RawState.Equals(device.LastRawState) || !device.RawState.IsConnected)
+                            if ((device.LastRawState.HasValue && device.RawState.Equals(device.LastRawState.Value))
+                                || !device.RawState.IsConnected)
                                 continue;
 
                             handleState(device, new OsuTKJoystickState(device));


### PR DESCRIPTION
With more than one joystick device where only one was connected, this would cause excess allocations / state changes.

This doesn't fix the fact that multiple joysticks providing different states will still exhibit the same behaviour (a more involved fix required for that).

![image](https://user-images.githubusercontent.com/191335/61303701-f0928780-a822-11e9-8ade-bdd8fe618bb3.png)
