### PR TITLE
Fix TabControl throwing bindable disabled errors on load complete

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -18,20 +18,24 @@ namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestSceneTabControl : FrameworkTestScene
     {
-        private readonly IEnumerable<TestEnum> items;
+        private readonly TestEnum[] items;
 
-        private readonly StyledTabControl pinnedAndAutoSort;
-        private readonly StyledTabControl switchingTabControl;
-        private readonly PlatformActionContainer platformActionContainer;
-        private readonly StyledTabControlWithoutDropdown withoutDropdownTabControl;
-        private readonly StyledTabControl removeAllTabControl;
-        private readonly StyledMultilineTabControl multilineTabControl;
-        private readonly StyledTabControl simpleTabcontrol;
+        private StyledTabControl pinnedAndAutoSort;
+        private StyledTabControl switchingTabControl;
+        private PlatformActionContainer platformActionContainer;
+        private StyledTabControlWithoutDropdown withoutDropdownTabControl;
+        private StyledTabControl removeAllTabControl;
+        private StyledMultilineTabControl multilineTabControl;
+        private StyledTabControl simpleTabcontrol;
 
         public TestSceneTabControl()
         {
-            items = ((TestEnum[])Enum.GetValues(typeof(TestEnum))).AsEnumerable();
+            items = (TestEnum[])Enum.GetValues(typeof(TestEnum));
+        }
 
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
             Add(new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.Both,
@@ -82,7 +86,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             items.Take(7).ForEach(item => pinnedAndAutoSort.AddItem(item));
             pinnedAndAutoSort.PinItem(TestEnum.Test5);
-        }
+        });
 
         [Test]
         public void Basic()
@@ -136,8 +140,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Switch forward", () => platformActionContainer.TriggerPressed(new PlatformAction(PlatformActionType.DocumentNext)));
             AddAssert("Ensure first tab", () => switchingTabControl.Current.Value == switchingTabControl.VisibleItems.First());
 
-            AddStep("Add all items", () => items.AsEnumerable().ForEach(item => removeAllTabControl.AddItem(item)));
-            AddAssert("Ensure all items", () => removeAllTabControl.Items.Count() == items.Count());
+            AddStep("Add all items", () => items.ForEach(item => removeAllTabControl.AddItem(item)));
+            AddAssert("Ensure all items", () => removeAllTabControl.Items.Count() == items.Length);
 
             AddStep("Remove all items", () => removeAllTabControl.Clear());
             AddAssert("Ensure no items", () => !removeAllTabControl.Items.Any());
@@ -146,8 +150,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Remove all items", () => withoutDropdownTabControl.Clear());
             AddAssert("Ensure no items", () => !withoutDropdownTabControl.Items.Any());
 
-            AddAssert("Ensure not all items visible on singleline", () => simpleTabcontrol.VisibleItems.Count() < items.Count());
-            AddAssert("Ensure all items visible on multiline", () => multilineTabControl.VisibleItems.Count() == items.Count());
+            AddAssert("Ensure not all items visible on singleline", () => simpleTabcontrol.VisibleItems.Count() < items.Length);
+            AddAssert("Ensure all items visible on multiline", () => multilineTabControl.VisibleItems.Count() == items.Length);
         }
 
         [Test]
@@ -161,6 +165,35 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("value changed", () => simpleTabcontrol.Current.Value == TestEnum.Test1);
             AddAssert("tab changed", () => simpleTabcontrol.SelectedTab.Value == TestEnum.Test1);
             AddStep("end lease", () => leased.UnbindAll());
+        }
+
+        [Test]
+        public void TestDisabledBindable()
+        {
+            Bindable<TestEnum?> bindable;
+
+            AddStep("add tabcontrol", () =>
+            {
+                bindable = new Bindable<TestEnum?> { Value = TestEnum.Test2 };
+
+                simpleTabcontrol = new StyledTabControl
+                {
+                    Size = new Vector2(200, 30)
+                };
+
+                foreach (var item in items)
+                    simpleTabcontrol.AddItem(item);
+
+                bindable.Disabled = true;
+                simpleTabcontrol.Current = bindable;
+
+                Child = simpleTabcontrol;
+            });
+
+            AddAssert("test2 selected", () => simpleTabcontrol.SelectedTab.Value == TestEnum.Test2);
+
+            // Todo: Should not fail
+            // AddStep("click a tab", () => simpleTabcontrol.TabMap[TestEnum.Test0].Click());
         }
 
         [Test]
@@ -192,6 +225,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class StyledTabControl : TabControl<TestEnum?>
         {
+            public new IReadOnlyDictionary<TestEnum?, TabItem<TestEnum?>> TabMap => base.TabMap;
+
             public new TabItem<TestEnum?> SelectedTab => base.SelectedTab;
 
             protected override Dropdown<TestEnum?> CreateDropdown() => new StyledDropdown();

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -99,6 +99,8 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         private readonly Dictionary<T, TabItem<T>> tabMap;
 
+        private bool firstSelection = true;
+
         protected TabControl()
         {
             Dropdown = CreateDropdown();
@@ -125,7 +127,7 @@ namespace osu.Framework.Graphics.UserInterface
             TabContainer.TabVisibilityChanged = updateDropdown;
             TabContainer.ChildrenEnumerable = tabMap.Values;
 
-            Current.ValueChanged += newSelection => selectTab(Current.Value != null ? tabMap[Current.Value] : null);
+            Current.ValueChanged += _ => firstSelection = false;
         }
 
         protected override void Update()
@@ -142,8 +144,10 @@ namespace osu.Framework.Graphics.UserInterface
         // Default to first selection in list
         protected override void LoadComplete()
         {
-            if (!Current.Disabled && SelectedTab == null && TabContainer.Children.Any())
-                SelectTab(TabContainer.Children.First());
+            if (firstSelection && !Current.Disabled && Items.Any())
+                Current.Value = Items.First();
+
+            Current.BindValueChanged(v => selectTab(v.NewValue != null ? tabMap[v.NewValue] : null), true);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -125,16 +125,7 @@ namespace osu.Framework.Graphics.UserInterface
             TabContainer.TabVisibilityChanged = updateDropdown;
             TabContainer.ChildrenEnumerable = tabMap.Values;
 
-            Current.ValueChanged += newSelection =>
-            {
-                var newTab = Current.Value != null ? tabMap[Current.Value] : null;
-
-                if (IsLoaded)
-                    selectTab(newTab);
-                else
-                    //will be handled in LoadComplete
-                    SelectedTab = newTab;
-            };
+            Current.ValueChanged += newSelection => selectTab(Current.Value != null ? tabMap[Current.Value] : null);
         }
 
         protected override void Update()
@@ -151,9 +142,7 @@ namespace osu.Framework.Graphics.UserInterface
         // Default to first selection in list
         protected override void LoadComplete()
         {
-            if (SelectedTab != null)
-                SelectTab(SelectedTab);
-            else if (TabContainer.Children.Any())
+            if (!Current.Disabled && SelectedTab == null && TabContainer.Children.Any())
                 SelectTab(TabContainer.Children.First());
         }
 


### PR DESCRIPTION
This is not a full fix (https://github.com/ppy/osu-framework/issues/2659) - it only covers the disabled-during-loadcomplete part.

Also adds a testcase for https://github.com/ppy/osu-framework/issues/2659.