### PR TITLE
Rework and simplify RenderBuffer to fix incorrect usages

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -142,15 +142,7 @@ namespace osu.Framework.Graphics
         protected ValueInvokeOnDisposal BindFrameBuffer(FrameBuffer frameBuffer)
         {
             if (!frameBuffer.IsInitialized)
-                frameBuffer.Initialize(true, filteringMode);
-
-            if (formats != null)
-            {
-                // These additional render buffers are only required if e.g. depth
-                // or stencil information needs to also be stored somewhere.
-                foreach (var f in formats)
-                    frameBuffer.Attach(f);
-            }
+                frameBuffer.Initialise(filteringMode, formats);
 
             // This setter will also take care of allocating a texture of appropriate size within the frame buffer.
             frameBuffer.Size = frameBufferSize;

--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -18,33 +18,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         private readonly List<RenderBuffer> attachedRenderBuffers = new List<RenderBuffer>();
 
-        #region Disposal
-
-        ~FrameBuffer()
-        {
-            GLWrapper.ScheduleDisposal(() => Dispose(false));
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        private bool isDisposed;
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (isDisposed)
-                return;
-
-            GLWrapper.DeleteFrameBuffer(frameBuffer);
-
-            isDisposed = true;
-        }
-
-        #endregion
-
         public bool IsInitialized { get; private set; }
 
         public void Initialize(bool withTexture = true, All filteringMode = All.Linear)
@@ -126,5 +99,32 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             foreach (var r in attachedRenderBuffers)
                 r.Unbind();
         }
+
+        #region Disposal
+
+        ~FrameBuffer()
+        {
+            GLWrapper.ScheduleDisposal(() => Dispose(false));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        private bool isDisposed;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (isDisposed)
+                return;
+
+            GLWrapper.DeleteFrameBuffer(frameBuffer);
+
+            isDisposed = true;
+        }
+
+        #endregion
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -96,8 +96,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         public void Unbind()
         {
             GLWrapper.UnbindFrameBuffer(frameBuffer);
-            foreach (var r in attachedRenderBuffers)
-                r.Unbind();
         }
 
         #region Disposal

--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -104,7 +104,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
             foreach (var buffer in attachedRenderBuffers)
                 buffer.Dispose();
-            attachedRenderBuffers.Clear();
 
             isDisposed = true;
         }

--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -120,6 +120,10 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
             GLWrapper.DeleteFrameBuffer(frameBuffer);
 
+            foreach (var buffer in attachedRenderBuffers)
+                buffer.Dispose();
+            attachedRenderBuffers.Clear();
+
             isDisposed = true;
         }
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -38,10 +38,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             if (isDisposed)
                 return;
 
-            isDisposed = true;
+            GLWrapper.DeleteFrameBuffer(frameBuffer);
 
-            GLWrapper.DeleteFramebuffer(frameBuffer);
-            frameBuffer = -1;
+            isDisposed = true;
         }
 
         #endregion

--- a/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             get => size;
             set
             {
-                if (size == value)
+                if (value.X <= size.X && value.Y <= size.Y)
                     return;
 
                 size = value;

--- a/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
@@ -101,7 +101,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
                         break;
 
                     case RenderbufferInternalFormat.StencilIndex8:
-                        GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, RenderbufferTarget.Renderbuffer, info.RenderBufferID);
+                        GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.StencilAttachment, RenderbufferTarget.Renderbuffer, info.RenderBufferID);
                         break;
                 }
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Framework.Threading;
 using osuTK;
 using osuTK.Graphics.ES30;
 
@@ -10,24 +11,56 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 {
     public class RenderBuffer : IDisposable
     {
-        private static readonly Dictionary<RenderbufferInternalFormat, Stack<RenderBufferInfo>> render_buffer_cache = new Dictionary<RenderbufferInternalFormat, Stack<RenderBufferInfo>>();
-
         public Vector2 Size = Vector2.One;
         public RenderbufferInternalFormat Format { get; }
 
-        private RenderBufferInfo info;
-        private bool isDisposed;
+        private int renderBuffer = -1;
 
         public RenderBuffer(RenderbufferInternalFormat format)
         {
             Format = format;
         }
 
+        /// <summary>
+        /// Binds the renderbuffer to the specfied framebuffer.
+        /// </summary>
+        /// <param name="frameBuffer">The framebuffer this renderbuffer should be bound to.</param>
+        internal void Bind(int frameBuffer)
+        {
+            if (renderBuffer == -1)
+                renderBuffer = GL.GenRenderbuffer();
+
+            GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, renderBuffer);
+            GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, Format, (int)Math.Ceiling(Size.X), (int)Math.Ceiling(Size.Y));
+
+            // Make sure the framebuffer we want to attach to is bound
+            GLWrapper.BindFrameBuffer(frameBuffer);
+
+            switch (Format)
+            {
+                case RenderbufferInternalFormat.DepthComponent16:
+                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, RenderbufferTarget.Renderbuffer, renderBuffer);
+                    break;
+
+                case RenderbufferInternalFormat.Rgb565:
+                case RenderbufferInternalFormat.Rgb5A1:
+                case RenderbufferInternalFormat.Rgba4:
+                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, RenderbufferTarget.Renderbuffer, renderBuffer);
+                    break;
+
+                case RenderbufferInternalFormat.StencilIndex8:
+                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.StencilAttachment, RenderbufferTarget.Renderbuffer, renderBuffer);
+                    break;
+            }
+
+            GLWrapper.UnbindFrameBuffer(frameBuffer);
+        }
+
         #region Disposal
 
         ~RenderBuffer()
         {
-            Dispose(false);
+            GLWrapper.ScheduleDisposal(() => Dispose(false));
         }
 
         public void Dispose()
@@ -36,101 +69,19 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             GC.SuppressFinalize(this);
         }
 
+        private bool isDisposed;
+
         protected virtual void Dispose(bool disposing)
         {
             if (isDisposed)
                 return;
 
-            isDisposed = true;
+            if (renderBuffer != -1)
+                GL.DeleteRenderbuffer(renderBuffer);
 
-            Unbind();
+            isDisposed = true;
         }
 
         #endregion
-
-        /// <summary>
-        /// Binds the renderbuffer to the specfied framebuffer.
-        /// </summary>
-        /// <param name="frameBuffer">The framebuffer this renderbuffer should be bound to.</param>
-        internal void Bind(int frameBuffer)
-        {
-            // Check if we're already bound
-            if (info != null)
-                return;
-
-            if (!render_buffer_cache.ContainsKey(Format))
-                render_buffer_cache[Format] = new Stack<RenderBufferInfo>();
-
-            // Make sure we have renderbuffers available
-            if (render_buffer_cache[Format].Count == 0)
-                render_buffer_cache[Format].Push(new RenderBufferInfo
-                {
-                    RenderBufferID = GL.GenRenderbuffer(),
-                    FrameBufferID = -1
-                });
-
-            // Get a renderbuffer from the cache
-            info = render_buffer_cache[Format].Pop();
-
-            // Check if we need to update the size
-            if (info.Size != Size)
-            {
-                GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, info.RenderBufferID);
-                GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, Format, (int)Math.Ceiling(Size.X), (int)Math.Ceiling(Size.Y));
-
-                info.Size = Size;
-            }
-
-            // For performance reasons, we only need to re-bind the renderbuffer to
-            // the framebuffer if it is not already attached to it
-            if (info.FrameBufferID != frameBuffer)
-            {
-                // Make sure the framebuffer we want to attach to is bound
-                GLWrapper.BindFrameBuffer(frameBuffer);
-
-                switch (Format)
-                {
-                    case RenderbufferInternalFormat.DepthComponent16:
-                        GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, RenderbufferTarget.Renderbuffer, info.RenderBufferID);
-                        break;
-
-                    case RenderbufferInternalFormat.Rgb565:
-                    case RenderbufferInternalFormat.Rgb5A1:
-                    case RenderbufferInternalFormat.Rgba4:
-                        GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, RenderbufferTarget.Renderbuffer, info.RenderBufferID);
-                        break;
-
-                    case RenderbufferInternalFormat.StencilIndex8:
-                        GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.StencilAttachment, RenderbufferTarget.Renderbuffer, info.RenderBufferID);
-                        break;
-                }
-
-                GLWrapper.UnbindFrameBuffer(frameBuffer);
-            }
-
-            info.FrameBufferID = frameBuffer;
-        }
-
-        /// <summary>
-        /// Unbinds the renderbuffer.
-        /// <para>The renderbuffer will remain internally attached to the framebuffer.</para>
-        /// </summary>
-        internal void Unbind()
-        {
-            if (info == null)
-                return;
-
-            // Return the renderbuffer to the cache
-            render_buffer_cache[Format].Push(info);
-
-            info = null;
-        }
-
-        private class RenderBufferInfo
-        {
-            public int RenderBufferID;
-            public int FrameBufferID;
-            public Vector2 Size;
-        }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -634,10 +634,10 @@ namespace osu.Framework.Graphics.OpenGL
         }
 
         /// <summary>
-        /// Deletes a framebuffer.
+        /// Deletes a frame buffer.
         /// </summary>
-        /// <param name="frameBuffer">The framebuffer to delete.</param>
-        internal static void DeleteFramebuffer(int frameBuffer)
+        /// <param name="frameBuffer">The frame buffer to delete.</param>
+        internal static void DeleteFrameBuffer(int frameBuffer)
         {
             if (frameBuffer == -1) return;
 


### PR DESCRIPTION
Fixes #2661
Fixes ppy/osu#5391

There were several issues here:
1. Caching wasn't working at all - frame buffers unbound their render buffers immediately so only one render buffer was ever used game-wide.
2. Caching seems to be done at the wrong place - we don't want the associated memory from render buffers present until the game is exited.
3. As far as I can tell, you need to bind the render buffer to attach it to a framebuffer, which wasn't being done previously except for when the size changed.

This change is mostly a simplification which removes all caching.

This is also in preparation for caching framebuffers/renderbuffers at a higher level, where they can be both reused and recycled.