### PR TITLE
Avoid disposing Path texture

### DIFF
--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -161,17 +161,16 @@ namespace osu.Framework.Graphics.Lines
             return segmentsBacking;
         }
 
-        private Texture texture = Texture.WhitePixel;
+        private Texture texture;
 
         protected Texture Texture
         {
-            get => texture;
+            get => texture ?? Texture.WhitePixel;
             set
             {
                 if (texture == value)
                     return;
 
-                texture?.Dispose();
                 texture = value;
 
                 Invalidate(Invalidation.DrawNode);

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -171,6 +171,7 @@ namespace osu.Framework.Graphics.Lines
                 if (texture == value)
                     return;
 
+                texture?.Dispose();
                 texture = value;
 
                 Invalidate(Invalidation.DrawNode);

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -193,6 +193,9 @@ namespace osu.Framework.Graphics.Lines
         {
             base.Dispose(isDisposing);
 
+            texture?.Dispose();
+            texture = null;
+
             sharedData.Dispose();
         }
     }


### PR DESCRIPTION
Potentially still being used by drawnode. Also stops needlessly disposing `Texture.WhitePixel` on `Texture_Set`.