### PR TITLE
Reduce LinearBatch size of CircularProgress

### DIFF
--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -41,8 +41,7 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         // We add 2 to the size param to account for the first triangle needing every vertex passed, subsequent triangles use the last two vertices of the previous triangle.
-        // MAX_RES is being multiplied by 2 to account for each circle part needing 2 triangles
-        // Otherwise overflowing the batch will result in wrong grouping of vertices into primitives.
+        // MAX_RES refers to a half-circle, so it is multiplied by 2 for the full circle and by 2 again to account for each circle part requiring two vertices.
         private readonly LinearBatch<TexturedVertex2D> halfCircleBatch = new LinearBatch<TexturedVertex2D>(MAX_RES * 4 + 2, 1, PrimitiveType.TriangleStrip);
 
         private Vector2 pointOnCircle(float angle) => new Vector2((float)Math.Sin(angle), -(float)Math.Cos(angle));

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Graphics.UserInterface
         // We add 2 to the size param to account for the first triangle needing every vertex passed, subsequent triangles use the last two vertices of the previous triangle.
         // MAX_RES is being multiplied by 2 to account for each circle part needing 2 triangles
         // Otherwise overflowing the batch will result in wrong grouping of vertices into primitives.
-        private readonly LinearBatch<TexturedVertex2D> halfCircleBatch = new LinearBatch<TexturedVertex2D>(MAX_RES * 100 * 2 + 2, 10, PrimitiveType.TriangleStrip);
+        private readonly LinearBatch<TexturedVertex2D> halfCircleBatch = new LinearBatch<TexturedVertex2D>(MAX_RES * 4 + 2, 1, PrimitiveType.TriangleStrip);
 
         private Vector2 pointOnCircle(float angle) => new Vector2((float)Math.Sin(angle), -(float)Math.Cos(angle));
         private float angleToUnitInterval(float angle) => angle / MathHelper.TwoPi + (angle >= 0 ? 0 : 1);


### PR DESCRIPTION
The previous setting assumes it would ever be batched, but in practice this basically never happens. Minimising batch size seems like a better short-term option until we have a better method of deciding and managing batch sizes.