### PR TITLE
Add TriangleVertexBatch to centralise and avoid incorrect vertex count specifications

### DIFF
--- a/osu.Framework/Graphics/Batches/TriangleBatch.cs
+++ b/osu.Framework/Graphics/Batches/TriangleBatch.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.OpenGL.Buffers;
+using osu.Framework.Graphics.OpenGL.Vertices;
+using osuTK.Graphics.ES30;
+
+namespace osu.Framework.Graphics.Batches
+{
+    public class TriangleBatch<T> : VertexBatch<T>
+        where T : struct, IEquatable<T>, IVertex
+    {
+        public TriangleBatch(int size, int maxBuffers)
+            : base(size, maxBuffers)
+        {
+        }
+
+        protected override VertexBuffer<T> CreateVertexBuffer() => new TriangleVertexBuffer(Size, BufferUsageHint.DynamicDraw);
+
+        private class TriangleVertexBuffer : LinearVertexBuffer<T>
+        {
+            public TriangleVertexBuffer(int size, BufferUsageHint dynamicDraw)
+                : base(size * 6, PrimitiveType.Triangles, dynamicDraw)
+            {
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Batches/TriangleBatch.cs
+++ b/osu.Framework/Graphics/Batches/TriangleBatch.cs
@@ -3,11 +3,15 @@
 
 using System;
 using osu.Framework.Graphics.OpenGL.Buffers;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Batches
 {
+    /// <summary>
+    /// A batch to be used when drawing triangles with <see cref="TextureGLSingle.DrawTriangle"/>.
+    /// </summary>
     public class TriangleBatch<T> : VertexBatch<T>
         where T : struct, IEquatable<T>, IVertex
     {
@@ -21,7 +25,7 @@ namespace osu.Framework.Graphics.Batches
         private class TriangleVertexBuffer : LinearVertexBuffer<T>
         {
             public TriangleVertexBuffer(int size, BufferUsageHint dynamicDraw)
-                : base(size * 6, PrimitiveType.Triangles, dynamicDraw)
+                : base(size * TextureGLSingle.VERTICES_PER_TRIANGLE, PrimitiveType.Triangles, dynamicDraw)
             {
             }
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -13,7 +13,6 @@ using System;
 using System.Runtime.CompilerServices;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.OpenGL.Vertices;
-using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -68,7 +67,7 @@ namespace osu.Framework.Graphics.Containers
             /// <summary>
             /// The vertex batch used for child triangles during the front-to-back pass.
             /// </summary>
-            private LinearBatch<TexturedVertex2D> triangleBatch;
+            private TriangleBatch<TexturedVertex2D> triangleBatch;
 
             public CompositeDrawableDrawNode(CompositeDrawable source)
                 : base(source)
@@ -190,7 +189,7 @@ namespace osu.Framework.Graphics.Containers
                 if (mayHaveOwnVertexBatch(clampedAmountChildren) && (triangleBatch == null || triangleBatch.Size < clampedAmountChildren))
                 {
                     // The same general idea as updateQuadBatch(), except that each child draws up to 3 vertices * 6 triangles after quad-quad intersection
-                    triangleBatch = new LinearBatch<TexturedVertex2D>(clampedAmountChildren * 2 * 3, 500, PrimitiveType.Triangles);
+                    triangleBatch = new TriangleBatch<TexturedVertex2D>(clampedAmountChildren * 2, 500);
                 }
             }
 

--- a/osu.Framework/Graphics/Lines/Path_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Path_DrawNode.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.Lines
             // We multiply the size param by 3 such that the amount of vertices is a multiple of the amount of vertices
             // per primitive (triangles in this case). Otherwise overflowing the batch will result in wrong
             // grouping of vertices into primitives.
-            private readonly LinearBatch<TexturedVertex3D> halfCircleBatch = new LinearBatch<TexturedVertex3D>(MAX_RES * 100 * 3, 10, PrimitiveType.Triangles);
+            private readonly TriangleBatch<TexturedVertex3D> halfCircleBatch = new TriangleBatch<TexturedVertex3D>(MAX_RES * 100, 10);
             private readonly QuadBatch<TexturedVertex3D> quadBatch = new QuadBatch<TexturedVertex3D>(200, 10);
 
             public PathDrawNode(Path source)

--- a/osu.Framework/Graphics/Lines/Path_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Path_DrawNode.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.Lines
             // We multiply the size param by 3 such that the amount of vertices is a multiple of the amount of vertices
             // per primitive (triangles in this case). Otherwise overflowing the batch will result in wrong
             // grouping of vertices into primitives.
-            private readonly TriangleBatch<TexturedVertex3D> halfCircleBatch = new TriangleBatch<TexturedVertex3D>(MAX_RES * 100, 10);
+            private readonly LinearBatch<TexturedVertex3D> halfCircleBatch = new LinearBatch<TexturedVertex3D>(MAX_RES * 100 * 3, 10, PrimitiveType.Triangles);
             private readonly QuadBatch<TexturedVertex3D> quadBatch = new QuadBatch<TexturedVertex3D>(200, 10);
 
             public PathDrawNode(Path source)

--- a/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osuTK.Graphics.ES30;
 
@@ -24,7 +25,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         private readonly int amountQuads;
 
         internal QuadVertexBuffer(int amountQuads, BufferUsageHint usage)
-            : base(amountQuads * 4, usage)
+            : base(amountQuads * TextureGLSingle.VERTICES_PER_QUAD, usage)
         {
             this.amountQuads = amountQuads;
         }
@@ -39,7 +40,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             {
                 ushort[] indices = new ushort[amountIndices];
 
-                for (ushort i = 0, j = 0; j < amountIndices; i += 4, j += 6)
+                for (ushort i = 0, j = 0; j < amountIndices; i += TextureGLSingle.VERTICES_PER_QUAD, j += 6)
                 {
                     indices[j] = i;
                     indices[j + 1] = (ushort)(i + 1);

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             // We multiply the size param by 3 such that the amount of vertices is a multiple of the amount of vertices
             // per primitive (triangles in this case). Otherwise overflowing the batch will result in wrong
             // grouping of vertices into primitives.
-            LinearBatch<TexturedVertex2D> triangleBatch = new LinearBatch<TexturedVertex2D>(512 * 3, 128, PrimitiveType.Triangles);
+            TriangleBatch<TexturedVertex2D> triangleBatch = new TriangleBatch<TexturedVertex2D>(512, 128);
             default_triangle_action = triangleBatch.AddAction;
         }
 

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -141,6 +141,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             return texRect;
         }
 
+        public const int VERTICES_PER_TRIANGLE = 6;
+
         internal override void DrawTriangle(Triangle vertexTriangle, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null,
                                             Vector2? inflationPercentage = null)
         {
@@ -215,6 +217,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
             FrameStatistics.Add(StatisticsCounterType.Pixels, (long)vertexTriangle.ConservativeArea);
         }
+
+        public const int VERTICES_PER_QUAD = 4;
 
         internal override void DrawQuad(Quad vertexQuad, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null,
                                         Vector2? blendRangeOverride = null)


### PR DESCRIPTION
We were using 3 vertices per triangle as specifications for LinearVertexBatch while it should have been 6. This centralises that logic to standardise and avoid similar issues in the future.