### PR TITLE
Fix compiling Xamarin projects on VS2017

### DIFF
--- a/osu.Framework.Android.props
+++ b/osu.Framework.Android.props
@@ -62,5 +62,7 @@
     <PackageReference Include="ManagedBass" Version="2.0.4" />
     <PackageReference Include="ManagedBass.Fx" Version="2.0.1" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <!--Workaround for https://github.com/ppy/osu/issues/5392-->
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -115,5 +115,7 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
+    <!--Workaround for https://github.com/ppy/osu/issues/5392-->
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
same as ppy/osu#5394