### PR TITLE
Optimise vertex buffer vertex additions

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -40,12 +40,12 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         /// <returns>Whether the vertex changed.</returns>
         public bool SetVertex(int vertexIndex, T vertex)
         {
-            var vertices = vertexMemory.Span;
+            ref var currentVertex = ref vertexMemory.Span[vertexIndex];
 
-            bool isNewVertex = !vertices[vertexIndex].Equals(vertex) || vertices[vertexIndex].BackbufferDrawDepth != GLWrapper.BackbufferDrawDepth;
+            bool isNewVertex = !currentVertex.Equals(vertex) || currentVertex.BackbufferDrawDepth != GLWrapper.BackbufferDrawDepth;
 
-            vertices[vertexIndex].Vertex = vertex;
-            vertices[vertexIndex].BackbufferDrawDepth = GLWrapper.BackbufferDrawDepth;
+            currentVertex.Vertex = vertex;
+            currentVertex.BackbufferDrawDepth = GLWrapper.BackbufferDrawDepth;
 
             return isNewVertex;
         }

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -18,7 +18,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         private readonly BufferUsageHint usage;
 
-        private IMemoryOwner<DepthWrappingVertex<T>> vertices;
+        private IMemoryOwner<DepthWrappingVertex<T>> memoryOwner;
+        private Memory<DepthWrappingVertex<T>> vertexMemory;
+
         private bool isInitialised;
         private int vboId;
 
@@ -26,7 +28,8 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         {
             this.usage = usage;
 
-            vertices = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<DepthWrappingVertex<T>>(amountVertices, AllocationOptions.Clean);
+            memoryOwner = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<DepthWrappingVertex<T>>(amountVertices, AllocationOptions.Clean);
+            vertexMemory = memoryOwner.Memory;
         }
 
         /// <summary>
@@ -37,10 +40,12 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         /// <returns>Whether the vertex changed.</returns>
         public bool SetVertex(int vertexIndex, T vertex)
         {
-            bool isNewVertex = !vertices.Memory.Span[vertexIndex].Equals(vertex) || vertices.Memory.Span[vertexIndex].BackbufferDrawDepth != GLWrapper.BackbufferDrawDepth;
+            var vertices = vertexMemory.Span;
 
-            vertices.Memory.Span[vertexIndex].Vertex = vertex;
-            vertices.Memory.Span[vertexIndex].BackbufferDrawDepth = GLWrapper.BackbufferDrawDepth;
+            bool isNewVertex = !vertices[vertexIndex].Equals(vertex) || vertices[vertexIndex].BackbufferDrawDepth != GLWrapper.BackbufferDrawDepth;
+
+            vertices[vertexIndex].Vertex = vertex;
+            vertices[vertexIndex].BackbufferDrawDepth = GLWrapper.BackbufferDrawDepth;
 
             return isNewVertex;
         }
@@ -48,7 +53,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         /// <summary>
         /// Gets the number of vertices in this <see cref="VertexBuffer{T}"/>.
         /// </summary>
-        public int Size => vertices.Memory.Length;
+        public int Size => vertexMemory.Length;
 
         private static readonly GlobalStatistic<long> loaded_vertex_bytes = GlobalStatistics.Get<long>("Native", nameof(VertexBuffer<T>));
 
@@ -90,8 +95,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
             int size = Size * STRIDE;
 
-            vertices.Dispose();
-            vertices = null;
+            memoryOwner.Dispose();
+            memoryOwner = null;
+            vertexMemory = null;
 
             if (isInitialised)
             {
@@ -131,7 +137,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         public void Draw()
         {
-            DrawRange(0, vertices.Memory.Length);
+            DrawRange(0, vertexMemory.Length);
         }
 
         public void DrawRange(int startIndex, int endIndex)
@@ -146,7 +152,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         public void Update()
         {
-            UpdateRange(0, vertices.Memory.Length);
+            UpdateRange(0, vertexMemory.Length);
         }
 
         public void UpdateRange(int startIndex, int endIndex)
@@ -154,7 +160,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             Bind(false);
 
             int amountVertices = endIndex - startIndex;
-            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)(startIndex * STRIDE), (IntPtr)(amountVertices * STRIDE), ref vertices.Memory.Span[startIndex]);
+            GL.BufferSubData(BufferTarget.ArrayBuffer, (IntPtr)(startIndex * STRIDE), (IntPtr)(amountVertices * STRIDE), ref vertexMemory.Span[startIndex]);
 
             Unbind();
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         {
             ref var currentVertex = ref vertexMemory.Span[vertexIndex];
 
-            bool isNewVertex = !currentVertex.Equals(vertex) || currentVertex.BackbufferDrawDepth != GLWrapper.BackbufferDrawDepth;
+            bool isNewVertex = !currentVertex.Vertex.Equals(vertex) || currentVertex.BackbufferDrawDepth != GLWrapper.BackbufferDrawDepth;
 
             currentVertex.Vertex = vertex;
             currentVertex.BackbufferDrawDepth = GLWrapper.BackbufferDrawDepth;

--- a/osu.Framework/Graphics/OpenGL/Vertices/DepthWrappingVertex.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/DepthWrappingVertex.cs
@@ -8,7 +8,7 @@ using osuTK.Graphics.ES30;
 namespace osu.Framework.Graphics.OpenGL.Vertices
 {
     [StructLayout(LayoutKind.Sequential)]
-    internal struct DepthWrappingVertex<TVertex> : IVertex, IEquatable<DepthWrappingVertex<TVertex>>, IEquatable<TVertex>
+    internal struct DepthWrappingVertex<TVertex> : IVertex, IEquatable<DepthWrappingVertex<TVertex>>
         where TVertex : IVertex, IEquatable<TVertex>
     {
         public TVertex Vertex;
@@ -19,8 +19,5 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         public bool Equals(DepthWrappingVertex<TVertex> other)
             => Vertex.Equals(other.Vertex)
                && BackbufferDrawDepth.Equals(other.BackbufferDrawDepth);
-
-        public bool Equals(TVertex other)
-            => Vertex.Equals(other);
     }
 }


### PR DESCRIPTION
```diff
  | Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
  |------- |---------:|----------:|----------:|------:|------:|------:|----------:|
- |    Add | 249.0 ns |  1.528 ns |  1.429 ns |     - |     - |     - |         - |
+ |    Add | 42.88 ns | 0.2655 ns | 0.2483 ns |     - |     - |     - |         - |
```

I go from 120fps -> 200fps with chat opened to #lazer.