### PR TITLE
Fix bindable potentially deadlocking on nested enumeration operations

### DIFF
--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Caching;
@@ -289,7 +290,9 @@ namespace osu.Framework.Bindables
             if (Bindings == null)
                 return;
 
-            foreach (var b in Bindings)
+            // ToArray required as this may be called from an async disposal thread.
+            // This can lead to deadlocks since each child is also enumerating its Bindings.
+            foreach (var b in Bindings.ToArray())
                 b.Unbind(this);
 
             Bindings.Clear();


### PR DESCRIPTION
If a drawable is disposed via anything that is not a `CompositeDrawable`, there is a chance the `UnbindAllBindables` will be run on the finalizer/async disposal thread. In this case, with the use of leased bindables, it is possible to reach a deadlock scenario. One such example follows:

![IMG_0677](https://user-images.githubusercontent.com/191335/61776006-0c0a1d80-ae35-11e9-9b81-faf5bac9032e.JPG)
