### PR TITLE
Allow memory clean-up via GameHost.Collect

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Android
         public override void OnTrimMemory([GeneratedEnum] TrimMemory level)
         {
             base.OnTrimMemory(level);
-            gameView.Host?.PurgeCaches();
+            gameView.Host?.Collect();
         }
 
         protected override void OnCreate(Bundle savedInstanceState)

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -13,19 +13,19 @@ namespace osu.Framework.Android
     {
         protected abstract Game CreateGame();
 
+        private AndroidGameView gameView;
+
         public override void OnTrimMemory([GeneratedEnum] TrimMemory level)
         {
             base.OnTrimMemory(level);
-
-            SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.ReleaseRetainedResources();
-            GC.Collect();
+            gameView.Host?.PurgeCaches();
         }
 
         protected override void OnCreate(Bundle savedInstanceState)
         {
             base.OnCreate(savedInstanceState);
 
-            SetContentView(new AndroidGameView(this, CreateGame()));
+            SetContentView(gameView = new AndroidGameView(this, CreateGame()));
         }
 
         protected override void OnPause() {

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -19,8 +19,8 @@ namespace osu.Framework.Android
 
         private readonly Game game;
 
-        public event Action<Keycode, KeyEvent> KeyDown;
-        public event Action<Keycode, KeyEvent> KeyUp;
+        public new event Action<Keycode, KeyEvent> KeyDown;
+        public new event Action<Keycode, KeyEvent> KeyUp;
         public event Action<Keycode, KeyEvent> KeyLongPress;
         public event Action<string> CommitText;
 

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -15,7 +15,8 @@ namespace osu.Framework.Android
 {
     public class AndroidGameView : osuTK.Android.AndroidGameView
     {
-        private AndroidGameHost host;
+        public AndroidGameHost Host { get; private set; }
+
         private readonly Game game;
 
         public event Action<Keycode, KeyEvent> KeyDown;
@@ -109,8 +110,8 @@ namespace osu.Framework.Android
         [STAThread]
         public void RenderGame()
         {
-            host = new AndroidGameHost(this);
-            host.Run(game);
+            Host = new AndroidGameHost(this);
+            Host.Run(game);
         }
 
         public override bool OnCheckIsTextEditor() => true;

--- a/osu.Framework.iOS/GameAppDelegate.cs
+++ b/osu.Framework.iOS/GameAppDelegate.cs
@@ -22,19 +22,16 @@ namespace osu.Framework.iOS
             aotImageSharp();
 
             Window = new UIWindow(UIScreen.MainScreen.Bounds);
+
             gameView = new IOSGameView(new RectangleF(0.0f, 0.0f, (float)Window.Frame.Size.Width, (float)Window.Frame.Size.Height));
+            host = new IOSGameHost(gameView);
 
-            GameViewController viewController = new GameViewController
-            {
-                View = gameView
-            };
-
-            Window.RootViewController = viewController;
+            Window.RootViewController = new GameViewController(gameView, host);
             Window.MakeKeyAndVisible();
 
+            // required to trigger the osuTK update loop, which is used for input handling.
             gameView.Run();
 
-            host = new IOSGameHost(gameView);
             host.Run(CreateGame());
 
             return true;
@@ -44,6 +41,7 @@ namespace osu.Framework.iOS
         {
             System.Runtime.CompilerServices.Unsafe.SizeOf<Rgba32>();
             System.Runtime.CompilerServices.Unsafe.SizeOf<long>();
+
             try
             {
                 new SixLabors.ImageSharp.Formats.Png.PngDecoder().Decode<Rgba32>(SixLabors.ImageSharp.Configuration.Default, null);

--- a/osu.Framework.iOS/GameViewController.cs
+++ b/osu.Framework.iOS/GameViewController.cs
@@ -3,22 +3,30 @@
 
 using System;
 using CoreGraphics;
+using osu.Framework.Platform;
 using UIKit;
 
 namespace osu.Framework.iOS
 {
     internal class GameViewController : UIViewController
     {
+        private readonly IOSGameView view;
+        private readonly GameHost host;
+
         public override bool PrefersStatusBarHidden() => true;
 
         public override UIRectEdge PreferredScreenEdgesDeferringSystemGestures => UIRectEdge.All;
 
+        public GameViewController(IOSGameView view, GameHost host)
+        {
+            View = view;
+            this.host = host;
+        }
+
         public override void DidReceiveMemoryWarning()
         {
             base.DidReceiveMemoryWarning();
-
-            SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.ReleaseRetainedResources();
-            GC.Collect();
+            host.Collect();
         }
 
         public override void ViewWillTransitionToSize(CGSize toSize, IUIViewControllerTransitionCoordinator coordinator)
@@ -27,7 +35,7 @@ namespace osu.Framework.iOS
             UIView.AnimationsEnabled = false;
             base.ViewWillTransitionToSize(toSize, coordinator);
 
-            (View as IOSGameView)?.RequestResizeFrameBuffer();
+            view.RequestResizeFrameBuffer();
         }
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -23,7 +23,6 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.OpenGL;
-using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -23,6 +23,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.OpenGL;
+using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
@@ -197,6 +198,16 @@ namespace osu.Framework.Platform
         {
             this.toolkitOptions = toolkitOptions;
             Name = gameName;
+        }
+
+        /// <summary>
+        /// Performs a GC collection and frees all framework caches.
+        /// This is a blocking call and should not be invoked during periods of user activity unless memory is critical.
+        /// </summary>
+        public void Collect()
+        {
+            SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.ReleaseRetainedResources();
+            GC.Collect();
         }
 
         private void unhandledExceptionHandler(object sender, UnhandledExceptionEventArgs args)


### PR DESCRIPTION
Moved out from per-platform implementations to allow for future agnostic additions (and potential invocation on desktop platform).