### PR TITLE
Expose CompositeDrawable's subtree specific positional input conditional

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1221,12 +1221,18 @@ namespace osu.Framework.Graphics.Containers
             return true;
         }
 
+        /// <summary>
+        /// Whether or not this Drawable should block its children from receiving input outside of its
+        /// draw rectangle regardless of whether or not they are masked away.
+        /// </summary>
+        protected virtual bool ConfinePositionalInput => false;
+
         internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
             if (!base.BuildPositionalInputQueue(screenSpacePos, queue))
                 return false;
 
-            if (Masking && !ReceivePositionalInputAt(screenSpacePos))
+            if ((Masking || ConfinePositionalInput) && !ReceivePositionalInputAt(screenSpacePos))
                 return false;
 
             for (int i = 0; i < aliveInternalChildren.Count; ++i)

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1222,16 +1222,22 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Whether or not this Drawable should block its children from receiving input outside of its draw rectangle.
+        /// Determines whether the subtree of this <see cref="CompositeDrawable"/> should receive positional input when the mouse is at the given screen-space position.
         /// </summary>
-        protected virtual bool ConfinePositionalInput => Masking;
+        /// <remarks>
+        /// By default, the subtree of this <see cref="CompositeDrawable"/> always receives input when masking is turned off, and only receives input if this
+        /// <see cref="CompositeDrawable"/> also receives input when masking is turned on.
+        /// </remarks>
+        /// <param name="screenSpacePos">The screen-space position where input could be received.</param>
+        /// <returns>True if the subtree should receive input at the given screen-space position.</returns>
+        protected virtual bool ReceiveSubTreePositionalInputAt(Vector2 screenSpacePos) => !Masking || ReceivePositionalInputAt(screenSpacePos);
 
         internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
             if (!base.BuildPositionalInputQueue(screenSpacePos, queue))
                 return false;
 
-            if (ConfinePositionalInput && !ReceivePositionalInputAt(screenSpacePos))
+            if (!ReceiveSubTreePositionalInputAt(screenSpacePos))
                 return false;
 
             for (int i = 0; i < aliveInternalChildren.Count; ++i)

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1225,7 +1225,7 @@ namespace osu.Framework.Graphics.Containers
         /// Whether or not this Drawable should block its children from receiving input outside of its
         /// draw rectangle regardless of whether or not they are masked away.
         /// </summary>
-        protected virtual bool ConfinePositionalInput => false;
+        protected virtual bool ConfinePositionalInput => Masking;
 
         internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1222,8 +1222,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Whether or not this Drawable should block its children from receiving input outside of its
-        /// draw rectangle regardless of whether or not they are masked away.
+        /// Whether or not this Drawable should block its children from receiving input outside of its draw rectangle.
         /// </summary>
         protected virtual bool ConfinePositionalInput => Masking;
 
@@ -1232,7 +1231,7 @@ namespace osu.Framework.Graphics.Containers
             if (!base.BuildPositionalInputQueue(screenSpacePos, queue))
                 return false;
 
-            if ((Masking || ConfinePositionalInput) && !ReceivePositionalInputAt(screenSpacePos))
+            if (ConfinePositionalInput && !ReceivePositionalInputAt(screenSpacePos))
                 return false;
 
             for (int i = 0; i < aliveInternalChildren.Count; ++i)

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1230,14 +1230,14 @@ namespace osu.Framework.Graphics.Containers
         /// </remarks>
         /// <param name="screenSpacePos">The screen-space position where input could be received.</param>
         /// <returns>True if the subtree should receive input at the given screen-space position.</returns>
-        protected virtual bool ReceiveSubTreePositionalInputAt(Vector2 screenSpacePos) => !Masking || ReceivePositionalInputAt(screenSpacePos);
+        protected virtual bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos) => !Masking || ReceivePositionalInputAt(screenSpacePos);
 
         internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
         {
             if (!base.BuildPositionalInputQueue(screenSpacePos, queue))
                 return false;
 
-            if (!ReceiveSubTreePositionalInputAt(screenSpacePos))
+            if (!ReceivePositionalInputAtSubTree(screenSpacePos))
                 return false;
 
             for (int i = 0; i < aliveInternalChildren.Count; ++i)

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -136,8 +136,6 @@ namespace osu.Framework.Graphics.Containers
 
         protected override Container<T> Content => content;
 
-        protected override bool ConfinePositionalInput => true;
-
         /// <summary>
         /// Whether we are currently scrolled as far as possible into the scroll direction.
         /// </summary>

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -136,6 +136,8 @@ namespace osu.Framework.Graphics.Containers
 
         protected override Container<T> Content => content;
 
+        protected override bool ConfinePositionalInput => true;
+
         /// <summary>
         /// Whether we are currently scrolled as far as possible into the scroll direction.
         /// </summary>


### PR DESCRIPTION
Previously, having `Masking` disabled on a `CompositeDrawable` means children contained inside it are able to receive positional input even if its from outside of the `CompositeDrawable`'s `DrawRectangle`. 

This behavior is undesirable for some scenarios, such as if we want to use a `Container` to denote the area for where input should be allowed, such as in https://github.com/ppy/osu/issues/5452.

This exposes a new virtual property that can be overridden to denote any `CompositeDrawable` as a positional input-confining drawable, forcing a `ReceivePositionalInputAt` check, as well as makes `ScrollContainers` override it by default.