### PR TITLE
Implement proper auto-sizing for Path

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestScenePathApproximator.cs
@@ -63,6 +63,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                 points[3] = new Vector2(200, 80);
                 points[4] = new Vector2(250, 50);
 
+                AutoSizeAxes = Axes.None;
                 RelativeSizeAxes = Axes.Both;
                 PathRadius = 2;
                 Vertices = approximator(points);

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputResampler.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputResampler.cs
@@ -54,7 +54,6 @@ namespace osu.Framework.Tests.Visual.Input
                 new UserDrawnPath
                 {
                     DrawText = text[2],
-                    RelativeSizeAxes = Axes.Both,
                     Texture = gradientTexture,
                     Colour = Color4.White,
                 },
@@ -78,7 +77,6 @@ namespace osu.Framework.Tests.Visual.Input
                 new SmoothedUserDrawnPath
                 {
                     DrawText = text[5],
-                    RelativeSizeAxes = Axes.Both,
                     Texture = gradientTexture,
                     Colour = Color4.White,
                     InputResampler = new InputResampler(),
@@ -103,7 +101,6 @@ namespace osu.Framework.Tests.Visual.Input
                 new SmoothedUserDrawnPath
                 {
                     DrawText = text[5],
-                    RelativeSizeAxes = Axes.Both,
                     Texture = gradientTexture,
                     Colour = Color4.White,
                     InputResampler = new InputResampler
@@ -162,10 +159,13 @@ namespace osu.Framework.Tests.Visual.Input
             public ArcPath(bool raw, bool keepFraction, InputResampler inputResampler, Texture texture, Color4 colour, SpriteText output)
             {
                 InputResampler = inputResampler;
-                const int target_raw = 1024;
+
+                AutoSizeAxes = Axes.None;
                 RelativeSizeAxes = Axes.Both;
                 Texture = texture;
                 Colour = colour;
+
+                const int target_raw = 1024;
 
                 for (int i = 0; i < target_raw; i++)
                 {
@@ -185,6 +185,12 @@ namespace osu.Framework.Tests.Visual.Input
         private class UserDrawnPath : SmoothedPath
         {
             public SpriteText DrawText;
+
+            public UserDrawnPath()
+            {
+                AutoSizeAxes = Axes.None;
+                RelativeSizeAxes = Axes.Both;
+            }
 
             protected virtual void AddUserVertex(Vector2 v) => AddRawVertex(v);
 

--- a/osu.Framework.Tests/Visual/Input/TestScenePathInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePathInput.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Lines;
@@ -18,11 +19,12 @@ namespace osu.Framework.Tests.Visual.Input
         private const float path_width = 50;
         private const float path_radius = path_width / 2;
 
-        private readonly Path path;
-        private readonly TestPoint testPoint;
-        private readonly SpriteText text;
+        private Path path;
+        private TestPoint testPoint;
+        private SpriteText text;
 
-        public TestScenePathInput()
+        [Test]
+        public void Setup() => Schedule(() =>
         {
             Children = new Drawable[]
             {
@@ -30,14 +32,10 @@ namespace osu.Framework.Tests.Visual.Input
                 testPoint = new TestPoint(),
                 text = new SpriteText { Anchor = Anchor.TopCentre, Origin = Anchor.TopCentre }
             };
+        });
 
-            testHorizontalPath();
-            testDiagonalPath();
-            testVShaped();
-            testOverlapping();
-        }
-
-        private void testHorizontalPath()
+        [Test]
+        public void TestHorizontalPath()
         {
             addPath("Horizontal path", new Vector2(100), new Vector2(300, 100));
             // Left out
@@ -58,7 +56,8 @@ namespace osu.Framework.Tests.Visual.Input
             test(new Vector2(190, 60), true);
         }
 
-        private void testDiagonalPath()
+        [Test]
+        public void TestDiagonalPath()
         {
             addPath("Diagonal path", new Vector2(300), new Vector2(100));
             // Top-left out
@@ -75,7 +74,8 @@ namespace osu.Framework.Tests.Visual.Input
             test(new Vector2(340, 300), true);
         }
 
-        private void testVShaped()
+        [Test]
+        public void TestVShaped()
         {
             addPath("V-shaped", new Vector2(100), new Vector2(300), new Vector2(500, 100));
             // Intersection out
@@ -88,7 +88,8 @@ namespace osu.Framework.Tests.Visual.Input
             test(new Vector2(300, 340), true);
         }
 
-        private void testOverlapping()
+        [Test]
+        public void TestOverlapping()
         {
             addPath("Overlapping", new Vector2(100), new Vector2(600), new Vector2(800, 300), new Vector2(100, 400));
             // Left intersection out

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDrawablePath.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDrawablePath.cs
@@ -4,9 +4,11 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Textures;
+using osu.Framework.MathUtils;
 using osuTK;
 using osuTK.Graphics;
 using SixLabors.ImageSharp;
@@ -160,6 +162,52 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     }
                 };
             });
+        }
+
+        [Test]
+        public void TestSizing()
+        {
+            Path path = null;
+
+            AddStep("create autosize path", () =>
+            {
+                Child = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(200),
+                    Child = path = new Path
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        PathRadius = 10,
+                        Vertices = new List<Vector2>
+                        {
+                            Vector2.Zero,
+                            new Vector2(100, 0)
+                        },
+                    }
+                };
+            });
+
+            AddAssert("size = (120, 20)", () => Precision.AlmostEquals(new Vector2(120, 20), path.DrawSize));
+
+            AddStep("make path relative-sized", () =>
+            {
+                path.AutoSizeAxes = Axes.None;
+                path.RelativeSizeAxes = Axes.Both;
+                path.Size = Vector2.One;
+            });
+
+            AddAssert("size = (200, 200)", () => Precision.AlmostEquals(new Vector2(200), path.DrawSize));
+
+            AddStep("make path absolute-sized", () =>
+            {
+                path.RelativeSizeAxes = Axes.None;
+                path.Size = new Vector2(100);
+            });
+
+            AddAssert("size = (100, 100)", () => Precision.AlmostEquals(new Vector2(100), path.DrawSize));
         }
     }
 }

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -160,20 +160,25 @@ namespace osu.Framework.Graphics.Lines
                 if (boundsCache.IsValid)
                     return boundsCache.Value;
 
-                float minX = 0;
-                float minY = 0;
-                float maxX = 0;
-                float maxY = 0;
-
-                foreach (var v in vertices)
+                if (vertices.Count > 0)
                 {
-                    minX = Math.Min(minX, v.X - PathRadius);
-                    minY = Math.Min(minY, v.Y - PathRadius);
-                    maxX = Math.Max(maxX, v.X + PathRadius);
-                    maxY = Math.Max(maxY, v.Y + PathRadius);
+                    float minX = float.MaxValue;
+                    float minY = float.MaxValue;
+                    float maxX = float.MinValue;
+                    float maxY = float.MinValue;
+
+                    foreach (var v in vertices)
+                    {
+                        minX = Math.Min(minX, v.X - PathRadius);
+                        minY = Math.Min(minY, v.Y - PathRadius);
+                        maxX = Math.Max(maxX, v.X + PathRadius);
+                        maxY = Math.Max(maxY, v.Y + PathRadius);
+                    }
+
+                    return boundsCache.Value = new RectangleF(minX, minY, maxX - minX, maxY - minY);
                 }
 
-                return boundsCache.Value = new RectangleF(minX, minY, maxX - minX, maxY - minY);
+                return boundsCache.Value = new RectangleF(0, 0, 0, 0);
             }
         }
 

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -74,6 +74,18 @@ namespace osu.Framework.Graphics.Lines
             }
         }
 
+        public override Axes RelativeSizeAxes
+        {
+            get => base.RelativeSizeAxes;
+            set
+            {
+                if ((AutoSizeAxes & value) != 0)
+                    throw new InvalidOperationException("No axis can be relatively sized and automatically sized at the same time.");
+
+                base.RelativeSizeAxes = value;
+            }
+        }
+
         private Axes autoSizeAxes;
 
         /// <summary>

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Graphics.Lines
                 vertices.Clear();
                 vertices.AddRange(value);
 
-                boundsCache.Invalidate();
+                vertexBoundsCache.Invalidate();
                 segmentsCache.Invalidate();
 
                 Invalidate(Invalidation.DrawSize);
@@ -67,7 +67,7 @@ namespace osu.Framework.Graphics.Lines
 
                 pathRadius = value;
 
-                boundsCache.Invalidate();
+                vertexBoundsCache.Invalidate();
                 segmentsCache.Invalidate();
 
                 Invalidate(Invalidation.DrawSize);
@@ -114,7 +114,7 @@ namespace osu.Framework.Graphics.Lines
             get
             {
                 if (AutoSizeAxes.HasFlag(Axes.X))
-                    return base.Width = bounds.Width;
+                    return base.Width = vertexBounds.Width;
 
                 return base.Width;
             }
@@ -132,7 +132,7 @@ namespace osu.Framework.Graphics.Lines
             get
             {
                 if (AutoSizeAxes.HasFlag(Axes.Y))
-                    return base.Height = bounds.Height;
+                    return base.Height = vertexBounds.Height;
 
                 return base.Height;
             }
@@ -150,7 +150,7 @@ namespace osu.Framework.Graphics.Lines
             get
             {
                 if (AutoSizeAxes != Axes.None)
-                    return base.Size = bounds.Size;
+                    return base.Size = vertexBounds.Size;
 
                 return base.Size;
             }
@@ -163,14 +163,14 @@ namespace osu.Framework.Graphics.Lines
             }
         }
 
-        private Cached<RectangleF> boundsCache;
+        private Cached<RectangleF> vertexBoundsCache;
 
-        private RectangleF bounds
+        private RectangleF vertexBounds
         {
             get
             {
-                if (boundsCache.IsValid)
-                    return boundsCache.Value;
+                if (vertexBoundsCache.IsValid)
+                    return vertexBoundsCache.Value;
 
                 if (vertices.Count > 0)
                 {
@@ -187,10 +187,10 @@ namespace osu.Framework.Graphics.Lines
                         maxY = Math.Max(maxY, v.Y + PathRadius);
                     }
 
-                    return boundsCache.Value = new RectangleF(minX, minY, maxX - minX, maxY - minY);
+                    return vertexBoundsCache.Value = new RectangleF(minX, minY, maxX - minX, maxY - minY);
                 }
 
-                return boundsCache.Value = new RectangleF(0, 0, 0, 0);
+                return vertexBoundsCache.Value = new RectangleF(0, 0, 0, 0);
             }
         }
 
@@ -206,7 +206,7 @@ namespace osu.Framework.Graphics.Lines
             return false;
         }
 
-        public Vector2 PositionInBoundingBox(Vector2 pos) => pos - bounds.TopLeft;
+        public Vector2 PositionInBoundingBox(Vector2 pos) => pos - vertexBounds.TopLeft;
 
         public void ClearVertices()
         {
@@ -215,7 +215,7 @@ namespace osu.Framework.Graphics.Lines
 
             vertices.Clear();
 
-            boundsCache.Invalidate();
+            vertexBoundsCache.Invalidate();
             segmentsCache.Invalidate();
 
             Invalidate(Invalidation.DrawSize);
@@ -225,7 +225,7 @@ namespace osu.Framework.Graphics.Lines
         {
             vertices.Add(pos);
 
-            boundsCache.Invalidate();
+            vertexBoundsCache.Invalidate();
             segmentsCache.Invalidate();
 
             Invalidate(Invalidation.DrawSize);
@@ -241,7 +241,7 @@ namespace osu.Framework.Graphics.Lines
 
             if (vertices.Count > 1)
             {
-                Vector2 offset = bounds.TopLeft;
+                Vector2 offset = vertexBounds.TopLeft;
                 for (int i = 0; i < vertices.Count - 1; ++i)
                     segmentsBacking.Add(new Line(vertices[i] - offset, vertices[i + 1] - offset));
             }

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -174,10 +174,10 @@ namespace osu.Framework.Graphics.Lines
 
                 if (vertices.Count > 0)
                 {
-                    float minX = float.MaxValue;
-                    float minY = float.MaxValue;
-                    float maxX = float.MinValue;
-                    float maxY = float.MinValue;
+                    float minX = 0;
+                    float minY = 0;
+                    float maxX = 0;
+                    float maxY = 0;
 
                     foreach (var v in vertices)
                     {


### PR DESCRIPTION
Currently, `Path` can take one of two sizing modes: relative, or "auto" size. In the case of "auto" size, it doesn't use the standard `AutoSizeAxes` convention. In the case of relative size, it cannot be turned back into auto-size without manually invalidating the draw size or otherwise invalidating the layout.

Basically, current `Path` sizing is generally inadequate for advanced usage scenarios. One such scenario which will be used osu!-side is the case where paths are initially auto-sized, but then forced to a static size to avoid continuous resizing.

To achieve this I've gone the full way to make `Path` support `AutoSizeAxes` much like `CompositeDrawable`.

# vNext

## `Path` now supports `AutoSizeAxes` and is set to auto-size in both axes by default

There are now three modes of operation for paths:
```
// Auto size
new Path()

// Static size
new Path
{
    AutoSizeAxes = Axes.None,
    Size = new Vector2(100)
}

// Relative size
new Container
{
    Size = new Vector2(100),
    new Path
    {
        AutoSizeAxes = Axes.None,
        RelativeSizeAxes = Axes.Both
    }
}
```

Current code usages that set `RelativeSizeAxes` must be updated to unset the relevant `AutoSizeAxes` before prior to doing so.