### PR TITLE
Eagerly dispose FrameBuffers' backing textures

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -98,6 +98,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             if (isDisposed)
                 return;
 
+            Texture?.Dispose();
+            Texture = null;
+
             GLWrapper.DeleteFrameBuffer(frameBuffer);
 
             foreach (var buffer in attachedRenderBuffers)


### PR DESCRIPTION
Split out of https://github.com/ppy/osu-framework/pull/2692 as an important fix. Was relying on GC until now (which is not optimal as this is a native memory heavy class).