### PR TITLE
Fix VertexBuffer JIT regression on iOS

### DIFF
--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -98,13 +98,13 @@
     <Reference Include="mscorlib" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Markdig" Version="0.17.0" />
-    <PackageReference Include="FFmpeg.AutoGen" Version="4.1.0.4" />
+    <PackageReference Include="Markdig" Version="0.17.1" />
+    <PackageReference Include="FFmpeg.AutoGen" Version="4.1.0.5" />
     <PackageReference Include="SharpFNT" Version="1.1.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0006" />
     <PackageReference Include="System.Drawing.Common" Version="4.5.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.0.0" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.101" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.1.0" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.111" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="ppy.Microsoft.Diagnostics.Runtime" Version="0.9.180305.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
@@ -114,6 +114,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.3.0" />
-    <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
+    <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
   </ItemGroup>
 </Project>

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -24,6 +24,12 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
         private bool isInitialised;
         private int vboId;
 
+        static VertexBuffer()
+        {
+            // seed ahead-of-time compiler for iOS
+            System.Runtime.CompilerServices.Unsafe.SizeOf<DepthWrappingVertex<T>>();
+        }
+
         protected VertexBuffer(int amountVertices, BufferUsageHint usage)
         {
             this.usage = usage;


### PR DESCRIPTION
It seems we regressed somewhere with the recent changes to `VertexBuffer`/`DepthWrappingVertex`, such that we now get a JIT exception on the call to `SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate`.

This change seeds the AOT compiler.  Note that it's done in `VertexBuffer.cs` rather than in the iOS project, as `DepthWrappingVertex` is internal.

Also updates packages in the iOS props.