### PR TITLE
Remove setting to bypass cached

### DIFF
--- a/osu.Framework/Caching/Cached.cs
+++ b/osu.Framework/Caching/Cached.cs
@@ -6,11 +6,6 @@ using System;
 
 namespace osu.Framework.Caching
 {
-    public static class StaticCached
-    {
-        internal static bool BypassCache = false;
-    }
-
     public struct Cached<T>
     {
         private T value;
@@ -35,7 +30,7 @@ namespace osu.Framework.Caching
 
         private bool isValid;
 
-        public bool IsValid => !StaticCached.BypassCache && isValid;
+        public bool IsValid => isValid;
 
         public static implicit operator T(Cached<T> value) => value.Value;
 
@@ -60,7 +55,7 @@ namespace osu.Framework.Caching
     {
         private bool isValid;
 
-        public bool IsValid => !StaticCached.BypassCache && isValid;
+        public bool IsValid => isValid;
 
         /// <summary>
         /// Invalidate the cache of this object.

--- a/osu.Framework/Configuration/FrameworkDebugConfig.cs
+++ b/osu.Framework/Configuration/FrameworkDebugConfig.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Caching;
-
 namespace osu.Framework.Configuration
 {
     public class FrameworkDebugConfigManager : IniConfigManager<DebugSetting>
@@ -18,14 +16,12 @@ namespace osu.Framework.Configuration
         {
             base.InitialiseDefaults();
 
-            Set(DebugSetting.BypassCaching, false).ValueChanged += delegate { StaticCached.BypassCache = Get<bool>(DebugSetting.BypassCaching); };
             Set(DebugSetting.BypassFrontToBackPass, false);
         }
     }
 
     public enum DebugSetting
     {
-        BypassCaching,
         BypassFrontToBackPass
     }
 }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1575,7 +1575,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.X))
+                if (!isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.X))
                     updateChildrenSizeDependencies();
                 return base.Width;
             }
@@ -1593,7 +1593,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.Y))
+                if (!isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.Y))
                     updateChildrenSizeDependencies();
                 return base.Height;
             }
@@ -1613,7 +1613,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!StaticCached.BypassCache && !isComputingChildrenSizeDependencies && AutoSizeAxes != Axes.None)
+                if (!isComputingChildrenSizeDependencies && AutoSizeAxes != Axes.None)
                     updateChildrenSizeDependencies();
                 return base.Size;
             }


### PR DESCRIPTION
We haven't used this recently. It causes cross-thread issues when in an enabled state, so it's best to be removed for now.

Closes https://github.com/ppy/osu-framework/issues/2457
Closes https://github.com/ppy/osu/issues/3517