### PR TITLE
Cleanup framebuffer initialisation process

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Primitives;
 using osuTK;
 using osuTK.Graphics;
-using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics
 {
@@ -38,18 +37,11 @@ namespace osu.Framework.Graphics
         private RectangleF screenSpaceDrawRectangle;
         private Vector2 frameBufferSize;
 
-        private readonly All filteringMode;
-        private readonly RenderbufferInternalFormat[] formats;
-
-        public BufferedDrawNode(IBufferedDrawable source, DrawNode child, BufferedDrawNodeSharedData sharedData, RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
+        public BufferedDrawNode(IBufferedDrawable source, DrawNode child, BufferedDrawNodeSharedData sharedData)
             : base(source)
         {
-            this.formats = formats;
-
             Child = child;
             SharedData = sharedData;
-
-            filteringMode = pixelSnapping ? All.Nearest : All.Linear;
         }
 
         public override void ApplyState()
@@ -61,7 +53,7 @@ namespace osu.Framework.Graphics
             DrawColourInfo = Source.FrameBufferDrawColour ?? new DrawColourInfo(Color4.White, base.DrawColourInfo.Blending);
 
             frameBufferSize = new Vector2((float)Math.Ceiling(screenSpaceDrawRectangle.Width), (float)Math.Ceiling(screenSpaceDrawRectangle.Height));
-            DrawRectangle = filteringMode == All.Nearest
+            DrawRectangle = SharedData.PixelSnapping
                 ? new RectangleF(screenSpaceDrawRectangle.X, screenSpaceDrawRectangle.Y, frameBufferSize.X, frameBufferSize.Y)
                 : screenSpaceDrawRectangle;
 
@@ -141,9 +133,6 @@ namespace osu.Framework.Graphics
         /// <returns>A token that must be disposed upon finishing use of <paramref name="frameBuffer"/>.</returns>
         protected ValueInvokeOnDisposal BindFrameBuffer(FrameBuffer frameBuffer)
         {
-            if (!frameBuffer.IsInitialized)
-                frameBuffer.Initialise(filteringMode, formats);
-
             // This setter will also take care of allocating a texture of appropriate size within the frame buffer.
             frameBuffer.Size = frameBufferSize;
 

--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
+using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics
 {
@@ -27,6 +28,12 @@ namespace osu.Framework.Graphics
         public FrameBuffer MainBuffer { get; }
 
         /// <summary>
+        /// Whether the frame buffer position should be snapped to the nearest pixel when blitting.
+        /// This amounts to setting the texture filtering mode to "nearest".
+        /// </summary>
+        public readonly bool PixelSnapping;
+
+        /// <summary>
         /// A set of <see cref="FrameBuffer"/>s which are used in a ping-pong manner to render effects to.
         /// </summary>
         private readonly FrameBuffer[] effectBuffers;
@@ -34,8 +41,8 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Creates a new <see cref="BufferedDrawNodeSharedData"/> with no effect buffers.
         /// </summary>
-        public BufferedDrawNodeSharedData()
-            : this(0)
+        public BufferedDrawNodeSharedData(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
+            : this(0, formats, pixelSnapping)
         {
         }
 
@@ -43,17 +50,23 @@ namespace osu.Framework.Graphics
         /// Creates a new <see cref="BufferedDrawNodeSharedData"/> with a specific amount of effect buffers.
         /// </summary>
         /// <param name="effectBufferCount">The number of effect buffers.</param>
+        /// <param name="formats">The render buffer formats to attach to each frame buffer.</param>
+        /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
+        /// This amounts to setting the texture filtering mode to "nearest".</param>
         /// <exception cref="ArgumentOutOfRangeException">If <paramref name="effectBufferCount"/> is less than 0.</exception>
-        public BufferedDrawNodeSharedData(int effectBufferCount)
+        public BufferedDrawNodeSharedData(int effectBufferCount, RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
         {
             if (effectBufferCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(effectBufferCount), "Must be positive.");
 
-            MainBuffer = new FrameBuffer();
+            PixelSnapping = pixelSnapping;
+            All filterMode = pixelSnapping ? All.Nearest : All.Linear;
+
+            MainBuffer = new FrameBuffer(formats, filterMode);
             effectBuffers = new FrameBuffer[effectBufferCount];
 
             for (int i = 0; i < effectBufferCount; i++)
-                effectBuffers[i] = new FrameBuffer();
+                effectBuffers[i] = new FrameBuffer(formats, filterMode);
         }
 
         private int currentEffectBuffer = -1;

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -223,9 +223,6 @@ namespace osu.Framework.Graphics.Containers
         public BufferedContainer(RenderbufferInternalFormat[] formats, bool pixelSnapping)
         {
             sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping);
-
-            // The initial draw cannot be cached, and thus we need to initialize with a forced draw.
-            ForceRedraw();
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -9,8 +9,6 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.MathUtils;
-using System;
-using System.Collections.Generic;
 using osu.Framework.Caching;
 using osu.Framework.Graphics.Sprites;
 
@@ -27,6 +25,16 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public class BufferedContainer : BufferedContainer<Drawable>
     {
+        /// <summary>
+        /// Constructs an empty buffered container.
+        /// </summary>
+        /// <param name="formats">The render buffer formats attached to the frame buffers of this <see cref="BufferedContainer"/>.</param>
+        /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
+        /// This amounts to setting the texture filtering mode to "nearest".</param>
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
+            : base(formats, pixelSnapping)
+        {
+        }
     };
 
     /// <summary>
@@ -94,25 +102,6 @@ namespace osu.Framework.Graphics.Containers
 
                 blurRotation = value;
                 ForceRedraw();
-            }
-        }
-
-        private bool pixelSnapping;
-
-        /// <summary>
-        /// Whether the framebuffer's position is snapped to the nearest pixel when blitting.
-        /// Since the framebuffer's texels have the same size as pixels, this amounts to setting
-        /// the texture filtering mode to "nearest".
-        /// </summary>
-        public bool PixelSnapping
-        {
-            get => pixelSnapping;
-            set
-            {
-                if (sharedData.MainBuffer.IsInitialized)
-                    throw new InvalidOperationException("May only set PixelSnapping before FrameBuffers are initialized (i.e. before the first draw).");
-
-                pixelSnapping = value;
             }
         }
 
@@ -223,13 +212,19 @@ namespace osu.Framework.Graphics.Containers
 
         private IShader blurShader;
 
+        private readonly BufferedContainerDrawNodeSharedData sharedData;
+
         /// <summary>
         /// Constructs an empty buffered container.
         /// </summary>
-        public BufferedContainer()
+        /// <param name="formats">The render buffer formats attached to the frame buffers of this <see cref="BufferedContainer"/>.</param>
+        /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
+        /// This amounts to setting the texture filtering mode to "nearest".</param>
+        public BufferedContainer(RenderbufferInternalFormat[] formats, bool pixelSnapping)
         {
-            // The initial draw cannot be cached, and thus we need to initialize
-            // with a forced draw.
+            sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping);
+
+            // The initial draw cannot be cached, and thus we need to initialize with a forced draw.
             ForceRedraw();
         }
 
@@ -241,30 +236,7 @@ namespace osu.Framework.Graphics.Containers
             blurShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.BLUR);
         }
 
-        private readonly BufferedContainerDrawNodeSharedData sharedData = new BufferedContainerDrawNodeSharedData();
-
-        protected override DrawNode CreateDrawNode() => new BufferedContainerDrawNode(this, sharedData, attachedFormats.ToArray(), PixelSnapping);
-
-        private readonly List<RenderbufferInternalFormat> attachedFormats = new List<RenderbufferInternalFormat>();
-
-        /// <summary>
-        /// Attach an additional component to this <see cref="BufferedContainer{T}"/>. Such a component can e.g.
-        /// be a depth component, such that the framebuffer can hold fragment depth information.
-        /// </summary>
-        /// <param name="format">The component format to attach.</param>
-        public void Attach(RenderbufferInternalFormat format)
-        {
-            if (attachedFormats.Exists(f => f == format))
-                return;
-
-            attachedFormats.Add(format);
-        }
-
-        /// <summary>
-        /// Detaches an additional component of this <see cref="BufferedContainer{T}"/>.
-        /// </summary>
-        /// <param name="format">The component format to detach.</param>
-        public void Detach(RenderbufferInternalFormat format) => attachedFormats.Remove(format);
+        protected override DrawNode CreateDrawNode() => new BufferedContainerDrawNode(this, sharedData);
 
         protected override RectangleF ComputeChildMaskingBounds(RectangleF maskingBounds) => ScreenSpaceDrawQuad.AABBFloat; // Make sure children never get masked away
 

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -25,17 +25,12 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public class BufferedContainer : BufferedContainer<Drawable>
     {
-        /// <summary>
-        /// Constructs an empty buffered container.
-        /// </summary>
-        /// <param name="formats">The render buffer formats attached to the frame buffers of this <see cref="BufferedContainer"/>.</param>
-        /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
-        /// This amounts to setting the texture filtering mode to "nearest".</param>
+        /// <inheritdoc />
         public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
             : base(formats, pixelSnapping)
         {
         }
-    };
+    }
 
     /// <summary>
     /// A container that renders its children to an internal framebuffer, and then
@@ -220,7 +215,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="formats">The render buffer formats attached to the frame buffers of this <see cref="BufferedContainer"/>.</param>
         /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
         /// This amounts to setting the texture filtering mode to "nearest".</param>
-        public BufferedContainer(RenderbufferInternalFormat[] formats, bool pixelSnapping)
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
         {
             sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping);
         }

--- a/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
@@ -5,13 +5,13 @@ using System.Collections.Generic;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osuTK;
-using osuTK.Graphics.ES30;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
 using System;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.MathUtils;
+using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -36,9 +36,8 @@ namespace osu.Framework.Graphics.Containers
 
             private IShader blurShader;
 
-            public BufferedContainerDrawNode(BufferedContainer<T> source, BufferedContainerDrawNodeSharedData sharedData, RenderbufferInternalFormat[] formats = null,
-                                             bool pixelSnapping = false)
-                : base(source, new CompositeDrawableDrawNode(source), sharedData, formats, pixelSnapping)
+            public BufferedContainerDrawNode(BufferedContainer<T> source, BufferedContainerDrawNodeSharedData sharedData)
+                : base(source, new CompositeDrawableDrawNode(source), sharedData)
             {
             }
 
@@ -129,8 +128,8 @@ namespace osu.Framework.Graphics.Containers
 
         private class BufferedContainerDrawNodeSharedData : BufferedDrawNodeSharedData
         {
-            public BufferedContainerDrawNodeSharedData()
-                : base(2)
+            public BufferedContainerDrawNodeSharedData(RenderbufferInternalFormat[] formats, bool pixelSnapping)
+                : base(2, formats, pixelSnapping)
             {
             }
         }

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -274,9 +274,9 @@ namespace osu.Framework.Graphics.Lines
 
         public Color4 BackgroundColour => new Color4(0, 0, 0, 0);
 
-        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData();
+        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(new[] { RenderbufferInternalFormat.DepthComponent16 });
 
-        protected override DrawNode CreateDrawNode() => new BufferedDrawNode(this, new PathDrawNode(this), sharedData, new[] { RenderbufferInternalFormat.DepthComponent16 });
+        protected override DrawNode CreateDrawNode() => new BufferedDrawNode(this, new PathDrawNode(this), sharedData);
 
         protected override void Dispose(bool isDisposing)
         {


### PR DESCRIPTION
Currently, we need to perform the following in order to use a `FrameBuffer`:

```
if (!frameBuffer.IsInitialized)
    frameBuffer.Initialise(filteringMode, formats);
```

This changes the process so that the framebuffer is initialised during `Bind()`, as is done for `VertexBuffer`. As a result of this:
1. `FrameBuffer` takes filtering mode and render formats as constructor arguments.
2. `BufferedDrawNodeSharedData` also ^
3. `BufferedContainer` takes ctor arguments for render format + filter mode.

# vNext

## `BufferedContainer` now takes render formats + pixel snapping values only during construction.

Previous code:
```csharp
var buffered = new BufferedContainer() { PixelSnapping = true };
buffered.Attach(RenderbufferInternalFormat.DepthComponent16);
```

New code:
```csharp
var buffered = new BufferedContainer(new[] { RenderbufferInternalFormat.DepthComponent16 }, true)
```

You can no longer detatch render formats from a `BufferedContainer`.