### PR TITLE
added generic Lines class for drawing any segments

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneMultiPathInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneMultiPathInput.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Lines;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.Events;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Input
+{
+    public class TestSceneMultiPathInput : FrameworkTestScene
+    {
+        private const float path_width = 50;
+        private const float path_radius = path_width / 2;
+
+        private MultiPath path;
+        private TestPoint testPoint;
+        private SpriteText text;
+
+        [Test]
+        public void Setup() => Schedule(() =>
+        {
+            Children = new Drawable[]
+            {
+                path = new HoverablePath(),
+                testPoint = new TestPoint(),
+                text = new SpriteText { Anchor = Anchor.TopCentre, Origin = Anchor.TopCentre }
+            };
+        });
+
+        [Test]
+        public void TestHorizontalPath()
+        {
+            addPath("Single horizontal path", new[] { new Vector2(100), new Vector2(300, 100) });
+            // Left out
+            test(new Vector2(40, 100), false);
+            // Left in
+            test(new Vector2(80, 100), true);
+            // Cap out
+            test(new Vector2(60), false);
+            // Cap in
+            test(new Vector2(70), true);
+            //Right out
+            test(new Vector2(360, 100), false);
+            // Centre
+            test(new Vector2(200, 100), true);
+            // Top out
+            test(new Vector2(190, 40), false);
+            // Top in
+            test(new Vector2(190, 60), true);
+        }
+
+        [Test]
+        public void TestDiagonalPath()
+        {
+            addPath("Single diagonal path", new[] { new Vector2(300), new Vector2(100) });
+            // Top-left out
+            test(new Vector2(50), false);
+            // Top-left in
+            test(new Vector2(80), true);
+            // Left out
+            test(new Vector2(145, 235), false);
+            // Left in
+            test(new Vector2(170, 235), true);
+            // Cap out
+            test(new Vector2(355, 300), false);
+            // Cap in
+            test(new Vector2(340, 300), true);
+        }
+
+        [Test]
+        public void TestTicTacToe()
+        {
+            addPath("4 disjoint overlapping linear paths",
+                new[] { new Vector2(100 - 50, 300 - 50), new Vector2(700 - 50, 300 - 50) },
+                new[] { new Vector2(100 - 50, 500 - 50), new Vector2(700 - 50, 500 - 50) },
+                new[] { new Vector2(300 - 50, 100 - 50), new Vector2(300 - 50, 700 - 50) },
+                new[] { new Vector2(500 - 50, 100 - 50), new Vector2(500 - 50, 700 - 50) });
+
+            // Outside first vertex cap
+            test(new Vector2(11, 214), false);
+            // Inside first vertex cap
+            test(new Vector2(19, 223), true);
+
+            // Outside last vertex cap
+            test(new Vector2(413, 692), false);
+            // Inside last vertex cap
+            test(new Vector2(428, 689), true);
+
+            // Outside middle vertex cap
+            test(new Vector2(14, 412), false);
+            // Inside middle vertex cap
+            test(new Vector2(26, 420), true);
+
+            // On line overlap
+            test(new Vector2(250, 250), true);
+            test(new Vector2(450, 250), true);
+            test(new Vector2(250, 450), true);
+
+            // On line segments
+            test(new Vector2(250, 150), true);
+            test(new Vector2(350, 250), true);
+
+            // in middle hole
+            test(new Vector2(305, 305), false);
+            test(new Vector2(350, 350), false);
+            test(new Vector2(395, 395), false);
+        }
+
+        protected override bool OnMouseMove(MouseMoveEvent e)
+        {
+            text.Text = path.ToLocalSpace(e.ScreenSpaceMousePosition).ToString();
+            return base.OnMouseMove(e);
+        }
+
+        private void addPath(string name, params IEnumerable<Vector2>[] parts) => AddStep(name, () =>
+        {
+            path.PathRadius = path_width;
+            path.ClearPaths();
+            foreach (var part in parts)
+                path.AddPath(part);
+        });
+
+        private void test(Vector2 position, bool shouldReceivePositionalInput)
+        {
+            AddAssert($"Test @ {position} = {shouldReceivePositionalInput}", () =>
+            {
+                testPoint.Position = position;
+                return path.ReceivePositionalInputAt(path.ToScreenSpace(position)) == shouldReceivePositionalInput;
+            });
+        }
+
+        private class TestPoint : CircularContainer
+        {
+            public TestPoint()
+            {
+                Origin = Anchor.Centre;
+
+                Size = new Vector2(5);
+                Colour = Color4.Red;
+                Masking = true;
+
+                InternalChild = new Box { RelativeSizeAxes = Axes.Both };
+            }
+        }
+
+        private class HoverablePath : MultiPath
+        {
+            protected override bool OnHover(HoverEvent e)
+            {
+                Colour = Color4.Green;
+                return true;
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                Colour = Color4.White;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Lines/Lines.cs
+++ b/osu.Framework/Graphics/Lines/Lines.cs
@@ -1,0 +1,261 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Textures;
+using osuTK;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Allocation;
+using System.Collections.Generic;
+using osu.Framework.Caching;
+using osuTK.Graphics;
+using osuTK.Graphics.ES30;
+using System;
+
+namespace osu.Framework.Graphics.Lines
+{
+    /// <summary>
+    /// Base class used for drawing 2D lines with line caps. For an implementation rendering one connected polyline, use <see cref="Path"/>.
+    /// </summary>
+    public abstract partial class Lines : Drawable, IBufferedDrawable
+    {
+        public IShader RoundedTextureShader { get; private set; }
+        public IShader TextureShader { get; private set; }
+        protected IShader pathShader;
+
+        public Lines()
+        {
+            AutoSizeAxes = Axes.Both;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(ShaderManager shaders)
+        {
+            RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
+            TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+            pathShader = shaders.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE);
+        }
+
+        public override Axes RelativeSizeAxes
+        {
+            get => base.RelativeSizeAxes;
+            set
+            {
+                if ((AutoSizeAxes & value) != 0)
+                    throw new InvalidOperationException("No axis can be relatively sized and automatically sized at the same time.");
+
+                base.RelativeSizeAxes = value;
+            }
+        }
+
+        private Axes autoSizeAxes;
+
+        /// <summary>
+        /// Controls which <see cref="Axes"/> are automatically sized w.r.t. the bounds of the vertices.
+        /// It is not allowed to manually set <see cref="Size"/> (or <see cref="Width"/> / <see cref="Height"/>)
+        /// on any <see cref="Axes"/> which are automatically sized.
+        /// </summary>
+        public virtual Axes AutoSizeAxes
+        {
+            get => autoSizeAxes;
+            set
+            {
+                if (value == autoSizeAxes)
+                    return;
+
+                if ((RelativeSizeAxes & value) != 0)
+                    throw new InvalidOperationException("No axis can be relatively sized and automatically sized at the same time.");
+
+                autoSizeAxes = value;
+                OnSizingChanged();
+            }
+        }
+
+        public override float Width
+        {
+            get
+            {
+                if (AutoSizeAxes.HasFlag(Axes.X))
+                    return base.Width = SegmentBounds.Width;
+
+                return base.Width;
+            }
+            set
+            {
+                if ((AutoSizeAxes & Axes.X) != 0)
+                    throw new InvalidOperationException($"The width of a {nameof(Path)} with {nameof(AutoSizeAxes)} can not be set manually.");
+
+                base.Width = value;
+            }
+        }
+
+        public override float Height
+        {
+            get
+            {
+                if (AutoSizeAxes.HasFlag(Axes.Y))
+                    return base.Height = SegmentBounds.Height;
+
+                return base.Height;
+            }
+            set
+            {
+                if ((AutoSizeAxes & Axes.Y) != 0)
+                    throw new InvalidOperationException($"The height of a {nameof(Path)} with {nameof(AutoSizeAxes)} can not be set manually.");
+
+                base.Height = value;
+            }
+        }
+
+        public override Vector2 Size
+        {
+            get
+            {
+                if (AutoSizeAxes != Axes.None)
+                    return base.Size = SegmentBounds.Size;
+
+                return base.Size;
+            }
+            set
+            {
+                if ((AutoSizeAxes & Axes.Both) != 0)
+                    throw new InvalidOperationException($"The Size of a {nameof(Path)} with {nameof(AutoSizeAxes)} can not be set manually.");
+
+                base.Size = value;
+            }
+        }
+
+        private float pathRadius = 10f;
+
+        /// <summary>
+        /// How wide this path is on each side of the line.
+        /// </summary>
+        /// <remarks>
+        /// The actual width of the path is twice the PathRadius.
+        /// </remarks>
+        public virtual float PathRadius
+        {
+            get => pathRadius;
+            set
+            {
+                if (pathRadius == value) return;
+
+                pathRadius = value;
+
+                sgmentBoundsCache.Invalidate();
+                segmentsCache.Invalidate();
+
+                Invalidate(Invalidation.DrawSize);
+            }
+        }
+
+        private Cached<RectangleF> sgmentBoundsCache;
+
+        public RectangleF SegmentBounds
+        {
+            get
+            {
+                if (sgmentBoundsCache.IsValid)
+                    return sgmentBoundsCache.Value;
+
+                float minX = 0;
+                float minY = 0;
+                float maxX = 0;
+                float maxY = 0;
+
+                foreach (var p in BoundingVertices)
+                {
+                    minX = Math.Min(minX, p.X - PathRadius);
+                    minY = Math.Min(minY, p.Y - PathRadius);
+                    maxX = Math.Max(maxX, p.X + PathRadius);
+                    maxY = Math.Max(maxY, p.Y + PathRadius);
+                }
+
+                return sgmentBoundsCache.Value = new RectangleF(minX, minY, maxX - minX, maxY - minY);
+            }
+        }
+
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
+        {
+            var localPos = ToLocalSpace(screenSpacePos);
+            var pathRadiusSquared = PathRadius * PathRadius;
+
+            foreach (var t in Segments)
+                if (t.DistanceSquaredToPoint(localPos) <= pathRadiusSquared)
+                    return true;
+
+            return false;
+        }
+
+        public Vector2 PositionInBoundingBox(Vector2 pos) => pos - SegmentBounds.TopLeft;
+
+        /// <summary>
+        /// List of at least all vertices used to generate this Lines object making up the bounding (outermost) vertices.
+        /// It may contain more vertices than needed and bounds will be computed as minimum and maximum from all vertices.
+        /// </summary>
+        protected abstract IEnumerable<Vector2> BoundingVertices
+        {
+            get;
+        }
+
+        private readonly List<Line> segmentsBacking = new List<Line>();
+        private Cached segmentsCache = new Cached();
+        public List<Line> Segments => segmentsCache.IsValid ? segmentsBacking : generateSegmentsImpl();
+
+        protected abstract IEnumerable<Line> GenerateSegments();
+
+        private List<Line> generateSegmentsImpl()
+        {
+            segmentsBacking.Clear();
+            segmentsBacking.AddRange(GenerateSegments());
+            segmentsCache.Validate();
+            return segmentsBacking;
+        }
+
+        private Texture texture;
+
+        protected Texture Texture
+        {
+            get => texture ?? Texture.WhitePixel;
+            set
+            {
+                if (texture == value)
+                    return;
+
+                texture?.Dispose();
+                texture = value;
+
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+
+        public DrawColourInfo? FrameBufferDrawColour => base.DrawColourInfo;
+
+        // The path should not receive the true colour to avoid colour doubling when the frame-buffer is rendered to the back-buffer.
+        public override DrawColourInfo DrawColourInfo => new DrawColourInfo(Color4.White, base.DrawColourInfo.Blending);
+
+        public Color4 BackgroundColour => new Color4(0, 0, 0, 0);
+
+        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(new[] { RenderbufferInternalFormat.DepthComponent16 });
+
+        protected override DrawNode CreateDrawNode() => new BufferedDrawNode(this, new LinesDrawNode(this), sharedData);
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+
+            texture?.Dispose();
+            texture = null;
+
+            sharedData.Dispose();
+        }
+
+        protected void InvalidateSegments()
+        {
+            sgmentBoundsCache.Invalidate();
+            segmentsCache.Invalidate();
+
+            Invalidate(Invalidation.DrawSize);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Lines/Lines_DrawNode.cs
+++ b/osu.Framework/Graphics/Lines/Lines_DrawNode.cs
@@ -16,13 +16,14 @@ using osu.Framework.Graphics.Shaders;
 
 namespace osu.Framework.Graphics.Lines
 {
-    public partial class Path
+    public partial class Lines
     {
-        private class PathDrawNode : DrawNode
+        private class LinesDrawNode : DrawNode
         {
             public const int MAX_RES = 24;
+            public const float JOIN_DISTANCE = 1;
 
-            protected new Path Source => (Path)base.Source;
+            protected new Lines Source => (Lines)base.Source;
 
             private readonly List<Line> segments = new List<Line>();
 
@@ -37,7 +38,7 @@ namespace osu.Framework.Graphics.Lines
             private readonly LinearBatch<TexturedVertex3D> halfCircleBatch = new LinearBatch<TexturedVertex3D>(MAX_RES * 100 * 3, 10, PrimitiveType.Triangles);
             private readonly QuadBatch<TexturedVertex3D> quadBatch = new QuadBatch<TexturedVertex3D>(200, 10);
 
-            public PathDrawNode(Path source)
+            public LinesDrawNode(Lines source)
                 : base(source)
             {
             }
@@ -47,7 +48,7 @@ namespace osu.Framework.Graphics.Lines
                 base.ApplyState();
 
                 segments.Clear();
-                segments.AddRange(Source.segments);
+                segments.AddRange(Source.Segments);
 
                 texture = Source.Texture;
                 drawSize = Source.DrawSize;
@@ -189,7 +190,17 @@ namespace osu.Framework.Graphics.Lines
                 {
                     Line nextLine = segments[i];
                     float nextTheta = nextLine.Theta;
-                    addLineCap(line.EndPoint, theta, nextTheta - theta, texRect);
+                    if ((line.EndPoint - nextLine.StartPoint).LengthSquared < JOIN_DISTANCE * JOIN_DISTANCE)
+                    {
+                        // joining line segments
+                        addLineCap(line.EndPoint, theta, nextTheta - theta, texRect);
+                    }
+                    else
+                    {
+                        // separate line segments
+                        addLineCap(line.EndPoint, theta, MathHelper.Pi, texRect);
+                        addLineCap(nextLine.StartPoint, nextTheta + MathHelper.Pi, MathHelper.Pi, texRect);
+                    }
 
                     line = nextLine;
                     theta = nextTheta;

--- a/osu.Framework/Graphics/Lines/MultiPath.cs
+++ b/osu.Framework/Graphics/Lines/MultiPath.cs
@@ -1,0 +1,103 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Textures;
+using osuTK;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.Allocation;
+using System.Collections.Generic;
+using osu.Framework.Caching;
+using osuTK.Graphics;
+using osuTK.Graphics.ES30;
+using System.Linq;
+
+namespace osu.Framework.Graphics.Lines
+{
+    /// <summary>
+    /// Renders many polylines or polygonal paths as one Drawable with more room for optimization than separate lines.
+    /// </summary>
+    public class MultiPath : Lines
+    {
+        public class SinglePath
+        {
+            internal readonly List<Vector2> vertices = new List<Vector2>();
+
+            public IReadOnlyList<Vector2> Vertices
+            {
+                get => vertices;
+            }
+        }
+
+        private readonly List<SinglePath> paths = new List<SinglePath>();
+
+        public IReadOnlyList<SinglePath> Paths
+        {
+            get => paths;
+            set
+            {
+                paths.Clear();
+                paths.AddRange(value);
+
+                InvalidateSegments();
+            }
+        }
+
+        public void ClearPaths()
+        {
+            if (paths.Count == 0)
+                return;
+
+            paths.Clear();
+
+            InvalidateSegments();
+        }
+
+        public void AddPath(IEnumerable<Vector2> vertices)
+        {
+            SinglePath path = new SinglePath();
+            path.vertices.AddRange(vertices);
+            paths.Add(path);
+
+            InvalidateSegments();
+        }
+
+        public void AddPath(SinglePath path)
+        {
+            paths.Add(path);
+
+            InvalidateSegments();
+        }
+
+        public void StartNewPath()
+        {
+            AddPath(new SinglePath());
+        }
+
+        public void AddVertex(Vector2 pos)
+        {
+            if (paths.Count == 0)
+                throw new InvalidOperationException("Cannot add a vertex if no path has been started yet.");
+
+            paths[paths.Count - 1].vertices.Add(pos);
+
+            InvalidateSegments();
+        }
+
+        protected override IEnumerable<Vector2> BoundingVertices => Paths.SelectMany(a => a.Vertices);
+
+        protected override IEnumerable<Line> GenerateSegments()
+        {
+            foreach (var path in Paths)
+            {
+                if (path.Vertices.Count > 1)
+                {
+                    Vector2 offset = SegmentBounds.TopLeft;
+                    for (int i = 0; i < path.Vertices.Count - 1; ++i)
+                        yield return new Line(path.Vertices[i] - offset, path.Vertices[i + 1] - offset);
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -14,25 +14,11 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Lines
 {
-    public partial class Path : Drawable, IBufferedDrawable
+    /// <summary>
+    /// Renders one continuous polyline or polygonal path.
+    /// </summary>
+    public class Path : Lines
     {
-        public IShader RoundedTextureShader { get; private set; }
-        public IShader TextureShader { get; private set; }
-        private IShader pathShader;
-
-        public Path()
-        {
-            AutoSizeAxes = Axes.Both;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(ShaderManager shaders)
-        {
-            RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
-            TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
-            pathShader = shaders.Load(VertexShaderDescriptor.TEXTURE_3, FragmentShaderDescriptor.TEXTURE);
-        }
-
         private readonly List<Vector2> vertices = new List<Vector2>();
 
         public IReadOnlyList<Vector2> Vertices
@@ -43,170 +29,9 @@ namespace osu.Framework.Graphics.Lines
                 vertices.Clear();
                 vertices.AddRange(value);
 
-                vertexBoundsCache.Invalidate();
-                segmentsCache.Invalidate();
-
-                Invalidate(Invalidation.DrawSize);
+                InvalidateSegments();
             }
         }
-
-        private float pathRadius = 10f;
-
-        /// <summary>
-        /// How wide this path is on each side of the line.
-        /// </summary>
-        /// <remarks>
-        /// The actual width of the path is twice the PathRadius.
-        /// </remarks>
-        public virtual float PathRadius
-        {
-            get => pathRadius;
-            set
-            {
-                if (pathRadius == value) return;
-
-                pathRadius = value;
-
-                vertexBoundsCache.Invalidate();
-                segmentsCache.Invalidate();
-
-                Invalidate(Invalidation.DrawSize);
-            }
-        }
-
-        public override Axes RelativeSizeAxes
-        {
-            get => base.RelativeSizeAxes;
-            set
-            {
-                if ((AutoSizeAxes & value) != 0)
-                    throw new InvalidOperationException("No axis can be relatively sized and automatically sized at the same time.");
-
-                base.RelativeSizeAxes = value;
-            }
-        }
-
-        private Axes autoSizeAxes;
-
-        /// <summary>
-        /// Controls which <see cref="Axes"/> are automatically sized w.r.t. the bounds of the vertices.
-        /// It is not allowed to manually set <see cref="Size"/> (or <see cref="Width"/> / <see cref="Height"/>)
-        /// on any <see cref="Axes"/> which are automatically sized.
-        /// </summary>
-        public virtual Axes AutoSizeAxes
-        {
-            get => autoSizeAxes;
-            set
-            {
-                if (value == autoSizeAxes)
-                    return;
-
-                if ((RelativeSizeAxes & value) != 0)
-                    throw new InvalidOperationException("No axis can be relatively sized and automatically sized at the same time.");
-
-                autoSizeAxes = value;
-                OnSizingChanged();
-            }
-        }
-
-        public override float Width
-        {
-            get
-            {
-                if (AutoSizeAxes.HasFlag(Axes.X))
-                    return base.Width = vertexBounds.Width;
-
-                return base.Width;
-            }
-            set
-            {
-                if ((AutoSizeAxes & Axes.X) != 0)
-                    throw new InvalidOperationException($"The width of a {nameof(Path)} with {nameof(AutoSizeAxes)} can not be set manually.");
-
-                base.Width = value;
-            }
-        }
-
-        public override float Height
-        {
-            get
-            {
-                if (AutoSizeAxes.HasFlag(Axes.Y))
-                    return base.Height = vertexBounds.Height;
-
-                return base.Height;
-            }
-            set
-            {
-                if ((AutoSizeAxes & Axes.Y) != 0)
-                    throw new InvalidOperationException($"The height of a {nameof(Path)} with {nameof(AutoSizeAxes)} can not be set manually.");
-
-                base.Height = value;
-            }
-        }
-
-        public override Vector2 Size
-        {
-            get
-            {
-                if (AutoSizeAxes != Axes.None)
-                    return base.Size = vertexBounds.Size;
-
-                return base.Size;
-            }
-            set
-            {
-                if ((AutoSizeAxes & Axes.Both) != 0)
-                    throw new InvalidOperationException($"The Size of a {nameof(Path)} with {nameof(AutoSizeAxes)} can not be set manually.");
-
-                base.Size = value;
-            }
-        }
-
-        private Cached<RectangleF> vertexBoundsCache;
-
-        private RectangleF vertexBounds
-        {
-            get
-            {
-                if (vertexBoundsCache.IsValid)
-                    return vertexBoundsCache.Value;
-
-                if (vertices.Count > 0)
-                {
-                    float minX = 0;
-                    float minY = 0;
-                    float maxX = 0;
-                    float maxY = 0;
-
-                    foreach (var v in vertices)
-                    {
-                        minX = Math.Min(minX, v.X - PathRadius);
-                        minY = Math.Min(minY, v.Y - PathRadius);
-                        maxX = Math.Max(maxX, v.X + PathRadius);
-                        maxY = Math.Max(maxY, v.Y + PathRadius);
-                    }
-
-                    return vertexBoundsCache.Value = new RectangleF(minX, minY, maxX - minX, maxY - minY);
-                }
-
-                return vertexBoundsCache.Value = new RectangleF(0, 0, 0, 0);
-            }
-        }
-
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos)
-        {
-            var localPos = ToLocalSpace(screenSpacePos);
-            var pathRadiusSquared = PathRadius * PathRadius;
-
-            foreach (var t in segments)
-                if (t.DistanceSquaredToPoint(localPos) <= pathRadiusSquared)
-                    return true;
-
-            return false;
-        }
-
-        public Vector2 PositionInBoundingBox(Vector2 pos) => pos - vertexBounds.TopLeft;
 
         public void ClearVertices()
         {
@@ -215,77 +40,26 @@ namespace osu.Framework.Graphics.Lines
 
             vertices.Clear();
 
-            vertexBoundsCache.Invalidate();
-            segmentsCache.Invalidate();
-
-            Invalidate(Invalidation.DrawSize);
+            InvalidateSegments();
         }
 
         public void AddVertex(Vector2 pos)
         {
             vertices.Add(pos);
 
-            vertexBoundsCache.Invalidate();
-            segmentsCache.Invalidate();
-
-            Invalidate(Invalidation.DrawSize);
+            InvalidateSegments();
         }
 
-        private readonly List<Line> segmentsBacking = new List<Line>();
-        private Cached segmentsCache = new Cached();
-        private List<Line> segments => segmentsCache.IsValid ? segmentsBacking : generateSegments();
+        protected override IEnumerable<Vector2> BoundingVertices => vertices;
 
-        private List<Line> generateSegments()
+        protected override IEnumerable<Line> GenerateSegments()
         {
-            segmentsBacking.Clear();
-
             if (vertices.Count > 1)
             {
-                Vector2 offset = vertexBounds.TopLeft;
+                Vector2 offset = SegmentBounds.TopLeft;
                 for (int i = 0; i < vertices.Count - 1; ++i)
-                    segmentsBacking.Add(new Line(vertices[i] - offset, vertices[i + 1] - offset));
+                    yield return new Line(vertices[i] - offset, vertices[i + 1] - offset);
             }
-
-            segmentsCache.Validate();
-            return segmentsBacking;
-        }
-
-        private Texture texture;
-
-        protected Texture Texture
-        {
-            get => texture ?? Texture.WhitePixel;
-            set
-            {
-                if (texture == value)
-                    return;
-
-                texture?.Dispose();
-                texture = value;
-
-                Invalidate(Invalidation.DrawNode);
-            }
-        }
-
-        public DrawColourInfo? FrameBufferDrawColour => base.DrawColourInfo;
-
-        // The path should not receive the true colour to avoid colour doubling when the frame-buffer is rendered to the back-buffer.
-        public override DrawColourInfo DrawColourInfo => new DrawColourInfo(Color4.White, base.DrawColourInfo.Blending);
-
-        public Color4 BackgroundColour => new Color4(0, 0, 0, 0);
-
-        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(new[] { RenderbufferInternalFormat.DepthComponent16 });
-
-        protected override DrawNode CreateDrawNode() => new BufferedDrawNode(this, new PathDrawNode(this), sharedData);
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            texture?.Dispose();
-            texture = null;
-
-            sharedData.Dispose();
         }
     }
 }

--- a/osu.Framework/Graphics/Primitives/Line.cs
+++ b/osu.Framework/Graphics/Primitives/Line.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using osu.Framework.MathUtils;
 using osuTK;
@@ -164,6 +165,18 @@ namespace osu.Framework.Graphics.Primitives
         /// It's the end of the world as we know it
         /// </summary>
         public Matrix4 EndWorldMatrix() => Matrix4.CreateRotationZ(Theta) * Matrix4.CreateTranslation(EndPoint.X, EndPoint.Y, 0);
+
+        /// <summary>
+        /// An enumerable of Vector2 points which contains the start and end point of this line.
+        /// </summary>
+        public IEnumerable<Vector2> Vertices
+        {
+            get
+            {
+                yield return StartPoint;
+                yield return EndPoint;
+            }
+        }
 
         public override string ToString() => $"{StartPoint} -> {EndPoint}";
     }


### PR DESCRIPTION
This change is for being able to draw multiple lines in one DrawNode. It simply moves out most logic of Path into the new Lines class for rendering and input and makes Path only handle Vertices now, which allows for new path classes with multiple disjoint lines.

When adding colors, variable widths of lines or other things to Line in the future then it should be relatively easy to create new APIs using `Lines` as common base API or for example having a simple renderer for a list of lines.

Includes `MultiPath` helper (alternative to `Path` with a list of vertex lists) and new input tests.

For example the new `MultiPath` can be used in Grids. If major and minor lines are desired, it can be made a container with 2 `MultiPath` objects.