### PR TITLE
Fix MaskingInfo being unnecessarily copied 

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -94,6 +94,7 @@ namespace osu.Framework.Graphics.Containers
                 RectangleF shrunkDrawRectangle = Source.DrawRectangle.Shrink(shrinkage);
 
                 isMasking = Source.Masking;
+
                 if (isMasking)
                 {
                     maskingInfo = new MaskingInfo

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.OpenGL
         public const int MAX_DRAW_NODES = 3;
 
         private static MaskingInfo currentMaskingInfo;
-        public static ref readonly MaskingInfo CurrentMaskingInfo => ref currentMaskingInfo; 
+        public static ref readonly MaskingInfo CurrentMaskingInfo => ref currentMaskingInfo;
         public static RectangleI Viewport { get; private set; }
         public static RectangleF Ortho { get; private set; }
         public static Matrix4 ProjectionMatrix { get; private set; }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.OpenGL
         public const int MAX_DRAW_NODES = 3;
 
         private static MaskingInfo currentMaskingInfo;
-        public static ref readonly MaskingInfo CurrentMaskingInfo { get => ref currentMaskingInfo; }
+        public static ref readonly MaskingInfo CurrentMaskingInfo => ref currentMaskingInfo; 
         public static RectangleI Viewport { get; private set; }
         public static RectangleF Ortho { get; private set; }
         public static Matrix4 ProjectionMatrix { get; private set; }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -31,7 +31,8 @@ namespace osu.Framework.Graphics.OpenGL
         /// </summary>
         public const int MAX_DRAW_NODES = 3;
 
-        public static MaskingInfo CurrentMaskingInfo { get; private set; }
+        private static MaskingInfo currentMaskingInfo;
+        public static ref readonly MaskingInfo CurrentMaskingInfo { get => ref currentMaskingInfo; }
         public static RectangleI Viewport { get; private set; }
         public static RectangleF Ortho { get; private set; }
         public static Matrix4 ProjectionMatrix { get; private set; }
@@ -469,7 +470,7 @@ namespace osu.Framework.Graphics.OpenGL
             GL.Scissor(scissorRect.X, scissorRect.Y, scissorRect.Width, scissorRect.Height);
         }
 
-        private static void setMaskingInfo(MaskingInfo maskingInfo, bool isPushing, bool overwritePreviousScissor)
+        private static void setMaskingInfo(in MaskingInfo maskingInfo, bool isPushing, bool overwritePreviousScissor)
         {
             FlushCurrentBatch();
 
@@ -544,13 +545,13 @@ namespace osu.Framework.Graphics.OpenGL
         /// </summary>
         /// <param name="maskingInfo">The masking info.</param>
         /// <param name="overwritePreviousScissor">Whether or not to shrink an existing scissor rectangle.</param>
-        public static void PushMaskingInfo(MaskingInfo maskingInfo, bool overwritePreviousScissor = false)
+        public static void PushMaskingInfo(in MaskingInfo maskingInfo, bool overwritePreviousScissor = false)
         {
             masking_stack.Push(maskingInfo);
             if (CurrentMaskingInfo.Equals(maskingInfo))
                 return;
 
-            CurrentMaskingInfo = maskingInfo;
+            currentMaskingInfo = maskingInfo;
             setMaskingInfo(CurrentMaskingInfo, true, overwritePreviousScissor);
         }
 
@@ -567,7 +568,7 @@ namespace osu.Framework.Graphics.OpenGL
             if (CurrentMaskingInfo.Equals(maskingInfo))
                 return;
 
-            CurrentMaskingInfo = maskingInfo;
+            currentMaskingInfo = maskingInfo;
             setMaskingInfo(CurrentMaskingInfo, false, true);
         }
 


### PR DESCRIPTION
Closes #2658, #2487, #2486 and #2485

Changes many ``GLWrapper`` methods to accept MaskingInfo by readonly reference (in).
Stores currentMaskingInfo as a private field and lets others access it by readonly reference through a property.
Changes the MaskingInfo in ``CompositeDrawable_DrawNode`` to not be nullable and instead adds an ``isMasking`` boolean.