### PR TITLE
Implement URL opening for android

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Collections.Generic;
+using Android.App;
+using Android.Content;
 using osu.Framework.Android.Graphics.Textures;
 using osu.Framework.Android.Input;
 using osu.Framework.Graphics.Textures;
@@ -10,6 +12,7 @@ using osu.Framework.Input;
 using osu.Framework.Input.Handlers;
 using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
+using Uri = Android.Net.Uri;
 
 namespace osu.Framework.Android
 {
@@ -48,7 +51,15 @@ namespace osu.Framework.Android
             => throw new NotImplementedException();
 
         public override void OpenUrlExternally(string url)
-            => throw new NotImplementedException();
+        {
+            var activity = (Activity)gameView.Context;
+
+            Uri webpage = Uri.Parse(url);
+            Intent intent = new Intent(Intent.ActionView, webpage);
+
+            if (intent.ResolveActivity(activity.PackageManager) != null)
+                activity.StartActivity(intent);
+        }
 
         public override IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore)
             => new AndroidTextureLoaderStore(underlyingStore);

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -54,11 +54,9 @@ namespace osu.Framework.Android
         {
             var activity = (Activity)gameView.Context;
 
-            Uri webpage = Uri.Parse(url);
-            Intent intent = new Intent(Intent.ActionView, webpage);
-
-            if (intent.ResolveActivity(activity.PackageManager) != null)
-                activity.StartActivity(intent);
+            using (var intent = new Intent(Intent.ActionView, Uri.Parse(url)))
+                if (intent.ResolveActivity(activity.PackageManager) != null)
+                    activity.StartActivity(intent);
         }
 
         public override IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore)


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/5562

Currently on my device, I can't seem to get the game to not close when switching to another app (even when not opening a URL) no matter what, so this change won't stop the app from closing. However, the URL will now open successfully.

This was implemented using the sample from https://developer.android.com/guide/components/intents-common.html#ViewUrl