### PR TITLE
Change Cached to a class to avoid incorrect usage

### DIFF
--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.Bindables
             TriggerValueChange(previousValue, source ?? this, true, bypassChecks);
         }
 
-        private Cached<WeakReference<Bindable<T>>> weakReferenceCache;
+        private readonly Cached<WeakReference<Bindable<T>>> weakReferenceCache = new Cached<WeakReference<Bindable<T>>>();
 
         private WeakReference<Bindable<T>> weakReference => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<Bindable<T>>(this);
 

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Bindables
 
         private readonly List<T> collection = new List<T>();
 
-        private Cached<WeakReference<BindableList<T>>> weakReferenceCache;
+        private readonly Cached<WeakReference<BindableList<T>>> weakReferenceCache = new Cached<WeakReference<BindableList<T>>>();
 
         private WeakReference<BindableList<T>> weakReference => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<BindableList<T>>(this);
 

--- a/osu.Framework/Caching/Cached.cs
+++ b/osu.Framework/Caching/Cached.cs
@@ -6,7 +6,7 @@ using System;
 
 namespace osu.Framework.Caching
 {
-    public struct Cached<T>
+    public class Cached<T>
     {
         private T value;
 
@@ -51,7 +51,7 @@ namespace osu.Framework.Caching
         }
     }
 
-    public struct Cached
+    public class Cached
     {
         private bool isValid;
 

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -233,7 +233,7 @@ namespace osu.Framework.Graphics.Containers
         protected override RectangleF ComputeChildMaskingBounds(RectangleF maskingBounds) => ScreenSpaceDrawQuad.AABBFloat; // Make sure children never get masked away
 
         private Vector2 lastScreenSpaceSize;
-        private Cached screenSpaceSizeBacking = new Cached();
+        private readonly Cached screenSpaceSizeBacking = new Cached();
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1569,7 +1569,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         internal event Action OnAutoSize;
 
-        private Cached childrenSizeDependencies = new Cached();
+        private readonly Cached childrenSizeDependencies = new Cached();
 
         public override float Width
         {

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -124,8 +124,8 @@ namespace osu.Framework.Graphics.Containers
 
         public bool DelayedLoadCompleted => InternalChildren.Count > 0;
 
-        private Cached optimisingContainerCache = new Cached();
-        private Cached isIntersectingCache = new Cached();
+        private readonly Cached optimisingContainerCache = new Cached();
+        private readonly Cached isIntersectingCache = new Cached();
 
         private ScheduledDelegate loadScheduledDelegate;
 

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -54,7 +54,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private Cached layout = new Cached();
+        private readonly Cached layout = new Cached();
 
         protected override bool RequiresChildrenUpdate => base.RequiresChildrenUpdate || !layout.IsValid;
 

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -124,8 +124,8 @@ namespace osu.Framework.Graphics.Containers
             base.InvalidateFromChild(invalidation, source);
         }
 
-        private Cached cellContent = new Cached();
-        private Cached cellLayout = new Cached();
+        private readonly Cached cellContent = new Cached();
+        private readonly Cached cellLayout = new Cached();
 
         private CellContainer[,] cells = new CellContainer[0, 0];
         private int cellRows => cells.GetLength(0);

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -136,7 +136,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
             }
         }
 
-        private Cached contentCache = new Cached();
+        private readonly Cached contentCache = new Cached();
 
         private readonly FillFlowContainer document;
 

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTable.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTable.cs
@@ -24,8 +24,8 @@ namespace osu.Framework.Graphics.Containers.Markdown
 
         private readonly Table table;
 
-        private Cached columnDefinitionCache = new Cached();
-        private Cached rowDefinitionCache = new Cached();
+        private readonly Cached columnDefinitionCache = new Cached();
+        private readonly Cached rowDefinitionCache = new Cached();
 
         public MarkdownTable(Table table)
         {

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Graphics.Containers
             filterValid.Invalidate();
         }
 
-        private Cached filterValid = new Cached();
+        private readonly Cached filterValid = new Cached();
 
         protected override void Update()
         {

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -328,7 +328,7 @@ namespace osu.Framework.Graphics.Containers
             return words.ToArray();
         }
 
-        private Cached layout = new Cached();
+        private readonly Cached layout = new Cached();
 
         private void computeLayout()
         {

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -734,7 +734,7 @@ namespace osu.Framework.Graphics
             }
         }
 
-        private Cached<Vector2> drawSizeBacking;
+        private readonly Cached<Vector2> drawSizeBacking = new Cached<Vector2>();
 
         /// <summary>
         /// Absolute size of this Drawable in the <see cref="Parent"/>'s coordinate system.
@@ -1511,7 +1511,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         internal bool IsMaskedAway { get; private set; }
 
-        private Cached<Quad> screenSpaceDrawQuadBacking;
+        private readonly Cached<Quad> screenSpaceDrawQuadBacking = new Cached<Quad>();
 
         protected virtual Quad ComputeScreenSpaceDrawQuad() => ToScreenSpace(DrawRectangle);
 
@@ -1520,7 +1520,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         public virtual Quad ScreenSpaceDrawQuad => screenSpaceDrawQuadBacking.IsValid ? screenSpaceDrawQuadBacking : screenSpaceDrawQuadBacking.Value = ComputeScreenSpaceDrawQuad();
 
-        private Cached<DrawInfo> drawInfoBacking;
+        private readonly Cached<DrawInfo> drawInfoBacking = new Cached<DrawInfo>();
 
         private DrawInfo computeDrawInfo()
         {
@@ -1542,7 +1542,7 @@ namespace osu.Framework.Graphics
         /// </summary>
         public virtual DrawInfo DrawInfo => drawInfoBacking.IsValid ? drawInfoBacking : drawInfoBacking.Value = computeDrawInfo();
 
-        private Cached<DrawColourInfo> drawColourInfoBacking;
+        private readonly Cached<DrawColourInfo> drawColourInfoBacking = new Cached<DrawColourInfo>();
 
         /// <summary>
         /// Contains the colour and blending information of this <see cref="Drawable"/> that are used during draw.
@@ -1594,7 +1594,7 @@ namespace osu.Framework.Graphics
             return ci;
         }
 
-        private Cached<Vector2> requiredParentSizeToFitBacking;
+        private readonly Cached<Vector2> requiredParentSizeToFitBacking = new Cached<Vector2>();
 
         private Vector2 computeRequiredParentSizeToFit()
         {

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -163,7 +163,7 @@ namespace osu.Framework.Graphics.Lines
             }
         }
 
-        private Cached<RectangleF> vertexBoundsCache;
+        private readonly Cached<RectangleF> vertexBoundsCache = new Cached<RectangleF>();
 
         private RectangleF vertexBounds
         {
@@ -232,7 +232,7 @@ namespace osu.Framework.Graphics.Lines
         }
 
         private readonly List<Line> segmentsBacking = new List<Line>();
-        private Cached segmentsCache = new Cached();
+        private readonly Cached segmentsCache = new Cached();
         private List<Line> segments => segmentsCache.IsValid ? segmentsBacking : generateSegments();
 
         private List<Line> generateSegments()

--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Graphics.Lines
             }
         }
 
-        private Cached textureCache = new Cached();
+        private readonly Cached textureCache = new Cached();
 
         protected void InvalidateTexture()
         {

--- a/osu.Framework/Graphics/Sprites/SpriteIcon.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteIcon.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Graphics.Sprites
         private Sprite spriteShadow;
         private Sprite spriteMain;
 
-        private Cached layout = new Cached();
+        private readonly Cached layout = new Cached();
         private Container shadowVisibility;
 
         private FontStore store;

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -425,7 +425,7 @@ namespace osu.Framework.Graphics.Sprites
 
         #region Characters
 
-        private Cached charactersCache = new Cached();
+        private readonly Cached charactersCache = new Cached();
         private readonly List<CharacterPart> charactersBacking = new List<CharacterPart>();
 
         /// <summary>
@@ -628,7 +628,7 @@ namespace osu.Framework.Graphics.Sprites
 
         private bool useFixedWidthForCharacter(char character) => Font.FixedWidth && UseFixedWidthForCharacter(character);
 
-        private Cached screenSpaceCharactersCache = new Cached();
+        private readonly Cached screenSpaceCharactersCache = new Cached();
         private readonly List<ScreenSpaceCharacterPart> screenSpaceCharactersBacking = new List<ScreenSpaceCharacterPart>();
 
         /// <summary>
@@ -662,10 +662,10 @@ namespace osu.Framework.Graphics.Sprites
             screenSpaceCharactersCache.Validate();
         }
 
-        private Cached<float> constantWidthCache;
+        private readonly Cached<float> constantWidthCache = new Cached<float>();
         private float constantWidth => constantWidthCache.IsValid ? constantWidthCache.Value : constantWidthCache.Value = getTextureForCharacter('D')?.DisplayWidth ?? 0;
 
-        private Cached<Vector2> shadowOffsetCache;
+        private readonly Cached<Vector2> shadowOffsetCache = new Cached<Vector2>();
 
         private Vector2 premultipliedShadowOffset => shadowOffsetCache.IsValid ? shadowOffsetCache.Value : shadowOffsetCache.Value = ToScreenSpace(shadowOffset * Font.Size) - ToScreenSpace(Vector2.Zero);
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         private readonly Box background;
 
-        private Cached sizeCache = new Cached();
+        private readonly Cached sizeCache = new Cached();
 
         private readonly Container<Menu> submenuContainer;
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -436,7 +436,7 @@ namespace osu.Framework.Graphics.UserInterface
         private int selectionLeft => Math.Min(selectionStart, selectionEnd);
         private int selectionRight => Math.Max(selectionStart, selectionEnd);
 
-        private Cached cursorAndLayout = new Cached();
+        private readonly Cached cursorAndLayout = new Cached();
 
         private void moveSelection(int offset, bool expand)
         {


### PR DESCRIPTION
There were a few cases `Cached` was being used as a `readonly` variable, which causes it to never actually work (due to implicit struct copy before method calls). We have decided it is safer to just make it a class.

# Breaking Changes

## `Cached` is now a class and requires object initialisation

Usages of `Cached` without initialising (via `new Cached()`) will need to be updated.