### PR TITLE
Fix TabControl never unhiding overflowed tabs

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -208,13 +208,14 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestRemovingFromDropdown()
+        public void TestRemovingTabMovesOutFromDropdown()
         {
             AddStep("Remove test3", () => simpleTabcontrol.RemoveItem(TestEnum.Test3));
             AddAssert("Test 4 is visible", () => simpleTabcontrol.TabMap[TestEnum.Test4].IsPresent);
-            AddUntilStep("Remove all items", () =>
+
+            AddUntilStep("Remove all visible items", () =>
             {
-                simpleTabcontrol.RemoveItem(simpleTabcontrol.Items.First());
+                simpleTabcontrol.RemoveItem(simpleTabcontrol.Items.First(d => simpleTabcontrol.TabMap[d].IsPresent));
                 return !simpleTabcontrol.Dropdown.Items.Any();
             });
         }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -36,6 +36,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [SetUp]
         public void Setup() => Schedule(() =>
         {
+            Clear();
+
             Add(new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.Both,
@@ -205,6 +207,18 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("null is selected", () => simpleTabcontrol.Current.Value == null);
         }
 
+        [Test]
+        public void TestRemovingFromDropdown()
+        {
+            AddStep("Remove test3", () => simpleTabcontrol.RemoveItem(TestEnum.Test3));
+            AddAssert("Test 4 is visible", () => simpleTabcontrol.TabMap[TestEnum.Test4].IsPresent);
+            AddUntilStep("Remove all items", () =>
+            {
+                simpleTabcontrol.RemoveItem(simpleTabcontrol.Items.First());
+                return !simpleTabcontrol.Dropdown.Items.Any();
+            });
+        }
+
         private class StyledTabControlWithoutDropdown : TabControl<TestEnum>
         {
             protected override Dropdown<TestEnum> CreateDropdown() => null;
@@ -228,6 +242,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
             public new IReadOnlyDictionary<TestEnum?, TabItem<TestEnum?>> TabMap => base.TabMap;
 
             public new TabItem<TestEnum?> SelectedTab => base.SelectedTab;
+
+            public new Dropdown<TestEnum?> Dropdown => base.Dropdown;
 
             protected override Dropdown<TestEnum?> CreateDropdown() => new StyledDropdown();
 

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -163,6 +163,12 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public virtual IEnumerable<Drawable> FlowingChildren => AliveInternalChildren.Where(d => d.IsPresent).OrderBy(d => layoutChildren[d]).ThenBy(d => d.ChildID);
 
+        /// <summary>
+        /// Gets the children in this <see cref="FlowContainer{T}"/> in the order which they would be processed in a flow layout,
+        /// regardless of whether or not they are displayed right now.
+        /// </summary>
+        protected IEnumerable<Drawable> ChildrenByLayoutOrder => AliveInternalChildren.OrderBy(d => layoutChildren[d]).ThenBy(d => d.ChildID);
+
         protected abstract IEnumerable<Vector2> ComputeLayoutPositions();
 
         private void performLayout()

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -390,7 +390,7 @@ namespace osu.Framework.Graphics.UserInterface
             /// The next item that would flow back into the visible tab items if a tab would be removed.
             /// Returns null if no tabs are hidden.
             /// </summary>
-            private TabItem<T> topHiddenItem => (TabItem<T>)AliveInternalChildren.FirstOrDefault(d => !TabItems.Contains(d));
+            private TabItem<T> topHiddenItem => (TabItem<T>)ChildrenByLayoutOrder.FirstOrDefault(d => !TabItems.Contains(d));
 
             protected override IEnumerable<Vector2> ComputeLayoutPositions()
             {
@@ -402,7 +402,9 @@ namespace osu.Framework.Graphics.UserInterface
                 // In the event that we allow multiline, we want the refill logic below to never be hit, so initialize to max value.
                 float rightPosition = float.MaxValue;
 
-                foreach (var (i, child) in TabItems.Select((item, index) => (index, item)))
+                int i = 0;
+
+                foreach (var child in TabItems)
                 {
                     bool isVisible = allowMultiline || result[i].Y == 0;
                     updateChildIfNeeded(child, isVisible);
@@ -413,18 +415,20 @@ namespace osu.Framework.Graphics.UserInterface
                     // Keep track of the rightpost position where a valid item could be placed on the topmost line.
                     if (!allowMultiline && result[i].Y == 0)
                         rightPosition = result[i].X + child.Width;
+
+                    i++;
                 }
+
+                TabItem<T> topItem;
 
                 // If our new visible elements would be less than what we could potentially display,
                 // pop the topmost hidden element until we refill the line again.
-                while (topHiddenItem != null && topHiddenItem.Width + rightPosition < ChildSize.X)
+                while ((topItem = topHiddenItem) != null && topItem.Width + rightPosition < ChildSize.X)
                 {
-                    var item = topHiddenItem;
-
-                    updateChildIfNeeded(item, true);
+                    updateChildIfNeeded(topItem, true);
                     yield return new Vector2(rightPosition, 0);
 
-                    rightPosition += item.Width;
+                    rightPosition += topItem.Width;
                 }
             }
 

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -399,7 +399,7 @@ namespace osu.Framework.Graphics.UserInterface
 
                 var result = base.ComputeLayoutPositions().ToArray();
 
-                // In the event that we allow multiline, we want the re-flow logic below to never be hit, so initialize to infinity.
+                // In the event that we allow multiline, we want the refill logic below to never be hit, so initialize to max value.
                 float rightPosition = float.MaxValue;
 
                 foreach (var (i, child) in TabItems.Select((item, index) => (index, item)))
@@ -415,19 +415,16 @@ namespace osu.Framework.Graphics.UserInterface
                         rightPosition = result[i].X + child.Width;
                 }
 
-                // If our new visible elements would be less than what we could potentially display
-                // pop the topmost hidden element until we fill the line again
-                while (topHiddenItem?.Width + rightPosition < ChildSize.X)
+                // If our new visible elements would be less than what we could potentially display,
+                // pop the topmost hidden element until we refill the line again.
+                while (topHiddenItem != null && topHiddenItem.Width + rightPosition < ChildSize.X)
                 {
                     var item = topHiddenItem;
-
-                    if (item == null)
-                        break;
 
                     updateChildIfNeeded(item, true);
                     yield return new Vector2(rightPosition, 0);
 
-                    rightPosition = rightPosition + item.Width;
+                    rightPosition += item.Width;
                 }
             }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/5448

This refills the flow container manually if space opens up in the `TabControl` area, allowing us to keep the showing/hiding logic for `TabItem`s isolated in `TabControl`

Edit: On thinking this one through a bit more, I can't say I'm certain this is the correct path to take here. 

I'm pretty certain through my testing that this works fine, but it seems like we're bypassing a lot of logic through the base implementation just to make sure we can isolate showing/hiding in `TabControl` and `TabFillFlowContainer`, which is uncomfortable to say the least.

~~I'm going to take one more look at this in the near future, so hold off on reviewing for now.~~ I'm having a lot of trouble seeing another way to go about this without substantial rewrites. Going to let this be reviewed and see what thoughts are thrown.