### PR TITLE
Re-implement proper renderbuffer re-use

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -50,9 +50,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
                     Texture.Height = (int)Math.Ceiling(size.Y);
                     Texture.SetData(new TextureUpload());
                     Texture.Upload();
-
-                    foreach (var buffer in attachedRenderBuffers)
-                        buffer.Size = value;
                 }
             }
         }
@@ -70,7 +67,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             if (renderBufferFormats != null)
             {
                 foreach (var format in renderBufferFormats)
-                    attachedRenderBuffers.Add(new RenderBuffer(format) { Size = Size });
+                    attachedRenderBuffers.Add(new RenderBuffer(format));
             }
         }
 
@@ -90,12 +87,24 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
                 // Buffer is bound during initialisation
                 GLWrapper.BindFrameBuffer(frameBuffer);
             }
+
+            foreach (var buffer in attachedRenderBuffers)
+                buffer.Bind(Size);
         }
 
         /// <summary>
         /// Unbinds the framebuffer.
         /// </summary>
-        public void Unbind() => GLWrapper.UnbindFrameBuffer(frameBuffer);
+        public void Unbind()
+        {
+            // See: https://community.arm.com/developer/tools-software/graphics/b/blog/posts/mali-performance-2-how-to-correctly-handle-framebuffers
+            // Unbinding renderbuffers causes an invalidation of the relevant attachment of this framebuffer on embedded devices, causing the renderbuffers to remain transient.
+            // This must be done _before_ the framebuffer is flushed via the framebuffer unbind process, otherwise the renderbuffer may be copied to system memory.
+            foreach (var buffer in attachedRenderBuffers)
+                buffer.Unbind();
+
+            GLWrapper.UnbindFrameBuffer(frameBuffer);
+        }
 
         #region Disposal
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
@@ -12,8 +12,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     {
         private readonly RenderbufferInternalFormat format;
         private readonly int renderBuffer;
-
         private readonly int sizePerPixel;
+
+        private FramebufferAttachment attachment;
 
         public RenderBuffer(RenderbufferInternalFormat format)
         {
@@ -30,45 +31,57 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             switch (format)
             {
                 case RenderbufferInternalFormat.DepthComponent16:
-                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.DepthAttachment, RenderbufferTarget.Renderbuffer, renderBuffer);
+                    attachment = FramebufferAttachment.DepthAttachment;
+                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, attachment, RenderbufferTarget.Renderbuffer, renderBuffer);
                     sizePerPixel = 2;
                     break;
 
                 case RenderbufferInternalFormat.Rgb565:
                 case RenderbufferInternalFormat.Rgb5A1:
                 case RenderbufferInternalFormat.Rgba4:
-                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, RenderbufferTarget.Renderbuffer, renderBuffer);
+                    attachment = FramebufferAttachment.ColorAttachment0;
+                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, attachment, RenderbufferTarget.Renderbuffer, renderBuffer);
                     sizePerPixel = 2;
                     break;
 
                 case RenderbufferInternalFormat.StencilIndex8:
-                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, FramebufferAttachment.StencilAttachment, RenderbufferTarget.Renderbuffer, renderBuffer);
+                    attachment = FramebufferAttachment.StencilAttachment;
+                    GL.FramebufferRenderbuffer(FramebufferTarget.Framebuffer, attachment, RenderbufferTarget.Renderbuffer, renderBuffer);
                     sizePerPixel = 1;
                     break;
             }
         }
 
-        private Vector2 size;
-
+        private Vector2 internalSize;
         private NativeMemoryTracker.NativeMemoryLease memoryLease;
 
-        internal Vector2 Size
+        public void Bind(Vector2 size)
         {
-            get => size;
-            set
+            // See: https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_multisampled_render_to_texture.txt
+            //    + https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/WorkingwithEAGLContexts/WorkingwithEAGLContexts.html
+            // OpenGL ES allows the driver to discard renderbuffer contents after they are presented to the screen, so the storage must always be re-initialised for embedded devices.
+            // Such discard does not exist on non-embedded platforms, so they are only re-initialised when required.
+            if (GLWrapper.IsEmbedded || internalSize.X < size.X || internalSize.Y < size.Y)
             {
-                // Todo: Investigate why this causes crashes on iOS
-                // if (value.X <= size.X && value.Y <= size.Y)
-                //     return;
-
-                memoryLease?.Dispose();
-
-                size = value;
-
-                memoryLease = NativeMemoryTracker.AddMemory(this, (int)(size.X * size.Y * sizePerPixel));
-
                 GL.BindRenderbuffer(RenderbufferTarget.Renderbuffer, renderBuffer);
-                GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, format, (int)Math.Ceiling(Size.X), (int)Math.Ceiling(Size.Y));
+                GL.RenderbufferStorage(RenderbufferTarget.Renderbuffer, format, (int)Math.Ceiling(size.X), (int)Math.Ceiling(size.Y));
+
+                if (!GLWrapper.IsEmbedded)
+                {
+                    memoryLease?.Dispose();
+                    memoryLease = NativeMemoryTracker.AddMemory(this, (long)(size.X * size.Y * sizePerPixel));
+                }
+
+                internalSize = size;
+            }
+        }
+
+        public void Unbind()
+        {
+            if (GLWrapper.IsEmbedded)
+            {
+                // Renderbuffers are not automatically discarded on all embedded devices, so invalidation is forced for extra performance and to unify logic between devices.
+                GL.InvalidateFramebuffer(FramebufferTarget.Framebuffer, 1, ref attachment);
             }
         }
 

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Graphics.OpenGL
 
         public static int DefaultFrameBuffer;
 
-        private static bool isEmbedded;
+        public static bool IsEmbedded { get; private set; }
 
         /// <summary>
         /// Check whether we have an initialised and non-disposed GL context.
@@ -70,7 +70,7 @@ namespace osu.Framework.Graphics.OpenGL
             if (IsInitialized) return;
 
             if (host.Window is GameWindow win)
-                isEmbedded = win.IsEmbedded;
+                IsEmbedded = win.IsEmbedded;
 
             GLWrapper.host = new WeakReference<GameHost>(host);
             reset_scheduler.SetCurrentThread();
@@ -162,7 +162,7 @@ namespace osu.Framework.Graphics.OpenGL
 
             if (clearInfo.Depth != currentClearInfo.Depth)
             {
-                if (isEmbedded)
+                if (IsEmbedded)
                 {
                     // GL ES only supports glClearDepthf
                     // See: https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glClearDepthf.xhtml


### PR DESCRIPTION
https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_multisampled_render_to_texture.txt

> The command
void RenderbufferStorageMultisampleEXT( enum target, sizei samples, enum internalformat, sizei width, sizei height );

> When the renderbuffer is used as a source or destination for any
        operation, when the attachment is flushed, or when the attachment is
        broken, an implicit resolve of the multisample data may be performed.
        After such a resolve, the contents of the multisample buffer become
        undefined.

>  The command
void RenderbufferStorage( enum target, enum internalformat, sizei width, sizei height );
is equivalent to calling RenderbufferStorageMultisampleEXT with samples equal to zero.

https://developer.apple.com/library/archive/documentation/3DDrawing/Conceptual/OpenGLES_ProgrammingGuide/WorkingwithEAGLContexts/WorkingwithEAGLContexts.html

> By default, you must assume that the contents of the renderbuffer are discarded after your app presents the renderbuffer. This means that every time your app presents a frame, it must completely re-create the frame’s contents when it renders a new frame.

https://developer.apple.com/library/archive/qa/qa1650/_index.html#//apple_ref/doc/uid/DTS40009769

> By default, the contents of a renderbuffer are invalidated after it is presented to the screen (by calling -EAGLContext/presentRenderbuffer:). Your application must completely redraw the contents of the renderbuffer every time you draw a frame, otherwise you may observe flickering or other unexpected results.