### PR TITLE
Allow binding multiple textures for use in shaders

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextureUnit.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextureUnit.cs
@@ -1,0 +1,137 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.OpenGL.Vertices;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Testing;
+using osuTK.Graphics.ES30;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace osu.Framework.Tests.Visual.Sprites
+{
+    public class TestSceneTextureUnit : GridTestScene
+    {
+        public TestSceneTextureUnit()
+            : base(2, 2)
+        {
+            Cell(0, 0).Child = createTest(TextureUnit.Texture0, "white");
+            Cell(0, 1).Child = createTest(TextureUnit.Texture1, "red");
+            Cell(1, 0).Child = createTest(TextureUnit.Texture2, "green");
+            Cell(1, 1).Child = createTest(TextureUnit.Texture3, "blue");
+        }
+
+        private Drawable createTest(TextureUnit unit, string expectedColour) => new Container
+        {
+            RelativeSizeAxes = Axes.Both,
+            Children = new Drawable[]
+            {
+                new SpriteText
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Text = $"Unit {unit - TextureUnit.Texture0} ({expectedColour})"
+                },
+                new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Padding = new MarginPadding { Top = 20 },
+                    Child = new TestSprite(unit)
+                    {
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                        RelativeSizeAxes = Axes.Both,
+                        FillMode = FillMode.Fit
+                    }
+                }
+            }
+        };
+
+        private class TestSprite : Sprite
+        {
+            private readonly TextureUnit unit;
+
+            private Texture redTex;
+            private Texture greenTex;
+            private Texture blueTex;
+
+            public TestSprite(TextureUnit unit)
+            {
+                this.unit = unit;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                // 0 -> White, 1 -> Red, 2 -> Green, 3 -> Blue
+                Texture = createTexture(new Rgba32(255, 255, 255, 255));
+                redTex = createTexture(new Rgba32(255, 0, 0, 255));
+                greenTex = createTexture(new Rgba32(0, 255, 0, 255));
+                blueTex = createTexture(new Rgba32(0, 0, 255, 255));
+            }
+
+            private Texture createTexture(Rgba32 pixel)
+            {
+                var texData = new Image<Rgba32>(32, 32);
+                for (int x = 0; x < texData.Width; x++)
+                for (int y = 0; y < texData.Height; y++)
+                    texData[x, y] = pixel;
+
+                var tex = new Texture(texData.Width, texData.Height, true);
+                tex.SetData(new TextureUpload(texData));
+
+                return tex;
+            }
+
+            protected override DrawNode CreateDrawNode() => new TestBoxDrawNode(this, unit);
+
+            private class TestBoxDrawNode : SpriteDrawNode
+            {
+                protected new TestSprite Source => (TestSprite)base.Source;
+
+                private readonly TextureUnit unit;
+
+                private Texture redTex;
+                private Texture greenTex;
+                private Texture blueTex;
+
+                public TestBoxDrawNode(TestSprite source, TextureUnit unit)
+                    : base(source)
+                {
+                    this.unit = unit;
+                }
+
+                public override void ApplyState()
+                {
+                    base.ApplyState();
+
+                    redTex = Source.redTex;
+                    greenTex = Source.greenTex;
+                    blueTex = Source.blueTex;
+                }
+
+                public override void Draw(Action<TexturedVertex2D> vertexAction)
+                {
+                    redTex.TextureGL.Bind(TextureUnit.Texture1);
+                    greenTex.TextureGL.Bind(TextureUnit.Texture2);
+                    blueTex.TextureGL.Bind(TextureUnit.Texture3);
+
+                    int unitId = unit - TextureUnit.Texture0;
+                    Shader.GetUniform<int>("m_Sampler").UpdateValue(ref unitId);
+
+                    base.Draw(vertexAction);
+
+                    unitId = 0;
+                    Shader.GetUniform<int>("m_Sampler").UpdateValue(ref unitId);
+                }
+
+                protected internal override bool CanDrawOpaqueInterior => false;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -301,6 +301,7 @@ namespace osu.Framework.Graphics.OpenGL
                 GL.ActiveTexture(unit);
                 GL.BindTexture(TextureTarget.Texture2D, texture?.TextureId ?? 0);
                 lastBoundTexture = texture;
+                lastTextureUnit = unit;
 
                 FrameStatistics.Increment(StatisticsCounterType.TextureBinds);
             }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -262,6 +262,7 @@ namespace osu.Framework.Graphics.OpenGL
         }
 
         private static IVertexBatch lastActiveBatch;
+        private static TextureUnit lastTextureUnit;
 
         /// <summary>
         /// Sets the last vertex batch used for drawing.
@@ -291,12 +292,13 @@ namespace osu.Framework.Graphics.OpenGL
         /// Binds a texture to darw with.
         /// </summary>
         /// <param name="texture"></param>
-        public static void BindTexture(TextureGL texture)
+        public static void BindTexture(TextureGL texture, TextureUnit unit = TextureUnit.Texture0)
         {
-            if (lastBoundTexture != texture)
+            if (lastBoundTexture != texture || lastTextureUnit != unit)
             {
                 FlushCurrentBatch();
 
+                GL.ActiveTexture(unit);
                 GL.BindTexture(TextureTarget.Texture2D, texture?.TextureId ?? 0);
                 lastBoundTexture = texture;
 

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -111,7 +111,7 @@ namespace osu.Framework.Graphics.OpenGL
 
             if (expensive_operations_queue.TryDequeue(out Action action))
                 action.Invoke();
-            
+
             lastBoundTexture = new TextureGL[16];
             lastActiveBatch = null;
             lastBlendingInfo = new BlendingInfo();
@@ -262,7 +262,7 @@ namespace osu.Framework.Graphics.OpenGL
         }
 
         private static IVertexBatch lastActiveBatch;
-        
+
         /// <summary>
         /// Sets the last vertex batch used for drawing.
         /// <para>

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -291,7 +291,8 @@ namespace osu.Framework.Graphics.OpenGL
         /// <summary>
         /// Binds a texture to darw with.
         /// </summary>
-        /// <param name="texture"></param>
+        /// <param name="texture">The texture to bind.</param>
+        /// <param name="unit">The texture unit to bind it to.</param>
         public static void BindTexture(TextureGL texture, TextureUnit unit = TextureUnit.Texture0)
         {
             if (lastBoundTexture != texture || lastTextureUnit != unit)

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -112,7 +112,7 @@ namespace osu.Framework.Graphics.OpenGL
             if (expensive_operations_queue.TryDequeue(out Action action))
                 action.Invoke();
 
-            lastBoundTexture = new TextureGL[16];
+            Array.Clear(last_bound_texture, 0, last_bound_texture.Length);
             lastActiveBatch = null;
             lastBlendingInfo = new BlendingInfo();
             lastBlendingEnabledState = null;
@@ -283,10 +283,10 @@ namespace osu.Framework.Graphics.OpenGL
             lastActiveBatch = batch;
         }
 
-        private static TextureGL[] lastBoundTexture;
+        private static readonly TextureGL[] last_bound_texture = new TextureGL[16];
 
         internal static int GetTextureUnitId(TextureUnit unit) => (int)unit - (int)TextureUnit.Texture0;
-        internal static bool AtlasTextureIsBound(TextureUnit unit) => lastBoundTexture[GetTextureUnitId(unit)] is TextureGLAtlas;
+        internal static bool AtlasTextureIsBound(TextureUnit unit) => last_bound_texture[GetTextureUnitId(unit)] is TextureGLAtlas;
 
         /// <summary>
         /// Binds a texture to darw with.
@@ -297,13 +297,13 @@ namespace osu.Framework.Graphics.OpenGL
         {
             var index = GetTextureUnitId(unit);
 
-            if (lastBoundTexture[index] != texture)
+            if (last_bound_texture[index] != texture)
             {
                 FlushCurrentBatch();
 
                 GL.ActiveTexture(unit);
                 GL.BindTexture(TextureTarget.Texture2D, texture?.TextureId ?? 0);
-                lastBoundTexture[index] = texture;
+                last_bound_texture[index] = texture;
 
                 FrameStatistics.Increment(StatisticsCounterType.TextureBinds);
             }

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -97,8 +97,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <summary>
         /// Bind as active texture.
         /// </summary>
+        /// <param name="unit">The texture unit to bind to. Defaults to Texture0.</param>
         /// <returns>True if bind was successful.</returns>
-        public abstract bool Bind();
+        public abstract bool Bind(TextureUnit unit = TextureUnit.Texture0);
 
         /// <summary>
         /// Uploads pending texture data to the GPU if it exists.

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlasWhite.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlasWhite.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Graphics.Primitives;
+using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.OpenGL.Textures
 {
@@ -16,13 +17,13 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         {
         }
 
-        public override bool Bind()
+        public override bool Bind(TextureUnit unit = TextureUnit.Texture0)
         {
             //we can use the special white space from any atlas texture.
             if (GLWrapper.AtlasTextureIsBound)
                 return true;
 
-            return base.Bind();
+            return base.Bind(unit);
         }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlasWhite.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlasWhite.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         public override bool Bind(TextureUnit unit = TextureUnit.Texture0)
         {
             //we can use the special white space from any atlas texture.
-            if (GLWrapper.AtlasTextureIsBound)
+            if (GLWrapper.AtlasTextureIsBound(unit))
                 return true;
 
             return base.Bind(unit);

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -312,7 +312,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
-        public override bool Bind()
+        public override bool Bind(TextureUnit unit = TextureUnit.Texture0)
         {
             if (!Available)
                 throw new ObjectDisposedException(ToString(), "Can not bind a disposed texture.");
@@ -325,7 +325,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             if (IsTransparent)
                 return false;
 
-            GLWrapper.BindTexture(this);
+            GLWrapper.BindTexture(this, unit);
 
             if (internalWrapMode != WrapMode)
                 updateWrapMode();

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
@@ -7,6 +7,7 @@ using osuTK;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Textures;
+using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.OpenGL.Textures
 {
@@ -79,14 +80,14 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         {
         }
 
-        public override bool Bind()
+        public override bool Bind(TextureUnit unit = TextureUnit.Texture0)
         {
             if (!Available)
                 throw new ObjectDisposedException(ToString(), "Can not bind disposed sub textures.");
 
             Upload();
 
-            return parent.Bind();
+            return parent.Bind(unit);
         }
 
         public override void SetData(ITextureUpload upload)

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -115,6 +115,10 @@ namespace osu.Framework.Graphics.Shaders
                         uniform = createUniform<Vector4>(uniformName);
                         break;
 
+                    case ActiveUniformType.Sampler2D:
+                        uniform = createUniform<int>(uniformName);
+                        break;
+
                     default:
                         continue;
                 }


### PR DESCRIPTION
Prior to changes, there was no way to bind more than one texture for use in a shader. The changes creates a `TextureUnit` parameter on the GLWrapper `Bind` function to allow it to to bind textures to other texture units if so desired. A default of `Texture0` is added as that is the most common use.

Additionally, to sample other texture units from a shader, `sampler2D` was added as a uniform on the `Shader` class. Previously this was not needed as the default value of 0 would always point to `Texture0`.