### PR TITLE
Invert TabbableContainer into TabbableContentContainer

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabbableComponents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabbableComponents.cs
@@ -1,0 +1,131 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Framework.Tests.Visual.UserInterface
+{
+    public class TestSceneTabbableComponents : ManualInputManagerTestScene
+    {
+        private const float component_width = 300f;
+        private const float component_height = 35f;
+        private BasicTextBox text1;
+        private BasicTextBox text2;
+        private BasicTextBox text4;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Add(new TabbableContentContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Padding = new MarginPadding(20),
+                    Spacing = new Vector2(20),
+                    Children = new[]
+                    {
+                        text1 = new BasicTextBox
+                        {
+                            Width = component_width,
+                            Height = component_height,
+                            Text = "I'm a textbox!",
+                        },
+                        text2 = new BasicTextBox
+                        {
+                            Width = component_width,
+                            Height = component_height,
+                            Text = "I'm a normal textbox too!",
+                        },
+                        new BasicTextBox
+                        {
+                            Width = component_width,
+                            Height = component_height,
+                            ReadOnly = true,
+                            Text = "I'm a read-only textbox.",
+                            Colour = Color4.Tomato
+                        },
+                        text4 = new BasicTextBox
+                        {
+                            Width = component_width,
+                            Height = component_height,
+                            Text = "Just another normal textbox",
+                        }
+                    }
+                }
+            });
+        }
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("Clear focus", () =>
+            {
+                InputManager.MoveMouseTo(new Vector2(0));
+                InputManager.Click(MouseButton.Left);
+            });
+        }
+
+        [Test]
+        public void TestTabWithNoFocus()
+        {
+            AddStep("Press tab with no focus", () =>
+            {
+                InputManager.PressKey(Key.Tab);
+                InputManager.ReleaseKey(Key.Tab);
+            });
+            AddAssert("No focused item", () => InputManager.FocusedDrawable == null);
+        }
+
+        [Test]
+        public void TestTabFromTexttoText()
+        {
+            performTabToTest(text1, text2);
+        }
+
+        [Test]
+        public void TestTabFromTexttoDisabledText()
+        {
+            // The spot where text3 would be is read-only, so it should have been skipped.
+            performTabToTest(text2, text4);
+        }
+
+        [Test]
+        public void TestTabInReverse()
+        {
+            performTabToTest(text2, text1, true);
+        }
+
+        private void performTabToTest(Drawable source, Drawable expectedTarget, bool reversed = false)
+        {
+            AddStep($"Click {source}", () =>
+            {
+                InputManager.MoveMouseTo(source);
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep($"Press tab with {source} focused", () =>
+            {
+                if (reversed)
+                    InputManager.PressKey(Key.ShiftLeft);
+
+                InputManager.PressKey(Key.Tab);
+                InputManager.ReleaseKey(Key.Tab);
+
+                if (reversed)
+                    InputManager.ReleaseKey(Key.ShiftLeft);
+            });
+
+            AddAssert($"{expectedTarget} focused", () => InputManager.FocusedDrawable == expectedTarget);
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabbableComponents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabbableComponents.cs
@@ -101,6 +101,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestWrappingTabTest()
+        {
+            performTabToTest(text4, text1);
+        }
+
+        [Test]
         public void TestTabInReverse()
         {
             performTabToTest(text2, text1, true);

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -31,18 +31,22 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             Schedule(() =>
             {
-                Child = textBoxes = new FillFlowContainer
+                Child = new TabbableContentContainer
                 {
-                    Direction = FillDirection.Vertical,
-                    Spacing = new Vector2(0, 50),
-                    Padding = new MarginPadding
-                    {
-                        Top = 50,
-                    },
-                    Anchor = Anchor.TopCentre,
-                    Origin = Anchor.TopCentre,
                     RelativeSizeAxes = Axes.Both,
-                    Size = new Vector2(0.9f, 1)
+                    Child = textBoxes = new FillFlowContainer
+                    {
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(0, 50),
+                        Padding = new MarginPadding
+                        {
+                            Top = 50,
+                        },
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(0.9f, 1)
+                    }
                 };
             });
         }
@@ -55,7 +59,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 textBoxes.Add(new BasicTextBox
                 {
                     Size = new Vector2(100, 16),
-                    TabbableContentContainer = textBoxes
                 });
 
                 textBoxes.Add(new BasicTextBox
@@ -63,21 +66,18 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     Text = @"Limited length",
                     Size = new Vector2(200, 20),
                     LengthLimit = 20,
-                    TabbableContentContainer = textBoxes
                 });
 
                 textBoxes.Add(new BasicTextBox
                 {
                     Text = @"Box with some more text",
                     Size = new Vector2(500, 30),
-                    TabbableContentContainer = textBoxes
                 });
 
                 textBoxes.Add(new BasicTextBox
                 {
                     PlaceholderText = @"Placeholder text",
                     Size = new Vector2(500, 30),
-                    TabbableContentContainer = textBoxes
                 });
 
                 textBoxes.Add(new BasicTextBox
@@ -85,7 +85,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     Text = @"prefilled placeholder",
                     PlaceholderText = @"Placeholder text",
                     Size = new Vector2(500, 30),
-                    TabbableContentContainer = textBoxes
                 });
 
                 textBoxes.Add(new BasicTextBox
@@ -93,7 +92,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     Text = "Readonly textbox",
                     Size = new Vector2(500, 30),
                     ReadOnly = true,
-                    TabbableContentContainer = textBoxes
                 });
 
                 FillFlowContainer otherTextBoxes = new FillFlowContainer
@@ -115,7 +113,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 {
                     PlaceholderText = @"Textbox in separate container",
                     Size = new Vector2(500, 30),
-                    TabbableContentContainer = otherTextBoxes
                 });
 
                 otherTextBoxes.Add(new PasswordTextBox
@@ -123,7 +120,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     PlaceholderText = @"Password textbox",
                     Text = "Secret ;)",
                     Size = new Vector2(500, 30),
-                    TabbableContentContainer = otherTextBoxes
                 });
 
                 FillFlowContainer nestedTextBoxes = new FillFlowContainer
@@ -139,26 +135,27 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 {
                     PlaceholderText = @"Nested textbox 1",
                     Size = new Vector2(457, 30),
-                    TabbableContentContainer = otherTextBoxes
                 });
 
                 nestedTextBoxes.Add(new BasicTextBox
                 {
                     PlaceholderText = @"Nested textbox 2",
                     Size = new Vector2(457, 30),
-                    TabbableContentContainer = otherTextBoxes
                 });
 
                 nestedTextBoxes.Add(new BasicTextBox
                 {
                     PlaceholderText = @"Nested textbox 3",
                     Size = new Vector2(457, 30),
-                    TabbableContentContainer = otherTextBoxes
                 });
 
                 otherTextBoxes.Add(nestedTextBoxes);
 
-                Add(otherTextBoxes);
+                Add(new TabbableContentContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = otherTextBoxes,
+                });
             });
         }
 
@@ -173,7 +170,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 {
                     PlaceholderText = @"Only numbers",
                     Size = new Vector2(500, 30),
-                    TabbableContentContainer = textBoxes
                 });
             });
 

--- a/osu.Framework/Graphics/Containers/TabbableContentContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContentContainer.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Containers
     /// <summary>
     /// An interface that allows an element to be tabbed-to if its contained inside a <see cref="TabbableContentContainer"/>
     /// </summary>
-    internal interface ITabbableContainer
+    internal interface ITabTarget
     {
         /// <summary>
         /// Whether this element can be tabbed to.
@@ -72,7 +72,7 @@ namespace osu.Framework.Graphics.Containers
 
                 if (!focusedDrawableFound)
                     focusedDrawableFound = drawable.HasFocus;
-                else if (drawable != this && drawable is ITabbableContainer tabbable && tabbable.CanBeTabbedTo)
+                else if (drawable != this && drawable is ITabTarget tabbable && tabbable.CanBeTabbedTo)
                     return drawable;
 
                 if (drawable is CompositeDrawable composite)

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -25,7 +25,7 @@ using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    public class TextBox : CompositeDrawable, ITabbableContainer, IHasCurrentValue<string>, IKeyBindingHandler<PlatformAction>
+    public class TextBox : CompositeDrawable, ITabTarget, IHasCurrentValue<string>, IKeyBindingHandler<PlatformAction>
     {
         protected FillFlowContainer TextFlow;
         protected Box Background;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -25,7 +25,7 @@ using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    public class TextBox : TabbableContainer, IHasCurrentValue<string>, IKeyBindingHandler<PlatformAction>
+    public class TextBox : CompositeDrawable, ICanBeTabbedTo, IHasCurrentValue<string>, IKeyBindingHandler<PlatformAction>
     {
         protected FillFlowContainer TextFlow;
         protected Box Background;
@@ -114,7 +114,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         public bool CommitOnFocusLost { get; set; }
 
-        public override bool CanBeTabbedTo => !ReadOnly;
+        public virtual bool CanBeTabbedTo => !ReadOnly;
 
         private ITextInputSource textInput;
         private Clipboard clipboard;
@@ -130,7 +130,7 @@ namespace osu.Framework.Graphics.UserInterface
             Masking = true;
             CornerRadius = 3;
 
-            Children = new Drawable[]
+            InternalChildren = new Drawable[]
             {
                 Background = new Box
                 {

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -25,7 +25,7 @@ using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.UserInterface
 {
-    public class TextBox : CompositeDrawable, ICanBeTabbedTo, IHasCurrentValue<string>, IKeyBindingHandler<PlatformAction>
+    public class TextBox : CompositeDrawable, ITabbableContainer, IHasCurrentValue<string>, IKeyBindingHandler<PlatformAction>
     {
         protected FillFlowContainer TextFlow;
         protected Box Background;


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/2550

The search logic remains unchanged (except to adapt to its new location in the hierarchy), but I have added comments to better describe what it is doing.

This allows any component that should accept tab focus to do so by implementing `ITabbableContainer` instead of inheriting `TabbableContainer`. 

Also adds tests for tabbing.

This requires an osu-side PR to change all usages of `TextBox`