### PR TITLE
Fix safe area containers causing potentially incorrect display

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaContainer.cs
@@ -20,6 +20,7 @@ namespace osu.Framework.Tests.Visual.Containers
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
             typeof(SafeAreaDefiningContainer),
+            typeof(SafeAreaContainer),
         };
 
         private readonly BindableSafeArea safeAreaPadding = new BindableSafeArea();
@@ -258,8 +259,6 @@ namespace osu.Framework.Tests.Visual.Containers
                             safeAreaBackground.SafeAreaOverrideEdges |= edge;
                         else
                             safeAreaBackground.SafeAreaOverrideEdges &= ~edge;
-
-                        safeAreaBackground.Invalidate(Invalidation.Parent);
                     };
 
                     safeCheckbox.Current.ValueChanged += e =>
@@ -268,8 +267,6 @@ namespace osu.Framework.Tests.Visual.Containers
                             safeAreaGrid.SafeAreaOverrideEdges |= edge;
                         else
                             safeAreaGrid.SafeAreaOverrideEdges &= ~edge;
-
-                        safeAreaGrid.Invalidate(Invalidation.Parent);
                     };
 
                     bindable.ValueChanged += e => valueText.Text = $"{e.NewValue:F1}";

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaContainer.cs
@@ -166,7 +166,7 @@ namespace osu.Framework.Tests.Visual.Containers
 
             private readonly BindableSafeArea bindableSafeArea;
 
-            public MarginPaddingControlsContainer(SafeAreaContainer safeAreaBackgroun, SafeAreaContainer safeAreaGrid, BindableSafeArea bindableSafeArea)
+            public MarginPaddingControlsContainer(SafeAreaContainer safeAreaBackground, SafeAreaContainer safeAreaGrid, BindableSafeArea bindableSafeArea)
             {
                 this.bindableSafeArea = bindableSafeArea;
 
@@ -179,10 +179,10 @@ namespace osu.Framework.Tests.Visual.Containers
                 Spacing = new Vector2(10);
                 Children = new Drawable[]
                 {
-                    new MarginPaddingControl(safeAreaBackgroun, safeAreaGrid, "Top", safeAreaPaddingTop, Edges.Top),
-                    new MarginPaddingControl(safeAreaBackgroun, safeAreaGrid, "Bottom", safeAreaPaddingBottom, Edges.Bottom),
-                    new MarginPaddingControl(safeAreaBackgroun, safeAreaGrid, "Left", safeAreaPaddingLeft, Edges.Left),
-                    new MarginPaddingControl(safeAreaBackgroun, safeAreaGrid, "Right", safeAreaPaddingRight, Edges.Right),
+                    new MarginPaddingControl(safeAreaBackground, safeAreaGrid, "Top", safeAreaPaddingTop, Edges.Top),
+                    new MarginPaddingControl(safeAreaBackground, safeAreaGrid, "Bottom", safeAreaPaddingBottom, Edges.Bottom),
+                    new MarginPaddingControl(safeAreaBackground, safeAreaGrid, "Left", safeAreaPaddingLeft, Edges.Left),
+                    new MarginPaddingControl(safeAreaBackground, safeAreaGrid, "Right", safeAreaPaddingRight, Edges.Right),
                 };
 
                 safeAreaPaddingTop.ValueChanged += updateMarginPadding;
@@ -258,6 +258,8 @@ namespace osu.Framework.Tests.Visual.Containers
                             safeAreaBackground.SafeAreaOverrideEdges |= edge;
                         else
                             safeAreaBackground.SafeAreaOverrideEdges &= ~edge;
+
+                        safeAreaBackground.Invalidate(Invalidation.Parent);
                     };
 
                     safeCheckbox.Current.ValueChanged += e =>
@@ -266,6 +268,8 @@ namespace osu.Framework.Tests.Visual.Containers
                             safeAreaGrid.SafeAreaOverrideEdges |= edge;
                         else
                             safeAreaGrid.SafeAreaOverrideEdges &= ~edge;
+
+                        safeAreaGrid.Invalidate(Invalidation.Parent);
                     };
 
                     bindable.ValueChanged += e => valueText.Text = $"{e.NewValue:F1}";

--- a/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;

--- a/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Caching;
 using osu.Framework.Graphics.Primitives;
+using osuTK;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -69,10 +70,10 @@ namespace osu.Framework.Graphics.Containers
 
             return new MarginPadding
             {
-                Left = SafeAreaOverrideEdges.HasFlag(Edges.Left) ? nonSafeLocalSpace.TopLeft.X : Math.Max(0, localTopLeft.X),
-                Right = SafeAreaOverrideEdges.HasFlag(Edges.Right) ? DrawRectangle.BottomRight.X - nonSafeLocalSpace.BottomRight.X : Math.Max(0, DrawSize.X - localBottomRight.X),
-                Top = SafeAreaOverrideEdges.HasFlag(Edges.Top) ? nonSafeLocalSpace.TopLeft.Y : Math.Max(0, localTopLeft.Y),
-                Bottom = SafeAreaOverrideEdges.HasFlag(Edges.Bottom) ? DrawRectangle.BottomRight.Y - nonSafeLocalSpace.BottomRight.Y : Math.Max(0, DrawSize.Y - localBottomRight.Y)
+                Left = SafeAreaOverrideEdges.HasFlag(Edges.Left) ? nonSafeLocalSpace.TopLeft.X : MathHelper.Clamp(localTopLeft.X, 0, DrawSize.X),
+                Right = SafeAreaOverrideEdges.HasFlag(Edges.Right) ? DrawRectangle.BottomRight.X - nonSafeLocalSpace.BottomRight.X : MathHelper.Clamp(DrawSize.X - localBottomRight.X, 0, DrawSize.X),
+                Top = SafeAreaOverrideEdges.HasFlag(Edges.Top) ? nonSafeLocalSpace.TopLeft.Y : MathHelper.Clamp(localTopLeft.Y, 0, DrawSize.Y),
+                Bottom = SafeAreaOverrideEdges.HasFlag(Edges.Bottom) ? DrawRectangle.BottomRight.Y - nonSafeLocalSpace.BottomRight.Y : MathHelper.Clamp(DrawSize.Y - localBottomRight.Y, 0, DrawSize.Y)
             };
         }
     }

--- a/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
@@ -31,7 +31,17 @@ namespace osu.Framework.Graphics.Containers
         /// The <see cref="Edges"/> that should bypass the defined <see cref="ISafeArea" /> to bleed to the screen edge.
         /// Defaults to <see cref="Edges.None"/>.
         /// </summary>
-        public Edges SafeAreaOverrideEdges { get; set; } = Edges.None;
+        public Edges SafeAreaOverrideEdges
+        {
+            get => safeAreaOverrideEdges;
+            set
+            {
+                safeAreaOverrideEdges = value;
+                PaddingCache.Invalidate();
+            }
+        }
+
+        private Edges safeAreaOverrideEdges = Edges.None;
 
         protected readonly Cached PaddingCache = new Cached();
 


### PR DESCRIPTION
Resolves #2748 

Fixes the case where a `SafeAreaContainer`'s padding may be set greater than than its `DrawSize`, potentially causing inverted children.

Also fixes `TestSceneSafeAreaContainer`'s checkboxes not triggering an update of the test containers.