### PR TITLE
Improve DrawVisualiser selection heuristics

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -254,6 +254,7 @@ namespace osu.Framework.Graphics
 
             RequestsNonPositionalInput = HandleInputCache.RequestsNonPositionalInput(this);
             RequestsPositionalInput = HandleInputCache.RequestsPositionalInput(this);
+            HasCustomDrawNode = GetType().GetMethod(nameof(CreateDrawNode), BindingFlags.Instance | BindingFlags.NonPublic)?.DeclaringType != typeof(Drawable);
 
             RequestsNonPositionalInputSubTree = RequestsNonPositionalInput;
             RequestsPositionalInputSubTree = RequestsPositionalInput;
@@ -1958,6 +1959,11 @@ namespace osu.Framework.Graphics
         /// Whether this drawable should receive positional input. This does not mean that the drawable will immediately handle the received input, but that it may handle it at some point.
         /// </summary>
         internal bool RequestsPositionalInput { get; private set; }
+
+        /// <summary>
+        /// Whether this drawable has overridden <see cref="CreateDrawNode"/>.
+        /// </summary>
+        internal bool HasCustomDrawNode { get; private set; }
 
         /// <summary>
         /// Conservatively approximates whether there is a descendant which <see cref="RequestsNonPositionalInput"/> in the sub-tree rooted at this drawable

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -254,7 +254,6 @@ namespace osu.Framework.Graphics
 
             RequestsNonPositionalInput = HandleInputCache.RequestsNonPositionalInput(this);
             RequestsPositionalInput = HandleInputCache.RequestsPositionalInput(this);
-            HasCustomDrawNode = GetType().GetMethod(nameof(CreateDrawNode), BindingFlags.Instance | BindingFlags.NonPublic)?.DeclaringType != typeof(Drawable);
 
             RequestsNonPositionalInputSubTree = RequestsNonPositionalInput;
             RequestsPositionalInputSubTree = RequestsPositionalInput;
@@ -1959,11 +1958,6 @@ namespace osu.Framework.Graphics
         /// Whether this drawable should receive positional input. This does not mean that the drawable will immediately handle the received input, but that it may handle it at some point.
         /// </summary>
         internal bool RequestsPositionalInput { get; private set; }
-
-        /// <summary>
-        /// Whether this drawable has overridden <see cref="CreateDrawNode"/>.
-        /// </summary>
-        internal bool HasCustomDrawNode { get; private set; }
 
         /// <summary>
         /// Conservatively approximates whether there is a descendant which <see cref="RequestsNonPositionalInput"/> in the sub-tree rooted at this drawable

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -237,9 +237,12 @@ namespace osu.Framework.Graphics.Visualisation
                         compositeTarget = composite;
 
                     // Allow targeting composites that don't have any content but display a border/glow
-                    if (composite.Masking
-                        && (composite.BorderThickness > 0 && composite.BorderColour.Linear.A > 0
-                            || composite.EdgeEffect.Type != EdgeEffectType.None && composite.EdgeEffect.Radius > 0 && composite.EdgeEffect.Colour.Linear.A > 0))
+
+                    if (!composite.Masking)
+                        return;
+
+                    if (composite.BorderThickness > 0 && composite.BorderColour.Linear.A > 0
+                        || composite.EdgeEffect.Type != EdgeEffectType.None && composite.EdgeEffect.Radius > 0 && composite.EdgeEffect.Colour.Linear.A > 0)
                     {
                         drawableTarget = composite;
                     }

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Effects;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.MathUtils;
@@ -191,6 +192,7 @@ namespace osu.Framework.Graphics.Visualisation
         {
             Drawable drawableTarget = null;
             CompositeDrawable compositeTarget = null;
+            Quad? maskingQuad = null;
 
             findTarget(inputManager);
 
@@ -199,11 +201,23 @@ namespace osu.Framework.Graphics.Visualisation
             // Finds the targeted drawable and composite drawable. The search stops if a drawable is targeted.
             void findTarget(Drawable drawable)
             {
-                if (!isValidTarget(drawable))
+                if (drawable == this || drawable is CursorContainer || drawable is Component)
+                    return;
+
+                if (!drawable.IsPresent)
+                    return;
+
+                if (drawable.AlwaysPresent && Precision.AlmostEquals(drawable.Alpha, 0f))
                     return;
 
                 if (drawable is CompositeDrawable composite)
                 {
+                    Quad? oldMaskingQuad = maskingQuad;
+
+                    // BufferedContainers implicitly mask via their frame buffer
+                    if (Masking || composite is BufferedContainer)
+                        maskingQuad = composite.ScreenSpaceDrawQuad;
+
                     for (int i = composite.AliveInternalChildren.Count - 1; i >= 0; i--)
                     {
                         findTarget(composite.AliveInternalChildren[i]);
@@ -212,9 +226,15 @@ namespace osu.Framework.Graphics.Visualisation
                             return;
                     }
 
+                    maskingQuad = oldMaskingQuad;
+
+                    if (!validForTarget(composite))
+                        return;
+
                     if (compositeTarget == null)
                         compositeTarget = composite;
 
+                    // Allow targeting composites that don't have any content but display a border/glow
                     if (composite.Masking
                         && (composite.BorderThickness > 0 && composite.BorderColour.Linear.A > 0
                             || composite.EdgeEffect.Type != EdgeEffectType.None && composite.EdgeEffect.Radius > 0 && composite.EdgeEffect.Colour.Linear.A > 0))
@@ -222,33 +242,23 @@ namespace osu.Framework.Graphics.Visualisation
                         drawableTarget = composite;
                     }
                 }
-                else if (!(drawable is Component))
+                else
+                {
+                    // Special case for full-screen overlays that act as input receptors, but don't display anything
+                    if (!drawable.HasCustomDrawNode)
+                        return;
+
+                    if (!validForTarget(drawable))
+                        return;
+
                     drawableTarget = drawable;
+                }
             }
 
-            bool isValidTarget(Drawable drawable)
-            {
-                if (drawable == this || drawable is CursorContainer)
-                    return false;
-
-                if (!drawable.IsPresent)
-                    return false;
-
-                if (drawable.AlwaysPresent && Precision.AlmostEquals(drawable.Alpha, 0f))
-                    return false;
-
-                if (!drawable.HasCustomDrawNode)
-                    return false;
-
-                bool containsCursor = drawable.ScreenSpaceDrawQuad.Contains(inputManager.CurrentState.Mouse.Position);
-                // This is an optimization: We don't need to consider drawables which we don't hover, and which do not
-                // forward input further to children (via d.ReceivePositionalInputAt). If they do forward input to children, then there
-                // is a good chance they have children poking out of their bounds, which we need to catch.
-                if (!containsCursor && !drawable.ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position))
-                    return false;
-
-                return true;
-            }
+            // Valid if the drawable contains the mouse position and the position wouldn't be masked by the parent
+            bool validForTarget(Drawable drawable)
+                => drawable.ScreenSpaceDrawQuad.Contains(inputManager.CurrentState.Mouse.Position)
+                   && maskingQuad?.Contains(inputManager.CurrentState.Mouse.Position) != false;
         }
 
         public bool Searching { get; private set; }

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
+using osu.Framework.Graphics.Effects;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.MathUtils;
@@ -213,6 +214,13 @@ namespace osu.Framework.Graphics.Visualisation
 
                     if (compositeTarget == null)
                         compositeTarget = composite;
+
+                    if (composite.Masking
+                        && (composite.BorderThickness > 0 && composite.BorderColour.Linear.A > 0
+                            || composite.EdgeEffect.Type != EdgeEffectType.None && composite.EdgeEffect.Radius > 0 && composite.EdgeEffect.Colour.Linear.A > 0))
+                    {
+                        drawableTarget = composite;
+                    }
                 }
                 else if (!(drawable is Component))
                     drawableTarget = drawable;

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -272,7 +272,7 @@ namespace osu.Framework.Graphics.Visualisation
             if (has_custom_drawnode_cache.TryGetValue(type, out var existing))
                 return existing;
 
-            return has_custom_drawnode_cache[type] = GetType().GetMethod(nameof(CreateDrawNode), BindingFlags.Instance | BindingFlags.NonPublic)?.DeclaringType != typeof(Drawable);
+            return has_custom_drawnode_cache[type] = type.GetMethod(nameof(CreateDrawNode), BindingFlags.Instance | BindingFlags.NonPublic)?.DeclaringType != typeof(Drawable);
         }
 
         public bool Searching { get; private set; }

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -103,7 +103,7 @@ namespace osu.Framework.Graphics.Visualisation
             inputManager = GetContainingInputManager();
         }
 
-        protected override bool BlockPositionalInput => false;
+        protected override bool BlockPositionalInput => Searching;
 
         protected override void PopIn()
         {

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -217,7 +217,7 @@ namespace osu.Framework.Graphics.Visualisation
                     Quad? oldMaskingQuad = maskingQuad;
 
                     // BufferedContainers implicitly mask via their frame buffer
-                    if (Masking || composite is BufferedContainer)
+                    if (composite.Masking || composite is BufferedContainer)
                         maskingQuad = composite.ScreenSpaceDrawQuad;
 
                     for (int i = composite.AliveInternalChildren.Count - 1; i >= 0; i--)

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -229,6 +229,9 @@ namespace osu.Framework.Graphics.Visualisation
                 if (drawable.AlwaysPresent && Precision.AlmostEquals(drawable.Alpha, 0f))
                     return false;
 
+                if (!drawable.HasCustomDrawNode)
+                    return false;
+
                 bool containsCursor = drawable.ScreenSpaceDrawQuad.Contains(inputManager.CurrentState.Mouse.Position);
                 // This is an optimization: We don't need to consider drawables which we don't hover, and which do not
                 // forward input further to children (via d.ReceivePositionalInputAt). If they do forward input to children, then there

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -203,7 +203,7 @@ namespace osu.Framework.Graphics.Visualisation
             // Finds the targeted drawable and composite drawable. The search stops if a drawable is targeted.
             void findTarget(Drawable drawable)
             {
-                if (drawable == this || drawable is CursorContainer || drawable is Component)
+                if (drawable == this || drawable is Component)
                     return;
 
                 if (!drawable.IsPresent)


### PR DESCRIPTION
1. Allows masking+effect `CompositeDrawable`s to be targeted. Sometimes these composites are combined with an `Alpha = 0, AlwaysPresent = true` box that is un-targetable.
2. Considers drawables outside the area of parents for targetting.
3. Disallows targetting of `Drawable`s without custom drawnodes (e.g. fullscreen input receptors).
4. Blocks game-wide input while searching.
5. Allows targeting of cursor containers.

Only tested by going around to various screens and cases in osu!. Let me know if testcases are desired, but this component is not easy to test yet.