### PR TITLE
Fix SafeAreaContainer padding not updating with transforms

### DIFF
--- a/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
-            if (invalidation.HasFlag(Invalidation.Parent))
+            if (invalidation.HasFlag(Invalidation.DrawInfo))
                 PaddingCache.Invalidate();
 
             return base.Invalidate(invalidation, source, shallPropagate);

--- a/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool Invalidate(Invalidation invalidation = Invalidation.All, Drawable source = null, bool shallPropagate = true)
         {
-            if (invalidation.HasFlag(Invalidation.DrawInfo))
+            if ((invalidation & (Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit)) > 0)
                 PaddingCache.Invalidate();
 
             return base.Invalidate(invalidation, source, shallPropagate);


### PR DESCRIPTION
Invalidates the padding cache on `DrawInfo` rather than `Parent`.