### PR TITLE
Allow overlays to only block click events

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
@@ -9,21 +9,81 @@ using osu.Framework.Input.Events;
 using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
+using osuTK.Input;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestSceneFocusedOverlayContainer : ManualInputManagerTestScene
     {
-        private TestFocusedOverlayContainer testContainer;
+        private TestFocusedOverlayContainer overlayContainer;
+
+        private ParentContainer parentContainer;
 
         [Test]
-        public void TestInputBlocking()
+        public void TestClickDismiss()
         {
-            AddStep("create container", () => Child = testContainer = new TestFocusedOverlayContainer());
+            AddStep("create container", () => { Child = overlayContainer = new TestFocusedOverlayContainer(); });
 
-            AddStep("show", () => testContainer.Show());
+            AddStep("show", () => overlayContainer.Show());
+            AddAssert("has focus", () => overlayContainer.HasFocus);
 
-            AddAssert("has focus", () => testContainer.HasFocus);
+            AddStep("click inside", () =>
+            {
+                InputManager.MoveMouseTo(overlayContainer.ScreenSpaceDrawQuad.Centre);
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.ReleaseButton(MouseButton.Left);
+            });
+
+            AddAssert("still has focus", () => overlayContainer.HasFocus);
+
+            AddStep("click outside", () =>
+            {
+                InputManager.MoveMouseTo(overlayContainer.ScreenSpaceDrawQuad.TopLeft - new Vector2(20));
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.ReleaseButton(MouseButton.Left);
+            });
+
+            AddAssert("lost focus", () => !overlayContainer.HasFocus);
+            AddAssert("not visible", () => overlayContainer.State.Value == Visibility.Hidden);
+        }
+
+        [Test]
+        public void TestScrollBlocking()
+        {
+            AddStep("create container", () =>
+            {
+                Child = parentContainer = new ParentContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        overlayContainer = new TestFocusedOverlayContainer()
+                    }
+                };
+            });
+
+            AddStep("show", () => overlayContainer.Show());
+
+            AddAssert("has focus", () => overlayContainer.HasFocus);
+
+            int initialScrollCount = 0;
+
+            AddStep("scroll inside", () =>
+            {
+                initialScrollCount = parentContainer.ScrollReceived;
+                InputManager.MoveMouseTo(overlayContainer.ScreenSpaceDrawQuad.Centre);
+                InputManager.ScrollVerticalBy(1);
+            });
+
+            AddAssert("scroll not received by parent", () => parentContainer.ScrollReceived == initialScrollCount);
+
+            AddStep("scroll outside", () =>
+            {
+                InputManager.MoveMouseTo(overlayContainer.ScreenSpaceDrawQuad.TopLeft - new Vector2(20));
+                InputManager.ScrollVerticalBy(1);
+            });
+
+            AddAssert("scroll received by parent", () => parentContainer.ScrollReceived == ++initialScrollCount);
         }
 
         private class TestFocusedOverlayContainer : FocusedOverlayContainer
@@ -94,6 +154,17 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
                 base.PopOut();
             }
+        }
+    }
+
+    public class ParentContainer : Container
+    {
+        public int ScrollReceived;
+
+        protected override bool OnScroll(ScrollEvent e)
+        {
+            ScrollReceived++;
+            return base.OnScroll(e);
         }
     }
 }

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -24,7 +24,7 @@ using osu.Framework.Platform;
 
 namespace osu.Framework
 {
-    public abstract class Game : Container, IKeyBindingHandler<FrameworkAction>, IHandleGlobalInput
+    public abstract class Game : Container, IKeyBindingHandler<FrameworkAction>, IHandleGlobalKeyboardInput
     {
         public IWindow Window => Host?.Window;
 

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Containers
 
                     break;
 
-                default:
+                case MouseEvent _:
                     if (BlockPositionalInput)
                         return true;
 

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -3,7 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Framework.Input;
-using osuTK;
+using osu.Framework.Input.Events;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -28,22 +28,27 @@ namespace osu.Framework.Graphics.Containers
             {
                 // when blocking non-positional input behind us, we still want to make sure the global handlers receive events
                 // but we don't want other drawables behind us handling them.
-                queue.RemoveAll(d => !(d is IHandleGlobalInput));
+                queue.RemoveAll(d => !(d is IHandleGlobalKeyboardInput));
             }
 
             return base.BuildNonPositionalInputQueue(queue, allowBlocking);
         }
 
-        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        protected override bool Handle(UIEvent e)
         {
-            if (PropagatePositionalInputSubTree && HandlePositionalInput && BlockPositionalInput && ReceivePositionalInputAt(screenSpacePos))
+            switch (e)
             {
-                // when blocking positional input behind us, we still want to make sure the global handlers receive events
-                // but we don't want other drawables behind us handling them.
-                queue.RemoveAll(d => !(d is IHandleGlobalInput));
+                case MouseButtonEvent _:
+                    if (BlockPositionalInput)
+                        return true;
+
+                    break;
+
+                default:
+                    break;
             }
 
-            return base.BuildPositionalInputQueue(screenSpacePos, queue);
+            return base.Handle(e);
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -38,13 +38,16 @@ namespace osu.Framework.Graphics.Containers
         {
             switch (e)
             {
-                case MouseButtonEvent _:
-                    if (BlockPositionalInput)
+                case ScrollEvent _:
+                    if (BlockPositionalInput && base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
                         return true;
 
                     break;
 
                 default:
+                    if (BlockPositionalInput)
+                        return true;
+
                     break;
             }
 

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Graphics.Cursor
     /// <summary>
     /// Displays Tooltips for all its children that inherit from the <see cref="IHasTooltip"/> or <see cref="IHasCustomTooltip"/> interfaces. Keep in mind that only children with <see cref="Drawable.HandlePositionalInput"/> set to true will be checked for their tooltips.
     /// </summary>
-    public class TooltipContainer : CursorEffectContainer<TooltipContainer, ITooltipContentProvider>, IHandleGlobalInput
+    public class TooltipContainer : CursorEffectContainer<TooltipContainer, ITooltipContentProvider>
     {
         private readonly CursorContainer cursorContainer;
         private readonly ITooltip defaultTooltip;

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -18,7 +18,8 @@ using osuTK;
 namespace osu.Framework.Graphics.Visualisation
 {
     [Cached]
-    internal class DrawVisualiser : OverlayContainer, IContainVisualisedDrawables
+    // Implementing IRequireHighFrequencyMousePosition is necessary to gain the ability to block high frequency mouse position updates.
+    internal class DrawVisualiser : OverlayContainer, IContainVisualisedDrawables, IRequireHighFrequencyMousePosition
     {
         public Vector2 ToolPosition
         {
@@ -110,7 +111,7 @@ namespace osu.Framework.Graphics.Visualisation
             inputManager = GetContainingInputManager();
         }
 
-        protected override bool BlockPositionalInput => Searching;
+        protected override bool Handle(UIEvent e) => Searching;
 
         protected override void PopIn()
         {

--- a/osu.Framework/Input/IHandleGlobalKeyboardInput.cs
+++ b/osu.Framework/Input/IHandleGlobalKeyboardInput.cs
@@ -4,9 +4,9 @@
 namespace osu.Framework.Input
 {
     /// <summary>
-    /// Denotes that this class handles input globally.
+    /// Denotes that this class handles keyboard input globally.
     /// </summary>
-    public interface IHandleGlobalInput
+    public interface IHandleGlobalKeyboardInput
     {
     }
 }

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Input
     /// can be created to handle events that should trigger specifically on a focused drawable.
     /// Will send repeat events by default.
     /// </summary>
-    public class PlatformActionContainer : KeyBindingContainer<PlatformAction>, IHandleGlobalInput
+    public class PlatformActionContainer : KeyBindingContainer<PlatformAction>, IHandleGlobalKeyboardInput
     {
         [Resolved]
         private GameHost host { get; set; }

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -33,7 +33,7 @@ using osuTK.Input;
 namespace osu.Framework.Testing
 {
     [Cached]
-    public class TestBrowser : KeyBindingContainer<TestBrowserAction>, IKeyBindingHandler<TestBrowserAction>, IHandleGlobalInput
+    public class TestBrowser : KeyBindingContainer<TestBrowserAction>, IKeyBindingHandler<TestBrowserAction>, IHandleGlobalKeyboardInput
     {
         public TestScene CurrentTest { get; private set; }
 


### PR DESCRIPTION
This is a proposal to help resolve https://github.com/ppy/osu/issues/5134.

Note that optimally, we would *only* allow scroll events through, as it is weird to be able to hover things behind overlays and have them respond to the hover. Unfortunately, this isn't easily possible due to elements like `TooltipContainer` expecting to still receive the move events. The only solution I can think of for this would be to ensure each overlay has its own tooltip container (which may actually be preferrable?).

Open to suggestion for alternative implementations.