### PR TITLE
Clear window with opaque blackness

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 Masking = true,
                 BorderColour = Color4.Green,
                 BorderThickness = 2,
-                Children = new Drawable[]
+                Children = new[]
                 {
                     background = new Box
                     {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Platform;
@@ -17,6 +18,7 @@ namespace osu.Framework.Tests.Visual.Sprites
         [Resolved]
         private GameHost host { get; set; }
 
+        private Drawable background;
         private Sprite display;
 
         [BackgroundDependencyLoader]
@@ -31,7 +33,16 @@ namespace osu.Framework.Tests.Visual.Sprites
                 Masking = true,
                 BorderColour = Color4.Green,
                 BorderThickness = 2,
-                Child = display = new Sprite { RelativeSizeAxes = Axes.Both }
+                Children = new Drawable[]
+                {
+                    background = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Color4.Red,
+                        Alpha = 0
+                    },
+                    display = new Sprite { RelativeSizeAxes = Axes.Both }
+                }
             };
 
             AddStep("take screenshot", takeScreenshot);
@@ -50,6 +61,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 tex.SetData(new TextureUpload(image));
 
                 display.Texture = tex;
+                background.Show();
             }));
         }
     }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -150,7 +150,7 @@ namespace osu.Framework.Graphics.OpenGL
             }, true);
 
             PushDepthInfo(DepthInfo.Default);
-            Clear(ClearInfo.Default);
+            Clear(new ClearInfo(Color4.Black));
         }
 
         private static ClearInfo currentClearInfo;


### PR DESCRIPTION
Fixes ppy/osu#5551, and also fixes the desktop appearing in the window on linux.

From:

![image](https://user-images.githubusercontent.com/1329837/63568382-00cf1c80-c5b0-11e9-8bf0-4aa6de1f47c9.png)

To:

![image](https://user-images.githubusercontent.com/1329837/63568389-03ca0d00-c5b0-11e9-9e66-c2c1b3295f85.png)

(Red should not be visible)