### PR TITLE
Call Handle in default case in TriggerEvent instead of returning false

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1915,7 +1915,7 @@ namespace osu.Framework.Graphics
                     return OnJoystickRelease(joystickRelease);
 
                 default:
-                    return false;
+                    return Handle(e);
             }
         }
 


### PR DESCRIPTION
- Closes #2792

Allows custom events to be consumed by drawables.