### PR TITLE
Remove obsolete FontUsage/SpriteText parameters

### DIFF
--- a/osu.Framework/Graphics/BlendingMode.cs
+++ b/osu.Framework/Graphics/BlendingMode.cs
@@ -11,25 +11,25 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Inherits from parent.
         /// </summary>
-        [Obsolete("Use BlendingParameters statics instead")]
+        [Obsolete("Use BlendingParameters statics instead")] // can be removed 20200220
         public static BlendingParameters Inherit => BlendingParameters.Inherit;
 
         /// <summary>
         /// Mixes with existing colour by a factor of the colour's alpha.
         /// </summary>
-        [Obsolete("Use BlendingParameters statics instead")]
+        [Obsolete("Use BlendingParameters statics instead")] // can be removed 20200220
         public static BlendingParameters Mixture => BlendingParameters.Mixture;
 
         /// <summary>
         /// Purely additive (by a factor of the colour's alpha) blending.
         /// </summary>
-        [Obsolete("Use BlendingParameters statics instead")]
+        [Obsolete("Use BlendingParameters statics instead")] // can be removed 20200220
         public static BlendingParameters Additive => BlendingParameters.Additive;
 
         /// <summary>
         /// No alpha blending whatsoever.
         /// </summary>
-        [Obsolete("Use BlendingParameters statics instead")]
+        [Obsolete("Use BlendingParameters statics instead")] // can be removed 20200220
         public static BlendingParameters None => BlendingParameters.None;
     }
 }

--- a/osu.Framework/Graphics/Sprites/FontUsage.cs
+++ b/osu.Framework/Graphics/Sprites/FontUsage.cs
@@ -81,7 +81,6 @@ namespace osu.Framework.Graphics.Sprites
                 FontName += "Italic";
 
             FontName = FontName.TrimEnd('-');
-            Legacy = false;
         }
 
         /// <summary>
@@ -122,23 +121,6 @@ namespace osu.Framework.Graphics.Sprites
         }
 
         #region Obsolete
-
-        internal bool Legacy { get; }
-
-        private FontUsage(string fontName, bool isLegacy)
-            : this(family: fontName)
-        {
-            Legacy = isLegacy;
-        }
-
-        [Obsolete("Setting font by name is deprecated. Use `Font = new FontUsage(...)` (see: https://github.com/ppy/osu-framework/pull/2043)")]
-        public static implicit operator FontUsage(string fontName) => new FontUsage(fontName, isLegacy: true);
-
-        [Obsolete("Comparing fonts as strings is deprecated. See: https://github.com/ppy/osu-framework/pull/2043")]
-        public static bool operator ==(FontUsage fontUsage, string fontName) => fontUsage.FontName == fontName;
-
-        [Obsolete("Comparing fonts as strings is deprecated. See: https://github.com/ppy/osu-framework/pull/2043")]
-        public static bool operator !=(FontUsage fontUsage, string fontName) => fontUsage.FontName != fontName;
 
         #endregion
     }

--- a/osu.Framework/Graphics/Sprites/FontUsage.cs
+++ b/osu.Framework/Graphics/Sprites/FontUsage.cs
@@ -119,9 +119,5 @@ namespace osu.Framework.Graphics.Sprites
                 return hashCode;
             }
         }
-
-        #region Obsolete
-
-        #endregion
     }
 }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -129,37 +129,11 @@ namespace osu.Framework.Graphics.Sprites
             get => font;
             set
             {
-                // The implicit operator can be used to convert strings to fonts, which discards size + fixedwidth in doing so
-                // For the time being, we'll forward those members from the original value
-                // Todo: Remove this along with all other obsolete members
-                if (value.Legacy)
-                    value = new FontUsage(value.Family, font.Size, value.Weight, value.Italics, font.FixedWidth);
-
                 font = value;
 
                 invalidate(true);
                 shadowOffsetCache.Invalidate();
             }
-        }
-
-        /// <summary>
-        /// The size of the text in local space. This means that if TextSize is set to 16, a single line will have a height of 16.
-        /// </summary>
-        [Obsolete("Setting TextSize directly is deprecated. Use `Font = text.Font.With(size: value)` (see: https://github.com/ppy/osu-framework/pull/2043)")]
-        public float TextSize
-        {
-            get => Font.Size;
-            set => Font = Font.With(size: value);
-        }
-
-        /// <summary>
-        /// True if all characters should be spaced apart the same distance.
-        /// </summary>
-        [Obsolete("Setting FixedWidth directly is deprecated. Use `Font = text.Font.With(fixedWidth: value)` (see: https://github.com/ppy/osu-framework/pull/2043)")]
-        public bool FixedWidth
-        {
-            get => Font.FixedWidth;
-            set => Font = Font.With(fixedWidth: value);
         }
 
         private bool allowMultiline = true;

--- a/osu.Framework/Lists/LockedWeakList.cs
+++ b/osu.Framework/Lists/LockedWeakList.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.Lists
                 list.Clear();
         }
 
-        [Obsolete("Use foreach() / GetEnumerator() (see: https://github.com/ppy/osu-framework/pull/2412)")]
+        [Obsolete("Use foreach() / GetEnumerator() (see: https://github.com/ppy/osu-framework/pull/2412)")] // can be removed 20191118
         public void ForEachAlive(Action<T> action)
         {
             foreach (var item in this)

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Lists
                 item.Invalidate();
         }
 
-        [Obsolete("Use foreach() / GetEnumerator() (see: https://github.com/ppy/osu-framework/pull/2412)")]
+        [Obsolete("Use foreach() / GetEnumerator() (see: https://github.com/ppy/osu-framework/pull/2412)")] // can be removed 20191118
         public void ForEachAlive(Action<T> action)
         {
             foreach (var obj in this)

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -327,7 +327,7 @@ namespace osu.Framework.Testing
             });
         });
 
-        [Obsolete("Parameter order didn't match other methods – switch order to fix")]
+        [Obsolete("Parameter order didn't match other methods – switch order to fix")] // can be removed 20190919
         protected void AddUntilStep(Func<bool> waitUntilTrueDelegate, string description = null)
             => AddUntilStep(description, waitUntilTrueDelegate);
 
@@ -339,7 +339,7 @@ namespace osu.Framework.Testing
             });
         });
 
-        [Obsolete("Parameter order didn't match other methods – switch order to fix")]
+        [Obsolete("Parameter order didn't match other methods – switch order to fix")] // can be removed 20190919
         protected void AddWaitStep(int waitCount, string description = null)
             => AddWaitStep(description, waitCount);
 


### PR DESCRIPTION
Obsoleted in 2019.221.0 (had no existing removal documentation)