### PR TITLE
Fix ProxyDrawable not correctly transferring LifetimeStart/LifetimeEnd

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawableLifetime.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawableLifetime.cs
@@ -1,0 +1,101 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    public class TestSceneProxyDrawableLifetime : FrameworkTestScene
+    {
+        [SetUp]
+        public void Setup() => Schedule(Clear);
+
+        [Test]
+        public void TestProxyAliveWhenOriginalAlive()
+        {
+            Box box = null;
+            Drawable proxy = null;
+
+            AddStep("add proxy", () =>
+            {
+                Add(box = new Box
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(100)
+                });
+
+                Add(proxy = box.CreateProxy());
+            });
+
+            AddAssert("proxy should be alive", () => proxy.ShouldBeAlive);
+            AddAssert("proxy is alive", () => proxy.IsAlive);
+
+            AddStep("expire box", () => box.Expire());
+
+            AddAssert("proxy should not be alive", () => !proxy.ShouldBeAlive);
+            AddAssert("proxy is not alive", () => !proxy.IsAlive);
+        }
+
+        [Test]
+        public void TestLifetimeTransferred()
+        {
+            Box box = null;
+            Drawable proxy = null;
+
+            AddStep("add proxy", () =>
+            {
+                Add(box = new Box
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(100)
+                });
+
+                Add(proxy = box.CreateProxy());
+            });
+
+            AddStep("set lifetimes", () =>
+            {
+                box.LifetimeStart = Time.Current - 5000;
+                box.LifetimeEnd = Time.Current + 5000;
+            });
+
+            AddAssert("lifetime transferred from box", () => proxy.LifetimeStart == box.LifetimeStart && proxy.LifetimeEnd == box.LifetimeEnd);
+        }
+
+        [Test]
+        public void TestRemovedWhenOriginalRemoved()
+        {
+            Container container = null;
+            Box box = null;
+            Drawable proxy = null;
+
+            AddStep("add proxy", () =>
+            {
+                Add(container = new Container
+                {
+                    RelativeSizeAxes = Axes.Both
+                });
+
+                container.Add(box = new Box
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(100)
+                });
+
+                container.Add(proxy = box.CreateProxy());
+            });
+
+            AddStep("expire box", () => box.Expire(true));
+
+            AddAssert("box removed", () => !container.Contains(box));
+            AddAssert("proxy removed", () => !container.Contains(proxy));
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawableLifetime.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneProxyDrawableLifetime.cs
@@ -46,9 +46,12 @@ namespace osu.Framework.Tests.Visual.Drawables
         {
             Box box = null;
             Drawable proxy = null;
+            bool lifetimeChanged = false;
 
             AddStep("add proxy", () =>
             {
+                lifetimeChanged = false;
+
                 Add(box = new Box
                 {
                     Anchor = Anchor.Centre,
@@ -56,7 +59,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                     Size = new Vector2(100)
                 });
 
-                Add(proxy = box.CreateProxy());
+                Add(proxy = box.CreateProxy().With(d => d.LifetimeChanged += _ => lifetimeChanged = true));
             });
 
             AddStep("set lifetimes", () =>
@@ -65,6 +68,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                 box.LifetimeEnd = Time.Current + 5000;
             });
 
+            AddAssert("lifetime changed", () => lifetimeChanged);
             AddAssert("lifetime transferred from box", () => proxy.LifetimeStart == box.LifetimeStart && proxy.LifetimeEnd == box.LifetimeEnd);
         }
 

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -281,6 +281,8 @@ namespace osu.Framework.Graphics
             GLWrapper.ScheduleDisposal(() => Dispose(false));
         }
 
+        protected internal bool IsDisposed { get; private set; }
+
         public void Dispose()
         {
             if (referenceCount.Decrement() != 0)
@@ -293,6 +295,7 @@ namespace osu.Framework.Graphics
         protected virtual void Dispose(bool isDisposing)
         {
             Source = null;
+            IsDisposed = true;
         }
     }
 }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Graphics
             GC.SuppressFinalize(this);
         }
 
-        protected bool IsDisposed { get; private set; }
+        protected internal bool IsDisposed { get; private set; }
 
         /// <summary>
         /// Disposes this drawable.
@@ -102,10 +102,6 @@ namespace osu.Framework.Graphics
 
                 OnUpdate = null;
                 OnInvalidate = null;
-
-                // If this Drawable is disposed, then we need to also
-                // stop remotely rendering it.
-                proxy?.Dispose();
 
                 OnDispose?.Invoke();
                 OnDispose = null;

--- a/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
+++ b/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
@@ -19,6 +19,8 @@ namespace osu.Framework.Graphics
             {
                 Original = original;
                 originalDrawNodes = (original as ProxyDrawable)?.originalDrawNodes ?? original.drawNodes;
+
+                original.LifetimeChanged += _ => LifetimeChanged?.Invoke(this);
             }
 
             internal override void ValidateProxyDrawNode(int treeIndex, ulong frame)
@@ -47,9 +49,13 @@ namespace osu.Framework.Graphics
 
             internal sealed override Drawable Original { get; }
 
-            public override bool RemoveWhenNotAlive => base.RemoveWhenNotAlive && Original.RemoveWhenNotAlive;
+            public override bool RemoveWhenNotAlive => Original.RemoveWhenNotAlive;
 
-            protected internal override bool ShouldBeAlive => base.ShouldBeAlive && Original.ShouldBeAlive;
+            protected internal override bool ShouldBeAlive => Original.ShouldBeAlive;
+
+            public override double LifetimeStart => Original.LifetimeStart;
+
+            public override double LifetimeEnd => Original.LifetimeEnd;
 
             // We do not want to receive updates. That is the business of the original drawable.
             public override bool IsPresent => false;

--- a/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
+++ b/osu.Framework/Graphics/Drawable_ProxyDrawable.cs
@@ -60,7 +60,13 @@ namespace osu.Framework.Graphics
             // We do not want to receive updates. That is the business of the original drawable.
             public override bool IsPresent => false;
 
-            public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds) => Original.UpdateSubTreeMasking(this, maskingBounds);
+            public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
+            {
+                if (Original.IsDisposed)
+                    return false;
+
+                return Original.UpdateSubTreeMasking(this, maskingBounds);
+            }
 
             private class ProxyDrawNode : DrawNode
             {
@@ -98,6 +104,9 @@ namespace osu.Framework.Graphics
                         return null;
 
                     if (Source.drawNodeValidationIds[DrawNodeIndex] != FrameCount)
+                        return null;
+
+                    if (target.IsDisposed)
                         return null;
 
                     return target;


### PR DESCRIPTION
1. Fixes LifetimeStart/LifetimeEnd not being transferred from the original `Drawable`. This is two-part:
    1. Lifetime is redirected.
    2. The `LifetimeChanged` action is invoked on the proxy.
2. Fixes `ProxyDrawable`s getting into a weird state when the original `Drawable` disposes - the proxy is also disposed (parent nulled), but is still part of a composite.
    1. `ProxyDrawable` is no longer disposed when the original `Drawable` disposes.
    2. Various methods inside `ProxyDrawable` now check for the original's disposal state.