### PR TITLE
Increase resolution of CircularProgress depending on radius

### DIFF
--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -161,7 +161,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             base.Dispose(isDisposing);
 
-            halfCircleBatch.Dispose();
+            halfCircleBatch?.Dispose();
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -15,9 +15,11 @@ namespace osu.Framework.Graphics.UserInterface
 {
     public class CircularProgressDrawNode : TexturedShaderDrawNode
     {
-        public const int MAX_RES = 24;
+        private const float arc_tolerance = 0.1f;
 
         protected new CircularProgress Source => (CircularProgress)base.Source;
+
+        private LinearBatch<TexturedVertex2D> halfCircleBatch;
 
         private float angle;
         private float innerRadius = 1;
@@ -40,10 +42,6 @@ namespace osu.Framework.Graphics.UserInterface
             innerRadius = Source.InnerRadius;
         }
 
-        // We add 2 to the size param to account for the first triangle needing every vertex passed, subsequent triangles use the last two vertices of the previous triangle.
-        // MAX_RES refers to a half-circle, so it is multiplied by 2 for the full circle and by 2 again to account for each circle part requiring two vertices.
-        private readonly LinearBatch<TexturedVertex2D> halfCircleBatch = new LinearBatch<TexturedVertex2D>(MAX_RES * 4 + 2, 1, PrimitiveType.TriangleStrip);
-
         private Vector2 pointOnCircle(float angle) => new Vector2((float)Math.Sin(angle), -(float)Math.Cos(angle));
         private float angleToUnitInterval(float angle) => angle / MathHelper.TwoPi + (angle >= 0 ? 0 : 1);
 
@@ -57,11 +55,22 @@ namespace osu.Framework.Graphics.UserInterface
         private void updateVertexBuffer()
         {
             const float start_angle = 0;
-            const float step = MathHelper.Pi / MAX_RES;
 
             float dir = Math.Sign(angle);
+            float radius = Math.Max(drawSize.X, drawSize.Y);
 
-            int amountPoints = (int)Math.Ceiling(Math.Abs(angle) / step);
+            // The amount of points are selected such that discrete curvature is smaller than the provided tolerance.
+            // The exact angle required to meet the tolerance is: 2 * Math.Acos(1 - TOLERANCE / r)
+            // The special case is for extremely small circles where the radius is smaller than the tolerance.
+            int amountPoints = 2 * radius <= arc_tolerance ? 2 : Math.Max(2, (int)Math.Ceiling(Math.PI / Math.Acos(1 - arc_tolerance / radius)));
+
+            if (halfCircleBatch == null || halfCircleBatch.Size < amountPoints * 2)
+            {
+                halfCircleBatch?.Dispose();
+
+                // Amount of points is multiplied by 2 to account for each part requiring two vertices.
+                halfCircleBatch = new LinearBatch<TexturedVertex2D>(amountPoints * 2, 1, PrimitiveType.TriangleStrip);
+            }
 
             Matrix3 transformationMatrix = DrawInfo.Matrix;
             MatrixExtensions.ScaleFromLeft(ref transformationMatrix, drawSize);
@@ -94,17 +103,17 @@ namespace osu.Framework.Graphics.UserInterface
                 Colour = currentColour
             });
 
-            for (int i = 1; i <= amountPoints; i++)
+            for (int i = 1; i < amountPoints; i++)
             {
+                float fract = (float)i / (amountPoints - 1);
+
                 // Clamps the angle so we don't overshoot.
                 // dir is used so negative angles result in negative angularOffset.
-                float angularOffset = dir * Math.Min(i * step, dir * angle);
+                float angularOffset = Math.Min(fract * MathHelper.TwoPi, dir * angle);
                 float normalisedOffset = angularOffset / MathHelper.TwoPi;
 
                 if (dir < 0)
-                {
                     normalisedOffset += 1.0f;
-                }
 
                 // Update `current`
                 current = origin + pointOnCircle(start_angle + angularOffset) * 0.5f;


### PR DESCRIPTION
Uses the same algorithm/tolerance as the circular arc path approximation, just adapted for CircularProgress.

Got annoyed at my circles being too jagged:

| old | new |
| --- | ---- |
| ![image](https://user-images.githubusercontent.com/1329837/63842394-6ad82f00-c9bf-11e9-8a9e-07a3dbd1af87.png) | ![image](https://user-images.githubusercontent.com/1329837/63842405-6f044c80-c9bf-11e9-9645-9fd21ccaeab2.png) |