### PR TITLE
Fix nullrefs when clicking outside the window

### DIFF
--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -190,6 +190,8 @@ namespace osu.Framework.Input
 
         protected virtual bool HandleMouseClick(InputState state)
         {
+            if (MouseDownInputQueue == null) return false;
+
             // due to the laziness of IEnumerable, .Where check should be done right before it is triggered for the event.
             var drawables = MouseDownInputQueue.Intersect(PositionalInputQueue)
                                                .Where(t => t.IsAlive && t.IsPresent && t.ReceivePositionalInputAt(state.Mouse.Position));


### PR DESCRIPTION
Fixes #2809.

The same conditional already existed in HandleMouseUp... 