### PR TITLE
Fix BindableFloat.IsDefault returning true for non-default values

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
@@ -22,6 +22,23 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(value, bindable.Value);
         }
 
+        [TestCase(-1.00000000, 1.00000000, 0.00000001)]
+        [TestCase(1.00000001, 1.00000000, 0.00000001)]
+        [TestCase(-1.00000001, 1.00000000, 0.00000001)]
+        [TestCase(0.99999999, 1.00000000, 0.00000001)]
+        [TestCase(-0.99999999, 1.00000000, 0.00000001)]
+        [TestCase(199.1223345568, 199.1223345567, 0.0000000001)]
+        [TestCase(-199.1223345568, 199.1223345567, 0.0000000001)]
+        [TestCase(-199.1223345567, 199.1223345567, 0.0000000001)]
+        public void TestDefaultCheck(double value, double def, double precision)
+        {
+            var bindable = new BindableDouble { Value = def, Default = def, Precision = precision };
+            Assert.IsTrue(bindable.IsDefault);
+
+            bindable.Value = value;
+            Assert.IsFalse(bindable.IsDefault);
+        }
+
         [TestCase("0", 0f)]
         [TestCase("1", 1f)]
         [TestCase("-0", 0f)]

--- a/osu.Framework.Tests/Bindables/BindableFloatTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableFloatTest.cs
@@ -22,6 +22,23 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(value, bindable.Value);
         }
 
+        [TestCase(-1.00f, 1.00f, 0.01f)]
+        [TestCase(1.01f, 1.00f, 0.01f)]
+        [TestCase(-1.01f, 1.00f, 0.01f)]
+        [TestCase(0.99f, 1.00f, 0.01f)]
+        [TestCase(-0.99f, 1.00f, 0.01f)]
+        [TestCase(105.123f, 105.122f, 0.001f)]
+        [TestCase(-105.123f, 105.122f, 0.001f)]
+        [TestCase(-105.122f, 105.122f, 0.001f)]
+        public void TestDefaultCheck(float value, float def, float precision)
+        {
+            var bindable = new BindableFloat { Value = def, Default = def, Precision = precision };
+            Assert.IsTrue(bindable.IsDefault);
+
+            bindable.Value = value;
+            Assert.IsFalse(bindable.IsDefault);
+        }
+
         [TestCase("0", 0f)]
         [TestCase("1", 1f)]
         [TestCase("-0", 0f)]

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -8,7 +8,8 @@ namespace osu.Framework.Bindables
 {
     public class BindableDouble : BindableNumber<double>
     {
-        public override bool IsDefault => Math.Abs(Value - Default) < Precision;
+        // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
+        public override bool IsDefault => Math.Abs(Value - Default) < (Precision / 2);
 
         protected override double DefaultMinValue => double.MinValue;
         protected override double DefaultMaxValue => double.MaxValue;

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -8,7 +8,8 @@ namespace osu.Framework.Bindables
 {
     public class BindableFloat : BindableNumber<float>
     {
-        public override bool IsDefault => Math.Abs(Value - Default) < Precision;
+        // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
+        public override bool IsDefault => Math.Abs(Value - Default) < (Precision / 2);
 
         protected override float DefaultMinValue => float.MinValue;
         protected override float DefaultMaxValue => float.MaxValue;


### PR DESCRIPTION
- Takes 50% of the precision to ensure no-underflow for values near to default (for example, `Value = 1.01f`, `Default = 1.00f`, `Precision = 0.01f`)

Fixes *"no revert button for UI-scale 1.01x"* part of ppy/osu#5940