### PR TITLE
Add an option to not redraw BufferedContainers on scale change

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Tests.Visual.Containers
         };
 
         public TestSceneCachedBufferedContainer()
-            : base(5, 2)
+            : base(5, 3)
         {
             string[] labels =
             {
@@ -35,12 +35,16 @@ namespace osu.Framework.Tests.Visual.Containers
                 "cached with parent scale",
                 "uncached with parent scale&fade",
                 "cached with parent scale&fade",
+                "cached with no redraw on parent scale&fade",
             };
 
             var boxes = new List<ContainingBox>();
 
             for (int i = 0; i < Rows * Cols; ++i)
             {
+                if (i >= labels.Length)
+                    break;
+
                 ContainingBox box;
 
                 Cell(i).AddRange(new Drawable[]
@@ -54,7 +58,8 @@ namespace osu.Framework.Tests.Visual.Containers
                     {
                         Child = new CountingBox(i == 2 || i == 3, i == 4 || i == 5)
                         {
-                            CacheDrawnFrameBuffer = i % 2 == 1,
+                            CacheDrawnFrameBuffer = i % 2 == 1 || i == 10,
+                            RedrawOnScale = i != 10
                         },
                     }
                 });
@@ -86,6 +91,8 @@ namespace osu.Framework.Tests.Visual.Containers
 
             // ensure we don't break on colour invalidations (due to blanket invalidation logic in Drawable.Invalidate).
             AddAssert("box 7 count equals box 8 count", () => boxes[7].Count == boxes[8].Count);
+
+            AddAssert("box 10 count is 1", () => boxes[10].Count == 1);
         }
 
         private class ContainingBox : Container<CountingBox>

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
@@ -76,20 +76,22 @@ namespace osu.Framework.Tests.Visual.Containers
 
             // ensure rotation changes are invalidating cache (for now).
             AddAssert("box 2 count > 0", () => boxes[2].Count > 0);
-            AddAssert("box 2 count equals box 3 count", () => boxes[2].Count == boxes[3].Count);
+            AddAssert("box 3 count is less than box 2 count", () => boxes[3].Count < boxes[2].Count);
 
             // ensure cached with only translation is never updating children.
             AddAssert("box 5 count is 1", () => boxes[1].Count == 1);
 
             // ensure a parent scaling is invalidating cache.
-            AddAssert("box 5 count equals box 6 count", () => boxes[5].Count == boxes[6].Count);
+            AddAssert("box 5 count is less than box 6 count", () => boxes[5].Count < boxes[6].Count);
 
             // ensure we don't break on colour invalidations (due to blanket invalidation logic in Drawable.Invalidate).
             AddAssert("box 7 count equals box 8 count", () => boxes[7].Count == boxes[8].Count);
         }
 
-        private class ContainingBox : Container
+        private class ContainingBox : Container<CountingBox>
         {
+            public new int Count => Child.Count;
+
             private readonly bool scaling;
             private readonly bool fading;
 
@@ -111,10 +113,11 @@ namespace osu.Framework.Tests.Visual.Containers
 
         private class CountingBox : BufferedContainer
         {
+            public new int Count;
+
             private readonly bool rotating;
             private readonly bool moving;
             private readonly SpriteText count;
-            public new int Count;
 
             public CountingBox(bool rotating = false, bool moving = false)
             {

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Statistics;
 using osuTK;
 using osuTK.Graphics;
 
@@ -79,6 +80,8 @@ namespace osu.Framework.Graphics
         {
             if (RequiresRedraw)
             {
+                FrameStatistics.Increment(StatisticsCounterType.FrameBufferRedraw);
+
                 SharedData.ResetCurrentEffectBuffer();
 
                 using (establishFrameBufferViewport())

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Graphics
         {
             if (RequiresRedraw)
             {
-                FrameStatistics.Increment(StatisticsCounterType.FrameBufferRedraw);
+                FrameStatistics.Increment(StatisticsCounterType.FBORedraw);
 
                 SharedData.ResetCurrentEffectBuffer();
 

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Statistics
         VBufBinds,
         VBufOverflow,
         TextureBinds,
-        FrameBufferRedraw,
+        FBORedraw,
         DrawCalls,
         ShaderBinds,
         VerticesDraw,

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -59,6 +59,7 @@ namespace osu.Framework.Statistics
         VBufBinds,
         VBufOverflow,
         TextureBinds,
+        FrameBufferRedraw,
         DrawCalls,
         ShaderBinds,
         VerticesDraw,

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -19,6 +19,7 @@ namespace osu.Framework.Threading
             StatisticsCounterType.VBufBinds,
             StatisticsCounterType.VBufOverflow,
             StatisticsCounterType.TextureBinds,
+            StatisticsCounterType.FrameBufferRedraw,
             StatisticsCounterType.DrawCalls,
             StatisticsCounterType.ShaderBinds,
             StatisticsCounterType.VerticesDraw,

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Threading
             StatisticsCounterType.VBufBinds,
             StatisticsCounterType.VBufOverflow,
             StatisticsCounterType.TextureBinds,
-            StatisticsCounterType.FrameBufferRedraw,
+            StatisticsCounterType.FBORedraw,
             StatisticsCounterType.DrawCalls,
             StatisticsCounterType.ShaderBinds,
             StatisticsCounterType.VerticesDraw,


### PR DESCRIPTION
Called it `RedrawOnScale`, am open to suggestions. It's `true` by default to not change current behaviour/behaviour when sprites/text are used.