### PR TITLE
Fix incorrect working directory when a nuget framework consumer is consumed by another project

### DIFF
--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -46,8 +46,13 @@ namespace osu.Framework.Development
         /// Will fall back to calling assembly if there is no Entry assembly.
         /// </summary>
         /// <returns>The entry assembly (usually obtained via <see cref="Assembly.GetEntryAssembly()"/>.</returns>
-        public static Assembly GetEntryAssembly() =>
-            HostAssembly ?? Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
+        public static Assembly GetEntryAssembly()
+        {
+            if (IsNUnitRunning && HostAssembly != null)
+                return HostAssembly;
+
+            return Assembly.GetEntryAssembly() ?? HostAssembly ?? Assembly.GetCallingAssembly();
+        }
 
         /// <summary>
         /// Get the entry path, even when running under nUnit.


### PR DESCRIPTION
osu.Game.Rulesets.Custom.Tests -> osu.Game -> osu.Framework would cause the working directory to become the location of the `osu.Game.dll` in nuget cache. This was due to an incorrect lookup order for `GetEntryAssembly`.

Full testing:

```

osu.Framework.Tests (rider)

HostAssembly C:\Users\Dean\Projects\osu-framework\osu.Framework.Tests\bin\Debug\netcoreapp2.2\osu.Framework.Tests.dll
Assembly.GetEntryAssembly() C:\Users\Dean\Projects\osu-framework\osu.Framework.Tests\bin\Debug\netcoreapp2.2\osu.Framework.Tests.dll
Assembly.GetCallingAssembly() C:\Users\Dean\Projects\osu-framework\osu.Framework.Tests\bin\Debug\netcoreapp2.2\osu.Framework.dll

osu.Framework.Tests (nUnit rider)

HostAssembly C:\Users\Dean\Projects\osu-framework\osu.Framework.Tests\bin\Debug\netcoreapp2.2\osu.Framework.dll
Assembly.GetEntryAssembly() C:\Users\Dean\.nuget\packages\microsoft.testplatform.testhost\16.2.0\lib\netstandard1.5\testhost.dll
Assembly.GetCallingAssembly() C:\Users\Dean\Projects\osu-framework\osu.Framework.Tests\bin\Debug\netcoreapp2.2\osu.Framework.dll

osu.Game (rider)

HostAssembly C:\Users\Dean\Projects\osu\osu.Desktop\bin\Debug\netcoreapp2.2\osu!.dll
Assembly.GetEntryAssembly() C:\Users\Dean\Projects\osu\osu.Desktop\bin\Debug\netcoreapp2.2\osu!.dll
Assembly.GetCallingAssembly() C:\Users\Dean\.nuget\packages\ppy.osu.framework\2019.830.1\lib\netstandard2.0\osu.Framework.dll

osu.Game (nUnit rider)

HostAssembly C:\Users\Dean\Projects\osu\osu.Game.Tests\bin\Debug\netcoreapp2.2\osu.Game.dll
Assembly.GetEntryAssembly() C:\Users\Dean\.nuget\packages\microsoft.testplatform.testhost\16.2.0\lib\netstandard1.5\testhost.dll
Assembly.GetCallingAssembly() C:\Users\Dean\.nuget\packages\ppy.osu.framework\2019.830.1\lib\netstandard2.0\osu.Framework.dll

osu.Game.Rulesets.Osu.Tests (rider, project reference)

HostAssembly C:\Users\Dean\Projects\osu\osu.Game.Rulesets.Osu.Tests\bin\Debug\netcoreapp2.2\osu.Game.dll
Assembly.GetEntryAssembly() C:\Users\Dean\Projects\osu\osu.Game.Rulesets.Osu.Tests\bin\Debug\netcoreapp2.2\osu.Game.Rulesets.Osu.Tests.dll
Assembly.GetCallingAssembly() C:\Users\Dean\.nuget\packages\ppy.osu.framework\2019.830.1\lib\netstandard2.0\osu.Framework.dll

osu.Game.Rulesets.Osu.Tests (nUnit rider, project reference)

HostAssembly C:\Users\Dean\Projects\osu\osu.Game.Tests\bin\Debug\netcoreapp2.2\osu.Game.dll
Assembly.GetEntryAssembly() C:\Users\Dean\.nuget\packages\microsoft.testplatform.testhost\16.2.0\lib\netstandard1.5\testhost.dll
Assembly.GetCallingAssembly() C:\Users\Dean\.nuget\packages\ppy.osu.framework\2019.830.1\lib\netstandard2.0\osu.Framework.dll

osu.Game.Rulesets.Pippidon.Tests (rider, nuget reference)

HostAssembly C:\Users\Dean\.nuget\packages\ppy.osu.game\2019.903.2\lib\netstandard2.0\osu.Game.dll
Assembly.GetEntryAssembly() C:\Users\Dean\Projects\osu-ruleset-pippicoin\osu.Game.Rulesets.Pippidon.Tests\bin\Debug\netcoreapp2.2\osu.Game.Rulesets.Pippidon.Tests.dll
Assembly.GetCallingAssembly() C:\Users\Dean\.nuget\packages\ppy.osu.framework\2019.830.1\lib\netstandard2.0\osu.Framework.dll

osu.Game.Rulesets.Pippidon.Tests (nUnit rider, nuget reference)

HostAssembly C:\Users\Dean\.nuget\packages\ppy.osu.game\2019.903.2\lib\netstandard2.0\osu.Game.dll
Assembly.GetEntryAssembly() C:\Users\Dean\.nuget\packages\microsoft.testplatform.testhost\16.2.0\lib\netstandard1.5\testhost.dll
Assembly.GetCallingAssembly() C:\Users\Dean\.nuget\packages\ppy.osu.framework\2019.830.1\lib\netstandard2.0\osu.Framework.dll
```