### PR TITLE
Fix android native libraries not being copied correctly on first build

### DIFF
--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -34,11 +34,6 @@
     <PackageReference Include="ppy.osuTK.Android" Version="1.0.111" />
   </ItemGroup>
   <ItemGroup>
-    <NativeLibs Include="$(MSBuildThisFileDirectory)*\*.so" />
-    <None Include="@(NativeLibs)">
-      <Pack>true</Pack>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\**\*.so"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes that you do not need to build the consuming project two times.
Also automatically adds the android native libraries to the apk.

No outputdirectory workarounds needed.

Contains commits from https://github.com/ppy/osu-framework/pull/2823. Merge that first.