### PR TITLE
Use Precision.AlmostEquals for checking BindableNumber.IsDefault

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
@@ -33,11 +33,11 @@ namespace osu.Framework.Tests.Bindables
         [TestCase(199.1223345568, 199.1223345567, 0.0000000001)]
         [TestCase(-199.1223345568, 199.1223345567, 0.0000000001)]
         [TestCase(-199.1223345567, 199.1223345567, 0.0000000001)]
-        public void TestDefaultCheck(double value, double def, double precision = 0)
+        public void TestDefaultCheck(double value, double def, double? precision = null)
         {
             var bindable = new BindableDouble { Value = def, Default = def };
-            if (precision != 0)
-                bindable.Precision = precision;
+            if (precision.HasValue)
+                bindable.Precision = precision.Value;
 
             Assert.IsTrue(bindable.IsDefault);
 

--- a/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
@@ -22,6 +22,9 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(value, bindable.Value);
         }
 
+        [TestCase(-1.0, 1.0)]
+        [TestCase(1.1, 1.0)]
+        [TestCase(-1.1, 1.0)]
         [TestCase(-1.00000000, 1.00000000, 0.00000001)]
         [TestCase(1.00000001, 1.00000000, 0.00000001)]
         [TestCase(-1.00000001, 1.00000000, 0.00000001)]
@@ -30,9 +33,12 @@ namespace osu.Framework.Tests.Bindables
         [TestCase(199.1223345568, 199.1223345567, 0.0000000001)]
         [TestCase(-199.1223345568, 199.1223345567, 0.0000000001)]
         [TestCase(-199.1223345567, 199.1223345567, 0.0000000001)]
-        public void TestDefaultCheck(double value, double def, double precision)
+        public void TestDefaultCheck(double value, double def, double precision = 0)
         {
-            var bindable = new BindableDouble { Value = def, Default = def, Precision = precision };
+            var bindable = new BindableDouble { Value = def, Default = def };
+            if (precision != 0)
+                bindable.Precision = precision;
+
             Assert.IsTrue(bindable.IsDefault);
 
             bindable.Value = value;

--- a/osu.Framework.Tests/Bindables/BindableFloatTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableFloatTest.cs
@@ -33,11 +33,11 @@ namespace osu.Framework.Tests.Bindables
         [TestCase(105.123f, 105.122f, 0.001f)]
         [TestCase(-105.123f, 105.122f, 0.001f)]
         [TestCase(-105.122f, 105.122f, 0.001f)]
-        public void TestDefaultCheck(float value, float def, float precision = 0)
+        public void TestDefaultCheck(float value, float def, float? precision = null)
         {
             var bindable = new BindableFloat { Value = def, Default = def };
-            if (precision != 0)
-                bindable.Precision = precision;
+            if (precision.HasValue)
+                bindable.Precision = precision.Value;
 
             Assert.IsTrue(bindable.IsDefault);
 

--- a/osu.Framework.Tests/Bindables/BindableFloatTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableFloatTest.cs
@@ -22,6 +22,9 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(value, bindable.Value);
         }
 
+        [TestCase(-1.0f, 1.0f)]
+        [TestCase(1.1f, 1.0f)]
+        [TestCase(-1.1f, 1.0f)]
         [TestCase(-1.00f, 1.00f, 0.01f)]
         [TestCase(1.01f, 1.00f, 0.01f)]
         [TestCase(-1.01f, 1.00f, 0.01f)]
@@ -30,9 +33,12 @@ namespace osu.Framework.Tests.Bindables
         [TestCase(105.123f, 105.122f, 0.001f)]
         [TestCase(-105.123f, 105.122f, 0.001f)]
         [TestCase(-105.122f, 105.122f, 0.001f)]
-        public void TestDefaultCheck(float value, float def, float precision)
+        public void TestDefaultCheck(float value, float def, float precision = 0)
         {
-            var bindable = new BindableFloat { Value = def, Default = def, Precision = precision };
+            var bindable = new BindableFloat { Value = def, Default = def };
+            if (precision != 0)
+                bindable.Precision = precision;
+
             Assert.IsTrue(bindable.IsDefault);
 
             bindable.Value = value;

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Globalization;
 
 namespace osu.Framework.Bindables

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -9,11 +9,11 @@ namespace osu.Framework.Bindables
     public class BindableDouble : BindableNumber<double>
     {
         // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
-        public override bool IsDefault => Math.Abs(Value - Default) < (Precision / 2);
+        public override bool IsDefault => Math.Abs(Value - Default) < Math.Max(Precision / 2, double.Epsilon);
 
         protected override double DefaultMinValue => double.MinValue;
         protected override double DefaultMaxValue => double.MaxValue;
-        protected override double DefaultPrecision => MathUtils.Precision.DOUBLE_EPSILON;
+        protected override double DefaultPrecision => double.Epsilon;
 
         public BindableDouble(double value = 0)
             : base(value)

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Bindables
 
         protected override double DefaultMinValue => double.MinValue;
         protected override double DefaultMaxValue => double.MaxValue;
-        protected override double DefaultPrecision => double.Epsilon;
+        protected override double DefaultPrecision => MathUtils.Precision.DOUBLE_EPSILON;
 
         public BindableDouble(double value = 0)
             : base(value)

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Bindables
     public class BindableDouble : BindableNumber<double>
     {
         // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
-        public override bool IsDefault => Math.Abs(Value - Default) < Math.Max(Precision / 2, double.Epsilon);
+        public override bool IsDefault => MathUtils.Precision.AlmostEquals(Value, Default, Precision / 2);
 
         protected override double DefaultMinValue => double.MinValue;
         protected override double DefaultMaxValue => double.MaxValue;

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Globalization;
 
 namespace osu.Framework.Bindables

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Bindables
     public class BindableFloat : BindableNumber<float>
     {
         // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
-        public override bool IsDefault => Math.Abs(Value - Default) < Math.Max(Precision / 2, float.Epsilon);
+        public override bool IsDefault => MathUtils.Precision.AlmostEquals(Value, Default, Precision / 2);
 
         protected override float DefaultMinValue => float.MinValue;
         protected override float DefaultMaxValue => float.MaxValue;

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Bindables
 
         protected override float DefaultMinValue => float.MinValue;
         protected override float DefaultMaxValue => float.MaxValue;
-        protected override float DefaultPrecision => float.Epsilon;
+        protected override float DefaultPrecision => MathUtils.Precision.FLOAT_EPSILON;
 
         public BindableFloat(float value = 0)
             : base(value)

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -9,11 +9,11 @@ namespace osu.Framework.Bindables
     public class BindableFloat : BindableNumber<float>
     {
         // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
-        public override bool IsDefault => Math.Abs(Value - Default) < (Precision / 2);
+        public override bool IsDefault => Math.Abs(Value - Default) < Math.Max(Precision / 2, float.Epsilon);
 
         protected override float DefaultMinValue => float.MinValue;
         protected override float DefaultMaxValue => float.MaxValue;
-        protected override float DefaultPrecision => MathUtils.Precision.FLOAT_EPSILON;
+        protected override float DefaultPrecision => float.Epsilon;
 
         public BindableFloat(float value = 0)
             : base(value)


### PR DESCRIPTION
- Fixes a regression occurred in #2816