### PR TITLE
Fix RenderBuffers disposing on the wrong thread

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -98,7 +98,7 @@ namespace osu.Framework.Graphics
 
         ~BufferedDrawNodeSharedData()
         {
-            Dispose(false);
+            GLWrapper.ScheduleDisposal(() => Dispose(false));
         }
 
         public void Dispose()


### PR DESCRIPTION
Easily replicable by deleting a slider from the editor.