### PR TITLE
Fix TriggerPressed/TriggerReleased crashing with null keybindings

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -1,0 +1,79 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Framework.Tests.Visual.Input
+{
+    public class TestSceneKeyBindingContainer : FrameworkTestScene
+    {
+        [Test]
+        public void TestTriggerWithNoKeyBindings()
+        {
+            bool pressedReceived = false;
+            bool releasedReceived = false;
+
+            TestKeyBindingContainer keyBindingContainer = null;
+
+            AddStep("add container", () =>
+            {
+                pressedReceived = false;
+                releasedReceived = false;
+
+                Clear();
+
+                Add(keyBindingContainer = new TestKeyBindingContainer
+                {
+                    Child = new TestKeyBindingReceptor
+                    {
+                        Pressed = _ => pressedReceived = true,
+                        Released = _ => releasedReceived = true
+                    }
+                });
+            });
+
+            AddStep("trigger press", () => keyBindingContainer.TriggerPressed(TestAction.Action1));
+            AddAssert("press received", () => pressedReceived);
+
+            AddStep("trigger release", () => keyBindingContainer.TriggerReleased(TestAction.Action1));
+            AddAssert("release received", () => releasedReceived);
+        }
+
+        private class TestKeyBindingReceptor : Drawable, IKeyBindingHandler<TestAction>
+        {
+            public Action<TestAction> Pressed;
+            public Action<TestAction> Released;
+
+            public TestKeyBindingReceptor()
+            {
+                RelativeSizeAxes = Axes.Both;
+            }
+
+            public bool OnPressed(TestAction action)
+            {
+                Pressed?.Invoke(action);
+                return true;
+            }
+
+            public bool OnReleased(TestAction action)
+            {
+                Released?.Invoke(action);
+                return true;
+            }
+        }
+
+        private class TestKeyBindingContainer : KeyBindingContainer<TestAction>
+        {
+            public override IEnumerable<KeyBinding> DefaultKeyBindings => null;
+        }
+
+        private enum TestAction
+        {
+            Action1
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -20,11 +20,11 @@ using osuTK.Input;
 
 namespace osu.Framework.Tests.Visual.Input
 {
-    public class TestSceneKeyBindings : ManualInputManagerTestScene
+    public class TestSceneKeyBindingsGrid : ManualInputManagerTestScene
     {
         private readonly KeyBindingTester none, noneExact, noneModifiers, unique, all;
 
-        public TestSceneKeyBindings()
+        public TestSceneKeyBindingsGrid()
         {
             Child = new GridContainer
             {

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -259,21 +259,14 @@ namespace osu.Framework.Input.Bindings
             return handled != null;
         }
 
-        public void TriggerReleased(T released)
-        {
-            var binding = KeyBindings.First(b => b.GetAction<T>().Equals(released));
-            PropagateReleased(getInputQueue(binding, true), released);
-            keyBindingQueues[binding].Clear();
-        }
+        public void TriggerReleased(T released) => PropagateReleased(KeyBindingInputQueue, released);
 
         public void TriggerPressed(T pressed)
         {
             if (simultaneousMode == SimultaneousBindingMode.None)
                 releasePressedActions();
 
-            var binding = KeyBindings.First(b => b.GetAction<T>().Equals(pressed));
-            PropagatePressed(getInputQueue(binding, true), pressed);
-            keyBindingQueues[binding].Clear();
+            PropagatePressed(KeyBindingInputQueue, pressed);
         }
 
         private IEnumerable<Drawable> getInputQueue(KeyBinding binding, bool rebuildIfEmpty = false)


### PR DESCRIPTION
Fixes #2836

Renamed `TestSceneKeyBindings` to `TestSceneKeyBindingsGrid` just to make it less of a catch-all test scene for where this stuff _should_ go. `TestSceneKeyBindingContainer` is its replacement.