### PR TITLE
Improve output of exceptions thrown during dependency injection

### DIFF
--- a/osu.Framework.Tests/Exceptions/TestSceneDependencyInjectionExceptions.cs
+++ b/osu.Framework.Tests/Exceptions/TestSceneDependencyInjectionExceptions.cs
@@ -1,0 +1,133 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Framework.Tests.Visual;
+
+namespace osu.Framework.Tests.Exceptions
+{
+    [HeadlessTest]
+    public class TestSceneDependencyInjectionExceptions : FrameworkTestScene
+    {
+        [Test]
+        public void TestImmediateException()
+        {
+            Exception thrownException = null;
+
+            AddStep("add thrower", () =>
+            {
+                try
+                {
+                    Child = new Thrower(typeof(Exception));
+                }
+                catch (Exception ex)
+                {
+                    thrownException = ex;
+                }
+            });
+
+            assertCorrectStack(() => thrownException);
+        }
+
+        [Test]
+        public void TestImmediateAggregateException()
+        {
+            Exception thrownException = null;
+
+            AddStep("add thrower", () =>
+            {
+                try
+                {
+                    Child = new Thrower(typeof(Exception), true);
+                }
+                catch (Exception ex)
+                {
+                    thrownException = ex;
+                }
+            });
+
+            assertCorrectStack(() => thrownException);
+        }
+
+        [Test]
+        public void TestAsyncException()
+        {
+            AsyncThrower thrower = null;
+
+            AddStep("add thrower", () => Child = thrower = new AsyncThrower(typeof(Exception)));
+            AddUntilStep("wait for exception", () => thrower.ThrownException != null);
+
+            assertCorrectStack(() => thrower.ThrownException);
+        }
+
+        private void assertCorrectStack(Func<Exception> exception)
+            => AddAssert("exception has correct callstack", () => exception().StackTrace.Contains($"{nameof(TestSceneDependencyInjectionExceptions)}.{nameof(Thrower)}"));
+
+        private class AsyncThrower : CompositeDrawable
+        {
+            public Exception ThrownException { get; private set; }
+
+            private readonly Type exceptionType;
+
+            public AsyncThrower(Type exceptionType)
+            {
+                this.exceptionType = exceptionType;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                LoadComponentAsync(new Thrower(exceptionType), AddInternal);
+            }
+
+            public override bool UpdateSubTree()
+            {
+                try
+                {
+                    return base.UpdateSubTree();
+                }
+                catch (Exception ex)
+                {
+                    ThrownException = ex;
+                }
+
+                return true;
+            }
+        }
+
+        private class Thrower : Drawable
+        {
+            private readonly Type exceptionType;
+            private readonly bool aggregate;
+
+            public Thrower(Type exceptionType, bool aggregate = false)
+            {
+                this.exceptionType = exceptionType;
+                this.aggregate = aggregate;
+            }
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                if (aggregate)
+                {
+                    try
+                    {
+                        throw (Exception)Activator.CreateInstance(exceptionType);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new AggregateException(ex);
+                    }
+                }
+
+                throw (Exception)Activator.CreateInstance(exceptionType);
+            }
+        }
+    }
+}

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -64,19 +64,7 @@ namespace osu.Framework.Allocation
                         }
                         catch (TargetInvocationException exc) // During non-await invocations
                         {
-                            switch (exc.InnerException)
-                            {
-                                case OperationCanceledException _:
-                                    // This activator is cancelled - propagate the cancellation as-is (it will be handled silently)
-                                    throw exc.InnerException;
-
-                                case DependencyInjectionException die:
-                                    // A nested activator has failed (multiple Invoke() calls) - propagate the original error
-                                    throw die;
-                            }
-
-                            // This activator has failed (single reflection call) - preserve the original stacktrace while notifying of the error
-                            throw new DependencyInjectionException { DispatchInfo = ExceptionDispatchInfo.Capture(exc.InnerException) };
+                            ExceptionDispatchInfo.Capture(exc.InnerException).Throw();
                         }
                     };
 

--- a/osu.Framework/Allocation/DependencyActivator.cs
+++ b/osu.Framework/Allocation/DependencyActivator.cs
@@ -5,9 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Runtime.ExceptionServices;
 using osu.Framework.Extensions.TypeExtensions;
-using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Allocation
@@ -155,14 +153,6 @@ namespace osu.Framework.Allocation
             : base(modifier, member, $"A property with an attached {nameof(ResolvedAttribute)} must have a private setter.")
         {
         }
-    }
-
-    /// <summary>
-    /// Occurs when dependencies dependency injection into a <see cref="Drawable"/> fails.
-    /// </summary>
-    internal class DependencyInjectionException : Exception
-    {
-        public ExceptionDispatchInfo DispatchInfo;
     }
 
     internal delegate void InjectDependencyDelegate(object target, IReadOnlyDependencyContainer dependencies);

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -180,8 +180,6 @@ namespace osu.Framework.Allocation
         /// </summary>
         /// <typeparam name="T">The type of the instance to inject dependencies into.</typeparam>
         /// <param name="instance">The instance to inject dependencies into.</param>
-        /// <exception cref="DependencyInjectionException">When any user error has occurred.
-        /// Rethrow <see cref="DependencyInjectionException.DispatchInfo"/> when appropriate to retrieve the original exception.</exception>
         /// <exception cref="OperationCanceledException">When the injection process was cancelled.</exception>
         public void Inject<T>(T instance)
             where T : class

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -255,7 +255,7 @@ namespace osu.Framework.Graphics.Containers
                     if (e is OperationCanceledException)
                         continue;
 
-                    throw e;
+                    ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Runtime.ExceptionServices;
 using System.Threading;
 using osuTK;
 using osuTK.Graphics;
@@ -164,7 +165,7 @@ namespace osu.Framework.Graphics.Containers
                     try
                     {
                         if (exception != null)
-                            throw exception;
+                            ExceptionDispatchInfo.Capture(exception).Throw();
 
                         if (!linkedSource.Token.IsCancellationRequested)
                             onLoaded?.Invoke(components);

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -233,7 +233,6 @@ namespace osu.Framework.Graphics.Containers
         /// Loads a <see cref="Drawable"/> child. This will not throw in the event of the load being cancelled.
         /// </summary>
         /// <param name="child">The <see cref="Drawable"/> child to load.</param>
-        /// <exception cref="DependencyInjectionException">When a user error occurred during dependency injection.</exception>
         private void loadChild(Drawable child)
         {
             try

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -297,15 +297,7 @@ namespace osu.Framework.Platform
             // Ensure we maintain a valid size for any children immediately scaling by the window size
             Root.Size = Vector2.ComponentMax(Vector2.One, Root.Size);
 
-            try
-            {
-                Root.UpdateSubTree();
-            }
-            catch (DependencyInjectionException die)
-            {
-                die.DispatchInfo.Throw();
-            }
-
+            Root.UpdateSubTree();
             Root.UpdateSubTreeMasking(Root, Root.ScreenSpaceDrawQuad.AABBFloat);
 
             using (var buffer = DrawRoots.Get(UsageType.Write))
@@ -635,14 +627,7 @@ namespace osu.Framework.Platform
 
             game.SetHost(this);
 
-            try
-            {
-                root.Load(SceneGraphClock, Dependencies);
-            }
-            catch (DependencyInjectionException die)
-            {
-                die.DispatchInfo.Throw();
-            }
+            root.Load(SceneGraphClock, Dependencies);
 
             //publish bootstrapped scene graph to all threads.
             Root = root;

--- a/osu.Framework/Testing/Drawables/Steps/StepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepButton.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -93,8 +92,6 @@ namespace osu.Framework.Testing.Drawables.Steps
             }
             catch (Exception exc)
             {
-                if (exc.InnerException is DependencyInjectionException die)
-                    exc = die.DispatchInfo.SourceException;
                 Logging.Logger.Error(exc, $"Step {this} triggered an error");
             }
 

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -101,10 +101,7 @@ namespace osu.Framework.Testing
                         Scheduler.AddDelayed(complete, time_between_tests);
                     }, e =>
                     {
-                        if (e is DependencyInjectionException die)
-                            exception = die.DispatchInfo;
-                        else
-                            exception = ExceptionDispatchInfo.Capture(e);
+                        exception = ExceptionDispatchInfo.Capture(e);
                         complete();
                     });
                 });


### PR DESCRIPTION
Fixes #2839

The DIE stuff was super ugly/wrong, and we only really needed to rethrow the inner exceptions while preserving stacktraces. This also fixes several other cases of unreadable exceptions.