### PR TITLE
Fix Quad.ConservativeArea being inaccurate in some cases

### DIFF
--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections;
+using NUnit.Framework;
+using osu.Framework.Extensions.MatrixExtensions;
+using osu.Framework.Graphics.Primitives;
+using osuTK;
+
+namespace osu.Framework.Tests.Primitives
+{
+    [TestFixture]
+    public class QuadTest
+    {
+        [TestCaseSource(typeof(AreaTestData), nameof(AreaTestData.TestCases))]
+        [DefaultFloatingPointTolerance(0.1f)]
+        public void TestArea(Quad testQuad)
+        {
+            Assert.That(testQuad.ConservativeArea, Is.EqualTo(testQuad.Area).Within(0.1f));
+        }
+
+        private class AreaTestData
+        {
+            public static IEnumerable TestCases
+            {
+                get
+                {
+                    // Point
+                    yield return new TestCaseData(new Quad(0, 0, 0, 0));
+
+                    // Lines
+                    yield return new TestCaseData(new Quad(0, 0, 100, 0));
+                    yield return new TestCaseData(new Quad(0, 0, 0, 100));
+                    yield return new TestCaseData(new Quad(0, 0, 100, 1));
+                    yield return new TestCaseData(new Quad(0, 0, 1, 100));
+
+                    // Simple quads
+                    yield return new TestCaseData(new Quad(0, 0, 10, 10));
+                    yield return new TestCaseData(new Quad(0, 0, 10, 5));
+                    yield return new TestCaseData(new Quad(0, 0, 5, 10));
+
+                    // Rotated simple quads
+                    yield return new TestCaseData(new Quad(10, 10, -10, -10));
+                    yield return new TestCaseData(new Quad(10, 5, -10, -5));
+                    yield return new TestCaseData(new Quad(5, 10, -5, -10));
+
+                    // Sheared quads
+                    yield return new TestCaseData(shear(new Quad(0, 0, 10, 10), new Vector2(10)));
+                    yield return new TestCaseData(shear(new Quad(0, 0, 10, 10), new Vector2(-10)));
+
+                    // Sheared rotated quads
+                    yield return new TestCaseData(shear(new Quad(10, 10, -10, -10), new Vector2(10)));
+                    yield return new TestCaseData(shear(new Quad(10, 5, -10, -5), new Vector2(10)));
+                    yield return new TestCaseData(shear(new Quad(5, 10, -5, -10), new Vector2(10)));
+                }
+            }
+
+            private static Quad shear(Quad quad, Vector2 amount)
+            {
+                var matrix = Matrix3.Identity;
+                MatrixExtensions.ShearFromLeft(ref matrix, Vector2.Divide(amount, quad.Size));
+
+                return quad * matrix;
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Tests.Primitives
     {
         [TestCaseSource(typeof(AreaTestData), nameof(AreaTestData.TestCases))]
         [DefaultFloatingPointTolerance(0.1f)]
-        public float TestArea(Quad testQuad) => testQuad.ConservativeArea;
+        public float TestArea(Quad testQuad) => testQuad.Area;
 
         private class AreaTestData
         {

--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -14,10 +14,7 @@ namespace osu.Framework.Tests.Primitives
     {
         [TestCaseSource(typeof(AreaTestData), nameof(AreaTestData.TestCases))]
         [DefaultFloatingPointTolerance(0.1f)]
-        public void TestArea(Quad testQuad)
-        {
-            Assert.That(testQuad.ConservativeArea, Is.EqualTo(testQuad.Area).Within(0.1f));
-        }
+        public float TestArea(Quad testQuad) => testQuad.ConservativeArea;
 
         private class AreaTestData
         {
@@ -26,32 +23,32 @@ namespace osu.Framework.Tests.Primitives
                 get
                 {
                     // Point
-                    yield return new TestCaseData(new Quad(0, 0, 0, 0));
+                    yield return new TestCaseData(new Quad(0, 0, 0, 0)).Returns(0);
 
                     // Lines
-                    yield return new TestCaseData(new Quad(0, 0, 100, 0));
-                    yield return new TestCaseData(new Quad(0, 0, 0, 100));
-                    yield return new TestCaseData(new Quad(0, 0, 100, 1));
-                    yield return new TestCaseData(new Quad(0, 0, 1, 100));
+                    yield return new TestCaseData(new Quad(0, 0, 100, 0)).Returns(0);
+                    yield return new TestCaseData(new Quad(0, 0, 0, 100)).Returns(0);
+                    yield return new TestCaseData(new Quad(0, 0, 100, 1)).Returns(100);
+                    yield return new TestCaseData(new Quad(0, 0, 1, 100)).Returns(100);
 
                     // Simple quads
-                    yield return new TestCaseData(new Quad(0, 0, 10, 10));
-                    yield return new TestCaseData(new Quad(0, 0, 10, 5));
-                    yield return new TestCaseData(new Quad(0, 0, 5, 10));
+                    yield return new TestCaseData(new Quad(0, 0, 10, 10)).Returns(100);
+                    yield return new TestCaseData(new Quad(0, 0, 10, 5)).Returns(50);
+                    yield return new TestCaseData(new Quad(0, 0, 5, 10)).Returns(50);
 
                     // Rotated simple quads
-                    yield return new TestCaseData(new Quad(10, 10, -10, -10));
-                    yield return new TestCaseData(new Quad(10, 5, -10, -5));
-                    yield return new TestCaseData(new Quad(5, 10, -5, -10));
+                    yield return new TestCaseData(new Quad(10, 10, -10, -10)).Returns(100);
+                    yield return new TestCaseData(new Quad(10, 5, -10, -5)).Returns(50);
+                    yield return new TestCaseData(new Quad(5, 10, -5, -10)).Returns(50);
 
                     // Sheared quads
-                    yield return new TestCaseData(shear(new Quad(0, 0, 10, 10), new Vector2(10)));
-                    yield return new TestCaseData(shear(new Quad(0, 0, 10, 10), new Vector2(-10)));
+                    yield return new TestCaseData(shear(new Quad(0, 0, 10, 10), new Vector2(2))).Returns(100);
+                    yield return new TestCaseData(shear(new Quad(0, 0, 10, 10), new Vector2(-2))).Returns(100);
 
                     // Sheared rotated quads
-                    yield return new TestCaseData(shear(new Quad(10, 10, -10, -10), new Vector2(10)));
-                    yield return new TestCaseData(shear(new Quad(10, 5, -10, -5), new Vector2(10)));
-                    yield return new TestCaseData(shear(new Quad(5, 10, -5, -10), new Vector2(10)));
+                    yield return new TestCaseData(shear(new Quad(10, 10, -10, -10), new Vector2(2))).Returns(100);
+                    yield return new TestCaseData(shear(new Quad(10, 5, -10, -5), new Vector2(2))).Returns(50);
+                    yield return new TestCaseData(shear(new Quad(5, 10, -5, -10), new Vector2(2))).Returns(50);
                 }
             }
 

--- a/osu.Framework.Tests/Primitives/QuadTest.cs
+++ b/osu.Framework.Tests/Primitives/QuadTest.cs
@@ -49,6 +49,10 @@ namespace osu.Framework.Tests.Primitives
                     yield return new TestCaseData(shear(new Quad(10, 10, -10, -10), new Vector2(2))).Returns(100);
                     yield return new TestCaseData(shear(new Quad(10, 5, -10, -5), new Vector2(2))).Returns(50);
                     yield return new TestCaseData(shear(new Quad(5, 10, -5, -10), new Vector2(2))).Returns(50);
+
+                    // Self-intersecting quads
+                    yield return new TestCaseData(new Quad(new Vector2(0, 5), new Vector2(0, -5), new Vector2(-5, 0), new Vector2(5, 0))).Returns(0);
+                    yield return new TestCaseData(new Quad(new Vector2(0, 5), new Vector2(0, -5), Vector2.Zero, new Vector2(5, 0))).Returns(12.5f);
                 }
             }
 

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -276,7 +276,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 Colour = drawColour.TopLeft.Linear,
             });
 
-            FrameStatistics.Add(StatisticsCounterType.Pixels, (long)vertexQuad.ConservativeArea);
+            FrameStatistics.Add(StatisticsCounterType.Pixels, (long)vertexQuad.Area);
         }
 
         private void updateWrapMode()

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -117,15 +117,13 @@ namespace osu.Framework.Graphics.Primitives
             new Triangle(BottomRight, BottomLeft, TopRight).Contains(pos) ||
             new Triangle(TopLeft, TopRight, BottomLeft).Contains(pos);
 
-        public float Area => new Triangle(BottomRight, BottomLeft, TopRight).Area + new Triangle(TopLeft, TopRight, BottomLeft).Area;
-
         /// <summary>
         /// Computes the area of this <see cref="Quad"/>.
         /// </summary>
         /// <remarks>
         /// If the quad is self-intersecting the area is interpreted as the sum of all positive and negative areas and not the "visible area" enclosed by the <see cref="Quad"/>.
         /// </remarks>
-        public float ConservativeArea => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
+        public float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
 
         public bool Equals(Quad other) =>
             TopLeft == other.TopLeft &&

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -119,6 +119,12 @@ namespace osu.Framework.Graphics.Primitives
 
         public float Area => new Triangle(BottomRight, BottomLeft, TopRight).Area + new Triangle(TopLeft, TopRight, BottomLeft).Area;
 
+        /// <summary>
+        /// Computes the area of this <see cref="Quad"/>.
+        /// </summary>
+        /// <remarks>
+        /// If the quad is self-intersecting the area is interpreted as the sum of all positive and negative areas and not the "visible area" enclosed by the <see cref="Quad"/>.
+        /// </remarks>
         public float ConservativeArea => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
 
         public bool Equals(Quad other) =>

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -119,25 +119,7 @@ namespace osu.Framework.Graphics.Primitives
 
         public float Area => new Triangle(BottomRight, BottomLeft, TopRight).Area + new Triangle(TopLeft, TopRight, BottomLeft).Area;
 
-        public float ConservativeArea
-        {
-            get
-            {
-                if (Precision.AlmostEquals(TopLeft.Y, TopRight.Y))
-                    return Math.Abs((TopLeft.Y - BottomLeft.Y) * (TopLeft.X - TopRight.X));
-
-                // Uncomment this to speed this computation up at the cost of losing accuracy when considering shearing.
-                //return Math.Sqrt(Vector2Extensions.DistanceSquared(TopLeft, TopRight) * Vector2Extensions.DistanceSquared(TopLeft, BottomLeft));
-
-                Vector2 d1 = TopLeft - TopRight;
-                float lsq1 = d1.LengthSquared;
-
-                Vector2 d2 = TopLeft - BottomLeft;
-                float lsq2 = Vector2Extensions.DistanceSquared(d2, d1 * Vector2.Dot(d2, d1 * MathHelper.InverseSqrtFast(lsq1)));
-
-                return (float)Math.Sqrt(lsq1 * lsq2);
-            }
-        }
+        public float ConservativeArea => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
 
         public bool Equals(Quad other) =>
             TopLeft == other.TopLeft &&

--- a/osu.Framework/Graphics/Vector2Extensions.cs
+++ b/osu.Framework/Graphics/Vector2Extensions.cs
@@ -77,7 +77,7 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
-        /// Retrieves the orientation of a set of vertices.
+        /// Retrieves the orientation of a set of vertices using the Shoelace formula (https://en.wikipedia.org/wiki/Shoelace_formula)
         /// </summary>
         /// <param name="vertices">The vertices.</param>
         /// <returns>Twice the area enclosed by the vertices.


### PR DESCRIPTION
Fixes pixel count being wholly incorrect on the transition into songselect (sheared buffered wedge).

Uses the same calculations as in the FTB pass. I've left the `Area` property as a ground-truth for unit testing.

Performance:

```diff
  |           Method |       Mean |     Error |    StdDev |
  |----------------- |-----------:|----------:|----------:|
- |             Area | 162.900 ns | 1.4873 ns | 1.3912 ns |
- | ConservativeArea |  60.541 ns | 0.8097 ns | 0.7178 ns |
+ |             Area |   4.551 ns | 0.0609 ns | 0.0540 ns |
```

Breaking changes:

# vNext

## `Quad.ConservativeArea` has been removed

It was inaccurate for certain `Quad`s. Use `Area` as a replacement.