### PR TITLE
Limit DrawVisualiser scope when clicking in tests

### DIFF
--- a/osu.Framework/Testing/DrawFrameRecordingContainer.cs
+++ b/osu.Framework/Testing/DrawFrameRecordingContainer.cs
@@ -14,8 +14,20 @@ namespace osu.Framework.Testing
     {
         private readonly Bindable<RecordState> recordState = new Bindable<RecordState>();
         private readonly BindableInt currentFrame = new BindableInt();
-
         private readonly List<DrawNode> recordedFrames = new List<DrawNode>();
+
+        protected override Container<Drawable> Content => content;
+
+        private readonly Container content;
+
+        public DrawFrameRecordingContainer()
+        {
+            InternalChildren = new Drawable[]
+            {
+                new InputCapturingDrawable { RelativeSizeAxes = Axes.Both },
+                content = new Container { RelativeSizeAxes = Axes.Both }
+            };
+        }
 
         [BackgroundDependencyLoader(true)]
         private void load([CanBeNull] TestBrowser browser)
@@ -77,6 +89,14 @@ namespace osu.Framework.Testing
 
             foreach (var child in composite.Children)
                 disposeRecursively(child);
+        }
+
+        // An empty drawable which captures DrawVisualiser input in this container
+        private class InputCapturingDrawable : Drawable
+        {
+            // Required for the DrawVisualiser to not treat this Drawable as an overlay input receptor
+            // ReSharper disable once RedundantOverriddenMember
+            protected override DrawNode CreateDrawNode() => base.CreateDrawNode();
         }
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1329837/65217589-7bc41e00-daef-11e9-9e4a-19ab3df60e79.png)
