### PR TITLE
Fix blending method potentially dividing by zero

### DIFF
--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -34,7 +34,7 @@ lowp vec4 blend(lowp vec4 src, lowp vec4 dst)
 {
     lowp float finalAlpha = src.a + dst.a * (1.0 - src.a);
 
-    if (finalAlpha == 0)
+    if (finalAlpha == 0.0)
         return vec4(0);
 
     return vec4(

--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -33,6 +33,10 @@ lowp vec4 toSRGB(lowp vec4 colour)
 lowp vec4 blend(lowp vec4 src, lowp vec4 dst)
 {
     lowp float finalAlpha = src.a + dst.a * (1.0 - src.a);
+
+	if (finalAlpha == 0)
+		return vec4(0);
+
     return vec4(
         (src.rgb * src.a + dst.rgb * dst.a * (1.0 - src.a)) / finalAlpha,
         finalAlpha

--- a/osu.Framework/Resources/Shaders/sh_Utils.h
+++ b/osu.Framework/Resources/Shaders/sh_Utils.h
@@ -34,8 +34,8 @@ lowp vec4 blend(lowp vec4 src, lowp vec4 dst)
 {
     lowp float finalAlpha = src.a + dst.a * (1.0 - src.a);
 
-	if (finalAlpha == 0)
-		return vec4(0);
+    if (finalAlpha == 0)
+        return vec4(0);
 
     return vec4(
         (src.rgb * src.a + dst.rgb * dst.a * (1.0 - src.a)) / finalAlpha,


### PR DESCRIPTION
- Fixes blending potentially dividing by zero by returning `vec4(0)` immediately on `finalAlpha == 0`. (thanks to @bdach for pointing the issue)

| Before | After |
|:--------------:|:-----------------:|
| ![dotnet_SwZPXHw0SM](https://user-images.githubusercontent.com/22781491/65332199-e1370e00-dbc6-11e9-900f-9a011d1544bd.png) | ![dotnet_pTY3f3roo4](https://user-images.githubusercontent.com/22781491/65332212-e6945880-dbc6-11e9-9aff-9e2fcd6ebd7a.png) |

Closes ppy/osu#5885