### PR TITLE
Always show test group headers

### DIFF
--- a/osu.Framework/Testing/Drawables/TestGroupButton.cs
+++ b/osu.Framework/Testing/Drawables/TestGroupButton.cs
@@ -60,17 +60,14 @@ namespace osu.Framework.Testing.Drawables
                 RelativeSizeAxes = Axes.X
             };
 
-            bool hasHeader = tests.Length > 1;
-
-            if (hasHeader)
-                buttonFlow.Add(headerButton = new TestButton(group.Name)
-                {
-                    Action = ToggleVisibility
-                });
+            buttonFlow.Add(headerButton = new TestButton(group.Name)
+            {
+                Action = ToggleVisibility
+            });
 
             foreach (var test in tests)
             {
-                buttonFlow.Add(new TestSceneSubButton(test, hasHeader ? 1 : 0)
+                buttonFlow.Add(new TestSceneSubButton(test, 1)
                 {
                     Action = () => loadTest(test)
                 });

--- a/osu.Framework/Testing/Drawables/TestGroupButton.cs
+++ b/osu.Framework/Testing/Drawables/TestGroupButton.cs
@@ -32,12 +32,11 @@ namespace osu.Framework.Testing.Drawables
         {
             set
             {
-                var contains = Group.TestTypes.Contains(value);
+                bool contains = Group.TestTypes.Contains(value);
                 if (contains) Show();
 
                 buttonFlow.ForEach(btn => btn.Current = btn.TestType == value);
-                if (headerButton != null)
-                    headerButton.Current = contains;
+                headerButton.Current = contains;
             }
         }
 
@@ -78,10 +77,6 @@ namespace osu.Framework.Testing.Drawables
 
         protected override void PopIn() => buttonFlow.ForEach(b => b.Collapsed = false);
 
-        protected override void PopOut()
-        {
-            if (headerButton != null)
-                buttonFlow.ForEach(b => b.Collapsed = true);
-        }
+        protected override void PopOut() => buttonFlow.ForEach(b => b.Collapsed = true);
     }
 }


### PR DESCRIPTION
Seems to be an annoying logic with namespaces that contain one test only as discussed.

| Before | After |
|-----|-------|
| ![dotnet_6Q08PPLYrC](https://user-images.githubusercontent.com/22781491/65400707-72c39d00-ddcc-11e9-8f90-87b0862da87c.png) | ![dotnet_FAYC89Dk43](https://user-images.githubusercontent.com/22781491/65400711-7d7e3200-ddcc-11e9-99a0-90105805d27e.png) |

