### PR TITLE
Adjust vertex batching for modern-day use cases

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -64,6 +64,8 @@ namespace osu.Framework.Graphics.Containers
             /// </summary>
             private QuadBatch<TexturedVertex2D> quadBatch;
 
+            private int sourceChildrenCount;
+
             public CompositeDrawableDrawNode(CompositeDrawable source)
                 : base(source)
             {
@@ -105,6 +107,7 @@ namespace osu.Framework.Graphics.Containers
                 screenSpaceMaskingQuad = null;
                 Shader = Source.Shader;
                 forceLocalVertexBatch = Source.ForceLocalVertexBatch;
+                sourceChildrenCount = Source.internalChildren.Count;
             }
 
             public virtual bool AddChildDrawNodes => true;
@@ -158,7 +161,7 @@ namespace osu.Framework.Graphics.Containers
                 GLWrapper.PopMaskingInfo();
             }
 
-            private const int min_amount_children_to_warrant_batch = 5;
+            private const int min_amount_children_to_warrant_batch = 8;
 
             private bool mayHaveOwnVertexBatch(int amountChildren) => forceLocalVertexBatch || amountChildren >= min_amount_children_to_warrant_batch;
 
@@ -167,10 +170,8 @@ namespace osu.Framework.Graphics.Containers
                 if (Children == null)
                     return;
 
-                // This logic got roughly copied from the old osu! code base. These constants seem to have worked well so far.
-                int clampedAmountChildren = MathHelper.Clamp(Children.Count, 1, 1000);
-                if (mayHaveOwnVertexBatch(clampedAmountChildren) && (quadBatch == null || quadBatch.Size < clampedAmountChildren))
-                    quadBatch = new QuadBatch<TexturedVertex2D>(clampedAmountChildren * 2, 500);
+                if (quadBatch == null && mayHaveOwnVertexBatch(sourceChildrenCount))
+                    quadBatch = new QuadBatch<TexturedVertex2D>(100, 1000);
             }
 
             public override void Draw(Action<TexturedVertex2D> vertexAction)

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         static TextureGLSingle()
         {
-            QuadBatch<TexturedVertex2D> quadBatch = new QuadBatch<TexturedVertex2D>(512, 128);
+            QuadBatch<TexturedVertex2D> quadBatch = new QuadBatch<TexturedVertex2D>(100, 1000);
             default_quad_action = quadBatch.AddAction;
         }
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -24,7 +24,6 @@ namespace osu.Framework.Input
             // UserInputManager is at the very top of the draw hierarchy, so it has no parnt updating its IsAlive state
             IsAlive = true;
             UseParentInput = false;
-            ForceLocalVertexBatch = true;
         }
 
         public override void HandleInputStateChange(InputStateChangeEvent inputStateChange)

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -24,6 +24,7 @@ namespace osu.Framework.Input
             // UserInputManager is at the very top of the draw hierarchy, so it has no parnt updating its IsAlive state
             IsAlive = true;
             UseParentInput = false;
+            ForceLocalVertexBatch = true;
         }
 
         public override void HandleInputStateChange(InputStateChangeEvent inputStateChange)


### PR DESCRIPTION
1. From my experimentation, o!f almost never goes above 50 vertices per draw, and every single draw uses a new VBO. osu! is even lower at <30 vertices per draw. So 50 is a good value but I picked 100 vertices for a "safe" value.
2. I found that using 8 as the minimum amount of children resulted in a slightly reduced number of VBO binds:

| old | new |
| --- | ---- |
| ![image](https://user-images.githubusercontent.com/1329837/65868166-c036a000-e3b2-11e9-87a4-470a854321b3.png) | ![image](https://user-images.githubusercontent.com/1329837/65868174-c3319080-e3b2-11e9-8aec-e90f59032d9a.png) |

The next step I believe is to implement mapped buffers which we can write to unsynchronised, and re-use the same VBO for subsequent `Draw()` calls.

This improves performance a tad (centipede is now mostly update limited for me), and reduces memory usage by at least 2x. Here's some comparisons:
Left = master, right = this branch

![image](https://user-images.githubusercontent.com/1329837/65869186-e8bf9980-e3b4-11e9-9563-ec9929bfaaf5.png)

![image](https://user-images.githubusercontent.com/1329837/65869193-ea895d00-e3b4-11e9-978e-6685b8115e2f.png)

![image](https://user-images.githubusercontent.com/1329837/65869196-ed844d80-e3b4-11e9-9d3e-edb6b2049636.png)

![image](https://user-images.githubusercontent.com/1329837/65869199-efe6a780-e3b4-11e9-9d38-bb334a9912b9.png)

![image](https://user-images.githubusercontent.com/1329837/65869203-f2e19800-e3b4-11e9-84ee-adf53203689c.png)

![image](https://user-images.githubusercontent.com/1329837/65869210-f5dc8880-e3b4-11e9-8265-271fc1c396f7.png)

![image](https://user-images.githubusercontent.com/1329837/65869217-f9700f80-e3b4-11e9-8555-8cfcabf8d997.png)
