### PR TITLE
Add tool window for selecting predefined device resolutions

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -183,6 +183,8 @@ namespace osu.Framework
 
         private GlobalStatisticsDisplay globalStatistics;
 
+        private DevicePresetsDisplay devicePresetsDisplay;
+
         public bool OnPressed(FrameworkAction action)
         {
             switch (action)
@@ -217,6 +219,20 @@ namespace osu.Framework
                     }
 
                     globalStatistics.ToggleVisibility();
+                    return true;
+
+                case FrameworkAction.ToggleDevicePresets:
+
+                    if (devicePresetsDisplay == null)
+                    {
+                        LoadComponentAsync(devicePresetsDisplay = new DevicePresetsDisplay
+                        {
+                            Depth = float.MinValue / 2,
+                            Position = new Vector2(100, 100 + ToolWindow.HEIGHT)
+                        }, AddInternal);
+                    }
+
+                    devicePresetsDisplay.ToggleVisibility();
                     return true;
 
                 case FrameworkAction.ToggleDrawVisualiser:

--- a/osu.Framework/Graphics/Visualisation/DevicePresetsDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/DevicePresetsDisplay.cs
@@ -132,7 +132,32 @@ namespace osu.Framework.Graphics.Visualisation
                     new DevicePreset { Name = "Test safe area", SafeAreaPadding = new MarginPadding(100) },
                 }
             },
-
+            // Android
+            new DevicePresetGroup
+            {
+                Name = "Common Android Resolutions",
+                Presets = new[]
+                {
+                    // 1280x800
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 800, Long = 1280 },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 800, Long = 1280 },
+                    // 1920x1080
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 1080, Long = 1920 },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 1080, Long = 1920 },
+                    // 2160x1080
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 1080, Long = 2160 },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 1080, Long = 2160 },
+                    // 2560x1440
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 1440, Long = 2560 },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 1440, Long = 2560 },
+                    // 2960x1440
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 1440, Long = 2960 },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 1440, Long = 2960 },
+                    // 2048x1536
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 1536, Long = 2048 },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 1536, Long = 2048 },
+                }
+            },
             // iPhone
             new DevicePresetGroup
             {
@@ -303,8 +328,8 @@ namespace osu.Framework.Graphics.Visualisation
                 {
                     if (str != "") str += " ";
 
-                    str += Orientation == Orientation.Portrait ? "Portrait, " : "Landscape, ";
-                    str += !Scale.HasValue ? "" : Scale.Value == 1f ? "Logical" : "Physical";
+                    str += Orientation == Orientation.Portrait ? "Portrait" : "Landscape";
+                    str += !Scale.HasValue ? "" : Scale.Value == 1f ? ", Logical" : ", Physical";
                     str += Orientation == Orientation.Portrait ? $" - ({Short}, {Long})" : $" - ({Long}, {Short})";
                     str += !Scale.HasValue ? "" : $" @ {Scale.Value:F1}x";
                     str += Downsample.HasValue ? " (Downsampled)" : "";

--- a/osu.Framework/Graphics/Visualisation/DevicePresetsDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/DevicePresetsDisplay.cs
@@ -1,0 +1,326 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using System.Collections.Generic;
+using System.Drawing;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Platform;
+using osuTK;
+
+namespace osu.Framework.Graphics.Visualisation
+{
+    /// <summary>
+    /// Displays a selectable list of resolution/safe area combinations for testing device layouts on desktop.
+    /// Apple device info taken from https://iosref.com/res/
+    /// </summary>
+    internal class DevicePresetsDisplay : ToolWindow
+    {
+        [Resolved]
+        private GameHost host { get; set; }
+
+        public DevicePresetsDisplay()
+            : base("Device Presets", "(Ctrl+F3 to toggle)")
+        {
+            ScrollContent.Children = new Drawable[]
+            {
+                new FillFlowContainer<DevicePresetGroupSection>
+                {
+                    Padding = new MarginPadding(5),
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(5),
+                    Children = presetGroups.Select(group => new DevicePresetGroupSection(group, this)).ToArray()
+                },
+            };
+        }
+
+        private class DevicePresetGroupSection : CompositeDrawable
+        {
+            public DevicePresetGroupSection(DevicePresetGroup group, DevicePresetsDisplay display)
+            {
+                RelativeSizeAxes = Axes.X;
+                AutoSizeAxes = Axes.Y;
+
+                InternalChild = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Children = new Drawable[]
+                    {
+                        new SpriteText
+                        {
+                            Text = group.Name,
+                            Font = FrameworkFont.Regular.With(weight: "Bold")
+                        },
+                        new FillFlowContainer<Button>
+                        {
+                            Padding = new MarginPadding { Left = 5 },
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Vertical,
+                            Spacing = new Vector2(2),
+                            Children = group.Presets.Select(preset => new DevicePresetButton(preset, display)).ToArray()
+                        }
+                    }
+                };
+            }
+
+            private class DevicePresetButton : Button
+            {
+                private readonly DevicePresetsDisplay display;
+                private readonly DevicePreset preset;
+
+                public DevicePresetButton(DevicePreset preset, DevicePresetsDisplay display)
+                {
+                    this.preset = preset;
+                    this.display = display;
+
+                    Text = preset.ToString();
+                    RelativeSizeAxes = Axes.X;
+                    Anchor = Anchor.CentreLeft;
+                    Origin = Anchor.CentreLeft;
+                    Height = 30;
+                    Action = selectPreset;
+                }
+
+                private void selectPreset()
+                {
+                    var scale = (preset.Scale ?? 1f) / (preset.Downsample ?? 1f);
+
+                    if (preset.Short != 0 && preset.Long != 0)
+                    {
+                        var width = preset.Orientation == Orientation.Portrait ? preset.Short : preset.Long;
+                        var height = preset.Orientation == Orientation.Portrait ? preset.Long : preset.Short;
+                        display.host.Window.ClientSize = new Size((int)(width * scale), (int)(height * scale));
+                    }
+
+                    display.host.Window.SafeAreaPadding.Value = new MarginPadding
+                    {
+                        Left = preset.SafeAreaPadding.Left * scale,
+                        Top = preset.SafeAreaPadding.Top * scale,
+                        Right = preset.SafeAreaPadding.Right * scale,
+                        Bottom = preset.SafeAreaPadding.Bottom * scale
+                    };
+                }
+
+                protected override SpriteText CreateText() => new SpriteText
+                {
+                    Depth = -1,
+                    Origin = Anchor.CentreLeft,
+                    Anchor = Anchor.CentreLeft,
+                    Font = FrameworkFont.Regular,
+                    Colour = FrameworkColour.Yellow
+                };
+            }
+        }
+
+        private readonly IEnumerable<DevicePresetGroup> presetGroups = new[]
+        {
+            // Non-device
+            new DevicePresetGroup
+            {
+                Name = "Desktop",
+                Presets = new[]
+                {
+                    new DevicePreset { Name = "No safe area" },
+                    new DevicePreset { Name = "Test safe area", SafeAreaPadding = new MarginPadding(100) },
+                }
+            },
+
+            // iPhone
+            new DevicePresetGroup
+            {
+                Name = "iPhone XS Max, 11 Pro Max",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 414, Long = 896, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Top = 44, Bottom = 34 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 414, Long = 896, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Left = 44, Right = 44, Bottom = 34 } },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 414, Long = 896, Scale = 3.0f, SafeAreaPadding = new MarginPadding { Top = 44, Bottom = 34 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 414, Long = 896, Scale = 3.0f, SafeAreaPadding = new MarginPadding { Left = 44, Right = 44, Bottom = 34 } },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPhone X, XS, 11 Pro",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 375, Long = 812, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Top = 44, Bottom = 34 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 375, Long = 812, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Left = 44, Right = 44, Bottom = 34 } },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 375, Long = 812, Scale = 3.0f, SafeAreaPadding = new MarginPadding { Top = 44, Bottom = 34 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 375, Long = 812, Scale = 3.0f, SafeAreaPadding = new MarginPadding { Left = 44, Right = 44, Bottom = 34 } },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPhone XR, 11",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 414, Long = 896, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Top = 44, Bottom = 34 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 414, Long = 896, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Left = 44, Right = 44, Bottom = 34 } },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 414, Long = 896, Scale = 2.0f, SafeAreaPadding = new MarginPadding { Top = 44, Bottom = 34 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 414, Long = 896, Scale = 2.0f, SafeAreaPadding = new MarginPadding { Left = 44, Right = 44, Bottom = 34 } },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPhone 6+, 6s+, 7+, 8+",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 414, Long = 736, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 414, Long = 736, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 414, Long = 736, Scale = 3.0f, Downsample = 1.15f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 414, Long = 736, Scale = 3.0f, Downsample = 1.15f },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPhone 6, 6s, 7, 8",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 375, Long = 667, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 375, Long = 667, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 375, Long = 667, Scale = 2.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 375, Long = 667, Scale = 2.0f },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPhone 5, 5s, 5c, SE",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 320, Long = 568, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 320, Long = 568, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 320, Long = 568, Scale = 2.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 320, Long = 568, Scale = 2.0f },
+                }
+            },
+
+            // iPad
+            new DevicePresetGroup
+            {
+                Name = "iPad 7th",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 810, Long = 1080, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 810, Long = 1080, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 810, Long = 1080, Scale = 2.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 810, Long = 1080, Scale = 2.0f },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPad Pro (12.9\") 2nd, 3rd",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 1024, Long = 1366, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Top = 24, Bottom = 20 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 1024, Long = 1366, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Top = 24, Bottom = 20 } },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 1024, Long = 1366, Scale = 2.0f, SafeAreaPadding = new MarginPadding { Top = 24, Bottom = 20 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 1024, Long = 1366, Scale = 2.0f, SafeAreaPadding = new MarginPadding { Top = 24, Bottom = 20 } },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPad Pro (12.9\") 1st",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 1024, Long = 1366, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 1024, Long = 1366, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 1024, Long = 1366, Scale = 2.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 1024, Long = 1366, Scale = 2.0f },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPad Pro (11\")",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 834, Long = 1194, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Top = 24, Bottom = 20 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 834, Long = 1194, Scale = 1.0f, SafeAreaPadding = new MarginPadding { Top = 24, Bottom = 20 } },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 834, Long = 1194, Scale = 2.0f, SafeAreaPadding = new MarginPadding { Top = 24, Bottom = 20 } },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 834, Long = 1194, Scale = 2.0f, SafeAreaPadding = new MarginPadding { Top = 24, Bottom = 20 } },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPad Pro (10.5\"), iPad Air (10.5\")",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 834, Long = 1112, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 834, Long = 1112, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 834, Long = 1112, Scale = 2.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 834, Long = 1112, Scale = 2.0f },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPad 3rd-6th, iPad Mini 2nd-5th, iPad Air 1st-2nd, iPad Pro 9.7\"",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 768, Long = 1024, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 768, Long = 1024, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 768, Long = 1024, Scale = 2.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 768, Long = 1024, Scale = 2.0f },
+                }
+            },
+            new DevicePresetGroup
+            {
+                Name = "iPad 1st-2nd, iPad Mini 1st",
+                Presets = new[]
+                {
+                    new DevicePreset { Orientation = Orientation.Portrait, Short = 768, Long = 1024, Scale = 1.0f },
+                    new DevicePreset { Orientation = Orientation.Landscape, Short = 768, Long = 1024, Scale = 1.0f },
+                }
+            },
+        };
+
+        private struct DevicePresetGroup
+        {
+            internal string Name;
+            internal DevicePreset[] Presets;
+        }
+
+        private struct DevicePreset
+        {
+            internal string Name;
+            internal float Short;
+            internal float Long;
+            internal float? Scale;
+            internal float? Downsample;
+            internal Orientation Orientation;
+            internal MarginPadding SafeAreaPadding;
+
+            public override string ToString()
+            {
+                var str = Name;
+
+                if (Short != 0 && Long != 0)
+                {
+                    if (str != "") str += " ";
+
+                    str += Orientation == Orientation.Portrait ? "Portrait, " : "Landscape, ";
+                    str += !Scale.HasValue ? "" : Scale.Value == 1f ? "Logical" : "Physical";
+                    str += Orientation == Orientation.Portrait ? $" - ({Short}, {Long})" : $" - ({Long}, {Short})";
+                    str += !Scale.HasValue ? "" : $" @ {Scale.Value:F1}x";
+                    str += Downsample.HasValue ? " (Downsampled)" : "";
+                }
+
+                if (SafeAreaPadding.Total != Vector2.Zero)
+                    str += $" - {SafeAreaPadding}";
+
+                return str;
+            }
+        }
+
+        private enum Orientation
+        {
+            Portrait,
+            Landscape,
+        }
+    }
+}

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -12,6 +12,7 @@ namespace osu.Framework.Input
         {
             new KeyBinding(new[] { InputKey.Control, InputKey.F1 }, FrameworkAction.ToggleDrawVisualiser),
             new KeyBinding(new[] { InputKey.Control, InputKey.F2 }, FrameworkAction.ToggleGlobalStatistics),
+            new KeyBinding(new[] { InputKey.Control, InputKey.F3 }, FrameworkAction.ToggleDevicePresets),
             new KeyBinding(new[] { InputKey.Control, InputKey.F11 }, FrameworkAction.CycleFrameStatistics),
             new KeyBinding(new[] { InputKey.Control, InputKey.F10 }, FrameworkAction.ToggleLogOverlay),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Enter }, FrameworkAction.ToggleFullscreen),
@@ -25,6 +26,7 @@ namespace osu.Framework.Input
         CycleFrameStatistics,
         ToggleDrawVisualiser,
         ToggleGlobalStatistics,
+        ToggleDevicePresets,
         ToggleLogOverlay,
         ToggleFullscreen
     }


### PR DESCRIPTION
Could potentially add overlay images in the future to simulate rounded corners/notches etc.

Screenshot shows the changes from #5403

<img width="1218" alt="Screen Shot 2019-10-06 at 10 16 02 pm" src="https://user-images.githubusercontent.com/2331297/66268927-d7c9c900-e889-11e9-8ba9-87c77bae77bb.png">
