### PR TITLE
Fix padding applied to a zero-size drawable giving it negative size

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestScenePadding.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestScenePadding.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Tests.Visual.Containers
     public class TestScenePadding : GridTestScene
     {
         public TestScenePadding()
-            : base(2, 2)
+            : base(2, 3)
         {
             Cell(0).AddRange(new Drawable[]
             {
@@ -97,6 +97,42 @@ namespace osu.Framework.Tests.Visual.Containers
 
             Cell(2).AddRange(new Drawable[]
             {
+                new SpriteText { Text = @"Padding on zero-size" },
+                new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.White,
+                        },
+                        new PaddedBox(Color4.Blue)
+                        {
+                            Padding = new MarginPadding(20),
+                            RelativeSizeAxes = Axes.Both,
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                new PaddedBox(Color4.DarkSeaGreen)
+                                {
+                                    Padding = new MarginPadding(40),
+                                    RelativeSizeAxes = Axes.Both,
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            Cell(3).AddRange(new Drawable[]
+            {
                 new SpriteText { Text = @"Margin - 20 All Sides" },
                 new Container
                 {
@@ -132,7 +168,7 @@ namespace osu.Framework.Tests.Visual.Containers
                 }
             });
 
-            Cell(3).AddRange(new Drawable[]
+            Cell(4).AddRange(new Drawable[]
             {
                 new SpriteText { Text = @"Margin - 20 Top, Left" },
                 new Container
@@ -155,6 +191,42 @@ namespace osu.Framework.Tests.Visual.Containers
                                 Left = 20,
                             },
                             Size = new Vector2(200),
+                            Origin = Anchor.Centre,
+                            Anchor = Anchor.Centre,
+                            Masking = true,
+                            Children = new Drawable[]
+                            {
+                                new PaddedBox(Color4.DarkSeaGreen)
+                                {
+                                    Padding = new MarginPadding(40),
+                                    RelativeSizeAxes = Axes.Both,
+                                    Origin = Anchor.Centre,
+                                    Anchor = Anchor.Centre
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            Cell(5).AddRange(new Drawable[]
+            {
+                new SpriteText { Text = @"Margin on zero-size" },
+                new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.White,
+                        },
+                        new PaddedBox(Color4.Blue)
+                        {
+                            Margin = new MarginPadding(20),
+                            RelativeSizeAxes = Axes.Both,
                             Origin = Anchor.Centre,
                             Anchor = Anchor.Centre,
                             Masking = true,

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1435,7 +1435,11 @@ namespace osu.Framework.Graphics.Containers
         /// The size of the coordinate space revealed to <see cref="InternalChildren"/>.
         /// Captures the effect of e.g. <see cref="Padding"/>.
         /// </summary>
-        public Vector2 ChildSize => DrawSize - new Vector2(Padding.TotalHorizontal, Padding.TotalVertical);
+        public Vector2 ChildSize =>
+            new Vector2(
+                DrawSize.X >= 0 ? Math.Max(0, DrawSize.X - Padding.TotalHorizontal) : Math.Min(0, DrawSize.X - Padding.TotalHorizontal),
+                DrawSize.Y >= 0 ? Math.Max(0, DrawSize.Y - Padding.TotalVertical) : Math.Min(0, DrawSize.Y - Padding.TotalVertical)
+            );
 
         /// <summary>
         /// Positional offset applied to <see cref="InternalChildren"/>.


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/191335/66385053-d075fd00-e9fa-11e9-9322-dde24b2dbc50.png)


After:

![image](https://user-images.githubusercontent.com/191335/66385150-fb605100-e9fa-11e9-8b09-321c1109cdbc.png)
