### PR TITLE
Fix ScrollIntoView not always working as expected

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -431,7 +431,7 @@ namespace osu.Framework.Graphics.Containers
             float minPos = Math.Min(childPos0, childPos1);
             float maxPos = Math.Max(childPos0, childPos1);
 
-            if (minPos < Current)
+            if (minPos < Current || (d.DrawSize[ScrollDim] > displayableContent && minPos > Current))
                 ScrollTo(minPos, animated);
             else if (maxPos > Current + displayableContent)
                 ScrollTo(maxPos - displayableContent, animated);

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -431,7 +431,7 @@ namespace osu.Framework.Graphics.Containers
             float minPos = Math.Min(childPos0, childPos1);
             float maxPos = Math.Max(childPos0, childPos1);
 
-            if (minPos < Current || (d.DrawSize[ScrollDim] > displayableContent && minPos > Current))
+            if (minPos < Current || (minPos > Current && d.DrawSize[ScrollDim] > displayableContent))
                 ScrollTo(minPos, animated);
             else if (maxPos > Current + displayableContent)
                 ScrollTo(maxPos - displayableContent, animated);


### PR DESCRIPTION
If the available view size of the `ScrollContainer` is larger than the `DrawSize` of the target `Drawable`, it is feasible that the wrong extremity will be scrolled into view, causing incorrect behaviour when the scroll view is restored to a larger size.

In such cases, the minimum extremity should be preferred to provide stable behaviour on resize (and arguably preferred beahviour even before resize).

This is mainly to fix the case where a `ScrollIntoView` is issues while a `ScrollContainer` is zero-size (as seen in osu!'s `PlaylistOverlay`).