### PR TITLE
Fix interpolating clock not considering rate in error allowance

### DIFF
--- a/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
+++ b/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
@@ -52,7 +52,8 @@ namespace osu.Framework.Tests.Clocks
 
             for (int i = 0; i < 100; i++)
             {
-                source.CurrentTime += 50;
+                // we want to interpolate but not fall behind and fail interpolation too much
+                source.CurrentTime += interpolating.AllowableErrorMilliseconds / 2 + 5;
                 interpolating.ProcessFrame();
 
                 Assert.GreaterOrEqual(interpolating.CurrentTime, lastValue, "Interpolating should not jump against rate.");

--- a/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
+++ b/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Tests.Clocks
                 lastValue = interpolating.CurrentTime;
             }
 
-            int interpolatingCount = 0;
+            int interpolatedCount = 0;
 
             // test with test clock elapsing
             lastValue = interpolating.CurrentTime;
@@ -58,14 +58,14 @@ namespace osu.Framework.Tests.Clocks
                 Assert.GreaterOrEqual(interpolating.CurrentTime, lastValue, "Interpolating should not jump against rate.");
                 Assert.LessOrEqual(Math.Abs(interpolating.CurrentTime - source.CurrentTime), interpolating.AllowableErrorMilliseconds, "Interpolating should be within allowance.");
 
-                if (interpolating.CurrentTime != source.CurrentTime)
-                    interpolatingCount++;
+                if (interpolating.IsInterpolating)
+                    interpolatedCount++;
 
                 Thread.Sleep((int)(interpolating.AllowableErrorMilliseconds / 2));
                 lastValue = interpolating.CurrentTime;
             }
 
-            Assert.Greater(interpolatingCount, 10);
+            Assert.Greater(interpolatedCount, 10);
         }
 
         [Test]

--- a/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
+++ b/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
@@ -71,19 +71,18 @@ namespace osu.Framework.Tests.Clocks
         [Test]
         public void NeverInterpolatesBackwardsOnInterpolationFail()
         {
+            const int sleep_time = 20;
+
             double lastValue = interpolating.CurrentTime;
-
             source.Start();
-            source.Rate = 10; // use a higher rate to ensure we may seek backwards.
-
-            int sleepTime = (int)(interpolating.AllowableErrorMilliseconds / 2);
-
             int interpolatedCount = 0;
 
             for (int i = 0; i < 200; i++)
             {
+                source.Rate += i * 10;
+
                 if (i < 100) // stop the elapsing at some point in time. should still work as source's ElapsedTime is zero.
-                    source.CurrentTime += sleepTime * source.Rate;
+                    source.CurrentTime += sleep_time * source.Rate;
 
                 interpolating.ProcessFrame();
 
@@ -93,7 +92,7 @@ namespace osu.Framework.Tests.Clocks
                 Assert.GreaterOrEqual(interpolating.CurrentTime, lastValue, "Interpolating should not jump against rate.");
                 Assert.LessOrEqual(Math.Abs(interpolating.CurrentTime - source.CurrentTime), interpolating.AllowableErrorMilliseconds, "Interpolating should be within allowance.");
 
-                Thread.Sleep(sleepTime);
+                Thread.Sleep(sleep_time);
                 lastValue = interpolating.CurrentTime;
             }
 

--- a/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
+++ b/osu.Framework.Tests/Clocks/InterpolatingClockTest.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Tests.Clocks
 
             int sleepTime = (int)(interpolating.AllowableErrorMilliseconds / 2);
 
-            int interpolatingCount = 0;
+            int interpolatedCount = 0;
 
             for (int i = 0; i < 200; i++)
             {
@@ -87,8 +87,8 @@ namespace osu.Framework.Tests.Clocks
 
                 interpolating.ProcessFrame();
 
-                if (interpolating.CurrentTime != source.CurrentTime)
-                    interpolatingCount++;
+                if (interpolating.IsInterpolating)
+                    interpolatedCount++;
 
                 Assert.GreaterOrEqual(interpolating.CurrentTime, lastValue, "Interpolating should not jump against rate.");
                 Assert.LessOrEqual(Math.Abs(interpolating.CurrentTime - source.CurrentTime), interpolating.AllowableErrorMilliseconds, "Interpolating should be within allowance.");
@@ -97,7 +97,7 @@ namespace osu.Framework.Tests.Clocks
                 lastValue = interpolating.CurrentTime;
             }
 
-            Assert.Greater(interpolatingCount, 10);
+            Assert.Greater(interpolatedCount, 10);
         }
 
         [Test]

--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -46,7 +46,10 @@ namespace osu.Framework.Timing
 
         private double currentTime;
 
-        public double AllowableErrorMilliseconds = 1000.0 / 60 * 2;
+        /// <summary>
+        /// The amount of error that is allowed between the source and interpolated time before the interpolated time is ignored and the source time is used.
+        /// </summary>
+        public virtual double AllowableErrorMilliseconds => 1000.0 / 60 * 2 * Rate;
 
         private bool sourceIsRunning;
 

--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -62,7 +62,10 @@ namespace osu.Framework.Timing
 
         public virtual double ElapsedFrameTime => CurrentInterpolatedTime - LastInterpolatedTime;
 
-        private bool allowInterpolation;
+        /// <summary>
+        /// Whether time is being interpolated for the frame currently being processed.
+        /// </summary>
+        public bool IsInterpolating { get; private set; }
 
         public virtual void ProcessFrame()
         {
@@ -78,18 +81,18 @@ namespace osu.Framework.Timing
             if (FramedSourceClock.IsRunning)
             {
                 if (FramedSourceClock.ElapsedFrameTime != 0)
-                    allowInterpolation = true;
+                    IsInterpolating = true;
 
                 CurrentInterpolatedTime += clock.ElapsedFrameTime * Rate;
 
-                if (!allowInterpolation || Math.Abs(FramedSourceClock.CurrentTime - CurrentInterpolatedTime) > AllowableErrorMilliseconds)
+                if (!IsInterpolating || Math.Abs(FramedSourceClock.CurrentTime - CurrentInterpolatedTime) > AllowableErrorMilliseconds)
                 {
                     // if we've exceeded the allowable error, we should use the source clock's time value.
                     // seeking backwards should only be allowed if the source is explicitly doing that.
                     CurrentInterpolatedTime = FramedSourceClock.ElapsedFrameTime < 0 ? FramedSourceClock.CurrentTime : Math.Max(LastInterpolatedTime, FramedSourceClock.CurrentTime);
 
                     // once interpolation fails, we don't want to resume interpolating until the source clock starts to move again.
-                    allowInterpolation = false;
+                    IsInterpolating = false;
                 }
                 else
                 {


### PR DESCRIPTION
Should fix test failures in the .net core 3.0 branch: https://ci.appveyor.com/project/peppy/osu-framework/builds/28006494