### PR TITLE
Fix fast clock having a huge rate

### DIFF
--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -77,7 +77,7 @@ namespace osu.Framework.Platform
             }
 
             public double CurrentTime => time += increment;
-            public double Rate => CLOCK_RATE;
+            public double Rate => 1;
             public bool IsRunning => true;
         }
     }


### PR DESCRIPTION
Will fix https://ci.appveyor.com/project/peppy/osu/builds/28032676/tests

This was causing interpolation to go out of control after the recent `InterpolatingFramedClock` change (https://github.com/ppy/osu-framework/pull/2880).