### PR TITLE
Fix potential wrong transitions on first-time loading model-backed drawable

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
@@ -142,6 +142,23 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddUntilStep("null model shown", () => backedDrawable.DisplayedDrawable is TestNullDrawableModel);
         }
 
+        [Test]
+        public void TestSlowLoadModel()
+        {
+            TestDrawableModel drawableModel = null;
+
+            AddStep("setup", () =>
+            {
+                createModelBackedDrawable(false, true);
+                backedDrawable.Model = new TestModel(drawableModel = new TestDrawableModel(1));
+            });
+
+            AddUntilStep("null model visible", () => backedDrawable.DisplayedDrawable is TestNullDrawableModel);
+
+            AddStep("allow model to load", () => drawableModel.AllowLoad.Set());
+            assertDrawableVisibility(1, () => drawableModel);
+        }
+
         private void assertIntermediateVisibility(bool hasIntermediate, Func<Drawable> getLastFunc)
         {
             if (hasIntermediate)

--- a/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
+++ b/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
@@ -88,7 +88,13 @@ namespace osu.Framework.Graphics.Containers
         protected override void LoadComplete()
         {
             base.LoadComplete();
-            updateDrawable();
+
+            loadDrawable(() => CreateDrawable(default));
+
+            if (currentWrapper != null)
+                currentWrapper.DelayedLoadComplete += _ => updateDrawable();
+            else
+                updateDrawable();
         }
 
         private void updateDrawable()


### PR DESCRIPTION
- Forces loading null-model drawable on `ModelBackedDrawable.LoadComplete`.

`ModelBackedDrawable` sub-classes may generally show a placeholder drawable when `null` model is provided in `CreateDrawable(model)`. This PR aims to fix wrong transitions on first-time loading when using that logic.

As on current master, the transition goes `null drawable -> actual drawable` on first-time, after this PR, it becomes `null drawable -> placeholder drawable (null model) -> actual drawable`. as can be seen in the attached videos: [Before](https://streamable.com/uqmwz)–[After](https://streamable.com/of94q)

Closes #2634 