### PR TITLE
Get rid of some non-generic/boxing calls

### DIFF
--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -1,0 +1,4 @@
+M:System.Object.Equals(System.Object,System.Object)~System.Boolean;Don't use object.Equals. Use IEquatable<T> or EqualityComparer<T>.Default instead.
+M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Use IEquatable<T> or EqualityComparer<T>.Default instead.
+M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
+T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.

--- a/osu.Framework.Tests/Visual/Bindables/TestSceneBindableNumbers.cs
+++ b/osu.Framework.Tests/Visual/Bindables/TestSceneBindableNumbers.cs
@@ -205,7 +205,7 @@ namespace osu.Framework.Tests.Visual.Bindables
         }
 
         private class BindableDisplayContainer<T> : CompositeDrawable
-            where T : struct, IComparable, IConvertible
+            where T : struct, IComparable<T>, IConvertible, IEquatable<T>
         {
             public BindableDisplayContainer(BindableNumber<T> bindable)
             {

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// Check whether the current <see cref="Value"/> is equal to <see cref="Default"/>.
         /// </summary>
-        public virtual bool IsDefault => Equals(value, Default);
+        public virtual bool IsDefault => EqualityComparer<T>.Default.Equals(value, Default);
 
         /// <summary>
         /// Revert the current <see cref="Value"/> to the defined <see cref="Default"/>.

--- a/osu.Framework/Bindables/BindableBool.cs
+++ b/osu.Framework/Bindables/BindableBool.cs
@@ -14,9 +14,9 @@ namespace osu.Framework.Bindables
 
         public override void Parse(object input)
         {
-            if (input.Equals("1"))
+            if (input is "1")
                 Value = true;
-            else if (input.Equals("0"))
+            else if (input is "0")
                 Value = false;
             else
                 base.Parse(input);

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 
 namespace osu.Framework.Bindables
@@ -12,23 +11,19 @@ namespace osu.Framework.Bindables
     {
         static BindableNumber()
         {
-            // check supported types against provided type argument.
-            var allowedTypes = new HashSet<Type>
-            {
-                typeof(sbyte),
-                typeof(byte),
-                typeof(short),
-                typeof(ushort),
-                typeof(int),
-                typeof(uint),
-                typeof(long),
-                typeof(ulong),
-                typeof(float),
-                typeof(double)
-            };
-
-            if (!allowedTypes.Contains(typeof(T)))
-                throw new ArgumentException(
+            // Directly comparing typeof(T) to type literal is recognized pattern of JIT and very fast.
+            // Just a pointer comparison.
+            if (typeof(T) != typeof(sbyte) &&
+                typeof(T) != typeof(byte) &&
+                typeof(T) != typeof(short) &&
+                typeof(T) != typeof(ushort) &&
+                typeof(T) != typeof(int) &&
+                typeof(T) != typeof(uint) &&
+                typeof(T) != typeof(long) &&
+                typeof(T) != typeof(ulong) &&
+                typeof(T) != typeof(float) &&
+                typeof(T) != typeof(double))
+                throw new NotSupportedException(
                     $"{nameof(BindableNumber<T>)} only accepts the primitive numeric types (except for {typeof(decimal).FullName}) as type arguments. You provided {typeof(T).FullName}.");
         }
 

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -238,76 +238,37 @@ namespace osu.Framework.Bindables
         public void Set<U>(U val) where U : struct,
             IComparable, IFormattable, IConvertible, IComparable<U>, IEquatable<U>
         {
-            switch (Type.GetTypeCode(typeof(T)))
+            switch (this)
             {
-                case TypeCode.Byte:
-                    var byteBindable = this as BindableNumber<byte>;
-                    if (byteBindable == null) throw new ArgumentNullException(nameof(byteBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    byteBindable.Value = Convert.ToByte(val);
+                case BindableNumber<byte> byteBindable:
+                    byteBindable.Value = val.ToByte(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.SByte:
-                    var sbyteBindable = this as BindableNumber<sbyte>;
-                    if (sbyteBindable == null) throw new ArgumentNullException(nameof(sbyteBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    sbyteBindable.Value = Convert.ToSByte(val);
+                case BindableNumber<sbyte> sbyteBindable:
+                    sbyteBindable.Value = val.ToSByte(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.UInt16:
-                    var ushortBindable = this as BindableNumber<ushort>;
-                    if (ushortBindable == null) throw new ArgumentNullException(nameof(ushortBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    ushortBindable.Value = Convert.ToUInt16(val);
+                case BindableNumber<ushort> ushortBindable:
+                    ushortBindable.Value = val.ToUInt16(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Int16:
-                    var shortBindable = this as BindableNumber<short>;
-                    if (shortBindable == null) throw new ArgumentNullException(nameof(shortBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    shortBindable.Value = Convert.ToInt16(val);
+                case BindableNumber<short> shortBindable:
+                    shortBindable.Value = val.ToInt16(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.UInt32:
-                    var uintBindable = this as BindableNumber<uint>;
-                    if (uintBindable == null) throw new ArgumentNullException(nameof(uintBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    uintBindable.Value = Convert.ToUInt32(val);
+                case BindableNumber<uint> uintBindable:
+                    uintBindable.Value = val.ToUInt32(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Int32:
-                    var intBindable = this as BindableNumber<int>;
-                    if (intBindable == null) throw new ArgumentNullException(nameof(intBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    intBindable.Value = Convert.ToInt32(val);
+                case BindableNumber<int> intBindable:
+                    intBindable.Value = val.ToInt32(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.UInt64:
-                    var ulongBindable = this as BindableNumber<ulong>;
-                    if (ulongBindable == null) throw new ArgumentNullException(nameof(ulongBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    ulongBindable.Value = Convert.ToUInt64(val);
+                case BindableNumber<ulong> ulongBindable:
+                    ulongBindable.Value = val.ToUInt64(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Int64:
-                    var longBindable = this as BindableNumber<long>;
-                    if (longBindable == null) throw new ArgumentNullException(nameof(longBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    longBindable.Value = Convert.ToInt64(val);
+                case BindableNumber<long> longBindable:
+                    longBindable.Value = val.ToInt64(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Single:
-                    var floatBindable = this as BindableNumber<float>;
-                    if (floatBindable == null) throw new ArgumentNullException(nameof(floatBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    floatBindable.Value = Convert.ToSingle(val);
+                case BindableNumber<float> floatBindable:
+                    floatBindable.Value = val.ToSingle(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Double:
-                    var doubleBindable = this as BindableNumber<double>;
-                    if (doubleBindable == null) throw new ArgumentNullException(nameof(doubleBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    doubleBindable.Value = Convert.ToDouble(val);
+                case BindableNumber<double> doubleBindable:
+                    doubleBindable.Value = val.ToDouble(NumberFormatInfo.InvariantInfo);
                     break;
             }
         }
@@ -315,76 +276,37 @@ namespace osu.Framework.Bindables
         public void Add<U>(U val) where U : struct,
             IComparable, IFormattable, IConvertible, IComparable<U>, IEquatable<U>
         {
-            switch (Type.GetTypeCode(typeof(T)))
+            switch (this)
             {
-                case TypeCode.Byte:
-                    var byteBindable = this as BindableNumber<byte>;
-                    if (byteBindable == null) throw new ArgumentNullException(nameof(byteBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    byteBindable.Value += Convert.ToByte(val);
+                case BindableNumber<byte> byteBindable:
+                    byteBindable.Value += val.ToByte(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.SByte:
-                    var sbyteBindable = this as BindableNumber<sbyte>;
-                    if (sbyteBindable == null) throw new ArgumentNullException(nameof(sbyteBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    sbyteBindable.Value += Convert.ToSByte(val);
+                case BindableNumber<sbyte> sbyteBindable:
+                    sbyteBindable.Value += val.ToSByte(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.UInt16:
-                    var ushortBindable = this as BindableNumber<ushort>;
-                    if (ushortBindable == null) throw new ArgumentNullException(nameof(ushortBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    ushortBindable.Value += Convert.ToUInt16(val);
+                case BindableNumber<ushort> ushortBindable:
+                    ushortBindable.Value += val.ToUInt16(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Int16:
-                    var shortBindable = this as BindableNumber<short>;
-                    if (shortBindable == null) throw new ArgumentNullException(nameof(shortBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    shortBindable.Value += Convert.ToInt16(val);
+                case BindableNumber<short> shortBindable:
+                    shortBindable.Value += val.ToInt16(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.UInt32:
-                    var uintBindable = this as BindableNumber<uint>;
-                    if (uintBindable == null) throw new ArgumentNullException(nameof(uintBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    uintBindable.Value += Convert.ToUInt32(val);
+                case BindableNumber<uint> uintBindable:
+                    uintBindable.Value += val.ToUInt32(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Int32:
-                    var intBindable = this as BindableNumber<int>;
-                    if (intBindable == null) throw new ArgumentNullException(nameof(intBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    intBindable.Value += Convert.ToInt32(val);
+                case BindableNumber<int> intBindable:
+                    intBindable.Value += val.ToInt32(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.UInt64:
-                    var ulongBindable = this as BindableNumber<ulong>;
-                    if (ulongBindable == null) throw new ArgumentNullException(nameof(ulongBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    ulongBindable.Value += Convert.ToUInt64(val);
+                case BindableNumber<ulong> ulongBindable:
+                    ulongBindable.Value += val.ToUInt64(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Int64:
-                    var longBindable = this as BindableNumber<long>;
-                    if (longBindable == null) throw new ArgumentNullException(nameof(longBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    longBindable.Value += Convert.ToInt64(val);
+                case BindableNumber<long> longBindable:
+                    longBindable.Value += val.ToInt64(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Single:
-                    var floatBindable = this as BindableNumber<float>;
-                    if (floatBindable == null) throw new ArgumentNullException(nameof(floatBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    floatBindable.Value += Convert.ToSingle(val);
+                case BindableNumber<float> floatBindable:
+                    floatBindable.Value += val.ToSingle(NumberFormatInfo.InvariantInfo);
                     break;
-
-                case TypeCode.Double:
-                    var doubleBindable = this as BindableNumber<double>;
-                    if (doubleBindable == null) throw new ArgumentNullException(nameof(doubleBindable), $"Generic type {typeof(T)} does not match actual bindable type {GetType()}.");
-
-                    doubleBindable.Value += Convert.ToDouble(val);
+                case BindableNumber<double> doubleBindable:
+                    doubleBindable.Value += val.ToDouble(NumberFormatInfo.InvariantInfo);
                     break;
             }
         }

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Bindables
                 if (precision.Equals(value))
                     return;
 
-                if (Convert.ToDouble(value) <= 0)
+                if (value.ToDouble(NumberFormatInfo.InvariantInfo) <= 0)
                     throw new ArgumentOutOfRangeException(nameof(Precision), "Must be greater than 0.");
 
                 precision = value;
@@ -67,8 +67,8 @@ namespace osu.Framework.Bindables
             {
                 if (Precision.CompareTo(DefaultPrecision) > 0)
                 {
-                    double doubleValue = Convert.ToDouble(clamp(value, MinValue, MaxValue));
-                    doubleValue = Math.Round(doubleValue / Convert.ToDouble(Precision)) * Convert.ToDouble(Precision);
+                    double doubleValue = clamp(value, MinValue, MaxValue).ToDouble(NumberFormatInfo.InvariantInfo);
+                    doubleValue = Math.Round(doubleValue / Precision.ToDouble(NumberFormatInfo.InvariantInfo)) * Precision.ToDouble(NumberFormatInfo.InvariantInfo);
 
                     base.Value = (T)Convert.ChangeType(doubleValue, typeof(T), CultureInfo.InvariantCulture);
                 }
@@ -313,8 +313,8 @@ namespace osu.Framework.Bindables
         /// </summary>
         public void SetProportional(float amt, float snap = 0)
         {
-            var min = Convert.ToDouble(MinValue);
-            var max = Convert.ToDouble(MaxValue);
+            var min = MinValue.ToDouble(NumberFormatInfo.InvariantInfo);
+            var max = MaxValue.ToDouble(NumberFormatInfo.InvariantInfo);
             var value = min + (max - min) * amt;
             if (snap > 0)
                 value = Math.Round(value / snap) * snap;

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Bindables
 
         public event Action<T> MaxValueChanged;
 
-        protected BindableNumber(T value = default)
+        private protected BindableNumber(T value = default)
             : base(value)
         {
             MinValue = DefaultMinValue;

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -7,7 +7,7 @@ using System.Globalization;
 namespace osu.Framework.Bindables
 {
     public abstract class BindableNumber<T> : Bindable<T>, IBindableNumber<T>
-        where T : struct, IComparable, IConvertible
+        where T : struct, IComparable<T>, IConvertible, IEquatable<T>
     {
         static BindableNumber()
         {
@@ -51,8 +51,8 @@ namespace osu.Framework.Bindables
                 if (precision.Equals(value))
                     return;
 
-                if (value.ToDouble(NumberFormatInfo.InvariantInfo) <= 0)
-                    throw new ArgumentOutOfRangeException(nameof(Precision), "Must be greater than 0.");
+                if (value.CompareTo(default) <= 0)
+                    throw new ArgumentOutOfRangeException(nameof(Precision), value, "Must be greater than 0.");
 
                 precision = value;
 
@@ -147,7 +147,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            if (Equals(beforePropagation, precision))
+            if (beforePropagation.Equals(precision))
                 PrecisionChanged?.Invoke(precision);
         }
 
@@ -165,7 +165,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            if (Equals(beforePropagation, minValue))
+            if (beforePropagation.Equals(minValue))
                 MinValueChanged?.Invoke(minValue);
         }
 
@@ -183,7 +183,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            if (Equals(beforePropagation, maxValue))
+            if (beforePropagation.Equals(maxValue))
                 MaxValueChanged?.Invoke(maxValue);
         }
 

--- a/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs
+++ b/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Extensions.IEnumerableExtensions
         /// <returns>The item in <paramref name="collection"/> appearing after <paramref name="pivot"/>, or null if no such item exists.</returns>
         public static T GetNext<T>(this IEnumerable<T> collection, T pivot)
         {
-            return collection.SkipWhile(i => !i.Equals(pivot)).Skip(1).FirstOrDefault();
+            return collection.SkipWhile(i => !EqualityComparer<T>.Default.Equals(i, pivot)).Skip(1).FirstOrDefault();
         }
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace osu.Framework.Extensions.IEnumerableExtensions
         /// <returns>The item in <paramref name="collection"/> appearing before <paramref name="pivot"/>, or null if no such item exists.</returns>
         public static T GetPrevious<T>(this IEnumerable<T> collection, T pivot)
         {
-            return collection.TakeWhile(i => !i.Equals(pivot)).LastOrDefault();
+            return collection.TakeWhile(i => !EqualityComparer<T>.Default.Equals(i, pivot)).LastOrDefault();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Shaders/Uniform.cs
+++ b/osu.Framework/Graphics/Shaders/Uniform.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Graphics.OpenGL;
 
 namespace osu.Framework.Graphics.Shaders
@@ -25,7 +26,7 @@ namespace osu.Framework.Graphics.Shaders
 
         public void UpdateValue(ref T newValue)
         {
-            if (newValue.Equals(Value))
+            if (EqualityComparer<T>.Default.Equals(newValue, Value))
                 return;
 
             Value = newValue;

--- a/osu.Framework/Graphics/Sprites/IconUsage.cs
+++ b/osu.Framework/Graphics/Sprites/IconUsage.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Graphics.Sprites
 
         public override string ToString() => $"Icon={Icon} Font={FontName}";
 
-        public bool Equals(IconUsage other) => Equals(Icon, other.Icon) && string.Equals(Family, other.Family) && string.Equals(Weight, other.Weight);
+        public bool Equals(IconUsage other) => Icon == other.Icon && string.Equals(Family, other.Family) && string.Equals(Weight, other.Weight);
 
         public override bool Equals(object obj)
         {

--- a/osu.Framework/Graphics/Sprites/SpriteIcon.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteIcon.cs
@@ -72,7 +72,7 @@ namespace osu.Framework.Graphics.Sprites
         {
             var loadableIcon = icon;
 
-            if (Equals(loadableIcon, loadedIcon)) return;
+            if (loadableIcon.Equals(loadedIcon)) return;
 
             var glyph = store.Get(loadableIcon.FontName, Icon.Icon);
 
@@ -129,7 +129,7 @@ namespace osu.Framework.Graphics.Sprites
             get => icon;
             set
             {
-                if (Equals(icon, value)) return;
+                if (icon.Equals(value)) return;
 
                 icon = value;
                 if (LoadState == LoadState.Loaded)

--- a/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicSliderBar.cs
@@ -9,7 +9,7 @@ using osu.Framework.Graphics.Shapes;
 namespace osu.Framework.Graphics.UserInterface
 {
     public class BasicSliderBar<T> : SliderBar<T>
-        where T : struct, IComparable, IConvertible
+        where T : struct, IComparable<T>, IConvertible, IEquatable<T>
     {
         public Color4 BackgroundColour
         {

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -11,7 +11,7 @@ using osu.Framework.Input.Events;
 namespace osu.Framework.Graphics.UserInterface
 {
     public abstract class SliderBar<T> : Container, IHasCurrentValue<T>
-        where T : struct, IComparable, IConvertible
+        where T : struct, IComparable<T>, IConvertible, IEquatable<T>
     {
         /// <summary>
         /// Range padding reduces the range of movement a slider bar is allowed to have

--- a/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
@@ -183,9 +183,8 @@ namespace osu.Framework.Graphics.Visualisation
                     value = $@"<{((e as TargetInvocationException)?.InnerException ?? e).GetType().ReadableName()} occured during evaluation>";
                 }
 
-#pragma warning disable RS0030 // Don't use banned API
-                if (!value.Equals(lastValue))
-#pragma warning restore RS0030 // Don't use banned API
+                // An alternative of object.Equals, which is banned.
+                if (!EqualityComparer<object>.Default.Equals(value, lastValue))
                 {
                     changeMarker.ClearTransforms();
                     changeMarker.Alpha = 0.8f;

--- a/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
@@ -183,7 +183,9 @@ namespace osu.Framework.Graphics.Visualisation
                     value = $@"<{((e as TargetInvocationException)?.InnerException ?? e).GetType().ReadableName()} occured during evaluation>";
                 }
 
+#pragma warning disable RS0030 // Don't use banned API
                 if (!value.Equals(lastValue))
+#pragma warning restore RS0030 // Don't use banned API
                 {
                     changeMarker.ClearTransforms();
                     changeMarker.Alpha = 0.8f;

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -213,7 +213,7 @@ namespace osu.Framework.Input.Bindings
         private void releasePressedActions()
         {
             foreach (var action in pressedActions)
-            foreach (var kvp in keyBindingQueues.Where(k => k.Key.GetAction<T>().Equals(action)))
+            foreach (var kvp in keyBindingQueues.Where(k => EqualityComparer<T>.Default.Equals(k.Key.GetAction<T>(), action)))
                 kvp.Value.OfType<IKeyBindingHandler<T>>().ForEach(d => d.OnReleased(action));
 
             pressedActions.Clear();
@@ -247,7 +247,7 @@ namespace osu.Framework.Input.Bindings
             // we either want multiple release events due to the simultaneous mode, or we only want one when we
             // - were pressed (as an action)
             // - are the last pressed binding with this action
-            if (simultaneousMode == SimultaneousBindingMode.All || pressedActions.Contains(released) && pressedBindings.All(b => !b.GetAction<T>().Equals(released)))
+            if (simultaneousMode == SimultaneousBindingMode.All || pressedActions.Contains(released) && pressedBindings.All(b => !EqualityComparer<T>.Default.Equals(b.GetAction<T>(), released)))
             {
                 handled = drawables.OfType<IKeyBindingHandler<T>>().FirstOrDefault(d => d.OnReleased(released));
                 pressedActions.Remove(released);

--- a/osu.Framework/Localisation/LocalisedString.cs
+++ b/osu.Framework/Localisation/LocalisedString.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Configuration;
 
 namespace osu.Framework.Localisation
@@ -8,7 +10,7 @@ namespace osu.Framework.Localisation
     /// <summary>
     /// A class representing text that can be localised and formatted.
     /// </summary>
-    public readonly struct LocalisedString
+    public readonly struct LocalisedString : IEquatable<LocalisedString>
     {
         /// <summary>
         /// The text to be localised.
@@ -68,5 +70,10 @@ namespace osu.Framework.Localisation
         public static implicit operator LocalisedString(string text) => new LocalisedString((text, text), false);
 
         public override string ToString() => Text.Original;
+
+        public bool Equals(LocalisedString other) =>
+            Text == other.Text &&
+            ShouldLocalise == other.ShouldLocalise &&
+            Args.SequenceEqual(other.Args);
     }
 }

--- a/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
@@ -14,7 +14,7 @@ using osu.Framework.Input.Events;
 namespace osu.Framework.Testing.Drawables.Steps
 {
     public class StepSlider<T> : SliderBar<T>
-        where T : struct, IComparable, IConvertible
+        where T : struct, IComparable<T>, IConvertible, IEquatable<T>
     {
         private readonly Box selection;
         private readonly Box background;

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -342,7 +342,7 @@ namespace osu.Framework.Testing
             });
         });
 
-        protected void AddSliderStep<T>(string description, T min, T max, T start, Action<T> valueChanged) where T : struct, IComparable, IConvertible => schedule(() =>
+        protected void AddSliderStep<T>(string description, T min, T max, T start, Action<T> valueChanged) where T : struct, IComparable<T>, IConvertible, IEquatable<T> => schedule(() =>
         {
             StepsContainer.Add(new StepSlider<T>(description, min, max, start)
             {

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -32,10 +32,14 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
   </PropertyGroup>
+  <ItemGroup Label="Code Analysis">
+    <AdditionalFiles Include="..\BannedSymbols.txt" />
+  </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Markdig" Version="0.17.1" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.6" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="SharpFNT" Version="1.1.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
     <PackageReference Include="System.Drawing.Common" Version="4.6.0" />


### PR DESCRIPTION
I'd rather call these "violation fixes" instead of "improvements".
`BindableNumber` violates some usage of exceptions, and they shouldn't be thrown ever.
The non-generic calls are harmful to both performance and architecture.
I'm a bit aggressive on this, and introducing banned API analyzer.

This is a technically **breaking change**, including:
- Generic constraints on some types are changed. Consumers are assumed to only construct them with primitive numbers, which always satisfy the constraints.
- `BindableNumber` can no longer be derived by consumer. No one should ever derived them though.
I assume it can't actually break anything.