### PR TITLE
Separate out xamarin build tasks

### DIFF
--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -5,4 +5,4 @@ image: Visual Studio 2019 Preview
 test: off
 build_script:
   - cmd: >-
-      msbuild /version
+      msbuild osu.Framework.iOS\osu.Framework.iOS.csproj

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -1,7 +1,7 @@
 clone_depth: 1
 skip_tags: true
 version: '{build}'
-image: Visual Studio 2019
+image: Visual Studio 2019 Preview
 test: off
 build_script:
   - cmd: >-

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -1,8 +1,9 @@
 clone_depth: 1
 skip_tags: true
 version: '{build}'
-image: Visual Studio 2019 Preview
+image: Visual Studio 2019
 test: off
 build_script:
-  - cmd: dotnet restore
-  - cmd: msbuild osu.Framework.iOS\osu.Framework.iOS.csproj
+  - cmd: >-
+      dotnet restore
+      msbuild osu.Framework.iOS\osu.Framework.iOS.csproj

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -1,8 +1,9 @@
 clone_depth: 1
 skip_tags: true
 version: '{build}'
-image: Visual Studio 2019
+image: Visual Studio 2019 Preview
 test: off
 build_script:
+  - cmd: PowerShell -Version 2.0 .\build.ps1
   - cmd: nuget restore osu-framework.iOS.sln
   - cmd: msbuild osu.Framework.iOS\osu.Framework.iOS.csproj

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -5,5 +5,4 @@ image: Visual Studio 2019 Preview
 test: off
 build_script:
   - cmd: >-
-      dotnet restore;
-      msbuild osu.Framework.iOS\osu.Framework.iOS.csproj;
+      msbuild /version

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -4,5 +4,5 @@ version: '{build}'
 image: Visual Studio 2019 Preview
 test: off
 build_script:
-  - cmd: dotnet restore osu-framework.iOS.sln
+  - cmd: nuget restore osu-framework.iOS.sln
   - cmd: msbuild osu.Framework.iOS\osu.Framework.iOS.csproj

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -1,7 +1,7 @@
 clone_depth: 1
 skip_tags: true
 version: '{build}'
-image: Visual Studio 2019 Preview
+image: Visual Studio 2019
 test: off
 build_script:
   - cmd: nuget restore osu-framework.iOS.sln

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -4,6 +4,5 @@ version: '{build}'
 image: Visual Studio 2019 Preview
 test: off
 build_script:
-  - cmd: >-
-      dotnet restore osu-framework.iOS.sln;
-      msbuild osu.Framework.iOS\osu.Framework.iOS.csproj;
+  - cmd: dotnet restore osu-framework.iOS.sln
+  - cmd: msbuild osu.Framework.iOS\osu.Framework.iOS.csproj

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -1,0 +1,7 @@
+clone_depth: 1
+skip_tags: true
+version: '{build}'
+image: Visual Studio 2017
+test: off
+build_script:
+  - cmd: PowerShell -Version 2.0 .\build.ps1 -Target BuildXamarin

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -1,7 +1,7 @@
 clone_depth: 1
 skip_tags: true
 version: '{build}'
-image: Visual Studio 2017
+image: Visual Studio 2019
 test: off
 build_script:
   - cmd: PowerShell -Version 2.0 .\build.ps1 -Target BuildXamarin

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -1,7 +1,8 @@
 clone_depth: 1
 skip_tags: true
 version: '{build}'
-image: Visual Studio 2019
+image: Visual Studio 2019 Preview
 test: off
 build_script:
-  - cmd: PowerShell -Version 2.0 .\build.ps1 -Target BuildXamarin
+  - cmd: dotnet restore
+  - cmd: msbuild osu.Framework.iOS\osu.Framework.iOS.csproj

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -5,4 +5,5 @@ image: Visual Studio 2019 Preview
 test: off
 build_script:
   - cmd: >-
-      msbuild osu.Framework.iOS\osu.Framework.iOS.csproj
+      dotnet restore osu-framework.iOS.sln;
+      msbuild osu-framework.iOS.sln;

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -5,5 +5,5 @@ image: Visual Studio 2019 Preview
 test: off
 build_script:
   - cmd: >-
-      dotnet restore
-      msbuild osu.Framework.iOS\osu.Framework.iOS.csproj
+      dotnet restore;
+      msbuild osu.Framework.iOS\osu.Framework.iOS.csproj;

--- a/appveyor_xamarin.yml
+++ b/appveyor_xamarin.yml
@@ -6,4 +6,4 @@ test: off
 build_script:
   - cmd: >-
       dotnet restore osu-framework.iOS.sln;
-      msbuild osu-framework.iOS.sln;
+      msbuild osu.Framework.iOS\osu.Framework.iOS.csproj;

--- a/build/build.cake
+++ b/build/build.cake
@@ -217,9 +217,15 @@ Task("Build")
     .IsDependentOn("Test")
     .IsDependentOn("DetermineAppveyorDeployProperties")
     .IsDependentOn("PackFramework")
+    .IsDependentOn("PackNativeLibs")
+    .IsDependentOn("Publish");
+
+Task("BuildXamarin")
+    .IsDependentOn("Clean")
+    .IsDependentOn("DetermineAppveyorBuildProperties")
+    .IsDependentOn("DetermineAppveyorDeployProperties")
     .IsDependentOn("PackiOSFramework")
     .IsDependentOn("PackAndroidFramework")
-    .IsDependentOn("PackNativeLibs")
     .IsDependentOn("Publish");
 
 Task("DeployFramework")

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <PackageReference Include="ppy.osuTK.iOS" Version="1.0.111" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
   <ItemGroup>
     <NativeLibs Include="$(MSBuildThisFileDirectory)\*.a" />

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -34,7 +34,6 @@
   <ItemGroup>
     <PackageReference Include="ppy.osuTK.iOS" Version="1.0.111" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
-    <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
   <ItemGroup>
     <NativeLibs Include="$(MSBuildThisFileDirectory)\*.a" />


### PR DESCRIPTION
Going forward, appveyor 2019 images will [not include VS2017](https://www.appveyor.com/updates/2019/10/16/) (and the msbuild required for our xamarin builds at the moment). Until we have updated xamarin projects, a new appveyor project can be used to run against the VS2017 image.

![image](https://user-images.githubusercontent.com/191335/67059133-b4105800-f192-11e9-9a2d-62466d4853c1.png)
