### PR TITLE
Use the shoelace formula for Triangle.Area

### DIFF
--- a/osu.Framework.Tests/Primitives/TriangleTest.cs
+++ b/osu.Framework.Tests/Primitives/TriangleTest.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Tests.Primitives
     {
         [TestCaseSource(typeof(AreaTestData), nameof(AreaTestData.TestCases))]
         [DefaultFloatingPointTolerance(0.1f)]
-        public float TestArea(Triangle testTriangle) => testTriangle.AreaNew;
+        public float TestArea(Triangle testTriangle) => testTriangle.Area;
 
         private class AreaTestData
         {

--- a/osu.Framework.Tests/Primitives/TriangleTest.cs
+++ b/osu.Framework.Tests/Primitives/TriangleTest.cs
@@ -1,4 +1,7 @@
-﻿using NUnit.Framework;
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
 using osu.Framework.Graphics.Primitives;
 using osuTK;
 using System;

--- a/osu.Framework.Tests/Primitives/TriangleTest.cs
+++ b/osu.Framework.Tests/Primitives/TriangleTest.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+using osu.Framework.Graphics.Primitives;
+using osuTK;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+
+namespace osu.Framework.Tests.Primitives
+{
+    [TestFixture]
+    class TriangleTest
+    {
+        [TestCaseSource(typeof(AreaTestData), nameof(AreaTestData.TestCases))]
+        [DefaultFloatingPointTolerance(0.1f)]
+        public float TestArea(Triangle testTriangle) => testTriangle.AreaNew;
+
+        private class AreaTestData
+        {
+            public static IEnumerable TestCases
+            {
+                get
+                {
+                    // Point
+                    yield return new TestCaseData(new Triangle(Vector2.Zero, Vector2.Zero, Vector2.Zero)).Returns(0);
+
+                    // Angled
+                    yield return new TestCaseData(new Triangle(Vector2.Zero, new Vector2(10, 0), new Vector2(10))).Returns(50);
+                    yield return new TestCaseData(new Triangle(Vector2.Zero, new Vector2(0, 10), new Vector2(10))).Returns(50);
+                    yield return new TestCaseData(new Triangle(Vector2.Zero, new Vector2(10, -10), new Vector2(10))).Returns(100);
+                    yield return new TestCaseData(new Triangle(Vector2.Zero, new Vector2(10, -10), new Vector2(10))).Returns(100);
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Primitives/TriangleTest.cs
+++ b/osu.Framework.Tests/Primitives/TriangleTest.cs
@@ -4,15 +4,12 @@
 using NUnit.Framework;
 using osu.Framework.Graphics.Primitives;
 using osuTK;
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Text;
 
 namespace osu.Framework.Tests.Primitives
 {
     [TestFixture]
-    class TriangleTest
+    public class TriangleTest
     {
         [TestCaseSource(typeof(AreaTestData), nameof(AreaTestData.TestCases))]
         [DefaultFloatingPointTolerance(0.1f)]

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -224,7 +224,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 Colour = drawColour.BottomRight.Linear,
             });
 
-            FrameStatistics.Add(StatisticsCounterType.Pixels, (long)vertexTriangle.ConservativeArea);
+            FrameStatistics.Add(StatisticsCounterType.Pixels, (long)vertexTriangle.Area);
         }
 
         public const int VERTICES_PER_QUAD = 4;

--- a/osu.Framework/Graphics/Primitives/Triangle.cs
+++ b/osu.Framework/Graphics/Primitives/Triangle.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 
 namespace osu.Framework.Graphics.Primitives
 {
-    public struct Triangle
+    public struct Triangle : IConvexPolygon, IEquatable<Triangle>
     {
         public Vector2 P0;
         public Vector2 P1;
@@ -20,10 +20,17 @@ namespace osu.Framework.Graphics.Primitives
             P2 = p2;
         }
 
+        public ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
+
         public unsafe ReadOnlySpan<Vector2> GetVertices()
         {
             return new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref this), 3);
         }
+
+        public bool Equals(Triangle other) =>
+            P0 == other.P0 &&
+            P1 == other.P1 &&
+            P2 == other.P2;
 
         /// <summary>
         /// Checks whether a point lies within the triangle.

--- a/osu.Framework/Graphics/Primitives/Triangle.cs
+++ b/osu.Framework/Graphics/Primitives/Triangle.cs
@@ -3,6 +3,7 @@
 
 using osuTK;
 using System;
+using System.Runtime.CompilerServices;
 
 namespace osu.Framework.Graphics.Primitives
 {
@@ -19,6 +20,10 @@ namespace osu.Framework.Graphics.Primitives
             P2 = p2;
         }
 
+        public unsafe ReadOnlySpan<Vector2> GetVertices()
+        {
+            return new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref this), 3);
+        }
         /// <summary>
         /// Checks whether a point lies within the triangle.
         /// </summary>
@@ -56,18 +61,6 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public float ConservativeArea => Math.Abs((P0.Y - P1.Y) * (P1.X - P2.X)) / 2;
-
-        public float Area
-        {
-            get
-            {
-                float a = (P0 - P1).Length;
-                float b = (P0 - P2).Length;
-                float c = (P1 - P2).Length;
-                float s = (a + b + c) / 2.0f;
-                return (float)Math.Sqrt(s * (s - a) * (s - b) * (s - c));
-            }
-        }
+        public float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
     }
 }

--- a/osu.Framework/Graphics/Primitives/Triangle.cs
+++ b/osu.Framework/Graphics/Primitives/Triangle.cs
@@ -24,6 +24,7 @@ namespace osu.Framework.Graphics.Primitives
         {
             return new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref this), 3);
         }
+
         /// <summary>
         /// Checks whether a point lies within the triangle.
         /// </summary>


### PR DESCRIPTION
## WIP, needs more tests to ensure that the values are correct.
Closes #2846.
This is basically a copy of what was done in #2842.

Benchmark results:
```
|         Method |      Mean |     Error |    StdDev |
|--------------- |----------:|----------:|----------:|
|   Conservative |  1.377 ns | 0.0058 ns | 0.0055 ns |
|        AreaOld | 46.166 ns | 0.1231 ns | 0.1028 ns |
|        AreaNew |  3.445 ns | 0.0166 ns | 0.0156 ns |
```
### Additions
This PR also implements `IConvexPolygon` and `IEquatable<Triangle>` for the Triangle struct.
Breaking changes:
## This PR removes `Triangle.ConservativeArea`
Use `Triangle.Area` instead.