### PR TITLE
Don't use preview image for deploys

### DIFF
--- a/appveyor_deploy.yml
+++ b/appveyor_deploy.yml
@@ -1,6 +1,6 @@
 clone_depth: 1
 version: '{build}'
-image: Visual Studio 2019 Preview
+image: Visual Studio 2019
 test: off
 skip_non_tags: true
 build_script:

--- a/appveyor_native_deploy.yml
+++ b/appveyor_native_deploy.yml
@@ -1,6 +1,6 @@
 clone_depth: 1
 version: '{build}'
-image: Visual Studio 2019 Preview
+image: Visual Studio 2019
 test: off
 skip_non_tags: true
 build_script:


### PR DESCRIPTION
Somehow got this back-to-front. Using preview still uses the wrong msbuild version.