### PR TITLE
Allow classes to be generic arguments for ButtonInput

### DIFF
--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -13,7 +13,6 @@ namespace osu.Framework.Input.StateChanges
     /// </summary>
     /// <typeparam name="TButton">The type of button.</typeparam>
     public abstract class ButtonInput<TButton> : IInput
-        where TButton : struct
     {
         public IEnumerable<ButtonInputEntry<TButton>> Entries;
 

--- a/osu.Framework/Input/StateChanges/ButtonInputEntry.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInputEntry.cs
@@ -8,7 +8,6 @@ namespace osu.Framework.Input.StateChanges
     /// </summary>
     /// <typeparam name="TButton">Type of button.</typeparam>
     public struct ButtonInputEntry<TButton>
-        where TButton : struct
     {
         /// <summary>
         /// The button referred to.

--- a/osu.Framework/Input/StateChanges/Events/ButtonStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/ButtonStateChangeEvent.cs
@@ -6,7 +6,6 @@ using osu.Framework.Input.States;
 namespace osu.Framework.Input.StateChanges.Events
 {
     public class ButtonStateChangeEvent<TButton> : InputStateChangeEvent
-        where TButton : struct
     {
         /// <summary>
         /// The button which changed state.

--- a/osu.Framework/Input/States/ButtonStates.cs
+++ b/osu.Framework/Input/States/ButtonStates.cs
@@ -14,7 +14,6 @@ namespace osu.Framework.Input.States
     /// </summary>
     /// <typeparam name="TButton">The type of button.</typeparam>
     public class ButtonStates<TButton> : IEnumerable<TButton>
-        where TButton : struct
     {
         private List<TButton> pressedButtons = new List<TButton>();
 


### PR DESCRIPTION
- Dependency for multi-touch button input which inherits `ButtonInput<PositionalPointer>` as `PositionalPointer` is a class.