### PR TITLE
Improvements for AsyncDisposalQueue

### DIFF
--- a/osu.Framework/Allocation/AsyncDisposalQueue.cs
+++ b/osu.Framework/Allocation/AsyncDisposalQueue.cs
@@ -22,18 +22,16 @@ namespace osu.Framework.Allocation
 
         private static readonly Lazy<Task> lazy_task = new Lazy<Task>(disposeLoopAsync, LazyThreadSafetyMode.ExecutionAndPublication);
 
-        public static void Enqueue(IDisposable disposable)
+        public static void Enqueue(IDisposable disposable) => enqueueCore(disposable);
+
+        public static void Enqueue(IAsyncDisposable asyncDisposable) => enqueueCore(asyncDisposable);
+
+        private static void enqueueCore(object disposable)
         {
             disposal_queue.Enqueue(disposable);
             semaphore.Release();
-            _ = lazy_task.Value;
-        }
-
-        public static void Enqueue(IAsyncDisposable asyncDisposable)
-        {
-            disposal_queue.Enqueue(asyncDisposable);
-            semaphore.Release();
-            _ = lazy_task.Value;
+            // ReSharper disable once AssignmentIsFullyDiscarded
+            _ = lazy_task.Value; // Touch the value to do a thread-safe creation.
         }
 
         private static async Task disposeLoopAsync()

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -25,6 +25,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Markdig" Version="0.18.0" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.6" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="SharpFNT" Version="1.1.0" />


### PR DESCRIPTION
Support `IAsyncDisposal`. We haven't started to use it, but some libraries has started, for example efcore.
The class is totally thread safe now. `Enqueue` can't be called from multiple threads before.
`ConcurrentQueue` is performant, especially when there's 1 producer and 1 consumer. And it nulls out taken elements.
The class is totally lock-free now, although locks are taken internally in framework types. We will get free benifits if their performance get improved.

Open question:
Should `Enqueue` method overloads for the same name? Some type may implement them both, then there will be an ambiguous call.