### PR TITLE
Introduce UIVisibilityFlags in AndroidGameActivity

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -19,8 +19,14 @@ namespace osu.Framework.Android
         public SystemUiFlags UIVisibilityFlags
         {
             get => (SystemUiFlags)Window.DecorView.SystemUiVisibility;
-            set => Window.DecorView.SystemUiVisibility = (StatusBarVisibility)value;
+            set
+            {
+                systemUiFlags = value;
+                Window.DecorView.SystemUiVisibility = (StatusBarVisibility)value;
+            }
         }
+
+        private SystemUiFlags systemUiFlags;
 
         private AndroidGameView gameView;
 
@@ -35,6 +41,16 @@ namespace osu.Framework.Android
             base.OnCreate(savedInstanceState);
 
             SetContentView(gameView = new AndroidGameView(this, CreateGame()));
+
+            //firing up the on-screen keyboard (eg: interacting with textboxes) may cause the UI visibility flags to be altered thus showing the navbar and potentially the status bar
+            //this sets back the UI flags to hidden once the interaction with the on-screen keyboard is finished.
+            Window.DecorView.SystemUiVisibilityChange += (_, e) =>
+            {
+                if ((SystemUiFlags)e.Visibility != systemUiFlags)
+                {
+                    UIVisibilityFlags = systemUiFlags;
+                }
+            };
         }
 
         protected override void OnPause()

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -44,8 +44,8 @@ namespace osu.Framework.Android
 
             UIVisibilityFlags = SystemUiFlags.LayoutFlags | SystemUiFlags.ImmersiveSticky | SystemUiFlags.HideNavigation;
 
-            //firing up the on-screen keyboard (eg: interacting with textboxes) may cause the UI visibility flags to be altered thus showing the navbar and potentially the status bar
-            //this sets back the UI flags to hidden once the interaction with the on-screen keyboard is finished.
+            // Firing up the on-screen keyboard (eg: interacting with textboxes) may cause the UI visibility flags to be altered thus showing the navigaton bar and potentially the status bar
+            // This sets back the UI flags to hidden once the interaction with the on-screen keyboard has finished.
             Window.DecorView.SystemUiVisibilityChange += (_, e) =>
             {
                 if ((SystemUiFlags)e.Visibility != systemUiFlags)

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -42,6 +42,8 @@ namespace osu.Framework.Android
 
             SetContentView(gameView = new AndroidGameView(this, CreateGame()));
 
+            UIVisibilityFlags = SystemUiFlags.LayoutFlags | SystemUiFlags.ImmersiveSticky | SystemUiFlags.HideNavigation;
+
             //firing up the on-screen keyboard (eg: interacting with textboxes) may cause the UI visibility flags to be altered thus showing the navbar and potentially the status bar
             //this sets back the UI flags to hidden once the interaction with the on-screen keyboard is finished.
             Window.DecorView.SystemUiVisibilityChange += (_, e) =>

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -13,6 +13,15 @@ namespace osu.Framework.Android
     {
         protected abstract Game CreateGame();
 
+        /// <summary>
+        /// The visibility flags for the system UI (status and navigation bars)
+        /// </summary>
+        public SystemUiFlags UIVisibilityFlags
+        {
+            get => (SystemUiFlags)Window.DecorView.SystemUiVisibility;
+            set => Window.DecorView.SystemUiVisibility = (StatusBarVisibility)value;
+        }
+
         private AndroidGameView gameView;
 
         public override void OnTrimMemory([GeneratedEnum] TrimMemory level)


### PR DESCRIPTION
In a Xamarin Android App, the visibility of the status bar and the navigation bar can be changed by changing the value of `Window.DecorView.SystemUiVisibility` (see https://docs.microsoft.com/fr-fr/xamarin/android/user-interface/controls/navigation-bar).

# `UIVisibilityFlags` property

This PR introduces the `UIVisibilityFlags` property in `AndroidGameActivity` which allows setting the visibility of the status & navigation bar in the form of bitwise flags.

Firing up the on-screen keyboard may cause the UI visibility flags to be altered to show the navigation (and or the status bar) while interacting with keyboard. An event handler tracking UI visibility flags changes has been added to return UI visibility flags to their original value once interaction with keyboard is finished.