### PR TITLE
Fix visibility container potentially getting in wrong visual state

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
@@ -45,6 +45,28 @@ namespace osu.Framework.Tests.Visual.Containers
             AddAssert("fire count is 2", () => testContainer.FireCount == 2);
         }
 
+        [Test]
+        public void TestShowInCtor()
+        {
+            AddStep("create container", () =>
+            {
+                var container = new TestVisibilityContainer(null);
+                container.Show();
+
+                var containingContainer = new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = testContainer = container
+                };
+
+                containingContainer.OnLoadComplete += _ => testContainer.Hide();
+
+                Child = containingContainer;
+            });
+
+            checkHidden();
+        }
+
         [TestCase(true, true)]
         [TestCase(false, true)]
         [TestCase(true, false)]
@@ -127,11 +149,13 @@ namespace osu.Framework.Tests.Visual.Containers
 
         private class TestVisibilityContainer : VisibilityContainer
         {
-            protected override bool StartHidden { get; }
+            private readonly bool? startHidden;
 
-            public TestVisibilityContainer(bool startHidden = true, Color4? colour = null)
+            protected override bool StartHidden => startHidden ?? base.StartHidden;
+
+            public TestVisibilityContainer(bool? startHidden = true, Color4? colour = null)
             {
-                this.StartHidden = startHidden;
+                this.startHidden = startHidden;
 
                 Size = new Vector2(0.5f);
                 RelativeSizeAxes = Axes.Both;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
@@ -75,11 +75,13 @@ namespace osu.Framework.Tests.Visual.Containers
         {
             TestNestedVisibilityContainer visibility = null;
 
-            AddStep("create container", () => Child = testContainer =
-                visibility = new TestNestedVisibilityContainer(startHidden) { State = { Value = immediatelyVisible ? Visibility.Visible : Visibility.Hidden } });
+            AddStep("create container", () =>
+            {
+                Child = testContainer =
+                    visibility = new TestNestedVisibilityContainer(startHidden) { State = { Value = immediatelyVisible ? Visibility.Visible : Visibility.Hidden } };
 
-            if (!immediatelyVisible)
-                AddStep("show", () => testContainer.Show());
+                if (!immediatelyVisible) testContainer.Show();
+            });
 
             checkVisible(!startHidden);
 
@@ -107,7 +109,7 @@ namespace osu.Framework.Tests.Visual.Containers
             if (instant)
                 AddAssert("alpha one", () => testContainer.Alpha == 1);
             else
-                AddUntilStep("alpha one", () => testContainer.Alpha == 1);
+                AddUntilStep("wait alpha one", () => testContainer.Alpha == 1);
         }
 
         private class TestNestedVisibilityContainer : TestVisibilityContainer

--- a/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
@@ -46,6 +46,17 @@ namespace osu.Framework.Tests.Visual.Containers
         }
 
         [Test]
+        public void TestNotStartHiddenButHidden()
+        {
+            AddStep("create container", () => Child = testContainer =
+                new TestVisibilityContainer(false) { State = { Value = Visibility.Hidden } });
+
+            AddAssert("alpha above zero", () => testContainer.Alpha > 0);
+
+            checkHidden(false);
+        }
+
+        [Test]
         public void TestShowInCtor()
         {
             AddStep("create container", () =>

--- a/osu.Framework/Graphics/Containers/VisibilityContainer.cs
+++ b/osu.Framework/Graphics/Containers/VisibilityContainer.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public readonly Bindable<Visibility> State = new Bindable<Visibility>();
 
-        private Visibility valueAtAsyncLoad;
+        private bool didInitialHide;
 
         /// <summary>
         /// Whether we should be in a hidden state when first displayed.
@@ -33,14 +33,13 @@ namespace osu.Framework.Graphics.Containers
                 // do this without triggering the StateChanged event, since hidden is a default.
                 PopOut();
                 FinishTransforms(true);
+                didInitialHide = true;
             }
-
-            valueAtAsyncLoad = State.Value;
         }
 
         protected override void LoadComplete()
         {
-            State.BindValueChanged(UpdateState, State.Value != valueAtAsyncLoad);
+            State.BindValueChanged(UpdateState, State.Value == Visibility.Visible || !didInitialHide);
 
             base.LoadComplete();
         }

--- a/osu.Framework/Graphics/Containers/VisibilityContainer.cs
+++ b/osu.Framework/Graphics/Containers/VisibilityContainer.cs
@@ -15,6 +15,8 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public readonly Bindable<Visibility> State = new Bindable<Visibility>();
 
+        private Visibility valueAtAsyncLoad;
+
         /// <summary>
         /// Whether we should be in a hidden state when first displayed.
         /// Override this and set to true to *always* perform a <see cref="PopIn"/> animation even when the state is non-hidden at
@@ -32,11 +34,13 @@ namespace osu.Framework.Graphics.Containers
                 PopOut();
                 FinishTransforms(true);
             }
+
+            valueAtAsyncLoad = State.Value;
         }
 
         protected override void LoadComplete()
         {
-            State.BindValueChanged(UpdateState, State.Value != Visibility.Hidden);
+            State.BindValueChanged(UpdateState, State.Value != valueAtAsyncLoad);
 
             base.LoadComplete();
         }


### PR DESCRIPTION
If a `VisibiltyContainer` was visible at the point of checking `ShowHidden` (`LoadCompleteAsync`), but then changed to `Hidden` in a parent's `LoadComplete` method, the `UpdateState` call would not be fired and the initial display state would be incorrect.