### PR TITLE
Fix some children potentially not getting state updates due to incorrect iteration

### DIFF
--- a/osu.Framework.Tests/Containers/TestSceneContainerState.cs
+++ b/osu.Framework.Tests/Containers/TestSceneContainerState.cs
@@ -237,5 +237,40 @@ namespace osu.Framework.Tests.Containers
                 HasCleared = true;
             }
         }
+
+        [Test]
+        public void TestAliveChangesDuringExpiry()
+        {
+            TestContainer container = null;
+
+            int count = 0;
+
+            void checkCount() => count = container.AliveInternalChildren.Count;
+
+            AddStep("create container", () => Child = container = new TestContainer());
+
+            AddStep("perform test", () =>
+            {
+                container.Add(new Box());
+                container.Add(new Box());
+                container.ScheduleAfterChildren(checkCount);
+            });
+
+            AddAssert("correct count", () => count == 2);
+
+            AddStep("perform test", () =>
+            {
+                container.First().Expire();
+                container.Add(new Box());
+                container.ScheduleAfterChildren(checkCount);
+            });
+
+            AddAssert("correct count", () => count == 2);
+        }
+
+        private class TestContainer : Container
+        {
+            public new void ScheduleAfterChildren(Action action) => SchedulerAfterChildren.AddDelayed(action, TransformDelay);
+        }
     }
 }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -640,7 +640,7 @@ namespace osu.Framework.Graphics.Containers
             {
                 var state = checkChildLife(internalChildren[i]);
 
-                anyAliveChanged |= state.HasFlag(ChildLifeStateChange.MadeAlive | ChildLifeStateChange.MadeDead);
+                anyAliveChanged |= state.HasFlag(ChildLifeStateChange.MadeAlive) || state.HasFlag(ChildLifeStateChange.MadeDead);
 
                 if (state.HasFlag(ChildLifeStateChange.Removed))
                     i--;

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -636,13 +636,17 @@ namespace osu.Framework.Graphics.Containers
         {
             bool anyAliveChanged = false;
 
-            // checkChildLife may remove a child from internalChildren. In order to not skip children,
-            // we keep track of the original amount children to apply an offset to the iterator
-            int originalCount = internalChildren.Count;
             for (int i = 0; i < internalChildren.Count; i++)
-                anyAliveChanged |= checkChildLife(internalChildren[i + internalChildren.Count - originalCount]);
+            {
+                var state = checkChildLife(internalChildren[i]);
 
-            FrameStatistics.Add(StatisticsCounterType.CCL, originalCount);
+                anyAliveChanged |= state.HasFlag(ChildLifeStateChange.MadeAlive | ChildLifeStateChange.MadeDead);
+
+                if (state.HasFlag(ChildLifeStateChange.Removed))
+                    i--;
+            }
+
+            FrameStatistics.Add(StatisticsCounterType.CCL, internalChildren.Count);
 
             if (anyAliveChanged)
                 childrenSizeDependencies.Invalidate();
@@ -660,8 +664,10 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="child">The child to check.</param>
         /// <returns>Whether the child's alive state has changed.</returns>
-        private bool checkChildLife(Drawable child)
+        private ChildLifeStateChange checkChildLife(Drawable child)
         {
+            ChildLifeStateChange state = ChildLifeStateChange.None;
+
             if (child.ShouldBeAlive)
             {
                 if (!child.IsAlive)
@@ -671,11 +677,11 @@ namespace osu.Framework.Graphics.Containers
                         // If we're already loaded, we can eagerly allow children to be loaded
                         loadChild(child);
                         if (child.LoadState < LoadState.Ready)
-                            return false;
+                            return ChildLifeStateChange.None;
                     }
 
                     MakeChildAlive(child);
-                    return true;
+                    state = ChildLifeStateChange.MadeAlive;
                 }
             }
             else
@@ -683,16 +689,26 @@ namespace osu.Framework.Graphics.Containers
                 if (child.IsAlive)
                 {
                     MakeChildDead(child);
-                    return true;
+                    state |= ChildLifeStateChange.MadeDead;
                 }
 
                 if (child.RemoveWhenNotAlive)
                 {
                     removeChildByDeath(child);
+                    state |= ChildLifeStateChange.Removed;
                 }
             }
 
-            return false;
+            return state;
+        }
+
+        [Flags]
+        private enum ChildLifeStateChange
+        {
+            None = 0,
+            MadeAlive = 1,
+            MadeDead = 1 << 1,
+            Removed = 1 << 2,
         }
 
         /// <summary>


### PR DESCRIPTION
Previous code was incorrectly decrementing the count value in the `for` loop, meaning some children could not be updated in the immediate frame they are expected to be when other drawables are removed in the same frame.