### PR TITLE
Update Microsoft.Diagnostics.Runtime to latest official package

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.3.1" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="ppy.Microsoft.Diagnostics.Runtime" Version="0.9.180305.1" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.46104" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="ManagedBass" Version="2.0.4" />


### PR DESCRIPTION
Seems our package just changed `lib/net40` to `lib/netstandard2.0`; effectively a workaround for `NU1701`.
Now official package contains `netstandard2.0` target from 1.0.0. We can move to it.

The risk should be low. I don't think they would ever make breaking changes after the latest version of 0.x.