### PR TITLE
Fix thread culture setting tests

### DIFF
--- a/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
+++ b/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
@@ -50,7 +50,13 @@ namespace osu.Framework.Tests.Localisation
             assertThreadCulture("ko-KR");
         }
 
-        private void setCulture(string name) => AddStep($"set culture = {name}", () => config.Set(FrameworkSetting.Locale, name));
+        private void setCulture(string name) => AddStep($"set culture = {name}", () =>
+        {
+            var locale = config.GetBindable<string>(FrameworkSetting.Locale);
+            // force ValueChanged to trigger by calling SetValue explicitly instead of setting .Value
+            // this is done since the existing value might have been the same and TestScene.SetUpTestForUnit() might have overridden the culture silently
+            locale.SetValue(locale.Value, name);
+        });
 
         private void assertCulture(string name)
         {

--- a/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
+++ b/osu.Framework.Tests/Localisation/ThreadCultureTest.cs
@@ -1,8 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -60,7 +61,7 @@ namespace osu.Framework.Tests.Localisation
 
         private void assertCulture(string name)
         {
-            var cultures = new List<CultureInfo>();
+            var cultures = new ConcurrentBag<CultureInfo>();
 
             AddStep("query cultures", () =>
             {
@@ -70,7 +71,7 @@ namespace osu.Framework.Tests.Localisation
             });
 
             AddUntilStep("wait for query", () => cultures.Count == 3);
-            AddAssert($"culture is {name}", () => cultures.TrueForAll(c => c.Name == name));
+            AddAssert($"culture is {name}", () => cultures.All(c => c.Name == name));
         }
 
         private void assertThreadCulture(string name)


### PR DESCRIPTION
Fixes for issues spotted in tests added as part of #2895.

# Summary

This PR introduces two, partly orthogonal fixes for issues that could cause test failures for the thread culture setting functionality.

## Fix headless test host overwriting culture set in tests

A test failure was spotted while locally running tests added in #2895 for setting culture loaded from the framework config, pertaining specifically to the invariant culture test. The desired invariant culture was being silently overwritten with the system culture.

The cause of this scenario was detected to be related to the way headless tests are ran.

1. When `GameHost` starts, it loads in default settings, as specified by `GetFrameworkConfigDefaults()`, and merges them with framework settings read from the `framework.ini` file. The invariant culture is used as the default locale, so at this point the bindable associated with the locale setting has an empty string value.
2. In accordance with the `BindValueChanged` callback set in `GameHost`, all threads get their culture set to the invariant one.
3. When `ThreadCultureTest` is supposed to be run, `TestScene` performs setup logic to prepare the test for execution in `SetUpTestForNUnit()`. In particular, it uses the NUnit test execution context to set the culture of all running threads to what NUnit says. This silently overwrites changes made in step (2), without changing the locale bindable value.
4. In the `TestDefaultCultureIsInvariant` test itself, the locale setting is set to the empty string again. If the value was set to the default in step (1), this means that the `ValueChanged` delegate will not fire due to the values being equal, and therefore the thread culture will not be set to what the test specifies.

To fix the above scenario, force `setCulture()` to explicitly trigger change events after setting the locale in the test.

It's very possible this issue has not surfaced thus far due to test execution order - if another test ran before, it might have changed the locale setting value between steps (1) and (4), making the scenario not reproducible.

## Replace normal list with concurrent collection

A sporadic test failure has been revealed in a CI build for PR #2915. After inspecting the failing test the problem was determined to be caused by scheduled adds to a non-thread-safe `List<T>`, which caused waits for all three desired items to be added to it to time out. This race condition could be reproduced by repeating any test in `ThreadCultureTest` enough times.

Replace the `List<T>` with a `ConcurrentBag<T>` to prevent race conditions from occurring. The change was tested by repeating all tests in the `ThreadCultureTest` fixture 500 times - I could not reproduce the failure after introducing it.