### PR TITLE
Fix first drag event potentially not being triggered 

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneMouseStates.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneMouseStates.cs
@@ -110,6 +110,7 @@ namespace osu.Framework.Tests.Visual.Input
         private static readonly Type mouse_down = typeof(MouseDownEvent);
         private static readonly Type mouse_up = typeof(MouseUpEvent);
         private static readonly Type drag_start = typeof(DragStartEvent);
+        private static readonly Type drag = typeof(DragEvent);
         private static readonly Type drag_end = typeof(DragEndEvent);
         private static readonly Type click = typeof(ClickEvent);
         private static readonly Type double_click = typeof(DoubleClickEvent);
@@ -216,6 +217,12 @@ namespace osu.Framework.Tests.Visual.Input
 
             AddStep("move bottom left", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomLeft));
             checkEventCount(drag_start, 1);
+            checkEventCount(drag, 1);
+            checkIsDragged(true);
+
+            AddStep("move bottom right", () => InputManager.MoveMouseTo(marginBox.ScreenSpaceDrawQuad.BottomRight));
+            checkEventCount(drag_start, 0);
+            checkEventCount(drag, 1);
             checkIsDragged(true);
 
             AddStep("release left button", () => InputManager.ReleaseButton(MouseButton.Left));
@@ -384,7 +391,7 @@ namespace osu.Framework.Tests.Visual.Input
             else
             {
                 // those types are handled by state tracker 2
-                if (!new[] { drag_start, drag_end, click, double_click }.Contains(type))
+                if (!new[] { drag_start, drag, drag_end, click, double_click }.Contains(type))
                     count1 += change;
                 count2 += change;
             }
@@ -435,6 +442,7 @@ namespace osu.Framework.Tests.Visual.Input
                             addCounter(typeof(ScrollEvent)),
                             addCounter(typeof(MouseMoveEvent)),
                             addCounter(typeof(DragStartEvent)),
+                            addCounter(typeof(DragEvent)),
                             addCounter(typeof(DragEndEvent)),
                             addCounter(typeof(MouseDownEvent)),
                             addCounter(typeof(MouseUpEvent)),

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -111,10 +111,9 @@ namespace osu.Framework.Input
                     if (mouse.IsPressed(Button) && Vector2Extensions.Distance(MouseDownPosition ?? mouse.Position, mouse.Position) > ClickDragDistance)
                         HandleMouseDragStart(state);
                 }
-                else
-                {
+
+                if (DragStarted)
                     HandleMouseDrag(state, lastPosition);
-                }
             }
         }
 


### PR DESCRIPTION
Even if a movement frame has enough movement to also be considered for a valid drag, it would not be fired, only firing a DragStart.