### PR TITLE
Add DragBlocksClick and more correctly handle off-axis drags

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneClickLenience.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneClickLenience.cs
@@ -1,0 +1,169 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Graphics;
+using osuTK.Input;
+
+namespace osu.Framework.Tests.Visual.Input
+{
+    public class TestSceneClickLenience : ManualInputManagerTestScene
+    {
+        private ClickBox box;
+
+        private Drawable createClickBox(TestType type)
+        {
+            switch (type)
+            {
+                case TestType.NonBlockingScroll:
+                    return new NonBlockingScroll()
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = box = new ClickBox()
+                    };
+
+                case TestType.Scroll:
+                    return new BasicScrollContainer()
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Child = box = new ClickBox()
+                    };
+
+                default:
+                    return box = new ClickBox();
+            }
+        }
+
+        [TestCase(TestType.Direct)]
+        [TestCase(TestType.Scroll)]
+        [TestCase(TestType.NonBlockingScroll)]
+        public void TestBasicClick(TestType type)
+        {
+            AddStep("create button", () => Child = createClickBox(type));
+
+            AddStep("move to button", () => InputManager.MoveMouseTo(box));
+            AddStep("click", () => InputManager.Click(MouseButton.Left));
+
+            checkClicked(true);
+        }
+
+        [TestCase(TestType.Direct)]
+        [TestCase(TestType.Scroll)]
+        [TestCase(TestType.NonBlockingScroll)]
+        public void TestVerticalDragOnButton(TestType type)
+        {
+            AddStep("create button", () => Child = createClickBox(type));
+
+            AddStep("move to TopLeft", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).TopLeft));
+            AddStep("mouse down", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move to BottomLeft", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).BottomLeft));
+            AddStep("mouse up", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            checkClicked(type != TestType.Scroll);
+        }
+
+        [TestCase(TestType.Direct)]
+        [TestCase(TestType.Scroll)]
+        [TestCase(TestType.NonBlockingScroll)]
+        public void TestHorizontalDragOnButton(TestType type)
+        {
+            AddStep("create button", () => Child = createClickBox(type));
+
+            AddStep("move to TopLeft", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).TopLeft));
+            AddStep("mouse down", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move to TopRight", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).TopRight + new Vector2(0, 5)));
+            AddStep("mouse up", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            checkClicked(true);
+        }
+
+        [TestCase(TestType.Direct)]
+        [TestCase(TestType.Scroll)]
+        [TestCase(TestType.NonBlockingScroll)]
+        public void TestDiagonalDragOnButton(TestType type)
+        {
+            AddStep("create button", () => Child = createClickBox(type));
+
+            AddStep("move to TopLeft", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).TopLeft));
+            AddStep("mouse down", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move to BottomRight", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).BottomRight));
+            AddStep("mouse up", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            checkClicked(type != TestType.Scroll);
+        }
+
+        [TestCase(TestType.Direct)]
+        [TestCase(TestType.Scroll)]
+        [TestCase(TestType.NonBlockingScroll)]
+        public void TestHorizontalDragOut(TestType type)
+        {
+            AddStep("create button", () => Child = createClickBox(type));
+
+            AddStep("move to TopLeft", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).TopLeft));
+            AddStep("mouse down", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move out", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.TopLeft - new Vector2(10, 0)));
+            AddStep("mouse up", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            checkClicked(false);
+        }
+
+        [TestCase(TestType.Direct)]
+        [TestCase(TestType.Scroll)]
+        [TestCase(TestType.NonBlockingScroll)]
+        public void TestHorizontalDragOutIn(TestType type)
+        {
+            AddStep("create button", () => Child = createClickBox(type));
+
+            AddStep("move to TopLeft", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).TopLeft));
+            AddStep("mouse down", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("move out", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.TopLeft - new Vector2(10, 0)));
+            AddStep("move back in", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).TopLeft));
+            AddStep("mouse up", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            checkClicked(true);
+        }
+
+        private void checkClicked(bool clicked) => AddAssert($"button {(clicked ? "clicked" : "not clicked")}", () => box.Clicked == clicked);
+
+        public class ClickBox : BasicButton
+        {
+            public bool Clicked;
+
+            public ClickBox()
+            {
+                Text = "Click me!";
+
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+
+                Action = () =>
+                {
+                    Clicked = true;
+                    Text = "Ouch!";
+                    this.ScaleTo(0.95f).Then().ScaleTo(1, 1000, Easing.In);
+                    this.FlashColour(Color4.Red, 1000, Easing.InQuint);
+                };
+
+                RelativeSizeAxes = Axes.X;
+                Height = 100;
+            }
+        }
+
+        public class NonBlockingScroll : BasicScrollContainer
+        {
+            public override bool DragBlocksClick => false;
+        }
+
+        public enum TestType
+        {
+            Direct,
+            Scroll,
+            NonBlockingScroll
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Input/TestSceneClickLenience.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneClickLenience.cs
@@ -21,14 +21,14 @@ namespace osu.Framework.Tests.Visual.Input
             switch (type)
             {
                 case TestType.NonBlockingScroll:
-                    return new NonBlockingScroll()
+                    return new NonBlockingScroll
                     {
                         RelativeSizeAxes = Axes.Both,
                         Child = box = new ClickBox()
                     };
 
                 case TestType.Scroll:
-                    return new BasicScrollContainer()
+                    return new BasicScrollContainer
                     {
                         RelativeSizeAxes = Axes.Both,
                         Child = box = new ClickBox()

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -34,6 +34,8 @@ namespace osu.Framework.Graphics.Containers
             return base.BuildNonPositionalInputQueue(queue, allowBlocking);
         }
 
+        public override bool DragBlocksClick => false;
+
         protected override bool Handle(UIEvent e)
         {
             switch (e)

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -237,6 +237,9 @@ namespace osu.Framework.Graphics.Containers
             averageDragDelta = averageDragTime = 0;
 
             IsDragging = true;
+
+            dragButtonManager = GetContainingInputManager().GetButtonEventManagerFor(e.Button);
+
             return true;
         }
 
@@ -281,6 +284,8 @@ namespace osu.Framework.Graphics.Containers
         private double averageDragTime;
         private double averageDragDelta;
 
+        private MouseButtonEventManager dragButtonManager;
+
         private bool dragBlocksClick;
 
         public override bool DragBlocksClick => dragBlocksClick;
@@ -309,12 +314,10 @@ namespace osu.Framework.Graphics.Containers
             // such that the user can feel it.
             scrollOffset = clampedScrollOffset + (scrollOffset - clampedScrollOffset) / 2;
 
-            var manager = GetContainingInputManager().GetButtonEventManagerFor(e.Button);
-
             // similar calculation to what is already done in MouseButtonEventManager.HandlePositionChange
             // handles the case where a drag was triggered on an axis we are not interested in.
             // can be removed if/when drag events are split out per axis or contain direction information.
-            dragBlocksClick |= Math.Abs(e.MouseDownPosition[ScrollDim] - e.MousePosition[ScrollDim]) > manager.ClickDragDistance;
+            dragBlocksClick |= Math.Abs(e.MouseDownPosition[ScrollDim] - e.MousePosition[ScrollDim]) > dragButtonManager.ClickDragDistance;
 
             offset(scrollOffset, false);
             return true;
@@ -325,6 +328,7 @@ namespace osu.Framework.Graphics.Containers
             Trace.Assert(IsDragging, "We should never receive OnDragEnd if we are not dragging.");
 
             dragBlocksClick = false;
+            dragButtonManager = null;
             IsDragging = false;
 
             if (averageDragTime <= 0.0)

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -281,6 +281,10 @@ namespace osu.Framework.Graphics.Containers
         private double averageDragTime;
         private double averageDragDelta;
 
+        private bool dragBlocksClick;
+
+        public override bool DragBlocksClick => dragBlocksClick;
+
         protected override bool OnDrag(DragEvent e)
         {
             Trace.Assert(IsDragging, "We should never receive OnDrag if we are not dragging.");
@@ -305,6 +309,13 @@ namespace osu.Framework.Graphics.Containers
             // such that the user can feel it.
             scrollOffset = clampedScrollOffset + (scrollOffset - clampedScrollOffset) / 2;
 
+            var manager = GetContainingInputManager().GetButtonEventManagerFor(e.Button);
+
+            // similar calculation to what is already done in MouseButtonEventManager.HandlePositionChange
+            // handles the case where a drag was triggered on an axis we are not interested in.
+            // can be removed if/when drag events are split out per axis or contain direction information.
+            dragBlocksClick |= Math.Abs(e.MouseDownPosition[ScrollDim] - e.MousePosition[ScrollDim]) > manager.ClickDragDistance;
+
             offset(scrollOffset, false);
             return true;
         }
@@ -313,6 +324,7 @@ namespace osu.Framework.Graphics.Containers
         {
             Trace.Assert(IsDragging, "We should never receive OnDragEnd if we are not dragging.");
 
+            dragBlocksClick = false;
             IsDragging = false;
 
             if (averageDragTime <= 0.0)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2174,6 +2174,14 @@ namespace osu.Framework.Graphics
         public virtual bool PropagatePositionalInputSubTree => IsPresent && RequestsPositionalInputSubTree && !IsMaskedAway;
 
         /// <summary>
+        /// Whether clicks should be blocked when this drawable is in a dragged state.
+        /// </summary>
+        /// <remarks>
+        /// This is queried when a click is to be actuated.
+        /// </remarks>
+        public virtual bool DragBlocksClick => true;
+
+        /// <summary>
         /// This method is responsible for building a queue of Drawables to receive non-positional input in reverse order.
         /// </summary>
         /// <param name="queue">The input queue to be built.</param>

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -157,6 +157,14 @@ namespace osu.Framework.Input
         }
 
         /// <summary>
+        /// Get the <see cref="MouseButtonEventManager"/> responsible for a specified mouse button.
+        /// </summary>
+        /// <param name="button">The button find the manager for.</param>
+        /// <returns>The <see cref="MouseButtonEventManager"/>.</returns>
+        public MouseButtonEventManager GetButtonEventManagerFor(MouseButton button) =>
+            mouseButtonEventManagers.TryGetValue(button, out var manager) ? manager : null;
+
+        /// <summary>
         /// Reset current focused drawable to the top-most drawable which is <see cref="Drawable.RequestsFocus"/>.
         /// </summary>
         /// <param name="triggerSource">The source which triggered this event.</param>

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -144,7 +144,7 @@ namespace osu.Framework.Input
             {
                 HandleMouseUp(state);
 
-                if (EnableClick && DraggedDrawable == null)
+                if (EnableClick && DraggedDrawable?.DragBlocksClick != true)
                 {
                     if (!BlockNextClick)
                     {


### PR DESCRIPTION
Changes `ScrollContainer` to no longer block clicks from contained items when a drag is only activated in the incorrect axis.

Also exposes `DragBlocksClick` to allow elements to avoid blocking clicks during a drag (used by `OverlayContainer`).

- [x] Depends on https://github.com/ppy/osu-framework/pull/2958 for test passing.