### PR TITLE
Fix negative frame time on frame time display

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -182,7 +182,7 @@ namespace osu.Framework.Graphics.Performance
                                     new TimeBar(),
                                 },
                             },
-                            frameTimeDisplay = new FrameTimeDisplay(monitor.Clock)
+                            frameTimeDisplay = new FrameTimeDisplay(monitor.Clock, monitor.Thread)
                             {
                                 Anchor = Anchor.BottomRight,
                                 Origin = Anchor.BottomRight,

--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.MathUtils;
+using osu.Framework.Threading;
 using osu.Framework.Timing;
 using osuTK;
 
@@ -17,12 +18,14 @@ namespace osu.Framework.Graphics.Performance
         private readonly SpriteText counter;
 
         private readonly ThrottledFrameClock clock;
+        private readonly GameThread thread;
 
         public bool Counting = true;
 
-        public FrameTimeDisplay(ThrottledFrameClock clock)
+        public FrameTimeDisplay(ThrottledFrameClock clock, GameThread thread)
         {
             this.clock = clock;
+            this.thread = thread;
 
             Masking = true;
             CornerRadius = 5;
@@ -57,33 +60,39 @@ namespace osu.Framework.Graphics.Performance
 
             double lastUpdate = 0;
 
-            Scheduler.AddDelayed(() =>
+            thread.Scheduler.AddDelayed(() =>
                 {
                     if (!Counting) return;
 
-                    if (!Precision.AlmostEquals(counter.DrawWidth, aimWidth))
+                    double clockFps = clock.FramesPerSecond;
+                    double actualElapsed = clock.ElapsedFrameTime - clock.SleptTime;
+                    double updateHz = clock.MaximumUpdateHz;
+
+                    Schedule(() =>
                     {
-                        ClearTransforms();
+                        if (!Precision.AlmostEquals(counter.DrawWidth, aimWidth))
+                        {
+                            ClearTransforms();
 
-                        if (aimWidth == 0)
-                            Size = counter.DrawSize;
-                        else if (Precision.AlmostBigger(counter.DrawWidth, aimWidth))
-                            this.ResizeTo(counter.DrawSize, 200, Easing.InOutSine);
-                        else
-                            this.Delay(1500).ResizeTo(counter.DrawSize, 500, Easing.InOutSine);
+                            if (aimWidth == 0)
+                                Size = counter.DrawSize;
+                            else if (Precision.AlmostBigger(counter.DrawWidth, aimWidth))
+                                this.ResizeTo(counter.DrawSize, 200, Easing.InOutSine);
+                            else
+                                this.Delay(1500).ResizeTo(counter.DrawSize, 500, Easing.InOutSine);
 
-                        aimWidth = counter.DrawWidth;
-                    }
+                            aimWidth = counter.DrawWidth;
+                        }
 
-                    double dampRate = Math.Max(Clock.CurrentTime - lastUpdate, 0) / 1000;
+                        double dampRate = Math.Max(Clock.CurrentTime - lastUpdate, 0) / 1000;
+                        lastUpdate = Clock.CurrentTime;
 
-                    displayFps = Interpolation.Damp(displayFps, clock.FramesPerSecond, 0.01, dampRate);
-                    displayFrameTime = Interpolation.Damp(displayFrameTime, clock.ElapsedFrameTime - clock.SleptTime, 0.01, dampRate);
+                        displayFps = Interpolation.Damp(displayFps, clockFps, 0.01, dampRate);
+                        displayFrameTime = Interpolation.Damp(displayFrameTime, actualElapsed, 0.01, dampRate);
 
-                    lastUpdate = clock.CurrentTime;
-
-                    counter.Text = $"{displayFps:0}fps({displayFrameTime:0.00}ms)"
-                                   + $"{(clock.MaximumUpdateHz < 10000 ? clock.MaximumUpdateHz.ToString("0") : "∞").PadLeft(4)}hz";
+                        counter.Text = $"{displayFps:0}fps({displayFrameTime:0.00}ms)"
+                                       + $"{(updateHz < 10000 ? updateHz.ToString("0") : "∞").PadLeft(4)}hz";
+                    });
                 }, 1000.0 / updates_per_second, true);
         }
 

--- a/osu.Framework/Statistics/PerformanceMonitor.cs
+++ b/osu.Framework/Statistics/PerformanceMonitor.cs
@@ -7,7 +7,7 @@ using osu.Framework.Timing;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Threading;
+using osu.Framework.Threading;
 
 namespace osu.Framework.Statistics
 {
@@ -38,15 +38,16 @@ namespace osu.Framework.Statistics
 
         private double consumptionTime;
 
-        internal ThrottledFrameClock Clock;
-        private readonly Thread thread;
+        internal readonly ThrottledFrameClock Clock;
+
+        internal readonly GameThread Thread;
 
         public double FrameAimTime => 1000.0 / (Clock?.MaximumUpdateHz ?? double.MaxValue);
 
-        internal PerformanceMonitor(ThrottledFrameClock clock, Thread thread, IEnumerable<StatisticsCounterType> counters)
+        internal PerformanceMonitor(GameThread thread, IEnumerable<StatisticsCounterType> counters)
         {
-            Clock = clock;
-            this.thread = thread;
+            Clock = thread.Clock;
+            Thread = thread;
             currentFrame = FramesHeap.ReserveObject();
 
             foreach (var c in counters)
@@ -58,7 +59,7 @@ namespace osu.Framework.Statistics
                 endCollectionDelegates[i] = new InvokeOnDisposal(() => endCollecting(t));
             }
 
-            traceCollector = new BackgroundStackTraceCollector(thread, ourClock);
+            traceCollector = new BackgroundStackTraceCollector(thread.Thread, ourClock);
         }
 
         /// <summary>
@@ -111,7 +112,7 @@ namespace osu.Framework.Statistics
                     var type = (StatisticsCounterType)i;
 
                     if (!globalStatistics.TryGetValue(type, out var global))
-                        globalStatistics[type] = global = GlobalStatistics.Get<long>(thread.Name, type.ToString());
+                        globalStatistics[type] = global = GlobalStatistics.Get<long>(Thread.Name, type.ToString());
 
                     global.Value = count;
                     currentFrame.Counts[type] = count;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -82,7 +82,7 @@ namespace osu.Framework.Threading
             Name = name;
             Clock = new ThrottledFrameClock();
             if (monitorPerformance)
-                Monitor = new PerformanceMonitor(Clock, Thread, StatisticsCounters);
+                Monitor = new PerformanceMonitor(this, StatisticsCounters);
             Scheduler = new Scheduler(null, Clock);
 
             IsActive.BindValueChanged(_ => updateMaximumHz(), true);


### PR DESCRIPTION
Fixes #696.

The true issue here was cross-threaded access of `TimeSlept` and `ElapsedFrameTime`, which are updated on a different thread for all but the `Update` display.