### PR TITLE
Use pattern matching for nullable value types

### DIFF
--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -2,3 +2,4 @@ M:System.Object.Equals(System.Object,System.Object)~System.Boolean;Don't use obj
 M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Use IEquatable<T> or EqualityComparer<T>.Default instead.
 M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
+P:System.Nullable`1.Value;Don't use T?.Value. Use pattern matching or GetValueOrDefault instead.

--- a/BannedSymbols.txt
+++ b/BannedSymbols.txt
@@ -3,3 +3,4 @@ M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Us
 M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
 P:System.Nullable`1.Value;Don't use T?.Value. Use pattern matching or GetValueOrDefault instead.
+P:System.Nullable`1.HasValue;Don't use T?.HasValue. Compare to null instead.

--- a/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDoubleTest.cs
@@ -36,8 +36,8 @@ namespace osu.Framework.Tests.Bindables
         public void TestDefaultCheck(double value, double def, double? precision = null)
         {
             var bindable = new BindableDouble { Value = def, Default = def };
-            if (precision.HasValue)
-                bindable.Precision = precision.Value;
+            if (precision is double p)
+                bindable.Precision = p;
 
             Assert.IsTrue(bindable.IsDefault);
 

--- a/osu.Framework.Tests/Bindables/BindableFloatTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableFloatTest.cs
@@ -36,8 +36,8 @@ namespace osu.Framework.Tests.Bindables
         public void TestDefaultCheck(float value, float def, float? precision = null)
         {
             var bindable = new BindableFloat { Value = def, Default = def };
-            if (precision.HasValue)
-                bindable.Precision = precision.Value;
+            if (precision is float p)
+                bindable.Precision = p;
 
             Assert.IsTrue(bindable.IsDefault);
 

--- a/osu.Framework.Tests/Bindables/BindableLeasingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableLeasingTest.cs
@@ -185,7 +185,7 @@ namespace osu.Framework.Tests.Bindables
 
             // regardless of revert specification, disabled should always be reverted to the original value.
             Assert.IsTrue(original.Disabled);
-            Assert.IsFalse(changedState.HasValue);
+            Assert.IsNull(changedState);
         }
 
         [Test]

--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -913,11 +913,7 @@ namespace osu.Framework.Tests.Bindables
 
             bindableStringList.Disabled = true;
 
-            Assert.Multiple(() =>
-            {
-                Assert.IsNotNull(isDisabled);
-                Assert.IsTrue(isDisabled.Value);
-            });
+            Assert.IsTrue(isDisabled);
         }
 
         [Test]
@@ -934,12 +930,9 @@ namespace osu.Framework.Tests.Bindables
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotNull(isDisabledA);
-                Assert.IsTrue(isDisabledA.Value);
-                Assert.IsNotNull(isDisabledB);
-                Assert.IsTrue(isDisabledB.Value);
-                Assert.IsNotNull(isDisabledC);
-                Assert.IsTrue(isDisabledC.Value);
+                Assert.IsTrue(isDisabledA);
+                Assert.IsTrue(isDisabledB);
+                Assert.IsTrue(isDisabledC);
             });
         }
 

--- a/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
@@ -194,8 +194,8 @@ namespace osu.Framework.Tests.Clocks
                 decoupleable.ProcessFrame();
                 Assert.AreEqual(0, source.CurrentTime);
 
-                if (last.HasValue)
-                    Assert.GreaterOrEqual(decoupleable.CurrentTime, last);
+                if (last is double lastValue)
+                    Assert.GreaterOrEqual(decoupleable.CurrentTime, lastValue);
 
                 last = decoupleable.CurrentTime;
             }

--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
@@ -260,8 +260,8 @@ namespace osu.Framework.Tests.Visual.Containers
 
         private void scrollIntoView(int index, float expectedPosition, float? heightAdjust = null, float? expectedPostAdjustPosition = null)
         {
-            if (heightAdjust != null)
-                AddStep("set container height zero", () => scrollContainer.Height = heightAdjust.Value);
+            if (heightAdjust is float h)
+                AddStep("set container height zero", () => scrollContainer.Height = h);
 
             AddStep($"scroll {index} into view", () => scrollContainer.ScrollIntoView(fill.Skip(index).First()));
             AddUntilStep($"{index} is visible", () => !fill.Skip(index).First().IsMaskedAway);
@@ -272,7 +272,7 @@ namespace osu.Framework.Tests.Visual.Containers
                 Debug.Assert(expectedPostAdjustPosition != null, nameof(expectedPostAdjustPosition) + " != null");
 
                 AddStep("restore height", () => scrollContainer.Height = 100);
-                checkPosition(expectedPostAdjustPosition.Value);
+                checkPosition(expectedPostAdjustPosition.GetValueOrDefault());
             }
         }
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneBorderSmoothing.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneBorderSmoothing.cs
@@ -108,7 +108,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                     RelativeSizeAxes = Axes.Both,
                     Child = new Box
                     {
-                        Alpha = OverlayColour.HasValue ? 1 : 0,
+                        Alpha = OverlayColour is null ? 0 : 1,
                         RelativeSizeAxes = Axes.Both,
                         Colour = OverlayColour ?? Color4.Transparent,
                     }

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -6,10 +6,14 @@
   <PropertyGroup>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
+  <ItemGroup Label="Code Analysis">
+    <AdditionalFiles Include="..\BannedSymbols.txt" />
+  </ItemGroup>
   <ItemGroup Label="Project References">
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup Label="Package References">
+    <PackageReference Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="2.9.7" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -55,9 +55,9 @@ namespace osu.Framework.Configuration
             }
 
             bindable.Default = value;
-            if (min.HasValue) bindable.MinValue = min.Value;
-            if (max.HasValue) bindable.MaxValue = max.Value;
-            if (precision.HasValue) bindable.Precision = precision.Value;
+            if (min is double minValue) bindable.MinValue = minValue;
+            if (max is double maxValue) bindable.MaxValue = maxValue;
+            if (precision is double precisionValue) bindable.Precision = precisionValue;
 
             return bindable;
         }
@@ -77,9 +77,9 @@ namespace osu.Framework.Configuration
             }
 
             bindable.Default = value;
-            if (min.HasValue) bindable.MinValue = min.Value;
-            if (max.HasValue) bindable.MaxValue = max.Value;
-            if (precision.HasValue) bindable.Precision = precision.Value;
+            if (min is float minValue) bindable.MinValue = minValue;
+            if (max is float maxValue) bindable.MaxValue = maxValue;
+            if (precision is float precisionValue) bindable.Precision = precisionValue;
 
             return bindable;
         }
@@ -99,8 +99,8 @@ namespace osu.Framework.Configuration
             }
 
             bindable.Default = value;
-            if (min.HasValue) bindable.MinValue = min.Value;
-            if (max.HasValue) bindable.MaxValue = max.Value;
+            if (min is int minValue) bindable.MinValue = minValue;
+            if (max is int maxValue) bindable.MaxValue = maxValue;
 
             return bindable;
         }
@@ -139,8 +139,8 @@ namespace osu.Framework.Configuration
             }
 
             bindable.Default = value;
-            if (min.HasValue) bindable.MinValue = min.Value;
-            if (max.HasValue) bindable.MaxValue = max.Value;
+            if (min is Size minValue) bindable.MinValue = minValue;
+            if (max is Size maxValue) bindable.MaxValue = maxValue;
 
             return bindable;
         }

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Cursor
             // required due to IRequireHighFrequencyMousePosition firing with the last known position even when the source is not in a
             // valid state (ie. receiving updates from user or otherwise). in this case, we generally want the cursor to remain at its
             // last *relative* position.
-            if (lastPosition.HasValue && Precision.AlmostEquals(e.ScreenSpaceMousePosition, lastPosition.Value))
+            if (lastPosition is Vector2 position && Precision.AlmostEquals(e.ScreenSpaceMousePosition, position))
                 return false;
 
             lastPosition = e.ScreenSpaceMousePosition;

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -327,14 +327,14 @@ namespace osu.Framework.Graphics.OpenGL
 
             if (blendingParameters.IsDisabled)
             {
-                if (!lastBlendingEnabledState.HasValue || lastBlendingEnabledState.Value)
+                if (lastBlendingEnabledState != false)
                     GL.Disable(EnableCap.Blend);
 
                 lastBlendingEnabledState = false;
             }
             else
             {
-                if (!lastBlendingEnabledState.HasValue || !lastBlendingEnabledState.Value)
+                if (lastBlendingEnabledState != true)
                     GL.Enable(EnableCap.Blend);
 
                 lastBlendingEnabledState = true;
@@ -697,9 +697,9 @@ namespace osu.Framework.Graphics.OpenGL
         {
             ThreadSafety.EnsureDrawThread();
 
-            if (shader != null)
+            if (shader is int sh)
             {
-                shader_stack.Push(shader.Value);
+                shader_stack.Push(sh);
             }
             else
             {

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -157,9 +157,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         public override RectangleF GetTextureRect(RectangleF? textureRect)
         {
-            RectangleF texRect = textureRect != null
-                ? new RectangleF(textureRect.Value.X, textureRect.Value.Y, textureRect.Value.Width, textureRect.Value.Height)
-                : new RectangleF(0, 0, Width, Height);
+            RectangleF texRect = textureRect ?? new RectangleF(0, 0, Width, Height);
 
             texRect.X /= width;
             texRect.Y /= height;
@@ -178,7 +176,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 throw new ObjectDisposedException(ToString(), "Can not draw a triangle with a disposed texture.");
 
             RectangleF texRect = GetTextureRect(textureRect);
-            Vector2 inflationAmount = inflationPercentage.HasValue ? new Vector2(inflationPercentage.Value.X * texRect.Width, inflationPercentage.Value.Y * texRect.Height) : Vector2.Zero;
+            Vector2 inflationAmount = inflationPercentage is Vector2 inflation ? new Vector2(inflation.X * texRect.Width, inflation.Y * texRect.Height) : Vector2.Zero;
             RectangleF inflatedTexRect = texRect.Inflate(inflationAmount);
 
             if (vertexAction == null)
@@ -236,7 +234,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 throw new ObjectDisposedException(ToString(), "Can not draw a quad with a disposed texture.");
 
             RectangleF texRect = GetTextureRect(textureRect);
-            Vector2 inflationAmount = inflationPercentage.HasValue ? new Vector2(inflationPercentage.Value.X * texRect.Width, inflationPercentage.Value.Y * texRect.Height) : Vector2.Zero;
+            Vector2 inflationAmount = inflationPercentage is Vector2 inflation ? new Vector2(inflation.X * texRect.Width, inflation.Y * texRect.Height) : Vector2.Zero;
             RectangleF inflatedTexRect = texRect.Inflate(inflationAmount);
             Vector2 blendRange = blendRangeOverride ?? inflationAmount;
 

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
@@ -48,9 +48,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         {
             RectangleF actualBounds = bounds;
 
-            if (textureRect.HasValue)
+            if (textureRect is RectangleF localBounds)
             {
-                RectangleF localBounds = textureRect.Value;
                 actualBounds.X += localBounds.X;
                 actualBounds.Y += localBounds.Y;
                 actualBounds.Width = Math.Min(localBounds.Width, bounds.Width);

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -463,18 +463,25 @@ namespace osu.Framework.Graphics.Performance
         private int addArea(FrameStatistics frame, PerformanceCollectionType? frameTimeType, int currentHeight, Span<Rgba32> image, int amountSteps)
         {
             int drawHeight;
+            Color4 col;
 
-            if (!frameTimeType.HasValue)
-                drawHeight = currentHeight;
-            else if (frame.CollectedTimes.TryGetValue(frameTimeType.Value, out double elapsedMilliseconds))
+            if (frameTimeType is PerformanceCollectionType collectionType)
             {
-                legendMapping[(int)frameTimeType].Alpha = 1;
-                drawHeight = (int)(elapsedMilliseconds * scale);
+                if (frame.CollectedTimes.TryGetValue(collectionType, out double elapsedMilliseconds))
+                {
+                    legendMapping[(int)frameTimeType].Alpha = 1;
+                    drawHeight = (int)(elapsedMilliseconds * scale);
+                }
+                else
+                    return currentHeight;
+
+                col = getColour(collectionType);
             }
             else
-                return currentHeight;
-
-            Color4 col = frameTimeType.HasValue ? getColour(frameTimeType.Value) : new Color4(0.1f, 0.1f, 0.1f, 1);
+            {
+                drawHeight = currentHeight;
+                col = new Color4(0.1f, 0.1f, 0.1f, 1);
+            }
 
             for (int i = currentHeight - 1; i >= 0; --i)
             {
@@ -484,7 +491,7 @@ namespace osu.Framework.Graphics.Performance
 
                 float brightnessAdjust = 1;
 
-                if (!frameTimeType.HasValue)
+                if (frameTimeType is null)
                 {
                     int step = amountSteps / HEIGHT;
                     brightnessAdjust *= 1 - i * step / 8f;

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -612,9 +612,8 @@ namespace osu.Framework.Graphics.Sprites
         {
             get
             {
-                var baseHeight = store.GetBaseHeight(Font.FontName);
-                if (baseHeight.HasValue)
-                    return baseHeight.Value * Font.Size;
+                if (store.GetBaseHeight(Font.FontName) is float baseHeight)
+                    return baseHeight * Font.Size;
 
                 if (string.IsNullOrEmpty(displayedText))
                     return 0;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -276,22 +276,22 @@ namespace osu.Framework.Graphics.UserInterface
                     break;
             }
 
-            if (amount.HasValue)
+            if (amount is int a)
             {
                 switch (action.ActionMethod)
                 {
                     case PlatformActionMethod.Move:
                         resetSelection();
-                        moveSelection(amount.Value, false);
+                        moveSelection(a, false);
                         break;
 
                     case PlatformActionMethod.Select:
-                        moveSelection(amount.Value, true);
+                        moveSelection(a, true);
                         break;
 
                     case PlatformActionMethod.Delete:
                         if (selectionLength == 0)
-                            selectionEnd = MathHelper.Clamp(selectionStart + amount.Value, 0, text.Length);
+                            selectionEnd = MathHelper.Clamp(selectionStart + a, 0, text.Length);
                         if (selectionLength > 0)
                             removeCharacterOrSelection();
                         break;

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -383,7 +383,7 @@ namespace osu.Framework.Graphics.Video
                                 {
                                     var frameTime = (frame->best_effort_timestamp - stream->start_time) * timeBaseInSeconds * 1000;
 
-                                    if (!skipOutputUntilTime.HasValue || skipOutputUntilTime.Value < frameTime)
+                                    if (!(skipOutputUntilTime >= frameTime)) // < > <= >= are always false with nulls
                                     {
                                         skipOutputUntilTime = null;
 

--- a/osu.Framework/Graphics/Video/VideoSprite.cs
+++ b/osu.Framework/Graphics/Video/VideoSprite.cs
@@ -58,12 +58,12 @@ namespace osu.Framework.Graphics.Video
         {
             get
             {
-                if (!startTime.HasValue)
+                if (!(startTime is double t))
                     return 0;
 
-                if (Loop) return (Clock.CurrentTime - startTime.Value) % Duration;
+                if (Loop) return (Clock.CurrentTime - t) % Duration;
 
-                return Math.Min(Clock.CurrentTime - startTime.Value, Duration);
+                return Math.Min(Clock.CurrentTime - t, Duration);
             }
         }
 

--- a/osu.Framework/Graphics/Video/VideoSprite.cs
+++ b/osu.Framework/Graphics/Video/VideoSprite.cs
@@ -126,9 +126,7 @@ namespace osu.Framework.Graphics.Video
         {
             base.Update();
 
-            if (!startTime.HasValue)
-                startTime = Clock.CurrentTime;
-
+            startTime = startTime ?? Clock.CurrentTime;
             var nextFrame = availableFrames.Count > 0 ? availableFrames.Peek() : null;
 
             if (nextFrame != null)

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -179,9 +179,8 @@ namespace osu.Framework.IO.Stores
         {
             foreach (var store in glyphStores)
             {
-                var bh = store.GetBaseHeight(fontName);
-                if (bh.HasValue)
-                    return bh.Value / ScaleAdjust;
+                if (store.GetBaseHeight(fontName) is int baseHeight)
+                    return baseHeight / ScaleAdjust;
             }
 
             foreach (var store in nestedFontStores)

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -167,8 +167,7 @@ namespace osu.Framework.IO.Stores
 
             foreach (var store in nestedFontStores)
             {
-                var height = store.GetBaseHeight(c);
-                if (height.HasValue)
+                if (store.GetBaseHeight(c) is float height)
                     return height;
             }
 
@@ -185,8 +184,7 @@ namespace osu.Framework.IO.Stores
 
             foreach (var store in nestedFontStores)
             {
-                var height = store.GetBaseHeight(fontName);
-                if (height.HasValue)
+                if (store.GetBaseHeight(fontName) is float height)
                     return height;
             }
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -353,8 +353,8 @@ namespace osu.Framework.Input.Bindings
                     keys.Add(FromMouseButton(button));
             }
 
-            if (scrollDelta.HasValue && scrollDelta.Value.Y != 0)
-                keys.Add(FromScrollDelta(scrollDelta.Value));
+            if (scrollDelta is Vector2 v && v.Y != 0)
+                keys.Add(FromScrollDelta(v));
 
             if (state.Keyboard != null)
             {

--- a/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Input.Handlers.Joystick
 
                         foreach (var device in devices)
                         {
-                            if ((device.LastRawState.HasValue && device.RawState.Equals(device.LastRawState.Value))
+                            if ((device.LastRawState is osuTK.Input.JoystickState rawState && device.RawState.Equals(rawState))
                                 || !device.RawState.IsConnected)
                                 continue;
 

--- a/osu.Framework/Input/InputResampler.cs
+++ b/osu.Framework/Input/InputResampler.cs
@@ -49,18 +49,18 @@ namespace osu.Framework.Input
                     isRawInput = true;
             }
 
-            if (lastRelevantPosition == null || lastActualPosition == null)
+            if (!(lastRelevantPosition is Vector2 relevant) || !(lastActualPosition is Vector2 actual))
             {
                 lastRelevantPosition = position;
                 lastActualPosition = position;
                 return new[] { position };
             }
 
-            Vector2 diff = position - lastRelevantPosition.Value;
+            Vector2 diff = position - relevant;
             float distance = diff.Length;
             Vector2 direction = diff / distance;
 
-            Vector2 realDiff = position - lastActualPosition.Value;
+            Vector2 realDiff = position - actual;
             float realMovementDistance = realDiff.Length;
             if (realMovementDistance < 1)
                 return Array.Empty<Vector2>();

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -191,8 +191,8 @@ namespace osu.Framework.Logging
         {
             try
             {
-                if (target.HasValue)
-                    GetLogger(target.Value).Add(message, level, exception, outputToListeners);
+                if (target is LoggingTarget t)
+                    GetLogger(t).Add(message, level, exception, outputToListeners);
                 else
                     GetLogger(loggerName).Add(message, level, exception, outputToListeners);
             }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -254,7 +254,7 @@ namespace osu.Framework.Platform
             UpdateThread.Scheduler.Add(delegate { response = Exiting?.Invoke() == true; });
 
             //wait for a potentially blocking response
-            while (!response.HasValue)
+            while (response is null)
                 Thread.Sleep(1);
 
             if (response ?? false)

--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -145,14 +145,12 @@ namespace osu.Framework.Platform.MacOS
         protected void OnUpdateFrame(object sender, FrameEventArgs e)
         {
             // update the window mode if we have an update queued
-            WindowMode? mode = pendingWindowMode;
-
-            if (mode.HasValue)
+            if (pendingWindowMode is WindowMode mode)
             {
                 pendingWindowMode = null;
 
                 bool currentFullScreen = styleMask.HasFlag(NSWindowStyleMask.FullScreen);
-                bool toggleFullScreen = mode.Value == Configuration.WindowMode.Fullscreen ? !currentFullScreen : currentFullScreen;
+                bool toggleFullScreen = mode == Configuration.WindowMode.Fullscreen ? !currentFullScreen : currentFullScreen;
 
                 if (toggleFullScreen)
                     Cocoa.SendVoid(WindowInfo.Handle, selToggleFullScreen, IntPtr.Zero);
@@ -161,7 +159,7 @@ namespace osu.Framework.Platform.MacOS
                 else if (isCursorHidden)
                     NSApplication.PresentationOptions = NSApplicationPresentationOptions.DisableCursorLocationAssistance;
 
-                WindowMode.Value = mode.Value;
+                WindowMode.Value = mode;
             }
 
             // If the cursor should be hidden, but something in the system has made it appear (such as a notification),

--- a/osu.Framework/Testing/ManualInputManagerTestScene.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestScene.cs
@@ -126,8 +126,7 @@ namespace osu.Framework.Testing
             var currentState = InputManager.CurrentState;
 
             var mouse = currentState.Mouse;
-            var position = InitialMousePosition;
-            if (position != null) InputManager.MoveMouseTo(position.Value);
+            if (InitialMousePosition is Vector2 position) InputManager.MoveMouseTo(position);
             mouse.Buttons.ForEach(InputManager.ReleaseButton);
 
             var keyboard = currentState.Keyboard;

--- a/osu.Framework/Text/TextBuilder.cs
+++ b/osu.Framework/Text/TextBuilder.cs
@@ -203,11 +203,11 @@ namespace osu.Framework.Text
 
                 currentPos.X = 0;
 
-                if (previousCharacter != null)
+                if (previousCharacter is TextBuilderGlyph previous)
                 {
                     // The character's draw rectangle is the only marker that keeps a constant state for the position, but it has the glyph's XOffset added into it
                     // So the post-kerned position can be retrieved by taking the XOffset away, and the post-XAdvanced position is retrieved by adding the XAdvance back in
-                    currentPos.X = previousCharacter.Value.DrawRectangle.Left - previousCharacter.Value.XOffset + previousCharacter.Value.XAdvance;
+                    currentPos.X = previous.DrawRectangle.Left - previous.XOffset + previous.XAdvance;
                 }
             }
             else
@@ -215,8 +215,8 @@ namespace osu.Framework.Text
                 // Move back within the current line, reversing the operations in AddCharacter()
                 currentPos.X -= removedCharacter.XAdvance;
 
-                if (previousCharacter != null)
-                    currentPos.X -= removedCharacter.GetKerning(previousCharacter.Value) + spacing.X;
+                if (previousCharacter is TextBuilderGlyph previous)
+                    currentPos.X -= removedCharacter.GetKerning(previous) + spacing.X;
             }
 
             Bounds = Vector2.Zero;


### PR DESCRIPTION
Ban the plain properties `HasValue` and `Value`.
**This does have a slight performance improvement** because `Value` is slow:
https://github.com/dotnet/coreclr/blob/68043c6306a0449bb5ed10fbdea9f14dafc99df4/src/System.Private.CoreLib/shared/System/Nullable.cs#L35-L48
And it does get called in hot path (GL drawing).

Now is at post-C# 7 timeframe, and we have pattern matching. C# compiler knows to [compile](https://sharplab.io/#v2:EYLgtghgzgLgpgJwD4AEBMBGAsAKFygZgAIUMA2EtIgYSIG9cimjHnCTySAWIgWQAoAlgDsYAfiIAPAJSsmDHMyVNBAMyL9JRQVG2jtsxcuYLjZ0gE4h0gNxzjAX3tOcDoA=) them into fast form.

_The downside is a new name needed for pattern variable, but developers are already creating aliases everyday._

Note:
Types can be omitted using `is { } v`, but I dislike this syntax because it's not straightforward that `{ }` means not null. Ones may expect `is var v`, but `is var` doesn't check anything but only do aliasing.