### PR TITLE
Fix IHasCurrent UI components potentially unbinding unrelated bindables

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
@@ -10,31 +10,60 @@ namespace osu.Framework.Tests.Bindables
     public class BindableWithCurrentTest
     {
         [Test]
-        public void TestChangeCurrentDoesntUnbindOthers()
+        public void TestBindableWithCurrentReceivesBoundValue()
         {
-            Bindable<string> bindable = new Bindable<string>("test");
-            Bindable<string> boundBindable = bindable.GetBoundCopy();
+            const string expected_value = "test";
 
-            Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
-
+            var bindable = new Bindable<string>(expected_value);
             var bindableWithCurrent = new BindableWithCurrent<string> { Current = bindable };
 
-            Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
-            Assert.That(bindableWithCurrent.Value, Is.EqualTo(bindable.Value));
+            Assert.That(bindable.Value, Is.EqualTo(expected_value));
+            Assert.That(bindableWithCurrent.Value, Is.EqualTo(expected_value));
+        }
 
-            bindable.Value = "test2";
+        [Test]
+        public void TestBindableWithCurrentReceivesValueChanges()
+        {
+            const string expected_value = "test2";
 
-            Assert.That(bindable.Value, Is.EqualTo("test2"));
-            Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
-            Assert.That(bindableWithCurrent.Value, Is.EqualTo(bindable.Value));
+            var bindable = new Bindable<string>();
+            var bindableWithCurrent = new BindableWithCurrent<string> { Current = bindable };
+
+            bindable.Value = expected_value;
+
+            Assert.That(bindableWithCurrent.Value, Is.EqualTo(expected_value));
+        }
+
+        [Test]
+        public void TestChangeCurrentDoesNotUnbindOthers()
+        {
+            const string expected_value = "test2";
+
+            var bindable1 = new Bindable<string>();
+            var bindable2 = bindable1.GetBoundCopy();
+            var bindableWithCurrent = new BindableWithCurrent<string> { Current = bindable1 };
 
             bindableWithCurrent.Current = new Bindable<string>();
+            bindable1.Value = expected_value;
 
-            bindable.Value = "test3";
+            Assert.That(bindable2.Value, Is.EqualTo(expected_value));
+            Assert.That(bindableWithCurrent.Value, Is.Not.EqualTo(expected_value));
+        }
 
-            Assert.That(bindable.Value, Is.EqualTo("test3"));
-            Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
-            Assert.That(bindableWithCurrent.Value, Is.Not.EqualTo(bindable.Value));
+        [Test]
+        public void TestChangeCurrentBindsToNewBindable()
+        {
+            const string expected_value = "test3";
+
+            var bindable1 = new Bindable<string>();
+            var bindable2 = new Bindable<string>();
+            var bindableWithCurrent = new BindableWithCurrent<string> { Current = bindable1 };
+
+            bindableWithCurrent.Current = bindable2;
+            bindableWithCurrent.Value = "test3";
+
+            Assert.That(bindable1.Value, Is.Not.EqualTo(expected_value));
+            Assert.That(bindable2.Value, Is.EqualTo(expected_value));
         }
     }
 }

--- a/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
@@ -1,0 +1,40 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableWithCurrentTest
+    {
+        [Test]
+        public void TestChangeCurrentDoesntUnbindOthers()
+        {
+            Bindable<string> bindable = new Bindable<string>("test");
+            Bindable<string> boundBindable = bindable.GetBoundCopy();
+
+            Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
+
+            var bindableWithCurrent = new BindableWithCurrent<string> { Current = bindable };
+
+            Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
+            Assert.That(bindableWithCurrent.Value, Is.EqualTo(bindable.Value));
+
+            bindable.Value = "test2";
+
+            Assert.That(bindable.Value, Is.EqualTo("test2"));
+            Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
+            Assert.That(bindableWithCurrent.Value, Is.EqualTo(bindable.Value));
+
+            bindableWithCurrent.Current = new Bindable<string>();
+
+            bindable.Value = "test3";
+
+            Assert.That(bindable.Value, Is.EqualTo("test3"));
+            Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
+            Assert.That(bindableWithCurrent.Value, Is.Not.EqualTo(bindable.Value));
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCheckboxes.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCheckboxes.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestDirectToggle()
         {
-            var testBindable = basic.Current.GetBoundCopy();
+            var testBindable = new Bindable<bool> { BindTarget = basic.Current };
 
             AddAssert("is unchecked", () => !basic.Current.Value);
             AddAssert("bindable unchecked", () => !testBindable.Value);

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -11,7 +11,6 @@ using osu.Framework.Input.Events;
 using osu.Framework.Testing;
 using osuTK;
 using osuTK.Input;
-
 namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestSceneDropdown : ManualInputManagerTestScene

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -11,6 +11,7 @@ using osu.Framework.Input.Events;
 using osu.Framework.Testing;
 using osuTK;
 using osuTK.Input;
+
 namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestSceneDropdown : ManualInputManagerTestScene

--- a/osu.Framework.Tests/Visual/UserInterface/TestUIComponentsWithCurrent.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestUIComponentsWithCurrent.cs
@@ -19,9 +19,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
 
-            var dropdown = new BasicDropdown<string>();
-
-            dropdown.Current = bindable;
+            var dropdown = new BasicDropdown<string> { Current = bindable };
 
             AddStep("add dropdown", () => Add(dropdown));
             AddStep("expire", () => dropdown.Expire());
@@ -39,9 +37,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             Bindable<string> bindable = new Bindable<string>("test");
             Bindable<string> bindable2 = new Bindable<string>("test2");
 
-            var dropdown = new BasicDropdown<string>();
-
-            dropdown.Current = bindable;
+            var dropdown = new BasicDropdown<string> { Current = bindable };
 
             AddStep("add dropdown", () => Add(dropdown));
             AddAssert("ensure current bound", () => dropdown.Current.Value == bindable.Value);

--- a/osu.Framework.Tests/Visual/UserInterface/TestUIComponentsWithCurrent.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestUIComponentsWithCurrent.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual.UserInterface
+{
+    [HeadlessTest]
+    public class TestUIComponentsWithCurrent : FrameworkTestScene
+    {
+        [Test]
+        public void TestUnbindDoesntUnbindBound()
+        {
+            Bindable<string> bindable = new Bindable<string>("test");
+            Bindable<string> boundBindable = bindable.GetBoundCopy();
+
+            Assert.That(boundBindable.Value, Is.EqualTo(bindable.Value));
+
+            var dropdown = new BasicDropdown<string>();
+
+            dropdown.Current = bindable;
+
+            AddStep("add dropdown", () => Add(dropdown));
+            AddStep("expire", () => dropdown.Expire());
+            AddUntilStep("wait for dispose", () => dropdown.IsDisposed);
+
+            AddStep("update unrelated bindable", () => bindable.Value = "test2");
+
+            AddAssert("ensure current unbound", () => dropdown.Current.Value != bindable.Value);
+            AddAssert("ensure externals still bound", () => boundBindable.Value == bindable.Value);
+        }
+
+        [Test]
+        public void TestChangeCurrent()
+        {
+            Bindable<string> bindable = new Bindable<string>("test");
+            Bindable<string> bindable2 = new Bindable<string>("test2");
+
+            var dropdown = new BasicDropdown<string>();
+
+            dropdown.Current = bindable;
+
+            AddStep("add dropdown", () => Add(dropdown));
+            AddAssert("ensure current bound", () => dropdown.Current.Value == bindable.Value);
+
+            AddStep("change target", () => dropdown.Current = bindable2);
+            AddAssert("ensure current switched", () => dropdown.Current.Value == bindable2.Value);
+            AddAssert("ensure original intact", () => dropdown.Current.Value != bindable.Value);
+
+            AddStep("change value", () => bindable2.Value = "test3");
+            AddAssert("ensure current bound", () => dropdown.Current.Value == bindable2.Value);
+            AddAssert("ensure original intact", () => dropdown.Current.Value != bindable.Value);
+        }
+
+        // TODO: add tests for other components
+    }
+}

--- a/osu.Framework/Bindables/BindableWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableWithCurrent.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.UserInterface;
+
+namespace osu.Framework.Bindables
+{
+    /// <summary>
+    /// A bindable which holds a reference to a bound target, allowing switching between targets and handling unbind/rebind.
+    /// </summary>
+    /// <typeparam name="T">The type of our stored <see cref="Bindable{T}.Value"/>.</typeparam>
+    public class BindableWithCurrent<T> : Bindable<T>, IHasCurrentValue<T>
+    {
+        private Bindable<T> currentBound;
+
+        public Bindable<T> Current
+        {
+            get => this;
+            set
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                if (currentBound != null) UnbindFrom(currentBound);
+                BindTo(currentBound = value);
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -95,21 +95,12 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
-        private readonly Bindable<string> current = new Bindable<string>(string.Empty);
-
-        private Bindable<string> currentBound;
+        private readonly BindableWithCurrent<string> current = new BindableWithCurrent<string>();
 
         public Bindable<string> Current
         {
-            get => current;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (currentBound != null) current.UnbindFrom(currentBound);
-                current.BindTo(currentBound = value);
-            }
+            get => current.Current;
+            set => current.Current = value;
         }
 
         private string displayedText => localisedText?.Value ?? text.Text.Original;

--- a/osu.Framework/Graphics/UserInterface/Checkbox.cs
+++ b/osu.Framework/Graphics/UserInterface/Checkbox.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
@@ -13,24 +12,12 @@ namespace osu.Framework.Graphics.UserInterface
     /// </summary>
     public abstract class Checkbox : Container, IHasCurrentValue<bool>
     {
-        private readonly Bindable<bool> current = new Bindable<bool>();
+        private readonly BindableWithCurrent<bool> current = new BindableWithCurrent<bool>();
 
-        private Bindable<bool> currentBound;
-
-        /// <summary>
-        /// A bindable that holds the value if the checkbox is checked or not.
-        /// </summary>
         public Bindable<bool> Current
         {
-            get => current;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (currentBound != null) current.UnbindFrom(currentBound);
-                current.BindTo(currentBound = value);
-            }
+            get => current.Current;
+            set => current.Current = value;
         }
 
         protected override bool OnClick(ClickEvent e)

--- a/osu.Framework/Graphics/UserInterface/CircularProgress.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgress.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Shaders;
@@ -13,21 +12,12 @@ namespace osu.Framework.Graphics.UserInterface
 {
     public class CircularProgress : Drawable, ITexturedShaderDrawable, IHasCurrentValue<double>
     {
-        private readonly Bindable<double> current = new Bindable<double>();
-
-        private Bindable<double> currentBound;
+        private readonly BindableWithCurrent<double> current = new BindableWithCurrent<double>();
 
         public Bindable<double> Current
         {
-            get => current;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (currentBound != null) current.UnbindFrom(currentBound);
-                current.BindTo(currentBound = value);
-            }
+            get => current.Current;
+            set => current.Current = value;
         }
 
         public CircularProgress()

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -164,21 +164,12 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        private readonly Bindable<T> current = new Bindable<T>();
-
-        private Bindable<T> currentBound;
+        private readonly BindableWithCurrent<T> current = new BindableWithCurrent<T>();
 
         public Bindable<T> Current
         {
-            get => current;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (currentBound != null) current.UnbindFrom(currentBound);
-                current.BindTo(currentBound = value);
-            }
+            get => current.Current;
+            set => current.Current = value;
         }
 
         private DropdownMenuItem<T> selectedItem;

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -27,21 +27,12 @@ namespace osu.Framework.Graphics.UserInterface
     /// <typeparam name="T">The type of item to be represented by tabs.</typeparam>
     public abstract class TabControl<T> : CompositeDrawable, IHasCurrentValue<T>, IKeyBindingHandler<PlatformAction>
     {
-        private readonly Bindable<T> current = new Bindable<T>();
-
-        private Bindable<T> currentBound;
+        private readonly BindableWithCurrent<T> current = new BindableWithCurrent<T>();
 
         public Bindable<T> Current
         {
-            get => current;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (currentBound != null) current.UnbindFrom(currentBound);
-                current.BindTo(currentBound = value);
-            }
+            get => current.Current;
+            set => current.Current = value;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -611,21 +611,12 @@ namespace osu.Framework.Graphics.UserInterface
             set => Placeholder.Text = value;
         }
 
-        private readonly Bindable<string> current = new Bindable<string>(string.Empty);
-
-        private Bindable<string> currentBound;
+        private readonly BindableWithCurrent<string> current = new BindableWithCurrent<string>();
 
         public Bindable<string> Current
         {
-            get => current;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                if (currentBound != null) current.UnbindFrom(currentBound);
-                current.BindTo(currentBound = value);
-            }
+            get => current.Current;
+            set => current.Current = value;
         }
 
         private string text = string.Empty;


### PR DESCRIPTION
Due to these classes storing a reference to the current bind target, on disposal they would forcefully unbind any bound bindables to that reference (due to automatically disposal logic in `UnbindAllBindablesSubtree`).