### PR TITLE
Allow all buttons to drag in scroll container

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -231,7 +231,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnDragStart(DragStartEvent e)
         {
-            if (IsDragging || e.Button != MouseButton.Left) return false;
+            if (IsDragging) return false;
 
             lastDragTime = Time.Current;
             averageDragDelta = averageDragTime = 0;
@@ -264,7 +264,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (IsDragging || e.Button != MouseButton.Left) return false;
+            if (IsDragging) return false;
 
             // Continue from where we currently are scrolled to.
             target = Current;
@@ -584,8 +584,6 @@ namespace osu.Framework.Graphics.Containers
 
             protected override bool OnMouseDown(MouseDownEvent e)
             {
-                if (e.Button != MouseButton.Left) return false;
-
                 dragOffset = Position[(int)ScrollDirection];
                 Dragged?.Invoke(dragOffset);
                 return true;


### PR DESCRIPTION
Any reasons why it's not already the case? [`MouseButtonEventManager.EnableDrag`](https://github.com/ppy/osu-framework/blob/b5c05a5422e4f3cda45e99baa32428d9c9815c73/osu.Framework/Input/MouseButtonEventManager.cs#L41) already decides whether a button can drag or not (thanks to #1678). Middle mouse button for dragging things around is common in lots of software (FL Studio for example).

Right now even if you make an inherited `InputManager` with enabled dragging on the middle mouse button, dragging to scroll still won't work because `ScrollContainer` is hard-coded to work only with the left mouse button. This means that a user cannot change this behaviour without re-implementing `OnDragStart` and `OnMouseDown` functions from scratch for both `ScrollContainer` and `ScrollbarContainer`, and that's not optimal.

(There are also other cases where everything seems to be accounting only for the left mouse button, like for example [`InputManager.DraggedDrawable`](https://github.com/ppy/osu-framework/blob/b5c05a5422e4f3cda45e99baa32428d9c9815c73/osu.Framework/Input/InputManager.cs#L70) - this checks only the left mouse button for dragged drawables.)