### PR TITLE
Fix SliderBar incorrectly updating visual state when not intending to handle a drag

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -54,7 +54,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     },
                     sliderBar = new BasicSliderBar<double>
                     {
-                        Size = new Vector2(200, 10),
+                        Size = new Vector2(200, 50),
                         BackgroundColour = Color4.White,
                         SelectionColour = Color4.Pink,
                         KeyboardStep = 1,
@@ -97,9 +97,22 @@ namespace osu.Framework.Tests.Visual.UserInterface
             sliderBar.Current.Value = 0;
         }
 
-        [TestCase(true)]
+        [Test]
+        public void TestVerticalDragHasNoEffect()
+        {
+            checkValue(0, false);
+            AddStep("Move Cursor",
+                () => { InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(0.75f, 0.0f))); });
+            AddStep("Click", () => { InputManager.PressButton(MouseButton.Left); });
+            AddStep("Drag",
+                () => { InputManager.MoveMouseTo(sliderBar.ToScreenSpace(sliderBar.DrawSize * new Vector2(0.75f, 1f))); });
+            AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
+            checkValue(0, false);
+        }
+
         [TestCase(false)]
-        public void SliderBar(bool disabled)
+        [TestCase(true)]
+        public void TestAdjustmentPrecision(bool disabled)
         {
             AddStep($"set disabled to {disabled}", () => sliderBar.Current.Disabled = disabled);
 
@@ -129,17 +142,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkValue(5, disabled);
         }
 
-        private void checkValue(int expected, bool disabled)
-        {
-            if (disabled)
-                AddAssert("value unchanged (disabled)", () => Precision.AlmostEquals(sliderBarValue.Value, 0, Precision.FLOAT_EPSILON));
-            else
-                AddAssert($"Value == {expected}", () => Precision.AlmostEquals(sliderBarValue.Value, expected, Precision.FLOAT_EPSILON));
-        }
-
-        [TestCase(true)]
         [TestCase(false)]
-        public void TransferValueOnCommit(bool disabled)
+        [TestCase(true)]
+        public void TestTransferValueOnCommit(bool disabled)
         {
             AddStep($"set disabled to {disabled}", () => sliderBar.Current.Disabled = disabled);
 
@@ -159,6 +164,14 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkValue(6, disabled);
             AddStep("Release Click", () => { InputManager.ReleaseButton(MouseButton.Left); });
             checkValue(-5, disabled);
+        }
+
+        private void checkValue(int expected, bool disabled)
+        {
+            if (disabled)
+                AddAssert("value unchanged (disabled)", () => Precision.AlmostEquals(sliderBarValue.Value, 0, Precision.FLOAT_EPSILON));
+            else
+                AddAssert($"Value == {expected}", () => Precision.AlmostEquals(sliderBarValue.Value, expected, Precision.FLOAT_EPSILON));
         }
 
         private void sliderBarValueChanged(ValueChangedEvent<double> args)

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -135,9 +135,13 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnDragStart(DragStartEvent e)
         {
-            handleMouseInput(e);
             Vector2 posDiff = e.MouseDownPosition - e.MousePosition;
-            return Math.Abs(posDiff.X) > Math.Abs(posDiff.Y);
+
+            if (Math.Abs(posDiff.X) < Math.Abs(posDiff.Y))
+                return false;
+
+            handleMouseInput(e);
+            return true;
         }
 
         protected override bool OnDragEnd(DragEndEvent e)


### PR DESCRIPTION
Previous logic would cause visual state to update on `OnDragStart` even when the drag is ignored, meaning no `commit` would be fired ever.