### PR TITLE
Move menu testing helper functions and structure to a base class

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
-using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
 using osuTK;
@@ -14,43 +13,22 @@ using osuTK.Input;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneNestedMenus : ManualInputManagerTestScene
+    public class TestSceneNestedMenus : MenuTestScene
     {
         private const int max_depth = 5;
         private const int max_count = 5;
 
-        public override IReadOnlyList<Type> RequiredTypes => new[]
-        {
-            typeof(Menu),
-            typeof(BasicMenu)
-        };
-
         private Random rng;
-
-        private MenuStructure menus;
 
         [SetUp]
         public override void SetUp() => Schedule(() =>
         {
             base.SetUp();
-            Clear();
 
             rng = new Random(1337);
-
-            Menu menu;
-            Children = new Drawable[]
-            {
-                new Container
-                {
-                    RelativeSizeAxes = Axes.Both,
-                    Child = menu = createMenu()
-                }
-            };
-
-            menus = new MenuStructure(menu);
         });
 
-        private Menu createMenu() => new ClickOpenMenu(TimePerAction)
+        protected override Menu CreateMenu() => new ClickOpenMenu(TimePerAction)
         {
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
@@ -83,7 +61,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         public void TestAlwaysOpen()
         {
             AddStep("Click outside", () => InputManager.Click(MouseButton.Left));
-            AddAssert("Check AlwaysOpen = true", () => menus.GetSubMenu(0).State == MenuState.Open);
+            AddAssert("Check AlwaysOpen = true", () => Menus.GetSubMenu(0).State == MenuState.Open);
         }
 
         /// <summary>
@@ -92,9 +70,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestHoverState()
         {
-            AddAssert("Check submenu closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
-            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetMenuItems()[0]));
-            AddAssert("Check item hovered", () => menus.GetMenuItems()[0].IsHovered);
+            AddAssert("Check submenu closed", () => Menus.GetSubMenu(1)?.State != MenuState.Open);
+            AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetMenuItems()[0]));
+            AddAssert("Check item hovered", () => Menus.GetMenuItems()[0].IsHovered);
         }
 
         /// <summary>
@@ -103,11 +81,11 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestTopLevelMenu()
         {
-            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItems()[0]));
-            AddAssert("Check closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
-            AddAssert("Check closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
+            AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(0).GetMenuItems()[0]));
+            AddAssert("Check closed", () => Menus.GetSubMenu(1)?.State != MenuState.Open);
+            AddAssert("Check closed", () => Menus.GetSubMenu(1)?.State != MenuState.Open);
             AddStep("Click item", () => InputManager.Click(MouseButton.Left));
-            AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
+            AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
         }
 
         /// <summary>
@@ -117,10 +95,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestDoubleClick()
         {
-            AddStep("Click item", () => clickItem(0, 0));
-            AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
-            AddStep("Click item", () => clickItem(0, 0));
-            AddAssert("Check closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
+            AddStep("Click item", () => ClickItem(0, 0));
+            AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
+            AddStep("Click item", () => ClickItem(0, 0));
+            AddAssert("Check closed", () => Menus.GetSubMenu(1)?.State != MenuState.Open);
         }
 
         /// <summary>
@@ -129,10 +107,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestInstantOpen()
         {
-            AddStep("Click item", () => clickItem(0, 1));
-            AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
-            AddStep("Click item", () => clickItem(1, 0));
-            AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
+            AddStep("Click item", () => ClickItem(0, 1));
+            AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
+            AddStep("Click item", () => ClickItem(1, 0));
+            AddAssert("Check open", () => Menus.GetSubMenu(2).State == MenuState.Open);
         }
 
         /// <summary>
@@ -141,9 +119,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestActionClick()
         {
-            AddStep("Click item", () => clickItem(0, 0));
-            AddStep("Click item", () => clickItem(1, 0));
-            AddAssert("Check closed", () => menus.GetSubMenu(1)?.State != MenuState.Open);
+            AddStep("Click item", () => ClickItem(0, 0));
+            AddStep("Click item", () => ClickItem(1, 0));
+            AddAssert("Check closed", () => Menus.GetSubMenu(1)?.State != MenuState.Open);
         }
 
         /// <summary>
@@ -152,13 +130,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestHoverOpen()
         {
-            AddStep("Click item", () => clickItem(0, 1));
-            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[0]));
-            AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
-            AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
-            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(2).GetMenuItems()[0]));
-            AddAssert("Check closed", () => menus.GetSubMenu(3)?.State != MenuState.Open);
-            AddAssert("Check open", () => menus.GetSubMenu(3).State == MenuState.Open);
+            AddStep("Click item", () => ClickItem(0, 1));
+            AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(1).GetMenuItems()[0]));
+            AddAssert("Check closed", () => Menus.GetSubMenu(2)?.State != MenuState.Open);
+            AddAssert("Check open", () => Menus.GetSubMenu(2).State == MenuState.Open);
+            AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(2).GetMenuItems()[0]));
+            AddAssert("Check closed", () => Menus.GetSubMenu(3)?.State != MenuState.Open);
+            AddAssert("Check open", () => Menus.GetSubMenu(3).State == MenuState.Open);
         }
 
         /// <summary>
@@ -169,22 +147,22 @@ namespace osu.Framework.Tests.Visual.UserInterface
         public void TestHoverChange()
         {
             IReadOnlyList<MenuItem> currentItems = null;
-            AddStep("Click item", () => { clickItem(0, 0); });
+            AddStep("Click item", () => { ClickItem(0, 0); });
 
-            AddStep("Get items", () => { currentItems = menus.GetSubMenu(1).Items; });
+            AddStep("Get items", () => { currentItems = Menus.GetSubMenu(1).Items; });
 
-            AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
-            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(0).GetMenuItems()[1]));
-            AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
+            AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
+            AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(0).GetMenuItems()[1]));
+            AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
 
-            AddAssert("Check new items", () => !menus.GetSubMenu(1).Items.SequenceEqual(currentItems));
+            AddAssert("Check new items", () => !Menus.GetSubMenu(1).Items.SequenceEqual(currentItems));
             AddAssert("Check closed", () =>
             {
                 int currentSubMenu = 3;
 
                 while (true)
                 {
-                    var subMenu = menus.GetSubMenu(currentSubMenu);
+                    var subMenu = Menus.GetSubMenu(currentSubMenu);
                     if (subMenu == null)
                         break;
 
@@ -205,15 +183,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestDelayedHoverChange()
         {
-            AddStep("Click item", () => clickItem(0, 2));
-            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[0]));
-            AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
-            AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
+            AddStep("Click item", () => ClickItem(0, 2));
+            AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(1).GetMenuItems()[0]));
+            AddAssert("Check closed", () => Menus.GetSubMenu(2)?.State != MenuState.Open);
+            AddAssert("Check closed", () => Menus.GetSubMenu(2)?.State != MenuState.Open);
 
-            AddStep("Hover item", () => { InputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[1]); });
+            AddStep("Hover item", () => { InputManager.MoveMouseTo(Menus.GetSubStructure(1).GetMenuItems()[1]); });
 
-            AddAssert("Check closed", () => menus.GetSubMenu(2)?.State != MenuState.Open);
-            AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
+            AddAssert("Check closed", () => Menus.GetSubMenu(2)?.State != MenuState.Open);
+            AddAssert("Check open", () => Menus.GetSubMenu(2).State == MenuState.Open);
 
             AddAssert("Check closed", () =>
             {
@@ -221,7 +199,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
                 while (true)
                 {
-                    var subMenu = menus.GetSubMenu(currentSubMenu);
+                    var subMenu = Menus.GetSubMenu(currentSubMenu);
                     if (subMenu == null)
                         break;
 
@@ -242,23 +220,23 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestMenuClicksDontClose()
         {
-            AddStep("Click item", () => clickItem(0, 1));
-            AddStep("Click item", () => clickItem(1, 0));
-            AddStep("Click item", () => clickItem(2, 0));
-            AddStep("Click item", () => clickItem(3, 0));
+            AddStep("Click item", () => ClickItem(0, 1));
+            AddStep("Click item", () => ClickItem(1, 0));
+            AddStep("Click item", () => ClickItem(2, 0));
+            AddStep("Click item", () => ClickItem(3, 0));
 
             for (int i = 3; i >= 1; i--)
             {
                 int menuIndex = i;
-                AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItems()[0]));
-                AddAssert("Check submenu open", () => menus.GetSubMenu(menuIndex + 1).State == MenuState.Open);
+                AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(menuIndex).GetMenuItems()[0]));
+                AddAssert("Check submenu open", () => Menus.GetSubMenu(menuIndex + 1).State == MenuState.Open);
                 AddStep("Click item", () => InputManager.Click(MouseButton.Left));
                 AddAssert("Check all open", () =>
                 {
                     for (int j = 0; j <= menuIndex; j++)
                     {
                         int menuIndex2 = j;
-                        if (menus.GetSubMenu(menuIndex2)?.State != MenuState.Open)
+                        if (Menus.GetSubMenu(menuIndex2)?.State != MenuState.Open)
                             return false;
                     }
 
@@ -273,18 +251,18 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestMenuClickClosesSubMenus()
         {
-            AddStep("Click item", () => clickItem(0, 1));
-            AddStep("Click item", () => clickItem(1, 0));
-            AddStep("Click item", () => clickItem(2, 0));
-            AddStep("Click item", () => clickItem(3, 0));
-            AddStep("Click item", () => clickItem(0, 1));
+            AddStep("Click item", () => ClickItem(0, 1));
+            AddStep("Click item", () => ClickItem(1, 0));
+            AddStep("Click item", () => ClickItem(2, 0));
+            AddStep("Click item", () => ClickItem(3, 0));
+            AddStep("Click item", () => ClickItem(0, 1));
 
             AddAssert("Check submenus closed", () =>
             {
                 for (int j = 1; j <= 3; j++)
                 {
                     int menuIndex2 = j;
-                    if (menus.GetSubMenu(menuIndex2).State == MenuState.Open)
+                    if (Menus.GetSubMenu(menuIndex2).State == MenuState.Open)
                         return false;
                 }
 
@@ -298,18 +276,18 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestActionClickClosesMenus()
         {
-            AddStep("Click item", () => clickItem(0, 1));
-            AddStep("Click item", () => clickItem(1, 0));
-            AddStep("Click item", () => clickItem(2, 0));
-            AddStep("Click item", () => clickItem(3, 0));
-            AddStep("Click item", () => clickItem(4, 0));
+            AddStep("Click item", () => ClickItem(0, 1));
+            AddStep("Click item", () => ClickItem(1, 0));
+            AddStep("Click item", () => ClickItem(2, 0));
+            AddStep("Click item", () => ClickItem(3, 0));
+            AddStep("Click item", () => ClickItem(4, 0));
 
             AddAssert("Check submenus closed", () =>
             {
                 for (int j = 1; j <= 3; j++)
                 {
                     int menuIndex2 = j;
-                    if (menus.GetSubMenu(menuIndex2).State == MenuState.Open)
+                    if (Menus.GetSubMenu(menuIndex2).State == MenuState.Open)
                         return false;
                 }
 
@@ -333,11 +311,11 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 {
                     int menuToOpen = j;
                     int itemToOpen = menuToOpen == 0 ? 1 : 0;
-                    AddStep("Click item", () => clickItem(menuToOpen, itemToOpen));
+                    AddStep("Click item", () => ClickItem(menuToOpen, itemToOpen));
                 }
 
                 if (hoverPrevious && i > 0)
-                    AddStep("Hover previous", () => InputManager.MoveMouseTo(menus.GetSubStructure(i2 - 1).GetMenuItems()[i2 > 1 ? 0 : 1]));
+                    AddStep("Hover previous", () => InputManager.MoveMouseTo(Menus.GetSubStructure(i2 - 1).GetMenuItems()[i2 > 1 ? 0 : 1]));
 
                 AddStep("Remove hover", () => InputManager.MoveMouseTo(Vector2.Zero));
                 AddStep("Click outside", () => InputManager.Click(MouseButton.Left));
@@ -346,7 +324,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     for (int j = 1; j <= i2 + 1; j++)
                     {
                         int menuIndex2 = j;
-                        if (menus.GetSubMenu(menuIndex2).State == MenuState.Open)
+                        if (Menus.GetSubMenu(menuIndex2).State == MenuState.Open)
                             return false;
                     }
 
@@ -361,36 +339,25 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestSelectedState()
         {
-            AddStep("Click item", () => clickItem(0, 2));
-            AddAssert("Check open", () => menus.GetSubMenu(1).State == MenuState.Open);
+            AddStep("Click item", () => ClickItem(0, 2));
+            AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
 
-            AddStep("Hover item", () => InputManager.MoveMouseTo(menus.GetSubStructure(1).GetMenuItems()[1]));
-            AddAssert("Check closed 1", () => menus.GetSubMenu(2)?.State != MenuState.Open);
-            AddAssert("Check open", () => menus.GetSubMenu(2).State == MenuState.Open);
-            AddAssert("Check selected index 1", () => menus.GetSubStructure(1).GetSelectedIndex() == 1);
+            AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(1).GetMenuItems()[1]));
+            AddAssert("Check closed 1", () => Menus.GetSubMenu(2)?.State != MenuState.Open);
+            AddAssert("Check open", () => Menus.GetSubMenu(2).State == MenuState.Open);
+            AddAssert("Check selected index 1", () => Menus.GetSubStructure(1).GetSelectedIndex() == 1);
 
-            AddStep("Change selection", () => menus.GetSubStructure(1).SetSelectedState(0, MenuItemState.Selected));
-            AddAssert("Check selected index", () => menus.GetSubStructure(1).GetSelectedIndex() == 0);
+            AddStep("Change selection", () => Menus.GetSubStructure(1).SetSelectedState(0, MenuItemState.Selected));
+            AddAssert("Check selected index", () => Menus.GetSubStructure(1).GetSelectedIndex() == 0);
 
-            AddStep("Change selection", () => menus.GetSubStructure(1).SetSelectedState(2, MenuItemState.Selected));
-            AddAssert("Check selected index 2", () => menus.GetSubStructure(1).GetSelectedIndex() == 2);
+            AddStep("Change selection", () => Menus.GetSubStructure(1).SetSelectedState(2, MenuItemState.Selected));
+            AddAssert("Check selected index 2", () => Menus.GetSubStructure(1).GetSelectedIndex() == 2);
 
-            AddStep("Close menus", () => menus.GetSubMenu(0).Close());
-            AddAssert("Check selected index 4", () => menus.GetSubStructure(1).GetSelectedIndex() == -1);
+            AddStep("Close menus", () => Menus.GetSubMenu(0).Close());
+            AddAssert("Check selected index 4", () => Menus.GetSubStructure(1).GetSelectedIndex() == -1);
         }
 
         #endregion
-
-        /// <summary>
-        /// Click an item in a menu.
-        /// </summary>
-        /// <param name="menuIndex">The level of menu our click targets.</param>
-        /// <param name="itemIndex">The item to click in the menu.</param>
-        private void clickItem(int menuIndex, int itemIndex)
-        {
-            InputManager.MoveMouseTo(menus.GetSubStructure(menuIndex).GetMenuItems()[itemIndex]);
-            InputManager.Click(MouseButton.Left);
-        }
 
         private MenuItem generateRandomMenuItem(string name = "Menu Item", int currDepth = 1)
         {
@@ -406,87 +373,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             item.Items = subItems;
             return item;
-        }
-
-        /// <summary>
-        /// Helper class used to retrieve various internal properties/items from a <see cref="Menu"/>.
-        /// </summary>
-        private class MenuStructure
-        {
-            private readonly Menu menu;
-
-            public MenuStructure(Menu menu)
-            {
-                this.menu = menu;
-            }
-
-            /// <summary>
-            /// Retrieves the <see cref="Menu.DrawableMenuItem"/>s of the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.
-            /// </summary>
-            public IReadOnlyList<Drawable> GetMenuItems()
-            {
-                var contents = (CompositeDrawable)menu.InternalChildren[0];
-                var contentContainer = (CompositeDrawable)contents.InternalChildren[1];
-                return ((CompositeDrawable)((CompositeDrawable)contentContainer.InternalChildren[0]).InternalChildren[0]).InternalChildren;
-            }
-
-            /// <summary>
-            /// Finds the <see cref="Menu.DrawableMenuItem"/> index in the <see cref="Menu"/> represented by this <see cref="MenuStructure"/> that
-            /// has <see cref="Menu.DrawableMenuItem.State"/> set to <see cref="MenuItemState.Selected"/>.
-            /// </summary>
-            public int GetSelectedIndex()
-            {
-                var items = GetMenuItems();
-
-                for (int i = 0; i < items.Count; i++)
-                {
-                    var state = (MenuItemState)(items[i]?.GetType().GetProperty("State")?.GetValue(items[i]) ?? MenuItemState.NotSelected);
-                    if (state == MenuItemState.Selected)
-                        return i;
-                }
-
-                return -1;
-            }
-
-            /// <summary>
-            /// Sets the <see cref="Menu.DrawableMenuItem"/> <see cref="Menu.DrawableMenuItem.State"/> at the specified index to a specified state.
-            /// </summary>
-            /// <param name="index">The index of the <see cref="Menu.DrawableMenuItem"/> to set the state of.</param>
-            /// <param name="state">The state to be set.</param>
-            public void SetSelectedState(int index, MenuItemState state)
-            {
-                var item = GetMenuItems()[index];
-                item.GetType().GetProperty("State")?.SetValue(item, state);
-            }
-
-            /// <summary>
-            /// Retrieves the sub-<see cref="Menu"/> at an index-offset from the current <see cref="Menu"/>.
-            /// </summary>
-            /// <param name="index">The sub-<see cref="Menu"/> index. An index of 0 is the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.</param>
-            public Menu GetSubMenu(int index)
-            {
-                var currentMenu = menu;
-
-                for (int i = 0; i < index; i++)
-                {
-                    if (currentMenu == null)
-                        break;
-
-                    var container = (CompositeDrawable)currentMenu.InternalChildren[1];
-
-                    // ReSharper disable once ArrangeRedundantParentheses
-                    // Broken resharper inspection (https://youtrack.jetbrains.com/issue/RIDER-19843)
-                    currentMenu = (container.InternalChildren.Count > 0 ? container.InternalChildren[0] : null) as Menu;
-                }
-
-                return currentMenu;
-            }
-
-            /// <summary>
-            /// Generates a new <see cref="MenuStructure"/> for the a sub-<see cref="Menu"/>.
-            /// </summary>
-            /// <param name="index">The sub-<see cref="Menu"/> index to generate the <see cref="MenuStructure"/> for. An index of 0 is the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.</param>
-            public MenuStructure GetSubStructure(int index) => new MenuStructure(GetSubMenu(index));
         }
     }
 }

--- a/osu.Framework/Testing/MenuTestScene.cs
+++ b/osu.Framework/Testing/MenuTestScene.cs
@@ -1,0 +1,136 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
+using osuTK.Input;
+
+namespace osu.Framework.Testing
+{
+    /// <summary>
+    /// A test scene that provides a set of helper functions and structures for testing a <see cref="Menu"/>.
+    /// </summary>
+    public abstract class MenuTestScene : ManualInputManagerTestScene
+    {
+        protected MenuStructure Menus;
+
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(Menu),
+            typeof(BasicMenu)
+        };
+
+        [SetUp]
+        public override void SetUp() => Schedule(() =>
+        {
+            base.SetUp();
+
+            Menu menu;
+            Child = new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = menu = CreateMenu(),
+            };
+
+            Menus = new MenuStructure(menu);
+        });
+
+        /// <summary>
+        /// Click an item in a menu.
+        /// </summary>
+        /// <param name="menuIndex">The level of menu our click targets.</param>
+        /// <param name="itemIndex">The item to click in the menu.</param>
+        protected void ClickItem(int menuIndex, int itemIndex)
+        {
+            InputManager.MoveMouseTo(Menus.GetSubStructure(menuIndex).GetMenuItems()[itemIndex]);
+            InputManager.Click(MouseButton.Left);
+        }
+
+        protected abstract Menu CreateMenu();
+
+        /// <summary>
+        /// Helper class used to retrieve various internal properties/items from a <see cref="Menu"/>.
+        /// </summary>
+        protected class MenuStructure
+        {
+            private readonly Menu menu;
+
+            public MenuStructure(Menu menu)
+            {
+                this.menu = menu;
+            }
+
+            /// <summary>
+            /// Retrieves the <see cref="Menu.DrawableMenuItem"/>s of the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.
+            /// </summary>
+            public IReadOnlyList<Drawable> GetMenuItems()
+            {
+                var contents = (CompositeDrawable)menu.InternalChildren[0];
+                var contentContainer = (CompositeDrawable)contents.InternalChildren[1];
+                return ((CompositeDrawable)((CompositeDrawable)contentContainer.InternalChildren[0]).InternalChildren[0]).InternalChildren;
+            }
+
+            /// <summary>
+            /// Finds the <see cref="Menu.DrawableMenuItem"/> index in the <see cref="Menu"/> represented by this <see cref="MenuStructure"/> that
+            /// has <see cref="Menu.DrawableMenuItem.State"/> set to <see cref="MenuItemState.Selected"/>.
+            /// </summary>
+            public int GetSelectedIndex()
+            {
+                var items = GetMenuItems();
+
+                for (int i = 0; i < items.Count; i++)
+                {
+                    var state = (MenuItemState)(items[i]?.GetType().GetProperty("State")?.GetValue(items[i]) ?? MenuItemState.NotSelected);
+                    if (state == MenuItemState.Selected)
+                        return i;
+                }
+
+                return -1;
+            }
+
+            /// <summary>
+            /// Sets the <see cref="Menu.DrawableMenuItem"/> <see cref="Menu.DrawableMenuItem.State"/> at the specified index to a specified state.
+            /// </summary>
+            /// <param name="index">The index of the <see cref="Menu.DrawableMenuItem"/> to set the state of.</param>
+            /// <param name="state">The state to be set.</param>
+            public void SetSelectedState(int index, MenuItemState state)
+            {
+                var item = GetMenuItems()[index];
+                item.GetType().GetProperty("State")?.SetValue(item, state);
+            }
+
+            /// <summary>
+            /// Retrieves the sub-<see cref="Menu"/> at an index-offset from the current <see cref="Menu"/>.
+            /// </summary>
+            /// <param name="index">The sub-<see cref="Menu"/> index. An index of 0 is the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.</param>
+            public Menu GetSubMenu(int index)
+            {
+                var currentMenu = menu;
+
+                for (int i = 0; i < index; i++)
+                {
+                    if (currentMenu == null)
+                        break;
+
+                    var container = (CompositeDrawable)currentMenu.InternalChildren[1];
+
+                    // ReSharper disable once ArrangeRedundantParentheses
+                    // Broken resharper inspection (https://youtrack.jetbrains.com/issue/RIDER-19843)
+                    currentMenu = (container.InternalChildren.Count > 0 ? container.InternalChildren[0] : null) as Menu;
+                }
+
+                return currentMenu;
+            }
+
+            /// <summary>
+            /// Generates a new <see cref="MenuStructure"/> for the a sub-<see cref="Menu"/>.
+            /// </summary>
+            /// <param name="index">The sub-<see cref="Menu"/> index to generate the <see cref="MenuStructure"/> for. An index of 0 is the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.</param>
+            public MenuStructure GetSubStructure(int index) => new MenuStructure(GetSubMenu(index));
+        }
+    }
+}

--- a/osu.Framework/Testing/MenuTestScene.cs
+++ b/osu.Framework/Testing/MenuTestScene.cs
@@ -21,7 +21,8 @@ namespace osu.Framework.Testing
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
             typeof(Menu),
-            typeof(BasicMenu)
+            typeof(BasicMenu),
+            typeof(MenuTestScene)
         };
 
         [SetUp]


### PR DESCRIPTION
- Moves menu testing helper functions and `MenuStructure` to a base test scene class.
- This is a dependency for testing different types of menus easily.