### PR TITLE
Implement Apple's "continuous curves"

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
@@ -16,6 +16,8 @@ namespace osu.Framework.Tests.Visual.Containers
     public class TestSceneMasking : FrameworkTestScene
     {
         protected Container TestContainer;
+        protected int currentTest;
+        protected float cornerExponent = 2f;
 
         public TestSceneMasking()
         {
@@ -41,6 +43,12 @@ namespace osu.Framework.Tests.Visual.Containers
                 int test = i;
                 AddStep(testNames[i], delegate { loadTest(test); });
             }
+
+            AddSliderStep<float>("Toggle continuous corner", 2, 5, 2, exponent =>
+            {
+                cornerExponent = exponent;
+                loadTest(currentTest);
+            });
 
             loadTest(0);
             addCrosshair();
@@ -84,6 +92,7 @@ namespace osu.Framework.Tests.Visual.Containers
         private void loadTest(int testType)
         {
             TestContainer.Clear();
+            currentTest = testType;
 
             switch (testType)
             {
@@ -96,6 +105,7 @@ namespace osu.Framework.Tests.Visual.Containers
                         Origin = Anchor.Centre,
                         Masking = true,
                         CornerRadius = 100,
+                        CornerExponent = cornerExponent,
                         BorderColour = Color4.Aquamarine,
                         BorderThickness = 3,
                         EdgeEffect = new EdgeEffectParameters
@@ -132,6 +142,7 @@ namespace osu.Framework.Tests.Visual.Containers
                             {
                                 Masking = true,
                                 CornerRadius = 100,
+                                CornerExponent = cornerExponent,
                                 Size = new Vector2(400, 400),
                                 Alpha = 0.5f,
                                 Origin = Anchor.Centre,
@@ -162,6 +173,7 @@ namespace osu.Framework.Tests.Visual.Containers
                             {
                                 Masking = true,
                                 CornerRadius = 25,
+                                CornerExponent = cornerExponent,
                                 Shear = new Vector2(0.5f, 0),
                                 Size = new Vector2(150, 150),
                                 Scale = new Vector2(2.5f, 1.5f),
@@ -204,6 +216,7 @@ namespace osu.Framework.Tests.Visual.Containers
                             {
                                 Masking = true,
                                 CornerRadius = 25,
+                                CornerExponent = cornerExponent,
                                 Shear = new Vector2(0.5f, 0),
                                 Alpha = 0.5f,
                                 Origin = Anchor.Centre,
@@ -215,6 +228,7 @@ namespace osu.Framework.Tests.Visual.Containers
                                     {
                                         Masking = true,
                                         CornerRadius = 25,
+                                        CornerExponent = cornerExponent,
                                         Shear = new Vector2(0.25f, 0.25f),
                                         Size = new Vector2(100, 200),
                                         Alpha = 0.5f,
@@ -234,13 +248,14 @@ namespace osu.Framework.Tests.Visual.Containers
 
                 case 4:
                 {
-                    static Drawable createMaskingBox(float scale)
+                    static Drawable createMaskingBox(float scale, float cornerExponent)
                     {
                         float size = 200 / scale;
                         return new Container
                         {
                             Masking = true,
                             CornerRadius = 25 / scale,
+                            CornerExponent = cornerExponent,
                             BorderThickness = 12.5f / scale,
                             BorderColour = Color4.Red,
                             Size = new Vector2(size),
@@ -278,28 +293,28 @@ namespace osu.Framework.Tests.Visual.Containers
                                 RelativeSizeAxes = Axes.Both,
                                 Size = new Vector2(0.5f),
                                 Masking = true,
-                                Children = new[] { createMaskingBox(100) }
+                                Children = new[] { createMaskingBox(100, cornerExponent) }
                             },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Size = new Vector2(0.5f),
                                 Masking = true,
-                                Children = new[] { createMaskingBox(10) }
+                                Children = new[] { createMaskingBox(10, cornerExponent) }
                             },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Size = new Vector2(0.5f),
                                 Masking = true,
-                                Children = new[] { createMaskingBox(1) }
+                                Children = new[] { createMaskingBox(1, cornerExponent) }
                             },
                             new Container
                             {
                                 RelativeSizeAxes = Axes.Both,
                                 Size = new Vector2(0.5f),
                                 Masking = true,
-                                Children = new[] { createMaskingBox(0.1f) }
+                                Children = new[] { createMaskingBox(0.1f, cornerExponent) }
                             },
                         }
                     });
@@ -320,6 +335,7 @@ namespace osu.Framework.Tests.Visual.Containers
                             {
                                 Masking = true,
                                 CornerRadius = 100f,
+                                CornerExponent = cornerExponent,
                                 BorderThickness = 50f,
                                 BorderColour = Color4.Red,
                                 RelativeSizeAxes = Axes.Both,
@@ -444,6 +460,7 @@ namespace osu.Framework.Tests.Visual.Containers
                         Origin = Anchor.Centre,
                         Masking = true,
                         CornerRadius = 100,
+                        CornerExponent = cornerExponent,
                         Alpha = 0.8f,
                         EdgeEffect = new EdgeEffectParameters
                         {

--- a/osu.Framework.Tests/Visual/Input/TestSceneNestedHover.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneNestedHover.cs
@@ -19,7 +19,10 @@ namespace osu.Framework.Tests.Visual.Input
             {
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre,
-                Size = new Vector2(300, 300)
+                Size = new Vector2(300, 300),
+                CornerRadius = 100,
+                CornerExponent = 5,
+                Masking = true,
             });
 
             HoverBox box2;

--- a/osu.Framework/Graphics/Containers/CircularContainer.cs
+++ b/osu.Framework/Graphics/Containers/CircularContainer.cs
@@ -6,7 +6,7 @@ using System;
 namespace osu.Framework.Graphics.Containers
 {
     /// <summary>
-    /// A container which is rounded (via automatic corner-radius) on the shortest edge.
+    /// A container which is rounded (via automatic corner-radius and corner-exponent=2) on the shortest edge.
     /// </summary>
     public class CircularContainer : Container
     {
@@ -15,6 +15,7 @@ namespace osu.Framework.Graphics.Containers
             // this shouldn't have to be done here, but it's the only place it works correctly.
             // see https://github.com/ppy/osu-framework/pull/1666
             CornerRadius = Math.Min(DrawSize.X, DrawSize.Y) / 2f;
+            CornerExponent = 2;
 
             return base.GenerateDrawNodeSubtree(frame, treeIndex, forceNewDrawNode);
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1217,13 +1217,14 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool Contains(Vector2 screenSpacePos)
         {
-            float cRadius = CornerRadius;
+            float cRadius = effectiveCornerRadius;
+            float cExponent = CornerExponent;
 
             // Select a cheaper contains method when we don't need rounded edges.
             if (cRadius == 0.0f)
                 return base.Contains(screenSpacePos);
 
-            return DrawRectangle.Shrink(cRadius).DistanceSquared(ToLocalSpace(screenSpacePos)) <= cRadius * cRadius;
+            return DrawRectangle.Shrink(cRadius).DistanceExponentiated(ToLocalSpace(screenSpacePos), cExponent) <= Math.Pow(cRadius, cExponent);
         }
 
         /// <summary>
@@ -1339,6 +1340,31 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        private float cornerExponent = 2.5f;
+
+        /// <summary>
+        /// Determines how gentle the curve of the corner straightens. A value of 2 results in
+        /// circular arcs, a value of 2.5 (default) results in something closer to apple's "continuous curve".
+        /// Recommended range: 2--5. Values outside of that range may result in unpredictable behavior.
+        /// Only has an effect when <see cref="Masking"/> is true and <see cref="CornerRadius"/> is non-zero.
+        /// </summary>
+        public float CornerExponent
+        {
+            get => cornerExponent;
+            protected set
+            {
+                if (cornerExponent == value)
+                    return;
+
+                cornerExponent = value;
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+
+        // This _hacky_ modification of the corner radius (obtained from playing around) ensures that the corner remains at roughly
+        // equal size (perceptually) compared to the circular arc as the CornerExponent is adjusted within the range ~2-5.
+        private float effectiveCornerRadius => CornerRadius * 0.8f * CornerExponent / 2 + 0.2f * CornerRadius;
+
         private float borderThickness;
 
         /// <summary>
@@ -1412,6 +1438,7 @@ namespace osu.Framework.Graphics.Containers
             get
             {
                 float cRadius = CornerRadius;
+                float cExponent = CornerExponent;
                 if (cRadius == 0.0f)
                     return base.BoundingBox;
 
@@ -1422,7 +1449,10 @@ namespace osu.Framework.Graphics.Containers
                 Vector2 offset = ToParentSpace(Vector2.Zero);
                 Vector2 u = ToParentSpace(new Vector2(cRadius, 0)) - offset;
                 Vector2 v = ToParentSpace(new Vector2(0, cRadius)) - offset;
-                Vector2 inflation = new Vector2((float)Math.Sqrt(u.X * u.X + v.X * v.X), (float)Math.Sqrt(u.Y * u.Y + v.Y * v.Y));
+                Vector2 inflation = new Vector2(
+                    (float)Math.Sqrt(u.X * u.X + v.X * v.X),
+                    (float)Math.Sqrt(u.Y * u.Y + v.Y * v.Y)
+                );
 
                 RectangleF result = ToParentSpace(drawRect).AABBFloat.Inflate(inflation);
                 // The above algorithm will return incorrect results if the rounded corners are not fully visible.

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -93,7 +93,8 @@ namespace osu.Framework.Graphics.Containers
                         MaskingRect = Source.DrawRectangle,
                         ConservativeScreenSpaceQuad = Quad.FromRectangle(shrunkDrawRectangle) * DrawInfo.Matrix,
                         ToMaskingSpace = DrawInfo.MatrixInverse,
-                        CornerRadius = Source.CornerRadius,
+                        CornerRadius = Source.effectiveCornerRadius,
+                        CornerExponent = Source.CornerExponent,
                         BorderThickness = Source.BorderThickness,
                         BorderColour = Source.BorderColour,
                         // We are setting the linear blend range to the approximate size of a _pixel_ here.

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -310,6 +310,18 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
+        /// Determines how gentle the curve of the corner straightens. A value of 2 results in
+        /// circular arcs, a value of 2.5 (default) results in something closer to apple's "continuous curve".
+        /// Recommended range: 2--5. Values outside of that range may result in unpredictable behavior.
+        /// Only has an effect when <see cref="Masking"/> is true and <see cref="CornerRadius"/> is non-zero.
+        /// </summary>
+        public new float CornerExponent
+        {
+            get => base.CornerExponent;
+            set => base.CornerExponent = value;
+        }
+
+        /// <summary>
         /// Determines how thick of a border to draw around the inside of the masked region.
         /// Only has an effect when <see cref="Masking"/> is true.
         /// The border only is drawn on top of children using a sprite shader.

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -147,6 +147,7 @@ namespace osu.Framework.Graphics.OpenGL
                 ToMaskingSpace = Matrix3.Identity,
                 BlendRange = 1,
                 AlphaExponent = 1,
+                CornerExponent = 2.5f,
             }, true);
 
             PushDepthInfo(DepthInfo.Default);
@@ -488,7 +489,9 @@ namespace osu.Framework.Graphics.OpenGL
                 maskingInfo.MaskingRect.Bottom));
 
             GlobalPropertyManager.Set(GlobalProperty.ToMaskingSpace, maskingInfo.ToMaskingSpace);
+
             GlobalPropertyManager.Set(GlobalProperty.CornerRadius, maskingInfo.CornerRadius);
+            GlobalPropertyManager.Set(GlobalProperty.CornerExponent, maskingInfo.CornerExponent);
 
             GlobalPropertyManager.Set(GlobalProperty.BorderThickness, maskingInfo.BorderThickness / maskingInfo.BlendRange);
 
@@ -784,6 +787,7 @@ namespace osu.Framework.Graphics.OpenGL
         public Matrix3 ToMaskingSpace;
 
         public float CornerRadius;
+        public float CornerExponent;
 
         public float BorderThickness;
         public SRGBColour BorderColour;
@@ -801,6 +805,7 @@ namespace osu.Framework.Graphics.OpenGL
             MaskingRect == other.MaskingRect &&
             ToMaskingSpace == other.ToMaskingSpace &&
             CornerRadius == other.CornerRadius &&
+            CornerExponent == other.CornerExponent &&
             BorderThickness == other.BorderThickness &&
             BorderColour.Equals(other.BorderColour) &&
             BlendRange == other.BlendRange &&

--- a/osu.Framework/Graphics/Primitives/RectangleF.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleF.cs
@@ -338,6 +338,16 @@ namespace osu.Framework.Graphics.Primitives
             return dist.LengthSquared;
         }
 
+        internal float DistanceExponentiated(Vector2 localSpacePos, float exponent)
+        {
+            Vector2 dist = new Vector2(
+                Math.Max(0.0f, Math.Max(localSpacePos.X - Right, Left - localSpacePos.X)),
+                Math.Max(0.0f, Math.Max(localSpacePos.Y - Bottom, Top - localSpacePos.Y))
+            );
+
+            return (float)Math.Pow(dist.X, exponent) + (float)Math.Pow(dist.Y, exponent);
+        }
+
         // This could be optimized further in the future, but made for a simple implementation right now.
         public RectangleI AABB => ((Quad)this).AABB;
 

--- a/osu.Framework/Graphics/Shaders/GlobalProperty.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalProperty.cs
@@ -12,6 +12,7 @@ namespace osu.Framework.Graphics.Shaders
         MaskingRect,
         ToMaskingSpace,
         CornerRadius,
+        CornerExponent,
         BorderThickness,
         BorderColour,
         MaskingBlendRange,

--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -23,6 +23,7 @@ namespace osu.Framework.Graphics.Shaders
             global_properties[(int)GlobalProperty.MaskingRect] = new UniformMapping<Vector4>("g_MaskingRect");
             global_properties[(int)GlobalProperty.ToMaskingSpace] = new UniformMapping<Matrix3>("g_ToMaskingSpace");
             global_properties[(int)GlobalProperty.CornerRadius] = new UniformMapping<float>("g_CornerRadius");
+            global_properties[(int)GlobalProperty.CornerExponent] = new UniformMapping<float>("g_CornerExponent");
             global_properties[(int)GlobalProperty.BorderThickness] = new UniformMapping<float>("g_BorderThickness");
             global_properties[(int)GlobalProperty.BorderColour] = new UniformMapping<Vector4>("g_BorderColour");
             global_properties[(int)GlobalProperty.MaskingBlendRange] = new UniformMapping<float>("g_MaskingBlendRange");

--- a/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_TextureRounded.fs
@@ -8,6 +8,7 @@ varying mediump vec2 v_BlendRange;
 
 uniform lowp sampler2D m_Sampler;
 uniform highp float g_CornerRadius;
+uniform highp float g_CornerExponent;
 uniform highp vec4 g_MaskingRect;
 uniform highp float g_BorderThickness;
 uniform lowp vec4 g_BorderColour;
@@ -40,7 +41,10 @@ highp float distanceFromRoundedRect(highp vec2 offset, highp float radius)
 		return maxDist;
 	// Outside of the shrunk rectangle
 	else
-		return length(max(vec2(0.0), distanceFromShrunkRect));
+	{
+		distanceFromShrunkRect = max(vec2(0.0), distanceFromShrunkRect);
+		return pow(pow(distanceFromShrunkRect.x, g_CornerExponent) + pow(distanceFromShrunkRect.y, g_CornerExponent), 1.0 / g_CornerExponent);
+	}
 }
 
 highp float distanceFromDrawingRect()


### PR DESCRIPTION
The gentleness of curves can be controlled by a `CornerRadius` property of `CompositeDrawable` / `Container`. A value of 2 reproduces former behavior (it is the default for `CircularContainer`) whereas a value of 2.5 produces behavior closer to Apple's usage. 2.5 is the new default for any `CompositeDrawable` that is not a `CircularContainer`.