### PR TITLE
Add the ability to create "solid" outer borders

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneMasking.cs
@@ -101,8 +101,8 @@ namespace osu.Framework.Tests.Visual.Containers
                         EdgeEffect = new EdgeEffectParameters
                         {
                             Type = EdgeEffectType.Shadow,
-                            Radius = 100,
-                            Colour = new Color4(0, 50, 100, 200),
+                            Inflation = 10,
+                            Colour = new Color4(0, 100, 200, 255),
                         },
                     });
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -114,10 +114,10 @@ namespace osu.Framework.Graphics.Containers
 
             private void drawEdgeEffect()
             {
-                if (maskingInfo == null || edgeEffect.Type == EdgeEffectType.None || edgeEffect.Radius <= 0.0f || edgeEffect.Colour.Linear.A <= 0)
+                if (maskingInfo == null || edgeEffect.Type == EdgeEffectType.None || (edgeEffect.Radius + edgeEffect.Inflation) <= 0.0f || edgeEffect.Colour.Linear.A <= 0)
                     return;
 
-                RectangleF effectRect = maskingInfo.Value.MaskingRect.Inflate(edgeEffect.Radius).Offset(edgeEffect.Offset);
+                RectangleF effectRect = maskingInfo.Value.MaskingRect.Inflate(edgeEffect.Radius).Inflate(edgeEffect.Inflation).Offset(edgeEffect.Offset);
 
                 if (!screenSpaceMaskingQuad.HasValue)
                     screenSpaceMaskingQuad = Quad.FromRectangle(effectRect) * DrawInfo.Matrix;
@@ -125,11 +125,11 @@ namespace osu.Framework.Graphics.Containers
                 MaskingInfo edgeEffectMaskingInfo = maskingInfo.Value;
                 edgeEffectMaskingInfo.MaskingRect = effectRect;
                 edgeEffectMaskingInfo.ScreenSpaceAABB = screenSpaceMaskingQuad.Value.AABB;
-                edgeEffectMaskingInfo.CornerRadius = maskingInfo.Value.CornerRadius + edgeEffect.Radius + edgeEffect.Roundness;
+                edgeEffectMaskingInfo.CornerRadius = maskingInfo.Value.CornerRadius + edgeEffect.Radius + edgeEffect.Roundness + edgeEffect.Inflation;
                 edgeEffectMaskingInfo.BorderThickness = 0;
                 // HACK HACK HACK. We abuse blend range to give us the linear alpha gradient of
                 // the edge effect along its radius using the same rounded-corners shader.
-                edgeEffectMaskingInfo.BlendRange = edgeEffect.Radius;
+                edgeEffectMaskingInfo.BlendRange = Math.Max(edgeEffect.Radius, maskingInfo.Value.BlendRange);
                 edgeEffectMaskingInfo.AlphaExponent = 2;
                 edgeEffectMaskingInfo.EdgeOffset = edgeEffect.Offset;
                 edgeEffectMaskingInfo.Hollow = edgeEffect.Hollow;

--- a/osu.Framework/Graphics/Effects/EdgeEffectParameters.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffectParameters.cs
@@ -42,6 +42,11 @@ namespace osu.Framework.Graphics.Effects
         public float Radius;
 
         /// <summary>
+        /// Width of a solid outer border made from the edge effect's color.
+        /// </summary>
+        public float Inflation;
+
+        /// <summary>
         /// Whether the inside of the EdgeEffect rectangle should be empty.
         /// </summary>
         public bool Hollow;


### PR DESCRIPTION
Solid outer borders can be achieved by setting the `Radius` of an edge effect to zero and setting `Inflation` to a positive number.

Optionally, `Inflation` can also be used to shrink the edge effect "into" its target.