### PR TITLE
Fix bad references in xml doc

### DIFF
--- a/osu.Framework/Bindables/AggregateBindable.cs
+++ b/osu.Framework/Bindables/AggregateBindable.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// Create a new aggregate bindable.
         /// </summary>
-        /// <param name="aggregateFunction">The function to be used for aggregation, taking two input <see cref="T"/> values and returning one output.</param>
+        /// <param name="aggregateFunction">The function to be used for aggregation, taking two input <typeparamref name="T"/> values and returning one output.</param>
         /// <param name="resultBindable">An optional newly constructed bindable to use for <see cref="Result"/>. The initial value of this bindable is used as the initial value for the aggregate.</param>
         public AggregateBindable(Func<T, T, T> aggregateFunction, Bindable<T> resultBindable = null)
         {

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -168,7 +168,7 @@ namespace osu.Framework.Bindables
         /// Bind an action to <see cref="ValueChanged"/> with the option of running the bound action once immediately.
         /// </summary>
         /// <param name="onChange">The action to perform when <see cref="Value"/> changes.</param>
-        /// <param name="runOnceImmediately">Whether the action provided in <see cref="onChange"/> should be run once immediately.</param>
+        /// <param name="runOnceImmediately">Whether the action provided in <paramref name="onChange"/> should be run once immediately.</param>
         public void BindValueChanged(Action<ValueChangedEvent<T>> onChange, bool runOnceImmediately = false)
         {
             ValueChanged += onChange;
@@ -180,7 +180,7 @@ namespace osu.Framework.Bindables
         /// Bind an action to <see cref="DisabledChanged"/> with the option of running the bound action once immediately.
         /// </summary>
         /// <param name="onChange">The action to perform when <see cref="Disabled"/> changes.</param>
-        /// <param name="runOnceImmediately">Whether the action provided in <see cref="onChange"/> should be run once immediately.</param>
+        /// <param name="runOnceImmediately">Whether the action provided in <paramref name="onChange"/> should be run once immediately.</param>
         public void BindDisabledChanged(Action<bool> onChange, bool runOnceImmediately = false)
         {
             DisabledChanged += onChange;

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -110,12 +110,12 @@ namespace osu.Framework.Bindables
         }
 
         /// <summary>
-        /// The default <see cref="MinValue"/>. This should be equal to the minimum value of type <see cref="T"/>.
+        /// The default <see cref="MinValue"/>. This should be equal to the minimum value of type <typeparamref name="T"/>.
         /// </summary>
         protected abstract T DefaultMinValue { get; }
 
         /// <summary>
-        /// The default <see cref="MaxValue"/>. This should be equal to the maximum value of type <see cref="T"/>.
+        /// The default <see cref="MaxValue"/>. This should be equal to the maximum value of type <typeparamref name="T"/>.
         /// </summary>
         protected abstract T DefaultMaxValue { get; }
 
@@ -206,7 +206,7 @@ namespace osu.Framework.Bindables
         }
 
         /// <summary>
-        /// Whether this bindable has a user-defined range that is not the full range of the <see cref="T"/> type.
+        /// Whether this bindable has a user-defined range that is not the full range of the <typeparamref name="T"/> type.
         /// </summary>
         public bool HasDefinedRange => !MinValue.Equals(DefaultMinValue) || !MaxValue.Equals(DefaultMaxValue);
 

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -6,7 +6,7 @@ using System;
 namespace osu.Framework.Bindables
 {
     /// <summary>
-    /// An interface which can be bound to other <see cref="IBindable"/>s in order to watch for (and react to) <see cref="IBindable.Disabled"/> changes.
+    /// An interface which can be bound to other <see cref="IBindable"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled"/> changes.
     /// </summary>
     public interface IBindable : IParseable, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
     {
@@ -26,7 +26,7 @@ namespace osu.Framework.Bindables
     }
 
     /// <summary>
-    /// An interface which can be bound to other <see cref="IBindable{T}"/>s in order to watch for (and react to) <see cref="IBindable{T}.Disabled"/> and <see cref="IBindable{T}.Value"/> changes.
+    /// An interface which can be bound to other <see cref="IBindable{T}"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled"/> and <see cref="IBindable{T}.Value"/> changes.
     /// </summary>
     /// <typeparam name="T">The type of value encapsulated by this <see cref="IBindable{T}"/>.</typeparam>
     public interface IBindable<T> : IBindable
@@ -42,7 +42,7 @@ namespace osu.Framework.Bindables
         T Value { get; }
 
         /// <summary>
-        /// The default value of this bindable. Used when querying <see cref="IBindable{T}.IsDefault"/>.
+        /// The default value of this bindable. Used when querying <see cref="IHasDefaultValue.IsDefault"/>.
         /// </summary>
         T Default { get; }
 

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Bindables
         /// Bind an action to <see cref="ValueChanged"/> with the option of running the bound action once immediately.
         /// </summary>
         /// <param name="onChange">The action to perform when <see cref="Value"/> changes.</param>
-        /// <param name="runOnceImmediately">Whether the action provided in <see cref="onChange"/> should be run once immediately.</param>
+        /// <param name="runOnceImmediately">Whether the action provided in <paramref name="onChange"/> should be run once immediately.</param>
         void BindValueChanged(Action<ValueChangedEvent<T>> onChange, bool runOnceImmediately = false);
 
         /// <summary>

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -6,7 +6,7 @@ using System;
 namespace osu.Framework.Bindables
 {
     /// <summary>
-    /// An interface which can be bound to other <see cref="IBindable"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled"/> changes.
+    /// An interface which can be bound to other <see cref="IBindable"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled">Disabled</see> changes.
     /// </summary>
     public interface IBindable : IParseable, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
     {
@@ -26,7 +26,7 @@ namespace osu.Framework.Bindables
     }
 
     /// <summary>
-    /// An interface which can be bound to other <see cref="IBindable{T}"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled"/> and <see cref="IBindable{T}.Value"/> changes.
+    /// An interface which can be bound to other <see cref="IBindable{T}"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled">Disabled</see> and <see cref="IBindable{T}.Value">Value</see> changes.
     /// </summary>
     /// <typeparam name="T">The type of value encapsulated by this <see cref="IBindable{T}"/>.</typeparam>
     public interface IBindable<T> : IBindable
@@ -42,7 +42,7 @@ namespace osu.Framework.Bindables
         T Value { get; }
 
         /// <summary>
-        /// The default value of this bindable. Used when querying <see cref="IHasDefaultValue.IsDefault"/>.
+        /// The default value of this bindable. Used when querying <see cref="IHasDefaultValue.IsDefault">IsDefault</see>.
         /// </summary>
         T Default { get; }
 

--- a/osu.Framework/Bindables/IBindableNumber.cs
+++ b/osu.Framework/Bindables/IBindableNumber.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Bindables
         T Precision { get; }
 
         /// <summary>
-        /// The minimum value of this bindable. <see cref="IBindableNumber{T}.Value"/> will never go below this value.
+        /// The minimum value of this bindable. <see cref="IBindable{T}.Value"/> will never go below this value.
         /// </summary>
         T MinValue { get; }
 

--- a/osu.Framework/Bindables/IBindableNumber.cs
+++ b/osu.Framework/Bindables/IBindableNumber.cs
@@ -28,12 +28,12 @@ namespace osu.Framework.Bindables
         T Precision { get; }
 
         /// <summary>
-        /// The minimum value of this bindable. <see cref="IBindable{T}.Value"/> will never go below this value.
+        /// The minimum value of this bindable. <see cref="IBindable{T}.Value">Value</see> will never go below this value.
         /// </summary>
         T MinValue { get; }
 
         /// <summary>
-        /// The maximum value of this bindable. <see cref="IBindableNumber{T}"/> will never go above this value.
+        /// The maximum value of this bindable. <see cref="IBindable{T}.Value">Value</see> will never go above this value.
         /// </summary>
         T MaxValue { get; }
 

--- a/osu.Framework/Bindables/ICanBeDisabled.cs
+++ b/osu.Framework/Bindables/ICanBeDisabled.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Bindables
         /// Bind an action to <see cref="DisabledChanged"/> with the option of running the bound action once immediately.
         /// </summary>
         /// <param name="onChange">The action to perform when <see cref="Disabled"/> changes.</param>
-        /// <param name="runOnceImmediately">Whether the action provided in <see cref="onChange"/> should be run once immediately.</param>
+        /// <param name="runOnceImmediately">Whether the action provided in <paramref name="onChange"/> should be run once immediately.</param>
         void BindDisabledChanged(Action<bool> onChange, bool runOnceImmediately = false);
 
         /// <summary>

--- a/osu.Framework/Extensions/ExceptionExtensions/ExceptionExtensions.cs
+++ b/osu.Framework/Extensions/ExceptionExtensions/ExceptionExtensions.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Extensions.ExceptionExtensions
         }
 
         /// <summary>
-        /// Rethrows the <see cref="AggregateException.InnerException"/> of an <see cref="AggregateException"/> if it exists,
+        /// Rethrows the <see cref="Exception.InnerException"/> of an <see cref="AggregateException"/> if it exists,
         /// otherwise, rethrows <paramref name="aggregateException"/>.
         /// This preserves the stack trace of the exception that is rethrown, and will not include the point of rethrow.
         /// </summary>

--- a/osu.Framework/Extensions/PolygonExtensions/ConvexPolygonExtensions.cs
+++ b/osu.Framework/Extensions/PolygonExtensions/ConvexPolygonExtensions.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Extensions.PolygonExtensions
         /// <param name="axes">The axes to check for intersections along.</param>
         /// <param name="firstVertices">The first set of vertices.</param>
         /// <param name="secondVertices">The second set of vertices.</param>
-        /// <returns>Whether there is an intersection between <paramref name="firstVertices"/> and <see cref="secondVertices"/> along any of <paramref name="axes"/>.</returns>
+        /// <returns>Whether there is an intersection between <paramref name="firstVertices"/> and <paramref name="secondVertices"/> along any of <paramref name="axes"/>.</returns>
         private static bool intersects(ReadOnlySpan<Vector2> axes, ReadOnlySpan<Vector2> firstVertices, ReadOnlySpan<Vector2> secondVertices)
         {
             foreach (Vector2 axis in axes)

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Graphics.Audio
         private float resolution = 1;
 
         /// <summary>
-        /// Gets or sets the amount of <see cref="Framework.Audio.Track.Waveform.Point"/>'s displayed relative to <see cref="WaveformGraph.DrawWidth"/>.
+        /// Gets or sets the amount of <see cref="Framework.Audio.Track.Waveform.Point"/>'s displayed relative to <see cref="Drawable.DrawWidth"/>.
         /// </summary>
         public float Resolution
         {

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Graphics.Audio
         private float resolution = 1;
 
         /// <summary>
-        /// Gets or sets the amount of <see cref="Framework.Audio.Track.Waveform.Point"/>'s displayed relative to <see cref="Drawable.DrawWidth"/>.
+        /// Gets or sets the amount of <see cref="Framework.Audio.Track.Waveform.Point"/>'s displayed relative to <see cref="Drawable.DrawWidth">DrawWidth</see>.
         /// </summary>
         public float Resolution
         {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -721,7 +721,7 @@ namespace osu.Framework.Graphics.Containers
         /// Make a child alive.
         /// </summary>
         /// <remarks>
-        /// Caller have to ensure that <see cref="child"/> is this <see cref="CompositeDrawable"/>'s non-alive <see cref="InternalChildren"/> and <see cref="LoadState"/> of the child is at least <see cref="LoadState.Ready"/>.
+        /// Caller have to ensure that <paramref name="child"/> is this <see cref="CompositeDrawable"/>'s non-alive <see cref="InternalChildren"/> and <see cref="LoadState"/> of the child is at least <see cref="LoadState.Ready"/>.
         /// </remarks>
         /// <param name="child">The child of this <see cref="CompositeDrawable"/>> to make alive.</param>
         protected void MakeChildAlive(Drawable child)
@@ -752,7 +752,7 @@ namespace osu.Framework.Graphics.Containers
         /// Make a child dead (not alive).
         /// </summary>
         /// <remarks>
-        /// Caller have to ensure that <see cref="child"/> is this <see cref="CompositeDrawable"/>'s <see cref="AliveInternalChildren"/>.
+        /// Caller have to ensure that <paramref name="child"/> is this <see cref="CompositeDrawable"/>'s <see cref="AliveInternalChildren"/>.
         /// </remarks>
         /// <param name="child">The child of this <see cref="CompositeDrawable"/>> to make dead.</param>
         /// <returns>Returns true if <paramref name="child"/> is removed by death.</returns>

--- a/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
+++ b/osu.Framework/Graphics/Containers/ModelBackedDrawable.cs
@@ -168,7 +168,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="createContentFunc">A function that creates the wrapped <see cref="Drawable"/>.</param>
         /// <param name="timeBeforeLoad">The time before loading should begin.</param>
-        /// <returns>A <see cref="DelayedLoadWrapper"/> or null if <see cref="createContentFunc"/> returns null.</returns>
+        /// <returns>A <see cref="DelayedLoadWrapper"/> or null if <paramref name="createContentFunc"/> returns null.</returns>
         private DelayedLoadWrapper createWrapper(Func<Drawable> createContentFunc, double timeBeforeLoad)
         {
             var content = createContentFunc?.Invoke();

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -150,7 +150,7 @@ namespace osu.Framework.Graphics
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void DrawTriangle(Texture texture, Triangle vertexTriangle, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null,
                                     Vector2? inflationPercentage = null)
@@ -164,7 +164,7 @@ namespace osu.Framework.Graphics
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void DrawTriangle(TextureGL texture, Triangle vertexTriangle, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null,
                                     Vector2? inflationPercentage = null)
@@ -178,8 +178,8 @@ namespace osu.Framework.Graphics
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
-        /// <param name="blendRangeOverride">The range over which the edges of the <see cref="textureRect"/> should be blended.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
+        /// <param name="blendRangeOverride">The range over which the edges of the <paramref name="textureRect"/> should be blended.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void DrawQuad(Texture texture, Quad vertexQuad, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null,
                                 Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
@@ -193,8 +193,8 @@ namespace osu.Framework.Graphics
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
-        /// <param name="blendRangeOverride">The range over which the edges of the <see cref="textureRect"/> should be blended.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
+        /// <param name="blendRangeOverride">The range over which the edges of the <paramref name="textureRect"/> should be blended.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void DrawQuad(TextureGL texture, Quad vertexQuad, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null,
                                 Vector2? inflationPercentage = null, Vector2? blendRangeOverride = null)
@@ -208,7 +208,7 @@ namespace osu.Framework.Graphics
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void DrawClipped<T>(ref T polygon, Texture texture, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null,
                                       Vector2? inflationPercentage = null)
@@ -232,7 +232,7 @@ namespace osu.Framework.Graphics
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void DrawClipped<T>(ref T polygon, TextureGL texture, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null,
                                       Vector2? inflationPercentage = null)

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -268,8 +268,8 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
-        /// Increments the reference count of this <see cref="DrawNode"/>, blocking <see cref="Dispose"/> until the count reaches 0.
-        /// Invoke <see cref="Dispose"/> to remove the reference.
+        /// Increments the reference count of this <see cref="DrawNode"/>, blocking <see cref="Dispose()"/> until the count reaches 0.
+        /// Invoke <see cref="Dispose()"/> to remove the reference.
         /// </summary>
         /// <remarks>
         /// All <see cref="DrawNode"/>s start with a reference count of 1.

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1473,7 +1473,7 @@ namespace osu.Framework.Graphics
         /// This can be a potentially expensive operation and should be used with discretion.
         /// </remarks>
         /// <typeparam name="T">The type to match.</typeparam>
-        /// <returns>The first matching parent, or null if no parent of type <see cref="T"/> is found.</returns>
+        /// <returns>The first matching parent, or null if no parent of type <typeparamref name="T"/> is found.</returns>
         internal T FindClosestParent<T>() where T : IDrawable
         {
             Drawable cursor = this;

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
         internal abstract void DrawTriangle(Triangle vertexTriangle, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null,
                                             Vector2? inflationPercentage = null);
 
@@ -89,8 +89,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
-        /// <param name="blendRangeOverride">The range over which the edges of the <see cref="textureRect"/> should be blended.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
+        /// <param name="blendRangeOverride">The range over which the edges of the <paramref name="textureRect"/> should be blended.</param>
         internal abstract void DrawQuad(Quad vertexQuad, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null,
                                         Vector2? blendRangeOverride = null);
 

--- a/osu.Framework/Graphics/OpenGL/Vertices/VertexUtils.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/VertexUtils.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         where T : IVertex
     {
         /// <summary>
-        /// The stride of the vertex of type <see cref="T"/>.
+        /// The stride of the vertex of type <typeparamref name="T"/>.
         /// </summary>
         public static readonly int STRIDE = Marshal.SizeOf(default(T));
 
@@ -55,7 +55,7 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         }
 
         /// <summary>
-        /// Enables and binds the vertex attributes/pointers for the vertex of type <see cref="T"/>.
+        /// Enables and binds the vertex attributes/pointers for the vertex of type <typeparamref name="T"/>.
         /// </summary>
         public static void Bind()
         {

--- a/osu.Framework/Graphics/Sprites/FontAwesome.cs
+++ b/osu.Framework/Graphics/Sprites/FontAwesome.cs
@@ -260,7 +260,7 @@ namespace osu.Framework.Graphics.Sprites
             public static IconUsage Buffer => Get(0xf837);
 
             /// <summary>
-            /// BÃ¼romÃ¶bel-Experte GmbH & Co. KG.
+            /// Büromöbel-Experte GmbH &amp; Co. KG.
             /// </summary>
             public static IconUsage Buromobelexperte => Get(0xf37f);
 
@@ -480,12 +480,12 @@ namespace osu.Framework.Graphics.Sprites
             public static IconUsage Cuttlefish => Get(0xf38c);
 
             /// <summary>
-            /// Dungeons & Dragons
+            /// Dungeons &amp; Dragons
             /// </summary>
             public static IconUsage DAndD => Get(0xf38d);
 
             /// <summary>
-            /// D&D Beyond
+            /// D&amp;D Beyond
             /// </summary>
             public static IconUsage DAndDBeyond => Get(0xf6ca);
 
@@ -6542,7 +6542,7 @@ namespace osu.Framework.Graphics.Sprites
             public static IconUsage Skull => Get(0xf54c);
 
             /// <summary>
-            /// Skull & Crossbones
+            /// Skull &amp; Crossbones
             /// </summary>
             public static IconUsage SkullCrossbones => Get(0xf714);
 

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -121,7 +121,7 @@ namespace osu.Framework.Graphics.Textures
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
         internal void DrawTriangle(Triangle vertexTriangle, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null,
                                    Vector2? inflationPercentage = null)
         {
@@ -137,8 +137,8 @@ namespace osu.Framework.Graphics.Textures
         /// <param name="drawColour">The vertex colour.</param>
         /// <param name="textureRect">The texture rectangle.</param>
         /// <param name="vertexAction">An action that adds vertices to a <see cref="VertexBatch{T}"/>.</param>
-        /// <param name="inflationPercentage">The percentage amount that <see cref="textureRect"/> should be inflated.</param>
-        /// <param name="blendRangeOverride">The range over which the edges of the <see cref="textureRect"/> should be blended.</param>
+        /// <param name="inflationPercentage">The percentage amount that <paramref name="textureRect"/> should be inflated.</param>
+        /// <param name="blendRangeOverride">The range over which the edges of the <paramref name="textureRect"/> should be blended.</param>
         internal void DrawQuad(Quad vertexQuad, ColourInfo drawColour, RectangleF? textureRect = null, Action<TexturedVertex2D> vertexAction = null, Vector2? inflationPercentage = null,
                                Vector2? blendRangeOverride = null)
         {

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -194,7 +194,7 @@ namespace osu.Framework.Graphics
             drawable.Delay(0).Spin(revolutionDuration, direction, startRotation);
 
         /// <summary>
-        /// Rotate <see cref="numRevolutions"/> times with provided parameters.
+        /// Rotate <paramref name="numRevolutions"/> times with provided parameters.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
         public static TransformSequence<T> Spin<T>(this T drawable, double revolutionDuration, RotationDirection direction, float startRotation, int numRevolutions) where T : Drawable =>

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -144,7 +144,7 @@ namespace osu.Framework.Graphics.Transforms
         private readonly InterpolationFunc<TValue> interpolationFunc;
 
         /// <summary>
-        /// Creates a new instance operating on a property or field of <see cref="T"/>. The property or field is
+        /// Creates a new instance operating on a property or field of <typeparamref name="T"/>. The property or field is
         /// denoted by its name, passed as <paramref name="propertyOrFieldName"/>.
         /// By default, an interpolation method "ValueAt" from <see cref="Interpolation"/> with suitable signature is
         /// picked for interpolating between <see cref="Transform{TValue}.StartValue"/> and

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// A delegate that generates a new <see cref="TransformSequence{T}"/> on a given <paramref name="origin"/>.
         /// </summary>
-        /// <param name="origin">The <typeparamref name="T"/> to generate a <see cref="TransformSequence{T}"/> for.</param>
+        /// <param name="origin">The origin to generate a <see cref="TransformSequence{T}"/> for.</param>
         /// <returns>The generated <see cref="TransformSequence{T}"/>.</returns>
         public delegate TransformSequence<T> Generator(T origin);
 

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// A delegate that generates a new <see cref="TransformSequence{T}"/> on a given <paramref name="origin"/>.
         /// </summary>
-        /// <param name="origin">The <see cref="T"/> to generate a <see cref="TransformSequence{T}"/> for.</param>
+        /// <param name="origin">The <typeparamref name="T"/> to generate a <see cref="TransformSequence{T}"/> for.</param>
         /// <returns>The generated <see cref="TransformSequence{T}"/>.</returns>
         public delegate TransformSequence<T> Generator(T origin);
 
@@ -42,7 +42,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// Creates a new empty <see cref="TransformSequence{T}"/> attached to a given <paramref name="origin"/>.
         /// </summary>
-        /// <param name="origin">The <see cref="T"/> to attach the new <see cref="TransformSequence{T}"/> to.</param>
+        /// <param name="origin">The <typeparamref name="T"/> to attach the new <see cref="TransformSequence{T}"/> to.</param>
         public TransformSequence(T origin)
         {
             if (origin == null)

--- a/osu.Framework/Input/Bindings/KeyBinding.cs
+++ b/osu.Framework/Input/Bindings/KeyBinding.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Input.Bindings
         /// Get the action associated with this binding, cast to the required enum type.
         /// </summary>
         /// <typeparam name="T">The enum type.</typeparam>
-        /// <returns>A cast <see cref="T"/> representation of <see cref="Action"/>.</returns>
+        /// <returns>A cast <typeparamref name="T"/> representation of <see cref="Action"/>.</returns>
         public virtual T GetAction<T>() => (T)Action;
 
         public override string ToString() => $"{KeyCombination}=>{Action}";

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -15,7 +15,7 @@ using osuTK;
 namespace osu.Framework.Input.Bindings
 {
     /// <summary>
-    /// Maps input actions to custom action data of type <see cref="T"/>. Use in conjunction with <see cref="Drawable"/>s implementing <see cref="IKeyBindingHandler{T}"/>.
+    /// Maps input actions to custom action data of type <typeparamref name="T"/>. Use in conjunction with <see cref="Drawable"/>s implementing <see cref="IKeyBindingHandler{T}"/>.
     /// </summary>
     /// <typeparam name="T">The type of the custom action.</typeparam>
     public abstract class KeyBindingContainer<T> : KeyBindingContainer
@@ -27,7 +27,7 @@ namespace osu.Framework.Input.Bindings
         /// <summary>
         /// Create a new instance.
         /// </summary>
-        /// <param name="simultaneousMode">Specify how to deal with multiple matches of <see cref="KeyCombination"/>s and <see cref="T"/>s.</param>
+        /// <param name="simultaneousMode">Specify how to deal with multiple matches of <see cref="KeyCombination"/>s and <typeparamref name="T"/>s.</param>
         /// <param name="matchingMode">Specify how to deal with exact <see cref="KeyCombination"/> matches.</param>
         protected KeyBindingContainer(SimultaneousBindingMode simultaneousMode = SimultaneousBindingMode.None, KeyCombinationMatchingMode matchingMode = KeyCombinationMatchingMode.Any)
         {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -177,9 +177,9 @@ namespace osu.Framework.Input
         }
 
         /// <summary>
-        /// Changes the currently-focused drawable. First checks that <see cref="potentialFocusTarget"/> is in a valid state to receive focus,
-        /// then unfocuses the current <see cref="FocusedDrawable"/> and focuses <see cref="potentialFocusTarget"/>.
-        /// <see cref="potentialFocusTarget"/> can be null to reset focus.
+        /// Changes the currently-focused drawable. First checks that <paramref name="potentialFocusTarget"/> is in a valid state to receive focus,
+        /// then unfocuses the current <see cref="FocusedDrawable"/> and focuses <paramref name="potentialFocusTarget"/>.
+        /// <paramref name="potentialFocusTarget"/> can be null to reset focus.
         /// If the given drawable is already focused, nothing happens and no events are fired.
         /// </summary>
         /// <param name="potentialFocusTarget">The drawable to become focused.</param>
@@ -187,9 +187,9 @@ namespace osu.Framework.Input
         public bool ChangeFocus(Drawable potentialFocusTarget) => ChangeFocus(potentialFocusTarget, CurrentState);
 
         /// <summary>
-        /// Changes the currently-focused drawable. First checks that <see cref="potentialFocusTarget"/> is in a valid state to receive focus,
-        /// then unfocuses the current <see cref="FocusedDrawable"/> and focuses <see cref="potentialFocusTarget"/>.
-        /// <see cref="potentialFocusTarget"/> can be null to reset focus.
+        /// Changes the currently-focused drawable. First checks that <paramref name="potentialFocusTarget"/> is in a valid state to receive focus,
+        /// then unfocuses the current <see cref="FocusedDrawable"/> and focuses <paramref name="potentialFocusTarget"/>.
+        /// <paramref name="potentialFocusTarget"/> can be null to reset focus.
         /// If the given drawable is already focused, nothing happens and no events are fired.
         /// </summary>
         /// <param name="potentialFocusTarget">The drawable to become focused.</param>
@@ -515,7 +515,7 @@ namespace osu.Framework.Input
         private bool handleJoystickRelease(InputState state, JoystickButton button) => PropagateBlockableEvent(NonPositionalInputQueue, new JoystickReleaseEvent(state, button));
 
         /// <summary>
-        /// Triggers events on drawables in <paramref cref="drawables"/> until it is handled.
+        /// Triggers events on drawables in <paramref name="drawables"/> until it is handled.
         /// </summary>
         /// <param name="drawables">The drawables in the queue.</param>
         /// <param name="e">The event.</param>

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -260,7 +260,7 @@ namespace osu.Framework.Input
         }
 
         /// <summary>
-        /// Triggers events on drawables in <paramref cref="drawables"/> until it is handled.
+        /// Triggers events on drawables in <paramref name="drawables"/> until it is handled.
         /// </summary>
         /// <param name="drawables">The drawables in the queue.</param>
         /// <param name="e">The event.</param>

--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -36,8 +36,8 @@ namespace osu.Framework.Input.StateChanges
         /// Creates a <see cref="ButtonInput{TButton}"/> from the difference of two <see cref="ButtonStates{TButton}"/>.
         /// </summary>
         /// <remarks>
-        /// Buttons that are pressed in <paramref name="previous"/> and not pressed in <see cref="current"/> will be listed as <see cref="ButtonStateChangeKind.Released"/>.
-        /// Buttons that are not pressed in <paramref name="previous"/> and pressed in <see cref="current"/> will be listed as <see cref="ButtonStateChangeKind.Pressed"/>.
+        /// Buttons that are pressed in <paramref name="previous"/> and not pressed in <paramref name="current"/> will be listed as <see cref="ButtonStateChangeKind.Released"/>.
+        /// Buttons that are not pressed in <paramref name="previous"/> and pressed in <paramref name="current"/> will be listed as <see cref="ButtonStateChangeKind.Pressed"/>.
         /// </remarks>
         /// <param name="current">The newer <see cref="ButtonStates{TButton}"/>.</param>
         /// <param name="previous">The older <see cref="ButtonStates{TButton}"/>.</param>

--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -23,9 +23,9 @@ namespace osu.Framework.Input.StateChanges
         }
 
         /// <summary>
-        /// Creates a <see cref="ButtonInput{TButton}"/> with a single <see cref="TButton"/> state.
+        /// Creates a <see cref="ButtonInput{TButton}"/> with a single <typeparamref name="TButton"/> state.
         /// </summary>
-        /// <param name="button">The <see cref="TButton"/> to add.</param>
+        /// <param name="button">The <typeparamref name="TButton"/> to add.</param>
         /// <param name="isPressed">The state of <paramref name="button"/>.</param>
         protected ButtonInput(TButton button, bool isPressed)
         {
@@ -55,10 +55,10 @@ namespace osu.Framework.Input.StateChanges
         protected abstract ButtonStates<TButton> GetButtonStates(InputState state);
 
         /// <summary>
-        /// Create a <see cref="TButton"/> state change event.
+        /// Create a <typeparamref name="TButton"/> state change event.
         /// </summary>
         /// <param name="state">The <see cref="InputState"/> which changed.</param>
-        /// <param name="button">The <see cref="TButton"/> that changed.</param>
+        /// <param name="button">The <typeparamref name="TButton"/> that changed.</param>
         /// <param name="kind">The type of change that occurred on <paramref name="button"/>.</param>
         protected virtual ButtonStateChangeEvent<TButton> CreateEvent(InputState state, TButton button, ButtonStateChangeKind kind) => new ButtonStateChangeEvent<TButton>(state, this, button, kind);
 

--- a/osu.Framework/Input/States/ButtonStates.cs
+++ b/osu.Framework/Input/States/ButtonStates.cs
@@ -25,15 +25,15 @@ namespace osu.Framework.Input.States
         }
 
         /// <summary>
-        /// Finds whether a <see cref="TButton"/> is currently pressed.
+        /// Finds whether a <typeparamref name="TButton"/> is currently pressed.
         /// </summary>
-        /// <param name="button">The <see cref="TButton"/> to check.</param>
+        /// <param name="button">The <typeparamref name="TButton"/> to check.</param>
         public bool IsPressed(TButton button) => pressedButtons.Contains(button);
 
         /// <summary>
-        /// Sets the state of a <see cref="TButton"/>.
+        /// Sets the state of a <typeparamref name="TButton"/>.
         /// </summary>
-        /// <param name="button">The <see cref="TButton"/> to set the state of.</param>
+        /// <param name="button">The <typeparamref name="TButton"/> to set the state of.</param>
         /// <param name="pressed">Whether <paramref name="button"/> should be pressed.</param>
         /// <returns>Whether the state of <paramref name="button"/> actually changed.</returns>
         public bool SetPressed(TButton button, bool pressed)

--- a/osu.Framework/Text/MultilineTextBuilder.cs
+++ b/osu.Framework/Text/MultilineTextBuilder.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Text
         /// </summary>
         /// <param name="store">The store from which glyphs are to be retrieved from.</param>
         /// <param name="font">The font to use for glyph lookups from <paramref name="store"/>.</param>
-        /// <param name="useFontSizeAsHeight">True to use the provided <see cref="font"/> size as the height for each line. False if the height of each individual glyph should be used.</param>
+        /// <param name="useFontSizeAsHeight">True to use the provided <paramref name="font"/> size as the height for each line. False if the height of each individual glyph should be used.</param>
         /// <param name="startOffset">The offset at which characters should begin being added at.</param>
         /// <param name="spacing">The spacing between characters.</param>
         /// <param name="maxWidth">The maximum width of the resulting text bounds.</param>

--- a/osu.Framework/Timing/FramedClock.cs
+++ b/osu.Framework/Timing/FramedClock.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Timing
         /// <summary>
         /// Construct a new FramedClock with an optional source clock.
         /// </summary>
-        /// <param name="source">A source clock which will be used as the backing time source. If null, a StopwatchClock will be created. When provided, the CurrentTime of <see cref="source" /> will be transferred instantly.</param>
+        /// <param name="source">A source clock which will be used as the backing time source. If null, a StopwatchClock will be created. When provided, the CurrentTime of <paramref name="source"/> will be transferred instantly.</param>
         public FramedClock(IClock source = null)
         {
             ChangeSource(source ?? new StopwatchClock(true));

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -6,6 +6,7 @@
     <AssemblyTitle>osu!framework</AssemblyTitle>
     <AssemblyName>osu.Framework</AssemblyName>
     <Description>A 2D application/game framework written with rhythm games in mind.</Description>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591</NoWarn>
     <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
   </PropertyGroup>


### PR DESCRIPTION
Rider doesn't colorize tooltip, make users not realizing that reference is broken. To be honest and surprisingly, no colorized tooltip is one of the biggest reasons make me not willing to use Rider.
Every reference element in documentation should be able to be precisely navigated via F12.
