### PR TITLE
Enforce CornerExponent of 2 for circles unless explicitly set

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1340,7 +1340,16 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private float cornerExponent = 2.5f;
+        /// <summary>
+        /// Ensures that the exponent will always be 2 if the corner radius is half the smallest edge,
+        /// unless the user has explicitly set CornerExponent.
+        /// </summary>
+        private float effectiveCornerExponent =>
+            cornerExponent ?? (Precision.AlmostEquals(cornerRadius, Math.Min(DrawSize.X, DrawSize.Y) / 2f) ? 2f : default_corner_exponent);
+
+        private const float default_corner_exponent = 2.5f;
+
+        private float? cornerExponent;
 
         /// <summary>
         /// Determines how gentle the curve of the corner straightens. A value of 2 results in
@@ -1353,7 +1362,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public float CornerExponent
         {
-            get => cornerExponent;
+            get => cornerExponent ?? default_corner_exponent;
             protected set
             {
                 if (!Precision.DefinitelyBigger(value, 0) || value > 10)
@@ -1369,7 +1378,7 @@ namespace osu.Framework.Graphics.Containers
 
         // This _hacky_ modification of the corner radius (obtained from playing around) ensures that the corner remains at roughly
         // equal size (perceptually) compared to the circular arc as the CornerExponent is adjusted within the range ~2-5.
-        private float effectiveCornerRadius => CornerRadius * 0.8f * CornerExponent / 2 + 0.2f * CornerRadius;
+        private float effectiveCornerRadius => CornerRadius * 0.8f * effectiveCornerExponent / 2 + 0.2f * CornerRadius;
 
         private float borderThickness;
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -94,7 +94,7 @@ namespace osu.Framework.Graphics.Containers
                         ConservativeScreenSpaceQuad = Quad.FromRectangle(shrunkDrawRectangle) * DrawInfo.Matrix,
                         ToMaskingSpace = DrawInfo.MatrixInverse,
                         CornerRadius = Source.effectiveCornerRadius,
-                        CornerExponent = Source.CornerExponent,
+                        CornerExponent = Source.effectiveCornerExponent,
                         BorderThickness = Source.BorderThickness,
                         BorderColour = Source.BorderColour,
                         // We are setting the linear blend range to the approximate size of a _pixel_ here.


### PR DESCRIPTION
There was a regression in rendering of circles that are not `CircularContainer`s (`RingPiece`, `CirclePiece` etc.), since they are not explicitly set to use a `CornerExponent` of 2.

This change will assume a `CornerExponent` of 2 if the `CornerRadius` is half of either of the `DrawSize` dimensions, unless the user has explicitly set a value for `CornerExponent`.

Are you ok with this change @Tom94 ?

Example of the pointy circles:
<img width="100" alt="Screen Shot 2019-11-21 at 7 00 30 pm" src="https://user-images.githubusercontent.com/2331297/69327859-905c9800-0c91-11ea-9840-3868f365ccad.png">
