### PR TITLE
Move performance logging setting to debug config

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -38,7 +38,6 @@ namespace osu.Framework.Configuration
             Set(FrameworkSetting.IgnoredInputHandlers, string.Empty);
             Set(FrameworkSetting.CursorSensitivity, 1.0, 0.1, 6, 0.01);
             Set(FrameworkSetting.Locale, string.Empty);
-            Set(FrameworkSetting.PerformanceLogging, false);
         }
 
         public FrameworkConfigManager(Storage storage, IDictionary<FrameworkSetting, object> defaultOverrides = null)
@@ -87,7 +86,5 @@ namespace osu.Framework.Configuration
         IgnoredInputHandlers,
         CursorSensitivity,
         MapAbsoluteInputToWindow,
-
-        PerformanceLogging
     }
 }

--- a/osu.Framework/Configuration/FrameworkDebugConfig.cs
+++ b/osu.Framework/Configuration/FrameworkDebugConfig.cs
@@ -17,11 +17,13 @@ namespace osu.Framework.Configuration
             base.InitialiseDefaults();
 
             Set(DebugSetting.BypassFrontToBackPass, false);
+            Set(DebugSetting.PerformanceLogging, false);
         }
     }
 
     public enum DebugSetting
     {
-        BypassFrontToBackPass
+        BypassFrontToBackPass,
+        PerformanceLogging
     }
 }

--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Development
         );
 
         /// <summary>
-        /// Whether the framework is currently logging performance issues via <see cref="FrameworkSetting.PerformanceLogging"/>.
+        /// Whether the framework is currently logging performance issues via <see cref="DebugSetting.PerformanceLogging"/>.
         /// This should be used only when a configuration is not available via DI or otherwise (ie. in a static context).
         /// </summary>
         public static bool LogPerformanceIssues { get; internal set; }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -781,7 +781,7 @@ namespace osu.Framework.Platform
 
             cursorSensitivity = Config.GetBindable<double>(FrameworkSetting.CursorSensitivity);
 
-            Config.BindWith(FrameworkSetting.PerformanceLogging, performanceLogging);
+            DebugConfig.BindWith(DebugSetting.PerformanceLogging, performanceLogging);
             performanceLogging.BindValueChanged(logging =>
             {
                 threads.ForEach(t => t.Monitor.EnablePerformanceProfiling = logging.NewValue);


### PR DESCRIPTION
## Breaking Change

### PerformanceLogging was moved to DebugConfig

As seen in https://github.com/ppy/osu/issues/6795, some users are turning on performance logging and leaving it on. This is not intended, as it adds a noticeable overhead to retrieve and write the stack traces to disk.

This change allows the setting to reset each game execution, rather than be saved to a user's configuration file.
