### PR TITLE
Fix TextureWithRefCount thread races

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
@@ -54,7 +55,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 avatar2.Dispose();
             });
 
-            AddUntilStep("gl textures disposed", () => texture.ReferenceCount == 0);
+            assertAvailability(() => texture, false);
         }
 
         /// <summary>
@@ -68,7 +69,7 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddStep("get texture", () => texture = largeStore.Get("https://a.ppy.sh/3"));
             AddStep("dispose texture", () => texture.Dispose());
 
-            AddAssert("texture is not available", () => !texture.Available);
+            assertAvailability(() => texture, false);
         }
 
         /// <summary>
@@ -84,6 +85,9 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             AddAssert("texture is still available", () => texture.Available);
         }
+
+        private void assertAvailability(Func<Texture> textureFunc, bool available)
+            => AddAssert($"texture available = {available}", () => ((TextureWithRefCount)textureFunc()).IsDisposed == !available);
 
         private Avatar addSprite(string url)
         {

--- a/osu.Framework/Graphics/Lines/SmoothPath.cs
+++ b/osu.Framework/Graphics/Lines/SmoothPath.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Graphics.Lines
                 raw[i, 0] = new Rgba32(colour.R, colour.G, colour.B, colour.A * Math.Min(progress / aa_portion, 1));
             }
 
-            var texture = new TextureWithRefCount(textureWidth, 1, true);
+            var texture = new DisposableTexture(textureWidth, 1, true);
             texture.SetData(new TextureUpload(raw));
             Texture = texture;
 

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Threading;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.Primitives;
 using osuTK.Graphics.ES30;
@@ -23,16 +22,6 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         ~TextureGL()
         {
             Dispose(false);
-        }
-
-        internal int ReferenceCount;
-
-        public void Reference() => Interlocked.Increment(ref ReferenceCount);
-
-        public void Dereference()
-        {
-            if (Interlocked.Decrement(ref ReferenceCount) == 0)
-                Dispose();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Textures/DisposableTexture.cs
+++ b/osu.Framework/Graphics/Textures/DisposableTexture.cs
@@ -6,6 +6,9 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Textures
 {
+    /// <summary>
+    /// A texture which can cleans up any resources held by the underlying <see cref="TextureGL"/> on <see cref="Dispose"/>.
+    /// </summary>
     public class DisposableTexture : Texture
     {
         public DisposableTexture(TextureGL textureGl)

--- a/osu.Framework/Graphics/Textures/DisposableTexture.cs
+++ b/osu.Framework/Graphics/Textures/DisposableTexture.cs
@@ -1,0 +1,27 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.OpenGL.Textures;
+using osuTK.Graphics.ES30;
+
+namespace osu.Framework.Graphics.Textures
+{
+    public class DisposableTexture : Texture
+    {
+        public DisposableTexture(TextureGL textureGl)
+            : base(textureGl)
+        {
+        }
+
+        public DisposableTexture(int width, int height, bool manualMipmaps = false, All filteringMode = All.Linear)
+            : base(width, height, manualMipmaps, filteringMode)
+        {
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            TextureGL.Dispose();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Textures/LargeTextureStore.cs
+++ b/osu.Framework/Graphics/Textures/LargeTextureStore.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
 using osu.Framework.IO.Stores;
 using osuTK.Graphics.ES30;
 
@@ -11,6 +14,9 @@ namespace osu.Framework.Graphics.Textures
     /// </summary>
     public class LargeTextureStore : TextureStore
     {
+        private readonly object referenceCountLock = new object();
+        private readonly Dictionary<string, TextureWithRefCount.ReferenceCount> referenceCounts = new Dictionary<string, TextureWithRefCount.ReferenceCount>();
+
         public LargeTextureStore(IResourceStore<TextureUpload> store = null)
             : base(store, false, All.Linear, true)
         {
@@ -25,12 +31,26 @@ namespace osu.Framework.Graphics.Textures
         /// <returns>The texture.</returns>
         public override Texture Get(string name)
         {
-            var baseTex = base.Get(name);
+            lock (referenceCountLock)
+            {
+                var tex = base.Get(name);
 
-            if (baseTex?.TextureGL == null) return null;
+                if (tex?.TextureGL == null)
+                    return null;
 
-            // encapsulate texture for ref counting
-            return new TextureWithRefCount(baseTex.TextureGL) { ScaleAdjust = ScaleAdjust };
+                if (!referenceCounts.TryGetValue(name, out TextureWithRefCount.ReferenceCount count))
+                    referenceCounts[name] = count = new TextureWithRefCount.ReferenceCount(referenceCountLock, () => onAllReferencesLost(name));
+
+                return new TextureWithRefCount(tex.TextureGL, count);
+            }
+        }
+
+        private void onAllReferencesLost(string name)
+        {
+            Debug.Assert(Monitor.IsEntered(referenceCountLock));
+
+            referenceCounts.Remove(name);
+            Purge(name);
         }
     }
 }

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -47,11 +47,11 @@ namespace osu.Framework.Graphics.Textures
             }
         }
 
-        private async Task<Texture> getTextureAsync(string name) => loadRaw(await base.GetAsync(name));
+        private async Task<Texture> getTextureAsync(string name) => loadRaw(name, await base.GetAsync(name));
 
-        private Texture getTexture(string name) => loadRaw(base.Get(name));
+        private Texture getTexture(string name) => loadRaw(name, base.Get(name));
 
-        private Texture loadRaw(TextureUpload upload)
+        private Texture loadRaw(string name, TextureUpload upload)
         {
             if (upload == null) return null;
 
@@ -67,7 +67,6 @@ namespace osu.Framework.Graphics.Textures
                 glTexture = new TextureGLSingle(upload.Width, upload.Height, manualMipmaps, filteringMode);
 
             Texture tex = new Texture(glTexture) { ScaleAdjust = ScaleAdjust };
-
             tex.SetData(upload);
 
             return tex;
@@ -89,7 +88,7 @@ namespace osu.Framework.Graphics.Textures
             lock (textureCache)
             {
                 // refresh the texture if no longer available (may have been previously disposed).
-                if (!textureCache.TryGetValue(name, out var tex) || tex?.Available == false)
+                if (!textureCache.TryGetValue(name, out var tex))
                 {
                     try
                     {
@@ -102,6 +101,16 @@ namespace osu.Framework.Graphics.Textures
                 }
 
                 return tex;
+            }
+        }
+
+        protected void Purge(string name)
+        {
+            lock (textureCache)
+            {
+                if (textureCache.TryGetValue(name, out var tex))
+                    tex.Dispose();
+                textureCache.Remove(name);
             }
         }
     }

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -104,6 +104,10 @@ namespace osu.Framework.Graphics.Textures
             }
         }
 
+        /// <summary>
+        /// Disposes and removes a texture with the specified name from the texture cache.
+        /// </summary>
+        /// <param name="name">The name of the texture to purge from the cache.</param>
         protected void Purge(string name)
         {
             lock (textureCache)

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -47,11 +47,11 @@ namespace osu.Framework.Graphics.Textures
             }
         }
 
-        private async Task<Texture> getTextureAsync(string name) => loadRaw(name, await base.GetAsync(name));
+        private async Task<Texture> getTextureAsync(string name) => loadRaw(await base.GetAsync(name));
 
-        private Texture getTexture(string name) => loadRaw(name, base.Get(name));
+        private Texture getTexture(string name) => loadRaw(base.Get(name));
 
-        private Texture loadRaw(string name, TextureUpload upload)
+        private Texture loadRaw(TextureUpload upload)
         {
             if (upload == null) return null;
 

--- a/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
+++ b/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
@@ -2,46 +2,40 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Graphics.OpenGL;
+using System.Threading;
 using osu.Framework.Graphics.OpenGL.Textures;
-using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Textures
 {
     /// <summary>
     /// A texture which updates the reference count of the underlying <see cref="TextureGL"/> on ctor and disposal.
     /// </summary>
-    public class TextureWithRefCount : Texture
+    internal class TextureWithRefCount : Texture
     {
-        public TextureWithRefCount(TextureGL textureGl)
+        private readonly ReferenceCount count;
+
+        public TextureWithRefCount(TextureGL textureGl, ReferenceCount count)
             : base(textureGl)
         {
-            textureGl.Reference();
-        }
+            this.count = count;
 
-        public TextureWithRefCount(int width, int height, bool manualMipmaps = false, All filteringMode = All.Linear)
-            : this(new TextureGLSingle(width, height, manualMipmaps, filteringMode))
-        {
+            count.Increment();
         }
-
-        internal int ReferenceCount => base.TextureGL.ReferenceCount;
 
         public sealed override TextureGL TextureGL
         {
             get
             {
-                var tex = base.TextureGL;
-                if (tex.ReferenceCount <= 0)
+                if (!Available)
                     throw new InvalidOperationException($"Attempting to access a {nameof(TextureWithRefCount)}'s underlying texture after all references are lost.");
 
-                return tex;
+                return base.TextureGL;
             }
         }
 
-        // The base property references TextureGL, but doing so may throw an exception (above)
+        // The base property invokes the overridden TextureGL property, which will throw an exception if not available
+        // So this property is redirected to reference the intended member
         public sealed override bool Available => base.TextureGL.Available;
-
-        #region Disposal
 
         ~TextureWithRefCount()
         {
@@ -49,20 +43,47 @@ namespace osu.Framework.Graphics.Textures
             Dispose(false);
         }
 
-        private bool isDisposed;
+        public bool IsDisposed { get; private set; }
 
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
 
-            if (isDisposed)
+            if (IsDisposed)
                 return;
 
-            isDisposed = true;
+            IsDisposed = true;
 
-            GLWrapper.ScheduleDisposal(() => base.TextureGL.Dereference());
+            count.Decrement();
         }
 
-        #endregion
+        public class ReferenceCount
+        {
+            private readonly object lockObject;
+            private readonly Action onAllReferencesLost;
+
+            private int referenceCount;
+
+            public ReferenceCount(object lockObject, Action onAllReferencesLost)
+            {
+                this.lockObject = lockObject;
+                this.onAllReferencesLost = onAllReferencesLost;
+            }
+
+            public void Increment()
+            {
+                lock (lockObject)
+                    Interlocked.Increment(ref referenceCount);
+            }
+
+            public void Decrement()
+            {
+                lock (lockObject)
+                {
+                    if (Interlocked.Decrement(ref referenceCount) == 0)
+                        onAllReferencesLost?.Invoke();
+                }
+            }
+        }
     }
 }

--- a/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
+++ b/osu.Framework/Graphics/Textures/TextureWithRefCount.cs
@@ -8,7 +8,7 @@ using osu.Framework.Graphics.OpenGL.Textures;
 namespace osu.Framework.Graphics.Textures
 {
     /// <summary>
-    /// A texture which updates the reference count of the underlying <see cref="TextureGL"/> on ctor and disposal.
+    /// A texture which shares a common reference count with all other textures using the same <see cref="TextureGL"/>.
     /// </summary>
     internal class TextureWithRefCount : Texture
     {
@@ -64,18 +64,30 @@ namespace osu.Framework.Graphics.Textures
 
             private int referenceCount;
 
+            /// <summary>
+            /// Creates a new <see cref="ReferenceCount"/>.
+            /// </summary>
+            /// <param name="lockObject">The <see cref="object"/> which locks will be taken out on.</param>
+            /// <param name="onAllReferencesLost">A delegate to invoke after all references have been lost.</param>
             public ReferenceCount(object lockObject, Action onAllReferencesLost)
             {
                 this.lockObject = lockObject;
                 this.onAllReferencesLost = onAllReferencesLost;
             }
 
+            /// <summary>
+            /// Increments the reference count.
+            /// </summary>
             public void Increment()
             {
                 lock (lockObject)
                     Interlocked.Increment(ref referenceCount);
             }
 
+            /// <summary>
+            /// Decrements the reference count, invoking <see cref="onAllReferencesLost"/> if there are no remaining references.
+            /// The delegate is invoked while a lock on the provided <see cref="lockObject"/> is held.
+            /// </summary>
             public void Decrement()
             {
                 lock (lockObject)


### PR DESCRIPTION
Between the `Available` check of `TextureStore` and the subsequent construction of the new `TextureWithRefCount`, no lock was held and `Available` could've been set to false in the mean time (disposing the texture). This could happen because `Available` is set by the draw thread.

This PR fixes this by ensuring that the entire `LargeTextureStore.Get()` method is locked until the increment happens, and that the disposal is locked on the same object until the decrement + disposal happens.

This fixes the case where exiting and re-entering song select rapidly causes backgrounds to disappear.