### PR TITLE
Fix audio not working when no audio devices are present

### DIFF
--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -18,7 +18,8 @@ namespace osu.Framework.Tests.Audio
     /// </summary>
     internal class AudioManagerWithDeviceLoss : AudioManager
     {
-        public AudioManagerWithDeviceLoss(AudioThread audioThread, ResourceStore<byte[]> trackStore, ResourceStore<byte[]> sampleStore) : base(audioThread, trackStore, sampleStore)
+        public AudioManagerWithDeviceLoss(AudioThread audioThread, ResourceStore<byte[]> trackStore, ResourceStore<byte[]> sampleStore)
+            : base(audioThread, trackStore, sampleStore)
         {
         }
 

--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using ManagedBass;
+using osu.Framework.Audio;
+using osu.Framework.IO.Stores;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Audio
+{
+    /// <summary>
+    /// <see cref="AudioManager"/> that can simulate the loss of a device.
+    /// This will NOT work without a physical audio device!
+    /// </summary>
+    internal class AudioManagerWithDeviceLoss : AudioManager
+    {
+        public AudioManagerWithDeviceLoss(AudioThread audioThread, ResourceStore<byte[]> trackStore, ResourceStore<byte[]> sampleStore) : base(audioThread, trackStore, sampleStore)
+        {
+        }
+
+        public volatile int CurrentDevice = -1;
+
+        private volatile bool simulateLoss;
+
+        protected override bool InitBass(int device)
+        {
+            if (simulateLoss)
+            {
+                if (device != 0 || !base.InitBass(device))
+                    return false;
+
+                CurrentDevice = device;
+                return true;
+            }
+
+            if (!base.InitBass(device))
+                return false;
+
+            CurrentDevice = device;
+            return true;
+        }
+
+        protected override IEnumerable<DeviceInfo> EnumerateAllDevices()
+        {
+            var devices = base.EnumerateAllDevices();
+
+            if (simulateLoss)
+                devices = devices.Take(1);
+
+            return devices;
+        }
+
+        public void SimulateDeviceLoss()
+        {
+            var current = CurrentDevice;
+
+            simulateLoss = true;
+
+            if (current != 0)
+                WaitForDeviceChange(current);
+        }
+
+        public void SimulateDeviceRestore()
+        {
+            var current = CurrentDevice;
+
+            simulateLoss = false;
+
+            if (current == 0)
+                WaitForDeviceChange(current);
+        }
+
+        public void WaitForDeviceChange(int? current = null, int timeoutMs = 5000)
+        {
+            current ??= CurrentDevice;
+
+            var watch = Stopwatch.StartNew();
+
+            while (watch.ElapsedMilliseconds < timeoutMs)
+            {
+                if (CurrentDevice != current)
+                    return;
+
+                System.Threading.Thread.Sleep(50);
+            }
+
+            throw new TimeoutException($"Timed out while waiting for the device to change from {current}.");
+        }
+    }
+}

--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -1,9 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using ManagedBass;
 using osu.Framework.Audio;
@@ -79,17 +77,7 @@ namespace osu.Framework.Tests.Audio
         {
             current ??= CurrentDevice;
 
-            var watch = Stopwatch.StartNew();
-
-            while (watch.ElapsedMilliseconds < timeoutMs)
-            {
-                if (CurrentDevice != current)
-                    return;
-
-                System.Threading.Thread.Sleep(50);
-            }
-
-            throw new TimeoutException($"Timed out while waiting for the device to change from {current}.");
+            AudioThreadTest.WaitForOrAssert(() => CurrentDevice != current, $"Timed out while waiting for the device to change from {current}.", 5000);
         }
     }
 }

--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Tests.Audio
         {
         }
 
-        public volatile int CurrentDevice = -1;
+        public volatile int CurrentDevice = Bass.DefaultDevice;
 
         private volatile bool simulateLoss;
 
@@ -29,7 +29,7 @@ namespace osu.Framework.Tests.Audio
         {
             if (simulateLoss)
             {
-                if (device != 0 || !base.InitBass(device))
+                if (device != Bass.NoSoundDevice || !base.InitBass(device))
                     return false;
 
                 CurrentDevice = device;
@@ -53,13 +53,21 @@ namespace osu.Framework.Tests.Audio
             return devices;
         }
 
+        protected override bool IsCurrentDeviceValid()
+        {
+            if (simulateLoss)
+                return CurrentDevice == Bass.NoSoundDevice && base.IsCurrentDeviceValid();
+
+            return CurrentDevice != Bass.NoSoundDevice && base.IsCurrentDeviceValid();
+        }
+
         public void SimulateDeviceLoss()
         {
             var current = CurrentDevice;
 
             simulateLoss = true;
 
-            if (current != 0)
+            if (current != Bass.NoSoundDevice)
                 WaitForDeviceChange(current);
         }
 
@@ -69,7 +77,7 @@ namespace osu.Framework.Tests.Audio
 
             simulateLoss = false;
 
-            if (current == 0)
+            if (current == Bass.NoSoundDevice)
                 WaitForDeviceChange(current);
         }
 
@@ -77,7 +85,7 @@ namespace osu.Framework.Tests.Audio
         {
             current ??= CurrentDevice;
 
-            AudioThreadTest.WaitForOrAssert(() => CurrentDevice != current, $"Timed out while waiting for the device to change from {current}.", 5000);
+            AudioThreadTest.WaitForOrAssert(() => CurrentDevice != current, $"Timed out while waiting for the device to change from {current}.", timeoutMs);
         }
     }
 }

--- a/osu.Framework.Tests/Audio/AudioThreadTest.cs
+++ b/osu.Framework.Tests/Audio/AudioThreadTest.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Audio.Track;
+using osu.Framework.IO.Stores;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Audio
+{
+    [TestFixture]
+    public abstract class AudioThreadTest
+    {
+        private AudioThread thread;
+        internal AudioManagerWithDeviceLoss Manager;
+
+        [SetUp]
+        public virtual void SetUp()
+        {
+            thread = new AudioThread();
+
+            var store = new NamespacedResourceStore<byte[]>(new DllResourceStore(@"osu.Framework.Tests.dll"), @"Resources");
+
+            Manager = new AudioManagerWithDeviceLoss(thread, store, store);
+
+            thread.Start();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Assert.IsFalse(thread.Exited);
+
+            thread.Exit();
+
+            WaitForOrAssert(() => thread.Exited, "Audio thread did not exit in time");
+        }
+
+        public void CheckTrackIsProgressing(Track track)
+        {
+            // playback should be continuing after device change
+            for (int i = 0; i < 2; i++)
+            {
+                var checkAfter = track.CurrentTime;
+                WaitForOrAssert(() => track.CurrentTime > checkAfter, "Track time did not increase", 1000);
+                Assert.IsTrue(track.IsRunning);
+            }
+        }
+
+        /// <summary>
+        /// Waits for a specified condition to become true, or timeout reached.
+        /// </summary>
+        /// <param name="condition">The condition which should become true.</param>
+        /// <param name="message">A message to display on timeout.</param>
+        /// <param name="timeout">Timeout in milliseconds.</param>
+        public static void WaitForOrAssert(Func<bool> condition, string message, int timeout = 60000) =>
+            Assert.IsTrue(Task.Run(() =>
+            {
+                while (!condition()) Thread.Sleep(50);
+            }).Wait(timeout), message);
+    }
+}

--- a/osu.Framework.Tests/Audio/DeviceLosingAudioTest.cs
+++ b/osu.Framework.Tests/Audio/DeviceLosingAudioTest.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Tests.Audio
             track.Seek(0);
 
             Assert.IsFalse(track.IsRunning);
-            Assert.AreEqual(track.CurrentTime, 0);
+            WaitForOrAssert(() => track.CurrentTime == 0, "Track did not seek correctly", 1000);
         }
     }
 }

--- a/osu.Framework.Tests/Audio/DeviceLosingAudioTest.cs
+++ b/osu.Framework.Tests/Audio/DeviceLosingAudioTest.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using NUnit.Framework;
+using osu.Framework.IO.Stores;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Audio
+{
+    /// <remarks>
+    /// This unit will ALWAYS SKIP if the system does not have a physical audio device!!!
+    /// A physical audio device is required to simulate the "loss" of it during playback.
+    /// </remarks>
+    [TestFixture]
+    public class DeviceLosingAudioTest
+    {
+        private AudioThread thread;
+        private NamespacedResourceStore<byte[]> store;
+        private AudioManagerWithDeviceLoss manager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            thread = new AudioThread();
+            store = new NamespacedResourceStore<byte[]>(new DllResourceStore(@"osu.Framework.Tests.dll"), @"Resources");
+
+            manager = new AudioManagerWithDeviceLoss(thread, store, store);
+
+            thread.Start();
+
+            // wait for any device to be initialized
+            manager.WaitForDeviceChange(-1);
+
+            // if the initialized device is "No sound", it indicates that no other physical devices are available, so this unit should be ignored
+            if (manager.CurrentDevice == 0)
+                Assert.Ignore("Physical audio devices are required for this unit.");
+
+            // we don't want music playing in unit tests :)
+            manager.Volume.Value = 0;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Assert.IsFalse(thread.Exited);
+
+            thread.Exit();
+
+            Thread.Sleep(500);
+
+            Assert.IsTrue(thread.Exited);
+        }
+
+        [Test]
+        public void TestPlaybackWithDeviceLoss() => testPlayback(manager.SimulateDeviceRestore, manager.SimulateDeviceLoss);
+
+        [Test]
+        public void TestPlaybackWithDeviceRestore() => testPlayback(manager.SimulateDeviceLoss, manager.SimulateDeviceRestore);
+
+        private void testPlayback(Action preparation, Action simulate)
+        {
+            preparation();
+
+            var track = manager.Tracks.Get("Tracks.sample-track.mp3");
+
+            // start track
+            track.Restart();
+
+            Thread.Sleep(100);
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.That(track.CurrentTime, Is.GreaterThan(0));
+
+            var timeBeforeLosing = track.CurrentTime;
+
+            // simulate change (loss/restore)
+            simulate();
+
+            Assert.IsTrue(track.IsRunning);
+
+            Thread.Sleep(100);
+
+            // playback should be continuing after device change
+            Assert.IsTrue(track.IsRunning);
+            Assert.That(track.CurrentTime, Is.GreaterThan(timeBeforeLosing));
+
+            // stop track
+            track.Stop();
+
+            Thread.Sleep(100);
+
+            Assert.IsFalse(track.IsRunning);
+
+            // seek track
+            track.Seek(0);
+
+            Thread.Sleep(100);
+
+            Assert.IsFalse(track.IsRunning);
+            Assert.AreEqual(track.CurrentTime, 0);
+        }
+    }
+}

--- a/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
+++ b/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using NUnit.Framework;
+using osu.Framework.IO.Stores;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Audio
+{
+    [TestFixture]
+    public class DevicelessAudioTest
+    {
+        private AudioThread thread;
+        private NamespacedResourceStore<byte[]> store;
+        private AudioManagerWithDeviceLoss manager;
+
+        [SetUp]
+        public void SetUp()
+        {
+            thread = new AudioThread();
+            store = new NamespacedResourceStore<byte[]>(new DllResourceStore(@"osu.Framework.Tests.dll"), @"Resources");
+
+            manager = new AudioManagerWithDeviceLoss(thread, store, store);
+
+            thread.Start();
+
+            // lose all devices
+            manager.SimulateDeviceLoss();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Assert.IsFalse(thread.Exited);
+
+            thread.Exit();
+
+            Thread.Sleep(500);
+
+            Assert.IsTrue(thread.Exited);
+        }
+
+        [Test]
+        public void TestPlayTrackWithoutDevices()
+        {
+            var track = manager.Tracks.Get("Tracks.sample-track.mp3");
+
+            // start track
+            track.Restart();
+
+            Thread.Sleep(100);
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.That(track.CurrentTime, Is.GreaterThan(0));
+
+            // stop track
+            track.Stop();
+
+            Thread.Sleep(100);
+
+            Assert.IsFalse(track.IsRunning);
+
+            // seek track
+            track.Seek(0);
+
+            Thread.Sleep(100);
+
+            Assert.IsFalse(track.IsRunning);
+            Assert.AreEqual(track.CurrentTime, 0);
+        }
+    }
+}

--- a/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
+++ b/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
@@ -1,70 +1,41 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Threading;
 using NUnit.Framework;
-using osu.Framework.IO.Stores;
-using osu.Framework.Threading;
 
 namespace osu.Framework.Tests.Audio
 {
     [TestFixture]
-    public class DevicelessAudioTest
+    public class DevicelessAudioTest : AudioThreadTest
     {
-        private AudioThread thread;
-        private NamespacedResourceStore<byte[]> store;
-        private AudioManagerWithDeviceLoss manager;
-
-        [SetUp]
-        public void SetUp()
+        public override void SetUp()
         {
-            thread = new AudioThread();
-            store = new NamespacedResourceStore<byte[]>(new DllResourceStore(@"osu.Framework.Tests.dll"), @"Resources");
-
-            manager = new AudioManagerWithDeviceLoss(thread, store, store);
-
-            thread.Start();
+            base.SetUp();
 
             // lose all devices
-            manager.SimulateDeviceLoss();
-        }
-
-        [TearDown]
-        public void TearDown()
-        {
-            Assert.IsFalse(thread.Exited);
-
-            thread.Exit();
-
-            Thread.Sleep(500);
-
-            Assert.IsTrue(thread.Exited);
+            Manager.SimulateDeviceLoss();
         }
 
         [Test]
         public void TestPlayTrackWithoutDevices()
         {
-            var track = manager.Tracks.Get("Tracks.sample-track.mp3");
+            var track = Manager.Tracks.Get("Tracks.sample-track.mp3");
 
             // start track
             track.Restart();
-
-            Thread.Sleep(100);
-
             Assert.IsTrue(track.IsRunning);
-            Assert.That(track.CurrentTime, Is.GreaterThan(0));
+
+            CheckTrackIsProgressing(track);
 
             // stop track
             track.Stop();
 
-            Thread.Sleep(100);
+            WaitForOrAssert(() => !track.IsRunning, "Track did not stop", 1000);
 
             Assert.IsFalse(track.IsRunning);
 
             // seek track
             track.Seek(0);
-
-            Thread.Sleep(100);
 
             Assert.IsFalse(track.IsRunning);
             Assert.AreEqual(track.CurrentTime, 0);

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -134,7 +134,7 @@ namespace osu.Framework.Audio
             {
                 updateAvailableAudioDevices();
                 checkAudioDeviceChanged();
-            }, 1000, true);
+            }, 100, true);
         }
 
         protected override void Dispose(bool disposing)

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -197,6 +197,16 @@ namespace osu.Framework.Audio
                 yield return Bass.GetDeviceInfo(i);
         }
 
+        private string noSoundDeviceNameCache;
+
+        /// <summary>
+        /// Gets the name of Bass "No sound" device.
+        /// </summary>
+        /// <remarks>
+        /// Although we can refer to this device by the string "No sound", this property can be used to avoid hardcoding that string.
+        /// </remarks>
+        private string noSoundDevice => noSoundDeviceNameCache ?? (noSoundDeviceNameCache = Bass.GetDeviceInfo(0).Name);
+
         private bool setAudioDevice(string preferredDevice = null)
         {
             updateAvailableAudioDevices();
@@ -206,7 +216,7 @@ namespace osu.Framework.Audio
 
             // use in the order: preferred device, default device, fallback "No sound" device (Bass ID: 0)
             // this allows us to initialize and continue using Bass without failing every subsequent Bass calls
-            newDevice ??= audioDevices.Find(df => df.IsDefault).Name ?? "No sound";
+            newDevice ??= audioDevices.Find(df => df.IsDefault).Name ?? noSoundDevice;
 
             bool oldDeviceValid = Bass.CurrentDevice >= 0;
 
@@ -244,7 +254,7 @@ namespace osu.Framework.Audio
             {
                 //the new device didn't go as planned. we need another option.
 
-                if (preferredDevice == "No sound")
+                if (preferredDevice == noSoundDevice)
                 {
                     //we're fucked. even "No sound" device won't initialise.
                     currentAudioDevice = null;
@@ -256,7 +266,7 @@ namespace osu.Framework.Audio
                     return setAudioDevice();
 
                 // default device failed: let's try using "No sound" device.
-                return setAudioDevice("No sound");
+                return setAudioDevice(noSoundDevice);
             }
 
             if (Bass.LastError == Errors.Already)

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -204,7 +204,7 @@ namespace osu.Framework.Audio
             string oldDevice = currentAudioDevice;
             string newDevice = preferredDevice;
 
-            // fall back to "No sound" device (Bass ID: 0) if no actual audio devices are found
+            // use in the order: preferred device, default device, fallback "No sound" device (Bass ID: 0)
             // this allows us to initialize and continue using Bass without failing every subsequent Bass calls
             newDevice ??= audioDevices.Find(df => df.IsDefault).Name ?? "No sound";
 
@@ -244,15 +244,19 @@ namespace osu.Framework.Audio
             {
                 //the new device didn't go as planned. we need another option.
 
-                if (preferredDevice == null)
+                if (preferredDevice == "No sound")
                 {
                     //we're fucked. even "No sound" device won't initialise.
                     currentAudioDevice = null;
                     return false;
                 }
 
-                //let's try again using the default device.
-                return setAudioDevice();
+                // preferred device failed: let's try using the default device.
+                if (preferredDevice != null)
+                    return setAudioDevice();
+
+                // default device failed: let's try using "No sound" device.
+                return setAudioDevice("No sound");
             }
 
             if (Bass.LastError == Errors.Already)

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -204,8 +204,9 @@ namespace osu.Framework.Audio
             string oldDevice = currentAudioDevice;
             string newDevice = preferredDevice;
 
-            if (string.IsNullOrEmpty(newDevice))
-                newDevice = audioDevices.Find(df => df.IsDefault).Name;
+            // get default device if no device is preferred
+            // this falls back to "No sound" device (Bass ID: 0) if no actual audio devices are found
+            newDevice ??= audioDevices.Find(df => df.IsDefault).Name ?? "No sound";
 
             bool oldDeviceValid = Bass.CurrentDevice >= 0;
 

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -322,16 +322,27 @@ namespace osu.Framework.Audio
             {
                 updateAvailableAudioDevices();
 
-                var index = audioDevices.FindIndex(d => d.IsEnabled && d.Name == currentAudioDevice);
-
-                // check if the current audio device became unavailable
-                if (index != -1)
-                    return;
-
-                // set to the preferred device (can fall back to default)
                 var preferred = string.IsNullOrEmpty(AudioDevice.Value) ? null : AudioDevice.Value;
 
-                setAudioDevice(preferred);
+                var currentIndex = audioDevices.FindIndex(d => d.IsEnabled && d.Name == currentAudioDevice);
+
+                // current audio device became unavailable
+                if (currentIndex == -1)
+                {
+                    setAudioDevice(preferred);
+                    return;
+                }
+
+                // preferred audio device, or a default device, became available
+                var preferredIndex = preferred == null
+                    ? audioDevices.FindIndex(d => d.IsDefault)
+                    : audioDevices.FindIndex(d => d.IsEnabled && d.Name == preferred);
+
+                if (preferredIndex != -1 && currentIndex != preferredIndex)
+                {
+                    setAudioDevice(preferred);
+                    return;
+                }
             }
             catch
             {

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -205,7 +205,7 @@ namespace osu.Framework.Audio
         /// <remarks>
         /// Although we can refer to this device by the string "No sound", this property can be used to avoid hardcoding that string.
         /// </remarks>
-        private string noSoundDevice => noSoundDeviceNameCache ??= Bass.GetDeviceInfo(0).Name;
+        private string noSoundDevice => noSoundDeviceNameCache ??= Bass.GetDeviceInfo(Bass.NoSoundDevice).Name;
 
         private bool setAudioDevice(string preferredDevice = null)
         {

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -204,8 +204,8 @@ namespace osu.Framework.Audio
             string oldDevice = currentAudioDevice;
             string newDevice = preferredDevice;
 
-            // get default device if no device is preferred
-            // this falls back to "No sound" device (Bass ID: 0) if no actual audio devices are found
+            // fall back to "No sound" device (Bass ID: 0) if no actual audio devices are found
+            // this allows us to initialize and continue using Bass without failing every subsequent Bass calls
             newDevice ??= audioDevices.Find(df => df.IsDefault).Name ?? "No sound";
 
             bool oldDeviceValid = Bass.CurrentDevice >= 0;
@@ -218,12 +218,6 @@ namespace osu.Framework.Audio
 
             if (newDevice == oldDevice && oldDeviceValid)
                 return true;
-
-            if (string.IsNullOrEmpty(newDevice))
-            {
-                Logger.Log(@"BASS Initialization failed (no audio device present)");
-                return false;
-            }
 
             int newDeviceIndex = audioDevices.FindIndex(df => df.Name == newDevice);
 
@@ -252,7 +246,7 @@ namespace osu.Framework.Audio
 
                 if (preferredDevice == null)
                 {
-                    //we're fucked. the default device won't initialise.
+                    //we're fucked. even "No sound" device won't initialise.
                     currentAudioDevice = null;
                     return false;
                 }

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -339,10 +339,7 @@ namespace osu.Framework.Audio
                     : audioDevices.FindIndex(d => d.IsEnabled && d.Name == preferred);
 
                 if (preferredIndex != -1 && currentIndex != preferredIndex)
-                {
                     setAudioDevice(preferred);
-                    return;
-                }
             }
             catch
             {

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -205,7 +205,7 @@ namespace osu.Framework.Audio
         /// <remarks>
         /// Although we can refer to this device by the string "No sound", this property can be used to avoid hardcoding that string.
         /// </remarks>
-        private string noSoundDevice => noSoundDeviceNameCache ?? (noSoundDeviceNameCache = Bass.GetDeviceInfo(0).Name);
+        private string noSoundDevice => noSoundDeviceNameCache ??= Bass.GetDeviceInfo(0).Name;
 
         private bool setAudioDevice(string preferredDevice = null)
         {

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Audio
                 return store;
             });
 
-            // check for device validity every frame
+            // check for device validity every 100ms
             scheduler.AddDelayed(() =>
             {
                 try
@@ -131,7 +131,7 @@ namespace osu.Framework.Audio
                 catch
                 {
                 }
-            }, 0, true);
+            }, 100, true);
 
             // enumerate new list of devices every second
             scheduler.AddDelayed(() =>

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -141,6 +141,10 @@ namespace osu.Framework.Audio.Track
         {
             Bass.ChannelSetDevice(activeStream, deviceIndex);
             Trace.Assert(Bass.LastError == Errors.OK);
+
+            // Bass may stop this track if the output device changes (this is true for "No sound" device)
+            if (isPlayed && Bass.ChannelIsActive(activeStream) != PlaybackState.Playing)
+                Start();
         }
 
         protected override void UpdateState()

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -148,10 +148,15 @@ namespace osu.Framework.Audio.Track
             Bass.ChannelSetDevice(activeStream, deviceIndex);
             Trace.Assert(Bass.LastError == Errors.OK);
 
-            // Bass may stop us if the output device changes (this is true for "No sound" device)
-            // so resume playing if we were playing previously
-            if (isPlayed && !isRunningState(Bass.ChannelIsActive(activeStream)))
+            // Bass may leave us in an invalid state after the output device changes (this is true for "No sound" device)
+            // if the observed state was playing before change, we should force things into a good state.
+            if (isPlayed)
+            {
+                // While on windows, changing to "No sound" changes the playback state correctly,
+                // on macOS it is left in a playing-but-stalled state. Forcefully stopping first fixes this.
+                Stop();
                 Start();
+            }
         }
 
         protected override void UpdateState()

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -161,9 +161,15 @@ namespace osu.Framework.Audio.Track
 
         protected override void UpdateState()
         {
-            isRunning = isRunningState(Bass.ChannelIsActive(activeStream));
+            var running = isRunningState(Bass.ChannelIsActive(activeStream));
+            var bytePosition = Bass.ChannelGetPosition(activeStream);
 
-            Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, Bass.ChannelGetPosition(activeStream)) * 1000);
+            // because device validity check isn't done frequently, when switching to "No sound" device,
+            // there will be a brief time where this track will be stopped, before we resume it manually (see comments in UpdateDevice(int).)
+            // this makes us appear to be playing, even if we may not be.
+            isRunning = running || (isPlayed && bytePosition != byteLength);
+
+            Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, bytePosition) * 1000);
 
             var leftChannel = isPlayed ? Bass.ChannelGetLevelLeft(activeStream) / 32768f : -1;
             var rightChannel = isPlayed ? Bass.ChannelGetLevelRight(activeStream) / 32768f : -1;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/1302
Fixes https://github.com/ppy/osu/issues/2598
Fixes https://github.com/ppy/osu/issues/5866

Supercedes https://github.com/ppy/osu-framework/pull/1165

This is my attempt at fixing this long standing issue.

- Prioritizes the preferred audio device when initializing devices, falling back gracefully to system default on fail, and then "No sound" device provided by Bass itself as last resort.
- Resumes track automatically when falling back to "No sound", because Bass will stop the track for some reason.

I only have tested this by disabling all audio devices, unplugging them and using service manager to stop the audio service.

There are no unit tests included because I don't know how to reproduce an environment with no or broken audio devices in a unit test.

- [x] Ensure getting the current device every frame is not going to be a performance issue.