### PR TITLE
Fix interpolation extremities on exponential and elastic curves

### DIFF
--- a/osu.Framework.Tests/MathUtils/TestInterpolation.cs
+++ b/osu.Framework.Tests/MathUtils/TestInterpolation.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.MathUtils;
@@ -12,6 +14,14 @@ namespace osu.Framework.Tests.MathUtils
     [TestFixture]
     public class TestInterpolation
     {
+        [TestCaseSource(nameof(getEasings))]
+        public void TestEasingStartsAtZero(Easing easing) => Assert.That(Interpolation.ApplyEasing(easing, 0), Is.EqualTo(0).Within(Precision.DOUBLE_EPSILON));
+
+        [TestCaseSource(nameof(getEasings))]
+        public void TestEasingEndsAtOne(Easing easing) => Assert.That(Interpolation.ApplyEasing(easing, 1), Is.EqualTo(1).Within(Precision.DOUBLE_EPSILON));
+
+        private static IEnumerable<Easing> getEasings() => Enum.GetValues(typeof(Easing)).OfType<Easing>();
+
         [Test]
         public void TestLerp()
         {

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneEasingCurves.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneEasingCurves.cs
@@ -41,7 +41,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             AddSliderStep("resize easings", default_size, 3 * default_size, default_size, size =>
             {
-                easingsContainer?.Children?.OfType<Visualiser>()?.ForEach(easing => easing.ResizeTo(new Vector2(size)));
+                easingsContainer?.Children?.OfType<Visualiser>().ForEach(easing => easing.ResizeTo(new Vector2(size)));
             });
 
             foreach (var type in easingTypes)

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneEasingCurves.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneEasingCurves.cs
@@ -1,0 +1,130 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    public class TestSceneEasingCurves : TestScene
+    {
+        private const float default_size = 300;
+
+        public TestSceneEasingCurves()
+        {
+            FillFlowContainer easingsContainer = null;
+
+            var easingTypes = Enum.GetValues(typeof(Easing))
+                                  .OfType<Easing>()
+                                  .ToList();
+
+            AddStep("set up easings", () => Child = new BasicScrollContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Child = easingsContainer = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Children = easingTypes.Select(type => new Visualiser(type))
+                                          .ToArray()
+                }
+            });
+
+            AddSliderStep("resize easings", default_size, 3 * default_size, default_size, size =>
+            {
+                easingsContainer?.Children?.OfType<Visualiser>()?.ForEach(easing => easing.ResizeTo(new Vector2(size)));
+            });
+
+            foreach (var type in easingTypes)
+            {
+                AddToggleStep($"toggle {type}", enabled =>
+                {
+                    var easingContainer = easingsContainer.Children.OfType<Visualiser>().Single(easing => easing.Easing == type);
+                    easingContainer.Visible.Value = enabled;
+                });
+            }
+        }
+
+        private class Visualiser : Container
+        {
+            private const float movement_duration = 1000f;
+            private const float pause_duration = 500f;
+
+            public readonly Easing Easing;
+
+            public Bindable<bool> Visible { get; } = new BindableBool();
+
+            private readonly CircularContainer dot;
+
+            public Visualiser(Easing easing)
+            {
+                Easing = easing;
+
+                Size = new Vector2(default_size);
+                Padding = new MarginPadding(25);
+
+                InternalChildren = new Drawable[]
+                {
+                    new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.BottomCentre,
+                        Origin = Anchor.BottomCentre,
+                        Children = new Drawable[]
+                        {
+                            new Box
+                            {
+                                Colour = Color4.DimGray,
+                                RelativeSizeAxes = Axes.Both
+                            },
+                            dot = new CircularContainer
+                            {
+                                Origin = Anchor.Centre,
+                                RelativePositionAxes = Axes.Both,
+                                Size = new Vector2(10),
+                                Masking = true,
+                                Child = new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Colour = Color4.White
+                                }
+                            }
+                        }
+                    },
+                    new SpriteText
+                    {
+                        Anchor = Anchor.TopCentre,
+                        Origin = Anchor.TopCentre,
+                        Y = 10,
+                        Text = easing.ToString()
+                    },
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Visible.BindValueChanged(e => Alpha = e.NewValue ? 1 : 0, true);
+
+                dot.MoveToX(1.0f, movement_duration, Easing)
+                   .Then(pause_duration)
+                   .MoveToX(0.0f, movement_duration, Easing)
+                   .Loop(pause_duration);
+                dot.MoveToY(1.0f, movement_duration)
+                   .Then(pause_duration)
+                   .MoveToY(0.0f, movement_duration)
+                   .Loop(pause_duration);
+            }
+        }
+    }
+}

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -341,22 +341,28 @@ namespace osu.Framework.MathUtils
                     return .5 * Math.Sqrt(1 - (time -= 2) * time) + .5;
 
                 case Easing.InElastic:
-                    return -Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - elastic_const2 - time) * elastic_const);
+                    return -Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - elastic_const2 - time) * elastic_const) + Math.Pow(2, -11) * (1 - time);
 
                 case Easing.OutElastic:
-                    return Math.Pow(2, -10 * time) * Math.Sin((time - elastic_const2) * elastic_const) + 1;
+                    return Math.Pow(2, -10 * time) * Math.Sin((time - elastic_const2) * elastic_const) + 1 - Math.Pow(2, -11) * time;
 
                 case Easing.OutElasticHalf:
-                    return Math.Pow(2, -10 * time) * Math.Sin((.5 * time - elastic_const2) * elastic_const) + 1;
+                    return Math.Pow(2, -10 * time) * Math.Sin((.5 * time - elastic_const2) * elastic_const) + 1
+                           - Math.Pow(2, -10) * Math.Sin((.5 - elastic_const2) * elastic_const) * time;
 
                 case Easing.OutElasticQuarter:
-                    return Math.Pow(2, -10 * time) * Math.Sin((.25 * time - elastic_const2) * elastic_const) + 1;
+                    return Math.Pow(2, -10 * time) * Math.Sin((.25 * time - elastic_const2) * elastic_const) + 1
+                           - Math.Pow(2, -10) * Math.Sin((.25 - elastic_const2) * elastic_const) * time;
 
                 case Easing.InOutElastic:
                     if ((time *= 2) < 1)
-                        return -.5 * Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - elastic_const2 * 1.5 - time) * elastic_const / 1.5);
+                    {
+                        return -.5 * (Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - elastic_const2 * 1.5 - time) * elastic_const / 1.5)
+                                      - Math.Pow(2, -10) * Math.Sin((1 - elastic_const2 * 1.5) * elastic_const / 1.5) * (1 - time));
+                    }
 
-                    return .5 * Math.Pow(2, -10 * --time) * Math.Sin((time - elastic_const2 * 1.5) * elastic_const / 1.5) + 1;
+                    return .5 * (Math.Pow(2, -10 * --time) * Math.Sin((time - elastic_const2 * 1.5) * elastic_const / 1.5)
+                                 - Math.Pow(2, -10) * Math.Sin((1 - elastic_const2 * 1.5) * elastic_const / 1.5) * time) + 1;
 
                 case Easing.InBack:
                     return time * time * ((back_const + 1) * time - back_const);

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -248,16 +248,27 @@ namespace osu.Framework.MathUtils
                 val1.Height + t * (val2.X - val1.Height));
         }
 
+        #region Easing constants
+
+        private const double elastic_const = 2 * Math.PI / .3;
+        private const double elastic_const2 = .3 / 4;
+
+        private const double back_const = 1.70158;
+        private const double back_const2 = back_const * 1.525;
+
+        private const double bounce_const = 1 / 2.75;
+
+        // constants used to fix expo and elastic curves to start/end at 0/1
+        private static readonly double expo_offset = Math.Pow(2, -10);
+        private static readonly double elastic_offset_full = Math.Pow(2, -11);
+        private static readonly double elastic_offset_half = Math.Pow(2, -10) * Math.Sin((.5 - elastic_const2) * elastic_const);
+        private static readonly double elastic_offset_quarter = Math.Pow(2, -10) * Math.Sin((.25 - elastic_const2) * elastic_const);
+        private static readonly double in_out_elastic_offset = Math.Pow(2, -10) * Math.Sin((1 - elastic_const2 * 1.5) * elastic_const / 1.5);
+
+        #endregion
+
         public static double ApplyEasing(Easing easing, double time)
         {
-            const double elastic_const = 2 * Math.PI / .3;
-            const double elastic_const2 = .3 / 4;
-
-            const double back_const = 1.70158;
-            const double back_const2 = back_const * 1.525;
-
-            const double bounce_const = 1 / 2.75;
-
             switch (easing)
             {
                 default:
@@ -319,15 +330,15 @@ namespace osu.Framework.MathUtils
                     return .5 - .5 * Math.Cos(Math.PI * time);
 
                 case Easing.InExpo:
-                    return Math.Pow(2, 10 * (time - 1)) + Math.Pow(2, -10) * (time - 1);
+                    return Math.Pow(2, 10 * (time - 1)) + expo_offset * (time - 1);
 
                 case Easing.OutExpo:
-                    return -Math.Pow(2, -10 * time) + 1 + Math.Pow(2, -10) * time;
+                    return -Math.Pow(2, -10 * time) + 1 + expo_offset * time;
 
                 case Easing.InOutExpo:
-                    if (time < .5) return .5 * (Math.Pow(2, 20 * time - 10) + Math.Pow(2, -10) * (2 * time - 1));
+                    if (time < .5) return .5 * (Math.Pow(2, 20 * time - 10) + expo_offset * (2 * time - 1));
 
-                    return 1 - .5 * (Math.Pow(2, -20 * time + 10) + Math.Pow(2, -10) * (-2 * time + 1));
+                    return 1 - .5 * (Math.Pow(2, -20 * time + 10) + expo_offset * (-2 * time + 1));
 
                 case Easing.InCirc:
                     return 1 - Math.Sqrt(1 - time * time);
@@ -341,28 +352,26 @@ namespace osu.Framework.MathUtils
                     return .5 * Math.Sqrt(1 - (time -= 2) * time) + .5;
 
                 case Easing.InElastic:
-                    return -Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - elastic_const2 - time) * elastic_const) + Math.Pow(2, -11) * (1 - time);
+                    return -Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - elastic_const2 - time) * elastic_const) + elastic_offset_full * (1 - time);
 
                 case Easing.OutElastic:
-                    return Math.Pow(2, -10 * time) * Math.Sin((time - elastic_const2) * elastic_const) + 1 - Math.Pow(2, -11) * time;
+                    return Math.Pow(2, -10 * time) * Math.Sin((time - elastic_const2) * elastic_const) + 1 - elastic_offset_full * time;
 
                 case Easing.OutElasticHalf:
-                    return Math.Pow(2, -10 * time) * Math.Sin((.5 * time - elastic_const2) * elastic_const) + 1
-                           - Math.Pow(2, -10) * Math.Sin((.5 - elastic_const2) * elastic_const) * time;
+                    return Math.Pow(2, -10 * time) * Math.Sin((.5 * time - elastic_const2) * elastic_const) + 1 - elastic_offset_half * time;
 
                 case Easing.OutElasticQuarter:
-                    return Math.Pow(2, -10 * time) * Math.Sin((.25 * time - elastic_const2) * elastic_const) + 1
-                           - Math.Pow(2, -10) * Math.Sin((.25 - elastic_const2) * elastic_const) * time;
+                    return Math.Pow(2, -10 * time) * Math.Sin((.25 * time - elastic_const2) * elastic_const) + 1 - elastic_offset_quarter * time;
 
                 case Easing.InOutElastic:
                     if ((time *= 2) < 1)
                     {
                         return -.5 * (Math.Pow(2, -10 + 10 * time) * Math.Sin((1 - elastic_const2 * 1.5 - time) * elastic_const / 1.5)
-                                      - Math.Pow(2, -10) * Math.Sin((1 - elastic_const2 * 1.5) * elastic_const / 1.5) * (1 - time));
+                                      - in_out_elastic_offset * (1 - time));
                     }
 
                     return .5 * (Math.Pow(2, -10 * --time) * Math.Sin((time - elastic_const2 * 1.5) * elastic_const / 1.5)
-                                 - Math.Pow(2, -10) * Math.Sin((1 - elastic_const2 * 1.5) * elastic_const / 1.5) * time) + 1;
+                                 - in_out_elastic_offset * time) + 1;
 
                 case Easing.InBack:
                     return time * time * ((back_const + 1) * time - back_const);

--- a/osu.Framework/MathUtils/Interpolation.cs
+++ b/osu.Framework/MathUtils/Interpolation.cs
@@ -319,15 +319,15 @@ namespace osu.Framework.MathUtils
                     return .5 - .5 * Math.Cos(Math.PI * time);
 
                 case Easing.InExpo:
-                    return Math.Pow(2, 10 * (time - 1));
+                    return Math.Pow(2, 10 * (time - 1)) + Math.Pow(2, -10) * (time - 1);
 
                 case Easing.OutExpo:
-                    return -Math.Pow(2, -10 * time) + 1;
+                    return -Math.Pow(2, -10 * time) + 1 + Math.Pow(2, -10) * time;
 
                 case Easing.InOutExpo:
-                    if (time < .5) return .5 * Math.Pow(2, 20 * time - 10);
+                    if (time < .5) return .5 * (Math.Pow(2, 20 * time - 10) + Math.Pow(2, -10) * (2 * time - 1));
 
-                    return 1 - .5 * Math.Pow(2, -20 * time + 10);
+                    return 1 - .5 * (Math.Pow(2, -20 * time + 10) + Math.Pow(2, -10) * (-2 * time + 1));
 
                 case Easing.InCirc:
                     return 1 - Math.Sqrt(1 - time * time);


### PR DESCRIPTION
Resolves #3015.

# Summary

`Elastic` and `Expo` curves due to the formulae used would not stop exactly at 0 or 1 at time 0 or 1, as pointed out in tests in c84b164. Resolve this discrepancy by introducing small linear factors to the appropriate easing curves.

The linear factors offset the differences at the extremities that were wrong, and then fade to 0 at the other ends which were correct. A special case are the `InOut` easings, in which the factor will be fully included at both ends and then fade out linearly to 0 at `time = 0.5`.

Since the adjustments involved are minuscule (less than 4 significant decimal places), they should not be noticeable during transitions, but fix the jumping at extreme points seen before.

# Remarks

Aside from the unit tests originally written by @peppy (sorry for taking co-credit on that commit, I don't quite know why that happened - might have been due to me rebasing a bit to clean up history before push) I also included a test scene that allows for previewing all available curves for comparison reasons.

To check the visual effects you can either run the test scene or see the attached videos: [before](https://streamable.com/94t0e), [after](https://streamable.com/ct70d). The difference is quite subtle and will mostly be apparent on large sizes, and at the very ends of the transitions.