### PR TITLE
Suppress MobileAuthenticatedStream exceptions

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -114,7 +114,18 @@ namespace osu.Framework.Android
         public void RenderGame()
         {
             Host = new AndroidGameHost(this);
+            Host.ExceptionThrown += handleException;
             Host.Run(game);
+        }
+
+        private bool handleException(Exception ex)
+        {
+            // suppress exceptions related to MobileAuthenticatedStream disposal
+            // (see: https://github.com/ppy/osu/issues/6264 and linked related mono/xamarin issues)
+            // to be removed when upstream fixes come in
+            return ex is AggregateException ae
+                && ae.InnerException is ObjectDisposedException ode
+                && ode.ObjectName == "MobileAuthenticatedStream";
         }
 
         public override bool OnCheckIsTextEditor() => true;


### PR DESCRIPTION
# Summary

This is a temporary targeted suppression for an outstanding Mono issue causing unobserved exceptions to pop up after cancellation of web requests (see ppy/osu#6264 and upstream issues: mono/mono#15462 and xamarin/xamarin-android#2159). Switching backends like in ppy/osu#6899 does not work for unknown reasons, and the legacy TLS provider is slated for removal anyway (see mono/mono#17391).

The suppression can hopefully be reverted when mono/mono#17393 makes its way into a release and gets integrated into Xamarin at xamarin/xamarin-android#3753.

# Remarks

The errors will still make their way into the logs, as per the current suppression logic:

https://github.com/ppy/osu-framework/blob/7f7dd04779bfa45d33d69a1c5599c894a9c64d33/osu.Framework/Platform/GameHost.cs#L228-L241

Therefore osu!-side there still will be notifications popping up notifying users about unobserved exceptions, but hopefully this should stop the game from outright dying. It seemed to work in my testing, but that doesn't mean much in the Android ecosystem.