### PR TITLE
Move texture loading logic to be more accessible

### DIFF
--- a/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
@@ -4,13 +4,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using osu.Framework.IO.Stores;
-using osu.Framework.Logging;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
-using StbiSharp;
 
 namespace osu.Framework.Graphics.Textures
 {
@@ -47,25 +44,7 @@ namespace osu.Framework.Graphics.Textures
         public Stream GetStream(string name) => store.GetStream(name);
 
         protected virtual Image<TPixel> ImageFromStream<TPixel>(Stream stream) where TPixel : unmanaged, IPixel<TPixel>
-        {
-            long initialPos = stream.Position;
-
-            try
-            {
-                using (var m = new MemoryStream())
-                {
-                    stream.CopyTo(m);
-                    using (var stbiImage = Stbi.LoadFromMemory(m, 4))
-                        return Image.LoadPixelData(MemoryMarshal.Cast<byte, TPixel>(stbiImage.Data), stbiImage.Width, stbiImage.Height);
-                }
-            }
-            catch (Exception e)
-            {
-                Logger.Error(e, "Texture could not be loaded via STB; falling back to ImageSharp.");
-                stream.Position = initialPos;
-                return Image.Load<TPixel>(stream);
-            }
-        }
+            => TextureUpload.LoadFromStream<TPixel>(stream);
 
         public IEnumerable<string> GetAvailableResources() => store.GetAvailableResources();
 

--- a/osu.Framework/Graphics/Textures/TextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/TextureUpload.cs
@@ -3,13 +3,16 @@
 
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Logging;
 using osuTK.Graphics.ES30;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
+using StbiSharp;
 
 namespace osu.Framework.Graphics.Textures
 {
@@ -59,11 +62,34 @@ namespace osu.Framework.Graphics.Textures
 
         /// <summary>
         /// Create an upload from an arbitrary image stream.
+        /// Note that this bypasses per-platform image loading optimisations.
+        /// Use <see cref="TextureLoaderStore"/> as provided from GameHost where possible.
         /// </summary>
         /// <param name="stream">The image content.</param>
         public TextureUpload(Stream stream)
-            : this(Image.Load<Rgba32>(stream))
+            : this(LoadFromStream<Rgba32>(stream))
         {
+        }
+
+        internal static Image<TPixel> LoadFromStream<TPixel>(Stream stream) where TPixel : unmanaged, IPixel<TPixel>
+        {
+            long initialPos = stream.Position;
+
+            try
+            {
+                using (var m = new MemoryStream())
+                {
+                    stream.CopyTo(m);
+                    using (var stbiImage = Stbi.LoadFromMemory(m, 4))
+                        return Image.LoadPixelData(MemoryMarshal.Cast<byte, TPixel>(stbiImage.Data), stbiImage.Width, stbiImage.Height);
+                }
+            }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Texture could not be loaded via STB; falling back to ImageSharp.");
+                stream.Position = initialPos;
+                return Image.Load<TPixel>(stream);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This is just a code quality thing, which doesn't affect any normal usage of the framework. Updates the deprecated method of texture loading to use the new Stbi pathway, and adds a note about it bypassing platform level implementations.