### PR TITLE
Move common logic to base implementation of GlyphStore

### DIFF
--- a/osu.Framework.Tests/IO/FontStoreTest.cs
+++ b/osu.Framework.Tests/IO/FontStoreTest.cs
@@ -24,8 +24,8 @@ namespace osu.Framework.Tests.IO
         [Test]
         public void TestNestedScaleAdjust()
         {
-            var fontStore = new FontStore(new GlyphStore(fontResourceStore, "OpenSans") { CacheStorage = storage }, scaleAdjust: 100);
-            var nestedFontStore = new FontStore(new GlyphStore(fontResourceStore, "OpenSans-Bold") { CacheStorage = storage }, 10);
+            var fontStore = new FontStore(new RawCachingGlyphStore(fontResourceStore, "OpenSans") { CacheStorage = storage }, scaleAdjust: 100);
+            var nestedFontStore = new FontStore(new RawCachingGlyphStore(fontResourceStore, "OpenSans-Bold") { CacheStorage = storage }, 10);
 
             fontStore.AddStore(nestedFontStore);
 

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -143,14 +143,14 @@ namespace osu.Framework
             // note that currently this means there could be two async font load operations.
             Fonts.AddStore(localFonts = new FontStore(useAtlas: false));
 
-            localFonts.AddStore(new GlyphStore(Resources, @"Fonts/OpenSans/OpenSans"));
-            localFonts.AddStore(new GlyphStore(Resources, @"Fonts/OpenSans/OpenSans-Bold"));
-            localFonts.AddStore(new GlyphStore(Resources, @"Fonts/OpenSans/OpenSans-Italic"));
-            localFonts.AddStore(new GlyphStore(Resources, @"Fonts/OpenSans/OpenSans-BoldItalic"));
+            localFonts.AddStore(new RawCachingGlyphStore(Resources, @"Fonts/OpenSans/OpenSans"));
+            localFonts.AddStore(new RawCachingGlyphStore(Resources, @"Fonts/OpenSans/OpenSans-Bold"));
+            localFonts.AddStore(new RawCachingGlyphStore(Resources, @"Fonts/OpenSans/OpenSans-Italic"));
+            localFonts.AddStore(new RawCachingGlyphStore(Resources, @"Fonts/OpenSans/OpenSans-BoldItalic"));
 
-            Fonts.AddStore(new GlyphStore(Resources, @"Fonts/FontAwesome5/FontAwesome-Solid"));
-            Fonts.AddStore(new GlyphStore(Resources, @"Fonts/FontAwesome5/FontAwesome-Regular"));
-            Fonts.AddStore(new GlyphStore(Resources, @"Fonts/FontAwesome5/FontAwesome-Brands"));
+            Fonts.AddStore(new RawCachingGlyphStore(Resources, @"Fonts/FontAwesome5/FontAwesome-Solid"));
+            Fonts.AddStore(new RawCachingGlyphStore(Resources, @"Fonts/FontAwesome5/FontAwesome-Regular"));
+            Fonts.AddStore(new RawCachingGlyphStore(Resources, @"Fonts/FontAwesome5/FontAwesome-Brands"));
 
             dependencies.Cache(Fonts);
 

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -61,8 +61,8 @@ namespace osu.Framework.IO.Stores
 
                 case GlyphStore gs:
 
-                    if (gs.CacheStorage == null)
-                        gs.CacheStorage = cacheStorage;
+                    if (gs is RawCachingGlyphStore raw && raw.CacheStorage == null)
+                        raw.CacheStorage = cacheStorage;
 
                     glyphStores.Add(gs);
                     queueLoad(gs);

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -83,9 +83,12 @@ namespace osu.Framework.IO.Stores
 
         protected virtual Image<Rgba32> GetPageImageForCharacter(Character character)
         {
-            using (var stream = Store.GetStream($@"{AssetName}_{character.Page.ToString().PadLeft((Font.Pages.Count - 1).ToString().Length, '0')}.png"))
+            using (var stream = Store.GetStream(GetFilenameForPage(character.Page)))
                 return TextureUpload.LoadFromStream<Rgba32>(stream);
         }
+
+        protected string GetFilenameForPage(int page)
+            => $@"{AssetName}_{page.ToString().PadLeft((Font.Pages.Count - 1).ToString().Length, '0')}.png";
 
         public CharacterGlyph Get(char character)
         {

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -75,9 +75,9 @@ namespace osu.Framework.IO.Stores
             return Font.Common.Base;
         }
 
-        protected virtual Image<Rgba32> GetPageImageForCharacter(Character character)
+        protected virtual Image<Rgba32> GetPageImage(int page)
         {
-            using (var stream = Store.GetStream(GetFilenameForPage(character.Page)))
+            using (var stream = Store.GetStream(GetFilenameForPage(page)))
                 return TextureUpload.LoadFromStream<Rgba32>(stream);
         }
 
@@ -122,7 +122,7 @@ namespace osu.Framework.IO.Stores
 
         protected virtual TextureUpload LoadCharacter(Character character)
         {
-            var page = GetPageImageForCharacter(character);
+            var page = GetPageImage(character.Page);
             LoadedGlyphCount++;
 
             var image = new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, character.Width, character.Height, new Rgba32(255, 255, 255, 0));

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -22,9 +22,6 @@ namespace osu.Framework.IO.Stores
     /// <summary>
     /// A basic glyph store that will load font sprite sheets every character retrieval.
     /// </summary>
-    /// <remarks>
-    /// For better performing solutions, consider <see cref="RawCachingGlyphStore"/> or <see cref="TimedExpiryGlyphStore"/>
-    /// </remarks>
     public class GlyphStore : IResourceStore<TextureUpload>, IGlyphStore
     {
         protected readonly string AssetName;

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -1,4 +1,7 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -6,62 +9,55 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using osu.Framework.Extensions;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
-using osu.Framework.Platform;
 using osu.Framework.Text;
 using SharpFNT;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.Primitives;
 
 namespace osu.Framework.IO.Stores
 {
     public class GlyphStore : IResourceStore<TextureUpload>, IGlyphStore
     {
-        private readonly string assetName;
+        protected readonly string AssetName;
 
         public readonly string FontName;
 
-        private const float default_size = 96;
-
-        private readonly ResourceStore<byte[]> store;
+        protected readonly ResourceStore<byte[]> Store;
 
         protected BitmapFont Font => completionSource.Task.Result;
 
         private readonly TaskCompletionSource<BitmapFont> completionSource = new TaskCompletionSource<BitmapFont>();
 
-        internal Storage CacheStorage;
-
-        private Task fontLoadTask;
-
         public GlyphStore(ResourceStore<byte[]> store, string assetName = null)
         {
-            this.store = new ResourceStore<byte[]>(store);
+            Store = new ResourceStore<byte[]>(store);
 
-            this.store.AddExtension("fnt");
-            this.store.AddExtension("bin");
+            Store.AddExtension("fnt");
+            Store.AddExtension("bin");
 
-            this.assetName = assetName;
+            AssetName = assetName;
 
             FontName = assetName?.Split('/').Last();
         }
+
+        private Task fontLoadTask;
 
         public Task LoadFontAsync() => fontLoadTask ??= Task.Factory.StartNew(() =>
         {
             try
             {
                 BitmapFont font;
-                using (var s = store.GetStream($@"{assetName}"))
+                using (var s = Store.GetStream($@"{AssetName}"))
                     font = BitmapFont.FromStream(s, FormatHint.Binary, false);
 
                 completionSource.SetResult(font);
             }
             catch (Exception ex)
             {
-                Logger.Error(ex, $"Couldn't load font asset from {assetName}.");
+                Logger.Error(ex, $"Couldn't load font asset from {AssetName}.");
                 completionSource.SetResult(null);
                 throw;
             }
@@ -79,6 +75,24 @@ namespace osu.Framework.IO.Stores
             return Font.Common.Base;
         }
 
+        protected virtual Image<Rgba32> GetPageImageForCharacter(Character character)
+        {
+            using (var stream = Store.GetStream($@"{AssetName}_{character.Page.ToString().PadLeft((Font.Pages.Count - 1).ToString().Length, '0')}.png"))
+                return TextureUpload.LoadFromStream<Rgba32>(stream);
+        }
+
+        public CharacterGlyph Get(char character)
+        {
+            var bmCharacter = Font.GetCharacter(character);
+            return new CharacterGlyph(character, bmCharacter.XOffset, bmCharacter.YOffset, bmCharacter.XAdvance, this);
+        }
+
+        public int GetKerning(char left, char right) => Font.GetKerningAmount(left, right);
+
+        Task<CharacterGlyph> IResourceStore<CharacterGlyph>.GetAsync(string name) => Task.Run(() => ((IGlyphStore)this).Get(name[0]));
+
+        CharacterGlyph IResourceStore<CharacterGlyph>.Get(string name) => Get(name[0]);
+
         public TextureUpload Get(string name)
         {
             if (name.Length > 1 && !name.StartsWith($@"{FontName}/", StringComparison.Ordinal))
@@ -87,7 +101,7 @@ namespace osu.Framework.IO.Stores
             if (!Font.Characters.TryGetValue(name.Last(), out Character c))
                 return null;
 
-            return loadCharacter(c);
+            return LoadCharacter(c);
         }
 
         public virtual async Task<TextureUpload> GetAsync(string name)
@@ -98,116 +112,36 @@ namespace osu.Framework.IO.Stores
             if (!(await completionSource.Task).Characters.TryGetValue(name.Last(), out Character c))
                 return null;
 
-            return loadCharacter(c);
+            return LoadCharacter(c);
         }
 
-        Task<CharacterGlyph> IResourceStore<CharacterGlyph>.GetAsync(string name) => Task.Run(() => ((IGlyphStore)this).Get(name[0]));
+        protected int LoadedGlyphCount;
 
-        CharacterGlyph IResourceStore<CharacterGlyph>.Get(string name) => Get(name[0]);
-
-        public CharacterGlyph Get(char character)
+        protected virtual TextureUpload LoadCharacter(Character character)
         {
-            var bmCharacter = Font.GetCharacter(character);
-            return new CharacterGlyph(character, bmCharacter.XOffset, bmCharacter.YOffset, bmCharacter.XAdvance, this);
-        }
+            var page = GetPageImageForCharacter(character);
+            LoadedGlyphCount++;
 
-        public int GetKerning(char left, char right) => Font.GetKerningAmount(left, right);
+            var image = new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, character.Width, character.Height, new Rgba32(255, 255, 255, 0));
 
-        private readonly Dictionary<int, PageInfo> pageLookup = new Dictionary<int, PageInfo>();
+            var dest = image.GetPixelSpan();
+            var source = page.GetPixelSpan();
 
-        private class PageInfo
-        {
-            public string Filename;
-            public Size Size;
-        }
+            // the spritesheet may have unused pixels trimmed
+            int readableHeight = Math.Min(character.Height, page.Height - character.Y);
+            int readableWidth = Math.Min(character.Width, page.Width - character.X);
 
-        private TextureUpload loadCharacter(Character c)
-        {
-            if (!pageLookup.TryGetValue(c.Page, out var pageInfo))
+            for (int y = 0; y < readableHeight; y++)
             {
-                string filename = $@"{assetName}_{c.Page.ToString().PadLeft((Font.Pages.Count - 1).ToString().Length, '0')}.png";
+                int readOffset = (character.Y + y) * page.Width + character.X;
+                int writeOffset = y * character.Width;
 
-                using (var stream = store.GetStream(filename))
-                using (var convert = Image.Load<Rgba32>(stream))
-                {
-                    string streamMd5 = stream.ComputeMD5Hash();
-                    string filenameMd5 = filename.ComputeMD5Hash();
-
-                    string accessFilename = $"{filenameMd5}#{streamMd5}";
-
-                    var existing = CacheStorage.GetFiles(string.Empty, $"{accessFilename}*").FirstOrDefault();
-
-                    if (existing != null)
-                    {
-                        var split = existing.Split('#');
-                        pageLookup[c.Page] = pageInfo = new PageInfo
-                        {
-                            Size = new Size(int.Parse(split[2]), int.Parse(split[3])),
-                            Filename = existing
-                        };
-                    }
-                    else
-                    {
-                        // todo: use i# memoryallocator once netstandard supports stream operations
-                        byte[] output = new byte[convert.Width * convert.Height];
-
-                        var pxl = convert.GetPixelSpan();
-
-                        for (int i = 0; i < convert.Width * convert.Height; i++)
-                            output[i] = pxl[i].A;
-
-                        // ensure any stale cached versions are deleted.
-                        foreach (var f in CacheStorage.GetFiles(string.Empty, $"{filenameMd5}*"))
-                            CacheStorage.Delete(f);
-
-                        accessFilename += $"#{convert.Width}#{convert.Height}";
-
-                        using (var outStream = CacheStorage.GetStream(accessFilename, FileAccess.Write, FileMode.Create))
-                            outStream.Write(output, 0, output.Length);
-
-                        pageLookup[c.Page] = pageInfo = new PageInfo
-                        {
-                            Size = new Size(convert.Width, convert.Height),
-                            Filename = accessFilename
-                        };
-                    }
-                }
-            }
-
-            int pageWidth = pageInfo.Size.Width;
-
-            int charWidth = c.Width;
-            int charHeight = c.Height;
-
-            if (readBuffer == null || readBuffer.Length < pageWidth)
-                readBuffer = new byte[pageWidth];
-
-            var image = new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, charWidth, charHeight, new Rgba32(255, 255, 255, 0));
-
-            using (var stream = CacheStorage.GetStream(pageInfo.Filename))
-            {
-                var pixels = image.GetPixelSpan();
-                stream.Seek(pageWidth * c.Y, SeekOrigin.Current);
-
-                // the spritesheet may have unused pixels trimmed
-                int readableHeight = Math.Min(c.Height, pageInfo.Size.Height - c.Y);
-                int readableWidth = Math.Min(c.Width, pageWidth - c.X);
-
-                for (int y = 0; y < readableHeight; y++)
-                {
-                    stream.Read(readBuffer, 0, pageWidth);
-
-                    int writeOffset = y * charWidth;
-
-                    for (int x = 0; x < readableWidth; x++)
-                        pixels[writeOffset + x] = new Rgba32(255, 255, 255, readBuffer[c.X + x]);
-                }
+                for (int x = 0; x < readableWidth; x++)
+                    dest[writeOffset + x] = source[readOffset + x];
             }
 
             return new TextureUpload(image);
         }
-
-        private byte[] readBuffer;
 
         public Stream GetStream(string name) => throw new NotSupportedException();
 

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -19,6 +19,12 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.IO.Stores
 {
+    /// <summary>
+    /// A basic glyph store that will load font sprite sheets every character retrieval.
+    /// </summary>
+    /// <remarks>
+    /// For better performing solutions, consider <see cref="RawCachingGlyphStore"/> or <see cref="TimedExpiryGlyphStore"/>
+    /// </remarks>
     public class GlyphStore : IResourceStore<TextureUpload>, IGlyphStore
     {
         protected readonly string AssetName;

--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -21,7 +21,6 @@ namespace osu.Framework.IO.Stores
     /// </summary>
     /// <remarks>
     /// This results in memory efficient lookups with good performance on solid state backed devices.
-    /// Consider <see cref="TimedExpiryGlyphStore"/> if memory usage is not an issue and performance should be prioritised.
     /// </remarks>
     public class RawCachingGlyphStore : GlyphStore
     {

--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Platform;
+using SharpFNT;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.Primitives;
+
+namespace osu.Framework.IO.Stores
+{
+    public class RawCachingGlyphStore : GlyphStore
+    {
+        public Storage CacheStorage;
+
+        public RawCachingGlyphStore(ResourceStore<byte[]> store, string assetName = null)
+            : base(store, assetName)
+        {
+        }
+
+        private readonly Dictionary<int, PageInfo> pageLookup = new Dictionary<int, PageInfo>();
+
+        protected override TextureUpload LoadCharacter(Character c)
+        {
+            if (!pageLookup.TryGetValue(c.Page, out var pageInfo))
+            {
+                string filename = $@"{AssetName}_{c.Page.ToString().PadLeft((Font.Pages.Count - 1).ToString().Length, '0')}.png";
+
+                using (var stream = Store.GetStream(filename))
+                {
+                    string streamMd5 = stream.ComputeMD5Hash();
+                    string filenameMd5 = filename.ComputeMD5Hash();
+
+                    string accessFilename = $"{filenameMd5}#{streamMd5}";
+
+                    var existing = CacheStorage.GetFiles(string.Empty, $"{accessFilename}*").FirstOrDefault();
+
+                    if (existing != null)
+                    {
+                        var split = existing.Split('#');
+                        pageLookup[c.Page] = pageInfo = new PageInfo
+                        {
+                            Size = new Size(int.Parse(split[2]), int.Parse(split[3])),
+                            Filename = existing
+                        };
+                    }
+                    else
+                    {
+                        using (var convert = GetPageImageForCharacter(c))
+                        {
+                            // todo: use i# memoryallocator once netstandard supports stream operations
+                            byte[] output = new byte[convert.Width * convert.Height];
+
+                            var pxl = convert.GetPixelSpan();
+
+                            for (int i = 0; i < convert.Width * convert.Height; i++)
+                                output[i] = pxl[i].A;
+
+                            // ensure any stale cached versions are deleted.
+                            foreach (var f in CacheStorage.GetFiles(string.Empty, $"{filenameMd5}*"))
+                                CacheStorage.Delete(f);
+
+                            accessFilename += $"#{convert.Width}#{convert.Height}";
+
+                            using (var outStream = CacheStorage.GetStream(accessFilename, FileAccess.Write, FileMode.Create))
+                                outStream.Write(output, 0, output.Length);
+
+                            pageLookup[c.Page] = pageInfo = new PageInfo
+                            {
+                                Size = new Size(convert.Width, convert.Height),
+                                Filename = accessFilename
+                            };
+                        }
+                    }
+                }
+            }
+
+            return createTextureUpload(c, pageInfo);
+        }
+
+        private TextureUpload createTextureUpload(Character character, PageInfo page)
+        {
+            int pageWidth = page.Size.Width;
+
+            int charWidth = character.Width;
+
+            int charHeight = character.Height;
+            if (readBuffer == null || readBuffer.Length < pageWidth)
+                readBuffer = new byte[pageWidth];
+
+            var image = new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, charWidth, charHeight, new Rgba32(255, 255, 255, 0));
+
+            using (var stream = CacheStorage.GetStream(page.Filename))
+            {
+                var pixels = image.GetPixelSpan();
+                stream.Seek(pageWidth * character.Y, SeekOrigin.Current);
+
+                // the spritesheet may have unused pixels trimmed
+                int readableHeight = Math.Min(character.Height, page.Size.Height - character.Y);
+                int readableWidth = Math.Min(character.Width, pageWidth - character.X);
+
+                for (int y = 0; y < readableHeight; y++)
+                {
+                    stream.Read(readBuffer, 0, pageWidth);
+
+                    int writeOffset = y * charWidth;
+
+                    for (int x = 0; x < readableWidth; x++)
+                        pixels[writeOffset + x] = new Rgba32(255, 255, 255, readBuffer[character.X + x]);
+                }
+            }
+
+            return new TextureUpload(image);
+        }
+
+        private byte[] readBuffer;
+
+        private class PageInfo
+        {
+            public string Filename;
+            public Size Size;
+        }
+    }
+}

--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -36,14 +36,14 @@ namespace osu.Framework.IO.Stores
         protected override TextureUpload LoadCharacter(Character character)
         {
             if (!pageLookup.TryGetValue(character.Page, out var pageInfo))
-                pageInfo = createCachedPageInfo(character);
+                pageInfo = createCachedPageInfo(character.Page);
 
             return createTextureUpload(character, pageInfo);
         }
 
-        private PageInfo createCachedPageInfo(Character character)
+        private PageInfo createCachedPageInfo(int page)
         {
-            string filename = GetFilenameForPage(character.Page);
+            string filename = GetFilenameForPage(page);
 
             using (var stream = Store.GetStream(filename))
             {
@@ -57,14 +57,14 @@ namespace osu.Framework.IO.Stores
                 if (existing != null)
                 {
                     var split = existing.Split('#');
-                    return pageLookup[character.Page] = new PageInfo
+                    return pageLookup[page] = new PageInfo
                     {
                         Size = new Size(int.Parse(split[2]), int.Parse(split[3])),
                         Filename = existing
                     };
                 }
 
-                using (var convert = GetPageImageForCharacter(character))
+                using (var convert = GetPageImage(page))
                 {
                     // todo: use i# memoryallocator once netstandard supports stream operations
                     byte[] output = new byte[convert.Width * convert.Height];
@@ -83,7 +83,7 @@ namespace osu.Framework.IO.Stores
                     using (var outStream = CacheStorage.GetStream(accessFilename, FileAccess.Write, FileMode.Create))
                         outStream.Write(output, 0, output.Length);
 
-                    return pageLookup[character.Page] = new PageInfo
+                    return pageLookup[page] = new PageInfo
                     {
                         Size = new Size(convert.Width, convert.Height),
                         Filename = accessFilename

--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -16,6 +16,13 @@ using SixLabors.Primitives;
 
 namespace osu.Framework.IO.Stores
 {
+    /// <summary>
+    /// A glyph store which caches font sprite sheets as raw pixels to disk on first use.
+    /// </summary>
+    /// <remarks>
+    /// This results in memory efficient lookups with good performance on solid state backed devices.
+    /// Consider <see cref="TimedExpiryGlyphStore"/> if memory usage is not an issue and performance should be prioritised.
+    /// </remarks>
     public class RawCachingGlyphStore : GlyphStore
     {
         public Storage CacheStorage;

--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -34,80 +34,78 @@ namespace osu.Framework.IO.Stores
 
         private readonly Dictionary<int, PageInfo> pageLookup = new Dictionary<int, PageInfo>();
 
-        protected override TextureUpload LoadCharacter(Character c)
+        protected override TextureUpload LoadCharacter(Character character)
         {
-            if (!pageLookup.TryGetValue(c.Page, out var pageInfo))
+            if (!pageLookup.TryGetValue(character.Page, out var pageInfo))
+                pageInfo = createCachedPageInfo(character);
+
+            return createTextureUpload(character, pageInfo);
+        }
+
+        private PageInfo createCachedPageInfo(Character character)
+        {
+            string filename = GetFilenameForPage(character.Page);
+
+            using (var stream = Store.GetStream(filename))
             {
-                string filename = $@"{AssetName}_{c.Page.ToString().PadLeft((Font.Pages.Count - 1).ToString().Length, '0')}.png";
+                string streamMd5 = stream.ComputeMD5Hash();
+                string filenameMd5 = filename.ComputeMD5Hash();
 
-                using (var stream = Store.GetStream(filename))
+                string accessFilename = $"{filenameMd5}#{streamMd5}";
+
+                var existing = CacheStorage.GetFiles(string.Empty, $"{accessFilename}*").FirstOrDefault();
+
+                if (existing != null)
                 {
-                    string streamMd5 = stream.ComputeMD5Hash();
-                    string filenameMd5 = filename.ComputeMD5Hash();
-
-                    string accessFilename = $"{filenameMd5}#{streamMd5}";
-
-                    var existing = CacheStorage.GetFiles(string.Empty, $"{accessFilename}*").FirstOrDefault();
-
-                    if (existing != null)
+                    var split = existing.Split('#');
+                    return pageLookup[character.Page] = new PageInfo
                     {
-                        var split = existing.Split('#');
-                        pageLookup[c.Page] = pageInfo = new PageInfo
-                        {
-                            Size = new Size(int.Parse(split[2]), int.Parse(split[3])),
-                            Filename = existing
-                        };
-                    }
-                    else
+                        Size = new Size(int.Parse(split[2]), int.Parse(split[3])),
+                        Filename = existing
+                    };
+                }
+
+                using (var convert = GetPageImageForCharacter(character))
+                {
+                    // todo: use i# memoryallocator once netstandard supports stream operations
+                    byte[] output = new byte[convert.Width * convert.Height];
+
+                    var pxl = convert.GetPixelSpan();
+
+                    for (int i = 0; i < convert.Width * convert.Height; i++)
+                        output[i] = pxl[i].A;
+
+                    // ensure any stale cached versions are deleted.
+                    foreach (var f in CacheStorage.GetFiles(string.Empty, $"{filenameMd5}*"))
+                        CacheStorage.Delete(f);
+
+                    accessFilename += $"#{convert.Width}#{convert.Height}";
+
+                    using (var outStream = CacheStorage.GetStream(accessFilename, FileAccess.Write, FileMode.Create))
+                        outStream.Write(output, 0, output.Length);
+
+                    return pageLookup[character.Page] = new PageInfo
                     {
-                        using (var convert = GetPageImageForCharacter(c))
-                        {
-                            // todo: use i# memoryallocator once netstandard supports stream operations
-                            byte[] output = new byte[convert.Width * convert.Height];
-
-                            var pxl = convert.GetPixelSpan();
-
-                            for (int i = 0; i < convert.Width * convert.Height; i++)
-                                output[i] = pxl[i].A;
-
-                            // ensure any stale cached versions are deleted.
-                            foreach (var f in CacheStorage.GetFiles(string.Empty, $"{filenameMd5}*"))
-                                CacheStorage.Delete(f);
-
-                            accessFilename += $"#{convert.Width}#{convert.Height}";
-
-                            using (var outStream = CacheStorage.GetStream(accessFilename, FileAccess.Write, FileMode.Create))
-                                outStream.Write(output, 0, output.Length);
-
-                            pageLookup[c.Page] = pageInfo = new PageInfo
-                            {
-                                Size = new Size(convert.Width, convert.Height),
-                                Filename = accessFilename
-                            };
-                        }
-                    }
+                        Size = new Size(convert.Width, convert.Height),
+                        Filename = accessFilename
+                    };
                 }
             }
-
-            return createTextureUpload(c, pageInfo);
         }
 
         private TextureUpload createTextureUpload(Character character, PageInfo page)
         {
             int pageWidth = page.Size.Width;
 
-            int charWidth = character.Width;
-
-            int charHeight = character.Height;
             if (readBuffer == null || readBuffer.Length < pageWidth)
                 readBuffer = new byte[pageWidth];
 
-            var image = new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, charWidth, charHeight, new Rgba32(255, 255, 255, 0));
+            var image = new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, character.Width, character.Height, new Rgba32(255, 255, 255, 0));
 
-            using (var stream = CacheStorage.GetStream(page.Filename))
+            using (var source = CacheStorage.GetStream(page.Filename))
             {
-                var pixels = image.GetPixelSpan();
-                stream.Seek(pageWidth * character.Y, SeekOrigin.Current);
+                var dest = image.GetPixelSpan();
+                source.Seek(pageWidth * character.Y, SeekOrigin.Current);
 
                 // the spritesheet may have unused pixels trimmed
                 int readableHeight = Math.Min(character.Height, page.Size.Height - character.Y);
@@ -115,12 +113,12 @@ namespace osu.Framework.IO.Stores
 
                 for (int y = 0; y < readableHeight; y++)
                 {
-                    stream.Read(readBuffer, 0, pageWidth);
+                    source.Read(readBuffer, 0, pageWidth);
 
-                    int writeOffset = y * charWidth;
+                    int writeOffset = y * character.Width;
 
                     for (int x = 0; x < readableWidth; x++)
-                        pixels[writeOffset + x] = new Rgba32(255, 255, 255, readBuffer[character.X + x]);
+                        dest[writeOffset + x] = new Rgba32(255, 255, 255, readBuffer[character.X + x]);
                 }
             }
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -131,12 +131,12 @@ namespace osu.Framework.Testing
             var resources = game.Resources;
 
             //Roboto
-            fonts.AddStore(new GlyphStore(resources, @"Fonts/Roboto/Roboto-Regular"));
-            fonts.AddStore(new GlyphStore(resources, @"Fonts/Roboto/Roboto-Bold"));
+            fonts.AddStore(new RawCachingGlyphStore(resources, @"Fonts/Roboto/Roboto-Regular"));
+            fonts.AddStore(new RawCachingGlyphStore(resources, @"Fonts/Roboto/Roboto-Bold"));
 
             //RobotoCondensed
-            fonts.AddStore(new GlyphStore(resources, @"Fonts/RobotoCondensed/RobotoCondensed-Regular"));
-            fonts.AddStore(new GlyphStore(resources, @"Fonts/RobotoCondensed/RobotoCondensed-Bold"));
+            fonts.AddStore(new RawCachingGlyphStore(resources, @"Fonts/RobotoCondensed/RobotoCondensed-Regular"));
+            fonts.AddStore(new RawCachingGlyphStore(resources, @"Fonts/RobotoCondensed/RobotoCondensed-Bold"));
 
             showLogOverlay = frameworkConfig.GetBindable<bool>(FrameworkSetting.ShowLogOverlay);
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/3035
- [x] Depends on https://github.com/ppy/osu-framework/pull/3036

Allowing for better testing of different caching / parsing algorithms. `GlyphStore` can also now be used to load with zero caching, as a baseline.

This also does some clean-up on `RawCachingGlyphStore` for readability purposes.