### PR TITLE
Replace macOS native osuTK reflection

### DIFF
--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -2,16 +2,18 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.InteropServices;
 
 namespace osu.Framework.Platform.MacOS.Native
 {
     internal static class Cocoa
     {
+        internal const string LIB_DL = "libdl.dylib";
+        internal const string LIB_APPKIT = "/System/Library/Frameworks/AppKit.framework/AppKit";
         internal const string LIB_OBJ_C = "/usr/lib/libobjc.dylib";
         internal const string LIB_CORE_GRAPHICS = "/System/Library/Frameworks/CoreGraphics.framework/Versions/Current/CoreGraphics";
+
+        internal const int RTLD_NOW = 2;
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector);
@@ -20,7 +22,13 @@ namespace osu.Framework.Platform.MacOS.Native
         public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, int arg);
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, ulong ulong1);
+
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr ptr1);
+
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr intPtr1, int int1);
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern IntPtr SendIntPtr(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
@@ -61,13 +69,7 @@ namespace osu.Framework.Platform.MacOS.Native
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern void SendVoid(IntPtr receiver, IntPtr selector, IntPtr intPtr1, IntPtr intPtr2, IntPtr intPtr3, IntPtr intPtr4);
 
-        private static readonly Type type_cocoa = typeof(osuTK.NativeWindow).Assembly.GetTypes().Single(x => x.Name == "Cocoa");
-        private static readonly MethodInfo method_cocoa_from_ns_string = type_cocoa.GetMethod("FromNSString");
-        private static readonly MethodInfo method_cocoa_to_ns_string = type_cocoa.GetMethod("ToNSString");
-        private static readonly MethodInfo method_cocoa_get_string_constant = type_cocoa.GetMethod("GetStringConstant");
-
         public static IntPtr AppKitLibrary;
-        public static IntPtr FoundationLibrary;
 
         [DllImport(LIB_CORE_GRAPHICS, EntryPoint = "CGCursorIsVisible")]
         public static extern bool CGCursorIsVisible();
@@ -75,16 +77,37 @@ namespace osu.Framework.Platform.MacOS.Native
         [DllImport(LIB_CORE_GRAPHICS, EntryPoint = "CGEventSourceFlagsState")]
         public static extern ulong CGEventSourceFlagsState(int stateID);
 
+        [DllImport(LIB_DL)]
+        private static extern IntPtr dlsym(IntPtr handle, string name);
+
+        [DllImport(LIB_DL)]
+        private static extern IntPtr dlopen(string fileName, int flags);
+
         static Cocoa()
         {
-            AppKitLibrary = (IntPtr)type_cocoa.GetField("AppKitLibrary").GetValue(null);
-            FoundationLibrary = (IntPtr)type_cocoa.GetField("FoundationLibrary").GetValue(null);
+            AppKitLibrary = dlopen(LIB_APPKIT, RTLD_NOW);
         }
 
-        public static string FromNSString(IntPtr handle) => (string)method_cocoa_from_ns_string.Invoke(null, new object[] { handle });
+        private static readonly IntPtr sel_c_string_using_encoding = Selector.Get("cStringUsingEncoding:");
 
-        public static IntPtr ToNSString(string str) => (IntPtr)method_cocoa_to_ns_string.Invoke(null, new object[] { str });
+        public static string FromNSString(IntPtr handle) => Marshal.PtrToStringUni(SendIntPtr(handle, sel_c_string_using_encoding, (uint)NSStringEncoding.Unicode));
 
-        public static IntPtr GetStringConstant(IntPtr handle, string symbol) => (IntPtr)method_cocoa_get_string_constant.Invoke(null, new object[] { handle, symbol });
+        public static unsafe IntPtr ToNSString(string str)
+        {
+            if (str == null)
+                return IntPtr.Zero;
+
+            fixed (char* ptrFirstChar = str)
+            {
+                var handle = SendIntPtr(Class.Get("NSString"), Selector.Get("alloc"));
+                return SendIntPtr(handle, Selector.Get("initWithCharacters:length:"), (IntPtr)ptrFirstChar, str.Length);
+            }
+        }
+
+        public static IntPtr GetStringConstant(IntPtr handle, string symbol)
+        {
+            IntPtr ptr = dlsym(handle, symbol);
+            return ptr == IntPtr.Zero ? IntPtr.Zero : Marshal.ReadIntPtr(ptr);
+        }
     }
 }

--- a/osu.Framework/Platform/MacOS/Native/NSStringEncoding.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSStringEncoding.cs
@@ -1,0 +1,123 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    public enum NSStringEncoding : uint
+    {
+        /// <summary>
+        /// 7-bit ASCII encoding within 8 bit chars.
+        /// </summary>
+        ASCII = 1,
+
+        /// <summary>
+        /// 8-bit ASCII encoding with NEXTSTEP extensions.
+        /// </summary>
+        NEXTSTEP = 2,
+
+        /// <summary>
+        /// 8-bit EUC encoding for Japanese text.
+        /// </summary>
+        JapaneseEUC = 3,
+
+        /// <summary>
+        /// 8-bit representation of Unicode characters.
+        /// </summary>
+        UTF8 = 4,
+
+        /// <summary>
+        /// 8-bit ISO Latin 1 encoding.
+        /// </summary>
+        ISOLatin1 = 5,
+
+        /// <summary>
+        /// 8-bit Adobe Symbol encoding vector.
+        /// </summary>
+        Symbol = 6,
+
+        /// <summary>
+        /// 7-bit verbose ASCII to represent all Unicode characters.
+        /// </summary>
+        NonLossyASCII = 7,
+
+        /// <summary>
+        /// 8-bit Shift-JIS encoding for Japanese text.
+        /// </summary>
+        ShiftJIS = 8,
+
+        /// <summary>
+        /// 8-bit ISO Latin 2 encoding.
+        /// </summary>
+        ISOLatin2 = 9,
+
+        /// <summary>
+        /// The canonical Unicode encoding.
+        /// </summary>
+        Unicode = 10,
+
+        /// <summary>
+        /// Microsoft Windows codepage 1251, encoding Cyrillic characters.
+        /// </summary>
+        WindowsCP1251 = 11,
+
+        /// <summary>
+        /// Microsoft Windows codepage 1252, encoding Latin 1 characters.
+        /// </summary>
+        WindowsCP1252 = 12,
+
+        /// <summary>
+        /// Microsoft Windows codepage 1253, encoding Greek characters.
+        /// </summary>
+        WindowsCP1253 = 13,
+
+        /// <summary>
+        /// Microsoft Windows codepage 1254, encoding Turkish characters.
+        /// </summary>
+        WindowsCP1254 = 14,
+
+        /// <summary>
+        /// Microsoft Windows codepage 1250, encoding Latin 2 characters.
+        /// </summary>
+        WindowsCP1250 = 15,
+
+        /// <summary>
+        /// ISO 2022 Japanese encoding.
+        /// </summary>
+        ISO2022JP = 21,
+
+        /// <summary>
+        /// Classing Macintosh Roman encoding.
+        /// </summary>
+        MacOSRoman = 30,
+
+        /// <summary>
+        /// 16-bit UTF encoding.
+        /// </summary>
+        UTF16 = Unicode,
+
+        /// <summary>
+        /// <see cref="UTF16"/> encoding with explicit endianness.
+        /// </summary>
+        UTF16BigEndian = 0x90000100,
+
+        /// <summary>
+        /// <see cref="UTF16"/> encoding with explicit endianness.
+        /// </summary>
+        UTF16LittleEndian = 0x94000100,
+
+        /// <summary>
+        /// 32-bit UTF encoding.
+        /// </summary>
+        UTF32 = 0x8c000100,
+
+        /// <summary>
+        /// <see cref="UTF32"/> encoding with explicit endianness.
+        /// </summary>
+        UTF32BigEndian = 0x98000100,
+
+        /// <summary>
+        /// <see cref="UTF32"/> encoding with explicit endianness.
+        /// </summary>
+        UTF32LittleEndian = 0x9c000100
+    }
+}


### PR DESCRIPTION
Replaces the reflected osuTK calls in `MacOS.Native` with real implementations.  Required as part of dropping osuTK.  Implementations loosely borrowed from osuTK.

Note that the `FoundationLibrary` reference is not required and has been removed.

Related to #2448