### PR TITLE
Fix audio thread disposal ordering

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -284,10 +284,10 @@ namespace osu.Framework
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
-
             Audio?.Dispose();
             Audio = null;
+
+            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -68,16 +68,23 @@ namespace osu.Framework.Testing
         public void DestroyGameHost()
         {
             host.Exit();
-            runTask.Wait();
-            host.Dispose();
 
             try
             {
-                // clean up after each run
-                host.Storage.DeleteDirectory(string.Empty);
+                runTask.Wait();
             }
-            catch
+            finally
             {
+                host.Dispose();
+
+                try
+                {
+                    // clean up after each run
+                    host.Storage.DeleteDirectory(string.Empty);
+                }
+                catch
+                {
+                }
             }
         }
 

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -59,6 +59,14 @@ namespace osu.Framework.Threading
         protected override void PerformExit()
         {
             base.PerformExit();
+
+            lock (managers)
+            {
+                // AudioManager's disposal triggers an un-registration
+                while (managers.Count > 0)
+                    managers[0].Dispose();
+            }
+
             ManagedBass.Bass.Free();
         }
     }

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -62,9 +62,9 @@ namespace osu.Framework.Threading
 
             lock (managers)
             {
-                // AudioManager's disposal triggers an un-registration
-                while (managers.Count > 0)
-                    managers[0].Dispose();
+                foreach (var manager in managers)
+                    manager.Dispose();
+                managers.Clear();
             }
 
             ManagedBass.Bass.Free();


### PR DESCRIPTION
It may be possible for the audio thread to exit before tracks in the game get disposed. One such example is `TestScene`, which explicitly exits before disposing the host, however there isn't a reason why this couldn't occur via a normal game startup.

This is particularly dangerous in the case of `OsuTestScene`, which stops a track during its disposal. In this case, the `Stop()` event gets enqueued to the `AudioComponent`, then `Dispose()` gets invoked (stopping all further actions from getting enqueued), but the audio thread isn't running so the `Stop()` event just hangs endlessly.

In short:

```csharp
host.Run(game)
host.Exit()
host.Dispose() // Disposal of the host triggers a disposal of all drawable components
testScene.Dispose() // Invoked by the host disposal
track.Stop() // Invoked by the test scene disposal
track.Dispose() // Invoked some time _after_ Stop(), likely on the finalizer thread (not important)
```

There are 3 fixes contained here:

1. The game will dispose the audio manager before disposing all drawable components. If the game is disposed (e.g. multiple games within a single host), this ensures that (as per above) `track.Stop()` will be invoked after `track.Dispose()`, so it won't get enqueued and return immediately.
2. In test cases it's possible for `runTask` to throw an exception, blocking the code that will dispose the host.
3. Relating to (2), `AudioThread.Exit()` will now dispose all registered `AudioManager`s, making sure that a call to `host.Exit()` before `host.Dispose()` won't cause an endless block block.

### Testing

It's kinda hard to test this one via test cases. I tried but didn't manage to make it work. I tested by applying the commit https://github.com/peppy/osu/commit/2663e5d756854a043ef091c66a8973f7ba9b3432 osu! side and testing that `TestSceneUserDimContainer.TransitionTest()` doesn't remain in a running state forever.