### PR TITLE
Fix OnEntering being called before drawable is loaded

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
@@ -348,6 +348,25 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestEventsNotFiredBeforeScreenLoad()
+        {
+            Screen screen1 = null;
+            bool wasLoaded = true;
+
+            pushAndEnsureCurrent(() => screen1 = new TestScreen
+            {
+                // ReSharper disable once AccessToModifiedClosure
+                Entered = () => wasLoaded &= screen1?.IsLoaded == true,
+                // ReSharper disable once AccessToModifiedClosure
+                Suspended = () => wasLoaded &= screen1?.IsLoaded == true,
+            });
+
+            pushAndEnsureCurrent(() => new TestScreen(), () => screen1);
+
+            AddAssert("was loaded before events", () => wasLoaded);
+        }
+
+        [Test]
         public void TestAsyncDoublePush()
         {
             TestScreenSlow screen1 = null;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
@@ -215,6 +215,18 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestScreenPushedAfterExiting()
+        {
+            TestScreen screen1 = null;
+
+            AddStep("push", () => stack.Push(screen1 = new TestScreen()));
+            AddStep("exit screen1", () => screen1.Exit());
+            AddUntilStep("ensure exited", () => !screen1.IsCurrentScreen());
+
+            AddStep("push again", () => Assert.Throws<InvalidOperationException>(() => stack.Push(screen1)));
+        }
+
+        [Test]
         public void TestPushToNonLoadedScreenFails()
         {
             TestScreenSlow screen1 = null;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
@@ -286,7 +286,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 {
                     // we can't use the [SetUp] screen stack as we need to change the ctor parameters.
                     Clear();
-                    Add(stack = new ScreenStack(baseScreen = new TestScreen())
+                    Add(stack = new ScreenStack(baseScreen = new TestScreen(id: 0))
                     {
                         RelativeSizeAxes = Axes.Both
                     });
@@ -296,13 +296,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Perform setup", () =>
             {
                 order = new List<int>();
-                screen1 = new TestScreenSlow
+                screen1 = new TestScreenSlow(1)
                 {
                     Entered = () => order.Add(1),
                     Suspended = () => order.Add(2),
                     Resumed = () => order.Add(5),
                 };
-                screen2 = new TestScreenSlow
+                screen2 = new TestScreenSlow(2)
                 {
                     Entered = () => order.Add(3),
                     Exited = () => order.Add(4),

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -101,6 +101,12 @@ namespace osu.Framework.Screens
 
             var newScreenDrawable = newScreen.AsDrawable();
 
+            if (newScreenDrawable.IsLoaded)
+                throw new InvalidOperationException("A screen should not be loaded before being pushed.");
+
+            // this needs to be queued here before the load is begun so it preceed any potential OnSuspending event (also attached to OnLoadComplete).
+            newScreenDrawable.OnLoadComplete += _ => newScreen.OnEntering(source);
+
             if (source == null)
             {
                 // this is the first screen to be loaded.
@@ -132,7 +138,6 @@ namespace osu.Framework.Screens
                 suspend(parent, child);
 
             AddInternal(child.AsDrawable());
-            child.OnEntering(parent);
         }
 
         /// <summary>

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -65,6 +65,9 @@ namespace osu.Framework.Screens
         /// <summary>
         /// Pushes a <see cref="IScreen"/> to this <see cref="ScreenStack"/>.
         /// </summary>
+        /// <remarks>
+        /// A <see cref="IScreen"/> cannot be pushed multiple times.
+        /// </remarks>
         /// <param name="screen">The <see cref="IScreen"/> to push.</param>
         public void Push(IScreen screen)
         {

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.Screens
         /// Pushes a <see cref="IScreen"/> to this <see cref="ScreenStack"/>.
         /// </summary>
         /// <remarks>
-        /// A <see cref="IScreen"/> cannot be pushed multiple times.
+        /// An <see cref="IScreen"/> cannot be pushed multiple times.
         /// </remarks>
         /// <param name="screen">The <see cref="IScreen"/> to push.</param>
         public void Push(IScreen screen)


### PR DESCRIPTION
Can lead to unintended failure if doing initialisation in `LoadComplete` that is expected to be completed before `OnEntering` is hit.