### PR TITLE
Fix LogOverlay causing a null reference on display via shortcut key

### DIFF
--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -113,7 +113,7 @@ namespace osu.Framework.Graphics.Visualisation
         private void setHoldState(bool controlPressed)
         {
             box.Alpha = controlPressed ? 1 : background_alpha;
-            clock.Rate = controlPressed ? 0 : 1;
+            if (clock != null) clock.Rate = controlPressed ? 0 : 1;
         }
 
         [BackgroundDependencyLoader]


### PR DESCRIPTION
Closes #3069.

Regressed in https://github.com/ppy/osu-framework/pull/2902.