### PR TITLE
Fix scheduler running in-place unintentionally

### DIFF
--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -358,17 +358,21 @@ namespace osu.Framework.Tests.Threading
         /// Delegate 3 - Added during Delegate 1 callback, should not get executed.
         /// </summary>
         [Test]
-        public void TestDelegateAddedInCallbackNotExecutedAfterIntermediateCompleteDelegate()
+        public void TestDelegateAddedInCallbackNotExecutedAfterIntermediateCancelledDelegate()
         {
             int invocations = 0;
 
+            // Delegate 2
             var cancelled = new ScheduledDelegate(() => { });
 
+            // Delegate 1
             scheduler.Add(() =>
             {
                 invocations++;
 
                 cancelled.Cancel();
+
+                // Delegate 3
                 scheduler.Add(() => invocations++);
             });
 

--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -350,8 +350,7 @@ namespace osu.Framework.Tests.Threading
         }
 
         /// <summary>
-        /// Tests that delegates added from inside a scheduled callback don't get executed when the scheduled callback
-        /// cancels an intermediate task that was previously cancelled.
+        /// Tests that delegates added from inside a scheduled callback don't get executed when the scheduled callback cancels a prior intermediate task.
         ///
         /// Delegate 1 - Added at the start.
         /// Delegate 2 - Added at the start, cancelled by Delegate 1.

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -104,11 +104,11 @@ namespace osu.Framework.Threading
 
             while (getNextTask(out ScheduledDelegate sd))
             {
-                if (sd.Cancelled || sd.Completed)
-                    continue;
-
-                //todo: error handling
-                sd.RunTask();
+                if (!sd.Cancelled && !sd.Completed)
+                {
+                    //todo: error handling
+                    sd.RunTask();
+                }
 
                 if (++countRun == countToRun)
                     break;


### PR DESCRIPTION
This is the only thing I can think of that could cause https://ci.appveyor.com/project/peppy/osu-framework/builds/29385150 since it schedules from inside a scheduled delegate, though I'm not sure on the exact case or how it could happen given the testing procedure.