### PR TITLE
Combine BindableNumber implementations into base class

### DIFF
--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -1,19 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Globalization;
 
 namespace osu.Framework.Bindables
 {
+    [Obsolete("Use BindableNumber<int> instead")] // can be removed 20200609
     public class BindableDouble : BindableNumber<double>
     {
-        // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
-        public override bool IsDefault => MathUtils.Precision.AlmostEquals(Value, Default, Precision / 2);
-
-        protected override double DefaultMinValue => double.MinValue;
-        protected override double DefaultMaxValue => double.MaxValue;
-        protected override double DefaultPrecision => double.Epsilon;
-
         public BindableDouble(double value = 0)
             : base(value)
         {

--- a/osu.Framework/Bindables/BindableDouble.cs
+++ b/osu.Framework/Bindables/BindableDouble.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Globalization;
 
 namespace osu.Framework.Bindables
 {
-    [Obsolete("Use BindableNumber<int> instead")] // can be removed 20200609
     public class BindableDouble : BindableNumber<double>
     {
         public BindableDouble(double value = 0)

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -1,19 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Globalization;
 
 namespace osu.Framework.Bindables
 {
+    [Obsolete("Use BindableNumber<int> instead")] // can be removed 20200609
     public class BindableFloat : BindableNumber<float>
     {
-        // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
-        public override bool IsDefault => MathUtils.Precision.AlmostEquals(Value, Default, Precision / 2);
-
-        protected override float DefaultMinValue => float.MinValue;
-        protected override float DefaultMaxValue => float.MaxValue;
-        protected override float DefaultPrecision => float.Epsilon;
-
         public BindableFloat(float value = 0)
             : base(value)
         {

--- a/osu.Framework/Bindables/BindableFloat.cs
+++ b/osu.Framework/Bindables/BindableFloat.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Globalization;
 
 namespace osu.Framework.Bindables
 {
-    [Obsolete("Use BindableNumber<int> instead")] // can be removed 20200609
     public class BindableFloat : BindableNumber<float>
     {
         public BindableFloat(float value = 0)

--- a/osu.Framework/Bindables/BindableInt.cs
+++ b/osu.Framework/Bindables/BindableInt.cs
@@ -1,12 +1,10 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Globalization;
 
 namespace osu.Framework.Bindables
 {
-    [Obsolete("Use BindableNumber<int> instead")] // can be removed 20200609
     public class BindableInt : BindableNumber<int>
     {
         public BindableInt(int value = 0)

--- a/osu.Framework/Bindables/BindableInt.cs
+++ b/osu.Framework/Bindables/BindableInt.cs
@@ -1,16 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Globalization;
 
 namespace osu.Framework.Bindables
 {
+    [Obsolete("Use BindableNumber<int> instead")] // can be removed 20200609
     public class BindableInt : BindableNumber<int>
     {
-        protected override int DefaultMinValue => int.MinValue;
-        protected override int DefaultMaxValue => int.MaxValue;
-        protected override int DefaultPrecision => 1;
-
         public BindableInt(int value = 0)
             : base(value)
         {

--- a/osu.Framework/Bindables/BindableLong.cs
+++ b/osu.Framework/Bindables/BindableLong.cs
@@ -1,21 +1,9 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Globalization;
-
 namespace osu.Framework.Bindables
 {
     public class BindableLong : BindableNumber<long>
     {
-        protected override long DefaultMinValue => long.MinValue;
-        protected override long DefaultMaxValue => long.MaxValue;
-        protected override long DefaultPrecision => 1;
-
-        public BindableLong(long value = 0)
-            : base(value)
-        {
-        }
-
-        public override string ToString() => Value.ToString(NumberFormatInfo.InvariantInfo);
     }
 }

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -122,6 +122,8 @@ namespace osu.Framework.Bindables
                     return (T)(object)float.MinValue;
                 if (typeof(T) == typeof(int))
                     return (T)(object)int.MinValue;
+                if (typeof(T) == typeof(long))
+                    return (T)(object)long.MinValue;
 
                 throw new NotSupportedException(
                     $"{nameof(BindableNumber<T>)} needs to override {nameof(DefaultMinValue)} to provide a sane default.");
@@ -141,6 +143,8 @@ namespace osu.Framework.Bindables
                     return (T)(object)float.MaxValue;
                 if (typeof(T) == typeof(int))
                     return (T)(object)int.MaxValue;
+                if (typeof(T) == typeof(long))
+                    return (T)(object)long.MaxValue;
 
                 throw new NotSupportedException(
                     $"{nameof(BindableNumber<T>)} needs to override {nameof(DefaultMaxValue)} to provide a sane default.");
@@ -159,6 +163,8 @@ namespace osu.Framework.Bindables
                 if (typeof(T) == typeof(float))
                     return (T)(object)float.Epsilon;
                 if (typeof(T) == typeof(int))
+                    return (T)(object)1;
+                if (typeof(T) == typeof(long))
                     return (T)(object)1;
 
                 throw new NotSupportedException(

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -165,7 +165,7 @@ namespace osu.Framework.Bindables
                 if (typeof(T) == typeof(int))
                     return (T)(object)1;
                 if (typeof(T) == typeof(long))
-                    return (T)(object)1;
+                    return (T)(object)1L;
 
                 throw new NotSupportedException(
                     $"{nameof(BindableNumber<T>)} needs to override {nameof(DefaultPrecision)} to provide a sane default.");

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 
 namespace osu.Framework.Bindables
 {
-    public abstract class BindableNumber<T> : Bindable<T>, IBindableNumber<T>
+    public class BindableNumber<T> : Bindable<T>, IBindableNumber<T>
         where T : struct, IComparable<T>, IConvertible, IEquatable<T>
     {
         public event Action<T> PrecisionChanged;
@@ -15,7 +15,7 @@ namespace osu.Framework.Bindables
 
         public event Action<T> MaxValueChanged;
 
-        private protected BindableNumber(T value = default)
+        public BindableNumber(T value = default)
             : base(value)
         {
             // Directly comparing typeof(T) to type literal is recognized pattern of JIT and very fast.
@@ -112,17 +112,59 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// The default <see cref="MinValue"/>. This should be equal to the minimum value of type <typeparamref name="T"/>.
         /// </summary>
-        protected abstract T DefaultMinValue { get; }
+        protected virtual T DefaultMinValue
+        {
+            get
+            {
+                if (typeof(T) == typeof(double))
+                    return (T)(object)double.MinValue;
+                if (typeof(T) == typeof(float))
+                    return (T)(object)float.MinValue;
+                if (typeof(T) == typeof(int))
+                    return (T)(object)int.MinValue;
+
+                throw new NotSupportedException(
+                    $"{nameof(BindableNumber<T>)} needs to override {nameof(DefaultMinValue)} to provide a sane default.");
+            }
+        }
 
         /// <summary>
         /// The default <see cref="MaxValue"/>. This should be equal to the maximum value of type <typeparamref name="T"/>.
         /// </summary>
-        protected abstract T DefaultMaxValue { get; }
+        protected virtual T DefaultMaxValue
+        {
+            get
+            {
+                if (typeof(T) == typeof(double))
+                    return (T)(object)double.MaxValue;
+                if (typeof(T) == typeof(float))
+                    return (T)(object)float.MaxValue;
+                if (typeof(T) == typeof(int))
+                    return (T)(object)int.MaxValue;
+
+                throw new NotSupportedException(
+                    $"{nameof(BindableNumber<T>)} needs to override {nameof(DefaultMaxValue)} to provide a sane default.");
+            }
+        }
 
         /// <summary>
         /// The default <see cref="Precision"/>.
         /// </summary>
-        protected abstract T DefaultPrecision { get; }
+        protected virtual T DefaultPrecision
+        {
+            get
+            {
+                if (typeof(T) == typeof(double))
+                    return (T)(object)double.Epsilon;
+                if (typeof(T) == typeof(float))
+                    return (T)(object)float.Epsilon;
+                if (typeof(T) == typeof(int))
+                    return (T)(object)1;
+
+                throw new NotSupportedException(
+                    $"{nameof(BindableNumber<T>)} needs to override {nameof(DefaultPrecision)} to provide a sane default.");
+            }
+        }
 
         public override void TriggerChange()
         {
@@ -191,9 +233,9 @@ namespace osu.Framework.Bindables
         {
             if (them is BindableNumber<T> other)
             {
-                Precision = max(Precision, other.Precision);
-                MinValue = max(MinValue, other.MinValue);
-                MaxValue = min(MaxValue, other.MaxValue);
+                Precision = other.Precision;
+                MinValue = other.MinValue;
+                MaxValue = other.MaxValue;
 
                 if (MinValue.CompareTo(MaxValue) > 0)
                 {
@@ -292,6 +334,28 @@ namespace osu.Framework.Bindables
         public new BindableNumber<T> GetBoundCopy() => (BindableNumber<T>)base.GetBoundCopy();
 
         public new BindableNumber<T> GetUnboundCopy() => (BindableNumber<T>)base.GetUnboundCopy();
+
+        public override string ToString() => Value.ToString(NumberFormatInfo.InvariantInfo);
+
+        public override bool IsDefault
+        {
+            get
+            {
+                switch (Value)
+                {
+                    case double dValue:
+                        // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
+                        return MathUtils.Precision.AlmostEquals(dValue, (double)(object)Default, (double)(object)Precision / 2);
+
+                    case float fValue:
+                        // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
+                        return MathUtils.Precision.AlmostEquals(fValue, (float)(object)Default, (float)(object)Precision / 2);
+
+                    default:
+                        return base.IsDefault;
+                }
+            }
+        }
 
         private static T max(T value1, T value2)
         {

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -347,19 +347,19 @@ namespace osu.Framework.Bindables
         {
             get
             {
-                switch (Value)
+                if (typeof(T) == typeof(double))
                 {
-                    case double dValue:
-                        // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
-                        return MathUtils.Precision.AlmostEquals(dValue, (double)(object)Default, (double)(object)Precision / 2);
-
-                    case float fValue:
-                        // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
-                        return MathUtils.Precision.AlmostEquals(fValue, (float)(object)Default, (float)(object)Precision / 2);
-
-                    default:
-                        return base.IsDefault;
+                    // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
+                    return MathUtils.Precision.AlmostEquals((double)(object)Value, (double)(object)Default, (double)(object)Precision / 2);
                 }
+
+                if (typeof(T) == typeof(float))
+                {
+                    // Take 50% of the precision to ensure the value doesn't underflow and return true for non-default values.
+                    return MathUtils.Precision.AlmostEquals((float)(object)Value, (float)(object)Default, (float)(object)Precision / 2);
+                }
+
+                return base.IsDefault;
             }
         }
 


### PR DESCRIPTION
Generally makes working with `BindableNumber<>` a lot better.