### PR TITLE
Fix runaway scenario in video decoding loop

### DIFF
--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using FFmpeg.AutoGen;
@@ -76,8 +76,6 @@ namespace osu.Framework.Graphics.Video
                 volatileState = value;
             }
         }
-
-        private void updateState() => bindableState.Value = volatileState;
 
         private readonly Scheduler scheduler;
 

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -62,6 +62,7 @@ namespace osu.Framework.Graphics.Video
         public IBindable<DecoderState> State => bindableState;
 
         private readonly Bindable<DecoderState> bindableState = new Bindable<DecoderState>();
+
         private volatile DecoderState volatileState;
 
         private DecoderState state
@@ -69,12 +70,14 @@ namespace osu.Framework.Graphics.Video
             get => volatileState;
             set
             {
-                if (bindableState.Value != value)
-                    scheduler?.AddOnce(() => bindableState.Value = value);
+                if (volatileState == value) return;
 
+                scheduler?.Add(() => bindableState.Value = value);
                 volatileState = value;
             }
         }
+
+        private void updateState() => bindableState.Value = volatileState;
 
         private readonly Scheduler scheduler;
 


### PR DESCRIPTION
If a video was not present, scheduled events were added even if the state hadn't changed due to missing early return (and non-matching delegate in `AddOnce`).