### PR TITLE
Set framesync based on the refresh rate of the current display

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -721,7 +721,7 @@ namespace osu.Framework.Platform
                 if (Window == null)
                     return;
 
-                float refreshRate = DisplayDevice.Default?.RefreshRate ?? 0;
+                float refreshRate = Window.CurrentDisplay?.RefreshRate ?? 0;
                 // For invalid refresh rates let's assume 60 Hz as it is most common.
                 if (refreshRate <= 0)
                     refreshRate = 60;


### PR DESCRIPTION
Previously the frame sync rate was always based on the refresh rate of the primary display.

The only caveat is that moving the window between displays will not automatically update the frame sync to the correct refresh rate until a change is triggered.

Needs testing on a system with multiple refresh rates.  I don't have access to one.

Note that this inadvertently fixes the broken macOS menu focus on the SDL branch as osuTK's `DisplayDevice` is no longer being initialised.

Related to #3013