### PR TITLE
Optimize some struct performance by using readonly methods and in modifier

### DIFF
--- a/osu.Framework/Allocation/ValueInvokeOnDisposal.cs
+++ b/osu.Framework/Allocation/ValueInvokeOnDisposal.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Allocation
     ///
     /// This is a struct version of <see cref="InvokeOnDisposal"/> to be used when allocations are to be minimised.
     /// </summary>
-    public struct ValueInvokeOnDisposal : IDisposable
+    public readonly struct ValueInvokeOnDisposal : IDisposable
     {
         private readonly Action action;
 

--- a/osu.Framework/Audio/Track/TrackAmplitudes.cs
+++ b/osu.Framework/Audio/Track/TrackAmplitudes.cs
@@ -10,9 +10,9 @@ namespace osu.Framework.Audio.Track
         public float LeftChannel;
         public float RightChannel;
 
-        public float Maximum => Math.Max(LeftChannel, RightChannel);
+        public readonly float Maximum => Math.Max(LeftChannel, RightChannel);
 
-        public float Average => (LeftChannel + RightChannel) / 2;
+        public readonly float Average => (LeftChannel + RightChannel) / 2;
 
         /// <summary>
         /// 256 length array of bins containing the average frequency of both channels at every ~78Hz step of the audible spectrum (0Hz - 20,000Hz).

--- a/osu.Framework/Graphics/BlendingParameters.cs
+++ b/osu.Framework/Graphics/BlendingParameters.cs
@@ -146,6 +146,20 @@ namespace osu.Framework.Graphics
             && other.RGBEquation == RGBEquation
             && other.AlphaEquation == AlphaEquation;
 
+        public static bool operator ==(in BlendingParameters left, in BlendingParameters right) =>
+            left.Source == right.Source &&
+            left.Destination == right.Destination &&
+            left.SourceAlpha == right.SourceAlpha &&
+            left.DestinationAlpha == right.DestinationAlpha &&
+            left.RGBEquation == right.RGBEquation &&
+            left.AlphaEquation == right.AlphaEquation;
+
+        public static bool operator !=(in BlendingParameters left, in BlendingParameters right) => !(left == right);
+
+        public override readonly bool Equals(object obj) => obj is BlendingParameters other && this == other;
+
+        public override readonly int GetHashCode() => HashCode.Combine(Source, Destination, SourceAlpha, DestinationAlpha, RGBEquation, AlphaEquation);
+
         public readonly bool IsDisabled =>
             Source == BlendingType.One
             && Destination == BlendingType.Zero

--- a/osu.Framework/Graphics/BlendingParameters.cs
+++ b/osu.Framework/Graphics/BlendingParameters.cs
@@ -138,7 +138,7 @@ namespace osu.Framework.Graphics
                 AlphaEquation = BlendingEquation.Add;
         }
 
-        public bool Equals(BlendingParameters other) =>
+        public readonly bool Equals(BlendingParameters other) =>
             other.Source == Source
             && other.Destination == Destination
             && other.SourceAlpha == SourceAlpha
@@ -146,7 +146,7 @@ namespace osu.Framework.Graphics
             && other.RGBEquation == RGBEquation
             && other.AlphaEquation == AlphaEquation;
 
-        public bool IsDisabled =>
+        public readonly bool IsDisabled =>
             Source == BlendingType.One
             && Destination == BlendingType.Zero
             && SourceAlpha == BlendingType.One
@@ -154,39 +154,39 @@ namespace osu.Framework.Graphics
             && RGBEquation == BlendingEquation.Add
             && AlphaEquation == BlendingEquation.Add;
 
-        public override string ToString() => $"BlendingParameter: Factor: {Source}/{Destination}/{SourceAlpha}/{DestinationAlpha} RGBEquation: {RGBEquation} AlphaEquation: {AlphaEquation}";
+        public override readonly string ToString() => $"BlendingParameter: Factor: {Source}/{Destination}/{SourceAlpha}/{DestinationAlpha} RGBEquation: {RGBEquation} AlphaEquation: {AlphaEquation}";
 
         #region GL Type Getters
 
         /// <summary>
         /// Gets the <see cref="BlendEquationMode"/> for the currently specified RGB Equation.
         /// </summary>
-        public BlendEquationMode RGBEquationMode => translateEquation(RGBEquation);
+        public readonly BlendEquationMode RGBEquationMode => translateEquation(RGBEquation);
 
         /// <summary>
         /// Gets the <see cref="BlendEquationMode"/> for the currently specified Alpha Equation.
         /// </summary>
-        public BlendEquationMode AlphaEquationMode => translateEquation(AlphaEquation);
+        public readonly BlendEquationMode AlphaEquationMode => translateEquation(AlphaEquation);
 
         /// <summary>
         /// Gets the <see cref="BlendingFactorSrc"/> for the currently specified source blending mode.
         /// </summary>
-        public BlendingFactorSrc SourceBlendingFactor => translateBlendingFactorSrc(Source);
+        public readonly BlendingFactorSrc SourceBlendingFactor => translateBlendingFactorSrc(Source);
 
         /// <summary>
         /// Gets the <see cref="BlendingFactorDest"/> for the currently specified destination blending mode.
         /// </summary>
-        public BlendingFactorDest DestinationBlendingFactor => translateBlendingFactorDest(Destination);
+        public readonly BlendingFactorDest DestinationBlendingFactor => translateBlendingFactorDest(Destination);
 
         /// <summary>
         /// Gets the <see cref="BlendingFactorSrc"/> for the currently specified source alpha mode.
         /// </summary>
-        public BlendingFactorSrc SourceAlphaBlendingFactor => translateBlendingFactorSrc(SourceAlpha);
+        public readonly BlendingFactorSrc SourceAlphaBlendingFactor => translateBlendingFactorSrc(SourceAlpha);
 
         /// <summary>
         /// Gets the <see cref="BlendingFactorDest"/> for the currently specified destination alpha mode.
         /// </summary>
-        public BlendingFactorDest DestinationAlphaBlendingFactor => translateBlendingFactorDest(DestinationAlpha);
+        public readonly BlendingFactorDest DestinationAlphaBlendingFactor => translateBlendingFactorDest(DestinationAlpha);
 
         private static BlendingFactorSrc translateBlendingFactorSrc(BlendingType factor)
         {

--- a/osu.Framework/Graphics/BlendingParameters.cs
+++ b/osu.Framework/Graphics/BlendingParameters.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics
@@ -158,6 +159,7 @@ namespace osu.Framework.Graphics
 
         public override readonly bool Equals(object obj) => obj is BlendingParameters other && this == other;
 
+        [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
         public override readonly int GetHashCode() => HashCode.Combine(Source, Destination, SourceAlpha, DestinationAlpha, RGBEquation, AlphaEquation);
 
         public readonly bool IsDisabled =>

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.Graphics.Colour
 
         private SRGBColour singleColour
         {
-            get
+            readonly get
             {
                 if (!HasSingleColour)
                     throw new InvalidOperationException("Attempted to read single colour from multi-colour ColourInfo.");
@@ -81,7 +81,7 @@ namespace osu.Framework.Graphics.Colour
             }
         }
 
-        public SRGBColour Interpolate(Vector2 interp) => SRGBColour.FromVector(
+        public readonly SRGBColour Interpolate(Vector2 interp) => SRGBColour.FromVector(
             (1 - interp.Y) * ((1 - interp.X) * TopLeft.ToVector() + interp.X * TopRight.ToVector()) +
             interp.Y * ((1 - interp.X) * BottomLeft.ToVector() + interp.X * BottomRight.ToVector()));
 
@@ -128,7 +128,7 @@ namespace osu.Framework.Graphics.Colour
         /// </summary>
         /// <param name="alpha">The alpha parameter to multiply the alpha values of all vertices with.</param>
         /// <returns>The new ColourInfo.</returns>
-        public ColourInfo MultiplyAlpha(float alpha)
+        public readonly ColourInfo MultiplyAlpha(float alpha)
         {
             if (alpha == 1.0)
                 return this;
@@ -148,7 +148,7 @@ namespace osu.Framework.Graphics.Colour
             return result;
         }
 
-        public bool Equals(ColourInfo other)
+        public readonly bool Equals(ColourInfo other)
         {
             if (!HasSingleColour)
             {
@@ -165,12 +165,12 @@ namespace osu.Framework.Graphics.Colour
             return other.HasSingleColour && TopLeft.Equals(other.TopLeft);
         }
 
-        public bool Equals(SRGBColour other) => HasSingleColour && TopLeft.Equals(other);
+        public readonly bool Equals(SRGBColour other) => HasSingleColour && TopLeft.Equals(other);
 
         /// <summary>
         /// The average colour of all corners.
         /// </summary>
-        public SRGBColour AverageColour
+        public readonly SRGBColour AverageColour
         {
             get
             {
@@ -185,7 +185,7 @@ namespace osu.Framework.Graphics.Colour
         /// <summary>
         /// The maximum alpha value of all four corners.
         /// </summary>
-        public float MaxAlpha
+        public readonly float MaxAlpha
         {
             get
             {
@@ -201,7 +201,7 @@ namespace osu.Framework.Graphics.Colour
         /// <summary>
         /// The minimum alpha value of all four corners.
         /// </summary>
-        public float MinAlpha
+        public readonly float MinAlpha
         {
             get
             {
@@ -214,7 +214,7 @@ namespace osu.Framework.Graphics.Colour
             }
         }
 
-        public override string ToString() => HasSingleColour ? $@"{TopLeft} (Single)" : $@"{TopLeft}, {TopRight}, {BottomLeft}, {BottomRight}";
+        public override readonly string ToString() => HasSingleColour ? $@"{TopLeft} (Single)" : $@"{TopLeft}, {TopRight}, {BottomLeft}, {BottomRight}";
 
         public static implicit operator ColourInfo(SRGBColour colour) => SingleColour(colour);
         public static implicit operator SRGBColour(ColourInfo colour) => colour.singleColour;

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Graphics.Colour
                 first.Linear.A + second.Linear.A),
         };
 
-        public Vector4 ToVector() => new Vector4(Linear.R, Linear.G, Linear.B, Linear.A);
+        public readonly Vector4 ToVector() => new Vector4(Linear.R, Linear.G, Linear.B, Linear.A);
         public static SRGBColour FromVector(Vector4 v) => new SRGBColour { Linear = new Color4(v.X, v.Y, v.Z, v.W) };
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace osu.Framework.Graphics.Colour
         /// <param name="alpha">The alpha factor to multiply with.</param>
         public void MultiplyAlpha(float alpha) => Linear.A *= alpha;
 
-        public bool Equals(SRGBColour other) => Linear.Equals(other.Linear);
-        public override string ToString() => Linear.ToString();
+        public readonly bool Equals(SRGBColour other) => Linear.Equals(other.Linear);
+        public override readonly string ToString() => Linear.ToString();
     }
 }

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -30,24 +30,24 @@ namespace osu.Framework.Graphics.Colour
         /// <param name="second">Second factor.</param>
         /// <returns>Product of first and second.</returns>
         public static SRGBColour operator *(SRGBColour first, SRGBColour second) => new Color4(
-                first.Linear.R * second.Linear.R,
-                first.Linear.G * second.Linear.G,
-                first.Linear.B * second.Linear.B,
-                first.Linear.A * second.Linear.A);
+            first.Linear.R * second.Linear.R,
+            first.Linear.G * second.Linear.G,
+            first.Linear.B * second.Linear.B,
+            first.Linear.A * second.Linear.A);
 
         public static SRGBColour operator *(SRGBColour first, float second) => new Color4(
-                first.Linear.R * second,
-                first.Linear.G * second,
-                first.Linear.B * second,
-                first.Linear.A * second);
+            first.Linear.R * second,
+            first.Linear.G * second,
+            first.Linear.B * second,
+            first.Linear.A * second);
 
         public static SRGBColour operator /(SRGBColour first, float second) => first * (1 / second);
 
         public static SRGBColour operator +(SRGBColour first, SRGBColour second) => new Color4(
-                first.Linear.R + second.Linear.R,
-                first.Linear.G + second.Linear.G,
-                first.Linear.B + second.Linear.B,
-                first.Linear.A + second.Linear.A);
+            first.Linear.R + second.Linear.R,
+            first.Linear.G + second.Linear.G,
+            first.Linear.B + second.Linear.B,
+            first.Linear.A + second.Linear.A);
 
         public Vector4 ToVector() => new Vector4(Linear.R, Linear.G, Linear.B, Linear.A);
         public static SRGBColour FromVector(Vector4 v) => new Color4(v.X, v.Y, v.Z, v.W);

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -14,13 +14,11 @@ namespace osu.Framework.Graphics.Colour
     /// This struct implicitly converts to sRGB space Color4 values (i.e. it can be assigned and implicitly cast)
     /// to sRGB Color4.
     /// </summary>
-    public readonly struct SRGBColour : IEquatable<SRGBColour>
+    public struct SRGBColour : IEquatable<SRGBColour>
     {
-        public readonly Color4 Linear;
+        public Color4 Linear;
 
-        public SRGBColour(Color4 linear) => Linear = linear;
-
-        public static implicit operator SRGBColour(Color4 value) => new SRGBColour(value.ToLinear());
+        public static implicit operator SRGBColour(Color4 value) => new SRGBColour { Linear = value.ToLinear() };
         public static implicit operator Color4(SRGBColour value) => value.Linear.ToSRGB();
 
         /// <summary>
@@ -29,45 +27,45 @@ namespace osu.Framework.Graphics.Colour
         /// <param name="first">First factor.</param>
         /// <param name="second">Second factor.</param>
         /// <returns>Product of first and second.</returns>
-        public static SRGBColour operator *(SRGBColour first, SRGBColour second) => new Color4(
-            first.Linear.R * second.Linear.R,
-            first.Linear.G * second.Linear.G,
-            first.Linear.B * second.Linear.B,
-            first.Linear.A * second.Linear.A);
+        public static SRGBColour operator *(SRGBColour first, SRGBColour second) => new SRGBColour
+        {
+            Linear = new Color4(
+                first.Linear.R * second.Linear.R,
+                first.Linear.G * second.Linear.G,
+                first.Linear.B * second.Linear.B,
+                first.Linear.A * second.Linear.A),
+        };
 
-        public static SRGBColour operator *(SRGBColour first, float second) => new Color4(
-            first.Linear.R * second,
-            first.Linear.G * second,
-            first.Linear.B * second,
-            first.Linear.A * second);
+        public static SRGBColour operator *(SRGBColour first, float second) => new SRGBColour
+        {
+            Linear = new Color4(
+                first.Linear.R * second,
+                first.Linear.G * second,
+                first.Linear.B * second,
+                first.Linear.A * second),
+        };
 
         public static SRGBColour operator /(SRGBColour first, float second) => first * (1 / second);
 
-        public static SRGBColour operator +(SRGBColour first, SRGBColour second) => new Color4(
-            first.Linear.R + second.Linear.R,
-            first.Linear.G + second.Linear.G,
-            first.Linear.B + second.Linear.B,
-            first.Linear.A + second.Linear.A);
+        public static SRGBColour operator +(SRGBColour first, SRGBColour second) => new SRGBColour
+        {
+            Linear = new Color4(
+                first.Linear.R + second.Linear.R,
+                first.Linear.G + second.Linear.G,
+                first.Linear.B + second.Linear.B,
+                first.Linear.A + second.Linear.A),
+        };
 
-        public Vector4 ToVector() => new Vector4(Linear.R, Linear.G, Linear.B, Linear.A);
-        public static SRGBColour FromVector(Vector4 v) => new Color4(v.X, v.Y, v.Z, v.W);
+        public readonly Vector4 ToVector() => new Vector4(Linear.R, Linear.G, Linear.B, Linear.A);
+        public static SRGBColour FromVector(Vector4 v) => new SRGBColour { Linear = new Color4(v.X, v.Y, v.Z, v.W) };
 
-        public bool Equals(SRGBColour other) => Linear.Equals(other.Linear);
-        public override string ToString() => Linear.ToString();
-    }
-
-    internal static class SRGBColorExtensions
-    {
         /// <summary>
         /// Multiplies the alpha value of this colour by the given alpha factor.
         /// </summary>
-        /// <param name="colour">The colour variable to multiply with.</param>
         /// <param name="alpha">The alpha factor to multiply with.</param>
-        public static void MultiplyAlpha(this ref SRGBColour colour, float alpha)
-        {
-            var linear = colour.Linear;
-            linear.A *= alpha;
-            colour = linear;
-        }
+        public void MultiplyAlpha(float alpha) => Linear.A *= alpha;
+
+        public readonly bool Equals(SRGBColour other) => Linear.Equals(other.Linear);
+        public override readonly string ToString() => Linear.ToString();
     }
 }

--- a/osu.Framework/Graphics/Colour/SRGBColour.cs
+++ b/osu.Framework/Graphics/Colour/SRGBColour.cs
@@ -14,11 +14,13 @@ namespace osu.Framework.Graphics.Colour
     /// This struct implicitly converts to sRGB space Color4 values (i.e. it can be assigned and implicitly cast)
     /// to sRGB Color4.
     /// </summary>
-    public struct SRGBColour : IEquatable<SRGBColour>
+    public readonly struct SRGBColour : IEquatable<SRGBColour>
     {
-        public Color4 Linear;
+        public readonly Color4 Linear;
 
-        public static implicit operator SRGBColour(Color4 value) => new SRGBColour { Linear = value.ToLinear() };
+        public SRGBColour(Color4 linear) => Linear = linear;
+
+        public static implicit operator SRGBColour(Color4 value) => new SRGBColour(value.ToLinear());
         public static implicit operator Color4(SRGBColour value) => value.Linear.ToSRGB();
 
         /// <summary>
@@ -27,45 +29,45 @@ namespace osu.Framework.Graphics.Colour
         /// <param name="first">First factor.</param>
         /// <param name="second">Second factor.</param>
         /// <returns>Product of first and second.</returns>
-        public static SRGBColour operator *(SRGBColour first, SRGBColour second) => new SRGBColour
-        {
-            Linear = new Color4(
+        public static SRGBColour operator *(SRGBColour first, SRGBColour second) => new Color4(
                 first.Linear.R * second.Linear.R,
                 first.Linear.G * second.Linear.G,
                 first.Linear.B * second.Linear.B,
-                first.Linear.A * second.Linear.A),
-        };
+                first.Linear.A * second.Linear.A);
 
-        public static SRGBColour operator *(SRGBColour first, float second) => new SRGBColour
-        {
-            Linear = new Color4(
+        public static SRGBColour operator *(SRGBColour first, float second) => new Color4(
                 first.Linear.R * second,
                 first.Linear.G * second,
                 first.Linear.B * second,
-                first.Linear.A * second),
-        };
+                first.Linear.A * second);
 
         public static SRGBColour operator /(SRGBColour first, float second) => first * (1 / second);
 
-        public static SRGBColour operator +(SRGBColour first, SRGBColour second) => new SRGBColour
-        {
-            Linear = new Color4(
+        public static SRGBColour operator +(SRGBColour first, SRGBColour second) => new Color4(
                 first.Linear.R + second.Linear.R,
                 first.Linear.G + second.Linear.G,
                 first.Linear.B + second.Linear.B,
-                first.Linear.A + second.Linear.A),
-        };
+                first.Linear.A + second.Linear.A);
 
-        public readonly Vector4 ToVector() => new Vector4(Linear.R, Linear.G, Linear.B, Linear.A);
-        public static SRGBColour FromVector(Vector4 v) => new SRGBColour { Linear = new Color4(v.X, v.Y, v.Z, v.W) };
+        public Vector4 ToVector() => new Vector4(Linear.R, Linear.G, Linear.B, Linear.A);
+        public static SRGBColour FromVector(Vector4 v) => new Color4(v.X, v.Y, v.Z, v.W);
 
+        public bool Equals(SRGBColour other) => Linear.Equals(other.Linear);
+        public override string ToString() => Linear.ToString();
+    }
+
+    internal static class SRGBColorExtensions
+    {
         /// <summary>
         /// Multiplies the alpha value of this colour by the given alpha factor.
         /// </summary>
+        /// <param name="colour">The colour variable to multiply with.</param>
         /// <param name="alpha">The alpha factor to multiply with.</param>
-        public void MultiplyAlpha(float alpha) => Linear.A *= alpha;
-
-        public readonly bool Equals(SRGBColour other) => Linear.Equals(other.Linear);
-        public override readonly string ToString() => Linear.ToString();
+        public static void MultiplyAlpha(this ref SRGBColour colour, float alpha)
+        {
+            var linear = colour.Linear;
+            linear.A *= alpha;
+            colour = linear;
+        }
     }
 }

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -131,7 +131,7 @@ namespace osu.Framework.Graphics.Containers
             get => effectBlending;
             set
             {
-                if (effectBlending.Equals(value))
+                if (effectBlending == value)
                     return;
 
                 effectBlending = value;

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -449,9 +449,9 @@ namespace osu.Framework.Graphics.Containers
 
             public void Reset() => currentIndex = -1;
 
-            public T Current => container[currentIndex];
+            public readonly T Current => container[currentIndex];
 
-            object IEnumerator.Current => Current;
+            readonly object IEnumerator.Current => Current;
 
             public void Dispose()
             {

--- a/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
+++ b/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
@@ -395,6 +395,6 @@ namespace osu.Framework.Graphics.Containers
             Direction = direction;
         }
 
-        public override string ToString() => $"({Child.ChildID}, {Kind}, {Direction})";
+        public override readonly string ToString() => $"({Child.ChildID}, {Kind}, {Direction})";
     }
 }

--- a/osu.Framework/Graphics/DrawColourInfo.cs
+++ b/osu.Framework/Graphics/DrawColourInfo.cs
@@ -18,6 +18,6 @@ namespace osu.Framework.Graphics
             Blending = blending ?? BlendingParameters.Inherit;
         }
 
-        public readonly bool Equals(DrawColourInfo other) => Colour.Equals(other.Colour) && Blending.Equals(other.Blending);
+        public readonly bool Equals(DrawColourInfo other) => Colour.Equals(other.Colour) && Blending == other.Blending;
     }
 }

--- a/osu.Framework/Graphics/DrawColourInfo.cs
+++ b/osu.Framework/Graphics/DrawColourInfo.cs
@@ -18,6 +18,6 @@ namespace osu.Framework.Graphics
             Blending = blending ?? BlendingParameters.Inherit;
         }
 
-        public bool Equals(DrawColourInfo other) => Colour.Equals(other.Colour) && Blending.Equals(other.Blending);
+        public readonly bool Equals(DrawColourInfo other) => Colour.Equals(other.Colour) && Blending.Equals(other.Blending);
     }
 }

--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -70,6 +70,6 @@ namespace osu.Framework.Graphics
 
         public readonly bool Equals(DrawInfo other) => Matrix.Equals(other.Matrix);
 
-        public override readonly string ToString() => $@"{GetType().ReadableName().Replace(@"DrawInfo", string.Empty)} DrawInfo";
+        public override string ToString() => $@"{GetType().ReadableName().Replace(@"DrawInfo", string.Empty)} DrawInfo";
     }
 }

--- a/osu.Framework/Graphics/DrawInfo.cs
+++ b/osu.Framework/Graphics/DrawInfo.cs
@@ -68,8 +68,8 @@ namespace osu.Framework.Graphics
             //MatrixExtensions.FastInvert(ref target.MatrixInverse);
         }
 
-        public bool Equals(DrawInfo other) => Matrix.Equals(other.Matrix);
+        public readonly bool Equals(DrawInfo other) => Matrix.Equals(other.Matrix);
 
-        public override string ToString() => $@"{GetType().ReadableName().Replace(@"DrawInfo", string.Empty)} DrawInfo";
+        public override readonly string ToString() => $@"{GetType().ReadableName().Replace(@"DrawInfo", string.Empty)} DrawInfo";
     }
 }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1302,7 +1302,7 @@ namespace osu.Framework.Graphics
             get => blending;
             set
             {
-                if (blending.Equals(value))
+                if (blending == value)
                     return;
 
                 blending = value;

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1603,12 +1603,12 @@ namespace osu.Framework.Graphics
                 Quad interp = Quad.FromRectangle(DrawRectangle) * (DrawInfo.Matrix * Parent.DrawInfo.MatrixInverse);
                 Vector2 parentSize = Parent.DrawSize;
 
-                interp.TopLeft = Vector2.Divide(interp.TopLeft, parentSize);
-                interp.TopRight = Vector2.Divide(interp.TopRight, parentSize);
-                interp.BottomLeft = Vector2.Divide(interp.BottomLeft, parentSize);
-                interp.BottomRight = Vector2.Divide(interp.BottomRight, parentSize);
-
-                ci.Colour.ApplyChild(ourColour, interp);
+                ci.Colour.ApplyChild(ourColour,
+                    new Quad(
+                        Vector2.Divide(interp.TopLeft, parentSize),
+                        Vector2.Divide(interp.TopRight, parentSize),
+                        Vector2.Divide(interp.BottomLeft, parentSize),
+                        Vector2.Divide(interp.BottomRight, parentSize)));
             }
 
             return ci;

--- a/osu.Framework/Graphics/Effects/EdgeEffectParameters.cs
+++ b/osu.Framework/Graphics/Effects/EdgeEffectParameters.cs
@@ -46,13 +46,13 @@ namespace osu.Framework.Graphics.Effects
         /// </summary>
         public bool Hollow;
 
-        public bool Equals(EdgeEffectParameters other) =>
+        public readonly bool Equals(EdgeEffectParameters other) =>
             Colour.Equals(other.Colour) &&
             Offset == other.Offset &&
             Type == other.Type &&
             Roundness == other.Roundness &&
             Radius == other.Radius;
 
-        public override string ToString() => Type != EdgeEffectType.None ? $@"{Radius} {Type}EdgeEffect" : @"EdgeEffect (Disabled)";
+        public override readonly string ToString() => Type != EdgeEffectType.None ? $@"{Radius} {Type}EdgeEffect" : @"EdgeEffect (Disabled)";
     }
 }

--- a/osu.Framework/Graphics/MarginPadding.cs
+++ b/osu.Framework/Graphics/MarginPadding.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Graphics
         /// the absolute size of the space left empty from the right and left of the container if used as padding.
         /// Effectively <see cref="Right"/> + <see cref="Left"/>.
         /// </summary>
-        public float TotalHorizontal => Left + Right;
+        public readonly float TotalHorizontal => Left + Right;
 
         /// <summary>
         /// Sets the values of both <see cref="Left"/> and <see cref="Right"/> to the assigned value.
@@ -58,7 +58,7 @@ namespace osu.Framework.Graphics
         /// the absolute size of the space left empty from the top and bottom of the container if used as padding.
         /// Effectively <see cref="Top"/> + <see cref="Bottom"/>.
         /// </summary>
-        public float TotalVertical => Top + Bottom;
+        public readonly float TotalVertical => Top + Bottom;
 
         /// <summary>
         /// Sets the values of both <see cref="Top"/> and <see cref="Bottom"/> to the assigned value.
@@ -71,7 +71,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Gets the total absolute size of the empty space horizontally (x coordinate) and vertically (y coordinate) around the <see cref="Drawable"/> or inside the container if used as padding.
         /// </summary>
-        public Vector2 Total => new Vector2(TotalHorizontal, TotalVertical);
+        public readonly Vector2 Total => new Vector2(TotalHorizontal, TotalVertical);
 
         /// <summary>
         /// Initializes all four sides (<see cref="Left"/>, <see cref="Right"/>, <see cref="Top"/> and <see cref="Bottom"/>) to the given value.
@@ -82,9 +82,9 @@ namespace osu.Framework.Graphics
             Top = Left = Bottom = Right = allSides;
         }
 
-        public bool Equals(MarginPadding other) => Top == other.Top && Left == other.Left && Bottom == other.Bottom && Right == other.Right;
+        public readonly bool Equals(MarginPadding other) => Top == other.Top && Left == other.Left && Bottom == other.Bottom && Right == other.Right;
 
-        public override string ToString() => $@"({Top}, {Left}, {Bottom}, {Right})";
+        public override readonly string ToString() => $@"({Top}, {Left}, {Bottom}, {Right})";
 
         public static MarginPadding operator -(MarginPadding mp) =>
             new MarginPadding

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -851,7 +851,7 @@ namespace osu.Framework.Graphics.OpenGL
         public bool Hollow;
         public float HollowCornerRadius;
 
-        public bool Equals(MaskingInfo other) =>
+        public readonly bool Equals(MaskingInfo other) =>
             ScreenSpaceAABB == other.ScreenSpaceAABB &&
             MaskingRect == other.MaskingRect &&
             ToMaskingSpace == other.ToMaskingSpace &&

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -30,7 +30,9 @@ namespace osu.Framework.Graphics.OpenGL
         /// </summary>
         public const int MAX_DRAW_NODES = 3;
 
-        public static MaskingInfo CurrentMaskingInfo { get; private set; }
+        public static ref readonly MaskingInfo CurrentMaskingInfo => ref currentMaskingInfo;
+        private static MaskingInfo currentMaskingInfo;
+
         public static RectangleI Viewport { get; private set; }
         public static RectangleF Ortho { get; private set; }
         public static RectangleI Scissor { get; private set; }
@@ -606,13 +608,13 @@ namespace osu.Framework.Graphics.OpenGL
         /// </summary>
         /// <param name="maskingInfo">The masking info.</param>
         /// <param name="overwritePreviousScissor">Whether or not to shrink an existing scissor rectangle.</param>
-        public static void PushMaskingInfo(MaskingInfo maskingInfo, bool overwritePreviousScissor = false)
+        public static void PushMaskingInfo(in MaskingInfo maskingInfo, bool overwritePreviousScissor = false)
         {
             masking_stack.Push(maskingInfo);
-            if (CurrentMaskingInfo.Equals(maskingInfo))
+            if (CurrentMaskingInfo == maskingInfo)
                 return;
 
-            CurrentMaskingInfo = maskingInfo;
+            currentMaskingInfo = maskingInfo;
             setMaskingInfo(CurrentMaskingInfo, true, overwritePreviousScissor);
         }
 
@@ -626,10 +628,10 @@ namespace osu.Framework.Graphics.OpenGL
             masking_stack.Pop();
             MaskingInfo maskingInfo = masking_stack.Peek();
 
-            if (CurrentMaskingInfo.Equals(maskingInfo))
+            if (CurrentMaskingInfo == maskingInfo)
                 return;
 
-            CurrentMaskingInfo = maskingInfo;
+            currentMaskingInfo = maskingInfo;
             setMaskingInfo(CurrentMaskingInfo, false, true);
         }
 
@@ -851,18 +853,26 @@ namespace osu.Framework.Graphics.OpenGL
         public bool Hollow;
         public float HollowCornerRadius;
 
-        public readonly bool Equals(MaskingInfo other) =>
-            ScreenSpaceAABB == other.ScreenSpaceAABB &&
-            MaskingRect == other.MaskingRect &&
-            ToMaskingSpace == other.ToMaskingSpace &&
-            CornerRadius == other.CornerRadius &&
-            CornerExponent == other.CornerExponent &&
-            BorderThickness == other.BorderThickness &&
-            BorderColour.Equals(other.BorderColour) &&
-            BlendRange == other.BlendRange &&
-            AlphaExponent == other.AlphaExponent &&
-            EdgeOffset == other.EdgeOffset &&
-            Hollow == other.Hollow &&
-            HollowCornerRadius == other.HollowCornerRadius;
+        public readonly bool Equals(MaskingInfo other) => this == other;
+
+        public static bool operator ==(in MaskingInfo left, in MaskingInfo right) =>
+            left.ScreenSpaceAABB == right.ScreenSpaceAABB &&
+            left.MaskingRect == right.MaskingRect &&
+            left.ToMaskingSpace == right.ToMaskingSpace &&
+            left.CornerRadius == right.CornerRadius &&
+            left.CornerExponent == right.CornerExponent &&
+            left.BorderThickness == right.BorderThickness &&
+            left.BorderColour.Equals(right.BorderColour) &&
+            left.BlendRange == right.BlendRange &&
+            left.AlphaExponent == right.AlphaExponent &&
+            left.EdgeOffset == right.EdgeOffset &&
+            left.Hollow == right.Hollow &&
+            left.HollowCornerRadius == right.HollowCornerRadius;
+
+        public static bool operator !=(in MaskingInfo left, in MaskingInfo right) => !(left == right);
+
+        public override readonly bool Equals(object obj) => obj is MaskingInfo other && this == other;
+
+        public override readonly int GetHashCode() => 0; // Shouldn't be used; simplifying implementation here.
     }
 }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -327,7 +327,7 @@ namespace osu.Framework.Graphics.OpenGL
         /// <param name="blendingParameters">The info we should use to update the active state.</param>
         public static void SetBlend(BlendingParameters blendingParameters)
         {
-            if (lastBlendingParameters.Equals(blendingParameters))
+            if (lastBlendingParameters == blendingParameters)
                 return;
 
             FlushCurrentBatch();

--- a/osu.Framework/Graphics/OpenGL/Vertices/DepthWrappingVertex.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/DepthWrappingVertex.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         [VertexMember(1, VertexAttribPointerType.Float)]
         public float BackbufferDrawDepth;
 
-        public bool Equals(DepthWrappingVertex<TVertex> other)
+        public readonly bool Equals(DepthWrappingVertex<TVertex> other)
             => Vertex.Equals(other.Vertex)
                && BackbufferDrawDepth.Equals(other.BackbufferDrawDepth);
     }

--- a/osu.Framework/Graphics/OpenGL/Vertices/ParticleVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/ParticleVertex2D.cs
@@ -27,6 +27,6 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         [VertexMember(2, VertexAttribPointerType.Float)]
         public Vector2 Direction;
 
-        public bool Equals(ParticleVertex2D other) => Position.Equals(other.Position) && TexturePosition.Equals(other.TexturePosition) && Colour.Equals(other.Colour) && Time.Equals(other.Time) && Direction.Equals(other.Direction);
+        public readonly bool Equals(ParticleVertex2D other) => Position.Equals(other.Position) && TexturePosition.Equals(other.TexturePosition) && Colour.Equals(other.Colour) && Time.Equals(other.Time) && Direction.Equals(other.Direction);
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex2D.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         [VertexMember(2, VertexAttribPointerType.Float)]
         public Vector2 BlendRange;
 
-        public bool Equals(TexturedVertex2D other) =>
+        public readonly bool Equals(TexturedVertex2D other) =>
             Position.Equals(other.Position)
             && TexturePosition.Equals(other.TexturePosition)
             && Colour.Equals(other.Colour)

--- a/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex3D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/TexturedVertex3D.cs
@@ -21,6 +21,6 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         [VertexMember(2, VertexAttribPointerType.Float)]
         public Vector2 TexturePosition;
 
-        public bool Equals(TexturedVertex3D other) => Position.Equals(other.Position) && TexturePosition.Equals(other.TexturePosition) && Colour.Equals(other.Colour);
+        public readonly bool Equals(TexturedVertex3D other) => Position.Equals(other.Position) && TexturePosition.Equals(other.TexturePosition) && Colour.Equals(other.Colour);
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Vertices/TimedTexturedVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/TimedTexturedVertex2D.cs
@@ -24,6 +24,6 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         [VertexMember(1, VertexAttribPointerType.Float)]
         public float Time;
 
-        public bool Equals(TimedTexturedVertex2D other) => Position.Equals(other.Position) && TexturePosition.Equals(other.TexturePosition) && Colour.Equals(other.Colour) && Time.Equals(other.Time);
+        public readonly bool Equals(TimedTexturedVertex2D other) => Position.Equals(other.Position) && TexturePosition.Equals(other.TexturePosition) && Colour.Equals(other.Colour) && Time.Equals(other.Time);
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Vertices/UncolouredVertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/UncolouredVertex2D.cs
@@ -14,6 +14,6 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         [VertexMember(2, VertexAttribPointerType.Float)]
         public Vector2 Position;
 
-        public bool Equals(UncolouredVertex2D other) => Position.Equals(other.Position);
+        public readonly bool Equals(UncolouredVertex2D other) => Position.Equals(other.Position);
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Vertices/Vertex2D.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/Vertex2D.cs
@@ -18,6 +18,6 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
         [VertexMember(4, VertexAttribPointerType.Float)]
         public Color4 Colour;
 
-        public bool Equals(Vertex2D other) => Position.Equals(other.Position) && Colour.Equals(other.Colour);
+        public readonly bool Equals(Vertex2D other) => Position.Equals(other.Position) && Colour.Equals(other.Colour);
     }
 }

--- a/osu.Framework/Graphics/Primitives/ProjectionRange.cs
+++ b/osu.Framework/Graphics/Primitives/ProjectionRange.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Graphics.Primitives
     /// A structure that tells how "far" along an axis
     /// the projection of vertices onto the axis would be.
     /// </summary>
-    internal struct ProjectionRange
+    internal readonly struct ProjectionRange
     {
         /// <summary>
         /// The minimum projected value.

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -105,7 +105,7 @@ namespace osu.Framework.Graphics.Primitives
 
         public ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
 
-        public readonly unsafe ReadOnlySpan<Vector2> GetVertices() => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in TopLeft), 4);
+        public ReadOnlySpan<Vector2> GetVertices() => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in TopLeft), 4);
 
         public bool Contains(Vector2 pos) =>
             new Triangle(BottomRight, BottomLeft, TopRight).Contains(pos) ||

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Graphics.Primitives
                 Vector2Extensions.Transform(r.BottomLeft, m),
                 Vector2Extensions.Transform(r.BottomRight, m));
 
-        public Matrix2 BasisTransform
+        public readonly Matrix2 BasisTransform
         {
             get
             {
@@ -71,13 +71,13 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public Vector2 Centre => (TopLeft + TopRight + BottomLeft + BottomRight) / 4;
-        public Vector2 Size => new Vector2(Width, Height);
+        public readonly Vector2 Centre => (TopLeft + TopRight + BottomLeft + BottomRight) / 4;
+        public readonly Vector2 Size => new Vector2(Width, Height);
 
-        public float Width => Vector2Extensions.Distance(TopLeft, TopRight);
-        public float Height => Vector2Extensions.Distance(TopLeft, BottomLeft);
+        public readonly float Width => Vector2Extensions.Distance(TopLeft, TopRight);
+        public readonly float Height => Vector2Extensions.Distance(TopLeft, BottomLeft);
 
-        public RectangleI AABB
+        public readonly RectangleI AABB
         {
             get
             {
@@ -90,7 +90,7 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public RectangleF AABBFloat
+        public readonly RectangleF AABBFloat
         {
             get
             {
@@ -103,17 +103,12 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
+        public readonly ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
 
-        public ReadOnlySpan<Vector2> GetVertices()
-        {
-            unsafe
-            {
-                return new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref this), 4);
-            }
-        }
+        public readonly unsafe ReadOnlySpan<Vector2> GetVertices()
+            => new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref Unsafe.AsRef(in this)), 4);
 
-        public bool Contains(Vector2 pos) =>
+        public readonly bool Contains(Vector2 pos) =>
             new Triangle(BottomRight, BottomLeft, TopRight).Contains(pos) ||
             new Triangle(TopLeft, TopRight, BottomLeft).Contains(pos);
 
@@ -123,15 +118,15 @@ namespace osu.Framework.Graphics.Primitives
         /// <remarks>
         /// If the quad is self-intersecting the area is interpreted as the sum of all positive and negative areas and not the "visible area" enclosed by the <see cref="Quad"/>.
         /// </remarks>
-        public float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
+        public readonly float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
 
-        public bool Equals(Quad other) =>
+        public readonly bool Equals(Quad other) =>
             TopLeft == other.TopLeft &&
             TopRight == other.TopRight &&
             BottomLeft == other.BottomLeft &&
             BottomRight == other.BottomRight;
 
-        public bool AlmostEquals(Quad other) =>
+        public readonly bool AlmostEquals(Quad other) =>
             Precision.AlmostEquals(TopLeft.X, other.TopLeft.X) &&
             Precision.AlmostEquals(TopLeft.Y, other.TopLeft.Y) &&
             Precision.AlmostEquals(TopRight.X, other.TopRight.X) &&
@@ -141,6 +136,6 @@ namespace osu.Framework.Graphics.Primitives
             Precision.AlmostEquals(BottomRight.X, other.BottomRight.X) &&
             Precision.AlmostEquals(BottomRight.Y, other.BottomRight.Y);
 
-        public override string ToString() => $"{TopLeft} {TopRight} {BottomLeft} {BottomRight}";
+        public override readonly string ToString() => $"{TopLeft} {TopRight} {BottomLeft} {BottomRight}";
     }
 }

--- a/osu.Framework/Graphics/Primitives/Quad.cs
+++ b/osu.Framework/Graphics/Primitives/Quad.cs
@@ -10,14 +10,14 @@ using osu.Framework.MathUtils;
 namespace osu.Framework.Graphics.Primitives
 {
     [StructLayout(LayoutKind.Sequential)]
-    public struct Quad : IConvexPolygon, IEquatable<Quad>
+    public readonly struct Quad : IConvexPolygon, IEquatable<Quad>
     {
         // Note: Do not change the order of vertices. They are ordered in screen-space counter-clockwise fashion.
         // See: IPolygon.GetVertices()
-        public Vector2 TopLeft;
-        public Vector2 BottomLeft;
-        public Vector2 BottomRight;
-        public Vector2 TopRight;
+        public readonly Vector2 TopLeft;
+        public readonly Vector2 BottomLeft;
+        public readonly Vector2 BottomRight;
+        public readonly Vector2 TopRight;
 
         public Quad(Vector2 topLeft, Vector2 topRight, Vector2 bottomLeft, Vector2 bottomRight)
         {
@@ -52,7 +52,7 @@ namespace osu.Framework.Graphics.Primitives
                 Vector2Extensions.Transform(r.BottomLeft, m),
                 Vector2Extensions.Transform(r.BottomRight, m));
 
-        public readonly Matrix2 BasisTransform
+        public Matrix2 BasisTransform
         {
             get
             {
@@ -71,13 +71,13 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public readonly Vector2 Centre => (TopLeft + TopRight + BottomLeft + BottomRight) / 4;
-        public readonly Vector2 Size => new Vector2(Width, Height);
+        public Vector2 Centre => (TopLeft + TopRight + BottomLeft + BottomRight) / 4;
+        public Vector2 Size => new Vector2(Width, Height);
 
-        public readonly float Width => Vector2Extensions.Distance(TopLeft, TopRight);
-        public readonly float Height => Vector2Extensions.Distance(TopLeft, BottomLeft);
+        public float Width => Vector2Extensions.Distance(TopLeft, TopRight);
+        public float Height => Vector2Extensions.Distance(TopLeft, BottomLeft);
 
-        public readonly RectangleI AABB
+        public RectangleI AABB
         {
             get
             {
@@ -90,7 +90,7 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public readonly RectangleF AABBFloat
+        public RectangleF AABBFloat
         {
             get
             {
@@ -103,12 +103,11 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public readonly ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
+        public ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
 
-        public readonly unsafe ReadOnlySpan<Vector2> GetVertices()
-            => new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref Unsafe.AsRef(in this)), 4);
+        public readonly unsafe ReadOnlySpan<Vector2> GetVertices() => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in TopLeft), 4);
 
-        public readonly bool Contains(Vector2 pos) =>
+        public bool Contains(Vector2 pos) =>
             new Triangle(BottomRight, BottomLeft, TopRight).Contains(pos) ||
             new Triangle(TopLeft, TopRight, BottomLeft).Contains(pos);
 
@@ -118,15 +117,15 @@ namespace osu.Framework.Graphics.Primitives
         /// <remarks>
         /// If the quad is self-intersecting the area is interpreted as the sum of all positive and negative areas and not the "visible area" enclosed by the <see cref="Quad"/>.
         /// </remarks>
-        public readonly float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
+        public float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
 
-        public readonly bool Equals(Quad other) =>
+        public bool Equals(Quad other) =>
             TopLeft == other.TopLeft &&
             TopRight == other.TopRight &&
             BottomLeft == other.BottomLeft &&
             BottomRight == other.BottomRight;
 
-        public readonly bool AlmostEquals(Quad other) =>
+        public bool AlmostEquals(Quad other) =>
             Precision.AlmostEquals(TopLeft.X, other.TopLeft.X) &&
             Precision.AlmostEquals(TopLeft.Y, other.TopLeft.Y) &&
             Precision.AlmostEquals(TopRight.X, other.TopRight.X) &&
@@ -136,6 +135,6 @@ namespace osu.Framework.Graphics.Primitives
             Precision.AlmostEquals(BottomRight.X, other.BottomRight.X) &&
             Precision.AlmostEquals(BottomRight.Y, other.BottomRight.Y);
 
-        public override readonly string ToString() => $"{TopLeft} {TopRight} {BottomLeft} {BottomRight}";
+        public override string ToString() => $"{TopLeft} {TopRight} {BottomLeft} {BottomRight}";
     }
 }

--- a/osu.Framework/Graphics/Primitives/Triangle.cs
+++ b/osu.Framework/Graphics/Primitives/Triangle.cs
@@ -4,14 +4,18 @@
 using osuTK;
 using System;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace osu.Framework.Graphics.Primitives
 {
-    public struct Triangle : IConvexPolygon, IEquatable<Triangle>
+    [StructLayout(LayoutKind.Sequential)]
+    public readonly struct Triangle : IConvexPolygon, IEquatable<Triangle>
     {
-        public Vector2 P0;
-        public Vector2 P1;
-        public Vector2 P2;
+        // Note: Do not change the order of vertices. They are ordered in screen-space counter-clockwise fashion.
+        // See: IPolygon.GetVertices()
+        public readonly Vector2 P0;
+        public readonly Vector2 P1;
+        public readonly Vector2 P2;
 
         public Triangle(Vector2 p0, Vector2 p1, Vector2 p2)
         {
@@ -20,12 +24,11 @@ namespace osu.Framework.Graphics.Primitives
             P2 = p2;
         }
 
-        public readonly ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
+        public ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
 
-        public readonly unsafe ReadOnlySpan<Vector2> GetVertices()
-            => new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref Unsafe.AsRef(in this)), 3);
+        public ReadOnlySpan<Vector2> GetVertices() => MemoryMarshal.CreateReadOnlySpan(ref Unsafe.AsRef(in P0), 3);
 
-        public readonly bool Equals(Triangle other) =>
+        public bool Equals(Triangle other) =>
             P0 == other.P0 &&
             P1 == other.P1 &&
             P2 == other.P2;
@@ -35,7 +38,7 @@ namespace osu.Framework.Graphics.Primitives
         /// </summary>
         /// <param name="pos">The point to check.</param>
         /// <returns>Outcome of the check.</returns>
-        public readonly bool Contains(Vector2 pos)
+        public bool Contains(Vector2 pos)
         {
             // This code parametrizes pos as a linear combination of 2 edges s*(p1-p0) + t*(p2->p0).
             // pos is contained if s>0, t>0, s+t<1
@@ -54,7 +57,7 @@ namespace osu.Framework.Graphics.Primitives
             return true;
         }
 
-        public readonly RectangleF AABBFloat
+        public RectangleF AABBFloat
         {
             get
             {
@@ -67,6 +70,6 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public readonly float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
+        public float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
     }
 }

--- a/osu.Framework/Graphics/Primitives/Triangle.cs
+++ b/osu.Framework/Graphics/Primitives/Triangle.cs
@@ -20,14 +20,12 @@ namespace osu.Framework.Graphics.Primitives
             P2 = p2;
         }
 
-        public ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
+        public readonly ReadOnlySpan<Vector2> GetAxisVertices() => GetVertices();
 
-        public unsafe ReadOnlySpan<Vector2> GetVertices()
-        {
-            return new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref this), 3);
-        }
+        public readonly unsafe ReadOnlySpan<Vector2> GetVertices()
+            => new ReadOnlySpan<Vector2>(Unsafe.AsPointer(ref Unsafe.AsRef(in this)), 3);
 
-        public bool Equals(Triangle other) =>
+        public readonly bool Equals(Triangle other) =>
             P0 == other.P0 &&
             P1 == other.P1 &&
             P2 == other.P2;
@@ -37,7 +35,7 @@ namespace osu.Framework.Graphics.Primitives
         /// </summary>
         /// <param name="pos">The point to check.</param>
         /// <returns>Outcome of the check.</returns>
-        public bool Contains(Vector2 pos)
+        public readonly bool Contains(Vector2 pos)
         {
             // This code parametrizes pos as a linear combination of 2 edges s*(p1-p0) + t*(p2->p0).
             // pos is contained if s>0, t>0, s+t<1
@@ -56,7 +54,7 @@ namespace osu.Framework.Graphics.Primitives
             return true;
         }
 
-        public RectangleF AABBFloat
+        public readonly RectangleF AABBFloat
         {
             get
             {
@@ -69,6 +67,6 @@ namespace osu.Framework.Graphics.Primitives
             }
         }
 
-        public float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
+        public readonly float Area => 0.5f * Math.Abs(Vector2Extensions.GetOrientation(GetVertices()));
     }
 }

--- a/osu.Framework/Graphics/Primitives/Vector2I.cs
+++ b/osu.Framework/Graphics/Primitives/Vector2I.cs
@@ -39,9 +39,9 @@ namespace osu.Framework.Graphics.Primitives
 
         public static Vector2I operator -(Vector2I left, Vector2I right) => new Vector2I(left.X - right.X, left.Y - right.Y);
 
-        public bool Equals(Vector2I other) => other.X == X && other.Y == Y;
+        public readonly bool Equals(Vector2I other) => other.X == X && other.Y == Y;
 
-        public override bool Equals(object obj)
+        public override readonly bool Equals(object obj)
         {
             if (!(obj is Vector2I))
                 return false;
@@ -50,6 +50,6 @@ namespace osu.Framework.Graphics.Primitives
         }
 
         [SuppressMessage("ReSharper", "NonReadonlyMemberInGetHashCode")]
-        public override int GetHashCode() => (int)(((uint)X ^ ((uint)Y << 13)) | ((uint)Y >> 0x13));
+        public override readonly int GetHashCode() => (int)(((uint)X ^ ((uint)Y << 13)) | ((uint)Y >> 0x13));
     }
 }

--- a/osu.Framework/Graphics/Shapes/Box.cs
+++ b/osu.Framework/Graphics/Shapes/Box.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Graphics.Shapes
                 conservativeScreenSpaceDrawQuad = Source.conservativeScreenSpaceDrawQuad;
 
                 hasOpaqueInterior = DrawColourInfo.Colour.MinAlpha == 1
-                                    && DrawColourInfo.Blending.Equals(BlendingParameters.Mixture)
+                                    && DrawColourInfo.Blending == BlendingParameters.Mixture
                                     && DrawColourInfo.Colour.HasSingleColour;
             }
 

--- a/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText_DrawNode.cs
@@ -63,12 +63,14 @@ namespace osu.Framework.Graphics.Sprites
                     if (shadow)
                     {
                         var shadowQuad = parts[i].DrawQuad;
-                        shadowQuad.TopLeft += shadowOffset;
-                        shadowQuad.TopRight += shadowOffset;
-                        shadowQuad.BottomLeft += shadowOffset;
-                        shadowQuad.BottomRight += shadowOffset;
 
-                        DrawQuad(parts[i].Texture, shadowQuad, finalShadowColour, vertexAction: vertexAction, inflationPercentage: parts[i].InflationPercentage);
+                        DrawQuad(parts[i].Texture,
+                            new Quad(
+                                shadowQuad.TopLeft + shadowOffset,
+                                shadowQuad.TopRight + shadowOffset,
+                                shadowQuad.BottomLeft + shadowOffset,
+                                shadowQuad.BottomRight + shadowOffset),
+                            finalShadowColour, vertexAction: vertexAction, inflationPercentage: parts[i].InflationPercentage);
                     }
 
                     DrawQuad(parts[i].Texture, parts[i].DrawQuad, DrawColourInfo.Colour, vertexAction: vertexAction, inflationPercentage: parts[i].InflationPercentage);

--- a/osu.Framework/Input/JoystickAxis.cs
+++ b/osu.Framework/Input/JoystickAxis.cs
@@ -3,7 +3,7 @@
 
 namespace osu.Framework.Input
 {
-    public struct JoystickAxis
+    public readonly struct JoystickAxis
     {
         public readonly int Axis;
         public readonly float Value;

--- a/osu.Framework/Input/States/ButtonStates.cs
+++ b/osu.Framework/Input/States/ButtonStates.cs
@@ -74,7 +74,7 @@ namespace osu.Framework.Input.States
         // for collection initializer
         public void Add(TButton button) => SetPressed(button, true);
 
-        public struct ButtonStateDifference
+        public readonly struct ButtonStateDifference
         {
             public readonly IEnumerable<TButton> Released;
             public readonly IEnumerable<TButton> Pressed;

--- a/osu.Framework/Lists/LockedWeakList.cs
+++ b/osu.Framework/Lists/LockedWeakList.cs
@@ -86,9 +86,9 @@ namespace osu.Framework.Lists
 
             public void Reset() => listEnumerator.Reset();
 
-            public T Current => listEnumerator.Current;
+            public readonly T Current => listEnumerator.Current;
 
-            object IEnumerator.Current => Current;
+            readonly object IEnumerator.Current => Current;
 
             public void Dispose()
             {

--- a/osu.Framework/Lists/SortedList.cs
+++ b/osu.Framework/Lists/SortedList.cs
@@ -162,9 +162,9 @@ namespace osu.Framework.Lists
 
             public void Reset() => currentIndex = -1;
 
-            public T Current => list[currentIndex];
+            public readonly T Current => list[currentIndex];
 
-            object IEnumerator.Current => Current;
+            readonly object IEnumerator.Current => Current;
 
             public void Dispose()
             {

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -104,9 +104,9 @@ namespace osu.Framework.Lists
                 currentObject = null;
             }
 
-            public T Current => currentObject;
+            public readonly T Current => currentObject;
 
-            object IEnumerator.Current => Current;
+            readonly object IEnumerator.Current => Current;
 
             public void Dispose()
             {

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Platform.MacOS
 {
     public class MacOSClipboard : Clipboard
     {
-        private NSPasteboard generalPasteboard = NSPasteboard.GeneralPasteboard();
+        private readonly NSPasteboard generalPasteboard = NSPasteboard.GeneralPasteboard();
 
         public override string GetText()
         {

--- a/osu.Framework/Platform/MacOS/Native/NSArray.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSArray.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace osu.Framework.Platform.MacOS.Native
 {
-    internal struct NSArray
+    internal readonly struct NSArray
     {
-        internal IntPtr Handle { get; private set; }
+        internal IntPtr Handle { get; }
 
         private static readonly IntPtr class_pointer = Class.Get("NSArray");
         private static readonly IntPtr mutable_class_pointer = Class.Get("NSMutableArray");

--- a/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace osu.Framework.Platform.MacOS.Native
 {
-    internal struct NSDictionary
+    internal readonly struct NSDictionary
     {
-        internal IntPtr Handle { get; private set; }
+        internal IntPtr Handle { get; }
 
         private static IntPtr classPointer = Class.Get("NSDictionary");
 

--- a/osu.Framework/Platform/MacOS/Native/NSPasteboard.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSPasteboard.cs
@@ -5,9 +5,9 @@ using System;
 
 namespace osu.Framework.Platform.MacOS.Native
 {
-    internal struct NSPasteboard
+    internal readonly struct NSPasteboard
     {
-        internal IntPtr Handle { get; private set; }
+        internal IntPtr Handle { get; }
 
         private static readonly IntPtr class_pointer = Class.Get("NSPasteboard");
         private static readonly IntPtr sel_general_pasteboard = Selector.Get("generalPasteboard");

--- a/osu.Framework/Platform/Windows/Native/IconGroup.cs
+++ b/osu.Framework/Platform/Windows/Native/IconGroup.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Platform.Windows.Native
             internal uint ImageOffset;
 
             // larger icons are defined as 0x0 and point to PNG data
-            internal bool HasRawData => Width == 0 && Height == 0;
+            internal readonly bool HasRawData => Width == 0 && Height == 0;
         }
 
         [StructLayout(LayoutKind.Sequential)]

--- a/osu.Framework/Text/TextBuilderGlyph.cs
+++ b/osu.Framework/Text/TextBuilderGlyph.cs
@@ -12,13 +12,13 @@ namespace osu.Framework.Text
     /// </summary>
     public struct TextBuilderGlyph : ITexturedCharacterGlyph
     {
-        public Texture Texture => Glyph.Texture;
-        public float XOffset => ((fixedWidth - Glyph.Width) / 2 ?? Glyph.XOffset) * textSize;
-        public float YOffset => Glyph.YOffset * textSize;
-        public float XAdvance => (fixedWidth ?? Glyph.XAdvance) * textSize;
-        public float Width => Glyph.Width * textSize;
-        public float Height => Glyph.Height * textSize;
-        public char Character => Glyph.Character;
+        public readonly Texture Texture => Glyph.Texture;
+        public readonly float XOffset => ((fixedWidth - Glyph.Width) / 2 ?? Glyph.XOffset) * textSize;
+        public readonly float YOffset => Glyph.YOffset * textSize;
+        public readonly float XAdvance => (fixedWidth ?? Glyph.XAdvance) * textSize;
+        public readonly float Width => Glyph.Width * textSize;
+        public readonly float Height => Glyph.Height * textSize;
+        public readonly char Character => Glyph.Character;
 
         public readonly ITexturedCharacterGlyph Glyph;
 
@@ -45,7 +45,7 @@ namespace osu.Framework.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public float GetKerning<T>(T lastGlyph)
+        public readonly float GetKerning<T>(T lastGlyph)
             where T : ICharacterGlyph
             => fixedWidth != null ? 0 : Glyph.GetKerning(lastGlyph);
     }

--- a/osu.Framework/Timing/FrameTimeInfo.cs
+++ b/osu.Framework/Timing/FrameTimeInfo.cs
@@ -18,6 +18,6 @@ namespace osu.Framework.Timing
         /// </summary>
         public double Current;
 
-        public override string ToString() => Math.Truncate(Current).ToString(CultureInfo.InvariantCulture);
+        public override readonly string ToString() => Math.Truncate(Current).ToString(CultureInfo.InvariantCulture);
     }
 }


### PR DESCRIPTION
Just updated the 2 large structs that be compared *directly* at *evert frame*.
The vertex types are compared via generic constraint. Adding a new interface that constrains `Equals(in T)` increases the complexity.

I'm looking forward to the record feature that can make most structs immutable.

Breaking changes:

# vNext

`Quad` and `Triangle` have been made readonly

Code that previously mutated the structs should be converted to create a new instance every time.