### PR TITLE
Fix framesync regression on Android and iOS

### DIFF
--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -2,9 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Configuration;
-using osu.Framework.Platform;
 using osuTK.Graphics;
 using System.Collections.Generic;
+using osuTK;
+using GameWindow = osu.Framework.Platform.GameWindow;
 
 namespace osu.Framework.Android
 {
@@ -48,6 +49,12 @@ namespace osu.Framework.Android
         public override void Run(double updateRate)
         {
             View.Run(updateRate);
+        }
+
+        public override DisplayDevice CurrentDisplay
+        {
+            get => null;
+            set { }
         }
     }
 }

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Android
 
         public override DisplayDevice CurrentDisplay
         {
-            get => null;
+            get => DisplayDevice.Default;
             set { }
         }
     }

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Configuration;
 using osuTK.Graphics;
 using System.Collections.Generic;
@@ -54,7 +55,7 @@ namespace osu.Framework.Android
         public override DisplayDevice CurrentDisplay
         {
             get => DisplayDevice.Default;
-            set { }
+            set => throw new InvalidOperationException();
         }
     }
 }

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -3,10 +3,11 @@
 
 using osuTK.Graphics;
 using osu.Framework.Configuration;
-using osu.Framework.Platform;
 using osu.Framework.Graphics;
 using System;
 using System.Collections.Generic;
+using osuTK;
+using GameWindow = osu.Framework.Platform.GameWindow;
 
 namespace osu.Framework.iOS
 {
@@ -33,6 +34,12 @@ namespace osu.Framework.iOS
         public override osuTK.WindowState WindowState
         {
             get => osuTK.WindowState.Normal;
+            set { }
+        }
+
+        public override DisplayDevice CurrentDisplay
+        {
+            get => null;
             set { }
         }
 

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.iOS
         public override DisplayDevice CurrentDisplay
         {
             get => DisplayDevice.Default;
-            set { }
+            set => throw new InvalidOperationException();
         }
 
         protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new[]

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.iOS
 
         public override DisplayDevice CurrentDisplay
         {
-            get => null;
+            get => DisplayDevice.Default;
             set { }
         }
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/7282
Regression from #3117 

The `CurrentDisplay` property in osuTK's Android and iOS implementations throws a `NotImplementedException`.  This change ensures we return null instead, which will then default to 60hz as per #3117 

The better solution would be to correctly implement `CurrentDisplay` and `DisplayDevice` in osuTK for iOS and Android, but this is non-trivial and an extreme edge case.  This problem can be easily solved with the SDL2 migration.  I would also like to avoid any and all large changes to osuTK where possible.

Edit: Would appreciate if someone could please test this on Android for me, as I do not have an Android device to test with.