### PR TITLE
Add extension method to easily access children of a specific type without manual traversal

### DIFF
--- a/osu.Framework/Testing/MenuTestScene.cs
+++ b/osu.Framework/Testing/MenuTestScene.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -68,12 +69,7 @@ namespace osu.Framework.Testing
             /// <summary>
             /// Retrieves the <see cref="Menu.DrawableMenuItem"/>s of the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.
             /// </summary>
-            public IReadOnlyList<Drawable> GetMenuItems()
-            {
-                var contents = (CompositeDrawable)menu.InternalChildren[0];
-                var contentContainer = (CompositeDrawable)contents.InternalChildren[1];
-                return ((CompositeDrawable)((CompositeDrawable)contentContainer.InternalChildren[0]).InternalChildren[0]).InternalChildren;
-            }
+            public IReadOnlyList<Drawable> GetMenuItems() => menu.ChildrenOfType<FillFlowContainer<Menu.DrawableMenuItem>>().First();
 
             /// <summary>
             /// Finds the <see cref="Menu.DrawableMenuItem"/> index in the <see cref="Menu"/> represented by this <see cref="MenuStructure"/> that

--- a/osu.Framework/Testing/TestingExtensions.cs
+++ b/osu.Framework/Testing/TestingExtensions.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Testing
+{
+    public static class TestingExtensions
+    {
+        /// <summary>
+        /// Find all children recursively of a specific type. As this is expensive and dangerous, it should only be used for testing purposes.
+        /// </summary>
+        public static IEnumerable<T> ChildrenOfType<T>(this Drawable drawable) where T : Drawable
+        {
+            switch (drawable)
+            {
+                case T found:
+                    yield return found;
+
+                    break;
+
+                case CompositeDrawable composite:
+                    foreach (var child in composite.InternalChildren)
+                    {
+                        foreach (var found in child.ChildrenOfType<T>())
+                            yield return found;
+                    }
+
+                    break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Hopefully simple enough that test coverage is not required.