### PR TITLE
Change TabControl.IsSwitchable to property

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -64,7 +64,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         Size = new Vector2(200, 30),
                         Child = switchingTabControl = new StyledTabControl
                         {
-                            RelativeSizeAxes = Axes.Both
+                            RelativeSizeAxes = Axes.Both,
+                            Tabbable = true,
                         }
                     },
                     removeAllTabControl = new StyledTabControl

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -65,7 +65,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         Child = switchingTabControl = new StyledTabControl
                         {
                             RelativeSizeAxes = Axes.Both,
-                            Tabbable = true,
+                            IsSwitchable = true,
                         }
                     },
                     removeAllTabControl = new StyledTabControl

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// When true, tabs can be switched back and forth using PlatformAction.DocumentPrevious and PlatformAction.DocumentNext respectively.
         /// </summary>
-        public virtual bool IsSwitchable => true;
+        public bool Tabbable { get; set; }
 
         /// <summary>
         /// Creates an optional overflow dropdown.
@@ -327,7 +327,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public bool OnPressed(PlatformAction action)
         {
-            if (IsSwitchable)
+            if (Tabbable)
             {
                 switch (action.ActionType)
                 {

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// When true, tabs can be switched back and forth using PlatformAction.DocumentPrevious and PlatformAction.DocumentNext respectively.
         /// </summary>
-        public bool Tabbable { get; set; }
+        public bool IsSwitchable { get; set; }
 
         /// <summary>
         /// Creates an optional overflow dropdown.
@@ -327,7 +327,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public bool OnPressed(PlatformAction action)
         {
-            if (Tabbable)
+            if (IsSwitchable)
             {
                 switch (action.ActionType)
                 {


### PR DESCRIPTION
## Breaking change

### `TabControl.IsSwitchable` is changed to auto-implemented property with default `false`

As there can be many similar tab controls on any one screen, the one with the highest depth will absorb all input. This change makes it more manageable by manually setting it where it's needed, and avoids nested classes.