### PR TITLE
Ensure ResourceStore returns null rather than exception on null request

### DIFF
--- a/osu.Framework/IO/Stores/ResourceStore.cs
+++ b/osu.Framework/IO/Stores/ResourceStore.cs
@@ -84,6 +84,9 @@ namespace osu.Framework.IO.Stores
         /// <returns>The object.</returns>
         public virtual async Task<T> GetAsync(string name)
         {
+            if (name == null)
+                return null;
+
             var filenames = GetFilenames(name);
 
             // required for locking
@@ -113,6 +116,9 @@ namespace osu.Framework.IO.Stores
         /// <returns>The object.</returns>
         public virtual T Get(string name)
         {
+            if (name == null)
+                return null;
+
             var filenames = GetFilenames(name);
 
             // Cache miss - get the resource
@@ -134,6 +140,9 @@ namespace osu.Framework.IO.Stores
 
         public Stream GetStream(string name)
         {
+            if (name == null)
+                return null;
+
             var filenames = GetFilenames(name);
 
             // Cache miss - get the resource


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/7216.
See https://github.com/dotnet/runtime/issues/1149 for reasoning.