### PR TITLE
Add Drawable.Empty static helper for empty construction

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2294,6 +2294,15 @@ namespace osu.Framework.Graphics
             else
                 return shortClass;
         }
+
+        /// <summary>
+        /// Represents a new instance of an empty <see cref="Drawable"/>.
+        /// </summary>
+        public static Drawable Empty => new EmptyDrawable();
+
+        private class EmptyDrawable : Drawable
+        {
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
For patterns such as:

```
protected virtual Drawable CreateXYZ() => new Container();
```

which can now be written as:

```
protected virtual Drawable CreateXYZ() => Drawable.Empty;
```

Where: returning `null` feels wrong in hierarchical construction, and returning a `Container` feels arbitrary.

Note: Empty Drawable instances aren't shared.