### PR TITLE
Change Drawable.Empty to a method

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2296,9 +2296,9 @@ namespace osu.Framework.Graphics
         }
 
         /// <summary>
-        /// Represents a new instance of an empty <see cref="Drawable"/>.
+        /// Creates a new instance of an empty <see cref="Drawable"/>.
         /// </summary>
-        public static Drawable Empty => new EmptyDrawable();
+        public static Drawable Empty() => new EmptyDrawable();
 
         private class EmptyDrawable : Drawable
         {


### PR DESCRIPTION
See discussion in https://github.com/ppy/osu-framework/pull/3143

Microsoft also seem to use this convention when `Empty()` creates a new instance, such as https://source.dot.net/#System.Linq.Expressions/System/Linq/Expressions/DefaultExpression.cs,52