### PR TITLE
Set UserAgent on WebRequest level

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -55,6 +55,24 @@ namespace osu.Framework.Tests.IO
                 AllowInsecureRequests = true
             };
 
+            testValidGetInternal(async, request, "osu-framework");
+        }
+
+        [Test, Retry(5)]
+        public void TestCustomUserAgent([ValueSource(nameof(protocols))] string protocol, [Values(true, false)] bool async)
+        {
+            var url = $"{protocol}://{host}/get";
+            var request = new CustomUserAgentWebRequest(url)
+            {
+                Method = HttpMethod.Get,
+                AllowInsecureRequests = true
+            };
+
+            testValidGetInternal(async, request, "custom-ua");
+        }
+
+        private static void testValidGetInternal(bool async, JsonWebRequest<HttpBinGetResponse> request, string expectedUserAgent)
+        {
             bool hasThrown = false;
             request.Failed += exception => hasThrown = exception != null;
 
@@ -69,7 +87,7 @@ namespace osu.Framework.Tests.IO
             var responseObject = request.ResponseObject;
 
             Assert.IsTrue(responseObject != null);
-            Assert.IsTrue(responseObject.Headers.UserAgent == "osu-framework");
+            Assert.IsTrue(responseObject.Headers.UserAgent == expectedUserAgent);
 
             // disabled due to hosted version returning incorrect response (https://github.com/postmanlabs/httpbin/issues/545)
             // Assert.AreEqual(url, responseObject.Url);
@@ -529,6 +547,16 @@ namespace osu.Framework.Tests.IO
         public class TestObject
         {
             public string TestString = "readable";
+        }
+
+        private class CustomUserAgentWebRequest : JsonWebRequest<HttpBinGetResponse>
+        {
+            public CustomUserAgentWebRequest(string url)
+                : base(url)
+            {
+            }
+
+            protected override string UserAgent => "custom-ua";
         }
 
         private class DelayedWebRequest : WebRequest

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Tests.IO
             var responseObject = request.ResponseObject;
 
             Assert.IsTrue(responseObject != null);
-            Assert.IsTrue(responseObject.Headers.UserAgent == "osu!");
+            Assert.IsTrue(responseObject.Headers.UserAgent == "osu-framework");
 
             // disabled due to hosted version returning incorrect response (https://github.com/postmanlabs/httpbin/issues/545)
             // Assert.AreEqual(url, responseObject.Url);

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -113,6 +113,11 @@ namespace osu.Framework.IO.Network
         /// </summary>
         protected virtual string Accept => string.Empty;
 
+        /// <summary>
+        /// The value of the User-agent HTTP header.
+        /// </summary>
+        protected virtual string UserAgent => "osu-framework";
+
         internal int RetryCount { get; private set; }
 
         /// <summary>
@@ -311,6 +316,8 @@ namespace osu.Framework.IO.Network
                         if (!string.IsNullOrEmpty(ContentType))
                             request.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(ContentType);
                     }
+
+                    request.Headers.UserAgent.TryParseAdd(UserAgent);
 
                     if (!string.IsNullOrEmpty(Accept))
                         request.Headers.Accept.TryParseAdd(Accept);

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -122,10 +122,6 @@ namespace osu.Framework.IO.Network
 
         private static readonly HttpClient client = new HttpClient(new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate })
         {
-            DefaultRequestHeaders =
-            {
-                UserAgent = { ProductInfoHeaderValue.Parse("osu!") }
-            },
             // Timeout is controlled manually through cancellation tokens because
             // HttpClient does not properly timeout while reading chunked data
             Timeout = System.Threading.Timeout.InfiniteTimeSpan


### PR DESCRIPTION
alternative to https://github.com/ppy/osu-framework/pull/1962

This PR moves UserAgent assigning from `DefaultRequestHeaders` to `internalPerform` and makes it customizable via `WebRequest.UserAgent` virtual property.