### PR TITLE
Disable sample ramping

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -67,6 +67,7 @@ namespace osu.Framework.Audio.Sample
                 // We are creating a new channel for every playback, since old channels may
                 // be overridden when too many other channels are created from the same sample.
                 channel = ((SampleBass)Sample).CreateChannel();
+                Bass.ChannelSetAttribute(channel, ChannelAttribute.NoRamp, 1);
                 Bass.ChannelGetAttribute(channel, ChannelAttribute.Frequency, out initialFrequency);
                 setLoopFlag(Looping);
             });


### PR DESCRIPTION
Applies same fix as seen in https://github.com/ppy/osu-stable-issues/issues/286.

Search for `BASS_ATTRIB_NORAMP` on http://www.bass.radio42.com/help/html/f00d6245-b20b-f37d-7982-8cc6549f4ae3.htm for full details.