### PR TITLE
Fix ScrollBarVisible calling unsafe method before loaded

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -41,7 +41,8 @@ namespace osu.Framework.Graphics.Containers
             set
             {
                 scrollbarVisible = value;
-                updateScrollbar();
+                if (IsLoaded)
+                    updateScrollbar();
             }
         }
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using osu.Framework.Caching;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
@@ -41,8 +42,7 @@ namespace osu.Framework.Graphics.Containers
             set
             {
                 scrollbarVisible = value;
-                if (IsLoaded)
-                    updateScrollbar();
+                scrollbarCache.Invalidate();
             }
         }
 
@@ -196,18 +196,11 @@ namespace osu.Framework.Graphics.Containers
             {
                 lastAvailableContent = availableContent;
                 lastUpdateDisplayableContent = displayableContent;
-                updateScrollbar();
+                scrollbarCache.Invalidate();
             }
         }
 
-        private void updateScrollbar()
-        {
-            var size = ScrollDirection == Direction.Horizontal ? DrawWidth : DrawHeight;
-            if (size > 0)
-                Scrollbar.ResizeTo(Math.Clamp(availableContent > 0 ? displayableContent / availableContent : 0, Scrollbar.MinimumDimSize / size, 1), 200, Easing.OutQuint);
-            Scrollbar.FadeTo(ScrollbarVisible && availableContent - 1 > displayableContent ? 1 : 0, 200);
-            updatePadding();
-        }
+        private readonly Cached scrollbarCache = new Cached();
 
         private void updatePadding()
         {
@@ -508,6 +501,17 @@ namespace osu.Framework.Graphics.Containers
 
             updateSize();
             updatePosition();
+
+            if (!scrollbarCache.IsValid)
+            {
+                var size = ScrollDirection == Direction.Horizontal ? DrawWidth : DrawHeight;
+                if (size > 0)
+                    Scrollbar.ResizeTo(Math.Clamp(availableContent > 0 ? displayableContent / availableContent : 0, Math.Min(Scrollbar.MinimumDimSize / size, 1), 1), 200, Easing.OutQuint);
+                Scrollbar.FadeTo(ScrollbarVisible && availableContent - 1 > displayableContent ? 1 : 0, 200);
+                updatePadding();
+
+                scrollbarCache.Validate();
+            }
 
             if (ScrollDirection == Direction.Horizontal)
             {

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -181,6 +181,7 @@ namespace osu.Framework.Graphics.Containers
                 Scrollbar = CreateScrollbar(scrollDirection)
             });
 
+            Scrollbar.Hide();
             Scrollbar.Dragged = onScrollbarMovement;
             ScrollbarAnchor = scrollDirection == Direction.Vertical ? Anchor.TopRight : Anchor.BottomLeft;
         }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/7471

Was causing a crash osu!-side due to uninitialised `DrawSize`

```
Unhandled exception. System.ArgumentException: '10' cannot be greater than 1.
   at System.Math.ThrowMinMaxException[T](T min, T max)
   at osu.Framework.Graphics.Containers.ScrollContainer`1.updateScrollbar()
   at osu.Framework.Graphics.Containers.ScrollContainer`1.set_ScrollbarVisible(Boolean value)
   at osu.Game.Overlays.SearchableList.SearchableListOverlay`3..ctor() in /Users/dean/Projects/osu/osu.Game/Overlays/SearchableList/SearchableListOverlay.cs:line 40
   at osu.Game.Overlays.DirectOverlay..ctor() in /Users/dean/Projects/osu/osu.Game/Overlays/DirectOverlay.cs:line 86
   at osu.Game.OsuGame.LoadComplete() in /Users/dean/Projects/osu/osu.Game/OsuGame.cs:line 611
   at osu.Desktop.OsuGameDesktop.LoadComplete() in /Users/dean/Projects/osu/osu.Desktop/OsuGameDesktop.cs:line 52
   at osu.Framework.Graphics.Drawable.loadComplete()
   at osu.Framework.Graphics.Drawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Graphics.Containers.CompositeDrawable.UpdateSubTree()
   at osu.Framework.Platform.GameHost.UpdateFrame()
   at osu.Framework.Threading.GameThread.ProcessFrame()
   at osu.Framework.Threading.GameThread.runWork()
```