### PR TITLE
Provide current mouse position with each mouse event

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
 using osu.Framework.Testing;
 using osuTK;
 using osuTK.Input;
@@ -148,8 +147,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             private class TestDropdownMenu : BasicDropdownMenu
             {
-                public void SelectItem(MenuItem item) => Children.FirstOrDefault(c => c.Item == item)?
-                    .TriggerEvent(new ClickEvent(GetContainingInputManager().CurrentState, MouseButton.Left));
+                public void SelectItem(MenuItem item) => Children.FirstOrDefault(c => c.Item == item)?.Click();
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -40,8 +40,8 @@ namespace osu.Framework.Graphics.Containers
         {
             switch (e)
             {
-                case ScrollEvent _:
-                    if (BlockPositionalInput && base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
+                case ScrollEvent scroll:
+                    if (BlockPositionalInput && base.ReceivePositionalInputAt(scroll.ScreenSpaceCurrentMousePosition))
                         return true;
 
                     break;

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -303,7 +303,7 @@ namespace osu.Framework.Graphics.Containers
 
             lastDragTime = currentTime;
 
-            Vector2 childDelta = ToLocalSpace(e.ScreenSpaceMousePosition) - ToLocalSpace(e.ScreenSpaceLastMousePosition);
+            Vector2 childDelta = ToLocalSpace(e.ScreenSpaceCurrentMousePosition) - ToLocalSpace(e.ScreenSpaceLastMousePosition);
 
             float scrollOffset = -childDelta[ScrollDim];
             float clampedScrollOffset = Clamp(target + scrollOffset) - Clamp(target);
@@ -317,7 +317,7 @@ namespace osu.Framework.Graphics.Containers
             // similar calculation to what is already done in MouseButtonEventManager.HandlePositionChange
             // handles the case where a drag was triggered on an axis we are not interested in.
             // can be removed if/when drag events are split out per axis or contain direction information.
-            dragBlocksClick |= Math.Abs(e.MouseDownPosition[ScrollDim] - e.MousePosition[ScrollDim]) > dragButtonManager.ClickDragDistance;
+            dragBlocksClick |= Math.Abs(e.MouseDownPosition[ScrollDim] - e.CurrentMousePosition[ScrollDim]) > dragButtonManager.ClickDragDistance;
 
             offset(scrollOffset, false);
             return true;
@@ -578,7 +578,7 @@ namespace osu.Framework.Graphics.Containers
 
             protected override bool OnDragStart(DragStartEvent e)
             {
-                dragOffset = e.MousePosition[(int)ScrollDirection] - Position[(int)ScrollDirection];
+                dragOffset = e.CurrentMousePosition[(int)ScrollDirection] - Position[(int)ScrollDirection];
                 return true;
             }
 
@@ -593,7 +593,7 @@ namespace osu.Framework.Graphics.Containers
 
             protected override bool OnDrag(DragEvent e)
             {
-                Dragged?.Invoke(e.MousePosition[(int)ScrollDirection] - dragOffset);
+                Dragged?.Invoke(e.CurrentMousePosition[(int)ScrollDirection] - dragOffset);
                 return true;
             }
         }

--- a/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
+++ b/osu.Framework/Graphics/Cursor/ContextMenuContainer.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Graphics.Cursor
 
                     menu.Items = items;
 
-                    targetRelativePosition = menuTarget.ToLocalSpace(e.ScreenSpaceMousePosition);
+                    targetRelativePosition = menuTarget.ToLocalSpace(e.ScreenSpaceCurrentMousePosition);
 
                     menu.Open();
                     return true;

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -44,13 +44,13 @@ namespace osu.Framework.Graphics.Cursor
             // required due to IRequireHighFrequencyMousePosition firing with the last known position even when the source is not in a
             // valid state (ie. receiving updates from user or otherwise). in this case, we generally want the cursor to remain at its
             // last *relative* position.
-            if (lastPosition.HasValue && Precision.AlmostEquals(e.ScreenSpaceMousePosition, lastPosition.Value))
+            if (lastPosition.HasValue && Precision.AlmostEquals(e.ScreenSpaceCurrentMousePosition, lastPosition.Value))
                 return false;
 
-            lastPosition = e.ScreenSpaceMousePosition;
+            lastPosition = e.ScreenSpaceCurrentMousePosition;
 
             ActiveCursor.RelativePositionAxes = Axes.None;
-            ActiveCursor.Position = e.MousePosition;
+            ActiveCursor.Position = e.CurrentMousePosition;
             ActiveCursor.RelativePositionAxes = Axes.Both;
             return base.OnMouseMove(e);
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1919,7 +1919,16 @@ namespace osu.Framework.Graphics
         /// Triggers a left click event for this <see cref="Drawable"/>.
         /// </summary>
         /// <returns>Whether the click event is handled.</returns>
-        public bool Click() => TriggerEvent(new ClickEvent(GetContainingInputManager()?.CurrentState ?? new InputState(), MouseButton.Left));
+        public bool Click()
+        {
+            var inputManager = GetContainingInputManager();
+
+            return TriggerEvent(new ClickEvent(
+                inputManager?.CurrentState ?? new InputState(),
+                inputManager?.CurrentState.Mouse.Position ?? Vector2.Zero,
+                MouseButton.Left
+            ));
+        }
 
         #region Individual event handlers
 

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -136,7 +136,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnDragStart(DragStartEvent e)
         {
-            Vector2 posDiff = e.MouseDownPosition - e.MousePosition;
+            Vector2 posDiff = e.MouseDownPosition - e.CurrentMousePosition;
 
             if (Math.Abs(posDiff.X) < Math.Abs(posDiff.Y))
             {
@@ -200,9 +200,9 @@ namespace osu.Framework.Graphics.UserInterface
             return true;
         }
 
-        private void handleMouseInput(UIEvent e)
+        private void handleMouseInput(MouseEvent e)
         {
-            var xPosition = ToLocalSpace(e.ScreenSpaceMousePosition).X - RangePadding;
+            var xPosition = ToLocalSpace(e.ScreenSpaceCurrentMousePosition).X - RangePadding;
 
             if (currentNumberInstantaneous.Disabled)
                 return;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -728,16 +728,16 @@ namespace osu.Framework.Graphics.UserInterface
             if (doubleClickWord != null)
             {
                 //select words at a time
-                if (getCharacterClosestTo(e.MousePosition) > doubleClickWord[1])
+                if (getCharacterClosestTo(e.CurrentMousePosition) > doubleClickWord[1])
                 {
                     selectionStart = doubleClickWord[0];
-                    selectionEnd = findSeparatorIndex(text, getCharacterClosestTo(e.MousePosition) - 1, 1);
+                    selectionEnd = findSeparatorIndex(text, getCharacterClosestTo(e.CurrentMousePosition) - 1, 1);
                     selectionEnd = selectionEnd >= 0 ? selectionEnd : text.Length;
                 }
-                else if (getCharacterClosestTo(e.MousePosition) < doubleClickWord[0])
+                else if (getCharacterClosestTo(e.CurrentMousePosition) < doubleClickWord[0])
                 {
                     selectionStart = doubleClickWord[1];
-                    selectionEnd = findSeparatorIndex(text, getCharacterClosestTo(e.MousePosition), -1);
+                    selectionEnd = findSeparatorIndex(text, getCharacterClosestTo(e.CurrentMousePosition), -1);
                     selectionEnd = selectionEnd >= 0 ? selectionEnd + 1 : 0;
                 }
                 else
@@ -753,7 +753,7 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 if (text.Length == 0) return true;
 
-                selectionEnd = getCharacterClosestTo(e.MousePosition);
+                selectionEnd = getCharacterClosestTo(e.CurrentMousePosition);
                 if (selectionLength > 0)
                     GetContainingInputManager().ChangeFocus(this);
 
@@ -767,7 +767,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             if (HasFocus) return true;
 
-            Vector2 posDiff = e.MouseDownPosition - e.MousePosition;
+            Vector2 posDiff = e.MouseDownPosition - e.CurrentMousePosition;
 
             return Math.Abs(posDiff.X) > Math.Abs(posDiff.Y);
         }
@@ -780,7 +780,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             if (AllowClipboardExport)
             {
-                int hover = Math.Min(text.Length - 1, getCharacterClosestTo(e.MousePosition));
+                int hover = Math.Min(text.Length - 1, getCharacterClosestTo(e.CurrentMousePosition));
 
                 int lastSeparator = findSeparatorIndex(text, hover, -1);
                 int nextSeparator = findSeparatorIndex(text, hover, 1);
@@ -818,7 +818,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             if (textInput?.ImeActive == true) return true;
 
-            selectionStart = selectionEnd = getCharacterClosestTo(e.MousePosition);
+            selectionStart = selectionEnd = getCharacterClosestTo(e.CurrentMousePosition);
 
             cursorAndLayout.Invalidate();
 

--- a/osu.Framework/Input/Events/ClickEvent.cs
+++ b/osu.Framework/Input/Events/ClickEvent.cs
@@ -12,8 +12,8 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public class ClickEvent : MouseButtonEvent
     {
-        public ClickEvent(InputState state, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
-            : base(state, button, screenSpaceMouseDownPosition)
+        public ClickEvent(InputState state, Vector2 screenSpaceCurrentMousePosition, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
+            : base(state, screenSpaceCurrentMousePosition, button, screenSpaceMouseDownPosition)
         {
         }
     }

--- a/osu.Framework/Input/Events/DoubleClickEvent.cs
+++ b/osu.Framework/Input/Events/DoubleClickEvent.cs
@@ -12,8 +12,8 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public class DoubleClickEvent : MouseButtonEvent
     {
-        public DoubleClickEvent(InputState state, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
-            : base(state, button, screenSpaceMouseDownPosition)
+        public DoubleClickEvent(InputState state, Vector2 screenSpaceCurrentMousePosition, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
+            : base(state, screenSpaceCurrentMousePosition, button, screenSpaceMouseDownPosition)
         {
         }
     }

--- a/osu.Framework/Input/Events/DragEndEvent.cs
+++ b/osu.Framework/Input/Events/DragEndEvent.cs
@@ -13,8 +13,8 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public class DragEndEvent : MouseButtonEvent
     {
-        public DragEndEvent(InputState state, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
-            : base(state, button, screenSpaceMouseDownPosition)
+        public DragEndEvent(InputState state, Vector2 screenSpaceCurrentMousePosition, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
+            : base(state, screenSpaceCurrentMousePosition, button, screenSpaceMouseDownPosition)
         {
         }
     }

--- a/osu.Framework/Input/Events/DragEvent.cs
+++ b/osu.Framework/Input/Events/DragEvent.cs
@@ -26,12 +26,12 @@ namespace osu.Framework.Input.Events
         /// <summary>
         /// The difference of mouse position from last position to current position in local space.
         /// </summary>
-        public Vector2 Delta => MousePosition - LastMousePosition;
+        public Vector2 Delta => CurrentMousePosition - LastMousePosition;
 
-        public DragEvent(InputState state, MouseButton button, Vector2? screenSpaceMousePosition = null, Vector2? screenSpaceLastMousePosition = null)
-            : base(state, button, screenSpaceMousePosition)
+        public DragEvent(InputState state, Vector2 screenSpaceCurrentMousePosition, MouseButton button, Vector2? screenSpaceMouseDownPosition = null, Vector2? screenSpaceLastMousePosition = null)
+            : base(state, screenSpaceCurrentMousePosition, button, screenSpaceMouseDownPosition)
         {
-            ScreenSpaceLastMousePosition = screenSpaceLastMousePosition ?? state.Mouse.Position;
+            ScreenSpaceLastMousePosition = screenSpaceLastMousePosition ?? ScreenSpaceCurrentMousePosition;
         }
     }
 }

--- a/osu.Framework/Input/Events/DragStartEvent.cs
+++ b/osu.Framework/Input/Events/DragStartEvent.cs
@@ -12,8 +12,8 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public class DragStartEvent : MouseButtonEvent
     {
-        public DragStartEvent(InputState state, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
-            : base(state, button, screenSpaceMouseDownPosition)
+        public DragStartEvent(InputState state, Vector2 screenSpaceCurrentMousePosition, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
+            : base(state, screenSpaceCurrentMousePosition, button, screenSpaceMouseDownPosition)
         {
         }
     }

--- a/osu.Framework/Input/Events/HoverEvent.cs
+++ b/osu.Framework/Input/Events/HoverEvent.cs
@@ -11,8 +11,9 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public class HoverEvent : MouseEvent
     {
+        // todo: pass current position of the pointer that fired this event.
         public HoverEvent(InputState state)
-            : base(state)
+            : base(state, state.Mouse.Position)
         {
         }
     }

--- a/osu.Framework/Input/Events/HoverLostEvent.cs
+++ b/osu.Framework/Input/Events/HoverLostEvent.cs
@@ -11,8 +11,9 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public class HoverLostEvent : MouseEvent
     {
+        // todo: pass current position of the pointer that fired this event.
         public HoverLostEvent(InputState state)
-            : base(state)
+            : base(state, state.Mouse.Position)
         {
         }
     }

--- a/osu.Framework/Input/Events/MouseButtonEvent.cs
+++ b/osu.Framework/Input/Events/MouseButtonEvent.cs
@@ -13,16 +13,26 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public abstract class MouseButtonEvent : MouseEvent
     {
+        /// <summary>
+        /// The mouse button that fired this event.
+        /// </summary>
         public readonly MouseButton Button;
+
+        /// <summary>
+        /// The mouse position at a <see cref="MouseDownEvent"/> in the screen space.
+        /// </summary>
         public readonly Vector2 ScreenSpaceMouseDownPosition;
 
+        /// <summary>
+        /// The mouse position at a <see cref="MouseDownEvent"/> in local space.
+        /// </summary>
         public Vector2 MouseDownPosition => ToLocalSpace(ScreenSpaceMouseDownPosition);
 
-        protected MouseButtonEvent(InputState state, MouseButton button, Vector2? screenSpaceMouseDownPosition)
-            : base(state)
+        protected MouseButtonEvent(InputState state, Vector2 screenSpaceCurrentMousePosition, MouseButton button, Vector2? screenSpaceMouseDownPosition)
+            : base(state, screenSpaceCurrentMousePosition)
         {
             Button = button;
-            ScreenSpaceMouseDownPosition = screenSpaceMouseDownPosition ?? ScreenSpaceMousePosition;
+            ScreenSpaceMouseDownPosition = screenSpaceMouseDownPosition ?? ScreenSpaceCurrentMousePosition;
         }
 
         public override string ToString() => $"{GetType().ReadableName()}({Button})";

--- a/osu.Framework/Input/Events/MouseDownEvent.cs
+++ b/osu.Framework/Input/Events/MouseDownEvent.cs
@@ -12,8 +12,8 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public class MouseDownEvent : MouseButtonEvent
     {
-        public MouseDownEvent(InputState state, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
-            : base(state, button, screenSpaceMouseDownPosition)
+        public MouseDownEvent(InputState state, Vector2 screenSpaceCurrentMousePosition, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
+            : base(state, screenSpaceCurrentMousePosition, button, screenSpaceMouseDownPosition)
         {
         }
     }

--- a/osu.Framework/Input/Events/MouseEvent.cs
+++ b/osu.Framework/Input/Events/MouseEvent.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using osu.Framework.Input.States;
+using osuTK;
 using osuTK.Input;
 
 namespace osu.Framework.Input.Events
@@ -12,6 +13,16 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public abstract class MouseEvent : UIEvent
     {
+        /// <summary>
+        /// The current mouse position in the screen space.
+        /// </summary>
+        public Vector2 ScreenSpaceCurrentMousePosition;
+
+        /// <summary>
+        /// The current mouse position in local space.
+        /// </summary>
+        public Vector2 CurrentMousePosition => ToLocalSpace(ScreenSpaceCurrentMousePosition);
+
         /// <summary>
         /// Whether a specific mouse button is pressed.
         /// </summary>
@@ -27,9 +38,10 @@ namespace osu.Framework.Input.Events
         /// </summary>
         public IEnumerable<MouseButton> PressedButtons => CurrentState.Mouse.Buttons;
 
-        protected MouseEvent(InputState state)
+        protected MouseEvent(InputState state, Vector2 screenSpaceCurrentMousePosition)
             : base(state)
         {
+            ScreenSpaceCurrentMousePosition = screenSpaceCurrentMousePosition;
         }
     }
 }

--- a/osu.Framework/Input/Events/MouseMoveEvent.cs
+++ b/osu.Framework/Input/Events/MouseMoveEvent.cs
@@ -24,12 +24,12 @@ namespace osu.Framework.Input.Events
         /// <summary>
         /// The difference of mouse position from last position to current position in local space.
         /// </summary>
-        public Vector2 Delta => MousePosition - LastMousePosition;
+        public Vector2 Delta => CurrentMousePosition - LastMousePosition;
 
-        public MouseMoveEvent(InputState state, Vector2? screenSpaceLastMousePosition = null)
-            : base(state)
+        public MouseMoveEvent(InputState state, Vector2 screenSpaceCurrentMousePosition, Vector2? screenSpaceLastMousePosition = null)
+            : base(state, screenSpaceCurrentMousePosition)
         {
-            ScreenSpaceLastMousePosition = screenSpaceLastMousePosition ?? ScreenSpaceMousePosition;
+            ScreenSpaceLastMousePosition = screenSpaceLastMousePosition ?? ScreenSpaceCurrentMousePosition;
         }
     }
 }

--- a/osu.Framework/Input/Events/MouseUpEvent.cs
+++ b/osu.Framework/Input/Events/MouseUpEvent.cs
@@ -12,8 +12,8 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public class MouseUpEvent : MouseButtonEvent
     {
-        public MouseUpEvent(InputState state, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
-            : base(state, button, screenSpaceMouseDownPosition)
+        public MouseUpEvent(InputState state, Vector2 screenSpaceCurrentMousePosition, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
+            : base(state, screenSpaceCurrentMousePosition, button, screenSpaceMouseDownPosition)
         {
         }
     }

--- a/osu.Framework/Input/Events/ScrollEvent.cs
+++ b/osu.Framework/Input/Events/ScrollEvent.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Input.Events
         public readonly bool IsPrecise;
 
         public ScrollEvent(InputState state, Vector2 scrollDelta, bool isPrecise = false)
-            : base(state)
+            : base(state, state.Mouse.Position)
         {
             ScrollDelta = scrollDelta;
             IsPrecise = isPrecise;

--- a/osu.Framework/Input/StateChanges/Events/MouseButtonStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/MouseButtonStateChangeEvent.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.States;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Input.StateChanges.Events
+{
+    public class MouseButtonStateChangeEvent : ButtonStateChangeEvent<MouseButton>
+    {
+        /// <summary>
+        /// The mouse position at the button change occurrence.
+        /// </summary>
+        public readonly Vector2 Position;
+
+        public MouseButtonStateChangeEvent(InputState state, IInput input, MouseButton button, ButtonStateChangeKind kind, Vector2 position)
+            : base(state, input, button, kind)
+        {
+            Position = position;
+        }
+    }
+}

--- a/osu.Framework/Input/StateChanges/Events/MousePositionChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/MousePositionChangeEvent.cs
@@ -9,13 +9,19 @@ namespace osu.Framework.Input.StateChanges.Events
     public class MousePositionChangeEvent : InputStateChangeEvent
     {
         /// <summary>
+        /// The current mouse position.
+        /// </summary>
+        public readonly Vector2 CurrentPosition;
+
+        /// <summary>
         /// The last mouse position.
         /// </summary>
         public readonly Vector2 LastPosition;
 
-        public MousePositionChangeEvent(InputState state, IInput input, Vector2 lastPosition)
+        public MousePositionChangeEvent(InputState state, IInput input, Vector2 currentPosition, Vector2 lastPosition)
             : base(state, input)
         {
+            CurrentPosition = currentPosition;
             LastPosition = lastPosition;
         }
     }

--- a/osu.Framework/Input/StateChanges/MouseButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseButtonInput.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
 using osuTK.Input;
 
@@ -25,5 +26,8 @@ namespace osu.Framework.Input.StateChanges
         }
 
         protected override ButtonStates<MouseButton> GetButtonStates(InputState state) => state.Mouse.Buttons;
+
+        protected override ButtonStateChangeEvent<MouseButton> CreateEvent(InputState state, MouseButton button, ButtonStateChangeKind kind)
+            => new MouseButtonStateChangeEvent(state, this, button, kind, state.Mouse.Position);
     }
 }

--- a/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Input.StateChanges
                 var lastPosition = mouse.IsPositionValid ? mouse.Position : Position;
                 mouse.IsPositionValid = true;
                 mouse.Position = Position;
-                handler.HandleInputStateChange(new MousePositionChangeEvent(state, this, lastPosition));
+                handler.HandleInputStateChange(new MousePositionChangeEvent(state, this, mouse.Position, lastPosition));
             }
         }
     }

--- a/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Input.StateChanges
             {
                 var lastPosition = mouse.Position;
                 mouse.Position += Delta;
-                handler.HandleInputStateChange(new MousePositionChangeEvent(state, this, lastPosition));
+                handler.HandleInputStateChange(new MousePositionChangeEvent(state, this, mouse.Position, lastPosition));
             }
         }
     }


### PR DESCRIPTION
This PR will allow the mouse events to be shared across multiple positional-affecting input as the event name will eventually be changed to `PositionalEvent` or similar.

## Breaking change
### `UIEvent.MousePosition` should not be used unless targeting the mouse position directly, use `MouseEvent.CurrentMousePosition` instead.