### PR TITLE
Disallow binding to already bound object

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -14,6 +14,15 @@ namespace osu.Framework.Tests.Bindables
     public class BindableBindingTest
     {
         [Test]
+        public void TestBindToAlreadyBound()
+        {
+            Bindable<string> bindable1 = new Bindable<string>("default");
+            Bindable<string> bindable2 = bindable1.GetBoundCopy();
+
+            Assert.Throws<InvalidOperationException>(() => bindable1.BindTo(bindable2));
+        }
+
+        [Test]
         public void TestPropagation()
         {
             Bindable<string> bindable1 = new Bindable<string>("default");

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -182,6 +182,7 @@ namespace osu.Framework.Bindables
         /// This will adopt any values and value limitations of the bindable bound to.
         /// </summary>
         /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager).</param>
+        /// <exception cref="InvalidOperationException">Thrown when attempting to bind to an already bound object.</exception>
         public virtual void BindTo(Bindable<T> them)
         {
             if (Bindings != null && Bindings.Contains(them))

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -184,6 +184,9 @@ namespace osu.Framework.Bindables
         /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager).</param>
         public virtual void BindTo(Bindable<T> them)
         {
+            if (Bindings != null && Bindings.Contains(them))
+                throw new InvalidOperationException($"The bindable is already bound to {them}");
+
             Value = them.Value;
             Default = them.Default;
             Disabled = them.Disabled;

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -185,8 +185,8 @@ namespace osu.Framework.Bindables
         /// <exception cref="InvalidOperationException">Thrown when attempting to bind to an already bound object.</exception>
         public virtual void BindTo(Bindable<T> them)
         {
-            if (Bindings != null && Bindings.Contains(them))
-                throw new InvalidOperationException($"The bindable is already bound to {them}");
+            if (Bindings?.Contains(them) == true)
+                throw new InvalidOperationException($"This bindable is already bound to the requested bindable ({them}).");
 
             Value = them.Value;
             Default = them.Default;


### PR DESCRIPTION
I guess we should not allow binding to the same object multiple times.