### PR TITLE
Add weaklist benchmarks

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkWeakList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkWeakList.cs
@@ -36,17 +36,25 @@ namespace osu.Framework.Benchmarks
         public void Remove() => weakList.Remove(objects[0]);
 
         [Benchmark]
+        public void RemoveEach()
+        {
+            foreach (var obj in objects)
+                weakList.Remove(obj);
+        }
+
+        [Benchmark]
+        public void Clear() => weakList.Clear();
+
+        [Benchmark]
         public bool Contains() => weakList.Contains(objects[0]);
 
         [Benchmark]
         public object[] Enumerate() => weakList.ToArray();
 
         [Benchmark]
-        public object[] RemoveAllAndEnumerate()
+        public object[] ClearAndEnumerate()
         {
-            foreach (var obj in objects)
-                weakList.Remove(obj);
-
+            weakList.Clear();
             return weakList.ToArray();
         }
     }

--- a/osu.Framework.Benchmarks/BenchmarkWeakList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkWeakList.cs
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Lists;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkWeakList : BenchmarkTest
+    {
+        private readonly object[] objects = new object[1000];
+        private WeakList<object> weakList;
+
+        public override void SetUp()
+        {
+            for (int i = 0; i < 1000; i++)
+                objects[i] = new object();
+        }
+
+        [IterationSetup]
+        [SetUp]
+        public void IterationSetup()
+        {
+            weakList = new WeakList<object>();
+
+            foreach (var obj in objects)
+                weakList.Add(obj);
+        }
+
+        [Benchmark]
+        public void Add() => weakList.Add(new object());
+
+        [Benchmark]
+        public void Remove() => weakList.Remove(objects[0]);
+
+        [Benchmark]
+        public bool Contains() => weakList.Contains(objects[0]);
+
+        [Benchmark]
+        public object[] Enumerate() => weakList.ToArray();
+
+        [Benchmark]
+        public object[] RemoveAllAndEnumerate()
+        {
+            foreach (var obj in objects)
+                weakList.Remove(obj);
+
+            return weakList.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
Might as well, while I'm here.

Before https://github.com/ppy/osu-framework/pull/3165

|            Method |           Mean |        Error |       StdDev |         Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |---------------:|-------------:|-------------:|---------------:|------:|------:|------:|----------:|
|               Add |     2,794.2 ns |    183.73 ns |    533.04 ns |     2,689.0 ns |     - |     - |     - |      80 B |
|            Remove |       389.6 ns |     11.60 ns |     22.35 ns |       388.0 ns |     - |     - |     - |         - |
|        RemoveEach | 4,202,945.1 ns | 79,652.43 ns | 74,506.93 ns | 4,207,885.5 ns |     - |     - |     - |         - |
|             Clear |     5,859.6 ns |     84.51 ns |     74.92 ns |     5,834.5 ns |     - |     - |     - |         - |
|          Contains |     2,760.8 ns |    102.12 ns |    294.65 ns |     2,673.0 ns |     - |     - |     - |     128 B |
|         Enumerate |    46,143.5 ns |    639.37 ns |    533.91 ns |    46,111.0 ns |     - |     - |     - |   16648 B |
| ClearAndEnumerate |    14,775.4 ns |    298.49 ns |    319.38 ns |    14,714.5 ns |     - |     - |     - |      40 B |


After https://github.com/ppy/osu-framework/pull/3165

|            Method |           Mean |        Error |        StdDev |         Median | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------ |---------------:|-------------:|--------------:|---------------:|------:|------:|------:|----------:|
|               Add |     2,427.5 ns |     84.98 ns |     242.47 ns |     2,351.0 ns |     - |     - |     - |      80 B |
|            Remove |       383.2 ns |     11.70 ns |      28.69 ns |       383.0 ns |     - |     - |     - |         - |
|        RemoveEach | 4,321,197.0 ns | 86,340.72 ns | 136,945.53 ns | 4,309,698.0 ns |     - |     - |     - |         - |
|             Clear |     5,876.8 ns |     96.95 ns |      80.96 ns |     5,898.0 ns |     - |     - |     - |         - |
|          Contains |       414.6 ns |     13.16 ns |      22.70 ns |       416.5 ns |     - |     - |     - |         - |
|         Enumerate |    46,015.4 ns |    671.62 ns |     628.24 ns |    46,112.0 ns |     - |     - |     - |   16648 B |
| ClearAndEnumerate |    14,835.1 ns |    293.14 ns |     410.95 ns |    14,714.0 ns |     - |     - |     - |      40 B |

