### PR TITLE
Improve performance/allocations of WeakList

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkWeakList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkWeakList.cs
@@ -3,59 +3,82 @@
 
 using System.Linq;
 using BenchmarkDotNet.Attributes;
-using NUnit.Framework;
 using osu.Framework.Lists;
 
 namespace osu.Framework.Benchmarks
 {
     public class BenchmarkWeakList : BenchmarkTest
     {
+        [Params(1, 10, 100, 1000)]
+        public int ItemCount { get; set; }
+
         private readonly object[] objects = new object[1000];
         private WeakList<object> weakList;
 
         public override void SetUp()
         {
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < ItemCount; i++)
                 objects[i] = new object();
         }
 
-        [IterationSetup]
-        [SetUp]
-        public void IterationSetup()
-        {
-            weakList = new WeakList<object>();
+        [Benchmark(Baseline = true)]
+        public void Add() => init();
 
-            foreach (var obj in objects)
-                weakList.Add(obj);
+        [Benchmark]
+        public void RemoveOne()
+        {
+            init();
+
+            weakList.Remove(objects[objects.Length - 1]);
         }
 
         [Benchmark]
-        public void Add() => weakList.Add(new object());
-
-        [Benchmark]
-        public void Remove() => weakList.Remove(objects[0]);
-
-        [Benchmark]
-        public void RemoveEach()
+        public void RemoveAllIteratively()
         {
-            foreach (var obj in objects)
-                weakList.Remove(obj);
+            init();
+
+            for (int i = 0; i < ItemCount; i++)
+                weakList.Remove(objects[i]);
         }
 
         [Benchmark]
-        public void Clear() => weakList.Clear();
+        public void Clear()
+        {
+            init();
+
+            weakList.Clear();
+        }
 
         [Benchmark]
-        public bool Contains() => weakList.Contains(objects[0]);
+        public bool Contains()
+        {
+            init();
+
+            return weakList.Contains(objects[objects.Length - 1]);
+        }
 
         [Benchmark]
-        public object[] Enumerate() => weakList.ToArray();
+        public object[] AddAndEnumerate()
+        {
+            init();
+
+            return weakList.ToArray();
+        }
 
         [Benchmark]
         public object[] ClearAndEnumerate()
         {
+            init();
+
             weakList.Clear();
             return weakList.ToArray();
+        }
+
+        private void init()
+        {
+            weakList = new WeakList<object>();
+            for (int i = 0; i < ItemCount; i++)
+                weakList.Add(objects[i]);
         }
     }
 }

--- a/osu.Framework.Benchmarks/BenchmarkWeakList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkWeakList.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Benchmarks
         {
             init();
 
-            weakList.Remove(objects[objects.Length - 1]);
+            weakList.Remove(objects[^1]);
         }
 
         [Benchmark]
@@ -54,7 +54,7 @@ namespace osu.Framework.Benchmarks
         {
             init();
 
-            return weakList.Contains(objects[objects.Length - 1]);
+            return weakList.Contains(objects[^1]);
         }
 
         [Benchmark]

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace osu.Framework.Lists
 {
@@ -22,13 +23,16 @@ namespace osu.Framework.Lists
 
         public void Remove(T item)
         {
-            foreach (var i in list)
+            for (int i = 0; i < list.Count; i++)
             {
-                if (i.Reference.TryGetTarget(out var obj) && obj == item)
-                {
-                    i.Invalidate();
-                    return;
-                }
+                if (list[i].Reference == null)
+                    continue;
+
+                if (!list[i].Reference.TryGetTarget(out var obj) || obj != item)
+                    continue;
+
+                list[i] = default;
+                break;
             }
         }
 
@@ -36,13 +40,14 @@ namespace osu.Framework.Lists
         {
             bool found = false;
 
-            foreach (var item in list)
+            for (int i = 0; i < list.Count; i++)
             {
-                if (item.Reference == weakReference)
-                {
-                    item.Invalidate();
-                    found = true;
-                }
+                if (list[i].Reference != weakReference)
+                    continue;
+
+                list[i] = default;
+                found = true;
+                break;
             }
 
             return found;
@@ -52,7 +57,10 @@ namespace osu.Framework.Lists
         {
             foreach (var t in list)
             {
-                if (!t.Invalid && t.Reference.TryGetTarget(out var obj) && obj == item)
+                if (t.Reference == null)
+                    continue;
+
+                if (t.Reference.TryGetTarget(out var obj) && obj == item)
                     return true;
             }
 
@@ -63,7 +71,7 @@ namespace osu.Framework.Lists
         {
             foreach (var t in list)
             {
-                if (!t.Invalid && t.Reference == weakReference)
+                if (t.Reference != null && t.Reference == weakReference)
                     return true;
             }
 
@@ -72,13 +80,13 @@ namespace osu.Framework.Lists
 
         public void Clear()
         {
-            foreach (var item in list)
-                item.Invalidate();
+            for (int i = 0; i < list.Count; i++)
+                list[i] = default;
         }
 
         public Enumerator GetEnumerator()
         {
-            list.RemoveAll(item => item.Invalid || !item.Reference.TryGetTarget(out _));
+            list.RemoveAll(item => item.Reference == null || !item.Reference.TryGetTarget(out _));
 
             return new Enumerator(list);
         }
@@ -106,7 +114,7 @@ namespace osu.Framework.Lists
             {
                 while (++currentIndex < list.Count)
                 {
-                    if (list[currentIndex].Invalid || !list[currentIndex].Reference.TryGetTarget(out currentObject))
+                    if (list[currentIndex].Reference == null || !list[currentIndex].Reference.TryGetTarget(out currentObject))
                         continue;
 
                     return true;
@@ -132,23 +140,20 @@ namespace osu.Framework.Lists
             }
         }
 
-        internal class InvalidatableWeakReference
+        internal readonly struct InvalidatableWeakReference
         {
+            [CanBeNull]
             public readonly WeakReference<T> Reference;
 
-            public bool Invalid { get; private set; }
-
-            public InvalidatableWeakReference(T reference)
+            public InvalidatableWeakReference([CanBeNull] T reference)
                 : this(new WeakReference<T>(reference))
             {
             }
 
-            public InvalidatableWeakReference(WeakReference<T> weakReference)
+            public InvalidatableWeakReference([CanBeNull] WeakReference<T> weakReference)
             {
                 Reference = weakReference;
             }
-
-            public void Invalidate() => Invalid = true;
         }
     }
 }


### PR DESCRIPTION
```diff
  |               Method | ItemCount |           Mean |        Error |       StdDev | Ratio | RatioSD |   Gen 0 |  Gen 1 | Gen 2 | Allocated |
  |--------------------- |---------- |---------------:|-------------:|-------------:|------:|--------:|--------:|-------:|------:|----------:|
- |                  Add |         1 |       228.5 ns |      2.95 ns |      2.62 ns |  1.00 |    0.00 |  0.0319 |      - |     - |     168 B |
+ |                  Add |         1 |       217.2 ns |      0.47 ns |      0.42 ns |  1.00 |    0.00 |  0.0260 |      - |     - |     136 B |
- |            RemoveOne |         1 |       251.9 ns |      1.47 ns |      1.38 ns |  1.10 |    0.01 |  0.0319 |      - |     - |     168 B |
+ |            RemoveOne |         1 |       226.6 ns |      1.30 ns |      1.15 ns |  1.04 |    0.01 |  0.0260 |      - |     - |     136 B |
- | RemoveAllIteratively |         1 |       248.4 ns |      1.16 ns |      0.97 ns |  1.09 |    0.01 |  0.0319 |      - |     - |     168 B |
+ | RemoveAllIteratively |         1 |       221.9 ns |      3.79 ns |      3.36 ns |  1.02 |    0.01 |  0.0260 |      - |     - |     136 B |
- |                Clear |         1 |       246.8 ns |      1.15 ns |      0.96 ns |  1.08 |    0.01 |  0.0319 |      - |     - |     168 B |
+ |                Clear |         1 |       221.0 ns |      4.34 ns |      3.62 ns |  1.02 |    0.02 |  0.0260 |      - |     - |     136 B |
- |             Contains |         1 |       256.3 ns |      1.46 ns |      1.30 ns |  1.12 |    0.02 |  0.0319 |      - |     - |     168 B |
+ |             Contains |         1 |       240.5 ns |      1.63 ns |      1.44 ns |  1.11 |    0.01 |  0.0257 |      - |     - |     136 B |
- |      AddAndEnumerate |         1 |       409.4 ns |      3.68 ns |      3.44 ns |  1.79 |    0.03 |  0.0563 |      - |     - |     296 B |
+ |      AddAndEnumerate |         1 |       402.7 ns |      1.40 ns |      1.31 ns |  1.85 |    0.01 |  0.0501 |      - |     - |     264 B |
- |    ClearAndEnumerate |         1 |       341.3 ns |      1.43 ns |      1.27 ns |  1.49 |    0.02 |  0.0396 |      - |     - |     208 B |
+ |    ClearAndEnumerate |         1 |       308.9 ns |      2.41 ns |      2.25 ns |  1.42 |    0.01 |  0.0334 |      - |     - |     176 B |
  |                      |           |                |              |              |       |         |         |        |       |           |
- |                  Add |        10 |     2,112.4 ns |      5.85 ns |      4.88 ns |  1.00 |    0.00 |  0.1717 |      - |     - |     912 B |
+ |                  Add |        10 |     1,992.9 ns |     10.71 ns |      9.49 ns |  1.00 |    0.00 |  0.1106 |      - |     - |     592 B |
- |            RemoveOne |        10 |     2,211.9 ns |     10.17 ns |      9.01 ns |  1.05 |    0.00 |  0.1717 |      - |     - |     912 B |
+ |            RemoveOne |        10 |     1,979.3 ns |      5.95 ns |      4.97 ns |  0.99 |    0.01 |  0.1106 |      - |     - |     592 B |
- | RemoveAllIteratively |        10 |     2,812.7 ns |     10.00 ns |      9.36 ns |  1.33 |    0.00 |  0.1717 |      - |     - |     912 B |
+ | RemoveAllIteratively |        10 |     2,034.0 ns |      6.82 ns |      6.04 ns |  1.02 |    0.01 |  0.1106 |      - |     - |     592 B |
- |                Clear |        10 |     2,197.6 ns |      6.83 ns |      6.39 ns |  1.04 |    0.00 |  0.1717 |      - |     - |     912 B |
+ |                Clear |        10 |     1,900.8 ns |      9.95 ns |      9.31 ns |  0.95 |    0.01 |  0.1106 |      - |     - |     592 B |
- |             Contains |        10 |     2,247.2 ns |     11.62 ns |      9.70 ns |  1.06 |    0.01 |  0.1717 |      - |     - |     912 B |
+ |             Contains |        10 |     2,080.4 ns |     15.15 ns |     14.17 ns |  1.04 |    0.01 |  0.1106 |      - |     - |     592 B |
- |      AddAndEnumerate |        10 |     2,600.6 ns |     13.13 ns |     12.28 ns |  1.23 |    0.01 |  0.2441 |      - |     - |    1288 B |
+ |      AddAndEnumerate |        10 |     2,531.8 ns |      8.31 ns |      7.78 ns |  1.27 |    0.01 |  0.1831 |      - |     - |     968 B |
- |    ClearAndEnumerate |        10 |     2,254.7 ns |     10.05 ns |      8.91 ns |  1.07 |    0.00 |  0.1793 |      - |     - |     952 B |
+ |    ClearAndEnumerate |        10 |     2,163.0 ns |      8.98 ns |      7.96 ns |  1.09 |    0.01 |  0.1183 |      - |     - |     632 B |
  |                      |           |                |              |              |       |         |         |        |       |           |
- |                  Add |       100 |    19,778.3 ns |    104.54 ns |     97.79 ns |  1.00 |    0.00 |  1.4648 | 0.0305 |     - |    7816 B |
+ |                  Add |       100 |    18,310.8 ns |     47.99 ns |     40.08 ns |  1.00 |    0.00 |  0.8545 |      - |     - |    4616 B |
- |            RemoveOne |       100 |    20,493.9 ns |     75.55 ns |     66.98 ns |  1.04 |    0.00 |  1.4648 | 0.0305 |     - |    7816 B |
+ |            RemoveOne |       100 |    18,631.9 ns |     75.94 ns |     63.41 ns |  1.02 |    0.00 |  0.8545 |      - |     - |    4616 B |
- | RemoveAllIteratively |       100 |    65,360.0 ns |    442.37 ns |    369.40 ns |  3.31 |    0.03 |  1.4648 |      - |     - |    7817 B |
+ | RemoveAllIteratively |       100 |    25,841.5 ns |    113.80 ns |    106.45 ns |  1.41 |    0.01 |  0.8545 |      - |     - |    4616 B |
- |                Clear |       100 |    19,854.9 ns |    120.74 ns |    112.94 ns |  1.00 |    0.01 |  1.4648 | 0.0305 |     - |    7816 B |
+ |                Clear |       100 |    18,571.8 ns |    148.20 ns |    138.62 ns |  1.01 |    0.01 |  0.8545 |      - |     - |    4616 B |
- |             Contains |       100 |    20,325.3 ns |    105.46 ns |     93.49 ns |  1.03 |    0.01 |  1.4648 | 0.0305 |     - |    7816 B |
+ |             Contains |       100 |    19,442.2 ns |     83.24 ns |     73.79 ns |  1.06 |    0.00 |  0.8545 |      - |     - |    4616 B |
- |      AddAndEnumerate |       100 |    22,951.7 ns |     92.78 ns |     86.78 ns |  1.16 |    0.01 |  1.8921 | 0.0305 |     - |    9936 B |
+ |      AddAndEnumerate |       100 |    22,085.6 ns |     54.55 ns |     45.55 ns |  1.21 |    0.00 |  1.2817 |      - |     - |    6736 B |
- |    ClearAndEnumerate |       100 |    20,965.4 ns |     50.41 ns |     39.36 ns |  1.06 |    0.01 |  1.4954 |      - |     - |    7856 B |
+ |    ClearAndEnumerate |       100 |    19,383.7 ns |     95.07 ns |     84.28 ns |  1.06 |    0.01 |  0.8850 |      - |     - |    4656 B |
  |                      |           |                |              |              |       |         |         |        |       |           |
- |                  Add |      1000 |   195,476.5 ns |  1,213.61 ns |  1,075.83 ns |  1.00 |    0.00 | 13.6719 | 2.1973 |     - |   72625 B |
+ |                  Add |      1000 |   183,005.2 ns |    996.16 ns |    931.81 ns |  1.00 |    0.00 |  7.5684 | 0.7324 |     - |   40626 B |
- |            RemoveOne |      1000 |   206,709.4 ns |    693.86 ns |    649.04 ns |  1.06 |    0.01 | 13.6719 | 2.1973 |     - |   72625 B |
+ |            RemoveOne |      1000 |   188,839.3 ns |  1,077.40 ns |    955.08 ns |  1.03 |    0.01 |  7.5684 | 0.7324 |     - |   40625 B |
- | RemoveAllIteratively |      1000 | 4,190,885.5 ns | 17,533.29 ns | 15,542.80 ns | 21.44 |    0.15 |  7.8125 |      - |     - |   72658 B |
+ | RemoveAllIteratively |      1000 |   722,326.1 ns |  3,306.34 ns |  2,930.99 ns |  3.95 |    0.02 |  6.8359 |      - |     - |   40628 B |
- |                Clear |      1000 |   196,903.9 ns |  1,572.28 ns |  1,470.71 ns |  1.01 |    0.01 | 13.6719 | 1.7090 |     - |   72626 B |
+ |                Clear |      1000 |   183,834.1 ns |    544.80 ns |    482.95 ns |  1.00 |    0.00 |  7.5684 | 0.4883 |     - |   40624 B |
- |             Contains |      1000 |   202,510.0 ns |    823.07 ns |    687.30 ns |  1.04 |    0.01 | 13.6719 | 2.1973 |     - |   72625 B |
+ |             Contains |      1000 |   190,322.9 ns |    907.56 ns |    848.93 ns |  1.04 |    0.01 |  7.5684 | 0.7324 |     - |   40625 B |
- |      AddAndEnumerate |      1000 |   220,213.8 ns |    867.15 ns |    724.11 ns |  1.13 |    0.01 | 16.8457 | 2.6855 |     - |   89272 B |
+ |      AddAndEnumerate |      1000 |   209,937.1 ns |    437.88 ns |    365.65 ns |  1.15 |    0.01 | 10.7422 | 1.2207 |     - |   57273 B |
- |    ClearAndEnumerate |      1000 |   201,974.2 ns |    639.44 ns |    499.23 ns |  1.03 |    0.01 | 13.6719 | 1.4648 |     - |   72664 B |
+ |    ClearAndEnumerate |      1000 |   188,629.8 ns |  1,413.97 ns |  1,322.63 ns |  1.03 |    0.01 |  7.5684 | 0.4883 |     - |   40664 B |
```

Of particular note is the almost 600% performance improvement of `RemoveAllIteratively` for 1000 items and the general reduction in allocations in all scenarios. Note that `RemoveAllIteratively` is still an algorithmically-bad method, but that's to be expected (`List<>` will exhibit the same).

In terms of real-world improvements, exiting from gameplay on https://osu.ppy.sh/beatmapsets/121591#osu/311269 is now slightly faster:
https://streamable.com/w92sv (master) vs https://streamable.com/6leer (this). However since bindables are synchronously unbound on disposal, this would have a slight effect pretty much everywhere in the game.

The changes to the benchmark code are a little noteworthy. They attempt to bypass https://github.com/dotnet/BenchmarkDotNet/issues/994 - the JIT overhead is massive which pushes the operation count down to 1. The workarounds provided in there are not sufficient to resolve the issue, likely with the occurrence of .NET Core 3.0.