### PR TITLE
Expose alive children from Container

### DIFF
--- a/osu.Framework.Tests/Containers/TestSceneContainerState.cs
+++ b/osu.Framework.Tests/Containers/TestSceneContainerState.cs
@@ -272,6 +272,30 @@ namespace osu.Framework.Tests.Containers
             AddAssert("correct count", () => count == 2);
         }
 
+        [Test]
+        public void TestAliveChildrenContainsOnlyAliveChildren()
+        {
+            Container container = null;
+            Drawable aliveChild = null;
+            Drawable nonAliveChild = null;
+
+            AddStep("create container", () =>
+            {
+                Child = container = new Container
+                {
+                    Children = new[]
+                    {
+                        aliveChild = new Box(),
+                        nonAliveChild = new Box { LifetimeStart = double.MaxValue }
+                    }
+                };
+            });
+
+            AddAssert("1 alive child", () => container.AliveChildren.Count == 1);
+            AddAssert("alive child contained", () => container.AliveChildren.Contains(aliveChild));
+            AddAssert("non-alive child not contained", () => !container.AliveChildren.Contains(nonAliveChild));
+        }
+
         private class TestContainer : Container
         {
             public new void ScheduleAfterChildren(Action action) => SchedulerAfterChildren.AddDelayed(action, TransformDelay);

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -43,6 +43,11 @@ namespace osu.Framework.Graphics.Containers
                 internalChildrenAsT = (IReadOnlyList<T>)InternalChildren;
             else
                 internalChildrenAsT = new LazyList<Drawable, T>(InternalChildren, c => (T)c);
+
+            if (typeof(T) == typeof(Drawable))
+                aliveInternalChildrenAsT = (IReadOnlyList<T>)AliveInternalChildren;
+            else
+                aliveInternalChildrenAsT = new LazyList<Drawable, T>(AliveInternalChildren, c => (T)c);
         }
 
         /// <summary>
@@ -73,6 +78,21 @@ namespace osu.Framework.Graphics.Containers
                 return internalChildrenAsT;
             }
             set => ChildrenEnumerable = value;
+        }
+
+        /// <summary>
+        /// The publicly accessibly list of alive children. Forwards to the alive children of <see cref="Content"/>.
+        /// If <see cref="Content"/> is this container, then returns <see cref="CompositeDrawable.AliveInternalChildren"/>.
+        /// </summary>
+        public IReadOnlyList<T> AliveChildren
+        {
+            get
+            {
+                if (Content != this)
+                    return Content.AliveChildren;
+
+                return aliveInternalChildrenAsT;
+            }
         }
 
         /// <summary>
@@ -142,6 +162,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         private readonly IReadOnlyList<T> internalChildrenAsT;
+        private readonly IReadOnlyList<T> aliveInternalChildrenAsT;
 
         /// <summary>
         /// The index of a given child within <see cref="Children"/>.

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -81,7 +81,7 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// The publicly accessibly list of alive children. Forwards to the alive children of <see cref="Content"/>.
+        /// The publicly accessible list of alive children. Forwards to the alive children of <see cref="Content"/>.
         /// If <see cref="Content"/> is this container, then returns <see cref="CompositeDrawable.AliveInternalChildren"/>.
         /// </summary>
         public IReadOnlyList<T> AliveChildren


### PR DESCRIPTION
Useful for cases where you want to iterate over only alive children for performance reasons, e.g.:

https://github.com/ppy/osu/blob/ef735f106e0899fc11554b7d290d4c5bd1262323/osu.Game/Rulesets/UI/HitObjectContainer.cs#L16

https://github.com/ppy/osu/blob/ef735f106e0899fc11554b7d290d4c5bd1262323/osu.Game/Screens/Edit/Compose/Components/BlueprintContainer.cs#L484