### PR TITLE
Make tab control not change tabs when clicked in a disabled state

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -18,6 +18,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestSceneTabControl : FrameworkTestScene
     {
+        public override IReadOnlyList<Type> RequiredTypes => new[]
+        {
+            typeof(TabControl<>),
+            typeof(TabItem),
+            typeof(BasicTabControl<>),
+        };
+
         private readonly TestEnum[] items;
 
         private StyledTabControl pinnedAndAutoSort;
@@ -171,7 +178,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestDisabledBindable()
+        public void TestTabSelectedWhenDisabledBindableIsBound()
         {
             Bindable<TestEnum?> bindable;
 
@@ -194,9 +201,29 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
 
             AddAssert("test2 selected", () => simpleTabcontrol.SelectedTab.Value == TestEnum.Test2);
+        }
 
-            // Todo: Should not fail
-            // AddStep("click a tab", () => simpleTabcontrol.TabMap[TestEnum.Test0].Click());
+        [Test]
+        public void TestClicksBlockedWhenBindableDisabled()
+        {
+            Bindable<TestEnum?> bindable = null;
+
+            AddStep("add tabcontrol", () =>
+            {
+                Child = simpleTabcontrol = new StyledTabControl { Size = new Vector2(200, 30) };
+
+                foreach (var item in items)
+                    simpleTabcontrol.AddItem(item);
+
+                simpleTabcontrol.Current = bindable = new Bindable<TestEnum?>
+                {
+                    Value = TestEnum.Test0,
+                    Disabled = true
+                };
+            });
+
+            AddStep("click a tab", () => simpleTabcontrol.TabMap[TestEnum.Test2].Click());
+            AddAssert("test0 still selected", () => simpleTabcontrol.SelectedTab.Value == TestEnum.Test0);
         }
 
         [TestCase(true)]

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -206,8 +206,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestClicksBlockedWhenBindableDisabled()
         {
-            Bindable<TestEnum?> bindable = null;
-
             AddStep("add tabcontrol", () =>
             {
                 Child = simpleTabcontrol = new StyledTabControl { Size = new Vector2(200, 30) };
@@ -215,7 +213,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 foreach (var item in items)
                     simpleTabcontrol.AddItem(item);
 
-                simpleTabcontrol.Current = bindable = new Bindable<TestEnum?>
+                simpleTabcontrol.Current = new Bindable<TestEnum?>
                 {
                     Value = TestEnum.Test0,
                     Disabled = true

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -214,8 +214,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected virtual void AddTabItem(TabItem<T> tab, bool addToDropdown = true)
         {
             tab.PinnedChanged += performTabSort;
-
-            tab.ActivationRequested += SelectTab;
+            tab.ActivationRequested += activationRequested;
 
             tabMap[tab.Value] = tab;
             if (addToDropdown)
@@ -312,6 +311,14 @@ namespace osu.Framework.Graphics.UserInterface
             targetIndex = Math.Min(tabCount - 1, Math.Max(0, targetIndex));
 
             SelectTab(switchableTabs[targetIndex]);
+        }
+
+        private void activationRequested(TabItem<T> tab)
+        {
+            if (Current.Disabled)
+                return;
+
+            SelectTab(tab);
         }
 
         private void performTabSort(TabItem<T> tab)

--- a/osu.Framework/Graphics/UserInterface/TabItem.cs
+++ b/osu.Framework/Graphics/UserInterface/TabItem.cs
@@ -19,8 +19,9 @@ namespace osu.Framework.Graphics.UserInterface
     public abstract class TabItem<T> : TabItem
     {
         internal Action<TabItem<T>> ActivationRequested;
-
         internal Action<TabItem<T>> PinnedChanged;
+
+        public readonly BindableBool Active = new BindableBool();
 
         public override bool IsPresent => base.IsPresent || Y == 0;
 
@@ -37,15 +38,13 @@ namespace osu.Framework.Graphics.UserInterface
         {
             Value = value;
 
-            Active.ValueChanged += active_ValueChanged;
-        }
-
-        private void active_ValueChanged(ValueChangedEvent<bool> args)
-        {
-            if (args.NewValue)
-                OnActivated();
-            else
-                OnDeactivated();
+            Active.ValueChanged += active =>
+            {
+                if (active.NewValue)
+                    OnActivated();
+                else
+                    OnDeactivated();
+            };
         }
 
         private bool pinned;
@@ -64,8 +63,6 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected abstract void OnActivated();
         protected abstract void OnDeactivated();
-
-        public readonly BindableBool Active = new BindableBool();
 
         protected override bool OnClick(ClickEvent e)
         {


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/2659

Current weirdnesses (not caused by this PR):
1. The `Enabled` state of `TabItem`s isn't used as a precondition to invoking `ActivationRequested`. It can't be either, since `Enabled` is false by default (`TabItem`s aren't generally given an `Action`).
2. `TabItem`s are `ClickableContainer`s, meaning they invoke their own actions on click.
3. `TabItem`s have their own individual `Enabled` state.

All of these should probably not exist:
1. `TabItem` should probably be a `CompositeDrawable`.
2. `TabItem` should not have an `Enabled` state.
3. `TabItem` should not have/should not invoke its own `Action`.

But all of those are breaking changes and not done in this PR.