### PR TITLE
Make TabControl better return contained items

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -144,7 +144,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("Ensure first tab", () => switchingTabControl.Current.Value == switchingTabControl.VisibleItems.First());
 
             AddStep("Add all items", () => items.ForEach(item => removeAllTabControl.AddItem(item)));
-            AddAssert("Ensure all items", () => removeAllTabControl.Items.Count() == items.Length);
+            AddAssert("Ensure all items", () => removeAllTabControl.Items.Count == items.Length);
 
             AddStep("Remove all items", () => removeAllTabControl.Clear());
             AddAssert("Ensure no items", () => !removeAllTabControl.Items.Any());
@@ -223,6 +223,39 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
         }
 
+        [Test]
+        public void TestItemsImmediatelyUpdatedAfterAdd()
+        {
+            TabControlWithNoDropdown tabControl = null;
+
+            AddStep("create tab control", () =>
+            {
+                tabControl = new TabControlWithNoDropdown { Size = new Vector2(200, 30) };
+
+                foreach (var item in items)
+                    tabControl.AddItem(item);
+            });
+
+            AddAssert("contained items match added items", () => tabControl.Items.SequenceEqual(items));
+        }
+
+        [Test]
+        public void TestItemsAddedWhenSet()
+        {
+            TabControlWithNoDropdown tabControl = null;
+
+            AddStep("create tab control", () =>
+            {
+                tabControl = new TabControlWithNoDropdown
+                {
+                    Size = new Vector2(200, 30),
+                    Items = items
+                };
+            });
+
+            AddAssert("contained items match added items", () => tabControl.Items.SequenceEqual(items));
+        }
+
         private class StyledTabControlWithoutDropdown : TabControl<TestEnum>
         {
             protected override Dropdown<TestEnum> CreateDropdown() => null;
@@ -298,6 +331,11 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     new Box { Width = 20, Height = 20 }
                 };
             }
+        }
+
+        private class TabControlWithNoDropdown : BasicTabControl<TestEnum>
+        {
+            protected override Dropdown<TestEnum> CreateDropdown() => null;
         }
 
         private enum TestEnum

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -5,8 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
@@ -35,19 +35,22 @@ namespace osu.Framework.Graphics.UserInterface
             set => current.Current = value;
         }
 
+        private readonly List<T> items = new List<T>();
+
         /// <summary>
-        /// A list of items currently in the tab control in the order they are dispalyed.
+        /// The list of all items contained by this <see cref="TabControl{T}"/>.
         /// </summary>
-        public IEnumerable<T> Items
+        [NotNull]
+        public IReadOnlyList<T> Items
         {
-            get
+            get => items;
+            set
             {
-                var items = TabContainer.TabItems.Select(t => t.Value);
+                foreach (var item in items.ToList())
+                    RemoveItem(item);
 
-                if (Dropdown != null)
-                    items = items.Concat(Dropdown.Items).Distinct();
-
-                return items;
+                foreach (var item in value)
+                    AddItem(item);
             }
         }
 
@@ -61,8 +64,6 @@ namespace osu.Framework.Graphics.UserInterface
         protected Dropdown<T> Dropdown;
 
         protected readonly TabFillFlowContainer TabContainer;
-
-        protected IReadOnlyDictionary<T, TabItem<T>> TabMap => tabMap;
 
         protected TabItem<T> SelectedTab;
 
@@ -92,7 +93,9 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// A mapping of tabs to their items.
         /// </summary>
-        private readonly Dictionary<T, TabItem<T>> tabMap;
+        protected IReadOnlyDictionary<T, TabItem<T>> TabMap => tabMap;
+
+        private readonly Dictionary<T, TabItem<T>> tabMap = new Dictionary<T, TabItem<T>>();
 
         private bool firstSelection = true;
 
@@ -111,16 +114,17 @@ namespace osu.Framework.Graphics.UserInterface
 
                 Trace.Assert(Dropdown.Header.Anchor.HasFlag(Anchor.x2), $@"The {nameof(Dropdown)} implementation should use a right-based anchor inside a TabControl.");
                 Trace.Assert(!Dropdown.Header.RelativeSizeAxes.HasFlag(Axes.X), $@"The {nameof(Dropdown)} implementation's header should have a specific size.");
-
-                // create tab items for already existing items in dropdown (if any).
-                tabMap = Dropdown.Items.ToDictionary(item => item, item => addTab(item, false));
             }
-            else
-                tabMap = new Dictionary<T, TabItem<T>>();
 
             AddInternal(TabContainer = CreateTabFlow());
             TabContainer.TabVisibilityChanged = updateDropdown;
-            TabContainer.ChildrenEnumerable = tabMap.Values;
+
+            if (Dropdown != null)
+            {
+                // create tab items for already existing items in dropdown (if any).
+                foreach (var item in Dropdown.Items)
+                    addTab(item, false);
+            }
 
             Current.ValueChanged += _ => firstSelection = false;
         }
@@ -184,7 +188,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Removes all items from the control.
         /// </summary>
-        public void Clear() => tabMap.Keys.ToArray().ForEach(item => removeTab(item));
+        public void Clear() => Items = Array.Empty<T>();
 
         private TabItem<T> addTab(T value, bool addToDropdown = true)
         {
@@ -217,9 +221,12 @@ namespace osu.Framework.Graphics.UserInterface
 
             tab.ActivationRequested += SelectTab;
 
+            items.Add(tab.Value);
             tabMap[tab.Value] = tab;
+
             if (addToDropdown)
                 Dropdown?.AddDropdownItem(tab.Value);
+
             TabContainer.Add(tab);
         }
 
@@ -236,6 +243,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (tab == SelectedTab)
                 SelectedTab = null;
 
+            items.Remove(tab.Value);
             tabMap.Remove(tab.Value);
 
             if (removeFromDropdown)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/2813

It does make `Items` become ordered by addition order, but there's only one case osu!-side which relied on this, and arguably did so in a way that should be handled by `TabControl` itself (`ChannelTabControl`).

I'd say it's best to remove in favour of simplification and to fix the mentioned issue.