### PR TITLE
Make Bindable.Parse() support all .NET conversions

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -1,6 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 
@@ -25,6 +28,67 @@ namespace osu.Framework.Tests.Bindables
         public void TestConstructorValueUsedAsInitialValue()
         {
             Assert.That(new Bindable<int>(10).Value, Is.EqualTo(10));
+        }
+
+        [TestCaseSource(nameof(getParsingConversionTests))]
+        public void TestParse(Type type, object input, object output)
+        {
+            IBindable bindable = (IBindable)Activator.CreateInstance(typeof(Bindable<>).MakeGenericType(type), type == typeof(string) ? "" : Activator.CreateInstance(type));
+
+            bindable.Parse(input);
+            object value = bindable.GetType().GetProperty(nameof(Bindable<object>.Value), BindingFlags.Public | BindingFlags.Instance)?.GetValue(bindable);
+
+            Assert.That(value, Is.EqualTo(output));
+        }
+
+        private static IEnumerable<object[]> getParsingConversionTests()
+        {
+            var testTypes = new[]
+            {
+                typeof(bool),
+                typeof(short),
+                typeof(ushort),
+                typeof(int),
+                typeof(uint),
+                typeof(long),
+                typeof(ulong),
+                typeof(float),
+                typeof(double),
+                typeof(short),
+                typeof(ushort),
+                typeof(byte),
+                typeof(sbyte),
+                typeof(decimal),
+                typeof(string)
+            };
+
+            var inputs = new object[]
+            {
+                1, "1", 1.0, 1.0f, 1L, 1m,
+                1.5, "1.5", 1.5f, 1.5m,
+                -1, "-1", -1.0, -1.0f, -1L, -1m,
+                -1.5, "-1.5", -1.5f, -1.5m,
+            };
+
+            foreach (var type in testTypes)
+            {
+                foreach (var input in inputs)
+                {
+                    object expectedOutput = null;
+
+                    try
+                    {
+                        expectedOutput = Convert.ChangeType(input, type);
+                    }
+                    catch
+                    {
+                        // Not worried about invalid conversions - they'll never work by the base bindable anyway
+                    }
+
+                    if (expectedOutput != null)
+                        yield return new[] { type, input, expectedOutput };
+                }
+            }
         }
     }
 }

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -249,7 +250,7 @@ namespace osu.Framework.Bindables
                     break;
 
                 default:
-                    Value = (T)Convert.ChangeType(input, underlyingType);
+                    Value = (T)Convert.ChangeType(input, underlyingType, CultureInfo.InvariantCulture);
                     break;
             }
         }

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -237,23 +236,21 @@ namespace osu.Framework.Bindables
         /// <param name="input">The input which is to be parsed.</param>
         public virtual void Parse(object input)
         {
+            Type underlyingType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
             switch (input)
             {
                 case T t:
                     Value = t;
                     break;
 
-                case string s:
-                    var underlyingType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
-
-                    if (underlyingType.IsEnum)
-                        Value = (T)Enum.Parse(underlyingType, s);
-                    else
-                        Value = (T)Convert.ChangeType(s, underlyingType, CultureInfo.InvariantCulture);
+                case string s when underlyingType.IsEnum:
+                    Value = (T)Enum.Parse(underlyingType, s);
                     break;
 
                 default:
-                    throw new ArgumentException($@"Could not parse provided {input.GetType()} ({input}) to {typeof(T)}.");
+                    Value = (T)Convert.ChangeType(input, underlyingType);
+                    break;
             }
         }
 


### PR DESCRIPTION
In my usage, this failed when parsing a `long` as a `double`, even though it's a supported conversion type in .NET.

Enum parsing was/is tested in `BindableEnumTest`.