### PR TITLE
Return if BASS failed to initialize instead of throwing assert exception

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -245,7 +245,11 @@ namespace osu.Framework.Audio
                 InitBass(deviceIndex);
             }
 
-            Trace.Assert(Bass.LastError == Errors.OK);
+            if (Bass.LastError != Errors.OK)
+            {
+                Logger.Log($@"BASS failed to initialize with error code {Bass.LastError:D}: {Bass.LastError}.", LoggingTarget.Runtime, LogLevel.Important);
+                return false;
+            }
 
             Logger.Log($@"BASS Initialized
                           BASS Version:               {Bass.Version}


### PR DESCRIPTION
Helps investigating cause of #3176 
- Errors will be logged as `BASS failed to initialize with error code 0: Name.`.