### PR TITLE
Make OnDrag, OnDragEnd, and OnMouseUp return void instead of bool

### DIFF
--- a/osu.Framework.Tests/Visual/Audio/TestSceneSamples.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneSamples.cs
@@ -180,10 +180,9 @@ namespace osu.Framework.Tests.Visual.Audio
 
             protected override bool OnDragStart(DragStartEvent e) => true;
 
-            protected override bool OnDrag(DragEvent e)
+            protected override void OnDrag(DragEvent e)
             {
                 Y = (int)(e.MousePosition.Y / (Parent.DrawHeight / notes));
-                return true;
             }
 
             public void Reset()

--- a/osu.Framework.Tests/Visual/Audio/TestSceneTrackAdjustments.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneTrackAdjustments.cs
@@ -182,7 +182,7 @@ namespace osu.Framework.Tests.Visual.Audio
             private void updateLocal(ValueChangedEvent<double> obj) =>
                 textLocal.Text = $"local: vol {audio.Volume.Value:F1} freq {audio.Frequency.Value:F1} tempo {audio.Tempo.Value:F1} bal {audio.Balance.Value:F1}";
 
-            protected override bool OnDrag(DragEvent e)
+            protected override void OnDrag(DragEvent e)
             {
                 Position += e.Delta;
 
@@ -191,7 +191,6 @@ namespace osu.Framework.Tests.Visual.Audio
                     audio.Tempo.Value = 1 - Y / 100f;
                 else
                     audio.Frequency.Value = 1 - Y / 100f;
-                return true;
             }
 
             protected override bool OnScroll(ScrollEvent e)
@@ -206,7 +205,9 @@ namespace osu.Framework.Tests.Visual.Audio
                 spinner.Rotation += (float)(audio.AggregateFrequency.Value * Clock.ElapsedFrameTime);
             }
 
-            protected override bool OnDragEnd(DragEndEvent e) => true;
+            protected override void OnDragEnd(DragEndEvent e)
+            {
+            }
 
             protected override bool OnDragStart(DragStartEvent e) => true;
         }

--- a/osu.Framework.Tests/Visual/Audio/TestSceneTrackAdjustments.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneTrackAdjustments.cs
@@ -205,10 +205,6 @@ namespace osu.Framework.Tests.Visual.Audio
                 spinner.Rotation += (float)(audio.AggregateFrequency.Value * Clock.ElapsedFrameTime);
             }
 
-            protected override void OnDragEnd(DragEndEvent e)
-            {
-            }
-
             protected override bool OnDragStart(DragStartEvent e) => true;
         }
     }

--- a/osu.Framework.Tests/Visual/Containers/TestScenePadding.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestScenePadding.cs
@@ -240,10 +240,6 @@ namespace osu.Framework.Tests.Visual.Containers
                 Position += e.Delta;
             }
 
-            protected override void OnDragEnd(DragEndEvent e)
-            {
-            }
-
             protected override bool OnDragStart(DragStartEvent e) => true;
         }
     }

--- a/osu.Framework.Tests/Visual/Containers/TestScenePadding.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestScenePadding.cs
@@ -235,13 +235,14 @@ namespace osu.Framework.Tests.Visual.Containers
                 return base.Invalidate(invalidation, source, shallPropagate);
             }
 
-            protected override bool OnDrag(DragEvent e)
+            protected override void OnDrag(DragEvent e)
             {
                 Position += e.Delta;
-                return true;
             }
 
-            protected override bool OnDragEnd(DragEndEvent e) => true;
+            protected override void OnDragEnd(DragEndEvent e)
+            {
+            }
 
             protected override bool OnDragStart(DragStartEvent e) => true;
         }

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
@@ -1163,10 +1163,6 @@ namespace osu.Framework.Tests.Visual.Containers
             Position += e.Delta;
         }
 
-        protected override void OnDragEnd(DragEndEvent e)
-        {
-        }
-
         protected override bool OnDragStart(DragStartEvent e) => AllowDrag;
 
         public InfofulBox()

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
@@ -1141,15 +1141,16 @@ namespace osu.Framework.Tests.Visual.Containers
 
         public bool AllowDrag = true;
 
-        protected override bool OnDrag(DragEvent e)
+        protected override void OnDrag(DragEvent e)
         {
-            if (!AllowDrag) return false;
+            if (!AllowDrag) return;
 
             Position += e.Delta;
-            return true;
         }
 
-        protected override bool OnDragEnd(DragEndEvent e) => true;
+        protected override void OnDragEnd(DragEndEvent e)
+        {
+        }
 
         protected override bool OnDragStart(DragStartEvent e) => AllowDrag;
     }
@@ -1159,15 +1160,16 @@ namespace osu.Framework.Tests.Visual.Containers
         public bool Chameleon = false;
         public bool AllowDrag = true;
 
-        protected override bool OnDrag(DragEvent e)
+        protected override void OnDrag(DragEvent e)
         {
-            if (!AllowDrag) return false;
+            if (!AllowDrag) return;
 
             Position += e.Delta;
-            return true;
         }
 
-        protected override bool OnDragEnd(DragEndEvent e) => true;
+        protected override void OnDragEnd(DragEndEvent e)
+        {
+        }
 
         protected override bool OnDragStart(DragStartEvent e) => AllowDrag;
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
@@ -1148,10 +1148,6 @@ namespace osu.Framework.Tests.Visual.Containers
             Position += e.Delta;
         }
 
-        protected override void OnDragEnd(DragEndEvent e)
-        {
-        }
-
         protected override bool OnDragStart(DragStartEvent e) => AllowDrag;
     }
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
@@ -225,10 +225,9 @@ namespace osu.Framework.Tests.Visual.Drawables
                 return true;
             }
 
-            protected override bool OnMouseUp(MouseUpEvent e)
+            protected override void OnMouseUp(MouseUpEvent e)
             {
                 mouseDown = false;
-                return true;
             }
 
             protected override bool OnMouseMove(MouseMoveEvent e)

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -128,11 +128,11 @@ namespace osu.Framework.Tests.Visual.Input
 
             public int MouseUpCount;
 
-            protected override bool OnMouseUp(MouseUpEvent e)
+            protected override void OnMouseUp(MouseUpEvent e)
             {
                 ++MouseUpCount;
                 onMouseUpStatus.Text = $"OnMouseUp {MouseUpCount}: Position={e.MousePosition}, MouseDownPosition={e.MouseDownPosition}";
-                return base.OnMouseUp(e);
+                base.OnMouseUp(e);
             }
 
             public int MouseMoveCount;

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputResampler.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputResampler.cs
@@ -201,11 +201,11 @@ namespace osu.Framework.Tests.Visual.Input
                 return true;
             }
 
-            protected override bool OnDrag(DragEvent e)
+            protected override void OnDrag(DragEvent e)
             {
                 AddUserVertex(e.MousePosition);
                 DrawText.Text = "Custom Smoothed Drawn: Smoothed=" + NumVertices + ", Raw=" + NumRaw;
-                return base.OnDrag(e);
+                base.OnDrag(e);
             }
         }
 

--- a/osu.Framework.Tests/Visual/Input/TestSceneMouseStates.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneMouseStates.cs
@@ -600,10 +600,10 @@ namespace osu.Framework.Tests.Visual.Input
                     return base.OnMouseDown(e);
                 }
 
-                protected override bool OnMouseUp(MouseUpEvent e)
+                protected override void OnMouseUp(MouseUpEvent e)
                 {
                     adjustForMouseDown(e);
-                    return base.OnMouseUp(e);
+                    base.OnMouseUp(e);
                 }
 
                 private void adjustForMouseDown(MouseEvent e)

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneBufferedContainerView.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneBufferedContainerView.cs
@@ -129,10 +129,6 @@ namespace osu.Framework.Tests.Visual.Sprites
                 Position += e.Delta;
             }
 
-            protected override void OnDragEnd(DragEndEvent e)
-            {
-            }
-
             protected override bool OnDragStart(DragStartEvent e) => true;
         }
     }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneBufferedContainerView.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneBufferedContainerView.cs
@@ -124,13 +124,15 @@ namespace osu.Framework.Tests.Visual.Sprites
                 };
             }
 
-            protected override bool OnDrag(DragEvent e)
+            protected override void OnDrag(DragEvent e)
             {
                 Position += e.Delta;
-                return true;
             }
 
-            protected override bool OnDragEnd(DragEndEvent e) => true;
+            protected override void OnDragEnd(DragEndEvent e)
+            {
+            }
+
             protected override bool OnDragStart(DragStartEvent e) => true;
         }
     }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTriangles.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTriangles.cs
@@ -178,10 +178,6 @@ namespace osu.Framework.Tests.Visual.Sprites
             Position += e.Delta;
         }
 
-        protected override void OnDragEnd(DragEndEvent e)
-        {
-        }
-
         protected override bool OnDragStart(DragStartEvent e) => AllowDrag;
     }
 }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTriangles.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTriangles.cs
@@ -171,15 +171,16 @@ namespace osu.Framework.Tests.Visual.Sprites
     {
         public bool AllowDrag = true;
 
-        protected override bool OnDrag(DragEvent e)
+        protected override void OnDrag(DragEvent e)
         {
-            if (!AllowDrag) return false;
+            if (!AllowDrag) return;
 
             Position += e.Delta;
-            return true;
         }
 
-        protected override bool OnDragEnd(DragEndEvent e) => true;
+        protected override void OnDragEnd(DragEndEvent e)
+        {
+        }
 
         protected override bool OnDragStart(DragStartEvent e) => AllowDrag;
     }

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -284,7 +284,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override bool DragBlocksClick => dragBlocksClick;
 
-        protected override bool OnDrag(DragEvent e)
+        protected override void OnDrag(DragEvent e)
         {
             Trace.Assert(IsDragging, "We should never receive OnDrag if we are not dragging.");
 
@@ -314,10 +314,9 @@ namespace osu.Framework.Graphics.Containers
             dragBlocksClick |= Math.Abs(e.MouseDownPosition[ScrollDim] - e.MousePosition[ScrollDim]) > dragButtonManager.ClickDragDistance;
 
             offset(scrollOffset, false);
-            return true;
         }
 
-        protected override bool OnDragEnd(DragEndEvent e)
+        protected override void OnDragEnd(DragEndEvent e)
         {
             Trace.Assert(IsDragging, "We should never receive OnDragEnd if we are not dragging.");
 
@@ -326,7 +325,7 @@ namespace osu.Framework.Graphics.Containers
             IsDragging = false;
 
             if (averageDragTime <= 0.0)
-                return true;
+                return;
 
             double velocity = averageDragDelta / averageDragTime;
 
@@ -341,8 +340,6 @@ namespace osu.Framework.Graphics.Containers
             double distance = velocity / (1 - Math.Exp(-DistanceDecayDrag));
 
             offset((float)distance, true, DistanceDecayDrag);
-
-            return true;
         }
 
         protected override bool OnScroll(ScrollEvent e)
@@ -596,10 +593,9 @@ namespace osu.Framework.Graphics.Containers
                 return true;
             }
 
-            protected override bool OnDrag(DragEvent e)
+            protected override void OnDrag(DragEvent e)
             {
                 Dragged?.Invoke(e.MousePosition[(int)ScrollDirection] - dragOffset);
-                return true;
             }
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1870,7 +1870,8 @@ namespace osu.Framework.Graphics
                     return OnMouseDown(mouseDown);
 
                 case MouseUpEvent mouseUp:
-                    return OnMouseUp(mouseUp);
+                    OnMouseUp(mouseUp);
+                    return false;
 
                 case ClickEvent click:
                     return OnClick(click);
@@ -1882,10 +1883,12 @@ namespace osu.Framework.Graphics
                     return OnDragStart(dragStart);
 
                 case DragEvent drag:
-                    return OnDrag(drag);
+                    OnDrag(drag);
+                    return false;
 
                 case DragEndEvent dragEnd:
-                    return OnDragEnd(dragEnd);
+                    OnDragEnd(dragEnd);
+                    return false;
 
                 case ScrollEvent scroll:
                     return OnScroll(scroll);
@@ -1932,12 +1935,12 @@ namespace osu.Framework.Graphics
         }
 
         protected virtual bool OnMouseDown(MouseDownEvent e) => Handle(e);
-        protected virtual bool OnMouseUp(MouseUpEvent e) => Handle(e);
+        protected virtual void OnMouseUp(MouseUpEvent e) => Handle(e);
         protected virtual bool OnClick(ClickEvent e) => Handle(e);
         protected virtual bool OnDoubleClick(DoubleClickEvent e) => Handle(e);
         protected virtual bool OnDragStart(DragStartEvent e) => Handle(e);
-        protected virtual bool OnDrag(DragEvent e) => Handle(e);
-        protected virtual bool OnDragEnd(DragEndEvent e) => Handle(e);
+        protected virtual void OnDrag(DragEvent e) => Handle(e);
+        protected virtual void OnDragEnd(DragEndEvent e) => Handle(e);
         protected virtual bool OnScroll(ScrollEvent e) => Handle(e);
 
         protected virtual void OnFocus(FocusEvent e)

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -128,10 +128,9 @@ namespace osu.Framework.Graphics.UserInterface
             return true;
         }
 
-        protected override bool OnDrag(DragEvent e)
+        protected override void OnDrag(DragEvent e)
         {
             handleMouseInput(e);
-            return true;
         }
 
         protected override bool OnDragStart(DragStartEvent e)
@@ -148,11 +147,10 @@ namespace osu.Framework.Graphics.UserInterface
             return true;
         }
 
-        protected override bool OnDragEnd(DragEndEvent e)
+        protected override void OnDragEnd(DragEndEvent e)
         {
             handleMouseInput(e);
             commit();
-            return true;
         }
 
         protected override bool OnKeyDown(KeyDownEvent e)

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -721,7 +721,7 @@ namespace osu.Framework.Graphics.UserInterface
             return base.OnKeyUp(e);
         }
 
-        protected override bool OnDrag(DragEvent e)
+        protected override void OnDrag(DragEvent e)
         {
             //if (textInput?.ImeActive == true) return true;
 
@@ -751,7 +751,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
             else
             {
-                if (text.Length == 0) return true;
+                if (text.Length == 0) return;
 
                 selectionEnd = getCharacterClosestTo(e.MousePosition);
                 if (selectionLength > 0)
@@ -759,8 +759,6 @@ namespace osu.Framework.Graphics.UserInterface
 
                 cursorAndLayout.Invalidate();
             }
-
-            return true;
         }
 
         protected override bool OnDragStart(DragStartEvent e)
@@ -825,10 +823,9 @@ namespace osu.Framework.Graphics.UserInterface
             return false;
         }
 
-        protected override bool OnMouseUp(MouseUpEvent e)
+        protected override void OnMouseUp(MouseUpEvent e)
         {
             doubleClickWord = null;
-            return true;
         }
 
         protected override void OnFocusLost(FocusLostEvent e)

--- a/osu.Framework/Graphics/Visualisation/TitleBar.cs
+++ b/osu.Framework/Graphics/Visualisation/TitleBar.cs
@@ -67,10 +67,10 @@ namespace osu.Framework.Graphics.Visualisation
 
         protected override bool OnDragStart(DragStartEvent e) => true;
 
-        protected override bool OnDrag(DragEvent e)
+        protected override void OnDrag(DragEvent e)
         {
             movableTarget.Position += e.Delta;
-            return base.OnDrag(e);
+            base.OnDrag(e);
         }
 
         protected override bool OnMouseDown(MouseDownEvent e) => true;

--- a/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.Testing.Drawables.Steps
             currentNumber.SetDefault();
         }
 
-        protected override bool OnDragEnd(DragEndEvent e)
+        protected override void OnDragEnd(DragEndEvent e)
         {
             var flash = new Box
             {
@@ -80,7 +80,7 @@ namespace osu.Framework.Testing.Drawables.Steps
             flash.FadeOut(200).Expire();
 
             Success();
-            return base.OnDragEnd(e);
+            base.OnDragEnd(e);
         }
 
         protected override void UpdateValue(float normalizedValue)

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -187,7 +187,7 @@ namespace osu.Framework.Testing.Input
                     return base.OnMouseDown(e);
                 }
 
-                protected override bool OnMouseUp(MouseUpEvent e)
+                protected override void OnMouseUp(MouseUpEvent e)
                 {
                     switch (e.Button)
                     {
@@ -201,7 +201,7 @@ namespace osu.Framework.Testing.Input
                     }
 
                     updateBorder(e);
-                    return base.OnMouseUp(e);
+                    base.OnMouseUp(e);
                 }
 
                 protected override bool OnScroll(ScrollEvent e)


### PR DESCRIPTION
While working on a related fix, I found an issue relating to mouse input whereby a hierarchy that received mouse-down events may not receive mouse-up events if a drawable above them blocked it.

This isn't limited to `OnMouseUp`, but all mouse-release events (`OnMouseUp`, `OnDrag`, `OnDragEnd`), for lack of better naming.

I'm doing this only for mouse events for now since they're the only input events that are correctly. Key, joystick, and keybinding events are all broken in other ways (I'm working on fixing them). Those other events will be changed after said fixes have been applied.

Here's an example illustrating this, although this isn't really testable anymore (hence why I haven't added a test):

```csharp
[Test]
public void DoTest()
{
    var receptors = new InputReceptor[3];

    AddStep("setup", () =>
    {
        Children = new Drawable[]
        {
            receptors[0] = new InputReceptor
            {
                Size = new Vector2(100),
                MouseDown = () => true,
            },
            receptors[1] = new InputReceptor { Size = new Vector2(100) },
            receptors[2] = new InputReceptor
            {
                Size = new Vector2(100),
                MouseUp = () => true,
            }
        };
    });

    AddStep("move mouse to receptors", () => InputManager.MoveMouseTo(receptors[0]));
    AddStep("mousedown", () => InputManager.PressButton(MouseButton.Left));
    AddStep("mouseup", () => InputManager.ReleaseButton(MouseButton.Left));

    AddAssert("all received down", () => receptors.All(r => r.DownReceived)); // Passes
    AddAssert("0 received up", () => receptors[0].UpReceived); // Fails
    AddAssert("1 received up", () => receptors[1].UpReceived); // Fails
    AddAssert("2 received up", () => receptors[2].UpReceived); // Passes
}

private class InputReceptor : Box
{
    public bool DownReceived;
    public bool UpReceived;

    public Func<bool> MouseDown;
    public Func<bool> MouseUp;

    protected override bool OnMouseDown(MouseDownEvent e)
    {
        DownReceived = true;
        return MouseDown?.Invoke() ?? false;
    }

    protected override bool OnMouseUp(MouseUpEvent e)
    {
        UpReceived = true;
        return MouseUp?.Invoke() ?? false;
    }
}
```

# Breaking changes:

# vNext

## `OnDrag`, `OnDragEnd`, and `OnMouseUp` now return `void`

These events can no longer be blocked by other `Drawable`s in the hierarchy.

This guarantees that `Drawable`s that have received the respective `OnDragStart` and `OnMouseDown` events will receive accompanying `OnDrag`, `OnDragEnd` and `OnMouseUp` events