### PR TITLE
Make OnJoystickRelease return void instead of bool

### DIFF
--- a/osu.Framework.Tests/Input/JoystickInputTest.cs
+++ b/osu.Framework.Tests/Input/JoystickInputTest.cs
@@ -72,10 +72,10 @@ namespace osu.Framework.Tests.Input
                 return Press?.Invoke() ?? false;
             }
 
-            protected override bool OnJoystickRelease(JoystickReleaseEvent e)
+            protected override void OnJoystickRelease(JoystickReleaseEvent e)
             {
                 ReleaseReceived = true;
-                return Release?.Invoke() ?? false;
+                Release?.Invoke();
             }
         }
     }

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
@@ -341,10 +341,10 @@ namespace osu.Framework.Tests.Visual.Drawables
                 return base.OnJoystickPress(e);
             }
 
-            protected override bool OnJoystickRelease(JoystickReleaseEvent e)
+            protected override void OnJoystickRelease(JoystickReleaseEvent e)
             {
                 ++JoystickReleaseCount;
-                return base.OnJoystickRelease(e);
+                base.OnJoystickRelease(e);
             }
         }
     }

--- a/osu.Framework.Tests/Visual/Input/TestSceneJoystick.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneJoystick.cs
@@ -90,13 +90,15 @@ namespace osu.Framework.Tests.Visual.Input
                 return true;
             }
 
-            protected override bool OnJoystickRelease(JoystickReleaseEvent e)
+            protected override void OnJoystickRelease(JoystickReleaseEvent e)
             {
                 if (e.Button != button)
-                    return base.OnJoystickRelease(e);
+                {
+                    base.OnJoystickRelease(e);
+                    return;
+                }
 
                 background.FadeOut(100);
-                return true;
             }
         }
 
@@ -178,7 +180,7 @@ namespace osu.Framework.Tests.Visual.Input
                 return true;
             }
 
-            protected override bool OnJoystickRelease(JoystickReleaseEvent e)
+            protected override void OnJoystickRelease(JoystickReleaseEvent e)
             {
                 if (e.Button == JoystickButton.FirstHatUp + hatIndex)
                     upBox.FadeOut(100);
@@ -189,9 +191,7 @@ namespace osu.Framework.Tests.Visual.Input
                 else if (e.Button == JoystickButton.FirstHatRight + hatIndex)
                     rightBox.FadeOut(100);
                 else
-                    return base.OnJoystickRelease(e);
-
-                return true;
+                    base.OnJoystickRelease(e);
             }
         }
 
@@ -255,14 +255,12 @@ namespace osu.Framework.Tests.Visual.Input
                 return true;
             }
 
-            protected override bool OnJoystickRelease(JoystickReleaseEvent e)
+            protected override void OnJoystickRelease(JoystickReleaseEvent e)
             {
                 if (e.Button == positiveAxisButton || e.Button == negativeAxisButton)
                     background.FadeColour(new Color4(0, 0, 0, 0), 100, Easing.OutQuint);
                 else
-                    return base.OnJoystickRelease(e);
-
-                return true;
+                    base.OnJoystickRelease(e);
             }
         }
     }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1908,7 +1908,8 @@ namespace osu.Framework.Graphics
                     return OnJoystickPress(joystickPress);
 
                 case JoystickReleaseEvent joystickRelease:
-                    return OnJoystickRelease(joystickRelease);
+                    OnJoystickRelease(joystickRelease);
+                    return false;
 
                 default:
                     return Handle(e);
@@ -1953,7 +1954,7 @@ namespace osu.Framework.Graphics
         protected virtual bool OnKeyDown(KeyDownEvent e) => Handle(e);
         protected virtual bool OnKeyUp(KeyUpEvent e) => Handle(e);
         protected virtual bool OnJoystickPress(JoystickPressEvent e) => Handle(e);
-        protected virtual bool OnJoystickRelease(JoystickReleaseEvent e) => Handle(e);
+        protected virtual void OnJoystickRelease(JoystickReleaseEvent e) => Handle(e);
 
         #endregion
 


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/3194

# Breaking changes:

# vNext

## `OnJoystickRelease` now returns `void`

This event can no longer be blocked by other `Drawable`s in the hierarchy.

This guarantees that `Drawable`s that have received the respective `OnJoystickPress` event will receive accompanying `OnJoystickRelease` event.