### PR TITLE
Reorder text box characters depth after removal action

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -323,11 +324,114 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("text is empty", () => textBox.Text.Length == 0);
         }
 
+        /// <summary>
+        /// Removes first 2 characters and append them, this tests layout positioning of the characters in the text box.
+        /// </summary>
+        [Test]
+        public void TestRemoveAndAppend()
+        {
+            InsertableTextBox textBox = null;
+
+            AddStep("add textbox", () =>
+            {
+                textBoxes.Add(textBox = new InsertableTextBox
+                {
+                    Size = new Vector2(200, 40),
+                });
+            });
+
+            AddStep("focus textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("insert word", () => textBox.InsertString("eventext"));
+            AddStep("remove 2 letters", remove2FirstLetters);
+            AddStep("append string", () => textBox.AppendString("ev"));
+            AddStep("remove 2 letters", remove2FirstLetters);
+            AddStep("append string", () => textBox.AppendString("en"));
+            AddStep("remove 2 letters", remove2FirstLetters);
+            AddStep("append string", () => textBox.AppendString("te"));
+            AddStep("remove 2 letters", remove2FirstLetters);
+            AddStep("append string", () => textBox.AppendString("xt"));
+            AddAssert("is correct displayed text", () => textBox.FlowingText == "eventext" && textBox.FlowingText == textBox.Text);
+
+            void remove2FirstLetters()
+            {
+                textBox.MoveToStart();
+                textBox.DeleteNextCharacter();
+                textBox.DeleteNextCharacter();
+            }
+        }
+
+        /// <summary>
+        /// Removes last 2 characters and prepend them, this tests layout positioning of the characters in the text box.
+        /// </summary>
+        [Test]
+        public void TestRemoveAndPrepend()
+        {
+            InsertableTextBox textBox = null;
+
+            AddStep("add textbox", () =>
+            {
+                textBoxes.Add(textBox = new InsertableTextBox
+                {
+                    Size = new Vector2(200, 40),
+                });
+            });
+
+            AddStep("focus textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("insert word", () => textBox.InsertString("eventext"));
+            AddStep("remove 2 letters", remove2LastLetters);
+            AddStep("prepend string", () => textBox.PrependString("xt"));
+            AddStep("remove 2 letters", remove2LastLetters);
+            AddStep("prepend string", () => textBox.PrependString("te"));
+            AddStep("remove 2 letters", remove2LastLetters);
+            AddStep("prepend string", () => textBox.PrependString("en"));
+            AddStep("remove 2 letters", remove2LastLetters);
+            AddStep("prepend string", () => textBox.PrependString("ev"));
+            AddAssert("is correct displayed text", () => textBox.FlowingText == "eventext" && textBox.FlowingText == textBox.Text);
+
+            void remove2LastLetters()
+            {
+                textBox.MoveToEnd();
+                textBox.DeletePreviousCharacter();
+                textBox.DeletePreviousCharacter();
+            }
+        }
+
         private class InsertableTextBox : BasicTextBox
         {
+            /// <summary>
+            /// Returns the shown-in-screen text.
+            /// </summary>
+            public string FlowingText => string.Concat(TextFlow.FlowingChildren.OfType<FallingDownContainer>().Select(c => c.OfType<SpriteText>().Single().Text.ToString()[0]));
+
             public new void InsertString(string text) => base.InsertString(text);
 
+            public void PrependString(string text)
+            {
+                MoveToStart();
+                InsertString(text);
+            }
+
+            public void AppendString(string text)
+            {
+                MoveToEnd();
+                InsertString(text);
+            }
+
             public void MoveToStart() => OnPressed(new PlatformAction(PlatformActionType.LineStart, PlatformActionMethod.Move));
+            public void MoveToEnd() => OnPressed(new PlatformAction(PlatformActionType.LineEnd, PlatformActionMethod.Move));
+
+            public void DeletePreviousCharacter() => OnPressed(new PlatformAction(PlatformActionType.CharPrevious, PlatformActionMethod.Delete));
+            public void DeleteNextCharacter() => OnPressed(new PlatformAction(PlatformActionType.CharNext, PlatformActionMethod.Delete));
 
             public void DeletePreviousWord() => OnPressed(new PlatformAction(PlatformActionType.WordPrevious, PlatformActionMethod.Delete));
             public void DeleteNextWord() => OnPressed(new PlatformAction(PlatformActionType.WordNext, PlatformActionMethod.Delete));

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -347,22 +347,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
 
             AddStep("insert word", () => textBox.InsertString("eventext"));
-            AddStep("remove 2 letters", remove2FirstLetters);
+            AddStep("remove 2 letters", () => textBox.RemoveFirstCharacters(2));
             AddStep("append string", () => textBox.AppendString("ev"));
-            AddStep("remove 2 letters", remove2FirstLetters);
+            AddStep("remove 2 letters", () => textBox.RemoveFirstCharacters(2));
             AddStep("append string", () => textBox.AppendString("en"));
-            AddStep("remove 2 letters", remove2FirstLetters);
+            AddStep("remove 2 letters", () => textBox.RemoveFirstCharacters(2));
             AddStep("append string", () => textBox.AppendString("te"));
-            AddStep("remove 2 letters", remove2FirstLetters);
+            AddStep("remove 2 letters", () => textBox.RemoveFirstCharacters(2));
             AddStep("append string", () => textBox.AppendString("xt"));
             AddAssert("is correct displayed text", () => textBox.FlowingText == "eventext" && textBox.FlowingText == textBox.Text);
-
-            void remove2FirstLetters()
-            {
-                textBox.MoveToStart();
-                textBox.DeleteNextCharacter();
-                textBox.DeleteNextCharacter();
-            }
         }
 
         /// <summary>
@@ -388,22 +381,15 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
 
             AddStep("insert word", () => textBox.InsertString("eventext"));
-            AddStep("remove 2 letters", remove2LastLetters);
+            AddStep("remove 2 letters", () => textBox.RemoveLastCharacters(2));
             AddStep("prepend string", () => textBox.PrependString("xt"));
-            AddStep("remove 2 letters", remove2LastLetters);
+            AddStep("remove 2 letters", () => textBox.RemoveLastCharacters(2));
             AddStep("prepend string", () => textBox.PrependString("te"));
-            AddStep("remove 2 letters", remove2LastLetters);
+            AddStep("remove 2 letters", () => textBox.RemoveLastCharacters(2));
             AddStep("prepend string", () => textBox.PrependString("en"));
-            AddStep("remove 2 letters", remove2LastLetters);
+            AddStep("remove 2 letters", () => textBox.RemoveLastCharacters(2));
             AddStep("prepend string", () => textBox.PrependString("ev"));
             AddAssert("is correct displayed text", () => textBox.FlowingText == "eventext" && textBox.FlowingText == textBox.Text);
-
-            void remove2LastLetters()
-            {
-                textBox.MoveToEnd();
-                textBox.DeletePreviousCharacter();
-                textBox.DeletePreviousCharacter();
-            }
         }
 
         private class InsertableTextBox : BasicTextBox
@@ -425,6 +411,22 @@ namespace osu.Framework.Tests.Visual.UserInterface
             {
                 MoveToEnd();
                 InsertString(text);
+            }
+
+            public void RemoveFirstCharacters(int count)
+            {
+                MoveToStart();
+
+                for (int i = 0; i < count; i++)
+                    DeleteNextCharacter();
+            }
+
+            public void RemoveLastCharacters(int count)
+            {
+                MoveToEnd();
+
+                for (int i = 0; i < count; i++)
+                    DeletePreviousCharacter();
             }
 
             public void MoveToStart() => OnPressed(new PlatformAction(PlatformActionType.LineStart, PlatformActionMethod.Move));

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Caching;
 using osu.Framework.Graphics.Containers;
@@ -450,6 +451,10 @@ namespace osu.Framework.Graphics.UserInterface
 
             text = text.Remove(start, count);
 
+            // Reorder characters depth after removal to avoid ordering issues with newly added characters.
+            for (int i = 0; i < TextFlow.Count; i++)
+                TextFlow.ChangeChildDepth(TextFlow[i], -i);
+
             if (selectionLength > 0)
                 selectionStart = selectionEnd = selectionLeft;
             else
@@ -483,6 +488,9 @@ namespace osu.Framework.Graphics.UserInterface
             // Add the character
             Drawable ch = GetDrawableCharacter(c);
             ch.Depth = -selectionLeft;
+
+            // Assert no existing character has same depth as this to avoid ordering issues on a text box.
+            Trace.Assert(TextFlow.All(d => d.Depth != ch.Depth), $"The {nameof(TextFlow)} has more than one character with the same depth.");
 
             TextFlow.Add(ch);
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -489,9 +489,6 @@ namespace osu.Framework.Graphics.UserInterface
             Drawable ch = GetDrawableCharacter(c);
             ch.Depth = -selectionLeft;
 
-            // Assert no existing character has same depth as this to avoid ordering issues on a text box.
-            Trace.Assert(TextFlow.All(d => d.Depth != ch.Depth), $"The {nameof(TextFlow)} has more than one character with the same depth.");
-
             TextFlow.Add(ch);
 
             // Add back all the previously removed characters

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -452,7 +452,7 @@ namespace osu.Framework.Graphics.UserInterface
             text = text.Remove(start, count);
 
             // Reorder characters depth after removal to avoid ordering issues with newly added characters.
-            for (int i = 0; i < TextFlow.Count; i++)
+            for (int i = start; i < TextFlow.Count; i++)
                 TextFlow.ChangeChildDepth(TextFlow[i], -i);
 
             if (selectionLength > 0)

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Caching;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -454,7 +454,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             // Reorder characters depth after removal to avoid ordering issues with newly added characters.
             for (int i = start; i < TextFlow.Count; i++)
-                TextFlow.ChangeChildDepth(TextFlow[i], -i);
+                TextFlow.ChangeChildDepth(TextFlow[i], getDepthForCharacterIndex(i));
 
             if (selectionLength > 0)
                 selectionStart = selectionEnd = selectionLeft;
@@ -482,13 +482,13 @@ namespace osu.Framework.Graphics.UserInterface
             TextFlow.RemoveRange(charsRight);
 
             // Update their depth to make room for the to-be inserted character.
-            int i = -selectionLeft;
+            int i = selectionLeft;
             foreach (Drawable d in charsRight)
-                d.Depth = --i;
+                d.Depth = getDepthForCharacterIndex(i++);
 
             // Add the character
             Drawable ch = GetDrawableCharacter(c);
-            ch.Depth = -selectionLeft;
+            ch.Depth = getDepthForCharacterIndex(selectionLeft);
 
             TextFlow.Add(ch);
 
@@ -497,6 +497,8 @@ namespace osu.Framework.Graphics.UserInterface
 
             return ch;
         }
+
+        private float getDepthForCharacterIndex(int index) => -index;
 
         protected float CalculatedTextSize => TextFlow.DrawSize.Y - (TextFlow.Padding.Top + TextFlow.Padding.Bottom);
 


### PR DESCRIPTION
- This would fix cases where newly added text would conflict depths with existing ones which causes ordering and incorrect caret positioning issues.

Before reordering on removal:
![LhiDfdVxfD](https://user-images.githubusercontent.com/22781491/72769419-b4921200-3c0b-11ea-8729-181b2b8b2c53.gif)
After reordering on removal:
![7BL0OdBYjP](https://user-images.githubusercontent.com/22781491/72769441-c96ea580-3c0b-11ea-94f8-d7eecc0baa81.gif)


Closes #2904