### PR TITLE
Make IKeyBindingHandler<T>.OnRelease return void instead of bool

### DIFF
--- a/osu.Framework.Tests/Input/KeybindingInputTest.cs
+++ b/osu.Framework.Tests/Input/KeybindingInputTest.cs
@@ -99,10 +99,12 @@ namespace osu.Framework.Tests.Input
                 return true;
             }
 
-            public bool OnReleased(TestKeyBinding action)
+            public void OnReleased(TestKeyBinding action)
             {
+                if (!keybindings)
+                    return;
+
                 ReleasedReceived = true;
-                return keybindings;
             }
         }
 

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -61,10 +61,9 @@ namespace osu.Framework.Tests.Visual.Input
                 return true;
             }
 
-            public bool OnReleased(TestAction action)
+            public void OnReleased(TestAction action)
             {
                 Released?.Invoke(action);
-                return true;
             }
         }
 

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingInputQueueChange.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingInputQueueChange.cs
@@ -89,10 +89,9 @@ namespace osu.Framework.Tests.Visual.Input
                 return true;
             }
 
-            public bool OnReleased(TestAction action)
+            public void OnReleased(TestAction action)
             {
                 Released = true;
-                return true;
             }
         }
 

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -508,7 +508,7 @@ namespace osu.Framework.Tests.Visual.Input
                 return false;
             }
 
-            public bool OnReleased(TestAction action)
+            public void OnReleased(TestAction action)
             {
                 if (Action == action)
                 {
@@ -520,11 +520,7 @@ namespace osu.Framework.Tests.Visual.Input
 
                     alphaTarget -= 0.2f;
                     Background.Alpha = alphaTarget;
-
-                    return true;
                 }
-
-                return false;
             }
 
             public virtual void Reset()

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -285,7 +285,9 @@ namespace osu.Framework
             return false;
         }
 
-        public bool OnReleased(FrameworkAction action) => false;
+        public void OnReleased(FrameworkAction action)
+        {
+        }
 
         public void Exit()
         {

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -623,6 +623,8 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        public bool OnReleased(PlatformAction action) => false;
+        public void OnReleased(PlatformAction action)
+        {
+        }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -588,7 +588,9 @@ namespace osu.Framework.Graphics.UserInterface
                 }
             }
 
-            public bool OnReleased(PlatformAction action) => false;
+            public void OnReleased(PlatformAction action)
+            {
+            }
         }
 
         #endregion

--- a/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
+++ b/osu.Framework/Graphics/UserInterface/DropdownHeader.cs
@@ -115,7 +115,9 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        public bool OnReleased(PlatformAction action) => false;
+        public void OnReleased(PlatformAction action)
+        {
+        }
 
         public enum DropdownSelectionAction
         {

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -359,7 +359,9 @@ namespace osu.Framework.Graphics.UserInterface
             return false;
         }
 
-        public bool OnReleased(PlatformAction action) => false;
+        public void OnReleased(PlatformAction action)
+        {
+        }
 
         protected virtual TabFillFlowContainer CreateTabFlow() => new TabFillFlowContainer
         {

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -264,7 +264,9 @@ namespace osu.Framework.Graphics.UserInterface
             return false;
         }
 
-        public virtual bool OnReleased(PlatformAction action) => false;
+        public virtual void OnReleased(PlatformAction action)
+        {
+        }
 
         internal override void UpdateClock(IFrameBasedClock clock)
         {

--- a/osu.Framework/Input/Bindings/IKeyBindingHandler.cs
+++ b/osu.Framework/Input/Bindings/IKeyBindingHandler.cs
@@ -24,9 +24,7 @@ namespace osu.Framework.Input.Bindings
         /// Triggered when an action is released.
         /// </summary>
         /// <param name="action">The action.</param>
-        /// <returns>True if this Drawable handled the event. If false, then the event
-        /// is propagated up the scene graph to the next eligible Drawable.</returns>
-        bool OnReleased(T action);
+        void OnReleased(T action);
     }
 
     public interface IKeyBindingHandler : IDrawable

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -389,7 +389,9 @@ namespace osu.Framework.Testing
             return false;
         }
 
-        public bool OnReleased(TestBrowserAction action) => false;
+        public void OnReleased(TestBrowserAction action)
+        {
+        }
 
         public void LoadTest(Type testType = null, Action onCompletion = null, bool isDynamicLoad = false)
         {


### PR DESCRIPTION
I've re-implemented the same "remove subsequent drawables from input queue" from https://github.com/ppy/osu-framework/pull/3191, as a temporary measure to homogenise input handling.
`KeyBindingContainer` was already changed recently to correctly handle per-keybind input queues, so this was the only thing missing from it.

I've got a WIP branch (https://github.com/smoogipoo/osu-framework/tree/keybinding-event-manager) that attempts to use the new `ButtonEventManager` for keybindings, but the entirety of `KeyBindingContainer` needs to be re-thought instead because it's doing some weird stuff with keeping bindings in a pressed state while the underlying actions aren't pressed, etc. In conclusion, it's not a simple change.

The `OnReleased` method is probably a perfect candidate for a default implementation, but it's probably best to leave that to a future point just so that it causes compilation failures. Furthermore, Rider doesn't correctly auto-complete default implementations (https://youtrack.jetbrains.com/issue/RIDER-38340).

In a similar fashion to https://github.com/ppy/osu-framework/pull/3190, here's a demonstration of the failure case of the `bool` return (likewise, this is no longer testable after this PR so a test hasn't been added):
```csharp
[Test]
public void DoTest()
{
    var receptors = new InputReceptor[3];

    AddStep("setup", () =>
    {
        Child = new TestKeyBindingContainer
        {
            RelativeSizeAxes = Axes.Both,
            Children = new Drawable[]
            {
                receptors[0] = new InputReceptor
                {
                    Size = new Vector2(100),
                    Pressed = () => true,
                },
                receptors[1] = new InputReceptor { Size = new Vector2(100) },
                receptors[2] = new InputReceptor
                {
                    Size = new Vector2(100),
                    Released = () => true,
                }
            }
        };
    });

    AddStep("move mouse to receptors", () => InputManager.MoveMouseTo(receptors[0]));
    AddStep("press", () => InputManager.PressKey(Key.A));
    AddStep("release", () => InputManager.ReleaseKey(Key.A));

    AddAssert("all received pressed", () => receptors.All(r => r.PressedReceived)); // Passes
    AddAssert("0 received released", () => receptors[0].ReleasedReceived); // Fails
    AddAssert("1 received released", () => receptors[1].ReleasedReceived); // Fails
    AddAssert("2 received released", () => receptors[2].ReleasedReceived); // Passes
}

private class InputReceptor : Box, IKeyBindingHandler<TestKeyBind>
{
    public bool PressedReceived;
    public bool ReleasedReceived;

    public Func<bool> Pressed;
    public Func<bool> Released;

    public bool OnPressed(TestKeyBind action)
    {
        PressedReceived = true;
        return Pressed?.Invoke() ?? false;
    }

    public bool OnReleased(TestKeyBind action)
    {
        ReleasedReceived = true;
        return Released?.Invoke() ?? false;
    }
}

private class TestKeyBindingContainer : KeyBindingContainer<TestKeyBind>
{
    public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
    {
        new KeyBinding(InputKey.A, TestKeyBind.Binding1),
    };
}

private enum TestKeyBind
{
    Binding1
}
```

# Breaking changes:

# vNext

## `IKeyBindingHandler<T>.OnRelease` now returns `void`

This event can no longer be blocked by other `Drawable`s in the hierarchy.

This guarantees that `Drawable`s that have received the respective `OnPressed` event will receive an accompanying `OnReleased()` event.