### PR TITLE
Fix ScrollContainer null-reference on key repeat

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
@@ -9,6 +9,7 @@ using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osu.Framework.Testing;
 using osuTK;
@@ -258,6 +259,41 @@ namespace osu.Framework.Tests.Visual.Containers
             checkScrollbarPosition(250);
         }
 
+        [Test]
+        public void TestHandleKeyboardRepeatAfterRemoval()
+        {
+            AddStep("create scroll container", () =>
+            {
+                Add(scrollContainer = new RepeatCountingScrollContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(500),
+                    Child = new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Vertical,
+                        Children = new[]
+                        {
+                            new Box { Size = new Vector2(500) },
+                            new Box { Size = new Vector2(500) },
+                            new Box { Size = new Vector2(500) },
+                        }
+                    }
+                });
+            });
+
+            AddStep("move mouse to scroll container", () => InputManager.MoveMouseTo(scrollContainer));
+            AddStep("press page down and remove scroll container", () => InputManager.PressKey(Key.PageDown));
+            AddStep("remove scroll container", () =>
+            {
+                Remove(scrollContainer);
+                ((RepeatCountingScrollContainer)scrollContainer).RepeatCount = 0;
+            });
+
+            AddUntilStep("wait for repeats", () => ((RepeatCountingScrollContainer)scrollContainer).RepeatCount > 0);
+        }
+
         private void scrollIntoView(int index, float expectedPosition, float? heightAdjust = null, float? expectedPostAdjustPosition = null)
         {
             if (heightAdjust != null)
@@ -295,6 +331,19 @@ namespace osu.Framework.Tests.Visual.Containers
 
         private void checkScrollbarPosition(float expected) =>
             AddUntilStep($"scrollbar position at {expected}", () => Precision.AlmostEquals(expected, scrollContainer.InternalChildren[1].DrawPosition.Y, 1));
+
+        private class RepeatCountingScrollContainer : BasicScrollContainer
+        {
+            public int RepeatCount { get; set; }
+
+            protected override bool OnKeyDown(KeyDownEvent e)
+            {
+                if (e.Repeat)
+                    RepeatCount++;
+
+                return base.OnKeyDown(e);
+            }
+        }
 
         private class ClampedScrollbarScrollContainer : BasicScrollContainer
         {

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -147,7 +147,17 @@ namespace osu.Framework.Graphics.Containers
 
         protected virtual bool IsDragging { get; private set; }
 
-        public bool IsHandlingKeyboardScrolling => IsHovered || ReceivePositionalInputAt(GetContainingInputManager().CurrentState.Mouse.Position);
+        public bool IsHandlingKeyboardScrolling
+        {
+            get
+            {
+                if (IsHovered)
+                    return true;
+
+                InputManager inputManager = GetContainingInputManager();
+                return inputManager != null && ReceivePositionalInputAt(inputManager.CurrentState.Mouse.Position);
+            }
+        }
 
         /// <summary>
         /// The direction in which scrolling is supported.


### PR DESCRIPTION
Still not 100% sure about the underlying input `KeyEventManager` logic here - it changed from previous and now uses the same input queue rather than refreshing it every time.

Regardless, this method would've failed if referenced previously (it's a public API), so I think this is a required fix in any case.