### PR TITLE
Make OnKeyDown() repeats only occur on still-valid Drawables

### DIFF
--- a/osu.Framework.Tests/Input/KeyboardInputTest.cs
+++ b/osu.Framework.Tests/Input/KeyboardInputTest.cs
@@ -77,6 +77,7 @@ namespace osu.Framework.Tests.Input
             });
 
             AddStep("press key", () => InputManager.PressKey(Key.A));
+
             AddStep("remove receptor 0 & reset repeat", () =>
             {
                 Remove(receptors[0]);
@@ -115,6 +116,7 @@ namespace osu.Framework.Tests.Input
 
             AddUntilStep("wait for repeat on receptor 1", () => receptors[1].RepeatReceived);
             AddStep("add back receptor 0", () => Add(receptors[0]));
+
             AddUntilStep("wait for repeat on receptor 0", () => receptors[0].RepeatReceived);
         }
 

--- a/osu.Framework.Tests/Input/KeyboardInputTest.cs
+++ b/osu.Framework.Tests/Input/KeyboardInputTest.cs
@@ -59,8 +59,7 @@ namespace osu.Framework.Tests.Input
         }
 
         /// <summary>
-        /// Tests that if a drawable is removed from the hierarchy (or is otherwise removed from the input queues),
-        /// it won't receive an OnKeyDown() event for every subsequent repeat.
+        /// Tests that a drawable that is removed from the hierarchy (or is otherwise removed from the input queues) won't receive OnKeyDown() events for every subsequent repeat.
         /// </summary>
         [Test]
         public void TestNoLongerValidDrawableDoesNotReceiveRepeat()
@@ -77,6 +76,7 @@ namespace osu.Framework.Tests.Input
             });
 
             AddStep("press key", () => InputManager.PressKey(Key.A));
+            AddUntilStep("wait for repeat on receptor 0", () => receptors[0].RepeatReceived);
 
             AddStep("remove receptor 0 & reset repeat", () =>
             {
@@ -90,7 +90,8 @@ namespace osu.Framework.Tests.Input
         }
 
         /// <summary>
-        /// Tests that a drawable that was previously removed from the hierarchy receives OnKeyDown() for repeat events if the drawable previously received OnKeyDown().
+        /// Tests that a drawable that was previously removed from the hierarchy receives repeat OnKeyDown() events when re-added to the hierarchy,
+        /// if it previously received a non-repeat OnKeyDown() event.
         /// </summary>
         [Test]
         public void TestReValidatedDrawableReceivesRepeat()

--- a/osu.Framework.Tests/Input/MouseInputTest.cs
+++ b/osu.Framework.Tests/Input/MouseInputTest.cs
@@ -16,8 +16,7 @@ namespace osu.Framework.Tests.Input
     public class MouseInputTest : ManualInputManagerTestScene
     {
         /// <summary>
-        /// Tests that if a drawable is removed from the hierarchy (or is otherwise removed from the input queues),
-        /// it won't receive an OnClick() event on mouse up.
+        /// Tests that a drawable that is removed from the hierarchy (or is otherwise removed from the input queues) does not receive an OnClick() event on mouse up.
         /// </summary>
         [Test]
         public void TestNoLongerValidDrawableDoesNotReceiveClick()
@@ -43,7 +42,7 @@ namespace osu.Framework.Tests.Input
         }
 
         /// <summary>
-        /// Tests that a drawable that is removed and re-added to the hierarchy can still handle OnClick().
+        /// Tests that a drawable that is removed and re-added to the hierarchy still receives an OnClick() event.
         /// </summary>
         [Test]
         public void TestReValidatedDrawableReceivesClick()
@@ -69,6 +68,9 @@ namespace osu.Framework.Tests.Input
             AddAssert("receptor 0 received click", () => receptors[0].ClickReceived);
         }
 
+        /// <summary>
+        /// Tests that a drawable that is removed from the hierarchy (or is otherwise removed from the input queues) does not receive an OnDoubleClick() event.
+        /// </summary>
         [Test]
         public void TestNoLongerValidDrawableDoesNotReceiveDoubleClick()
         {

--- a/osu.Framework.Tests/Input/MouseInputTest.cs
+++ b/osu.Framework.Tests/Input/MouseInputTest.cs
@@ -85,6 +85,7 @@ namespace osu.Framework.Tests.Input
 
             AddStep("move mouse to receptor", () => InputManager.MoveMouseTo(receptor));
             AddStep("click", () => InputManager.Click(MouseButton.Left));
+
             AddStep("remove receptor and double click", () =>
             {
                 Remove(receptor); // Test correctness can be asserted by removing this line and ensuring the test fails

--- a/osu.Framework.Tests/Input/MouseInputTest.cs
+++ b/osu.Framework.Tests/Input/MouseInputTest.cs
@@ -1,0 +1,82 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Input.Events;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Tests.Input
+{
+    [HeadlessTest]
+    public class MouseInputTest : ManualInputManagerTestScene
+    {
+        /// <summary>
+        /// Tests that if a drawable is removed from the hierarchy (or is otherwise removed from the input queues),
+        /// it won't receive an OnClick() event on mouse up.
+        /// </summary>
+        [Test]
+        public void TestNoLongerValidDrawableDoesNotReceiveOnClick()
+        {
+            var receptors = new InputReceptor[3];
+
+            AddStep("create hierarchy", () =>
+            {
+                Children = new Drawable[]
+                {
+                    receptors[0] = new InputReceptor { Size = new Vector2(100) },
+                    receptors[1] = new InputReceptor { Size = new Vector2(100) }
+                };
+            });
+
+            AddStep("move mouse to receptors", () => InputManager.MoveMouseTo(receptors[0]));
+            AddStep("press button", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("remove receptor 0", () => Remove(receptors[0]));
+
+            AddStep("release button", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddAssert("receptor 0 did not receive click", () => !receptors[0].ClickReceived);
+        }
+
+        /// <summary>
+        /// Tests that a drawable that is removed and re-added to the hierarchy can still handle OnClick().
+        /// </summary>
+        [Test]
+        public void TestReValidatedDrawableReceivesOnClick()
+        {
+            var receptors = new InputReceptor[3];
+
+            AddStep("create hierarchy", () =>
+            {
+                Children = new Drawable[]
+                {
+                    receptors[0] = new InputReceptor { Size = new Vector2(100) },
+                    receptors[1] = new InputReceptor { Size = new Vector2(100) }
+                };
+            });
+
+            AddStep("move mouse to receptors", () => InputManager.MoveMouseTo(receptors[0]));
+            AddStep("press button", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("remove receptor 0", () => Remove(receptors[0]));
+            AddStep("add back receptor 0", () => Add(receptors[0]));
+
+            AddStep("release button", () => InputManager.ReleaseButton(MouseButton.Left));
+            AddAssert("receptor 0 received click", () => receptors[0].ClickReceived);
+        }
+
+        private class InputReceptor : Box
+        {
+            public bool ClickReceived { get; set; }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                ClickReceived = true;
+                return false;
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
@@ -291,7 +291,7 @@ namespace osu.Framework.Tests.Visual.Containers
                 ((RepeatCountingScrollContainer)scrollContainer).RepeatCount = 0;
             });
 
-            AddUntilStep("wait for repeats", () => ((RepeatCountingScrollContainer)scrollContainer).RepeatCount > 0);
+            AddWaitStep("wait for repeats", 5);
         }
 
         private void scrollIntoView(int index, float expectedPosition, float? heightAdjust = null, float? expectedPostAdjustPosition = null)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1971,7 +1971,8 @@ namespace osu.Framework.Graphics
         /// An event that occurs when a <see cref="MouseButton"/> is clicked on this <see cref="Drawable"/>.
         /// </summary>
         /// <remarks>
-        /// This can only be invoked if <see cref="OnMouseDown"/> was invoked, but invocation is not guaranteed.<br />
+        /// This can only be invoked on the <see cref="Drawable"/>s that received a previous <see cref="OnMouseDown"/> invocation
+        /// which are still present in the input queue (via <see cref="BuildPositionalInputQueue"/>) when the click occurs.<br />
         /// This will not occur if a drag was started (<see cref="OnDragStart"/> was invoked) or a double-click occurred (<see cref="OnDoubleClick"/> was invoked).
         /// </remarks>
         /// <param name="e">The <see cref="ClickEvent"/> containing information about the input event.</param>
@@ -2041,6 +2042,10 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// An event that occurs when a <see cref="Key"/> is pressed.
         /// </summary>
+        /// <remarks>
+        /// Repeat events can only be invoked on the <see cref="Drawable"/>s that received a previous non-repeat <see cref="OnKeyDown"/> invocation
+        /// which are still present in the input queue (via <see cref="BuildNonPositionalInputQueue"/>) when the repeat occurs.
+        /// </remarks>
         /// <param name="e">The <see cref="KeyDownEvent"/> containing information about the input event.</param>
         /// <returns>Whether to block the event from propagating to other <see cref="Drawable"/>s in the hierarchy.</returns>
         protected virtual bool OnKeyDown(KeyDownEvent e) => Handle(e);

--- a/osu.Framework/Input/KeyEventManager.cs
+++ b/osu.Framework/Input/KeyEventManager.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
@@ -19,7 +20,13 @@ namespace osu.Framework.Input
         {
         }
 
-        public void HandleRepeat(InputState state) => PropagateButtonEvent(ButtonDownInputQueue, new KeyDownEvent(state, Button, true));
+        public void HandleRepeat(InputState state)
+        {
+            // Only drawables that can still handle input should handle the repeat
+            var drawables = ButtonDownInputQueue.Intersect(InputQueue).Where(t => t.IsAlive && t.IsPresent);
+
+            PropagateButtonEvent(drawables, new KeyDownEvent(state, Button, true));
+        }
 
         protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new KeyDownEvent(state, Button));
 


### PR DESCRIPTION
Similar to the old behaviour. This is probably more expected behaviour from the framework considering that mouse buttons do the same thing on click.

It would also solve the issue presented in https://github.com/ppy/osu-framework/pull/3206, but that's still a valid PR.

Adds further test cases for these scenarios.