### PR TITLE
Only trim test from test methods

### DIFF
--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -454,22 +454,19 @@ namespace osu.Framework.Testing
 
             updateButtons();
 
-            var methods = newTest.GetType().GetMethods()
-                                 .Where(m =>
-                                     m.Name != nameof(TestScene.TestConstructor) &&
-                                     (m.GetCustomAttribute(typeof(TestAttribute), false) != null ||
-                                      m.GetCustomAttributes(typeof(TestCaseAttribute), false).Length > 0)
-                                 ).ToArray();
-
             var setUpMethods = newTest.GetRunnableMethodsFor(typeof(SetUpAttribute));
 
             bool hadTestAttributeTest = false;
 
-            string commonPrefix = methods.Select(m => m.Name).GetCommonPrefix();
-
-            foreach (var m in methods)
+            foreach (var m in newTest.GetType().GetMethods())
             {
-                var name = m.Name.Substring(commonPrefix.Length);
+                var name = m.Name;
+
+                if (name == nameof(TestScene.TestConstructor))
+                    continue;
+
+                if (name.StartsWith("Test"))
+                    name = name.Substring(4);
 
                 if (m.GetCustomAttribute(typeof(TestAttribute), false) != null)
                 {
@@ -488,7 +485,7 @@ namespace osu.Framework.Testing
                 foreach (var tc in m.GetCustomAttributes(typeof(TestCaseAttribute), false).OfType<TestCaseAttribute>())
                 {
                     hadTestAttributeTest = true;
-                    CurrentTest.AddLabel($"{m.Name}({string.Join(", ", tc.Arguments)})");
+                    CurrentTest.AddLabel($"{name}({string.Join(", ", tc.Arguments)})");
 
                     addSetUpSteps();
 


### PR DESCRIPTION
Previous merged method was a bit too aggressive, resulting in empty or illegible step names.