### PR TITLE
Consider grid cell content presence and lifetime when auto-sizing

### DIFF
--- a/osu.Framework.Tests/Visual/Layout/TestSceneGridContainer.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneGridContainer.cs
@@ -652,6 +652,86 @@ namespace osu.Framework.Tests.Visual.Layout
             AddAssert("content spans grid size", () => Precision.AlmostEquals(grid.DrawWidth, grid.Content[0].Sum(d => d.DrawWidth)));
         }
 
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestAutoSizedCellsWithTransparentContent(bool alwaysPresent)
+        {
+            AddStep("set content", () =>
+            {
+                grid.RowDimensions = new[]
+                {
+                    new Dimension(),
+                    new Dimension(),
+                    new Dimension(GridSizeMode.AutoSize)
+                };
+                grid.ColumnDimensions = new[]
+                {
+                    new Dimension(),
+                    new Dimension(GridSizeMode.AutoSize),
+                    new Dimension()
+                };
+                grid.Content = new[]
+                {
+                    new Drawable[] { new FillBox(), transparentBox(alwaysPresent), new FillBox() },
+                    new Drawable[] { new FillBox(), transparentBox(alwaysPresent), new FillBox() },
+                    new Drawable[] { transparentBox(alwaysPresent), transparentBox(alwaysPresent), transparentBox(alwaysPresent) }
+                };
+            });
+
+            float desiredTransparentBoxSize = alwaysPresent ? 50 : 0;
+            AddAssert("non-transparent fill boxes have correct size", () =>
+                grid.Content
+                    .SelectMany(row => row)
+                    .Where(box => box.Alpha > 0)
+                    .All(box => Precision.AlmostEquals(box.DrawWidth, (grid.DrawWidth - desiredTransparentBoxSize) / 2)
+                                && Precision.AlmostEquals(box.DrawHeight, (grid.DrawHeight - desiredTransparentBoxSize) / 2)));
+        }
+
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestAutoSizedColumnTransparentContent(bool row)
+        {
+            float getDimension(Drawable drawable) => row ? drawable.DrawHeight : drawable.DrawWidth;
+
+            var boxes = new FillBox[5];
+
+            var dimensions = new[]
+            {
+                new Dimension(GridSizeMode.Absolute, 100),
+                new Dimension(),
+                new Dimension(GridSizeMode.AutoSize),
+                new Dimension(GridSizeMode.Relative, 0.2f),
+                new Dimension()
+            };
+
+            setSingleDimensionContent(() => new[]
+            {
+                new Drawable[]
+                {
+                    boxes[0] = new FillBox(),
+                    boxes[1] = new FillBox(),
+                    boxes[2] = transparentBox(false),
+                    boxes[3] = new FillBox(),
+                    boxes[4] = new FillBox()
+                }
+            }.Invert(), dimensions, row);
+
+            AddAssert("box 0 has correct size", () => Precision.AlmostEquals(getDimension(boxes[0]), 100f));
+            AddAssert("box 1 has correct size", () =>
+                Precision.AlmostEquals(getDimension(boxes[1]), (getDimension(grid) * 0.8f - 100f) / 2));
+            AddAssert("box 3 has correct size", () => Precision.AlmostEquals(getDimension(boxes[3]), getDimension(grid) * 0.2f));
+            AddAssert("box 4 has correct size", () =>
+                Precision.AlmostEquals(getDimension(boxes[4]), (getDimension(grid) * 0.8f - 100f) / 2));
+        }
+
+        private FillBox transparentBox(bool alwaysPresent) => new FillBox
+        {
+            Alpha = 0,
+            AlwaysPresent = alwaysPresent,
+            RelativeSizeAxes = Axes.None,
+            Size = new Vector2(50)
+        };
+
         private void checkClampedSizes(bool row, FillBox[] boxes, Dimension[] dimensions)
         {
             AddAssert("sizes not over/underflowed", () =>

--- a/osu.Framework.Tests/Visual/Layout/TestSceneGridContainer.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneGridContainer.cs
@@ -689,7 +689,7 @@ namespace osu.Framework.Tests.Visual.Layout
 
         [TestCase(true)]
         [TestCase(false)]
-        public void TestAutoSizedColumnTransparentContent(bool row)
+        public void TestAutoSizedRowOrColumnWithTransparentContent(bool row)
         {
             float getDimension(Drawable drawable) => row ? drawable.DrawHeight : drawable.DrawWidth;
 

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -277,8 +277,9 @@ namespace osu.Framework.Graphics.Containers
             return sizes;
         }
 
-        private float getCellWidth(Drawable cell) => cell?.IsPresent == true ? cell.BoundingBox.Width : 0;
-        private float getCellHeight(Drawable cell) => cell?.IsPresent == true ? cell.BoundingBox.Height : 0;
+        private static bool shouldConsiderCell(Drawable cell) => cell != null && cell.IsAlive && cell.IsPresent;
+        private static float getCellWidth(Drawable cell) => shouldConsiderCell(cell) ? cell.BoundingBox.Width : 0;
+        private static float getCellHeight(Drawable cell) => shouldConsiderCell(cell) ? cell.BoundingBox.Height : 0;
 
         /// <summary>
         /// Distributes any available length along all distributed dimensions, if required.

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -258,13 +258,13 @@ namespace osu.Framework.Graphics.Containers
                         {
                             // Go through each row and get the width of the cell at the indexed column
                             for (int r = 0; r < cellRows; r++)
-                                size = Math.Max(size, Content[r]?[i]?.BoundingBox.Width ?? 0);
+                                size = Math.Max(size, getCellWidth(Content[r]?[i]));
                         }
                         else
                         {
                             // Go through each column and get the height of the cell at the indexed row
                             for (int c = 0; c < cellColumns; c++)
-                                size = Math.Max(size, Content[i]?[c]?.BoundingBox.Height ?? 0);
+                                size = Math.Max(size, getCellHeight(Content[i]?[c]));
                         }
 
                         sizes[i] = size;
@@ -276,6 +276,9 @@ namespace osu.Framework.Graphics.Containers
 
             return sizes;
         }
+
+        private float getCellWidth(Drawable cell) => cell?.IsPresent == true ? cell.BoundingBox.Width : 0;
+        private float getCellHeight(Drawable cell) => cell?.IsPresent == true ? cell.BoundingBox.Height : 0;
 
         /// <summary>
         /// Distributes any available length along all distributed dimensions, if required.


### PR DESCRIPTION
Resolves #3214.

# Summary

If a `GridContainer` cell's content is not present and alive at the time of update, do not consider its bounding box dimensions and assume 0 instead.

# Remarks

Various test cases attached, also including setting `IsPresent = true` in addition to `Alpha = 0` to make sure that case still behaves as desired. Can expand if coverage is deemed insufficient.