### PR TITLE
Fix culture dependence in bindable conversion test

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Reflection;
 using NUnit.Framework;
 using osu.Framework.Bindables;
@@ -78,7 +79,7 @@ namespace osu.Framework.Tests.Bindables
 
                     try
                     {
-                        expectedOutput = Convert.ChangeType(input, type);
+                        expectedOutput = Convert.ChangeType(input, type, CultureInfo.InvariantCulture);
                     }
                     catch
                     {


### PR DESCRIPTION
# Summary

Running `dotnet test` locally rather than via AppVeyor on a fork has revealed that the bindable conversion test was dependent on current system culture due to `Convert.ChangeType` being culture-aware (test failure message complained of a decimal comma instead of a decimal point). Resolve the dependence by passing invariant culture to the `ChangeType` call.

# Remarks

Only noticed this because you can't push only to the fork when updating an existing PR (#3226, to be exact), so I wanted to run tests locally before pushing again and found this in the process.