### PR TITLE
Add BindTarget to IBindable and implementations

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -49,6 +49,30 @@ namespace osu.Framework.Tests.Bindables
 
         #endregion
 
+        #region BindTarget
+
+        /// <summary>
+        /// Tests binding via the various <see cref="BindableList{T}.BindTarget"/> methods.
+        /// </summary>
+        [Test]
+        public void TestBindViaBindTarget()
+        {
+            BindableList<int> parentBindable = new BindableList<int>();
+
+            BindableList<int> bindable1 = new BindableList<int>();
+            IBindableList<int> bindable2 = new BindableList<int>();
+
+            bindable1.BindTarget = parentBindable;
+            bindable2.BindTarget = parentBindable;
+
+            parentBindable.Add(5);
+
+            Assert.That(bindable1[0], Is.EqualTo(5));
+            Assert.That(bindable2[0], Is.EqualTo(5));
+        }
+
+        #endregion
+
         #region list[index]
 
         [Test]

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -30,6 +30,30 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(new Bindable<int>(10).Value, Is.EqualTo(10));
         }
 
+        /// <summary>
+        /// Tests binding via the various <see cref="Bindable{T}.BindTarget"/> methods.
+        /// </summary>
+        [Test]
+        public void TestBindViaBindTarget()
+        {
+            Bindable<int> parentBindable = new Bindable<int>();
+
+            Bindable<int> bindable1 = new Bindable<int>();
+            IBindable<int> bindable2 = new Bindable<int>();
+            IBindable bindable3 = new Bindable<int>();
+
+            bindable1.BindTarget = parentBindable;
+            bindable2.BindTarget = parentBindable;
+            bindable3.BindTarget = parentBindable;
+
+            parentBindable.Value = 5;
+            parentBindable.Disabled = true;
+
+            Assert.That(bindable1.Value, Is.EqualTo(5));
+            Assert.That(bindable2.Value, Is.EqualTo(5));
+            Assert.That(bindable3.Disabled, Is.True); // Only have access to disabled
+        }
+
         [TestCaseSource(nameof(getParsingConversionTests))]
         public void TestParse(Type type, object input, object output)
         {

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -160,11 +160,6 @@ namespace osu.Framework.Bindables
             BindTo(tThem);
         }
 
-        IBindable IBindable.BindTarget
-        {
-            set => ((IBindable)this).BindTo(value);
-        }
-
         void IBindable<T>.BindTo(IBindable<T> them)
         {
             if (!(them is Bindable<T> tThem))

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -160,6 +160,11 @@ namespace osu.Framework.Bindables
             BindTo(tThem);
         }
 
+        IBindable IBindable.BindTarget
+        {
+            set => ((IBindable)this).BindTo(value);
+        }
+
         void IBindable<T>.BindTo(IBindable<T> them)
         {
             if (!(them is Bindable<T> tThem))
@@ -172,9 +177,9 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        public Bindable<T> BindTarget
+        public IBindable<T> BindTarget
         {
-            set => BindTo(value);
+            set => ((IBindable<T>)this).BindTo(value);
         }
 
         /// <summary>

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -536,6 +536,15 @@ namespace osu.Framework.Bindables
         }
 
         /// <summary>
+        /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
+        /// Passes the provided value as the foreign (more permanent) bindable.
+        /// </summary>
+        public BindableList<T> BindTarget
+        {
+            set => BindTo(value);
+        }
+
+        /// <summary>
         /// Binds this <see cref="BindableList{T}"/> to another.
         /// </summary>
         /// <param name="them">The <see cref="BindableList{T}"/> to be bound to.</param>

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -527,11 +527,6 @@ namespace osu.Framework.Bindables
             BindTo(tThem);
         }
 
-        IBindable IBindable.BindTarget
-        {
-            set => ((IBindable)this).BindTarget = value;
-        }
-
         void IBindableList<T>.BindTo(IBindableList<T> them)
         {
             if (!(them is BindableList<T> tThem))

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -527,6 +527,11 @@ namespace osu.Framework.Bindables
             BindTo(tThem);
         }
 
+        IBindable IBindable.BindTarget
+        {
+            set => ((IBindable)this).BindTarget = value;
+        }
+
         void IBindableList<T>.BindTo(IBindableList<T> them)
         {
             if (!(them is BindableList<T> tThem))
@@ -539,9 +544,9 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        public BindableList<T> BindTarget
+        public IBindableList<T> BindTarget
         {
-            set => BindTo(value);
+            set => ((IBindableList<T>)this).BindTo(value);
         }
 
         /// <summary>

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -20,7 +20,10 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        public IBindable BindTarget { set; }
+        public IBindable BindTarget
+        {
+            set => BindTo(value);
+        }
 
         /// <summary>
         /// Retrieve a new bindable instance weakly bound to the configuration backing.
@@ -62,7 +65,10 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        public new IBindable<T> BindTarget { set; }
+        public new IBindable<T> BindTarget
+        {
+            set => BindTo(value);
+        }
 
         /// <summary>
         /// Bind an action to <see cref="ValueChanged"/> with the option of running the bound action once immediately.

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        public IBindable BindTarget
+        public sealed IBindable BindTarget
         {
             set => BindTo(value);
         }
@@ -65,7 +65,7 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        public new IBindable<T> BindTarget
+        new IBindable<T> BindTarget
         {
             set => BindTo(value);
         }

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -17,6 +17,12 @@ namespace osu.Framework.Bindables
         void BindTo(IBindable them);
 
         /// <summary>
+        /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
+        /// Passes the provided value as the foreign (more permanent) bindable.
+        /// </summary>
+        public IBindable BindTarget { set; }
+
+        /// <summary>
         /// Retrieve a new bindable instance weakly bound to the configuration backing.
         /// If you are further binding to events of a bindable retrieved using this method, ensure to hold
         /// a local reference.
@@ -51,6 +57,12 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
         void BindTo(IBindable<T> them);
+
+        /// <summary>
+        /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
+        /// Passes the provided value as the foreign (more permanent) bindable.
+        /// </summary>
+        public new IBindable<T> BindTarget { set; }
 
         /// <summary>
         /// Bind an action to <see cref="ValueChanged"/> with the option of running the bound action once immediately.

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        new IBindableList<T> BindTarget
+        new sealed IBindableList<T> BindTarget
         {
             set => BindTo(value);
         }

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -29,6 +29,12 @@ namespace osu.Framework.Bindables
         void BindTo(IBindableList<T> them);
 
         /// <summary>
+        /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
+        /// Passes the provided value as the foreign (more permanent) bindable.
+        /// </summary>
+        new IBindableList<T> BindTarget { set; }
+
+        /// <summary>
         /// Retrieve a new bindable instance weakly bound to the configuration backing.
         /// If you are further binding to events of a bindable retrieved using this method, ensure to hold
         /// a local reference.

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -32,7 +32,10 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        new IBindableList<T> BindTarget { set; }
+        new IBindableList<T> BindTarget
+        {
+            set => BindTo(value);
+        }
 
         /// <summary>
         /// Retrieve a new bindable instance weakly bound to the configuration backing.


### PR DESCRIPTION
quick and easy.

* Closes #3212.
* Closes #3213.

# Breaking changes

## `IBindable.BindTarget` has been added

`BindTarget` has been added as a convenience setter-only property, which is intended to be an alias for `BindTo` in object initializer scenarios.