### PR TITLE
Fix ManualInputManager incorrectly starting in wrong input mode

### DIFF
--- a/osu.Framework/Testing/ManualInputManagerTestScene.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestScene.cs
@@ -121,7 +121,6 @@ namespace osu.Framework.Testing
         /// </summary>
         protected void ResetInput()
         {
-            InputManager.UseParentInput = true;
             var currentState = InputManager.CurrentState;
 
             var mouse = currentState.Mouse;
@@ -133,6 +132,8 @@ namespace osu.Framework.Testing
 
             var joystick = currentState.Joystick;
             joystick.Buttons.ForEach(InputManager.ReleaseJoystickButton);
+
+            InputManager.UseParentInput = true;
         }
 
         private void returnUserInput() =>


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu-framework/pull/3204.