### PR TITLE
Fix test methods potentially being duplicated

### DIFF
--- a/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTest.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTest.cs
@@ -1,17 +1,20 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
+using osu.Framework.Testing;
+
 namespace osu.Framework.Tests.Visual.Testing
 {
     public class TestSceneDerivedTest : TestSceneTest
     {
-        // ReSharper disable once RedundantOverriddenMember
+        [SetUp]
         public override void SetUp() => base.SetUp();
 
-        // ReSharper disable once RedundantOverriddenMember
+        [SetUpSteps]
         public override void SetUpSteps() => base.SetUpSteps();
 
-        // ReSharper disable once RedundantOverriddenMember
+        [TearDownSteps]
         public override void TearDownSteps() => base.TearDownSteps();
     }
 }

--- a/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethods.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethods.cs
@@ -1,20 +1,17 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using NUnit.Framework;
-using osu.Framework.Testing;
-
 namespace osu.Framework.Tests.Visual.Testing
 {
-    public class TestSceneDerivedTest : TestSceneTest
+    public class TestSceneDerivedTestWithDerivedMethods : TestSceneTest
     {
-        [SetUp]
+        // ReSharper disable once RedundantOverriddenMember
         public override void SetUp() => base.SetUp();
 
-        [SetUpSteps]
+        // ReSharper disable once RedundantOverriddenMember
         public override void SetUpSteps() => base.SetUpSteps();
 
-        [TearDownSteps]
+        // ReSharper disable once RedundantOverriddenMember
         public override void TearDownSteps() => base.TearDownSteps();
     }
 }

--- a/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethodsWithAttributes.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethodsWithAttributes.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual.Testing
+{
+    public class TestSceneDerivedTestWithOverriddenTestMethodsWithCustomAttributes : TestSceneTest
+    {
+        [SetUp]
+        public override void SetUp() => base.SetUp();
+
+        [SetUpSteps]
+        public override void SetUpSteps() => base.SetUpSteps();
+
+        [TearDownSteps]
+        public override void TearDownSteps() => base.TearDownSteps();
+    }
+}

--- a/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethodsWithAttributes.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedMethodsWithAttributes.cs
@@ -6,7 +6,7 @@ using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.Testing
 {
-    public class TestSceneDerivedTestWithOverriddenTestMethodsWithCustomAttributes : TestSceneTest
+    public class TestSceneDerivedTestWithDerivedMethodsWithAttributes : TestSceneTest
     {
         [SetUp]
         public override void SetUp() => base.SetUp();

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -29,6 +30,7 @@ using osu.Framework.Timing;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
+using Logger = osu.Framework.Logging.Logger;
 
 namespace osu.Framework.Testing
 {
@@ -454,7 +456,7 @@ namespace osu.Framework.Testing
 
             updateButtons();
 
-            var setUpMethods = newTest.GetRunnableMethodsFor(typeof(SetUpAttribute));
+            var setUpMethods = Reflect.GetMethodsWithAttribute(newTest.GetType(), typeof(SetUpAttribute), true);
 
             bool hadTestAttributeTest = false;
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -22,7 +22,6 @@ using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.IO.Stores;
-using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Testing.Drawables;
 using osu.Framework.Testing.Drawables.Steps;

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using NUnit.Framework;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
@@ -375,27 +374,14 @@ namespace osu.Framework.Testing
 
         internal void RunSetUpSteps()
         {
-            foreach (var method in GetRunnableMethodsFor(typeof(SetUpStepsAttribute)))
+            foreach (var method in Reflect.GetMethodsWithAttribute(GetType(), typeof(SetUpStepsAttribute), true))
                 method.Invoke(this, null);
         }
 
         internal void RunTearDownSteps()
         {
-            foreach (var method in GetRunnableMethodsFor(typeof(TearDownStepsAttribute)))
+            foreach (var method in Reflect.GetMethodsWithAttribute(GetType(), typeof(TearDownStepsAttribute), true))
                 method.Invoke(this, null);
-        }
-
-        internal ICollection<MethodInfo> GetRunnableMethodsFor(Type attributeType)
-        {
-            var methods = new List<MethodInfo>();
-
-            foreach (var type in GetType().EnumerateBaseTypes())
-                methods.AddRange(type.GetMethods().Where(m => m.DeclaringType == type && m.GetCustomAttributes(attributeType, false).Length > 0));
-
-            // To match NUnit, methods should be invoked from base classes before derived classes
-            methods.Reverse();
-
-            return methods;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/3234

Uses internal nunit method to determine the methods to invoke, which is also used by their own code:

https://github.com/nunit/nunit/blob/c7df8ecb5fe8cbcbe26eb2c34e906452bedb77a4/src/NUnitFramework/framework/Internal/Tests/TestFixture.cs#L43-L46