### PR TITLE
Fix drawables potentially becoming disposed during an async load

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -154,7 +154,7 @@ namespace osu.Framework.Graphics.Containers
 
             var taskScheduler = components.Any(c => c.IsLongRunning) ? long_load_scheduler : threaded_scheduler;
 
-            return Task.Factory.StartNew(() => loadComponents(components, deps, true, linkedSource.Token), linkedSource.Token, TaskCreationOptions.HideScheduler, taskScheduler).ContinueWith(t =>
+            return Task.Factory.StartNew(() => loadComponents(ref components, deps, true, linkedSource.Token), linkedSource.Token, TaskCreationOptions.HideScheduler, taskScheduler).ContinueWith(t =>
             {
                 var exception = t.Exception?.AsSingular();
 
@@ -199,17 +199,18 @@ namespace osu.Framework.Graphics.Containers
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString());
 
-            loadComponents(components, Dependencies, false);
+            loadComponents(ref components, Dependencies, false);
         }
 
-        private void loadComponents<TLoadable>(IEnumerable<TLoadable> components, IReadOnlyDependencyContainer dependencies, bool isDirectAsyncContext, CancellationToken cancellation = default) where TLoadable : Drawable
+        private void loadComponents<TLoadable>(ref IEnumerable<TLoadable> components, IReadOnlyDependencyContainer dependencies, bool isDirectAsyncContext, CancellationToken cancellation = default) where TLoadable : Drawable
         {
             foreach (var c in components)
             {
                 if (cancellation.IsCancellationRequested)
                     return;
 
-                c.Load(Clock, dependencies, isDirectAsyncContext);
+                if (!c.LoadFromAsync(Clock, dependencies, isDirectAsyncContext))
+                    components = components.Except(c.Yield());
             }
         }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -214,6 +214,26 @@ namespace osu.Framework.Graphics
         private static double getPerfTime() => perf.CurrentTime;
 
         /// <summary>
+        /// Load this drawable from an async context.
+        /// Because we can't be sure of the disposal state, it is returned as a bool rather than thrown as in <see cref="Load"/>.
+        /// </summary>
+        /// <param name="clock">The clock we should use by default.</param>
+        /// <param name="dependencies">The dependency tree we will inherit by default. May be extended via <see cref="CompositeDrawable.CreateChildDependencies"/></param>
+        /// <param name="isDirectAsyncContext">Whether this call is being executed from a directly async context (not a parent).</param>
+        /// <returns>Whether the load was successful.</returns>
+        internal bool LoadFromAsync(IFrameBasedClock clock, IReadOnlyDependencyContainer dependencies, bool isDirectAsyncContext = false)
+        {
+            lock (loadLock)
+            {
+                if (IsDisposed)
+                    return false;
+
+                Load(clock, dependencies, isDirectAsyncContext);
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Loads this drawable, including the gathering of dependencies and initialisation of required resources.
         /// </summary>
         /// <param name="clock">The clock we should use by default.</param>


### PR DESCRIPTION
There was nothing to stop an exception being thrown was a `Drawable` to be disposed before it started loading in an async context.

- Resolves https://github.com/ppy/osu/issues/7693.
- [x] Depends on #3246 (for merge stability only).