### PR TITLE
Android pen hover support

### DIFF
--- a/osu.Framework.Android/Input/AndroidTouchHandler.cs
+++ b/osu.Framework.Android/Input/AndroidTouchHandler.cs
@@ -22,6 +22,8 @@ namespace osu.Framework.Android.Input
 
         private void handleTouches(object sender, View.TouchEventArgs e)
         {
+            handlePointerEvent(e.Event);
+
             switch (e.Event.Action & MotionEventActions.Mask)
             {
                 case MotionEventActions.Down:
@@ -33,15 +35,13 @@ namespace osu.Framework.Android.Input
                     PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Left, false));
                     break;
             }
-
-            handlePointerEvent(e.Event);
         }
 
         private void handleHover(object sender, View.HoverEventArgs e)
         {
-            PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, e.Event.ButtonState == MotionEventButtonState.StylusPrimary));
-
             handlePointerEvent(e.Event);
+
+            PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, e.Event.ButtonState == MotionEventButtonState.StylusPrimary));
         }
 
         private void handlePointerEvent(MotionEvent e)

--- a/osu.Framework.Android/Input/AndroidTouchHandler.cs
+++ b/osu.Framework.Android/Input/AndroidTouchHandler.cs
@@ -22,22 +22,7 @@ namespace osu.Framework.Android.Input
 
         private void handleTouches(object sender, View.TouchEventArgs e)
         {
-            handlePointerEvent(e.Event);
-        }
-
-        private void handleHover(object sender, View.HoverEventArgs e)
-        {
-            handlePointerEvent(e.Event);
-        }
-
-        private void handlePointerEvent(MotionEvent e)
-        {
-            PendingInputs.Enqueue(new MousePositionAbsoluteInput
-            {
-                Position = new osuTK.Vector2(e.GetX() * view.ScaleX, e.GetY() * view.ScaleY)
-            });
-
-            switch (e.Action & MotionEventActions.Mask)
+            switch (e.Event.Action & MotionEventActions.Mask)
             {
                 case MotionEventActions.Down:
                 case MotionEventActions.Move:
@@ -48,6 +33,23 @@ namespace osu.Framework.Android.Input
                     PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Left, false));
                     break;
             }
+
+            handlePointerEvent(e.Event);
+        }
+
+        private void handleHover(object sender, View.HoverEventArgs e)
+        {
+            PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, e.Event.ButtonState == MotionEventButtonState.StylusPrimary));
+
+            handlePointerEvent(e.Event);
+        }
+
+        private void handlePointerEvent(MotionEvent e)
+        {
+            PendingInputs.Enqueue(new MousePositionAbsoluteInput
+            {
+                Position = new osuTK.Vector2(e.GetX() * view.ScaleX, e.GetY() * view.ScaleY)
+            });
         }
 
         protected override void Dispose(bool disposing)

--- a/osu.Framework.Android/Input/AndroidTouchHandler.cs
+++ b/osu.Framework.Android/Input/AndroidTouchHandler.cs
@@ -17,16 +17,27 @@ namespace osu.Framework.Android.Input
         {
             this.view = view;
             view.Touch += handleTouches;
+            view.Hover += handleHover;
         }
 
         private void handleTouches(object sender, View.TouchEventArgs e)
         {
+            handlePointerEvent(e.Event);
+        }
+
+        private void handleHover(object sender, View.HoverEventArgs e)
+        {
+            handlePointerEvent(e.Event);
+        }
+
+        private void handlePointerEvent(MotionEvent e)
+        {
             PendingInputs.Enqueue(new MousePositionAbsoluteInput
             {
-                Position = new osuTK.Vector2(e.Event.GetX() * view.ScaleX, e.Event.GetY() * view.ScaleY)
+                Position = new osuTK.Vector2(e.GetX() * view.ScaleX, e.GetY() * view.ScaleY)
             });
 
-            switch (e.Event.Action & MotionEventActions.Mask)
+            switch (e.Action & MotionEventActions.Mask)
             {
                 case MotionEventActions.Down:
                 case MotionEventActions.Move:
@@ -42,6 +53,7 @@ namespace osu.Framework.Android.Input
         protected override void Dispose(bool disposing)
         {
             view.Touch -= handleTouches;
+            view.Hover -= handleHover;
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
Mouse position events are sent while the pen is hovering.
Additionally, pressing the pen's side button while hovering will send a right click.

Closes ppy/osu#6401