### PR TITLE
Apply correct current value on rewind between disparate transforms

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -237,7 +237,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                     box.FadeOutFromOne(interval);
                     box.Delay(interval * 3).FadeOutFromOne(interval);
 
-                    //FadeOutFromOne adds extra transforms which disallow testing this scenario, so we remove them.
+                    // FadeOutFromOne adds extra transforms which disallow testing this scenario, so we remove them.
                     box.RemoveTransform(box.Transforms[2]);
                     box.RemoveTransform(box.Transforms[0]);
                 }

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -227,7 +227,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                 box.Alpha = 0;
             });
 
-            // move forward to future point in time;
+            // move forward to future point in time before adding transforms.
             checkAtTime(interval * 4, _ => true);
 
             AddStep("add transforms", () =>

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -220,6 +220,38 @@ namespace osu.Framework.Tests.Visual.Drawables
         }
 
         [Test]
+        public void RewindBetweenDisparateValues()
+        {
+            boxTest(box =>
+            {
+                box.Alpha = 0;
+            });
+
+            // move forward to future point in time;
+            checkAtTime(interval * 4, _ => true);
+
+            AddStep("add transforms", () =>
+            {
+                using (box.BeginAbsoluteSequence(0))
+                {
+                    box.FadeInFromZero(interval);
+                    box.Delay(interval * 3).FadeInFromZero(interval);
+
+                    box.RemoveTransform(box.Transforms[2]);
+                }
+            });
+
+            checkAtTime(0, box => Precision.AlmostEquals(box.Alpha, 0));
+            checkAtTime(interval * 1, box => Precision.AlmostEquals(box.Alpha, 1));
+            checkAtTime(interval * 2, box => Precision.AlmostEquals(box.Alpha, 1));
+            checkAtTime(interval * 3, box => Precision.AlmostEquals(box.Alpha, 0));
+            checkAtTime(interval * 4, box => Precision.AlmostEquals(box.Alpha, 1));
+
+            // importantly, this should be 0 not 1, reading from the EndValue of the first FadeInFromZero transform.
+            checkAtTime(interval * 2, box => Precision.AlmostEquals(box.Alpha, 1));
+        }
+
+        [Test]
         public void LoopSequence()
         {
             boxTest(box => { box.RotateTo(0).RotateTo(90, interval).Loop(); });

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -234,21 +234,23 @@ namespace osu.Framework.Tests.Visual.Drawables
             {
                 using (box.BeginAbsoluteSequence(0))
                 {
-                    box.FadeInFromZero(interval);
-                    box.Delay(interval * 3).FadeInFromZero(interval);
+                    box.FadeOutFromOne(interval);
+                    box.Delay(interval * 3).FadeOutFromOne(interval);
 
+                    //FadeOutFromOne adds extra transforms which disallow testing this scenario, so we remove them.
                     box.RemoveTransform(box.Transforms[2]);
+                    box.RemoveTransform(box.Transforms[0]);
                 }
             });
 
-            checkAtTime(0, box => Precision.AlmostEquals(box.Alpha, 0));
-            checkAtTime(interval * 1, box => Precision.AlmostEquals(box.Alpha, 1));
-            checkAtTime(interval * 2, box => Precision.AlmostEquals(box.Alpha, 1));
-            checkAtTime(interval * 3, box => Precision.AlmostEquals(box.Alpha, 0));
-            checkAtTime(interval * 4, box => Precision.AlmostEquals(box.Alpha, 1));
+            checkAtTime(0, box => Precision.AlmostEquals(box.Alpha, 1));
+            checkAtTime(interval * 1, box => Precision.AlmostEquals(box.Alpha, 0));
+            checkAtTime(interval * 2, box => Precision.AlmostEquals(box.Alpha, 0));
+            checkAtTime(interval * 3, box => Precision.AlmostEquals(box.Alpha, 1));
+            checkAtTime(interval * 4, box => Precision.AlmostEquals(box.Alpha, 0));
 
-            // importantly, this should be 0 not 1, reading from the EndValue of the first FadeInFromZero transform.
-            checkAtTime(interval * 2, box => Precision.AlmostEquals(box.Alpha, 1));
+            // importantly, this should be 0 not 1, reading from the EndValue of the first FadeOutFromOne transform.
+            checkAtTime(interval * 2, box => Precision.AlmostEquals(box.Alpha, 0));
         }
 
         [Test]

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -127,6 +127,9 @@ namespace osu.Framework.Graphics.Transforms
                         {
                             if (time < t.EndTime)
                                 t.AppliedToEnd = false;
+                            else
+                                t.Apply(t.EndTime);
+
                             appliedToEndReverts.Add(t.TargetMember);
                         }
                     }


### PR DESCRIPTION
While this has not been noticed until now due to how transform methods like FadeInFromZero are implemented (they use two transforms), rewinding between transforms where the `EndValue` was different to the `StartValue` of the next transform could leave us in a bad state. Reverse playback would actually look different to forward playback.

Example (opposite fade direction to implemented test):

<img width="1657" alt="PNG image-A892C2269293-1" src="https://user-images.githubusercontent.com/191335/74326832-73d28680-4dce-11ea-9013-587cecff5b1c.png">
