### PR TITLE
Add touch input methods to ManualInputManager

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -491,7 +491,7 @@ namespace osu.Framework.Input
                     HandleMouseScrollChange(mouseScrollChange);
                     return;
 
-                case ButtonStateChangeEvent<MouseButton> mouseButtonStateChange:
+                case MouseButtonStateChangeEvent mouseButtonStateChange:
                     HandleMouseButtonStateChange(mouseButtonStateChange);
                     return;
 
@@ -529,7 +529,7 @@ namespace osu.Framework.Input
             handleScroll(e.State, e.LastScroll, e.IsPrecise);
         }
 
-        protected virtual void HandleMouseButtonStateChange(ButtonStateChangeEvent<MouseButton> e)
+        protected virtual void HandleMouseButtonStateChange(MouseButtonStateChangeEvent e)
         {
             if (mouseButtonEventManagers.TryGetValue(e.Button, out var manager))
                 manager.HandleButtonStateChange(e.State, e.Kind);

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -51,9 +51,9 @@ namespace osu.Framework.Input
 
         /// <summary>
         /// The initial input state. <see cref="CurrentState"/> is always equal (as a reference) to the value returned from this.
-        /// <see cref="InputState.Mouse"/>, <see cref="InputState.Keyboard"/> and <see cref="InputState.Joystick"/> should be non-null.
+        /// <see cref="InputState.Mouse"/>, <see cref="InputState.Keyboard"/>, <see cref="InputState.Touch"/> and <see cref="InputState.Joystick"/> should be non-null.
         /// </summary>
-        protected virtual InputState CreateInitialState() => new InputState(new MouseState { IsPositionValid = false }, new KeyboardState(), new JoystickState());
+        protected virtual InputState CreateInitialState() => new InputState(new MouseState { IsPositionValid = false }, new KeyboardState(), new TouchState(), new JoystickState());
 
         /// <summary>
         /// The last processed state.

--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -72,8 +72,21 @@ namespace osu.Framework.Input.StateChanges
                 {
                     var buttonStateChange = CreateEvent(state, entry.Button, entry.IsPressed ? ButtonStateChangeKind.Pressed : ButtonStateChangeKind.Released);
                     handler.HandleInputStateChange(buttonStateChange);
+
+                    OnButtonStateChanged(state, entry.Button, entry.IsPressed);
                 }
             }
+        }
+
+        /// <summary>
+        /// Invoked when a <paramref name="button"/>'s pressed state changed after it's handled on <see cref="IInputStateChangeHandler"/>.
+        /// Used to apply other changes than just setting <see cref="button"/>'s new state.
+        /// </summary>
+        /// <param name="state">The current <see cref="InputState"/>.</param>
+        /// <param name="button">The button that its state changed.</param>
+        /// <param name="isPressed">Whether the button is now pressed.</param>
+        protected virtual void OnButtonStateChanged(InputState state, TButton button, bool isPressed)
+        {
         }
     }
 }

--- a/osu.Framework/Input/StateChanges/Events/MouseButtonStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/MouseButtonStateChangeEvent.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.States;
+using osuTK.Input;
+
+namespace osu.Framework.Input.StateChanges.Events
+{
+    public class MouseButtonStateChangeEvent : ButtonStateChangeEvent<MouseButton>
+    {
+        public MouseButtonStateChangeEvent(InputState state, IInput input, MouseButton button, ButtonStateChangeKind kind)
+            : base(state, input, button, kind)
+        {
+        }
+    }
+}

--- a/osu.Framework/Input/StateChanges/Events/TouchActivityChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/TouchActivityChangeEvent.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.States;
+using osuTK.Input;
+
+namespace osu.Framework.Input.StateChanges.Events
+{
+    public class TouchActivityChangeEvent : ButtonStateChangeEvent<MouseButton>
+    {
+        public TouchActivityChangeEvent(InputState state, IInput input, MouseButton button, ButtonStateChangeKind kind)
+            : base(state, input, button, kind)
+        {
+        }
+    }
+}

--- a/osu.Framework/Input/StateChanges/Events/TouchPositionChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/TouchPositionChangeEvent.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.States;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Input.StateChanges.Events
+{
+    public class TouchPositionChangeEvent : InputStateChangeEvent
+    {
+        /// <summary>
+        /// The touch source of this change event.
+        /// </summary>
+        public readonly MouseButton Source;
+
+        /// <summary>
+        /// The last position of <see cref="Touch"/>.
+        /// </summary>
+        public readonly Vector2 LastPosition;
+
+        public TouchPositionChangeEvent(InputState state, IInput input, MouseButton source, Vector2 lastPosition)
+            : base(state, input)
+        {
+            Source = source;
+            LastPosition = lastPosition;
+        }
+    }
+}

--- a/osu.Framework/Input/StateChanges/MouseButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseButtonInput.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
 using osuTK.Input;
 
@@ -25,5 +26,8 @@ namespace osu.Framework.Input.StateChanges
         }
 
         protected override ButtonStates<MouseButton> GetButtonStates(InputState state) => state.Mouse.Buttons;
+
+        protected override ButtonStateChangeEvent<MouseButton> CreateEvent(InputState state, MouseButton button, ButtonStateChangeKind kind)
+            => new MouseButtonStateChangeEvent(state, this, button, kind);
     }
 }

--- a/osu.Framework/Input/StateChanges/TouchActivityInput.cs
+++ b/osu.Framework/Input/StateChanges/TouchActivityInput.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using osu.Framework.Input.StateChanges.Events;
+using osu.Framework.Input.States;
+using osuTK.Input;
+
+namespace osu.Framework.Input.StateChanges
+{
+    /// <summary>
+    /// Denotes a change of the touch activity state (finger down, up).
+    /// Any provided touch source should always be in the range <see cref="MouseButton.Touch1"/>-<see cref="MouseButton.Touch10"/>.
+    /// </summary>
+    public class TouchActivityInput : ButtonInput<MouseButton>
+    {
+        public TouchActivityInput(IEnumerable<ButtonInputEntry<MouseButton>> entries)
+            : base(entries)
+        {
+            Trace.Assert(Entries.All(e => e.Button >= MouseButton.Touch1));
+        }
+
+        public TouchActivityInput(MouseButton button, bool isActive)
+            : base(button, isActive)
+        {
+            Trace.Assert(button >= MouseButton.Touch1);
+        }
+
+        public TouchActivityInput(ButtonStates<MouseButton> current, ButtonStates<MouseButton> previous)
+            : base(current, previous)
+        {
+            Trace.Assert(Entries.All(e => e.Button >= MouseButton.Touch1));
+        }
+
+        protected override ButtonStates<MouseButton> GetButtonStates(InputState state) => state.Touch.ActiveSources;
+
+        protected override ButtonStateChangeEvent<MouseButton> CreateEvent(InputState state, MouseButton button, ButtonStateChangeKind kind)
+            => new TouchActivityChangeEvent(state, this, button, kind);
+
+        protected override void OnButtonStateChanged(InputState state, MouseButton button, bool isPressed)
+        {
+            if (isPressed == false)
+                state.Touch.TouchPositions.Remove(button);
+        }
+    }
+}

--- a/osu.Framework/Input/StateChanges/TouchPositionInput.cs
+++ b/osu.Framework/Input/StateChanges/TouchPositionInput.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.StateChanges.Events;
+using osu.Framework.Input.States;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Input.StateChanges
+{
+    /// <summary>
+    /// Denotes an absolute change of a provided touch source's position.
+    /// Any provided touch source should always be in the range <see cref="MouseButton.Touch1"/>-<see cref="MouseButton.Touch10"/>.
+    /// </summary>
+    public class TouchPositionInput : IInput
+    {
+        /// <summary>
+        /// The touch source to be modified.
+        /// </summary>
+        public readonly MouseButton Source;
+
+        /// <summary>
+        /// The new position to move to.
+        /// </summary>
+        public readonly Vector2 Position;
+
+        public TouchPositionInput(MouseButton source, Vector2 newPosition)
+        {
+            Source = source;
+            Position = newPosition;
+        }
+
+        public void Apply(InputState state, IInputStateChangeHandler handler)
+        {
+            var touch = state.Touch;
+
+            if (Source < MouseButton.Touch1)
+                return;
+
+            Vector2? lastPosition = touch.GetTouchPosition(Source);
+            if (lastPosition == Position)
+                return;
+
+            touch.TouchPositions[Source] = Position;
+            handler.HandleInputStateChange(new TouchPositionChangeEvent(state, this, Source, lastPosition ?? Position));
+        }
+    }
+}

--- a/osu.Framework/Input/States/InputState.cs
+++ b/osu.Framework/Input/States/InputState.cs
@@ -7,12 +7,14 @@ namespace osu.Framework.Input.States
     {
         public readonly MouseState Mouse;
         public readonly KeyboardState Keyboard;
+        public readonly TouchState Touch;
         public readonly JoystickState Joystick;
 
-        public InputState(MouseState mouse = null, KeyboardState keyboard = null, JoystickState joystick = null)
+        public InputState(MouseState mouse = null, KeyboardState keyboard = null, TouchState touch = null, JoystickState joystick = null)
         {
             Mouse = mouse ?? new MouseState();
             Keyboard = keyboard ?? new KeyboardState();
+            Touch = touch ?? new TouchState();
             Joystick = joystick ?? new JoystickState();
         }
     }

--- a/osu.Framework/Input/States/TouchState.cs
+++ b/osu.Framework/Input/States/TouchState.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Input.States
+{
+    public class TouchState
+    {
+        /// <summary>
+        /// The list of currently active touch sources.
+        /// </summary>
+        public readonly ButtonStates<MouseButton> ActiveSources = new ButtonStates<MouseButton>();
+
+        /// <summary>
+        /// The dictionary to retrieve current touch positions from and save them.
+        /// </summary>
+        public readonly Dictionary<MouseButton, Vector2> TouchPositions = new Dictionary<MouseButton, Vector2>();
+
+        /// <summary>
+        /// Retrieves the current touch position of a specified <paramref name="source"/>, or null if not existing in the <see cref="TouchPositions"/> dictionary.
+        /// </summary>
+        /// <param name="source"></param>
+        /// <returns></returns>
+        public Vector2? GetTouchPosition(MouseButton source)
+        {
+            if (!TouchPositions.TryGetValue(source, out var pos))
+                return null;
+
+            return pos;
+        }
+
+        public bool IsActive(MouseButton source) => ActiveSources.IsPressed(source);
+    }
+}

--- a/osu.Framework/Input/Touch.cs
+++ b/osu.Framework/Input/Touch.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Input
+{
+    /// <summary>
+    /// Represents a touch structure that provides a touch source and current position.
+    /// </summary>
+    public readonly struct Touch : IEquatable<Touch>
+    {
+        /// <summary>
+        /// The source of this touch.
+        /// </summary>
+        public readonly MouseButton Source;
+
+        /// <summary>
+        /// The current position of this touch.
+        /// </summary>
+        public readonly Vector2 Position;
+
+        public Touch(MouseButton source, Vector2 position)
+        {
+            Source = source;
+            Position = position;
+        }
+
+        /// <summary>
+        /// Indicates whether the <see cref="Source"/> of this touch is equal to <see cref="Source"/> of the other touch.
+        /// </summary>
+        /// <param name="other">The other touch.</param>
+        public bool Equals(Touch other) => Source == other.Source;
+
+        public static bool operator ==(Touch left, Touch right) => left.Equals(right);
+        public static bool operator !=(Touch left, Touch right) => !(left == right);
+
+        public override bool Equals(object obj) => obj is Touch other && Equals(other);
+
+        public override int GetHashCode() => Source.GetHashCode();
+    }
+}

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -53,6 +53,9 @@ namespace osu.Framework.Testing.Input
         public void MoveMouseTo(Drawable drawable, Vector2? offset = null) => MoveMouseTo(drawable.ToScreenSpace(drawable.LayoutRectangle.Centre) + (offset ?? Vector2.Zero));
         public void MoveMouseTo(Vector2 position) => Input(new MousePositionAbsoluteInput { Position = position });
 
+        public void MoveTouchTo(Drawable drawable, MouseButton source) => MoveTouchTo(drawable.ToScreenSpace(drawable.LayoutRectangle.Centre), source);
+        public void MoveTouchTo(Vector2 position, MouseButton source) => Input(new TouchPositionInput(source, position));
+
         public void Click(MouseButton button)
         {
             PressButton(button);
@@ -64,6 +67,18 @@ namespace osu.Framework.Testing.Input
 
         public void PressJoystickButton(JoystickButton button) => Input(new JoystickButtonInput(button, true));
         public void ReleaseJoystickButton(JoystickButton button) => Input(new JoystickButtonInput(button, false));
+
+        public void ActivateTouch(MouseButton source) => Input(new TouchActivityInput(source, true));
+
+        public void ActivateTouchAt(Drawable drawable, MouseButton source) => ActivateTouchAt(drawable.ToScreenSpace(drawable.LayoutRectangle.Centre), source);
+
+        public void ActivateTouchAt(Vector2 position, MouseButton source)
+        {
+            MoveTouchTo(position, source);
+            ActivateTouch(source);
+        }
+
+        public void DeactivateTouch(MouseButton source) => Input(new TouchActivityInput(source, false));
 
         private class ManualInputHandler : InputHandler
         {

--- a/osu.Framework/Testing/ManualInputManagerTestScene.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestScene.cs
@@ -130,6 +130,9 @@ namespace osu.Framework.Testing
             var keyboard = currentState.Keyboard;
             keyboard.Keys.ForEach(InputManager.ReleaseKey);
 
+            var touch = currentState.Touch;
+            touch.ActiveSources.ForEach(InputManager.DeactivateTouch);
+
             var joystick = currentState.Joystick;
             joystick.Buttons.ForEach(InputManager.ReleaseJoystickButton);
 


### PR DESCRIPTION
Split from #2925 

- [ ] Depends on #3266

Adds touch `IInput` methods in `ManualInputManager` for testing purposes:
| Method | Summary |
| --------- | ---------- |
| `MoveTouchTo(pos, source)` | Enqueues `TouchPositionInput` with provided touch source and provided position. |
| `ActivateTouch(source)` | Enqueues `TouchButtonInput` with provided touch source and set to pressed / down.
| `ActivateTouchAt(drawable, source)` | Enqueues `TouchPositionInput` with position set to the center of provided drawable followed by a `TouchButtonInput` with provided touch source and set to pressed / down.
| `ActivateTouchAt(pos, source)` | Enqueues `TouchPositionInput` with provided position followed by a `TouchButtonInput` with provided touch source and set to pressed / down.
| `DeactivateTouch(source)` | Enqueues `TouchButtonInput` with provided touch source set to released / up.