### PR TITLE
Add BindableList.CollectionChanged event implementing NotifyCollectionChangedEventHandler

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -1020,7 +1020,9 @@ namespace osu.Framework.Tests.Bindables
 
             Assert.IsTrue(wasNotified);
 
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Reset));
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new[] { "testA", "testA", "testA", "testA", "testA" }));
+            Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
         }
 
         [Test]
@@ -1352,7 +1354,9 @@ namespace osu.Framework.Tests.Bindables
             });
 
             Assert.That(triggeredArgs, Has.Count.EqualTo(1));
-            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Reset));
+            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.First().OldItems, Is.EquivalentTo(strings));
+            Assert.That(triggeredArgs.First().OldStartingIndex, Is.EqualTo(0));
         }
 
         [Test]
@@ -1390,7 +1394,9 @@ namespace osu.Framework.Tests.Bindables
             });
 
             Assert.That(triggeredArgs, Has.Count.EqualTo(2));
-            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Reset));
+            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.First().OldItems, Is.EquivalentTo("test123".Yield()));
+            Assert.That(triggeredArgs.First().OldStartingIndex, Is.EqualTo(0));
             Assert.That(triggeredArgs.ElementAt(1).Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
             Assert.That(triggeredArgs.ElementAt(1).NewItems, Is.EquivalentTo(strings));
             Assert.That(triggeredArgs.ElementAt(1).NewStartingIndex, Is.EqualTo(0));

--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 
 namespace osu.Framework.Tests.Bindables
 {
@@ -118,16 +120,25 @@ namespace osu.Framework.Tests.Bindables
         {
             bindableStringList.Add("0");
 
+#pragma warning disable 618 can be removed 20200817
             IEnumerable<string> addedItem = null;
             IEnumerable<string> removedItem = null;
-
             bindableStringList.ItemsAdded += v => addedItem = v;
             bindableStringList.ItemsRemoved += v => removedItem = v;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList[0] = "1";
 
             Assert.That(removedItem.Single(), Is.EqualTo("0"));
             Assert.That(addedItem.Single(), Is.EqualTo("1"));
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Replace));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo("0".Yield()));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo("1".Yield()));
+            Assert.That(triggeredArgs.OldStartingIndex, Is.Zero);
+            Assert.That(triggeredArgs.NewStartingIndex, Is.Zero);
         }
 
         [Test]
@@ -135,18 +146,28 @@ namespace osu.Framework.Tests.Bindables
         {
             bindableStringList.Add("0");
 
-            IEnumerable<string> addedItem = null;
-            IEnumerable<string> removedItem = null;
-
             var list = new BindableList<string>();
             list.BindTo(bindableStringList);
+
+#pragma warning disable 618 can be removed 20200817
+            IEnumerable<string> addedItem = null;
+            IEnumerable<string> removedItem = null;
             list.ItemsAdded += v => addedItem = v;
             list.ItemsRemoved += v => removedItem = v;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList[0] = "1";
 
             Assert.That(removedItem.Single(), Is.EqualTo("0"));
             Assert.That(addedItem.Single(), Is.EqualTo("1"));
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Replace));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo("0".Yield()));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo("1".Yield()));
+            Assert.That(triggeredArgs.OldStartingIndex, Is.Zero);
+            Assert.That(triggeredArgs.NewStartingIndex, Is.Zero);
         }
 
         #endregion
@@ -168,12 +189,20 @@ namespace osu.Framework.Tests.Bindables
         [TestCase(null)]
         public void TestAddWithStringNotifiesSubscriber(string str)
         {
+#pragma warning disable 618 can be removed 20200817
             string addedString = null;
             bindableStringList.ItemsAdded += s => addedString = s.SingleOrDefault();
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.Add(str);
 
             Assert.AreEqual(str, addedString);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(str.Yield()));
+            Assert.That(triggeredArgs.NewStartingIndex, Is.Zero);
         }
 
         [TestCase("a random string")]
@@ -181,12 +210,18 @@ namespace osu.Framework.Tests.Bindables
         [TestCase(null)]
         public void TestAddWithStringNotifiesSubscriberOnce(string str)
         {
+#pragma warning disable 618 can be removed 20200817
             int notificationCount = 0;
             bindableStringList.ItemsAdded += s => notificationCount++;
+#pragma warning restore 618
+            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs.Add(args);
 
             bindableStringList.Add(str);
 
             Assert.AreEqual(1, notificationCount);
+
+            Assert.That(triggeredArgs, Has.Count.EqualTo(1));
         }
 
         [TestCase("a random string")]
@@ -194,18 +229,30 @@ namespace osu.Framework.Tests.Bindables
         [TestCase(null)]
         public void TestAddWithStringNotifiesMultipleSubscribers(string str)
         {
+#pragma warning disable 618 can be removed 20200817
             bool subscriberANotified = false;
             bool subscriberBNotified = false;
             bool subscriberCNotified = false;
             bindableStringList.ItemsAdded += s => subscriberANotified = true;
             bindableStringList.ItemsAdded += s => subscriberBNotified = true;
             bindableStringList.ItemsAdded += s => subscriberCNotified = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgsA = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB = null;
+            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsA = args;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsB = args;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsC = args;
 
             bindableStringList.Add(str);
 
             Assert.IsTrue(subscriberANotified);
             Assert.IsTrue(subscriberBNotified);
             Assert.IsTrue(subscriberCNotified);
+
+            Assert.That(triggeredArgsA, Is.Not.Null);
+            Assert.That(triggeredArgsB, Is.Not.Null);
+            Assert.That(triggeredArgsC, Is.Not.Null);
         }
 
         [TestCase("a random string")]
@@ -213,16 +260,28 @@ namespace osu.Framework.Tests.Bindables
         [TestCase(null)]
         public void TestAddWithStringNotifiesMultipleSubscribersOnlyAfterTheAdd(string str)
         {
+#pragma warning disable 618 can be removed 20200817
             bool subscriberANotified = false;
             bool subscriberBNotified = false;
             bool subscriberCNotified = false;
             bindableStringList.ItemsAdded += s => subscriberANotified = true;
             bindableStringList.ItemsAdded += s => subscriberBNotified = true;
             bindableStringList.ItemsAdded += s => subscriberCNotified = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgsA = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB = null;
+            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsA = args;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsB = args;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsC = args;
 
             Assert.IsFalse(subscriberANotified);
             Assert.IsFalse(subscriberBNotified);
             Assert.IsFalse(subscriberCNotified);
+
+            Assert.That(triggeredArgsA, Is.Null);
+            Assert.That(triggeredArgsB, Is.Null);
+            Assert.That(triggeredArgsC, Is.Null);
 
             bindableStringList.Add(str);
         }
@@ -309,8 +368,13 @@ namespace osu.Framework.Tests.Bindables
             string[] items = { "test1", "test2", "test3" };
             var list = new BindableList<string>();
             bindableStringList.BindTo(list);
+
+#pragma warning disable 618 can be removed 20200817
             IEnumerable<string> addedItems = null;
             list.ItemsAdded += e => addedItems = e;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.AddRange(items);
 
@@ -320,6 +384,9 @@ namespace osu.Framework.Tests.Bindables
                 CollectionAssert.AreEquivalent(items, addedItems);
                 CollectionAssert.AreEquivalent(items, list);
             });
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(items));
         }
 
         [Test]
@@ -328,9 +395,6 @@ namespace osu.Framework.Tests.Bindables
             BindableList<int> list1 = new BindableList<int>();
             BindableList<int> list2 = new BindableList<int>();
             list2.BindTo(list1);
-
-            int addeditem = 0;
-            list1.ItemsAdded += items => addeditem = items.Single();
 
             int counter = 0;
 
@@ -341,9 +405,9 @@ namespace osu.Framework.Tests.Bindables
 
             list1.AddRange(valueEnumerable());
 
-            Assert.That(list1[0], Is.EqualTo(0));
-            Assert.That(list2[0], Is.EqualTo(0));
-            Assert.That(addeditem, Is.EqualTo(0));
+            Assert.That(list1, Is.EquivalentTo(0.Yield()));
+            Assert.That(list2, Is.EquivalentTo(0.Yield()));
+            Assert.That(counter, Is.EqualTo(1));
         }
 
         #endregion
@@ -372,12 +436,20 @@ namespace osu.Framework.Tests.Bindables
             bindableStringList.Add("0");
             bindableStringList.Add("2");
 
+#pragma warning disable 618 can be removed 20200817
             bool wasAdded = false;
             bindableStringList.ItemsAdded += _ => wasAdded = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.Insert(1, "1");
 
             Assert.IsTrue(wasAdded);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.NewItems, Has.One.Items.EqualTo("1"));
+            Assert.That(triggeredArgs.NewStartingIndex, Is.EqualTo(1));
         }
 
         [Test]
@@ -386,15 +458,23 @@ namespace osu.Framework.Tests.Bindables
             bindableStringList.Add("0");
             bindableStringList.Add("2");
 
-            bool wasAdded = false;
-
             var list = new BindableList<string>();
             list.BindTo(bindableStringList);
+
+#pragma warning disable 618 can be removed 20200817
+            bool wasAdded = false;
             list.ItemsAdded += _ => wasAdded = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.Insert(1, "1");
 
             Assert.IsTrue(wasAdded);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.NewItems, Has.One.Items.EqualTo("1"));
+            Assert.That(triggeredArgs.NewStartingIndex, Is.EqualTo(1));
         }
 
         [Test]
@@ -464,12 +544,21 @@ namespace osu.Framework.Tests.Bindables
         {
             const string item = "item";
             bindableStringList.Add(item);
+
+#pragma warning disable 618 can be removed 20200817
             bool updated = false;
             bindableStringList.ItemsRemoved += s => updated = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.Remove(item);
 
             Assert.True(updated);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo(item));
+            Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
         }
 
         [Test]
@@ -477,12 +566,21 @@ namespace osu.Framework.Tests.Bindables
         {
             const string item = "item";
             bindableStringList.Add(item);
+
+#pragma warning disable 618 can be removed 20200817
             bool updatedA = false;
             bool updatedB = false;
             bool updatedC = false;
             bindableStringList.ItemsRemoved += s => updatedA = true;
             bindableStringList.ItemsRemoved += s => updatedB = true;
             bindableStringList.ItemsRemoved += s => updatedC = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgsA = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB = null;
+            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsA = args;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsB = args;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsC = args;
 
             bindableStringList.Remove(item);
 
@@ -492,6 +590,10 @@ namespace osu.Framework.Tests.Bindables
                 Assert.True(updatedB);
                 Assert.True(updatedC);
             });
+
+            Assert.That(triggeredArgsA, Is.Not.Null);
+            Assert.That(triggeredArgsB, Is.Not.Null);
+            Assert.That(triggeredArgsC, Is.Not.Null);
         }
 
         [Test]
@@ -536,12 +638,21 @@ namespace osu.Framework.Tests.Bindables
             bindableStringList.Add(item);
             var list = new BindableList<string>();
             list.BindTo(bindableStringList);
+
+#pragma warning disable 618 can be removed 20200817
             bool wasRemoved = false;
             list.ItemsRemoved += s => wasRemoved = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.Remove(item);
 
             Assert.True(wasRemoved);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo(item));
+            Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
         }
 
         [Test]
@@ -551,16 +662,31 @@ namespace osu.Framework.Tests.Bindables
             bindableStringList.Add(item);
             var listA = new BindableList<string>();
             listA.BindTo(bindableStringList);
+
+#pragma warning disable 618 can be removed 20200817
             bool wasRemovedA1 = false;
             bool wasRemovedA2 = false;
             listA.ItemsRemoved += s => wasRemovedA1 = true;
             listA.ItemsRemoved += s => wasRemovedA2 = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgsA1 = null;
+            NotifyCollectionChangedEventArgs triggeredArgsA2 = null;
+            listA.CollectionChanged += (_, args) => triggeredArgsA1 = args;
+            listA.CollectionChanged += (_, args) => triggeredArgsA2 = args;
+
             var listB = new BindableList<string>();
             listB.BindTo(bindableStringList);
+
+#pragma warning disable 618 can be removed 20200817
             bool wasRemovedB1 = false;
             bool wasRemovedB2 = false;
             listB.ItemsRemoved += s => wasRemovedB1 = true;
             listB.ItemsRemoved += s => wasRemovedB2 = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgsB1 = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB2 = null;
+            listB.CollectionChanged += (_, args) => triggeredArgsB1 = args;
+            listB.CollectionChanged += (_, args) => triggeredArgsB2 = args;
 
             bindableStringList.Remove(item);
 
@@ -571,6 +697,11 @@ namespace osu.Framework.Tests.Bindables
                 Assert.IsTrue(wasRemovedB1);
                 Assert.IsTrue(wasRemovedB2);
             });
+
+            Assert.That(triggeredArgsA1, Is.Not.Null);
+            Assert.That(triggeredArgsA2, Is.Not.Null);
+            Assert.That(triggeredArgsB1, Is.Not.Null);
+            Assert.That(triggeredArgsB2, Is.Not.Null);
         }
 
         [Test]
@@ -615,17 +746,27 @@ namespace osu.Framework.Tests.Bindables
             bindableStringList.Add("0");
             bindableStringList.Add("1");
 
+#pragma warning disable 618 can be removed 20200817
             List<string> itemsRemoved = null;
             bindableStringList.ItemsRemoved += i => itemsRemoved = i.ToList();
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
+
             bindableStringList.RemoveRange(1, 1);
+
+            Assert.AreEqual(1, bindableStringList.Count);
+            Assert.AreEqual("0", bindableStringList.FirstOrDefault());
 
             Assert.Multiple(() =>
             {
-                Assert.AreEqual(1, bindableStringList.Count);
-                Assert.AreEqual("0", bindableStringList.FirstOrDefault());
                 Assert.AreEqual(1, itemsRemoved.Count);
                 Assert.AreEqual("1", itemsRemoved.FirstOrDefault());
             });
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo("1"));
+            Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(1));
         }
 
         [Test]
@@ -634,10 +775,15 @@ namespace osu.Framework.Tests.Bindables
             bindableStringList.Add("0");
             bindableStringList.Add("1");
 
-            List<string> itemsRemoved = null;
             var list = new BindableList<string>();
             list.BindTo(bindableStringList);
+
+#pragma warning disable 618 can be removed 20200817
+            List<string> itemsRemoved = null;
             list.ItemsRemoved += i => itemsRemoved = i.ToList();
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.RemoveRange(0, 1);
 
@@ -646,6 +792,10 @@ namespace osu.Framework.Tests.Bindables
                 Assert.AreEqual(1, itemsRemoved.Count);
                 Assert.AreEqual("0", itemsRemoved.FirstOrDefault());
             });
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo("0"));
+            Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
         }
 
         [Test]
@@ -653,14 +803,21 @@ namespace osu.Framework.Tests.Bindables
         {
             bindableStringList.Add("0");
 
-            bool notified = false;
             var list = new BindableList<string>();
             list.BindTo(bindableStringList);
+
+#pragma warning disable 618 can be removed 20200817
+            bool notified = false;
             list.ItemsRemoved += i => notified = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.RemoveRange(0, 0);
 
             Assert.IsFalse(notified);
+
+            Assert.That(triggeredArgs, Is.Null);
         }
 
         #endregion
@@ -692,14 +849,22 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestRemoveAtNotifiesSubscribers()
         {
-            bool wasRemoved = false;
-
             bindableStringList.Add("abc");
+
+#pragma warning disable 618 can be removed 20200817
+            bool wasRemoved = false;
             bindableStringList.ItemsRemoved += _ => wasRemoved = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.RemoveAt(0);
 
             Assert.IsTrue(wasRemoved);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo("abc"));
+            Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
         }
 
         [Test]
@@ -707,15 +872,23 @@ namespace osu.Framework.Tests.Bindables
         {
             bindableStringList.Add("abc");
 
-            bool wasRemoved = false;
-
             var list = new BindableList<string>();
             list.BindTo(bindableStringList);
+
+#pragma warning disable 618 can be removed 20200817
+            bool wasRemoved = false;
             list.ItemsRemoved += s => wasRemoved = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.RemoveAt(0);
 
             Assert.IsTrue(wasRemoved);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Has.One.Items.EqualTo("abc"));
+            Assert.That(triggeredArgs.OldStartingIndex, Is.EqualTo(0));
         }
 
         #endregion
@@ -747,11 +920,19 @@ namespace osu.Framework.Tests.Bindables
             bindableStringList.Add("0");
             bindableStringList.Add("0");
 
+#pragma warning disable 618 can be removed 20200817
             List<string> itemsRemoved = null;
             bindableStringList.ItemsRemoved += i => itemsRemoved = i.ToList();
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
+
             bindableStringList.RemoveAll(m => m == "0");
 
             Assert.AreEqual(2, itemsRemoved.Count);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new[] { "0", "0" }));
         }
 
         [Test]
@@ -760,14 +941,22 @@ namespace osu.Framework.Tests.Bindables
             bindableStringList.Add("0");
             bindableStringList.Add("0");
 
-            List<string> itemsRemoved = null;
             var list = new BindableList<string>();
             list.BindTo(bindableStringList);
+
+#pragma warning disable 618 can be removed 20200817
+            List<string> itemsRemoved = null;
             list.ItemsRemoved += i => itemsRemoved = i.ToList();
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.RemoveAll(m => m == "0");
 
             Assert.AreEqual(2, itemsRemoved.Count);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new[] { "0", "0" }));
         }
 
         #endregion
@@ -819,23 +1008,37 @@ namespace osu.Framework.Tests.Bindables
         {
             for (int i = 0; i < 5; i++)
                 bindableStringList.Add("testA");
+
+#pragma warning disable 618 can be removed 20200817
             bool wasNotified = false;
             bindableStringList.ItemsRemoved += items => wasNotified = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.Clear();
 
             Assert.IsTrue(wasNotified);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Reset));
         }
 
         [Test]
         public void TestClearDoesNotNotifySubscriberBeforeClear()
         {
-            bool wasNotified = false;
-            bindableStringList.ItemsRemoved += items => wasNotified = true;
             for (int i = 0; i < 5; i++)
                 bindableStringList.Add("testA");
 
+#pragma warning disable 618 can be removed 20200817
+            bool wasNotified = false;
+            bindableStringList.ItemsRemoved += items => wasNotified = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
+
             Assert.IsFalse(wasNotified);
+
+            Assert.That(triggeredArgs, Is.Null);
 
             bindableStringList.Clear();
         }
@@ -845,12 +1048,21 @@ namespace osu.Framework.Tests.Bindables
         {
             for (int i = 0; i < 5; i++)
                 bindableStringList.Add("testA");
+
+#pragma warning disable 618 can be removed 20200817
             bool wasNotifiedA = false;
-            bindableStringList.ItemsRemoved += items => wasNotifiedA = true;
             bool wasNotifiedB = false;
-            bindableStringList.ItemsRemoved += items => wasNotifiedB = true;
             bool wasNotifiedC = false;
+            bindableStringList.ItemsRemoved += items => wasNotifiedA = true;
+            bindableStringList.ItemsRemoved += items => wasNotifiedB = true;
             bindableStringList.ItemsRemoved += items => wasNotifiedC = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgsA = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB = null;
+            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsA = args;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsB = args;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgsC = args;
 
             bindableStringList.Clear();
 
@@ -860,6 +1072,10 @@ namespace osu.Framework.Tests.Bindables
                 Assert.IsTrue(wasNotifiedB);
                 Assert.IsTrue(wasNotifiedC);
             });
+
+            Assert.That(triggeredArgsA, Is.Not.Null);
+            Assert.That(triggeredArgsB, Is.Not.Null);
+            Assert.That(triggeredArgsC, Is.Not.Null);
         }
 
         [Test]
@@ -1114,6 +1330,8 @@ namespace osu.Framework.Tests.Bindables
         {
             string[] strings = { "testA", "testB", "testC" };
             bindableStringList.AddRange(strings);
+
+#pragma warning disable 618 can be removed 20200817
             bool itemsGotCleared = false;
             IEnumerable<string> clearedItems = null;
             bindableStringList.ItemsRemoved += items =>
@@ -1121,6 +1339,9 @@ namespace osu.Framework.Tests.Bindables
                 itemsGotCleared = true;
                 clearedItems = items;
             };
+#pragma warning restore 618
+            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs.Add(args);
 
             bindableStringList.Parse(null);
 
@@ -1129,14 +1350,18 @@ namespace osu.Framework.Tests.Bindables
                 CollectionAssert.AreEquivalent(strings, clearedItems);
                 Assert.IsTrue(itemsGotCleared);
             });
+
+            Assert.That(triggeredArgs, Has.Count.EqualTo(1));
+            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Reset));
         }
 
         [Test]
         public void TestParseWithItemsNotifiesAddRangeAndClearSubscribers()
         {
             bindableStringList.Add("test123");
-
             IEnumerable<string> strings = new[] { "testA", "testB" };
+
+#pragma warning disable 618 can be removed 20200817
             IEnumerable<string> addedItems = null;
             bool? itemsWereFirstCleaned = null;
             bindableStringList.ItemsAdded += items =>
@@ -1150,6 +1375,9 @@ namespace osu.Framework.Tests.Bindables
                 if (itemsWereFirstCleaned == null)
                     itemsWereFirstCleaned = true;
             };
+#pragma warning restore 618
+            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs.Add(args);
 
             bindableStringList.Parse(strings);
 
@@ -1160,6 +1388,12 @@ namespace osu.Framework.Tests.Bindables
                 Assert.NotNull(itemsWereFirstCleaned);
                 Assert.IsTrue(itemsWereFirstCleaned ?? false);
             });
+
+            Assert.That(triggeredArgs, Has.Count.EqualTo(2));
+            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Reset));
+            Assert.That(triggeredArgs.ElementAt(1).Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.ElementAt(1).NewItems, Is.EquivalentTo(strings));
+            Assert.That(triggeredArgs.ElementAt(1).NewStartingIndex, Is.EqualTo(0));
         }
 
         #endregion
@@ -1170,12 +1404,21 @@ namespace osu.Framework.Tests.Bindables
         public void TestBoundCopyWithAdd()
         {
             var boundCopy = bindableStringList.GetBoundCopy();
+
+#pragma warning disable 618 can be removed 20200817
             bool boundCopyItemAdded = false;
             boundCopy.ItemsAdded += item => boundCopyItemAdded = true;
+#pragma warning restore 618
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            boundCopy.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringList.Add("test");
 
             Assert.IsTrue(boundCopyItemAdded);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo("test".Yield()));
+            Assert.That(triggeredArgs.NewStartingIndex, Is.EqualTo(0));
         }
 
         #endregion

--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -126,8 +126,8 @@ namespace osu.Framework.Tests.Bindables
 
             bindableStringList[0] = "1";
 
-            Assert.AreEqual(removedItem.Single(), "0");
-            Assert.AreEqual(addedItem.Single(), "1");
+            Assert.That(removedItem.Single(), Is.EqualTo("0"));
+            Assert.That(addedItem.Single(), Is.EqualTo("1"));
         }
 
         [Test]
@@ -145,8 +145,8 @@ namespace osu.Framework.Tests.Bindables
 
             bindableStringList[0] = "1";
 
-            Assert.AreEqual(removedItem.Single(), "0");
-            Assert.AreEqual(addedItem.Single(), "1");
+            Assert.That(removedItem.Single(), Is.EqualTo("0"));
+            Assert.That(addedItem.Single(), Is.EqualTo("1"));
         }
 
         #endregion

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using osu.Framework.Caching;
 using osu.Framework.Lists;
@@ -15,12 +16,19 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// An event which is raised when any items are added to this <see cref="BindableList{T}"/>.
         /// </summary>
+        [Obsolete("Use CollectionChanged instead.")]
         public event Action<IEnumerable<T>> ItemsAdded;
 
         /// <summary>
         /// An event which is raised when any items are removed from this <see cref="BindableList{T}"/>.
         /// </summary>
+        [Obsolete("Use CollectionChanged instead.")]
         public event Action<IEnumerable<T>> ItemsRemoved;
+
+        /// <summary>
+        /// An event which is raised when this <see cref="BindableList{T}"/> changes.
+        /// </summary>
+        public event NotifyCollectionChangedEventHandler CollectionChanged;
 
         /// <summary>
         /// An event which is raised when <see cref="Disabled"/>'s state has changed (or manually via <see cref="triggerDisabledChange(bool)"/>).
@@ -77,8 +85,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            ItemsRemoved?.Invoke(new[] { lastItem });
-            ItemsAdded?.Invoke(new[] { item });
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, item, lastItem, index));
         }
 
         /// <summary>
@@ -106,7 +113,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            ItemsAdded?.Invoke(new[] { item });
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, collection.Count - 1));
         }
 
         /// <summary>
@@ -142,7 +149,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            ItemsAdded?.Invoke(new[] { item });
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, index));
         }
 
         /// <summary>
@@ -175,7 +182,12 @@ namespace osu.Framework.Bindables
                 }
             }
 
+#pragma warning disable 618 // can be removed 20200817
+            // The collection changed event does not provide items upon clearing, but the old interface expects it to.
             ItemsRemoved?.Invoke(clearedItems);
+#pragma warning restore 618
+
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
         /// <summary>
@@ -199,25 +211,27 @@ namespace osu.Framework.Bindables
         {
             ensureMutationAllowed();
 
-            bool removed = collection.Remove(item);
+            int index = collection.IndexOf(item);
 
-            if (removed)
+            if (index < 0)
+                return false;
+
+            collection.RemoveAt(index);
+
+            if (bindings != null)
             {
-                if (bindings != null)
+                foreach (var b in bindings)
                 {
-                    foreach (var b in bindings)
-                    {
-                        // prevent re-adding the item back to the callee.
-                        // That would result in a <see cref="StackOverflowException"/>.
-                        if (b != caller)
-                            b.remove(item, this);
-                    }
+                    // prevent re-adding the item back to the callee.
+                    // That would result in a <see cref="StackOverflowException"/>.
+                    if (b != caller)
+                        b.remove(item, this);
                 }
-
-                ItemsRemoved?.Invoke(new[] { item });
             }
 
-            return removed;
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
+
+            return true;
         }
 
         /// <summary>
@@ -252,7 +266,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            ItemsRemoved?.Invoke(removedItems);
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removedItems, index));
         }
 
         /// <summary>
@@ -282,7 +296,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            ItemsRemoved?.Invoke(new[] { item });
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, index));
         }
 
         /// <summary>
@@ -312,7 +326,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            ItemsRemoved?.Invoke(removed);
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, removed));
 
             return removed.Count;
         }
@@ -447,8 +461,12 @@ namespace osu.Framework.Bindables
 
         public void UnbindEvents()
         {
+#pragma warning disable 618 can be removed 20200817
             ItemsAdded = null;
             ItemsRemoved = null;
+#pragma warning restore 618
+
+            CollectionChanged = null;
             DisabledChanged = null;
         }
 
@@ -497,13 +515,13 @@ namespace osu.Framework.Bindables
         /// <param name="items">The collection whose items should be added to this collection.</param>
         /// <exception cref="InvalidOperationException">Thrown if this collection is <see cref="Disabled"/></exception>
         public void AddRange(IEnumerable<T> items)
-            => addRange(items as ICollection<T> ?? items.ToArray(), null);
+            => addRange(items as IList ?? items.ToArray(), null);
 
-        private void addRange(ICollection<T> items, BindableList<T> caller)
+        private void addRange(IList items, BindableList<T> caller)
         {
             ensureMutationAllowed();
 
-            collection.AddRange(items);
+            collection.AddRange(items.Cast<T>());
 
             if (bindings != null)
             {
@@ -516,7 +534,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            ItemsAdded?.Invoke(items);
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, items, collection.Count - items.Count));
         }
 
         void IBindable.BindTo(IBindable them)
@@ -602,6 +620,33 @@ namespace osu.Framework.Bindables
             => GetEnumerator();
 
         #endregion IEnumerable
+
+        private void notifyCollectionChanged(NotifyCollectionChangedEventArgs args)
+        {
+#pragma warning disable 618 can be removed 20200817
+            switch (args.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    ItemsAdded?.Invoke(args.NewItems.Cast<T>());
+                    break;
+
+                case NotifyCollectionChangedAction.Replace:
+                case NotifyCollectionChangedAction.Move:
+                    ItemsRemoved?.Invoke(args.OldItems.Cast<T>());
+                    ItemsAdded?.Invoke(args.NewItems.Cast<T>());
+                    break;
+
+                case NotifyCollectionChangedAction.Remove:
+                    ItemsRemoved?.Invoke(args.OldItems.Cast<T>());
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                    break;
+            }
+#pragma warning restore 618
+
+            CollectionChanged?.Invoke(this, args);
+        }
 
         private void ensureMutationAllowed()
         {

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -182,12 +182,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-#pragma warning disable 618 // can be removed 20200817
-            // The collection changed event does not provide items upon clearing, but the old interface expects it to.
-            ItemsRemoved?.Invoke(clearedItems);
-#pragma warning restore 618
-
-            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, clearedItems, 0));
         }
 
         /// <summary>

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 
 namespace osu.Framework.Bindables
 {
@@ -10,7 +11,7 @@ namespace osu.Framework.Bindables
     /// An readonly interface which can be bound to other <see cref="IBindableList{T}"/>s in order to watch for state and content changes.
     /// </summary>
     /// <typeparam name="T">The type of value encapsulated by this <see cref="IBindableList{T}"/>.</typeparam>
-    public interface IBindableList<T> : IReadOnlyList<T>, IBindable
+    public interface IBindableList<T> : IReadOnlyList<T>, IBindable, INotifyCollectionChanged
     {
         /// <summary>
         /// An event which is raised when an range of items get added.

--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -89,16 +89,16 @@ namespace osu.Framework.Graphics.Containers
                 case NotifyCollectionChangedAction.Remove:
                     removeItems(e.OldItems);
                     reSort();
+
+                    // Explicitly reset scroll position here so that ScrollContainer doesn't retain our
+                    // scroll position if we quickly add new items after calling a Clear().
+                    ScrollContainer.ScrollToStart();
                     break;
 
                 case NotifyCollectionChangedAction.Reset:
                     currentlyDraggedItem = null;
                     ListContainer.Clear();
                     itemMap.Clear();
-
-                    // Explicitly reset scroll position here so that ScrollContainer doesn't retain our
-                    // scroll position if we quickly add new items after calling a Clear().
-                    ScrollContainer.ScrollToStart();
                     break;
 
                 case NotifyCollectionChangedAction.Replace:

--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -85,20 +85,16 @@ namespace osu.Framework.Graphics.Containers
                 case NotifyCollectionChangedAction.Remove:
                     removeItems(e.OldItems);
                     reSort();
-
-                    if (Items.Count == 0)
-                    {
-                        // Explicitly reset scroll position here so that ScrollContainer doesn't retain our
-                        // scroll position if we quickly add new items after calling a Clear().
-                        ScrollContainer.ScrollToStart();
-                    }
-
                     break;
 
                 case NotifyCollectionChangedAction.Reset:
                     currentlyDraggedItem = null;
                     ListContainer.Clear();
                     itemMap.Clear();
+
+                    // Explicitly reset scroll position here so that ScrollContainer doesn't retain our
+                    // scroll position if we quickly add new items after calling a Clear().
+                    ScrollContainer.ScrollToStart();
                     break;
 
                 case NotifyCollectionChangedAction.Replace:

--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -2,7 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Input.Events;
 using osuTK;
@@ -48,7 +51,6 @@ namespace osu.Framework.Graphics.Containers
         private readonly Dictionary<TModel, RearrangeableListItem<TModel>> itemMap = new Dictionary<TModel, RearrangeableListItem<TModel>>();
         private RearrangeableListItem<TModel> currentlyDraggedItem;
         private Vector2 screenSpaceDragPosition;
-        private bool isCurrentlyRearranging; // Will be true only for the duration that indices are being moved around
 
         /// <summary>
         /// Creates a new <see cref="RearrangeableListContainer{TModel}"/>.
@@ -68,20 +70,65 @@ namespace osu.Framework.Graphics.Containers
                 d.Child = ListContainer;
             });
 
-            Items.ItemsAdded += itemsAdded;
-            Items.ItemsRemoved += itemsRemoved;
+            Items.CollectionChanged += collectionChanged;
         }
 
-        private void itemsAdded(IEnumerable<TModel> items)
+        private void collectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
-            if (isCurrentlyRearranging)
-                return;
+            switch (e.Action)
+            {
+                case NotifyCollectionChangedAction.Add:
+                    addItems(e.NewItems);
+                    reSort();
+                    break;
 
-            foreach (var item in items)
+                case NotifyCollectionChangedAction.Remove:
+                    removeItems(e.OldItems);
+                    reSort();
+
+                    if (Items.Count == 0)
+                    {
+                        // Explicitly reset scroll position here so that ScrollContainer doesn't retain our
+                        // scroll position if we quickly add new items after calling a Clear().
+                        ScrollContainer.ScrollToStart();
+                    }
+
+                    break;
+
+                case NotifyCollectionChangedAction.Reset:
+                    currentlyDraggedItem = null;
+                    ListContainer.Clear();
+                    itemMap.Clear();
+                    break;
+
+                case NotifyCollectionChangedAction.Replace:
+                    removeItems(e.OldItems);
+                    addItems(e.NewItems);
+                    reSort();
+                    break;
+            }
+        }
+
+        private void removeItems(IList items)
+        {
+            foreach (var item in items.Cast<TModel>())
+            {
+                if (currentlyDraggedItem != null && EqualityComparer<TModel>.Default.Equals(currentlyDraggedItem.Model, item))
+                    currentlyDraggedItem = null;
+
+                ListContainer.Remove(itemMap[item]);
+                itemMap.Remove(item);
+            }
+        }
+
+        private void addItems(IList items)
+        {
+            foreach (var item in items.Cast<TModel>())
             {
                 if (itemMap.ContainsKey(item))
                 {
-                    throw new InvalidOperationException($"Duplicate items cannot be added to a {nameof(BindableList<TModel>)} that is currently bound with a {nameof(RearrangeableListContainer<TModel>)}.");
+                    throw new InvalidOperationException(
+                        $"Duplicate items cannot be added to a {nameof(BindableList<TModel>)} that is currently bound with a {nameof(RearrangeableListContainer<TModel>)}.");
                 }
 
                 var drawable = CreateDrawable(item).With(d =>
@@ -93,32 +140,6 @@ namespace osu.Framework.Graphics.Containers
 
                 ListContainer.Add(drawable);
                 itemMap[item] = drawable;
-            }
-
-            reSort();
-        }
-
-        private void itemsRemoved(IEnumerable<TModel> items)
-        {
-            if (isCurrentlyRearranging)
-                return;
-
-            foreach (var item in items)
-            {
-                if (currentlyDraggedItem != null && EqualityComparer<TModel>.Default.Equals(currentlyDraggedItem.Model, item))
-                    currentlyDraggedItem = null;
-
-                ListContainer.Remove(itemMap[item]);
-                itemMap.Remove(item);
-            }
-
-            reSort();
-
-            if (Items.Count == 0)
-            {
-                // Explicitly reset scroll position here so that ScrollContainer doesn't retain our
-                // scroll position if we quickly add new items after calling a Clear().
-                ScrollContainer.ScrollToStart();
             }
         }
 
@@ -215,15 +236,11 @@ namespace osu.Framework.Graphics.Containers
             if (srcIndex == dstIndex)
                 return;
 
-            isCurrentlyRearranging = true;
-
             Items.RemoveAt(srcIndex);
             Items.Insert(dstIndex, currentlyDraggedItem.Model);
 
             // Todo: this could be optimised, but it's a very simple iteration over all the items
             reSort();
-
-            isCurrentlyRearranging = false;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
+++ b/osu.Framework/Graphics/Containers/RearrangeableListContainer.cs
@@ -51,6 +51,7 @@ namespace osu.Framework.Graphics.Containers
         private readonly Dictionary<TModel, RearrangeableListItem<TModel>> itemMap = new Dictionary<TModel, RearrangeableListItem<TModel>>();
         private RearrangeableListItem<TModel> currentlyDraggedItem;
         private Vector2 screenSpaceDragPosition;
+        private bool isCurrentlyRearranging; // Will be true only for the duration that indices are being moved around
 
         /// <summary>
         /// Creates a new <see cref="RearrangeableListContainer{TModel}"/>.
@@ -75,6 +76,9 @@ namespace osu.Framework.Graphics.Containers
 
         private void collectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
+            if (isCurrentlyRearranging)
+                return;
+
             switch (e.Action)
             {
                 case NotifyCollectionChangedAction.Add:
@@ -232,8 +236,12 @@ namespace osu.Framework.Graphics.Containers
             if (srcIndex == dstIndex)
                 return;
 
+            isCurrentlyRearranging = true;
+
             Items.RemoveAt(srcIndex);
             Items.Insert(dstIndex, currentlyDraggedItem.Model);
+
+            isCurrentlyRearranging = false;
 
             // Todo: this could be optimised, but it's a very simple iteration over all the items
             reSort();


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/3081

Follows the model of https://source.dot.net/#System.ObjectModel/System/Collections/ObjectModel/ObservableCollection.cs .

We're going to try out providing the complete event handler with this to:
1. Implement the interface.
2. Follow other implementations such as realm-dotnet.
3. Look into how this affects us in the long term complexity wise. I discovered early on one potential advantage of it, which is as a potential performance improvement to remove a variable capture.

Tests cover both scenarios simultaneously, pending removal in 20200817.

Breaking changes:

# vNext

## `BindableList<T>.ItemsAdded` is now obsolete

The `ItemsAdded` event failed to provide enough context when items are moved around or inserted into the list.

It has been replaced by the `CollectionChanged` [NotifyCollectionChangedEventHandler](https://docs.microsoft.com/en-au/dotnet/api/system.collections.specialized.notifycollectionchangedeventhandler?view=netframework-4.8), which provides context such as the newly-added items and the indices at which the addition took place.

This event is triggered by the following methods with `Action = NotifyCollectionChangedAction.Add`:
```csharp
BindableList<T>.Add(T item)
BindableList<T>.Insert(int index, T item)
BindableList<T>.AddRange(IEnumerable<T> items)
```

The following is an example migration utilising the new `CollectionChanged` event:
```diff
BindableList<int> list = new BindableList<int>();

- list.ItemsAdded += items =>
- {
-     foreach (var item in items)
-         Console.WriteLine($"Added: {item}");
- }

+ list.CollectionChanged += (_, args) =>
+ {
+     switch (args.Action)
+     {
+         case NotifyCollectionChangedAction.Add:
+             foreach (var item in args.NewItems.Cast<int>())
+                 Console.WriteLine($"Added: {item});
+             break;
+     }
+ }
```

Note that `CollectionChanged` should _not_ be used in conjunction with the `ItemsAdded` event.

## `BindableList<T>.ItemsRemoved` is now obsolete

As above, the `ItemsRemoved` revent has also been replaced by the `CollectionChanged` [NotifyCollectionChangedEventHandler](https://docs.microsoft.com/en-au/dotnet/api/system.collections.specialized.notifycollectionchangedeventhandler?view=netframework-4.8).

This event is triggered by the following methods with `Action = NotifyCollectionChangedAction.Remove`:
```csharp
BindableList<T>.Clear()
BindableList<T>.Remove(T item)
BindableList<T>.RemoveRange(int index, int count)
BindableList<T>.RemoveAt(int index)
BindableList<T>.RemoveAll(Predicate<T> match)
```

The following is an example migration utilising the new `CollectionChanged` event:
```diff
BindableList<int> list = new BindableList<int>();

- list.ItemsRemoved += items =>
- {
-     foreach (var item in items)
-         Console.WriteLine($"Removed: {item}");
- }

+ list.CollectionChanged += (_, args) =>
+ {
+     switch (args.Action)
+     {
+         // Handles both clear and remove events
+         case NotifyCollectionChangedAction.Remove:
+             foreach (var item in args.OldItems.Cast<int>())
+                 Console.WriteLine($"Removed: {item});
+             break;
+     }
+ }
```

Note that `CollectionChanged` should _not_ be used in conjunction with the `ItemsRemoved` event.