### PR TITLE
Fix ManualInputManagerTestScene not resetting input properly

### DIFF
--- a/osu.Framework.Tests/Visual/Testing/TestSceneManualInputManagerTestScene.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneManualInputManagerTestScene.cs
@@ -25,9 +25,9 @@ namespace osu.Framework.Tests.Visual.Testing
 
             AddAssert("mouse position reset", () => InputManager.CurrentState.Mouse.Position == InitialMousePosition);
             AddAssert("all input states released", () =>
-                InputManager.CurrentState.Mouse.Buttons.HasAnyButtonPressed &&
-                InputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed &&
-                InputManager.CurrentState.Joystick.Buttons.HasAnyButtonPressed);
+                !InputManager.CurrentState.Mouse.Buttons.HasAnyButtonPressed &&
+                !InputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed &&
+                !InputManager.CurrentState.Joystick.Buttons.HasAnyButtonPressed);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Testing/TestSceneManualInputManagerTestScene.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneManualInputManagerTestScene.cs
@@ -1,0 +1,36 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Tests.Visual.Testing
+{
+    public class TestSceneManualInputManagerTestScene : ManualInputManagerTestScene
+    {
+        protected override Vector2 InitialMousePosition => new Vector2(10f);
+
+        [Test]
+        public void TestResetInput()
+        {
+            AddStep("move mouse", () => InputManager.MoveMouseTo(Vector2.Zero));
+            AddStep("press mouse", () => InputManager.PressButton(MouseButton.Left));
+            AddStep("press key", () => InputManager.PressKey(Key.Z));
+            AddStep("press joystick", () => InputManager.PressJoystickButton(JoystickButton.Button1));
+
+            AddStep("reset input", ResetInput);
+
+            AddAssert("mouse position reset", () => InputManager.CurrentState.Mouse.Position == InitialMousePosition);
+            AddAssert("all input states released", () =>
+                InputManager.CurrentState.Mouse.Buttons.HasAnyButtonPressed &&
+                InputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed &&
+                InputManager.CurrentState.Joystick.Buttons.HasAnyButtonPressed);
+        }
+
+        [Test]
+        public void TestMousePositionSetToInitial() => AddAssert("mouse position set to initial", () => InputManager.CurrentState.Mouse.Position == InitialMousePosition);
+    }
+}

--- a/osu.Framework/Testing/ManualInputManagerTestScene.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestScene.cs
@@ -134,7 +134,7 @@ namespace osu.Framework.Testing
             joystick.Buttons.ForEach(InputManager.ReleaseJoystickButton);
 
             // schedule after children to ensure pending inputs have been applied before using parent input manager.
-            ScheduleAfterChildren(() => InputManager.UseParentInput = true);
+            ScheduleAfterChildren(returnUserInput);
         }
 
         private void returnUserInput() => InputManager.UseParentInput = true;

--- a/osu.Framework/Testing/ManualInputManagerTestScene.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestScene.cs
@@ -133,13 +133,12 @@ namespace osu.Framework.Testing
             var joystick = currentState.Joystick;
             joystick.Buttons.ForEach(InputManager.ReleaseJoystickButton);
 
-            InputManager.UseParentInput = true;
+            // schedule after children to ensure pending inputs have been applied before using parent input manager.
+            ScheduleAfterChildren(() => InputManager.UseParentInput = true);
         }
 
-        private void returnUserInput() =>
-            InputManager.UseParentInput = true;
+        private void returnUserInput() => InputManager.UseParentInput = true;
 
-        private void returnTestInput() =>
-            InputManager.UseParentInput = false;
+        private void returnTestInput() => InputManager.UseParentInput = false;
     }
 }


### PR DESCRIPTION
The cause of this is that `UseParentInput` is set right after inputs have been enqueued to the pending list, I was quite unsure whether to solve this by applying pending inputs enqueued to `PassThroughInputManager` for the first time `GetPendingInputs()` is invoked **after** `UsePendingInput` is set, so I fixed it here for now.

Also added tests to ensure that this doesn't regress again. (and explicitly checks that `InitialMousePosition` works)