### PR TITLE
Minor optimizations/cleanups

### DIFF
--- a/osu.Framework/Configuration/IniConfigManager.cs
+++ b/osu.Framework/Configuration/IniConfigManager.cs
@@ -48,8 +48,8 @@ namespace osu.Framework.Configuration
 
                         if (line.Length == 0 || line[0] == '#' || equalsIndex < 0) continue;
 
-                        string key = line.Substring(0, equalsIndex).Trim();
-                        string val = line.Remove(0, equalsIndex + 1).Trim();
+                        string key = line.AsSpan(0, equalsIndex).Trim().ToString();
+                        string val = line.AsSpan(equalsIndex + 1).Trim().ToString();
 
                         if (!Enum.TryParse(key, out TLookup lookup))
                             continue;

--- a/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
+++ b/osu.Framework/Extensions/TypeExtensions/TypeExtensions.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Extensions.TypeExtensions
             string result = t.Name;
 
             // Trim away amount of type arguments
-            int amountTypeArgumentsPos = result.IndexOf("`", StringComparison.Ordinal);
+            int amountTypeArgumentsPos = result.IndexOf('`');
             if (amountTypeArgumentsPos >= 0)
                 result = result.Substring(0, amountTypeArgumentsPos);
 

--- a/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
@@ -108,17 +108,17 @@ namespace osu.Framework.Graphics.Containers
                     if (placeholderEnd != -1)
                     {
                         strPiece = str[index..nextPlaceholderIndex];
-                        string placeholderStr = str.Substring(nextPlaceholderIndex + 1, placeholderEnd - nextPlaceholderIndex - 1).Trim();
+                        string placeholderStr = str.AsSpan(nextPlaceholderIndex + 1, placeholderEnd - nextPlaceholderIndex - 1).Trim().ToString();
                         string placeholderName = placeholderStr;
                         string paramStr = "";
                         int parensOpen = placeholderStr.IndexOf('(');
 
                         if (parensOpen != -1)
                         {
-                            placeholderName = placeholderStr.Substring(0, parensOpen).Trim();
+                            placeholderName = placeholderStr.AsSpan(0, parensOpen).Trim().ToString();
                             int parensClose = placeholderStr.IndexOf(')', parensOpen);
                             if (parensClose != -1)
-                                paramStr = placeholderStr.Substring(parensOpen + 1, parensClose - parensOpen - 1).Trim();
+                                paramStr = placeholderStr.AsSpan(parensOpen + 1, parensClose - parensOpen - 1).Trim().ToString();
                             else
                                 throw new ArgumentException($"Missing ) in placeholder {placeholderStr}.");
                         }

--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Platform
             {
                 if (!path.StartsWith(basePath)) throw new ArgumentException($"\"{path}\" does not start with \"{basePath}\" and is probably malformed");
 
-                return path.Substring(basePath.Length).TrimStart(Path.DirectorySeparatorChar);
+                return path.AsSpan(basePath.Length).TrimStart(Path.DirectorySeparatorChar).ToString();
             });
         }
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -92,7 +92,7 @@ namespace osu.Framework.Testing
                                                 .GroupBy(
                                                     t =>
                                                     {
-                                                        string group = t.Namespace?.Substring(namespacePrefix.Length).TrimStart('.');
+                                                        string group = t.Namespace?.AsSpan(namespacePrefix.Length).TrimStart('.').ToString();
                                                         return string.IsNullOrWhiteSpace(group) ? "Ungrouped" : group;
                                                     },
                                                     t => t,


### PR DESCRIPTION
- Replace string.Substring(...).Trim() (or siimlar) calls with string.AsSpan(...).Trim().ToString()
- Replace remaining string.IndexOf(string, StringComparison.Ordinal) call with string.IndexOf(char)

No changes in behaviour.
