### PR TITLE
Improve texture queueing mechanism

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -148,6 +148,8 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             public FrameBufferTexture(Vector2 size, All filteringMode = All.Linear)
                 : base((int)Math.Ceiling(size.X), (int)Math.Ceiling(size.Y), true, filteringMode)
             {
+                BypassTextureUploadQueueing = true;
+
                 SetData(new TextureUpload());
                 Upload();
             }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -131,14 +131,19 @@ namespace osu.Framework.Graphics.OpenGL
 
             stat_texture_uploads_dequeued.Value = 0;
 
-            // continue attempting to upload textures until one actually performed an upload.
+            // increase the number of items processed with the queue length to ensure it doesn't get out of hand.
+            int targetUploads = Math.Max(1, texture_upload_queue.Count / 2);
+            int uploads = 0;
+
+            // continue attempting to upload textures until enough perform uploads.
             while (texture_upload_queue.TryDequeue(out TextureGL texture))
             {
-                stat_texture_uploads_dequeued.Value++;
                 texture.IsQueuedForUpload = false;
-                if (texture.Upload())
+                if (texture.Upload() && ++uploads >= targetUploads)
                     break;
             }
+
+            stat_texture_uploads_dequeued.Value = uploads;
 
             Array.Clear(last_bound_texture, 0, last_bound_texture.Length);
 

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -108,11 +108,15 @@ namespace osu.Framework.Graphics.OpenGL
             });
         }
 
+        private static readonly GlobalStatistic<int> stat_expensive_operations = GlobalStatistics.Get<int>(nameof(GLWrapper), "Expensive operations queue");
+
         internal static void Reset(Vector2 size)
         {
             Trace.Assert(shader_stack.Count == 0);
 
             reset_scheduler.Update();
+
+            stat_expensive_operations.Value = expensive_operations_queue.Count;
 
             if (expensive_operations_queue.TryDequeue(out Action action))
                 action.Invoke();

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Graphics.OpenGL
         /// <summary>
         /// A queue from which a maximum of one operation is invoked per draw frame.
         /// </summary>
-        private static readonly ConcurrentQueue<Action> expensive_operations_queue = new ConcurrentQueue<Action>();
+        private static readonly ConcurrentQueue<Action> expensive_operation_queue = new ConcurrentQueue<Action>();
 
         private static readonly ConcurrentQueue<TextureGL> texture_upload_queue = new ConcurrentQueue<TextureGL>();
 
@@ -110,8 +110,8 @@ namespace osu.Framework.Graphics.OpenGL
             });
         }
 
-        private static readonly GlobalStatistic<int> stat_expensive_operations_queued = GlobalStatistics.Get<int>(nameof(GLWrapper), "Expensive operations queued");
-        private static readonly GlobalStatistic<int> stat_texture_uploads_queued = GlobalStatistics.Get<int>(nameof(GLWrapper), "Texture uploads queued");
+        private static readonly GlobalStatistic<int> stat_expensive_operations_queued = GlobalStatistics.Get<int>(nameof(GLWrapper), "Expensive operation queue length");
+        private static readonly GlobalStatistic<int> stat_texture_uploads_queued = GlobalStatistics.Get<int>(nameof(GLWrapper), "Texture upload queue length");
         private static readonly GlobalStatistic<int> stat_texture_uploads_dequeued = GlobalStatistics.Get<int>(nameof(GLWrapper), "Texture uploads dequeued");
         private static readonly GlobalStatistic<int> stat_texture_uploads_performed = GlobalStatistics.Get<int>(nameof(GLWrapper), "Texture uploads performed");
 
@@ -121,8 +121,8 @@ namespace osu.Framework.Graphics.OpenGL
 
             reset_scheduler.Update();
 
-            stat_expensive_operations_queued.Value = expensive_operations_queue.Count;
-            if (expensive_operations_queue.TryDequeue(out Action action))
+            stat_expensive_operations_queued.Value = expensive_operation_queue.Count;
+            if (expensive_operation_queue.TryDequeue(out Action action))
                 action.Invoke();
 
             stat_texture_uploads_queued.Value = texture_upload_queue.Count;
@@ -284,7 +284,7 @@ namespace osu.Framework.Graphics.OpenGL
         public static void EnqueueShaderCompile(Shader shader)
         {
             if (host != null)
-                expensive_operations_queue.Enqueue(shader.EnsureLoaded);
+                expensive_operation_queue.Enqueue(shader.EnsureLoaded);
         }
 
         private static readonly int[] last_bound_buffers = new int[2];

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -27,6 +27,13 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         internal virtual bool IsQueuedForUpload { get; set; }
 
         /// <summary>
+        /// By default, texture uploads are queued for upload at the beginning of each frame, allowing loading them ahead of time.
+        /// When this is true, this will be bypassed and textures will only be uploaded on use. Should be set for every-frame texture uploads
+        /// to avoid overloading the global queue.
+        /// </summary>
+        public bool BypassTextureUploadQueueing;
+
+        /// <summary>
         /// Whether this <see cref="TextureGL"/> can used for drawing.
         /// </summary>
         public bool Available { get; private set; } = true;

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -24,6 +24,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             Dispose(false);
         }
 
+        internal virtual bool IsQueuedForUpload { get; set; }
+
         /// <summary>
         /// Whether this <see cref="TextureGL"/> can used for drawing.
         /// </summary>

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -302,7 +302,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 bool requireUpload = uploadQueue.Count == 0;
                 uploadQueue.Enqueue(upload);
 
-                if (requireUpload)
+                if (requireUpload && !BypassTextureUploadQueueing)
                     GLWrapper.EnqueueTextureUpload(this);
             }
         }

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -301,6 +301,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             {
                 bool requireUpload = uploadQueue.Count == 0;
                 uploadQueue.Enqueue(upload);
+
                 if (requireUpload)
                     GLWrapper.EnqueueTextureUpload(this);
             }

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSub.cs
@@ -21,6 +21,12 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         public override int TextureId => parent.TextureId;
         public override bool Loaded => parent.Loaded;
 
+        internal override bool IsQueuedForUpload
+        {
+            get => parent.IsQueuedForUpload;
+            set => parent.IsQueuedForUpload = value;
+        }
+
         public TextureGLSub(RectangleI bounds, TextureGLSingle parent)
         {
             // If GLWrapper is not initialized at this point, it means we do not have OpenGL available

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -509,7 +509,7 @@ namespace osu.Framework.Graphics.Performance
                 Size = new Vector2(WIDTH, HEIGHT);
                 Child = Sprite = new Sprite();
 
-                Sprite.Texture = new Texture(WIDTH, HEIGHT);
+                Sprite.Texture = new Texture(WIDTH, HEIGHT) { TextureGL = { BypassTextureUploadQueueing = true } };
             }
         }
 


### PR DESCRIPTION
Until now, the mechanism we had in place for background texture uploading had a few issues:

- It would only upload one item per frame
- This wouldn't be so bad, but it would also only process one item, even if it was already uploaded

This was particularly bad when the `FrameStatisticsDisplay` was visible, as it would queue four texture uploads per frame (even though it was only performing one actual upload), causing a runaway scenario where the queue would never recover.

This PR makes the queue aware of the texture's upload and queued state to ensure the queue stays under control. It also allows more than one texture to be uploaded per frame if the queue grows too large.

Should hopefully resolve the issues experienced on https://github.com/ppy/osu-framework/pull/1842/files (I think this PR may be able to be closed as a result).