### PR TITLE
Improve initialisation error handling in video decoder

### DIFF
--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -89,6 +89,7 @@ namespace osu.Framework.Graphics.Video
         private avio_alloc_context_read_packet readPacketCallback;
         private avio_alloc_context_seek seekCallback;
 
+        private bool inputOpened;
         private bool isDisposed;
         private Stream videoStream;
 
@@ -338,7 +339,8 @@ namespace osu.Framework.Graphics.Video
             formatContext->pb = ffmpeg.avio_alloc_context(contextBuffer, context_buffer_size, 0, (void*)handle.Handle, readPacketCallback, null, seekCallback);
 
             int openInputResult = ffmpeg.avformat_open_input(&fcPtr, "dummy", null, null);
-            if (openInputResult < 0)
+            inputOpened = openInputResult >= 0;
+            if (!inputOpened)
                 throw new InvalidOperationException($"Error opening file or stream: {getErrorMessage(openInputResult)}");
 
             int findStreamInfoResult = ffmpeg.avformat_find_stream_info(formatContext, null);
@@ -598,7 +600,7 @@ namespace osu.Framework.Graphics.Video
 
             StopDecoding(true);
 
-            if (formatContext != null)
+            if (formatContext != null && inputOpened)
             {
                 fixed (AVFormatContext** ptr = &formatContext)
                     ffmpeg.avformat_close_input(ptr);

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -238,6 +238,9 @@ namespace osu.Framework.Graphics.Video
         // https://en.wikipedia.org/wiki/YCbCr
         public Matrix3 GetConversionMatrix()
         {
+            if (stream == null)
+                return Matrix3.Zero;
+
             switch (stream->codec->colorspace)
             {
                 case AVColorSpace.AVCOL_SPC_BT709:


### PR DESCRIPTION
Resolves ppy/osu#7947 (or at least the hard crash part of it).

- [x] Depends on #3294.

# Summary

After crashes on startup were reported osu!-side, I investigated and diagnosed two issues with the video decoder that could result in hard crashes.

## Failing calls to `GetConversionMatrix()`

If video initialisation failed in any way (in my case, it was due to a missing `libavformat.so` on linux), subsequent accesses to `GetConversionMatrix` could crash with a null reference exception due to uninitialised video stream. Guard `GetConversionMatrix()` with a null-check to alleviate this.

## Incorrect disposal if initialisation failed

If `avformat_open_input()` failed when trying initialising a decoder, but a format context was created, it was possible that during disposal an attempt to call `avformat_close_input()` without a matching open was made, which led to a segfault.

Prevent unmatched close calls by introducing a flag tracking if an input was ever opened.

# Remarks

This was quite the journey to debug altogether.

* First off, the very first issue I hit on my ubuntu 16.04 install was that I somehow had ffmpeg but had `libavformat` missing, so after patching up `GetConversionMatrix()` with a null check I installed the version that was in the official package lists.
* That fixed the crashes, but still led to video not working with an arcane error code, which was the primary rationale for #3294. I also noticed by looking at `VideoSpriteTestScene` that changing out of it would lead to sudden unclean exits, so I debugged disposal logic and found problem no. 2.
* At that point I could no longer get the thing to crash, but it still didn't work. After some googling I found out that apparently the error code I got (`Invalid data found when processing input`) meant a missing `av_register_all()` call, which I attempted to add, to find that it was deprecated at `AGffmpeg`.

  Turns out, on ffmpeg >= 4 you no longer *need* to call it, but on previous versions not calling that would just leave you with a useless ffmpeg with no formats or codecs loaded.
* To check it out I added ffmpeg 4 from a PPA, to no effect. Firing up `LD_DEBUG` again, I saw that it was hitting the proper path, but upon inspecting symlinks in `/usr/lib/x86_64-linux-gnu` I noticed that the root `libavformat.so` was hooked up to the wrong ffmpeg version (the one I installed at the very beginning from the package lists). After removing the versions from the package lists I finally had a fully working video setup.

Therefore this *will* mean that this will no longer crash even with the `.so`s fully missing (which I tested by manually moving them away from `/usr/lib`), but it might mean that some users on linux won't have working video due to linux foibles and outdated package lists.

I guess this is a call for me to finally perform the dreaded upgrade...?

FWIW, tested both with framework test scene and osu!-side with a local framework checkout on both Windows and Linux.