### PR TITLE
Add update CPU time profiling to global statistics

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -832,11 +832,21 @@ namespace osu.Framework.Graphics.Containers
 
             UpdateAfterChildrenLife();
 
-            for (int i = 0; i < aliveInternalChildren.Count; ++i)
+            if (TypePerformanceMonitor.Active)
             {
-                Drawable c = aliveInternalChildren[i];
-                Debug.Assert(c.LoadState >= LoadState.Ready);
-                c.UpdateSubTree();
+                for (int i = 0; i < aliveInternalChildren.Count; ++i)
+                {
+                    Drawable c = aliveInternalChildren[i];
+
+                    TypePerformanceMonitor.BeginCollecting(c);
+                    updateChild(c);
+                    TypePerformanceMonitor.EndCollecting(c);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < aliveInternalChildren.Count; ++i)
+                    updateChild(aliveInternalChildren[i]);
             }
 
             if (schedulerAfterChildren.IsValueCreated)
@@ -850,6 +860,12 @@ namespace osu.Framework.Graphics.Containers
             updateChildrenSizeDependencies();
             UpdateAfterAutoSize();
             return true;
+        }
+
+        private void updateChild(Drawable c)
+        {
+            Debug.Assert(c.LoadState >= LoadState.Ready);
+            c.UpdateSubTree();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Visualisation;
@@ -50,6 +51,13 @@ namespace osu.Framework.Graphics.Performance
 
             // ToArray is to guard against collection modification in underlying bindable.
             add(GlobalStatistics.Statistics.ToArray());
+
+            State.BindValueChanged(visibilityChanged, true);
+        }
+
+        private void visibilityChanged(ValueChangedEvent<Visibility> state)
+        {
+            TypePerformanceMonitor.Active = state.NewValue == Visibility.Visible;
         }
 
         private void remove(IEnumerable<IGlobalStatistic> stats) => Schedule(() =>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -307,6 +307,8 @@ namespace osu.Framework.Platform
             // Ensure we maintain a valid size for any children immediately scaling by the window size
             Root.Size = Vector2.ComponentMax(Vector2.One, Root.Size);
 
+            TypePerformanceMonitor.NewFrame();
+
             Root.UpdateSubTree();
             Root.UpdateSubTreeMasking(Root, Root.ScreenSpaceDrawQuad.AABBFloat);
 

--- a/osu.Framework/Statistics/GlobalStatistics.cs
+++ b/osu.Framework/Statistics/GlobalStatistics.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using osu.Framework.Bindables;
 
@@ -38,12 +39,16 @@ namespace osu.Framework.Statistics
             }
         }
 
-        public static void Clear()
+        /// <summary>
+        /// Clear all statistics.
+        /// </summary>
+        /// <param name="group">An optional group identifier, limiting the clear operation to the matching group.</param>
+        public static void Clear(string group = null)
         {
             lock (statistics)
             {
-                foreach (var stat in statistics)
-                    stat.Clear();
+                foreach (var stat in statistics.Where(s => group?.Equals(s.Group, StringComparison.Ordinal) != false).ToArray())
+                    statistics.Remove(stat);
             }
         }
 

--- a/osu.Framework/Statistics/TypePerformanceMonitor.cs
+++ b/osu.Framework/Statistics/TypePerformanceMonitor.cs
@@ -1,0 +1,111 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Timing;
+
+namespace osu.Framework.Statistics
+{
+    internal static class TypePerformanceMonitor
+    {
+        private static readonly StopwatchClock clock = new StopwatchClock(true);
+
+        private static readonly Stack<Type> current_collection_type_stack = new Stack<Type>();
+
+        private static readonly Dictionary<Type, double> collected_times = new Dictionary<Type, double>();
+
+        private static double consumptionTime;
+
+        private static bool active;
+
+        public static bool Active;
+
+        /// <summary>
+        /// Start collecting time for a specific object type.
+        /// </summary>
+        internal static void BeginCollecting(object obj)
+        {
+            if (!active) return;
+
+            var type = obj.GetType();
+
+            if (current_collection_type_stack.Count > 0)
+            {
+                Type t = current_collection_type_stack.Peek();
+
+                if (!collected_times.ContainsKey(t)) collected_times[t] = 0;
+                collected_times[t] += consumeStopwatchElapsedTime();
+            }
+
+            current_collection_type_stack.Push(type);
+        }
+
+        /// <summary>
+        /// End collecting time for a specific object type.
+        /// </summary>
+        internal static void EndCollecting(object obj)
+        {
+            if (!active) return;
+
+            var type = obj.GetType();
+
+            current_collection_type_stack.Pop();
+
+            if (!collected_times.ContainsKey(type)) collected_times[type] = 0;
+            collected_times[type] += consumeStopwatchElapsedTime();
+        }
+
+        private static double lastReport;
+
+        private static int framesSinceLastReport;
+
+        private const string group_name = "Update (Top CPU consumers)";
+
+        public static void NewFrame()
+        {
+            if (Active != active)
+            {
+                active = Active;
+
+                if (!active)
+                {
+                    lastReport = 0;
+                    GlobalStatistics.Clear(group_name);
+                    collected_times.Clear();
+                    framesSinceLastReport = 0;
+                    return;
+                }
+            }
+
+            //reset frame totals
+            current_collection_type_stack.Clear();
+            consumeStopwatchElapsedTime();
+
+            if (framesSinceLastReport > 0 && clock.CurrentTime - lastReport > 1000)
+            {
+                GlobalStatistics.Clear(group_name);
+
+                int i = 0;
+                foreach (var t in collected_times.OrderByDescending(t => t.Value).Take(5))
+                    GlobalStatistics.Get<string>(group_name, $"{++i}. {t.Key.Name}").Value = $"{t.Value / framesSinceLastReport:N1}ms";
+
+                collected_times.Clear();
+                framesSinceLastReport = 0;
+                lastReport = clock.CurrentTime;
+            }
+
+            framesSinceLastReport++;
+        }
+
+        private static double consumeStopwatchElapsedTime()
+        {
+            double last = consumptionTime;
+
+            consumptionTime = clock.CurrentTime;
+
+            return consumptionTime - last;
+        }
+    }
+}


### PR DESCRIPTION
Generally we rely on existing profilers for tracking down performance issues, but as profilers do not show local class names, we end up having to work with this kind of mess:

![dotTraceView64_2020-02-23_02-43-23](https://user-images.githubusercontent.com/191335/75096797-68f5ce00-55e6-11ea-8461-a9ceb0d76aa5.png)

This solves the issue and gives a quick overview of what components are using the most CPU during their update operations.

![image](https://user-images.githubusercontent.com/191335/75096765-174d4380-55e6-11ea-9be6-fb572d44e947.gif)

- Updates at most once every second for readability purposes.
- Aims to be lowest overhead possible. Split the update loop into two versions to avoid the function call overhead when disabled (it does make a difference).