### PR TITLE
Add ability to toggle between single and multi-threaded execution

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Android
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
             if (!defaultOverrides.ContainsKey(FrameworkSetting.ExecutionMode))
-                defaultOverrides.Add(FrameworkSetting.ExecutionMode, ExecutionMode.SingleThreaded);
+                defaultOverrides.Add(FrameworkSetting.ExecutionMode, ExecutionMode.SingleThread);
 
             base.SetupConfig(defaultOverrides);
         }

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -9,6 +9,7 @@ using Android.Content;
 using osu.Framework.Android.Graphics.Textures;
 using osu.Framework.Android.Graphics.Video;
 using osu.Framework.Android.Input;
+using osu.Framework.Configuration;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Video;
 using osu.Framework.Input;
@@ -33,6 +34,13 @@ namespace osu.Framework.Android
         {
             base.SetupForRun();
             AndroidGameWindow.View = gameView;
+        }
+
+        protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
+        {
+            defaultOverrides.Add(FrameworkSetting.SingleThreaded, true);
+
+            base.SetupConfig(defaultOverrides);
         }
 
         protected override IWindow CreateWindow() => new AndroidGameWindow();

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -38,7 +38,8 @@ namespace osu.Framework.Android
 
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
-            defaultOverrides.Add(FrameworkSetting.SingleThreaded, true);
+            if (!defaultOverrides.ContainsKey(FrameworkSetting.ExecutionMode))
+                defaultOverrides.Add(FrameworkSetting.ExecutionMode, ExecutionMode.SingleThreaded);
 
             base.SetupConfig(defaultOverrides);
         }

--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.Android" Version="1.0.140" />
+    <PackageReference Include="ppy.osuTK.Android" Version="1.0.149" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\**\*.so"/>

--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -69,7 +69,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.140" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.149" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="ppy.Microsoft.Diagnostics.Runtime" Version="0.9.180305.1" />
     <PackageReference Include="NUnit" Version="3.12.0" />
@@ -80,7 +80,7 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    
+
     <!-- Manually downgrade for 4.5.1-4.5.3. Should be removed when 4.6.0 released. -->
     <PackageReference Include="System.Memory" Version="4.5.0" NoWarn="NU1605" />
   </ItemGroup>

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -69,8 +69,8 @@ namespace osu.Framework.iOS
 
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
-            if (!defaultOverrides.ContainsKey(FrameworkSetting.SingleThreaded))
-                defaultOverrides.Add(FrameworkSetting.SingleThreaded, true);
+            if (!defaultOverrides.ContainsKey(FrameworkSetting.ExecutionMode))
+                defaultOverrides.Add(FrameworkSetting.ExecutionMode, ExecutionMode.SingleThreaded);
 
             base.SetupConfig(defaultOverrides);
 

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -67,9 +67,12 @@ namespace osu.Framework.iOS
 
         protected override IWindow CreateWindow() => new IOSGameWindow();
 
-        protected override void SetupConfig(IDictionary<FrameworkSetting, object> gameDefaults)
+        protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
-            base.SetupConfig(gameDefaults);
+            if (!defaultOverrides.ContainsKey(FrameworkSetting.SingleThreaded))
+                defaultOverrides.Add(FrameworkSetting.SingleThreaded, true);
+
+            base.SetupConfig(defaultOverrides);
 
             DebugConfig.Set(DebugSetting.BypassFrontToBackPass, true);
         }

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.iOS
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
             if (!defaultOverrides.ContainsKey(FrameworkSetting.ExecutionMode))
-                defaultOverrides.Add(FrameworkSetting.ExecutionMode, ExecutionMode.SingleThreaded);
+                defaultOverrides.Add(FrameworkSetting.ExecutionMode, ExecutionMode.SingleThread);
 
             base.SetupConfig(defaultOverrides);
 

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.140" />
+    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.149" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
   </ItemGroup>
   <ItemGroup>

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Audio
         /// <returns>A task which can be used for continuation logic. May return a <see cref="Task.CompletedTask"/> if called while already on the audio thread.</returns>
         protected Task EnqueueAction(Action action)
         {
-            if (ThreadSafety.ExecutionMode == ExecutionMode.SingleThreaded)
+            if (ThreadSafety.ExecutionMode == ExecutionMode.SingleThread)
             {
                 if (ThreadSafety.IsDrawThread)
                     throw new InvalidOperationException("Cannot perform audio operation from draw thread.");
@@ -38,7 +38,7 @@ namespace osu.Framework.Audio
                     throw new InvalidOperationException("Cannot perform audio operation from input thread.");
             }
 
-            if (ThreadSafety.IsAudioThread || (ThreadSafety.ExecutionMode == ExecutionMode.SingleThreaded && ThreadSafety.IsUpdateThread))
+            if (ThreadSafety.IsAudioThread || (ThreadSafety.ExecutionMode == ExecutionMode.SingleThread && ThreadSafety.IsUpdateThread))
             {
                 action();
                 return Task.CompletedTask;

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -80,6 +80,7 @@ namespace osu.Framework.Audio
         public void Update()
         {
             ThreadSafety.EnsureNotUpdateThread();
+
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not update disposed audio components.");
 

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Threading.Tasks;
 using osu.Framework.Development;
+using osu.Framework.Platform;
 using osu.Framework.Statistics;
 
 namespace osu.Framework.Audio
@@ -28,7 +29,7 @@ namespace osu.Framework.Audio
         /// <returns>A task which can be used for continuation logic. May return a <see cref="Task.CompletedTask"/> if called while already on the audio thread.</returns>
         protected Task EnqueueAction(Action action)
         {
-            if (ThreadSafety.IsAudioThread)
+            if (ThreadSafety.IsAudioThread || (ThreadSafety.ExecutionMode == ExecutionMode.SingleThreaded && ThreadSafety.IsUpdateThread))
             {
                 action();
                 return Task.CompletedTask;

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -32,10 +32,10 @@ namespace osu.Framework.Audio
             if (ThreadSafety.ExecutionMode == ExecutionMode.SingleThreaded)
             {
                 if (ThreadSafety.IsDrawThread)
-                    throw new InvalidOperationException($"Cannot perform audio operation from draw thread.");
+                    throw new InvalidOperationException("Cannot perform audio operation from draw thread.");
 
                 if (ThreadSafety.IsInputThread)
-                    throw new InvalidOperationException($"Cannot perform audio operation from input thread.");
+                    throw new InvalidOperationException("Cannot perform audio operation from input thread.");
             }
 
             if (ThreadSafety.IsAudioThread || (ThreadSafety.ExecutionMode == ExecutionMode.SingleThreaded && ThreadSafety.IsUpdateThread))

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -29,6 +29,15 @@ namespace osu.Framework.Audio
         /// <returns>A task which can be used for continuation logic. May return a <see cref="Task.CompletedTask"/> if called while already on the audio thread.</returns>
         protected Task EnqueueAction(Action action)
         {
+            if (ThreadSafety.ExecutionMode == ExecutionMode.SingleThreaded)
+            {
+                if (ThreadSafety.IsDrawThread)
+                    throw new InvalidOperationException($"Cannot perform audio operation from draw thread.");
+
+                if (ThreadSafety.IsInputThread)
+                    throw new InvalidOperationException($"Cannot perform audio operation from input thread.");
+            }
+
             if (ThreadSafety.IsAudioThread || (ThreadSafety.ExecutionMode == ExecutionMode.SingleThreaded && ThreadSafety.IsUpdateThread))
             {
                 action();

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Configuration
             Set(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480));
             Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen);
             Set(FrameworkSetting.MapAbsoluteInputToWindow, false);
-            Set(FrameworkSetting.SingleThreaded, false);
+            Set(FrameworkSetting.ExecutionMode, ExecutionMode.MultiThreaded);
             Set(FrameworkSetting.WindowedPositionX, 0.5, -0.5, 1.5);
             Set(FrameworkSetting.WindowedPositionY, 0.5, -0.5, 1.5);
             Set(FrameworkSetting.LastDisplayDevice, DisplayIndex.Default);
@@ -81,7 +81,7 @@ namespace osu.Framework.Configuration
         WindowMode,
         ConfineMouseMode,
         FrameSync,
-        SingleThreaded,
+        ExecutionMode,
 
         ShowUnicode,
         Locale,

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -24,6 +24,7 @@ namespace osu.Framework.Configuration
             Set(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480));
             Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen);
             Set(FrameworkSetting.MapAbsoluteInputToWindow, false);
+            Set(FrameworkSetting.SingleThreaded, false);
             Set(FrameworkSetting.WindowedPositionX, 0.5, -0.5, 1.5);
             Set(FrameworkSetting.WindowedPositionY, 0.5, -0.5, 1.5);
             Set(FrameworkSetting.LastDisplayDevice, DisplayIndex.Default);
@@ -80,6 +81,7 @@ namespace osu.Framework.Configuration
         WindowMode,
         ConfineMouseMode,
         FrameSync,
+        SingleThreaded,
 
         ShowUnicode,
         Locale,

--- a/osu.Framework/Development/ThreadSafety.cs
+++ b/osu.Framework/Development/ThreadSafety.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Development
         internal static void EnsureUpdateThread() => Debug.Assert(IsUpdateThread);
 
         [Conditional("DEBUG")]
-        internal static void EnsureNotUpdateThread() => Debug.Assert(SingleThreadThread != null && is_main_thread.Value || !IsUpdateThread);
+        internal static void EnsureNotUpdateThread() => Debug.Assert((SingleThreadThread != null && is_main_thread.Value) || !IsUpdateThread);
 
         [Conditional("DEBUG")]
         internal static void EnsureDrawThread() => Debug.Assert(IsDrawThread);

--- a/osu.Framework/Development/ThreadSafety.cs
+++ b/osu.Framework/Development/ThreadSafety.cs
@@ -17,6 +17,14 @@ namespace osu.Framework.Development
         [Conditional("DEBUG")]
         internal static void EnsureDrawThread() => Debug.Assert(IsDrawThread);
 
+        internal static void ResetAllForCurrentThread()
+        {
+            IsInputThread = false;
+            IsUpdateThread = false;
+            IsDrawThread = false;
+            IsAudioThread = false;
+        }
+
         [ThreadStatic]
         public static bool IsInputThread;
 

--- a/osu.Framework/Development/ThreadSafety.cs
+++ b/osu.Framework/Development/ThreadSafety.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Diagnostics;
+using osu.Framework.Platform;
 
 namespace osu.Framework.Development
 {
@@ -24,6 +25,8 @@ namespace osu.Framework.Development
             IsDrawThread = false;
             IsAudioThread = false;
         }
+
+        public static ExecutionMode ExecutionMode;
 
         [ThreadStatic]
         public static bool IsInputThread;

--- a/osu.Framework/Development/ThreadSafety.cs
+++ b/osu.Framework/Development/ThreadSafety.cs
@@ -12,18 +12,24 @@ namespace osu.Framework.Development
         [Conditional("DEBUG")]
         internal static void EnsureUpdateThread()
         {
+            if (SingleThreaded) return;
+
             Debug.Assert(IsUpdateThread);
         }
 
         [Conditional("DEBUG")]
         internal static void EnsureNotUpdateThread()
         {
+            if (SingleThreaded) return;
+
             Debug.Assert(!IsUpdateThread);
         }
 
         [Conditional("DEBUG")]
         internal static void EnsureDrawThread()
         {
+            if (SingleThreaded) return;
+
             Debug.Assert(IsDrawThread);
         }
 
@@ -35,6 +41,8 @@ namespace osu.Framework.Development
 
         private static readonly ThreadLocal<bool> is_audio_thread = new ThreadLocal<bool>(() =>
             Thread.CurrentThread.Name == GameThread.PrefixedThreadNameFor("Audio"));
+
+        internal static bool SingleThreaded;
 
         public static bool IsUpdateThread => is_update_thread.Value;
 

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -206,7 +206,7 @@ namespace osu.Framework
 
             PerformanceOverlay performanceOverlay;
 
-            LoadComponentAsync(performanceOverlay = new PerformanceOverlay(Host.Threads.Reverse())
+            LoadComponentAsync(performanceOverlay = new PerformanceOverlay(Host.Threads)
             {
                 Margin = new MarginPadding(5),
                 Direction = FillDirection.Vertical,

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -164,7 +164,7 @@ namespace osu.Framework
 
             frameSyncMode = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
 
-            singleThreaded = config.GetBindable<bool>(FrameworkSetting.SingleThreaded);
+            executionMode = config.GetBindable<ExecutionMode>(FrameworkSetting.ExecutionMode);
 
             logOverlayVisibility = config.GetBindable<bool>(FrameworkSetting.ShowLogOverlay);
             logOverlayVisibility.BindValueChanged(visibility =>
@@ -228,7 +228,7 @@ namespace osu.Framework
 
         private Bindable<FrameSync> frameSyncMode;
 
-        private Bindable<bool> singleThreaded;
+        private Bindable<ExecutionMode> executionMode;
 
         public bool OnPressed(FrameworkAction action)
         {
@@ -289,16 +289,21 @@ namespace osu.Framework
                     return true;
 
                 case FrameworkAction.CycleFrameSync:
-                    var nextMode = frameSyncMode.Value + 1;
+                    var nextFrameSync = frameSyncMode.Value + 1;
 
-                    if (nextMode > FrameSync.Unlimited)
-                        nextMode = FrameSync.VSync;
+                    if (nextFrameSync > FrameSync.Unlimited)
+                        nextFrameSync = FrameSync.VSync;
 
-                    frameSyncMode.Value = nextMode;
+                    frameSyncMode.Value = nextFrameSync;
                     break;
 
-                case FrameworkAction.ToggleSingleThreaded:
-                    singleThreaded.Value = !singleThreaded.Value;
+                case FrameworkAction.CycleExecutionMode:
+                    var nextExecutionMode = executionMode.Value + 1;
+
+                    if (nextExecutionMode > ExecutionMode.MultiThreaded)
+                        nextExecutionMode = ExecutionMode.SingleThreaded;
+
+                    executionMode.Value = nextExecutionMode;
                     break;
             }
 

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -301,7 +301,7 @@ namespace osu.Framework
                     var nextExecutionMode = executionMode.Value + 1;
 
                     if (nextExecutionMode > ExecutionMode.MultiThreaded)
-                        nextExecutionMode = ExecutionMode.SingleThreaded;
+                        nextExecutionMode = ExecutionMode.SingleThread;
 
                     executionMode.Value = nextExecutionMode;
                     break;

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -165,6 +165,8 @@ namespace osu.Framework
 
             frameSyncMode = config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
 
+            singleThreaded = config.GetBindable<bool>(FrameworkSetting.SingleThreaded);
+
             logOverlayVisibility = config.GetBindable<bool>(FrameworkSetting.ShowLogOverlay);
             logOverlayVisibility.BindValueChanged(visibility =>
             {
@@ -226,6 +228,8 @@ namespace osu.Framework
         private Bindable<bool> logOverlayVisibility;
 
         private Bindable<FrameSync> frameSyncMode;
+
+        private Bindable<bool> singleThreaded;
 
         public bool OnPressed(FrameworkAction action)
         {
@@ -292,6 +296,10 @@ namespace osu.Framework
                         nextMode = FrameSync.VSync;
 
                     frameSyncMode.Value = nextMode;
+                    break;
+
+                case FrameworkAction.ToggleSingleThreaded:
+                    singleThreaded.Value = !singleThreaded.Value;
                     break;
             }
 

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -587,6 +587,8 @@ namespace osu.Framework.Graphics.Containers
 
         private void ensureChildMutationAllowed()
         {
+            if (ThreadSafety.SingleThreaded) return;
+
             switch (LoadState)
             {
                 case LoadState.NotLoaded:

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -587,8 +587,6 @@ namespace osu.Framework.Graphics.Containers
 
         private void ensureChildMutationAllowed()
         {
-            if (ThreadSafety.SingleThreaded) return;
-
             switch (LoadState)
             {
                 case LoadState.NotLoaded:

--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -91,7 +91,7 @@ namespace osu.Framework.Graphics.Performance
                     displayFrameTime = Interpolation.Damp(displayFrameTime, actualElapsed, 0.01, dampRate);
 
                     counter.Text = $"{displayFps:0}fps({displayFrameTime:0.00}ms)"
-                                   + $"{(updateHz < 10000 ? updateHz.ToString("0") : "∞").PadLeft(4)}hz";
+                                   + (clock.Throttling ? $"{(updateHz < 10000 ? updateHz.ToString("0") : "∞").PadLeft(4)}hz" : string.Empty);
                 });
             }, 1000.0 / updates_per_second, true);
         }

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -13,11 +13,17 @@ namespace osu.Framework.Input
             new KeyBinding(new[] { InputKey.Control, InputKey.F1 }, FrameworkAction.ToggleDrawVisualiser),
             new KeyBinding(new[] { InputKey.Control, InputKey.F2 }, FrameworkAction.ToggleGlobalStatistics),
             new KeyBinding(new[] { InputKey.Control, InputKey.F7 }, FrameworkAction.CycleFrameSync),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.F7 }, FrameworkAction.ToggleSingleThreaded),
             new KeyBinding(new[] { InputKey.Control, InputKey.F11 }, FrameworkAction.CycleFrameStatistics),
             new KeyBinding(new[] { InputKey.Control, InputKey.F10 }, FrameworkAction.ToggleLogOverlay),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Enter }, FrameworkAction.ToggleFullscreen),
             new KeyBinding(new[] { InputKey.F11 }, FrameworkAction.ToggleFullscreen)
         };
+
+        public FrameworkActionContainer()
+            : base(matchingMode: KeyCombinationMatchingMode.Exact)
+        {
+        }
 
         protected override bool Prioritised => true;
     }

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Input
             new KeyBinding(new[] { InputKey.Control, InputKey.F1 }, FrameworkAction.ToggleDrawVisualiser),
             new KeyBinding(new[] { InputKey.Control, InputKey.F2 }, FrameworkAction.ToggleGlobalStatistics),
             new KeyBinding(new[] { InputKey.Control, InputKey.F7 }, FrameworkAction.CycleFrameSync),
-            new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.F7 }, FrameworkAction.ToggleSingleThreaded),
+            new KeyBinding(new[] { InputKey.Control, InputKey.Alt, InputKey.F7 }, FrameworkAction.CycleExecutionMode),
             new KeyBinding(new[] { InputKey.Control, InputKey.F11 }, FrameworkAction.CycleFrameStatistics),
             new KeyBinding(new[] { InputKey.Control, InputKey.F10 }, FrameworkAction.ToggleLogOverlay),
             new KeyBinding(new[] { InputKey.Alt, InputKey.Enter }, FrameworkAction.ToggleFullscreen),
@@ -36,6 +36,6 @@ namespace osu.Framework.Input
         ToggleLogOverlay,
         ToggleFullscreen,
         CycleFrameSync,
-        ToggleSingleThreaded
+        CycleExecutionMode
     }
 }

--- a/osu.Framework/Platform/ExecutionMode.cs
+++ b/osu.Framework/Platform/ExecutionMode.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+
+namespace osu.Framework.Platform
+{
+    public enum ExecutionMode
+    {
+        [Description("Single thread")]
+        SingleThread,
+
+        [Description("Multithreaded")]
+        MultiThreaded
+    }
+}

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -621,21 +621,24 @@ namespace osu.Framework.Platform
             {
                 if (value == runningSingleThreaded) return;
 
-                if (!value)
+                InputThread.Scheduler.Add(() =>
                 {
-                    foreach (var t in threads)
-                        t.Start();
-                }
-                else
-                {
-                    foreach (var t in threads)
-                        t.Pause();
+                    if (!value)
+                    {
+                        foreach (var t in threads)
+                            t.Start();
+                    }
+                    else
+                    {
+                        foreach (var t in threads)
+                            t.Pause();
 
-                    while (threads.Any(t => t.Running))
-                        Thread.Sleep(1);
-                }
+                        while (threads.Any(t => t.Running))
+                            Thread.Sleep(1);
+                    }
 
-                ThreadSafety.SingleThreaded = runningSingleThreaded = value;
+                    ThreadSafety.SingleThreaded = runningSingleThreaded = value;
+                });
             }
         }
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -282,8 +282,11 @@ namespace osu.Framework.Platform
 
         protected virtual void UpdateInitialize()
         {
-            //this was added due to the dependency on GLWrapper.MaxTextureSize begin initialised.
-            DrawThread.WaitUntilInitialized();
+            if (!singleThreaded.Value)
+            {
+                //this was added due to the dependency on GLWrapper.MaxTextureSize begin initialised.
+                DrawThread.WaitUntilInitialized();
+            }
         }
 
         protected Container Root;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -260,7 +260,7 @@ namespace osu.Framework.Platform
             //wait for a potentially blocking response
             while (!response.HasValue)
             {
-                if (threadRunner.ExecutionMode == ExecutionMode.SingleThreaded)
+                if (ThreadSafety.ExecutionMode == ExecutionMode.SingleThreaded)
                     threadRunner.RunMainLoop();
                 else
                     Thread.Sleep(1);
@@ -282,7 +282,7 @@ namespace osu.Framework.Platform
 
         protected virtual void UpdateInitialize()
         {
-            if (executionMode.Value != ExecutionMode.SingleThreaded)
+            if (ThreadSafety.ExecutionMode != ExecutionMode.SingleThreaded)
             {
                 //this was added due to the dependency on GLWrapper.MaxTextureSize begin initialised.
                 DrawThread.WaitUntilInitialized();

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -686,7 +686,7 @@ namespace osu.Framework.Platform
                 cycleFrameSync();
 
             if (e.Control && e.Key == Key.F6)
-                SingleThreaded.Value = !SingleThreaded.Value;
+                singleThreaded.Value = !singleThreaded.Value;
         }
 
         private void keyDown(KeyboardKeyInput e)
@@ -720,6 +720,8 @@ namespace osu.Framework.Platform
 
         private Bindable<WindowMode> windowMode;
 
+        private Bindable<bool> singleThreaded;
+
         private Bindable<string> threadLocale;
 
         protected virtual void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
@@ -740,8 +742,8 @@ namespace osu.Framework.Platform
                     windowMode.Value = Window.DefaultWindowMode;
             }, true);
 
-            SingleThreaded = Config.GetBindable<bool>(FrameworkSetting.SingleThreaded);
-            SingleThreaded.BindValueChanged(e => threadRunner.SingleThreaded = e.NewValue, true);
+            singleThreaded = Config.GetBindable<bool>(FrameworkSetting.SingleThreaded);
+            singleThreaded.BindValueChanged(e => threadRunner.SingleThreaded = e.NewValue, true);
 
             frameSyncMode = Config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
             frameSyncMode.ValueChanged += e =>
@@ -858,8 +860,6 @@ namespace osu.Framework.Platform
         private bool isDisposed;
 
         private readonly ManualResetEventSlim stoppedEvent = new ManualResetEventSlim(false);
-
-        private Bindable<bool> SingleThreaded;
 
         protected virtual void Dispose(bool disposing)
         {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -282,7 +282,7 @@ namespace osu.Framework.Platform
 
         protected virtual void UpdateInitialize()
         {
-            if (!singleThreaded.Value)
+            if (executionMode.Value != ExecutionMode.SingleThreaded)
             {
                 //this was added due to the dependency on GLWrapper.MaxTextureSize begin initialised.
                 DrawThread.WaitUntilInitialized();
@@ -688,7 +688,7 @@ namespace osu.Framework.Platform
 
         private Bindable<WindowMode> windowMode;
 
-        private Bindable<bool> singleThreaded;
+        private Bindable<ExecutionMode> executionMode;
 
         private Bindable<string> threadLocale;
 
@@ -710,11 +710,8 @@ namespace osu.Framework.Platform
                     windowMode.Value = Window.DefaultWindowMode;
             }, true);
 
-            singleThreaded = Config.GetBindable<bool>(FrameworkSetting.SingleThreaded);
-            singleThreaded.BindValueChanged(e =>
-            {
-                threadRunner.ExecutionMode = e.NewValue ? ExecutionMode.SingleThreaded : ExecutionMode.MultiThreaded;
-            }, true);
+            executionMode = Config.GetBindable<ExecutionMode>(FrameworkSetting.ExecutionMode);
+            executionMode.BindValueChanged(e => threadRunner.ExecutionMode = e.NewValue, true);
 
             frameSyncMode = Config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
             frameSyncMode.ValueChanged += e =>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -637,7 +637,8 @@ namespace osu.Framework.Platform
                             Thread.Sleep(1);
                     }
 
-                    ThreadSafety.SingleThreaded = runningSingleThreaded = value;
+                    runningSingleThreaded = value;
+                    ThreadSafety.SingleThreadThread = runningSingleThreaded ? Thread.CurrentThread : null;
                 });
             }
         }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -586,7 +586,7 @@ namespace osu.Framework.Platform
                     else
                     {
                         while (ExecutionState != ExecutionState.Stopped)
-                            InputThread.ProcessFrame(true);
+                            InputThread.ProcessFrame();
                     }
                 }
                 catch (OutOfMemoryException)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -260,7 +260,7 @@ namespace osu.Framework.Platform
             //wait for a potentially blocking response
             while (!response.HasValue)
             {
-                if (threadRunner.SingleThreaded)
+                if (threadRunner.ExecutionMode == ExecutionMode.SingleThreaded)
                     threadRunner.RunMainLoop();
                 else
                     Thread.Sleep(1);
@@ -711,7 +711,10 @@ namespace osu.Framework.Platform
             }, true);
 
             singleThreaded = Config.GetBindable<bool>(FrameworkSetting.SingleThreaded);
-            singleThreaded.BindValueChanged(e => threadRunner.SingleThreaded = e.NewValue, true);
+            singleThreaded.BindValueChanged(e =>
+            {
+                threadRunner.ExecutionMode = e.NewValue ? ExecutionMode.SingleThreaded : ExecutionMode.MultiThreaded;
+            }, true);
 
             frameSyncMode = Config.GetBindable<FrameSync>(FrameworkSetting.FrameSync);
             frameSyncMode.ValueChanged += e =>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -167,7 +167,7 @@ namespace osu.Framework.Platform
         public double MaximumUpdateHz
         {
             get => maximumUpdateHz;
-            set => UpdateThread.ActiveHz = maximumUpdateHz = value;
+            set => threadRunner.MaximumUpdateHz = UpdateThread.ActiveHz = maximumUpdateHz = value;
         }
 
         private double maximumDrawHz;
@@ -184,7 +184,7 @@ namespace osu.Framework.Platform
             set
             {
                 DrawThread.InactiveHz = value;
-                UpdateThread.InactiveHz = value;
+                threadRunner.MaximumInactiveHz = UpdateThread.InactiveHz = value;
             }
         }
 
@@ -602,7 +602,7 @@ namespace osu.Framework.Platform
 
         private ThreadRunner threadRunner;
 
-        public bool RunningSingleThreaded
+        public bool SingleThreaded
         {
             get => threadRunner.SingleThreaded;
             set => threadRunner.SingleThreaded = value;
@@ -692,7 +692,7 @@ namespace osu.Framework.Platform
                 cycleFrameSync();
 
             if (e.Control && e.Key == Key.F6)
-                RunningSingleThreaded = !RunningSingleThreaded;
+                SingleThreaded = !SingleThreaded;
         }
 
         private void keyDown(KeyboardKeyInput e)
@@ -797,8 +797,8 @@ namespace osu.Framework.Platform
                         break;
                 }
 
-                if (DrawThread != null) DrawThread.ActiveHz = drawLimiter;
-                if (UpdateThread != null) UpdateThread.ActiveHz = updateLimiter;
+                MaximumDrawHz = drawLimiter;
+                MaximumUpdateHz = updateLimiter;
             };
 
             ignoredInputHandlers = Config.GetBindable<string>(FrameworkSetting.IgnoredInputHandlers);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -260,7 +260,7 @@ namespace osu.Framework.Platform
             //wait for a potentially blocking response
             while (!response.HasValue)
             {
-                if (ThreadSafety.ExecutionMode == ExecutionMode.SingleThreaded)
+                if (ThreadSafety.ExecutionMode == ExecutionMode.SingleThread)
                     threadRunner.RunMainLoop();
                 else
                     Thread.Sleep(1);
@@ -282,7 +282,7 @@ namespace osu.Framework.Platform
 
         protected virtual void UpdateInitialize()
         {
-            if (ThreadSafety.ExecutionMode != ExecutionMode.SingleThreaded)
+            if (ThreadSafety.ExecutionMode != ExecutionMode.SingleThread)
             {
                 //this was added due to the dependency on GLWrapper.MaxTextureSize begin initialised.
                 DrawThread.WaitUntilInitialized();

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -52,14 +52,6 @@ namespace osu.Framework.Platform
         {
         }
 
-        protected override void UpdateInitialize()
-        {
-        }
-
-        protected override void DrawInitialize()
-        {
-        }
-
         protected override void DrawFrame()
         {
             //we can't draw.

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -34,10 +34,11 @@ namespace osu.Framework.Platform
             this.realtime = realtime;
         }
 
-        protected override void SetupConfig(IDictionary<FrameworkSetting, object> gameDefaults)
+        protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
-            base.SetupConfig(gameDefaults);
-            Config.Set(FrameworkSetting.AudioDevice, "No sound");
+            defaultOverrides[FrameworkSetting.AudioDevice] = "No sound";
+
+            base.SetupConfig(defaultOverrides);
         }
 
         protected override void SetupForRun()

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -105,13 +105,7 @@ namespace osu.Framework.Platform
                     lock (threads)
                     {
                         foreach (var t in threads)
-                        {
-                            // required as we are constantly changing thread contexts while remaining on the same logical thread
-                            ThreadSafety.ResetAllForCurrentThread();
-
-                            t.MakeCurrent();
                             t.ProcessFrame();
-                        }
                     }
 
                     break;

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Threading;
 using osu.Framework.Development;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Logging;
@@ -146,7 +145,9 @@ namespace osu.Framework.Platform
             {
                 case ExecutionMode.MultiThreaded:
                 {
-                    ThreadSafety.SingleThreadThread = null;
+                    ThreadSafety.IsAudioThread = false;
+                    ThreadSafety.IsDrawThread = false;
+                    ThreadSafety.IsInputThread = false;
 
                     // switch to multi-threaded
                     foreach (var t in Threads)
@@ -160,8 +161,6 @@ namespace osu.Framework.Platform
 
                 case ExecutionMode.SingleThreaded:
                 {
-                    ThreadSafety.SingleThreadThread = Thread.CurrentThread;
-
                     // switch to single-threaded.
                     foreach (var t in Threads)
                         t.Pause();

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -170,6 +170,8 @@ namespace osu.Framework.Platform
                     // switch to single-threaded.
                     foreach (var t in Threads)
                     {
+                        t.MakeCurrent();
+
                         // only throttle for the main thread
                         t.Initialize(withThrottling: t == mainThread);
                     }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -105,7 +105,13 @@ namespace osu.Framework.Platform
                     lock (threads)
                     {
                         foreach (var t in threads)
+                        {
+                            // required as we are constantly changing thread contexts while remaining on the same logical thread
+                            ThreadSafety.ResetAllForCurrentThread();
+
+                            t.MakeCurrent();
                             t.ProcessFrame();
+                        }
                     }
 
                     break;
@@ -145,10 +151,6 @@ namespace osu.Framework.Platform
             {
                 case ExecutionMode.MultiThreaded:
                 {
-                    ThreadSafety.IsAudioThread = false;
-                    ThreadSafety.IsDrawThread = false;
-                    ThreadSafety.IsInputThread = false;
-
                     // switch to multi-threaded
                     foreach (var t in Threads)
                     {

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Development;
@@ -100,7 +101,7 @@ namespace osu.Framework.Platform
 
             switch (activeExecutionMode.Value)
             {
-                case ExecutionMode.SingleThreaded:
+                case ExecutionMode.SingleThread:
                 {
                     lock (threads)
                     {
@@ -161,7 +162,7 @@ namespace osu.Framework.Platform
                     break;
                 }
 
-                case ExecutionMode.SingleThreaded:
+                case ExecutionMode.SingleThread:
                 {
                     // switch to single-threaded.
                     foreach (var t in Threads)
@@ -187,7 +188,7 @@ namespace osu.Framework.Platform
 
         private void updateMainThreadRates()
         {
-            if (activeExecutionMode == ExecutionMode.SingleThreaded)
+            if (activeExecutionMode == ExecutionMode.SingleThread)
             {
                 mainThread.ActiveHz = maximumUpdateHz;
                 mainThread.InactiveHz = maximumInactiveHz;
@@ -202,7 +203,10 @@ namespace osu.Framework.Platform
 
     public enum ExecutionMode
     {
-        SingleThreaded,
+        [Description("Single thread")]
+        SingleThread,
+
+        [Description("Multithreaded")]
         MultiThreaded
     }
 }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -164,7 +164,9 @@ namespace osu.Framework.Platform
                 case ExecutionMode.SingleThread:
                 {
                     // switch to single-threaded.
-                    foreach (var t in Threads)
+
+                    // shut down threads in reverse to ensure audio stops last (other threads may be waiting on a queued event otherwise)
+                    foreach (var t in Threads.Reverse())
                         t.Pause();
 
                     foreach (var t in Threads)

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -81,12 +81,18 @@ namespace osu.Framework.Platform
                         if (!value)
                         {
                             foreach (var t in threads)
+                            {
                                 t.Start();
+                                t.Clock.Throttling = true;
+                            }
                         }
                         else
                         {
                             foreach (var t in threads)
+                            {
                                 t.Pause();
+                                t.Clock.Throttling = t == mainThread;
+                            }
 
                             while (threads.Any(t => t.Running))
                                 Thread.Sleep(1);
@@ -112,7 +118,7 @@ namespace osu.Framework.Platform
                         if (t == mainThread)
                             continue;
 
-                        t.ProcessFrame(false);
+                        t.ProcessFrame();
                     }
                 }
             }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -134,6 +134,8 @@ namespace osu.Framework.Platform
             // as the input thread isn't actually handled by a thread, the above join does not necessarily mean it has been completed to an exiting state.
             while (!mainThread.Exited)
                 mainThread.ProcessFrame();
+
+            ThreadSafety.ResetAllForCurrentThread();
         }
 
         private void ensureCorrectExecutionMode()

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -170,8 +170,6 @@ namespace osu.Framework.Platform
                     // switch to single-threaded.
                     foreach (var t in Threads)
                     {
-                        t.MakeCurrent();
-
                         // only throttle for the main thread
                         t.Initialize(withThrottling: t == mainThread);
                     }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Development;
@@ -199,14 +198,5 @@ namespace osu.Framework.Platform
                 mainThread.InactiveHz = GameThread.DEFAULT_INACTIVE_HZ;
             }
         }
-    }
-
-    public enum ExecutionMode
-    {
-        [Description("Single thread")]
-        SingleThread,
-
-        [Description("Multithreaded")]
-        MultiThreaded
     }
 }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Platform
 
         private ExecutionMode? activeExecutionMode;
 
-        public ExecutionMode ExecutionMode = ExecutionMode.MultiThreaded;
+        public ExecutionMode ExecutionMode { private get; set; } = ExecutionMode.MultiThreaded;
 
         public void RunMainLoop()
         {
@@ -146,6 +146,10 @@ namespace osu.Framework.Platform
         {
             if (ExecutionMode == activeExecutionMode)
                 return;
+
+            if (activeExecutionMode == null)
+                // in the case we have not yet got an execution mode, set this early to allow usage in GameThread.Initialize overrides.
+                activeExecutionMode = ThreadSafety.ExecutionMode = ExecutionMode;
 
             switch (ExecutionMode)
             {

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -1,0 +1,160 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using osu.Framework.Development;
+using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Logging;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Platform
+{
+    /// <summary>
+    /// Runs a game host in a specifc threading mode.
+    /// </summary>
+    internal class ThreadRunner
+    {
+        private readonly InputThread mainThread;
+
+        private readonly List<GameThread> threads = new List<GameThread>();
+
+        public IReadOnlyCollection<GameThread> Threads
+        {
+            get
+            {
+                lock (threads)
+                    return threads.ToArray();
+            }
+        }
+
+        private bool singleThreaded;
+
+        /// <summary>
+        /// Construct a new ThreadRunner instance.
+        /// </summary>
+        /// <param name="mainThread">The main window thread. Used for input in multi-threaded execution; all game logic in single-threaded execution.</param>
+        /// <exception cref="NotImplementedException"></exception>
+        public ThreadRunner(InputThread mainThread)
+        {
+            this.mainThread = mainThread;
+            AddThread(mainThread);
+        }
+
+        /// <summary>
+        /// Add a new non-main thread. In single-threaded execution, threads will be executed in the order they are added.
+        /// </summary>
+        public void AddThread(GameThread thread)
+        {
+            lock (threads)
+            {
+                if (!threads.Contains(thread))
+                    threads.Add(thread);
+            }
+        }
+
+        /// <summary>
+        /// Remove a non-main thread.
+        /// </summary>
+        public void RemoveThread(GameThread thread)
+        {
+            lock (threads)
+                threads.Remove(thread);
+        }
+
+        public bool SingleThreaded
+        {
+            get => singleThreaded;
+            set
+            {
+                if (value == singleThreaded) return;
+
+                mainThread.Scheduler.Add(() =>
+                {
+                    lock (threads)
+                    {
+                        if (!value)
+                        {
+                            foreach (var t in threads)
+                                t.Start();
+                        }
+                        else
+                        {
+                            foreach (var t in threads)
+                                t.Pause();
+
+                            while (threads.Any(t => t.Running))
+                                Thread.Sleep(1);
+                        }
+                    }
+
+                    singleThreaded = value;
+                    ThreadSafety.SingleThreadThread = singleThreaded ? Thread.CurrentThread : null;
+                });
+            }
+        }
+
+        public void RunMainLoop()
+        {
+            mainThread.ProcessFrame();
+
+            if (singleThreaded)
+            {
+                lock (threads)
+                {
+                    foreach (var t in threads)
+                    {
+                        if (t == mainThread)
+                            continue;
+
+                        t.ProcessFrame(false);
+                    }
+                }
+            }
+        }
+
+        public void Start()
+        {
+            lock (threads)
+            {
+                if (singleThreaded)
+                {
+                    foreach (var t in threads)
+                    {
+                        t.OnThreadStart?.Invoke();
+                        t.OnThreadStart = null;
+                    }
+                }
+                else
+                {
+                    foreach (var t in threads)
+                        t.Start();
+                }
+            }
+        }
+
+        private const int thread_join_timeout = 30000;
+
+        public void Stop()
+        {
+            lock (threads)
+            {
+                threads.ForEach(t => t.Exit());
+                threads.Where(t => t.Running).ForEach(t =>
+                {
+                    if (!t.Thread.Join(thread_join_timeout))
+                        Logger.Log($"Thread {t.Name} failed to exit in allocated time ({thread_join_timeout}ms).", LoggingTarget.Runtime, LogLevel.Important);
+                });
+            }
+
+            // as the input thread isn't actually handled by a thread, the above join does not necessarily mean it has been completed to an exiting state.
+            while (!mainThread.Exited)
+                mainThread.ProcessFrame();
+        }
+    }
+}

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -33,6 +33,28 @@ namespace osu.Framework.Platform
             }
         }
 
+        private double maximumUpdateHz;
+
+        public double MaximumUpdateHz
+        {
+            set
+            {
+                maximumUpdateHz = value;
+                updateMainThreadRates();
+            }
+        }
+
+        private double maximumInactiveHz;
+
+        public double MaximumInactiveHz
+        {
+            set
+            {
+                maximumInactiveHz = value;
+                updateMainThreadRates();
+            }
+        }
+
         private bool singleThreaded;
 
         /// <summary>
@@ -101,6 +123,7 @@ namespace osu.Framework.Platform
 
                     singleThreaded = value;
                     ThreadSafety.SingleThreadThread = singleThreaded ? Thread.CurrentThread : null;
+                    updateMainThreadRates();
                 });
             }
         }
@@ -161,6 +184,20 @@ namespace osu.Framework.Platform
             // as the input thread isn't actually handled by a thread, the above join does not necessarily mean it has been completed to an exiting state.
             while (!mainThread.Exited)
                 mainThread.ProcessFrame();
+        }
+
+        private void updateMainThreadRates()
+        {
+            if (singleThreaded)
+            {
+                mainThread.ActiveHz = maximumUpdateHz;
+                mainThread.InactiveHz = maximumInactiveHz;
+            }
+            else
+            {
+                mainThread.ActiveHz = GameThread.DEFAULT_ACTIVE_HZ;
+                mainThread.InactiveHz = GameThread.DEFAULT_INACTIVE_HZ;
+            }
         }
     }
 }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Platform
             }
         }
 
-        private double maximumUpdateHz;
+        private double maximumUpdateHz = GameThread.DEFAULT_ACTIVE_HZ;
 
         public double MaximumUpdateHz
         {
@@ -44,7 +44,7 @@ namespace osu.Framework.Platform
             }
         }
 
-        private double maximumInactiveHz;
+        private double maximumInactiveHz = GameThread.DEFAULT_INACTIVE_HZ;
 
         public double MaximumInactiveHz
         {

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -173,6 +173,9 @@ namespace osu.Framework.Platform
                         t.Initialize(withThrottling: t == mainThread);
                     }
 
+                    // this is usually done in the execution loop, but required here for the initial game startup,
+                    // which would otherwise leave values in an incorrect state.
+                    ThreadSafety.ResetAllForCurrentThread();
                     break;
                 }
             }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -147,6 +147,10 @@ namespace osu.Framework.Platform
                 // in the case we have not yet got an execution mode, set this early to allow usage in GameThread.Initialize overrides.
                 activeExecutionMode = ThreadSafety.ExecutionMode = ExecutionMode;
 
+            // shut down threads in reverse to ensure audio stops last (other threads may be waiting on a queued event otherwise)
+            foreach (var t in Threads.Reverse())
+                t.Pause();
+
             switch (ExecutionMode)
             {
                 case ExecutionMode.MultiThreaded:
@@ -164,11 +168,6 @@ namespace osu.Framework.Platform
                 case ExecutionMode.SingleThread:
                 {
                     // switch to single-threaded.
-
-                    // shut down threads in reverse to ensure audio stops last (other threads may be waiting on a queued event otherwise)
-                    foreach (var t in Threads.Reverse())
-                        t.Pause();
-
                     foreach (var t in Threads)
                     {
                         // only throttle for the main thread

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -177,7 +177,8 @@ namespace osu.Framework.Platform
                 }
             }
 
-            activeExecutionMode = ExecutionMode;
+            activeExecutionMode = ThreadSafety.ExecutionMode = ExecutionMode;
+
             updateMainThreadRates();
         }
 

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Threading
 
         public override bool IsCurrent => ThreadSafety.IsAudioThread;
 
-        internal override void MakeCurrent()
+        internal sealed override void MakeCurrent()
         {
             base.MakeCurrent();
 

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -23,6 +23,7 @@ namespace osu.Framework.Threading
         internal override void MakeCurrent()
         {
             base.MakeCurrent();
+
             ThreadSafety.IsAudioThread = true;
         }
 

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -5,23 +5,54 @@ using osu.Framework.Statistics;
 using System;
 using System.Collections.Generic;
 using osu.Framework.Development;
+using osu.Framework.Graphics.OpenGL;
+using osu.Framework.Platform;
+using osuTK;
+using osuTK.Graphics;
 
 namespace osu.Framework.Threading
 {
     public class DrawThread : GameThread
     {
-        public DrawThread(Action onNewFrame)
+        private readonly GameHost host;
+
+        public DrawThread(Action onNewFrame, GameHost host)
             : base(onNewFrame, "Draw")
         {
+            this.host = host;
         }
 
         public override bool IsCurrent => ThreadSafety.IsDrawThread;
+
+        internal override void Initialize(bool withThrottling)
+        {
+            var window = host.Window;
+
+            if (window != null)
+            {
+                window.MakeCurrent();
+
+                GLWrapper.Initialize(host);
+                GLWrapper.Reset(new Vector2(window.ClientSize.Width, window.ClientSize.Height));
+            }
+
+            base.Initialize(withThrottling);
+        }
 
         internal sealed override void MakeCurrent()
         {
             base.MakeCurrent();
 
             ThreadSafety.IsDrawThread = true;
+        }
+
+        protected override void Cleanup()
+        {
+            base.Cleanup();
+
+            // specifically for mobile platforms so SDL does not need to be considered yet
+            if (GraphicsContext.CurrentContext != null)
+                GraphicsContext.CurrentContext.MakeCurrent(null);
         }
 
         internal override IEnumerable<StatisticsCounterType> StatisticsCounters => new[]

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Threading
 
         public override bool IsCurrent => ThreadSafety.IsDrawThread;
 
-        protected override void OnInitialize()
+        protected sealed override void OnInitialize()
         {
             var window = host.Window;
 
@@ -44,7 +44,7 @@ namespace osu.Framework.Threading
             ThreadSafety.IsDrawThread = true;
         }
 
-        protected override void Cleanup()
+        protected sealed override void Cleanup()
         {
             base.Cleanup();
 

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Threading
 
         public override bool IsCurrent => ThreadSafety.IsDrawThread;
 
-        internal override void Initialize(bool withThrottling)
+        protected override void OnInitialize()
         {
             var window = host.Window;
 
@@ -35,8 +35,6 @@ namespace osu.Framework.Threading
                 GLWrapper.Initialize(host);
                 GLWrapper.Reset(new Vector2(window.ClientSize.Width, window.ClientSize.Height));
             }
-
-            base.Initialize(withThrottling);
         }
 
         internal sealed override void MakeCurrent()

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -17,9 +17,10 @@ namespace osu.Framework.Threading
 
         public override bool IsCurrent => ThreadSafety.IsDrawThread;
 
-        internal override void MakeCurrent()
+        internal sealed override void MakeCurrent()
         {
             base.MakeCurrent();
+
             ThreadSafety.IsDrawThread = true;
         }
 

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 
 namespace osu.Framework.Threading
 {
@@ -145,7 +146,10 @@ namespace osu.Framework.Threading
         /// <summary>
         /// Run when thread transitions into an active/processing state.
         /// </summary>
-        internal virtual void MakeCurrent() { }
+        internal virtual void MakeCurrent()
+        {
+            ThreadSafety.ResetAllForCurrentThread();
+        }
 
         internal void ProcessFrame()
         {

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -75,9 +75,9 @@ namespace osu.Framework.Threading
 
             OnThreadStart?.Invoke();
 
-            Scheduler.SetCurrentThread();
-
             initializedEvent.Set();
+
+            MakeCurrent();
         }
 
         internal virtual IEnumerable<StatisticsCounterType> StatisticsCounters => Array.Empty<StatisticsCounterType>();
@@ -121,8 +121,7 @@ namespace osu.Framework.Threading
         {
             try
             {
-                Initialize();
-                MakeCurrent();
+                Initialize(true);
 
                 while (!exitCompleted && !paused)
                 {
@@ -143,12 +142,6 @@ namespace osu.Framework.Threading
             {
                 Thread = null;
             }
-        }
-
-        internal virtual void Initialize()
-        {
-            OnThreadStart?.Invoke();
-            initializedEvent.Set();
         }
 
         /// <summary>

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -76,8 +76,6 @@ namespace osu.Framework.Threading
             OnThreadStart?.Invoke();
 
             initializedEvent.Set();
-
-            MakeCurrent();
         }
 
         internal virtual IEnumerable<StatisticsCounterType> StatisticsCounters => Array.Empty<StatisticsCounterType>();
@@ -160,6 +158,8 @@ namespace osu.Framework.Threading
                 exitCompleted = true;
                 return;
             }
+
+            MakeCurrent();
 
             Monitor?.NewFrame();
 

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -68,12 +68,18 @@ namespace osu.Framework.Threading
 
         private readonly ManualResetEvent initializedEvent = new ManualResetEvent(false);
 
-        internal virtual void Initialize(bool withThrottling)
+        internal void Initialize(bool withThrottling)
         {
+            MakeCurrent();
+
+            OnInitialize();
+
             Clock.Throttling = withThrottling;
 
             initializedEvent.Set();
         }
+
+        protected virtual void OnInitialize() { }
 
         internal virtual IEnumerable<StatisticsCounterType> StatisticsCounters => Array.Empty<StatisticsCounterType>();
 

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -116,7 +116,7 @@ namespace osu.Framework.Threading
             {
                 try
                 {
-                    ProcessFrame(true);
+                    ProcessFrame();
                 }
                 catch (Exception e)
                 {
@@ -130,7 +130,7 @@ namespace osu.Framework.Threading
             Thread = null;
         }
 
-        public void ProcessFrame(bool throttle = true)
+        public void ProcessFrame()
         {
             if (exitCompleted)
                 return;
@@ -150,15 +150,8 @@ namespace osu.Framework.Threading
             using (Monitor?.BeginCollecting(PerformanceCollectionType.Work))
                 OnNewFrame?.Invoke();
 
-            if (throttle)
-            {
-                using (Monitor?.BeginCollecting(PerformanceCollectionType.Sleep))
-                {
-                    Clock.ProcessFrame();
-                }
-            }
-            else
-                Clock.ProcessFrameWithoutThrottling();
+            using (Monitor?.BeginCollecting(PerformanceCollectionType.Sleep))
+                Clock.ProcessFrame();
         }
 
         private volatile bool exitRequested;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -116,7 +116,7 @@ namespace osu.Framework.Threading
             {
                 try
                 {
-                    ProcessFrame();
+                    ProcessFrame(true);
                 }
                 catch (Exception e)
                 {
@@ -130,7 +130,7 @@ namespace osu.Framework.Threading
             Thread = null;
         }
 
-        public void ProcessFrame()
+        public void ProcessFrame(bool throttle = true)
         {
             if (exitCompleted)
                 return;
@@ -150,8 +150,15 @@ namespace osu.Framework.Threading
             using (Monitor?.BeginCollecting(PerformanceCollectionType.Work))
                 OnNewFrame?.Invoke();
 
-            using (Monitor?.BeginCollecting(PerformanceCollectionType.Sleep))
-                Clock.ProcessFrame();
+            if (throttle)
+            {
+                using (Monitor?.BeginCollecting(PerformanceCollectionType.Sleep))
+                {
+                    Clock.ProcessFrame();
+                }
+            }
+            else
+                Clock.ProcessFrameWithoutThrottling();
         }
 
         private volatile bool exitRequested;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -67,8 +67,10 @@ namespace osu.Framework.Threading
 
         public Action OnThreadStart;
 
-        internal void Initialize()
+        internal void Initialize(bool withThrottling)
         {
+            Clock.Throttling = withThrottling;
+
             OnThreadStart?.Invoke();
 
             Scheduler.SetCurrentThread();
@@ -117,7 +119,7 @@ namespace osu.Framework.Threading
         {
             try
             {
-                Initialize();
+                Initialize(true);
 
                 while (!exitCompleted && !paused)
                 {
@@ -195,6 +197,8 @@ namespace osu.Framework.Threading
         public void Pause()
         {
             paused = true;
+            while (Running)
+                Thread.Sleep(1);
         }
 
         public void Exit() => exitRequested = true;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -68,13 +68,9 @@ namespace osu.Framework.Threading
 
         private readonly ManualResetEvent initializedEvent = new ManualResetEvent(false);
 
-        public Action OnThreadStart;
-
-        internal void Initialize(bool withThrottling)
+        internal virtual void Initialize(bool withThrottling)
         {
             Clock.Throttling = withThrottling;
-
-            OnThreadStart?.Invoke();
 
             initializedEvent.Set();
         }
@@ -129,7 +125,7 @@ namespace osu.Framework.Threading
             }
             finally
             {
-                Thread = null;
+                Cleanup();
             }
         }
 
@@ -207,9 +203,21 @@ namespace osu.Framework.Threading
 
         public void Pause()
         {
-            paused = true;
-            while (Running)
-                Thread.Sleep(1);
+            if (Thread != null)
+            {
+                paused = true;
+                while (Running)
+                    Thread.Sleep(1);
+            }
+            else
+            {
+                Cleanup();
+            }
+        }
+
+        protected virtual void Cleanup()
+        {
+            Thread = null;
         }
 
         public void Exit() => exitRequested = true;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -147,10 +147,7 @@ namespace osu.Framework.Threading
         /// <summary>
         /// Run when thread transitions into an active/processing state.
         /// </summary>
-        internal virtual void MakeCurrent()
-        {
-            Scheduler.SetCurrentThread();
-        }
+        internal virtual void MakeCurrent() { }
 
         internal void ProcessFrame()
         {

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -166,7 +166,8 @@ namespace osu.Framework.Threading
             }
             catch (Exception e)
             {
-                if (UnhandledException != null)
+                if (UnhandledException != null && !ThreadSafety.IsInputThread)
+                    // the handler schedules back to the input thread, so don't run it if we are already on the input thread
                     UnhandledException.Invoke(this, new UnhandledExceptionEventArgs(e, false));
                 else
                     throw;

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -24,7 +24,5 @@ namespace osu.Framework.Threading
         {
             // InputThread does not get started. it is run manually by GameHost.
         }
-
-        public void RunUpdate() => ProcessFrame();
     }
 }

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -27,7 +27,6 @@ namespace osu.Framework.Threading
         {
             base.MakeCurrent();
 
-            ThreadSafety.ResetAllForCurrentThread();
             ThreadSafety.IsInputThread = true;
         }
 

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -23,9 +23,11 @@ namespace osu.Framework.Threading
 
         public override bool IsCurrent => ThreadSafety.IsInputThread;
 
-        internal override void MakeCurrent()
+        internal sealed override void MakeCurrent()
         {
             base.MakeCurrent();
+
+            ThreadSafety.ResetAllForCurrentThread();
             ThreadSafety.IsInputThread = true;
         }
 

--- a/osu.Framework/Threading/UpdateThread.cs
+++ b/osu.Framework/Threading/UpdateThread.cs
@@ -20,6 +20,7 @@ namespace osu.Framework.Threading
         internal override void MakeCurrent()
         {
             base.MakeCurrent();
+
             ThreadSafety.IsUpdateThread = true;
         }
 

--- a/osu.Framework/Threading/UpdateThread.cs
+++ b/osu.Framework/Threading/UpdateThread.cs
@@ -5,14 +5,29 @@ using osu.Framework.Statistics;
 using System;
 using System.Collections.Generic;
 using osu.Framework.Development;
+using osu.Framework.Platform;
 
 namespace osu.Framework.Threading
 {
     public class UpdateThread : GameThread
     {
-        public UpdateThread(Action onNewFrame)
+        private readonly DrawThread drawThread;
+
+        public UpdateThread(Action onNewFrame, DrawThread drawThread)
             : base(onNewFrame, "Update")
         {
+            this.drawThread = drawThread;
+        }
+
+        internal override void Initialize(bool withThrottling)
+        {
+            if (ThreadSafety.ExecutionMode != ExecutionMode.SingleThread)
+            {
+                //this was added due to the dependency on GLWrapper.MaxTextureSize begin initialised.
+                drawThread?.WaitUntilInitialized();
+            }
+
+            base.Initialize(withThrottling);
         }
 
         public override bool IsCurrent => ThreadSafety.IsUpdateThread;

--- a/osu.Framework/Threading/UpdateThread.cs
+++ b/osu.Framework/Threading/UpdateThread.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Threading
             this.drawThread = drawThread;
         }
 
-        protected override void OnInitialize()
+        protected sealed override void OnInitialize()
         {
             if (ThreadSafety.ExecutionMode != ExecutionMode.SingleThread)
             {
@@ -30,7 +30,7 @@ namespace osu.Framework.Threading
 
         public override bool IsCurrent => ThreadSafety.IsUpdateThread;
 
-        internal override void MakeCurrent()
+        internal sealed override void MakeCurrent()
         {
             base.MakeCurrent();
 

--- a/osu.Framework/Threading/UpdateThread.cs
+++ b/osu.Framework/Threading/UpdateThread.cs
@@ -19,15 +19,13 @@ namespace osu.Framework.Threading
             this.drawThread = drawThread;
         }
 
-        internal override void Initialize(bool withThrottling)
+        protected override void OnInitialize()
         {
             if (ThreadSafety.ExecutionMode != ExecutionMode.SingleThread)
             {
                 //this was added due to the dependency on GLWrapper.MaxTextureSize begin initialised.
                 drawThread?.WaitUntilInitialized();
             }
-
-            base.Initialize(withThrottling);
         }
 
         public override bool IsCurrent => ThreadSafety.IsUpdateThread;

--- a/osu.Framework/Timing/ThrottledFrameClock.cs
+++ b/osu.Framework/Timing/ThrottledFrameClock.cs
@@ -18,14 +18,14 @@ namespace osu.Framework.Timing
         public double MaximumUpdateHz = 1000.0;
 
         /// <summary>
+        /// Whether throttling should be enabled. Defaults to true.
+        /// </summary>
+        public bool Throttling = true;
+
+        /// <summary>
         /// The time spent in a Thread.Sleep state during the last frame.
         /// </summary>
         public double TimeSlept { get; private set; }
-
-        public void ProcessFrameWithoutThrottling()
-        {
-            base.ProcessFrame();
-        }
 
         public override void ProcessFrame()
         {
@@ -33,7 +33,7 @@ namespace osu.Framework.Timing
 
             base.ProcessFrame();
 
-            if (MaximumUpdateHz > 0)
+            if (MaximumUpdateHz > 0 && Throttling)
             {
                 throttle();
             }

--- a/osu.Framework/Timing/ThrottledFrameClock.cs
+++ b/osu.Framework/Timing/ThrottledFrameClock.cs
@@ -22,6 +22,11 @@ namespace osu.Framework.Timing
         /// </summary>
         public double TimeSlept { get; private set; }
 
+        public void ProcessFrameWithoutThrottling()
+        {
+            base.ProcessFrame();
+        }
+
         public override void ProcessFrame()
         {
             Debug.Assert(MaximumUpdateHz >= 0);

--- a/osu.Framework/Timing/ThrottledFrameClock.cs
+++ b/osu.Framework/Timing/ThrottledFrameClock.cs
@@ -33,15 +33,22 @@ namespace osu.Framework.Timing
 
             base.ProcessFrame();
 
-            if (MaximumUpdateHz > 0 && Throttling)
+            if (Throttling)
             {
-                throttle();
+                if (MaximumUpdateHz > 0)
+                {
+                    throttle();
+                }
+                else
+                {
+                    // Even when running at unlimited frame-rate, we should call the scheduler
+                    // to give lower-priority background processes a chance to do work.
+                    TimeSlept = sleepAndUpdateCurrent(0);
+                }
             }
             else
             {
-                // Even when running at unlimited frame-rate, we should call the scheduler
-                // to give lower-priority background processes a chance to do work.
-                TimeSlept = sleepAndUpdateCurrent(0);
+                TimeSlept = 0;
             }
 
             Debug.Assert(TimeSlept <= ElapsedFrameTime);

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="ManagedBass.Fx" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.140" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.149" />
     <PackageReference Include="StbiSharp" Version="1.0.11" />
     <PackageReference Include="Veldrid" Version="4.7.0" />
     <PackageReference Include="Veldrid.Sdl2" Version="4.7.0" />


### PR DESCRIPTION
Toggle with Ctrl+Alt+F7

Note that the execution rate becomes dependent on the window loop at this point, which is generally locked to whatever the WM or OS is providing us with. Our local threads still attempt to keep their relative execution rates, meaning there is potential for sub-optimal frame times depending on frame limiter setting (using unlimited or vsync is recommended for consistency).

**This is intended only for profiling/benchmarking purposes.** It is a barebones implementation with missing safeties (for example, the thread checks are bypassed, rather than checking for input thread). I mainly just want this on appveyor for easier testability.

That said, I won't decline reviews or discussion on the direction of implementation.

Road forward:
- Test performance / heat / energy metrics on mobile devices
- Short term: if a huge improvement is seen on mobile, consider hardcoding enabled (and remove toggle logic if it seen as too complex)
- Compare performance on single core desktop (for fair comparisons I intend on creating a BenchmarkDotNet game loop for this)

Update:

- Initial benchmarks show a 60-70% reduction in CPU usage (iPhone SE / SampleGame).
- Blocking audio operations will cause a hard freeze due to waiting on a threaded operation that will never be reached.

.

- [x] Depends on https://github.com/ppy/osu-framework/pull/3313
- [x] Depends on https://github.com/ppy/osu-framework/pull/3314
- [x] Depends on https://github.com/ppy/osu-framework/pull/3317