### PR TITLE
Reduce the overhead of checking for blocking synchronous drawable loads

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -210,8 +210,7 @@ namespace osu.Framework.Graphics
 
         private readonly object loadLock = new object();
 
-        private static readonly StopwatchClock perf = new StopwatchClock(true);
-        private static double getPerfTime() => perf.CurrentTime;
+        private static readonly StopwatchClock perf_clock = new StopwatchClock(true);
 
         /// <summary>
         /// Load this drawable from an async context.
@@ -266,15 +265,9 @@ namespace osu.Framework.Graphics
         {
             LoadThread = Thread.CurrentThread;
 
-            double t0 = getPerfTime();
-
-            double lockDuration = getPerfTime() - t0;
-            if (getPerfTime() > 1000 && lockDuration > 50 && ThreadSafety.IsUpdateThread)
-                Logger.Log($@"Drawable [{ToString()}] load was blocked for {lockDuration:0.00}ms!", LoggingTarget.Performance);
-
             UpdateClock(clock);
 
-            double t1 = getPerfTime();
+            double timeBefore = DebugUtils.LogPerformanceIssues ? perf_clock.CurrentTime : 0;
 
             RequestsNonPositionalInput = HandleInputCache.RequestsNonPositionalInput(this);
             RequestsPositionalInput = HandleInputCache.RequestsPositionalInput(this);
@@ -288,9 +281,12 @@ namespace osu.Framework.Graphics
 
             LoadAsyncComplete();
 
-            double loadDuration = perf.CurrentTime - t1;
-            if (perf.CurrentTime > 1000 && loadDuration > 50 && ThreadSafety.IsUpdateThread)
-                Logger.Log($@"Drawable [{ToString()}] took {loadDuration:0.00}ms to load and was not async!", LoggingTarget.Performance);
+            if (DebugUtils.LogPerformanceIssues && timeBefore > 1000)
+            {
+                double loadDuration = perf_clock.CurrentTime - timeBefore;
+                if (loadDuration > 50 && ThreadSafety.IsUpdateThread)
+                    Logger.Log($@"Drawable [{ToString()}] took {loadDuration:0.00}ms to load and was not async!", LoggingTarget.Performance);
+            }
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -281,11 +281,16 @@ namespace osu.Framework.Graphics
 
             LoadAsyncComplete();
 
-            if (DebugUtils.LogPerformanceIssues && timeBefore > 1000)
+            if (timeBefore > 1000)
             {
                 double loadDuration = perf_clock.CurrentTime - timeBefore;
-                if (loadDuration > 50 && ThreadSafety.IsUpdateThread)
-                    Logger.Log($@"Drawable [{ToString()}] took {loadDuration:0.00}ms to load and was not async!", LoggingTarget.Performance);
+
+                bool blocking = ThreadSafety.IsUpdateThread;
+
+                double allowedDuration = blocking ? 16 : 100;
+
+                if (loadDuration > allowedDuration)
+                    Logger.Log($@"{ToString()} took {loadDuration:0.00}ms to load" + (blocking ? " (and blocked the update thread)" : " (async)"), LoggingTarget.Performance, blocking ? LogLevel.Important : LogLevel.Verbose);
             }
         }
 


### PR DESCRIPTION
Calls to get stopwatch time could add a perceivable overhead during execution:

![image](https://user-images.githubusercontent.com/191335/75323099-8614f000-58b7-11ea-99f4-37b8653b5a7c.png)

- Only runs when performance logging is turned on.
- Adds logging of async loads which take >100ms (and changed cutoff for blocking loads to 16ms).