### PR TITLE
Remove debug performance logging setting, instead making it activate when GlobalStatistics is open

### DIFF
--- a/osu.Framework/Configuration/FrameworkDebugConfig.cs
+++ b/osu.Framework/Configuration/FrameworkDebugConfig.cs
@@ -17,13 +17,11 @@ namespace osu.Framework.Configuration
             base.InitialiseDefaults();
 
             Set(DebugSetting.BypassFrontToBackPass, false);
-            Set(DebugSetting.PerformanceLogging, false);
         }
     }
 
     public enum DebugSetting
     {
         BypassFrontToBackPass,
-        PerformanceLogging
     }
 }

--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -7,7 +7,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
-using osu.Framework.Configuration;
 
 namespace osu.Framework.Development
 {
@@ -33,7 +32,7 @@ namespace osu.Framework.Development
         );
 
         /// <summary>
-        /// Whether the framework is currently logging performance issues via <see cref="DebugSetting.PerformanceLogging"/>.
+        /// Whether the framework is currently logging performance issues.
         /// This should be used only when a configuration is not available via DI or otherwise (ie. in a static context).
         /// </summary>
         public static bool LogPerformanceIssues { get; internal set; }

--- a/osu.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
@@ -8,6 +8,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Visualisation;
+using osu.Framework.Platform;
 using osu.Framework.Statistics;
 
 namespace osu.Framework.Graphics.Performance
@@ -20,6 +21,8 @@ namespace osu.Framework.Graphics.Performance
         private readonly FillFlowContainer<StatisticsGroup> groups;
 
         private DotNetRuntimeListener listener;
+
+        private Bindable<bool> performanceLogging;
 
         public GlobalStatisticsDisplay()
             : base("Global Statistics", "(Ctrl+F2 to toggle)")
@@ -37,9 +40,11 @@ namespace osu.Framework.Graphics.Performance
         }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(GameHost host)
         {
             listener = new DotNetRuntimeListener();
+
+            performanceLogging = host.PerformanceLogging.GetBoundCopy();
         }
 
         protected override void LoadComplete()
@@ -57,7 +62,7 @@ namespace osu.Framework.Graphics.Performance
 
         private void visibilityChanged(ValueChangedEvent<Visibility> state)
         {
-            TypePerformanceMonitor.Active = state.NewValue == Visibility.Visible;
+            performanceLogging.Value = state.NewValue == Visibility.Visible;
         }
 
         private void remove(IEnumerable<IGlobalStatistic> stats) => Schedule(() =>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -143,7 +143,7 @@ namespace osu.Framework.Platform
             threads.Add(thread);
             thread.IsActive.BindTo(IsActive);
             thread.UnhandledException = unhandledExceptionHandler;
-            thread.Monitor.EnablePerformanceProfiling = performanceLogging.Value;
+            thread.Monitor.EnablePerformanceProfiling = PerformanceLogging.Value;
         }
 
         /// <summary>
@@ -718,7 +718,8 @@ namespace osu.Framework.Platform
         private Bindable<string> ignoredInputHandlers;
 
         private Bindable<double> cursorSensitivity;
-        private readonly Bindable<bool> performanceLogging = new Bindable<bool>();
+
+        public readonly Bindable<bool> PerformanceLogging = new Bindable<bool>();
 
         private Bindable<WindowMode> windowMode;
 
@@ -824,11 +825,11 @@ namespace osu.Framework.Platform
 
             cursorSensitivity = Config.GetBindable<double>(FrameworkSetting.CursorSensitivity);
 
-            DebugConfig.BindWith(DebugSetting.PerformanceLogging, performanceLogging);
-            performanceLogging.BindValueChanged(logging =>
+            PerformanceLogging.BindValueChanged(logging =>
             {
                 threads.ForEach(t => t.Monitor.EnablePerformanceProfiling = logging.NewValue);
                 DebugUtils.LogPerformanceIssues = logging.NewValue;
+                TypePerformanceMonitor.Active = logging.NewValue;
             }, true);
 
             bypassFrontToBackPass = DebugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass);


### PR DESCRIPTION
It was kind of a pain to manually turn this on. Now it can easily be toggled by opening global statistics (`Ctrl+F2`).

## Breaking Changes

### `FrameworkDebugConfig` no longer exposes `PerformanceLogging`

Performance logging is now toggled by opening "Global Statistics" overlay via Ctrl+F2. To manually toggle it, you may access `GameHost.PerformanceLogging`, but note that a change to this bindable will be overridden by toggling the statistics overlay.