### PR TITLE
Calculate elapsed time values using FrameStatistics source instead of clock

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -399,6 +399,7 @@ namespace osu.Framework.Graphics.Performance
                 while (monitor.PendingFrames.TryDequeue(out FrameStatistics frame))
                 {
                     applyFrame(frame);
+                    frameTimeDisplay.NewFrame(frame);
                     monitor.FramesPool.Return(frame);
                 }
             }

--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -6,6 +6,7 @@ using osuTK.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Statistics;
 using osu.Framework.Utils;
 using osu.Framework.Threading;
 using osu.Framework.Timing;
@@ -49,8 +50,14 @@ namespace osu.Framework.Graphics.Performance
         }
 
         private float aimWidth;
+
         private double displayFps;
-        private double displayFrameTime;
+
+        private double rollingElapsed;
+
+        private int framesSinceLastUpdate;
+
+        private double elapsedSinceLastUpdate;
 
         private const int updates_per_second = 10;
 
@@ -65,7 +72,6 @@ namespace osu.Framework.Graphics.Performance
                 if (!Counting) return;
 
                 double clockFps = clock.FramesPerSecond;
-                double actualElapsed = clock.ElapsedFrameTime - clock.TimeSlept;
                 double updateHz = clock.MaximumUpdateHz;
 
                 Schedule(() =>
@@ -85,12 +91,16 @@ namespace osu.Framework.Graphics.Performance
                     }
 
                     double dampRate = Math.Max(Clock.CurrentTime - lastUpdate, 0) / 1000;
-                    lastUpdate = Clock.CurrentTime;
 
                     displayFps = Interpolation.Damp(displayFps, clockFps, 0.01, dampRate);
-                    displayFrameTime = Interpolation.Damp(displayFrameTime, actualElapsed, 0.01, dampRate);
+                    rollingElapsed = Interpolation.Damp(rollingElapsed, elapsedSinceLastUpdate / framesSinceLastUpdate, 0.01, dampRate);
 
-                    counter.Text = $"{displayFps:0}fps({displayFrameTime:0.00}ms)"
+                    lastUpdate = Clock.CurrentTime;
+
+                    framesSinceLastUpdate = 0;
+                    elapsedSinceLastUpdate = 0;
+
+                    counter.Text = $"{displayFps:0}fps({rollingElapsed:0.00}ms)"
                                    + $"{(updateHz < 10000 ? updateHz.ToString("0") : "∞").PadLeft(4)}hz";
                 });
             }, 1000.0 / updates_per_second, true);
@@ -104,6 +114,19 @@ namespace osu.Framework.Graphics.Performance
             }
 
             protected override char[] FixedWidthExcludeCharacters { get; } = { ',', '.', ' ' };
+        }
+
+        public void NewFrame(FrameStatistics frame)
+        {
+            if (!Counting) return;
+
+            foreach (var pair in frame.CollectedTimes)
+            {
+                if (pair.Key != PerformanceCollectionType.Sleep)
+                    elapsedSinceLastUpdate += pair.Value;
+            }
+
+            framesSinceLastUpdate++;
         }
     }
 }

--- a/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameTimeDisplay.cs
@@ -93,7 +93,8 @@ namespace osu.Framework.Graphics.Performance
                     double dampRate = Math.Max(Clock.CurrentTime - lastUpdate, 0) / 1000;
 
                     displayFps = Interpolation.Damp(displayFps, clockFps, 0.01, dampRate);
-                    rollingElapsed = Interpolation.Damp(rollingElapsed, elapsedSinceLastUpdate / framesSinceLastUpdate, 0.01, dampRate);
+                    if (framesSinceLastUpdate > 0)
+                        rollingElapsed = Interpolation.Damp(rollingElapsed, elapsedSinceLastUpdate / framesSinceLastUpdate, 0.01, dampRate);
 
                     lastUpdate = Clock.CurrentTime;
 


### PR DESCRIPTION
Until now, we were reading `ElapsedFrameTime` from threads' clock, but only 10 times per second. This means it could be inaccurate if frame times were different between these polls.

- Now considers every frame
- Uses `FrameStatistics.CollectedTimes` instead of `ElapsedFrameTime`. This is a prerequisite for making the elapsed time display actually work with single threaded execution. In practice, this means a small framework overhead may be excluded from the calculation, but if anything this makes the display more correct in its context.