### PR TITLE
Attached Screen FPS to game update loop on iOS

### DIFF
--- a/osu.Framework.iOS/GameAppDelegate.cs
+++ b/osu.Framework.iOS/GameAppDelegate.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.iOS
             Window.MakeKeyAndVisible();
 
             // required to trigger the osuTK update loop, which is used for input handling.
-            gameView.Run();
+            gameView.Run(UIScreen.MainScreen.MaximumFramesPerSecond);
 
             host.Run(CreateGame());
 

--- a/osu.Framework.iOS/GameAppDelegate.cs
+++ b/osu.Framework.iOS/GameAppDelegate.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.iOS
             Window.MakeKeyAndVisible();
 
             // required to trigger the osuTK update loop, which is used for input handling.
-            gameView.Run(UIScreen.MainScreen.MaximumFramesPerSecond);
+            gameView.RunWithFrameInterval((int)UIScreen.MainScreen.MaximumFramesPerSecond);
 
             host.Run(CreateGame());
 


### PR DESCRIPTION
As discussed in https://github.com/ppy/osu-framework/issues/3312, here's my branch/PR ~in progress~ for making this work better on high-FPS devices. It looks like previously, the game view was relying on an osuTK API that set up an `NSTimer` under the hood, but this one instead uses `CADisplayLink`.

`UIScreen` actually exposes the number of FPS the device is capable of, which is what `CADisplayLink` is then configured against.

