### PR TITLE
Use ThreadStatic for ThreadSafety implementation

### DIFF
--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.IO.Stores;
 using osu.Framework.Threading;
 
@@ -289,6 +290,8 @@ namespace osu.Framework.Tests.Audio
 
             new Thread(() =>
             {
+                ThreadSafety.IsAudioThread = true;
+
                 action();
 
                 resetEvent.Set();

--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Threading;
 using osu.Framework.Timing;
@@ -14,17 +13,18 @@ namespace osu.Framework.Tests.Threading
     {
         private Scheduler scheduler;
 
+        private bool fromMainThread;
+
         [SetUp]
         public void Setup()
         {
-            scheduler = new Scheduler(new Thread(() => { }));
+            scheduler = new Scheduler(() => fromMainThread, new StopwatchClock(true));
         }
 
         [Test]
         public void TestScheduleOnce([Values(false, true)] bool fromMainThread, [Values(false, true)] bool forceScheduled)
         {
-            if (fromMainThread)
-                scheduler.SetCurrentThread();
+            this.fromMainThread = fromMainThread;
 
             int invocations = 0;
 
@@ -302,8 +302,7 @@ namespace osu.Framework.Tests.Threading
         {
             const int max_reschedules = 3;
 
-            if (!forceScheduled)
-                scheduler.SetCurrentThread();
+            fromMainThread = !forceScheduled;
 
             int reschedules = 0;
 

--- a/osu.Framework/Development/ThreadSafety.cs
+++ b/osu.Framework/Development/ThreadSafety.cs
@@ -1,9 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
-using System.Threading;
-using osu.Framework.Threading;
 
 namespace osu.Framework.Development
 {
@@ -27,19 +26,16 @@ namespace osu.Framework.Development
             Debug.Assert(IsDrawThread);
         }
 
-        private static readonly ThreadLocal<bool> is_update_thread = new ThreadLocal<bool>(() =>
-            Thread.CurrentThread.Name == GameThread.PrefixedThreadNameFor("Update"));
+        [ThreadStatic]
+        public static bool IsInputThread;
 
-        private static readonly ThreadLocal<bool> is_draw_thread = new ThreadLocal<bool>(() =>
-            Thread.CurrentThread.Name == GameThread.PrefixedThreadNameFor("Draw"));
+        [ThreadStatic]
+        public static bool IsUpdateThread;
 
-        private static readonly ThreadLocal<bool> is_audio_thread = new ThreadLocal<bool>(() =>
-            Thread.CurrentThread.Name == GameThread.PrefixedThreadNameFor("Audio"));
+        [ThreadStatic]
+        public static bool IsDrawThread;
 
-        public static bool IsUpdateThread => is_update_thread.Value;
-
-        public static bool IsDrawThread => is_draw_thread.Value;
-
-        public static bool IsAudioThread => is_audio_thread.Value;
+        [ThreadStatic]
+        public static bool IsAudioThread;
     }
 }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected CompositeDrawable()
         {
-            schedulerAfterChildren = new Lazy<Scheduler>(() => new Scheduler(MainThread, Clock));
+            schedulerAfterChildren = new Lazy<Scheduler>(() => new Scheduler(() => ThreadSafety.IsUpdateThread, Clock));
 
             internalChildren = new SortedList<Drawable>(new ChildComparer(this));
             aliveInternalChildren = new SortedList<Drawable>(new ChildComparer(this));
@@ -276,12 +276,6 @@ namespace osu.Framework.Graphics.Containers
                     ExceptionDispatchInfo.Capture(e).Throw();
                 }
             }
-        }
-
-        protected override void LoadComplete()
-        {
-            if (schedulerAfterChildren.IsValueCreated) schedulerAfterChildren.Value.SetCurrentThread(MainThread);
-            base.LoadComplete();
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Graphics
 
         protected Drawable()
         {
-            scheduler = new Lazy<Scheduler>(() => new Scheduler(MainThread, Clock));
+            scheduler = new Lazy<Scheduler>(() => new Scheduler(() => ThreadSafety.IsUpdateThread, Clock));
             total_count.Value++;
         }
 
@@ -307,9 +307,6 @@ namespace osu.Framework.Graphics
         {
             if (loadState < LoadState.Ready) return false;
 
-            MainThread = Thread.CurrentThread;
-            if (scheduler.IsValueCreated) scheduler.Value.SetCurrentThread(MainThread);
-
             loadState = LoadState.Loaded;
             Invalidate();
             LoadComplete();
@@ -425,8 +422,6 @@ namespace osu.Framework.Graphics
         internal event Action OnUnbindAllBindables;
 
         private readonly Lazy<Scheduler> scheduler;
-
-        internal Thread MainThread { get; private set; }
 
         /// <summary>
         /// A lazily-initialized scheduler used to schedule tasks to be invoked in future <see cref="Update"/>s calls.

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -18,6 +18,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Platform;
+using osu.Framework.Timing;
 using GameWindow = osu.Framework.Platform.GameWindow;
 
 namespace osu.Framework.Graphics.OpenGL
@@ -56,7 +57,7 @@ namespace osu.Framework.Graphics.OpenGL
         public static int MaxTextureSize { get; private set; } = 4096; // default value is to allow roughly normal flow in cases we don't have a GL context, like headless CI.
         public static int MaxRenderBufferSize { get; private set; } = 4096; // default value is to allow roughly normal flow in cases we don't have a GL context, like headless CI.
 
-        private static readonly Scheduler reset_scheduler = new Scheduler(null); // force no thread set until we are actually on the draw thread.
+        private static readonly Scheduler reset_scheduler = new Scheduler(() => ThreadSafety.IsDrawThread, new StopwatchClock(true)); // force no thread set until we are actually on the draw thread.
 
         /// <summary>
         /// A queue from which a maximum of one operation is invoked per draw frame.
@@ -79,7 +80,6 @@ namespace osu.Framework.Graphics.OpenGL
                 IsEmbedded = win.IsEmbedded;
 
             GLWrapper.host = new WeakReference<GameHost>(host);
-            reset_scheduler.SetCurrentThread();
 
             MaxTextureSize = GL.GetInteger(GetPName.MaxTextureSize);
             MaxRenderBufferSize = GL.GetInteger(GetPName.MaxRenderbufferSize);

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -16,6 +16,7 @@ using osuTK.Input;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.Platform;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
@@ -89,7 +90,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public OnCommitHandler OnCommit;
 
-        private readonly Scheduler textUpdateScheduler = new Scheduler();
+        private readonly Scheduler textUpdateScheduler = new Scheduler(() => ThreadSafety.IsUpdateThread, null);
 
         protected TextBox()
         {
@@ -143,12 +144,6 @@ namespace osu.Framework.Graphics.UserInterface
                     cursorAndLayout.Invalidate();
                 };
             }
-        }
-
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-            textUpdateScheduler.SetCurrentThread(MainThread);
         }
 
         public virtual bool OnPressed(PlatformAction action)

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using ManagedBass;
 using osu.Framework.Audio;
+using osu.Framework.Development;
 
 namespace osu.Framework.Threading
 {
@@ -15,6 +16,12 @@ namespace osu.Framework.Threading
             : base(name: "Audio")
         {
             OnNewFrame = onNewFrame;
+        }
+
+        internal override void MakeCurrent()
+        {
+            base.MakeCurrent();
+            ThreadSafety.IsAudioThread = true;
         }
 
         internal override IEnumerable<StatisticsCounterType> StatisticsCounters => new[]

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -18,6 +18,8 @@ namespace osu.Framework.Threading
             OnNewFrame = onNewFrame;
         }
 
+        public override bool IsCurrent => ThreadSafety.IsAudioThread;
+
         internal override void MakeCurrent()
         {
             base.MakeCurrent();

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Statistics;
 using System;
 using System.Collections.Generic;
+using osu.Framework.Development;
 
 namespace osu.Framework.Threading
 {
@@ -12,6 +13,12 @@ namespace osu.Framework.Threading
         public DrawThread(Action onNewFrame)
             : base(onNewFrame, "Draw")
         {
+        }
+
+        internal override void MakeCurrent()
+        {
+            base.MakeCurrent();
+            ThreadSafety.IsDrawThread = true;
         }
 
         internal override IEnumerable<StatisticsCounterType> StatisticsCounters => new[]

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -15,6 +15,8 @@ namespace osu.Framework.Threading
         {
         }
 
+        public override bool IsCurrent => ThreadSafety.IsDrawThread;
+
         internal override void MakeCurrent()
         {
             base.MakeCurrent();

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -97,11 +97,8 @@ namespace osu.Framework.Threading
 
         private void runWork()
         {
-            Scheduler.SetCurrentThread();
-
-            OnThreadStart?.Invoke();
-
-            initializedEvent.Set();
+            Initialize();
+            MakeCurrent();
 
             while (!exitCompleted)
             {
@@ -117,6 +114,20 @@ namespace osu.Framework.Threading
                         throw;
                 }
             }
+        }
+
+        internal virtual void Initialize()
+        {
+            OnThreadStart?.Invoke();
+            initializedEvent.Set();
+        }
+
+        /// <summary>
+        /// Run when thread transitions into an active/processing state.
+        /// </summary>
+        internal virtual void MakeCurrent()
+        {
+            Scheduler.SetCurrentThread();
         }
 
         protected void ProcessFrame()

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -127,10 +127,7 @@ namespace osu.Framework.Threading
         /// <summary>
         /// Run when thread transitions into an active/processing state.
         /// </summary>
-        internal virtual void MakeCurrent()
-        {
-            Scheduler.SetCurrentThread();
-        }
+        internal virtual void MakeCurrent() { }
 
         protected void ProcessFrame()
         {
@@ -172,14 +169,9 @@ namespace osu.Framework.Threading
 
         public class GameThreadScheduler : Scheduler
         {
-            private readonly GameThread thread;
-
-            protected override bool IsMainThread => thread.IsCurrent;
-
             public GameThreadScheduler(GameThread thread)
-                : base(null, thread.Clock)
+                : base(() => thread.IsCurrent, thread.Clock)
             {
-                this.thread = thread;
             }
         }
     }

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -21,6 +21,8 @@ namespace osu.Framework.Threading
             StatisticsCounterType.JoystickEvents,
         };
 
+        public override bool IsCurrent => ThreadSafety.IsInputThread;
+
         internal override void MakeCurrent()
         {
             base.MakeCurrent();

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Statistics;
 using System.Collections.Generic;
+using osu.Framework.Development;
 
 namespace osu.Framework.Threading
 {
@@ -19,6 +20,12 @@ namespace osu.Framework.Threading
             StatisticsCounterType.KeyEvents,
             StatisticsCounterType.JoystickEvents,
         };
+
+        internal override void MakeCurrent()
+        {
+            base.MakeCurrent();
+            ThreadSafety.IsInputThread = true;
+        }
 
         public override void Start()
         {

--- a/osu.Framework/Threading/UpdateThread.cs
+++ b/osu.Framework/Threading/UpdateThread.cs
@@ -15,6 +15,8 @@ namespace osu.Framework.Threading
         {
         }
 
+        public override bool IsCurrent => ThreadSafety.IsUpdateThread;
+
         internal override void MakeCurrent()
         {
             base.MakeCurrent();

--- a/osu.Framework/Threading/UpdateThread.cs
+++ b/osu.Framework/Threading/UpdateThread.cs
@@ -4,6 +4,7 @@
 using osu.Framework.Statistics;
 using System;
 using System.Collections.Generic;
+using osu.Framework.Development;
 
 namespace osu.Framework.Threading
 {
@@ -12,6 +13,12 @@ namespace osu.Framework.Threading
         public UpdateThread(Action onNewFrame)
             : base(onNewFrame, "Update")
         {
+        }
+
+        internal override void MakeCurrent()
+        {
+            base.MakeCurrent();
+            ThreadSafety.IsUpdateThread = true;
         }
 
         internal override IEnumerable<StatisticsCounterType> StatisticsCounters => new[]


### PR DESCRIPTION
Allows for more flexibility in switching variables. For single-threaded execution this is imperative to ensure we are running things in the correct context (even though they are all on the same logical thread).