### PR TITLE
Fix collection stack becoming unbalanced during exit cancellation

### DIFF
--- a/osu.Framework/Statistics/PerformanceMonitor.cs
+++ b/osu.Framework/Statistics/PerformanceMonitor.cs
@@ -153,8 +153,6 @@ namespace osu.Framework.Statistics
             //check for dropped (stutter) frames
             traceCollector.NewFrame(Clock.ElapsedFrameTime, Math.Max(10, Math.Max(1000 / Clock.MaximumUpdateHz, averageFrameTime) * 4));
 
-            //reset frame totals
-            currentCollectionTypeStack.Clear();
             consumeStopwatchElapsedTime();
         }
 


### PR DESCRIPTION
Due to the call

https://github.com/ppy/osu-framework/blob/48143da22385831aebc9d0eee10ea84236b52576/osu.Framework/Platform/GameHost.cs#L264

being run inside an already running thread in the case of single thread execution, we were nesting frames. The clear call would clear the stack while inside a frame, causing it do become unbalanced and die on the outer `Pop`.