### PR TITLE
Add fast invalidation path for bypass autosize axes

### DIFF
--- a/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
+++ b/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
@@ -123,6 +123,80 @@ namespace osu.Framework.Tests.Layout
             AddUntilStep("content height matches box height", () => Precision.AlmostEquals(content.DrawHeight, child.DrawHeight));
         }
 
+        [TestCase(Axes.X)]
+        [TestCase(Axes.Y)]
+        [TestCase(Axes.Both)]
+        public void TestParentNotInvalidatedByBypassedSize(Axes axes)
+        {
+            Box child = null;
+
+            bool autoSized = false;
+
+            AddStep("create test", () =>
+            {
+                Child = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Child = child = new Box { BypassAutoSizeAxes = axes }
+                }.With(c => c.OnAutoSize += () => autoSized = true);
+            });
+
+            AddUntilStep("wait for autosize", () => autoSized);
+
+            AddStep("adjust child size", () =>
+            {
+                autoSized = false;
+
+                if (axes == Axes.Both)
+                    child.Size = new Vector2(50);
+                else if (axes == Axes.X)
+                    child.Width = 50;
+                else if (axes == Axes.Y)
+                    child.Height = 50;
+            });
+
+            AddWaitStep("wait for autosize", 1);
+
+            AddAssert("not autosized", () => !autoSized);
+        }
+
+        [TestCase(Axes.X)]
+        [TestCase(Axes.Y)]
+        [TestCase(Axes.Both)]
+        public void TestParentNotInvalidatedByBypassedPosition(Axes axes)
+        {
+            Box child = null;
+
+            bool autoSized = false;
+
+            AddStep("create test", () =>
+            {
+                Child = new Container
+                {
+                    AutoSizeAxes = Axes.Both,
+                    Child = child = new Box { BypassAutoSizeAxes = axes }
+                }.With(c => c.OnAutoSize += () => autoSized = true);
+            });
+
+            AddUntilStep("wait for autosize", () => autoSized);
+
+            AddStep("adjust child size", () =>
+            {
+                autoSized = false;
+
+                if (axes == Axes.Both)
+                    child.Position = new Vector2(50);
+                else if (axes == Axes.X)
+                    child.X = 50;
+                else if (axes == Axes.Y)
+                    child.Y = 50;
+            });
+
+            AddWaitStep("wait for autosize", 1);
+
+            AddAssert("not autosized", () => !autoSized);
+        }
+
         private class TestBox1 : Box
         {
             public override bool RemoveWhenNotAlive => false;

--- a/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
+++ b/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
@@ -123,6 +123,10 @@ namespace osu.Framework.Tests.Layout
             AddUntilStep("content height matches box height", () => Precision.AlmostEquals(content.DrawHeight, child.DrawHeight));
         }
 
+        /// <summary>
+        /// Tests that a parent container is not re-auto-sized when a child's size changes along the bypassed axes.
+        /// </summary>
+        /// <param name="axes">The bypassed axes that are bypassed.</param>
         [TestCase(Axes.X)]
         [TestCase(Axes.Y)]
         [TestCase(Axes.Both)]
@@ -160,6 +164,10 @@ namespace osu.Framework.Tests.Layout
             AddAssert("not autosized", () => !autoSized);
         }
 
+        /// <summary>
+        /// Tests that a parent container is not re-auto-sized when a child's position changes along the bypassed axes.
+        /// </summary>
+        /// <param name="axes">The bypassed axes that are bypassed.</param>
         [TestCase(Axes.X)]
         [TestCase(Axes.Y)]
         [TestCase(Axes.Both)]

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -984,6 +984,27 @@ namespace osu.Framework.Graphics.Containers
             return anyInvalidated;
         }
 
+        /// <summary>
+        /// Invalidates the children size dependencies of this <see cref="CompositeDrawable"/> when a child's position or size changes.
+        /// </summary>
+        /// <param name="invalidation">The <see cref="Invalidation"/> to invalidate with.</param>
+        /// <param name="axes">The position or size <see cref="Axes"/> that changed.</param>
+        /// <param name="source">The source <see cref="Drawable"/>.</param>
+        internal void InvalidateChildrenSizeDependencies(Invalidation invalidation, Axes axes, Drawable source)
+        {
+            // Store the current state of the children size dependencies.
+            // This state may be restored later if the invalidation proved to be unnecessary.
+            bool wasValid = childrenSizeDependencies.IsValid;
+
+            // The invalidation still needs to occur as normal, since a derived CompositeDrawable may want to respond to children size invalidations.
+            Invalidate(invalidation, InvalidationSource.Child);
+
+            // If all the changed axes were bypassed and an invalidation occurred, the children size dependencies can immediately be
+            // re-validated without a recomputation, as a recomputation would not change the auto-sized size.
+            if (wasValid && (axes & source.BypassAutoSizeAxes) == axes)
+                childrenSizeDependencies.Validate();
+        }
+
         #endregion
 
         #region DrawNode


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/8056

This was caused by the judgements container inside `ManiaStage`, which is defined as:

```
judgements = new JudgementContainer<DrawableManiaJudgement>
{
    Anchor = Anchor.TopCentre,
    Origin = Anchor.Centre,
    AutoSizeAxes = Axes.Both,
    Y = HIT_TARGET_POSITION + 150,
    BypassAutoSizeAxes = Axes.Both
},
```

Whenever a child was added to this container, its own auto-size would be recomputed, and then that would propagate upwards to invalidate the parent's auto-size.

At specific window sizes, the parent's auto-size would ping-pong between 350 and 349.99997 or something like that likely due to bounding box calculations. That would then invalidate the hierarchy of that container, which would invalidate the scrolling container, which would re-compute the hitobject starting lifetimes/positions/etc.

Note that this isn't an issue with the new layout system, this was already a thing before. The reason why it was ping-ponging is still an unknown to me.

This is a performance enhancement to reduce the amount of invalidations that occur when `BypassAutoSizeAxes` is involved. When an invalidation request happens, there are two things that should happen:
1. The parent _must_ get invalidated with `DrawSize` or `MiscGeometry`, whatever values it's already being invalidated with. This is to cover the case of e.g. `FlowContainer`, which doesn't doesn't bypass layout via `BypassAutoSizeAxes`.
2. The parent _can_ choose to forego re-computing the children size, if it's already valid and the axes that caused the invalidation are bypassed.