### PR TITLE
Fix CircularProgress incorrectly SRGBing

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneCircularProgress.cs
@@ -177,7 +177,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     break;
 
                 case 1:
-                    clock.Colour = new Color4(255, 128, 128, 255);
+                    clock.Colour = new Color4(255, 88, 88, 255);
                     break;
 
                 case 2:

--- a/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
+++ b/osu.Framework/Graphics/UserInterface/CircularProgressDrawNode.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         // Gets colour at the localPos position in the unit square of our Colour gradient box.
         private Color4 colourAt(Vector2 localPos) => DrawColourInfo.Colour.HasSingleColour
-            ? (Color4)DrawColourInfo.Colour
+            ? DrawColourInfo.Colour.TopLeft.Linear
             : DrawColourInfo.Colour.Interpolate(localPos).Linear;
 
         private static readonly Vector2 origin = new Vector2(0.5f, 0.5f);


### PR DESCRIPTION
The process is a little bit confusing, but casting from `ColourInfo` to `Color4` happens through the implicit operators:

```
implicit operator Color4(ColourInfo colour) => (SRGBColour)colour
implicit operator SRGBColour(ColourInfo colour) => colour.singleColour
implicit operator Color4(SRGBColour value) => value.Linear.ToSRGB()
```

The shader itself will also call `toSRGB` with our given colour. The end result is that we're doubly-SRGB'ing the colour.
The same effect can be observed by attaching a `.ToSRGB()` to the `.Linear` that was added in this PR.

This is something that we'll need to improve on in the future - shooting ourselves in the foot via SRGB conversion is a well-known issue for us at this point.

I've made minimal changes to the test scene since it needs to be completely rewritten before it's usable.