### PR TITLE
Fix virtual track entering a running state when length is zero

### DIFF
--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -1,0 +1,287 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using NUnit.Framework;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
+using osu.Framework.Development;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Audio
+{
+    [TestFixture]
+    public class TrackVirtualTest
+    {
+        private TrackVirtual track;
+
+        [SetUp]
+        public void Setup()
+        {
+            track = new TrackVirtual(10000);
+            updateTrack();
+        }
+
+        [Test]
+        public void TestStart()
+        {
+            track.Start();
+            updateTrack();
+
+            Thread.Sleep(50);
+
+            updateTrack();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.Greater(track.CurrentTime, 0);
+        }
+
+        [Test]
+        public void TestStartZeroLength()
+        {
+            // override default with custom length
+            track = new TrackVirtual(0);
+
+            track.Start();
+            updateTrack();
+
+            Thread.Sleep(50);
+
+            Assert.IsTrue(!track.IsRunning);
+            Assert.AreEqual(0, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestStop()
+        {
+            track.Start();
+            track.Stop();
+            updateTrack();
+
+            Assert.IsFalse(track.IsRunning);
+
+            double expectedTime = track.CurrentTime;
+            Thread.Sleep(50);
+
+            Assert.AreEqual(expectedTime, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestStopAtEnd()
+        {
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            updateTrack();
+            track.Stop();
+            updateTrack();
+
+            Assert.IsFalse(track.IsRunning);
+            Assert.AreEqual(track.Length, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestSeek()
+        {
+            track.Seek(1000);
+            updateTrack();
+
+            Assert.IsFalse(track.IsRunning);
+            Assert.AreEqual(1000, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestSeekWhileRunning()
+        {
+            track.Start();
+            track.Seek(1000);
+            updateTrack();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.GreaterOrEqual(track.CurrentTime, 1000);
+        }
+
+        [Test]
+        public void TestSeekBackToSamePosition()
+        {
+            track.Seek(1000);
+            track.Seek(0);
+            updateTrack();
+
+            Thread.Sleep(50);
+
+            updateTrack();
+
+            Assert.GreaterOrEqual(track.CurrentTime, 0);
+            Assert.Less(track.CurrentTime, 1000);
+        }
+
+        [Test]
+        public void TestPlaybackToEnd()
+        {
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            updateTrack();
+
+            Assert.IsFalse(track.IsRunning);
+            Assert.AreEqual(track.Length, track.CurrentTime);
+        }
+
+        /// <summary>
+        /// Bass restarts the track from the beginning if Start is called when the track has been completed.
+        /// This is blocked locally in <see cref="TrackVirtual"/>, so this test expects the track to not restart.
+        /// </summary>
+        [Test]
+        public void TestStartFromEndDoesNotRestart()
+        {
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            updateTrack();
+            track.Start();
+            updateTrack();
+
+            Assert.AreEqual(track.Length, track.CurrentTime);
+        }
+
+        [Test]
+        public void TestRestart()
+        {
+            startPlaybackAt(1000);
+
+            Thread.Sleep(50);
+
+            updateTrack();
+            restartTrack();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.Less(track.CurrentTime, 1000);
+        }
+
+        [Test]
+        public void TestRestartAtEnd()
+        {
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            updateTrack();
+            restartTrack();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.LessOrEqual(track.CurrentTime, 1000);
+        }
+
+        [Test]
+        public void TestRestartFromRestartPoint()
+        {
+            track.RestartPoint = 1000;
+
+            startPlaybackAt(3000);
+            restartTrack();
+
+            Assert.IsTrue(track.IsRunning);
+            Assert.GreaterOrEqual(track.CurrentTime, 1000);
+            Assert.Less(track.CurrentTime, 3000);
+        }
+
+        [Test]
+        public void TestLoopingRestart()
+        {
+            track.Looping = true;
+
+            startPlaybackAt(track.Length - 1);
+
+            Thread.Sleep(50);
+
+            // The first update brings the track to its end time and restarts it
+            updateTrack();
+
+            // The second update updates the IsRunning state
+            updateTrack();
+
+            // In a perfect world the track will be running after the update above, but during testing it's possible that the track is in
+            // a stalled state due to updates running on Bass' own thread, so we'll loop until the track starts running again
+            // Todo: This should be fixed in the future if/when we invoke Bass.Update() ourselves
+            int loopCount = 0;
+
+            while (++loopCount < 50 && !track.IsRunning)
+            {
+                updateTrack();
+                Thread.Sleep(10);
+            }
+
+            if (loopCount == 50)
+                throw new TimeoutException("Track failed to start in time.");
+
+            Assert.LessOrEqual(track.CurrentTime, 1000);
+        }
+
+        [Test]
+        public void TestSetTempoNegative()
+        {
+            Assert.IsFalse(track.IsReversed);
+
+            track.Tempo.Value = 0.05f;
+
+            Assert.IsFalse(track.IsReversed);
+            Assert.AreEqual(0.05f, track.Tempo.Value);
+        }
+
+        [Test]
+        public void TestRateWithAggregateAdjustments()
+        {
+            track.AddAdjustment(AdjustableProperty.Frequency, new BindableDouble(1.5f));
+            Assert.AreEqual(1.5, track.Rate);
+        }
+
+        private void startPlaybackAt(double time)
+        {
+            track.Seek(time);
+            track.Start();
+            updateTrack();
+        }
+
+        private void updateTrack() => RunOnAudioThread(() => track.Update());
+
+        private void restartTrack()
+        {
+            RunOnAudioThread(() =>
+            {
+                track.Restart();
+                track.Update();
+            });
+        }
+
+        /// <summary>
+        /// Certain actions are invoked on the audio thread.
+        /// Here we simulate this process on a correctly named thread to avoid endless blocking.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        public static void RunOnAudioThread(Action action)
+        {
+            var resetEvent = new ManualResetEvent(false);
+
+            new Thread(() =>
+            {
+                ThreadSafety.IsAudioThread = true;
+
+                action();
+
+                resetEvent.Set();
+            })
+            {
+                Name = GameThread.PrefixedThreadNameFor("Audio")
+            }.Start();
+
+            if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException();
+        }
+    }
+}

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -38,6 +38,9 @@ namespace osu.Framework.Audio.Track
 
         public override void Start()
         {
+            if (Length == 0)
+                return;
+
             lock (clock) clock.Start();
         }
 

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Audio.Track
         {
             get
             {
-                lock (clock) return seekOffset + clock.CurrentTime;
+                lock (clock) return Math.Min(Length, seekOffset + clock.CurrentTime);
             }
         }
 


### PR DESCRIPTION
Also

- Adds test coverage
- Fixes `CurrentTime` exceeding `Length`