### PR TITLE
Remove custom interpolation function from TransformCustom/TransformBinable

### DIFF
--- a/osu.Framework/Graphics/TransformSequenceExtensions.cs
+++ b/osu.Framework/Graphics/TransformSequenceExtensions.cs
@@ -10,7 +10,6 @@ using osu.Framework.Threading;
 using System;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
-using osu.Framework.Utils;
 
 namespace osu.Framework.Graphics
 {
@@ -240,9 +239,8 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformBindableTo<T, TValue>(this TransformSequence<T> t, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None,
-                                                                          InterpolationFunc<TValue> interpolationFunc = null)
+        public static TransformSequence<T> TransformBindableTo<T, TValue>(this TransformSequence<T> t, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
             where T : class, ITransformable =>
-            t.Append(o => o.TransformBindableTo(bindable, newValue, duration, easing, interpolationFunc));
+            t.Append(o => o.TransformBindableTo(bindable, newValue, duration, easing));
     }
 }

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Effects;
-using osu.Framework.Utils;
 
 namespace osu.Framework.Graphics
 {
@@ -414,9 +413,8 @@ namespace osu.Framework.Graphics
         /// Smoothly adjusts the value of a <see cref="Bindable{TValue}"/> over time.
         /// </summary>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<T> TransformBindableTo<T, TValue>(this T drawable, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None,
-                                                                          InterpolationFunc<TValue> interpolationFunc = null)
+        public static TransformSequence<T> TransformBindableTo<T, TValue>(this T drawable, [NotNull] Bindable<TValue> bindable, TValue newValue, double duration = 0, Easing easing = Easing.None)
             where T : class, ITransformable =>
-            drawable.TransformTo(drawable.PopulateTransform(new TransformBindable<TValue, T>(bindable, interpolationFunc), newValue, duration, easing));
+            drawable.TransformTo(drawable.PopulateTransform(new TransformBindable<TValue, T>(bindable), newValue, duration, easing));
     }
 }

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -12,12 +12,12 @@ namespace osu.Framework.Graphics.Transforms
         public override string TargetMember { get; }
 
         private readonly Bindable<TValue> targetBindable;
-        private readonly InterpolationFunc<TValue> interpolationFunc;
+        private readonly Interpolation<TValue>.InterpolationDelegate interpolationDelegate;
 
-        public TransformBindable(Bindable<TValue> targetBindable, InterpolationFunc<TValue> interpolationFunc)
+        public TransformBindable(Bindable<TValue> targetBindable)
         {
             this.targetBindable = targetBindable;
-            this.interpolationFunc = interpolationFunc ?? Interpolation<TValue>.ValueAt;
+            interpolationDelegate = Interpolation<TValue>.FUNCTION;
 
             TargetMember = $"{targetBindable.GetHashCode()}.Value";
         }
@@ -27,7 +27,7 @@ namespace osu.Framework.Graphics.Transforms
             if (time < StartTime) return StartValue;
             if (time >= EndTime) return EndValue;
 
-            return interpolationFunc(time, StartValue, EndValue, StartTime, EndTime, Easing);
+            return interpolationDelegate(time, StartValue, EndValue, StartTime, EndTime, Easing);
         }
 
         protected override void Apply(T d, double time) => targetBindable.Value = valueAt(time);

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -12,12 +12,12 @@ namespace osu.Framework.Graphics.Transforms
         public override string TargetMember { get; }
 
         private readonly Bindable<TValue> targetBindable;
-        private readonly Interpolation<TValue>.InterpolationDelegate interpolationDelegate;
+        private readonly InterpolationFunc<TValue> interpolationFunc;
 
         public TransformBindable(Bindable<TValue> targetBindable)
         {
             this.targetBindable = targetBindable;
-            interpolationDelegate = Interpolation<TValue>.FUNCTION;
+            interpolationFunc = Interpolation<TValue>.ValueAt;
 
             TargetMember = $"{targetBindable.GetHashCode()}.Value";
         }
@@ -27,7 +27,7 @@ namespace osu.Framework.Graphics.Transforms
             if (time < StartTime) return StartValue;
             if (time >= EndTime) return EndValue;
 
-            return interpolationDelegate(time, StartValue, EndValue, StartTime, EndTime, Easing);
+            return interpolationFunc(time, StartValue, EndValue, StartTime, EndTime, Easing);
         }
 
         protected override void Apply(T d, double time) => targetBindable.Value = valueAt(time);

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -141,7 +141,7 @@ namespace osu.Framework.Graphics.Transforms
         private static Accessor getAccessor(string propertyOrFieldName) => accessors.GetOrAdd(propertyOrFieldName, key => findAccessor(typeof(T), key));
 
         private readonly Accessor accessor;
-        private readonly Interpolation<TValue>.InterpolationDelegate interpolationDelegate;
+        private readonly InterpolationFunc<TValue> interpolationFunc;
 
         /// <summary>
         /// Creates a new instance operating on a property or field of <typeparamref name="T"/>. The property or field is
@@ -159,7 +159,7 @@ namespace osu.Framework.Graphics.Transforms
             accessor = getAccessor(propertyOrFieldName);
             Trace.Assert(accessor.Read != null && accessor.Write != null, $"Failed to populate {nameof(accessor)}.");
 
-            interpolationDelegate = Interpolation<TValue>.FUNCTION;
+            interpolationFunc = Interpolation<TValue>.FUNCTION;
         }
 
         private TValue valueAt(double time)
@@ -167,7 +167,7 @@ namespace osu.Framework.Graphics.Transforms
             if (time < StartTime) return StartValue;
             if (time >= EndTime) return EndValue;
 
-            return interpolationDelegate(time, StartValue, EndValue, StartTime, EndTime, Easing);
+            return interpolationFunc(time, StartValue, EndValue, StartTime, EndTime, Easing);
         }
 
         public override string TargetMember { get; }

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -141,7 +141,7 @@ namespace osu.Framework.Graphics.Transforms
         private static Accessor getAccessor(string propertyOrFieldName) => accessors.GetOrAdd(propertyOrFieldName, key => findAccessor(typeof(T), key));
 
         private readonly Accessor accessor;
-        private readonly InterpolationFunc<TValue> interpolationFunc;
+        private readonly Interpolation<TValue>.InterpolationDelegate interpolationDelegate;
 
         /// <summary>
         /// Creates a new instance operating on a property or field of <typeparamref name="T"/>. The property or field is
@@ -150,31 +150,16 @@ namespace osu.Framework.Graphics.Transforms
         /// picked for interpolating between <see cref="Transform{TValue}.StartValue"/> and
         /// <see cref="Transform{TValue}.EndValue"/> according to <see cref="Transform.StartTime"/>,
         /// <see cref="Transform.EndTime"/>, and a current time.
-        /// Optionally, or when no suitable "ValueAt" from <see cref="Interpolation"/> exists, a custom function can be supplied
-        /// via <paramref name="interpolationFunc"/>.
         /// </summary>
         /// <param name="propertyOrFieldName">The property or field name to be operated upon.</param>
-        /// <param name="interpolationFunc">
-        /// The function to be used for interpolating between <see cref="Transform{TValue}.StartValue"/> and
-        /// <see cref="Transform{TValue}.EndValue"/> according to <see cref="Transform.StartTime"/>,
-        /// <see cref="Transform.EndTime"/>, and a current time.
-        /// If null, an interpolation method "ValueAt" from <see cref="Interpolation"/> with a suitable signature is picked.
-        /// If none exists, then this parameter must not be null.
-        /// </param>
-        public TransformCustom(string propertyOrFieldName, InterpolationFunc<TValue> interpolationFunc = null)
+        public TransformCustom(string propertyOrFieldName)
         {
             TargetMember = propertyOrFieldName;
 
             accessor = getAccessor(propertyOrFieldName);
             Trace.Assert(accessor.Read != null && accessor.Write != null, $"Failed to populate {nameof(accessor)}.");
 
-            this.interpolationFunc = interpolationFunc ?? Interpolation<TValue>.FUNCTION;
-
-            if (this.interpolationFunc == null)
-            {
-                throw new InvalidOperationException(
-                    $"Need to pass a custom {nameof(interpolationFunc)} since no default {nameof(Interpolation)}.{nameof(Interpolation.ValueAt)} exists.");
-            }
+            interpolationDelegate = Interpolation<TValue>.FUNCTION;
         }
 
         private TValue valueAt(double time)
@@ -182,7 +167,7 @@ namespace osu.Framework.Graphics.Transforms
             if (time < StartTime) return StartValue;
             if (time >= EndTime) return EndValue;
 
-            return interpolationFunc(time, StartValue, EndValue, StartTime, EndTime, Easing);
+            return interpolationDelegate(time, StartValue, EndValue, StartTime, EndTime, Easing);
         }
 
         public override string TargetMember { get; }

--- a/osu.Framework/Utils/Interpolation.cs
+++ b/osu.Framework/Utils/Interpolation.cs
@@ -418,27 +418,27 @@ namespace osu.Framework.Utils
 
     internal static class Interpolation<TValue>
     {
-        public static readonly InterpolationDelegate FUNCTION;
+        public static readonly InterpolationFunc<TValue> FUNCTION;
 
         static Interpolation()
         {
             const string interpolation_method = nameof(Interpolation.ValueAt);
 
-            var parameters = typeof(InterpolationDelegate)
-                             .GetMethod(nameof(InterpolationDelegate.Invoke))
+            var parameters = typeof(InterpolationFunc<TValue>)
+                             .GetMethod(nameof(InterpolationFunc<TValue>.Invoke))
                              ?.GetParameters().Select(p => p.ParameterType).ToArray();
 
             var valueAtMethod = typeof(Interpolation).GetMethod(interpolation_method, parameters)
                                 ?? typeof(TValue).GetMethod(interpolation_method, parameters)
                                 ?? throw new NotSupportedException(
-                                    $"Type {typeof(TValue)} has no interpolation function. Add a method with the name {interpolation_method} with the parameters of {nameof(InterpolationDelegate)} or interpolate the value manually.");
+                                    $"Type {typeof(TValue)} has no interpolation function. Add a method with the name {interpolation_method} with the parameters of {nameof(InterpolationFunc<TValue>)} or interpolate the value manually.");
 
-            FUNCTION = (InterpolationDelegate)valueAtMethod.CreateDelegate(typeof(InterpolationDelegate));
+            FUNCTION = (InterpolationFunc<TValue>)valueAtMethod.CreateDelegate(typeof(InterpolationFunc<TValue>));
         }
 
-        public static TValue ValueAt(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easingType = Easing.None)
-            => FUNCTION(time, startValue, endValue, startTime, endTime, easingType);
-
-        public delegate TValue InterpolationDelegate(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easingType);
+        public static TValue ValueAt(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easing = Easing.None)
+            => FUNCTION(time, startValue, endValue, startTime, endTime, easing);
     }
+
+    public delegate TValue InterpolationFunc<TValue>(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easingType);
 }

--- a/osu.Framework/Utils/Interpolation.cs
+++ b/osu.Framework/Utils/Interpolation.cs
@@ -418,26 +418,27 @@ namespace osu.Framework.Utils
 
     internal static class Interpolation<TValue>
     {
-        public static readonly InterpolationFunc<TValue> FUNCTION;
+        public static readonly InterpolationDelegate FUNCTION;
 
         static Interpolation()
         {
             const string interpolation_method = nameof(Interpolation.ValueAt);
 
-            var parameters = typeof(InterpolationFunc<TValue>)
-                             .GetMethod(nameof(InterpolationFunc<TValue>.Invoke))
+            var parameters = typeof(InterpolationDelegate)
+                             .GetMethod(nameof(InterpolationDelegate.Invoke))
                              ?.GetParameters().Select(p => p.ParameterType).ToArray();
 
             var valueAtMethod = typeof(Interpolation).GetMethod(interpolation_method, parameters)
                                 ?? typeof(TValue).GetMethod(interpolation_method, parameters)
-                                ?? throw new NotSupportedException($"Type {typeof(TValue)} has no interpolation function. Add a method with the name {interpolation_method} with the parameters of {nameof(InterpolationFunc<TValue>)} or interpolate the value manually.");
+                                ?? throw new NotSupportedException(
+                                    $"Type {typeof(TValue)} has no interpolation function. Add a method with the name {interpolation_method} with the parameters of {nameof(InterpolationDelegate)} or interpolate the value manually.");
 
-            FUNCTION = (InterpolationFunc<TValue>)valueAtMethod.CreateDelegate(typeof(InterpolationFunc<TValue>));
+            FUNCTION = (InterpolationDelegate)valueAtMethod.CreateDelegate(typeof(InterpolationDelegate));
         }
 
-        public static TValue ValueAt(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easing = Easing.None)
-            => FUNCTION(time, startValue, endValue, startTime, endTime, easing);
-    }
+        public static TValue ValueAt(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easingType = Easing.None)
+            => FUNCTION(time, startValue, endValue, startTime, endTime, easingType);
 
-    public delegate TValue InterpolationFunc<TValue>(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easingType);
+        public delegate TValue InterpolationDelegate(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easingType);
+    }
 }


### PR DESCRIPTION
Not going to put a breaking change on this one since I _highly_ doubt it was used. Certainly osu! had no usages of it. This will only become more complicated to implement for users.

The interpolation function should _always_ be defined by the type in question. It's likely that the code that did that came later than `interpolationFunc` itself.