### PR TITLE
Expose Interpolation.ValueAt<T>

### DIFF
--- a/osu.Framework.Tests/MathUtils/TestInterpolation.cs
+++ b/osu.Framework.Tests/MathUtils/TestInterpolation.cs
@@ -63,15 +63,15 @@ namespace osu.Framework.Tests.MathUtils
         public void TestGenericInterpolation()
         {
             // Implementations from Interpolation
-            Assert.AreEqual(10, Interpolation<int>.ValueAt(0.1, 0, 100, 0, 1));
-            Assert.IsTrue(Precision.AlmostEquals(0.01, Interpolation<double>.ValueAt(0.1, 0, 0.1, 0, 1)));
+            Assert.AreEqual(10, Interpolation.ValueAt<int>(0.1, 0, 100, 0, 1));
+            Assert.IsTrue(Precision.AlmostEquals(0.01, Interpolation.ValueAt<double>(0.1, 0, 0.1, 0, 1)));
 
             // Implementations inside struct
-            Assert.AreEqual(new MarginPadding(10), Interpolation<MarginPadding>.ValueAt(0.1, new MarginPadding(0), new MarginPadding(100), 0, 1));
-            Assert.AreEqual(new TestClassWithValueAt(50), Interpolation<TestClassWithValueAt>.ValueAt(10, new TestClassWithValueAt(0), new TestClassWithValueAt(100), 0, 20));
+            Assert.AreEqual(new MarginPadding(10), Interpolation.ValueAt(0.1, new MarginPadding(0), new MarginPadding(100), 0, 1));
+            Assert.AreEqual(new TestClassWithValueAt(50), Interpolation.ValueAt(10, new TestClassWithValueAt(0), new TestClassWithValueAt(100), 0, 20));
 
             // Without implementations
-            Assert.Throws<TypeInitializationException>(() => Interpolation<TestClassWithoutValueAt>.ValueAt(0, new TestClassWithoutValueAt(), new TestClassWithoutValueAt(), 0, 0));
+            Assert.Throws<TypeInitializationException>(() => Interpolation.ValueAt(0, new TestClassWithoutValueAt(), new TestClassWithoutValueAt(), 0, 0));
         }
 
         private struct TestClassWithoutValueAt

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Graphics.Transforms
         public TransformBindable(Bindable<TValue> targetBindable)
         {
             this.targetBindable = targetBindable;
-            interpolationFunc = Interpolation<TValue>.ValueAt;
+            interpolationFunc = Interpolation.ValueAt;
 
             TargetMember = $"{targetBindable.GetHashCode()}.Value";
         }

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -159,7 +159,7 @@ namespace osu.Framework.Graphics.Transforms
             accessor = getAccessor(propertyOrFieldName);
             Trace.Assert(accessor.Read != null && accessor.Write != null, $"Failed to populate {nameof(accessor)}.");
 
-            interpolationFunc = Interpolation<TValue>.FUNCTION;
+            interpolationFunc = Interpolation.ValueAt;
         }
 
         private TValue valueAt(double time)

--- a/osu.Framework/Utils/Interpolation.cs
+++ b/osu.Framework/Utils/Interpolation.cs
@@ -248,6 +248,9 @@ namespace osu.Framework.Utils
                 val1.Height + t * (val2.X - val1.Height));
         }
 
+        public static TValue ValueAt<TValue>(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easing = Easing.None)
+            => GenericInterpolation<TValue>.FUNCTION(time, startValue, endValue, startTime, endTime, easing);
+
         #region Easing constants
 
         private const double elastic_const = 2 * Math.PI / .3;
@@ -414,30 +417,27 @@ namespace osu.Framework.Utils
                     return --time * Math.Pow(time, 10) + 1;
             }
         }
-    }
 
-    internal static class Interpolation<TValue>
-    {
-        public static readonly InterpolationFunc<TValue> FUNCTION;
-
-        static Interpolation()
+        private static class GenericInterpolation<TValue>
         {
-            const string interpolation_method = nameof(Interpolation.ValueAt);
+            public static readonly InterpolationFunc<TValue> FUNCTION;
 
-            var parameters = typeof(InterpolationFunc<TValue>)
-                             .GetMethod(nameof(InterpolationFunc<TValue>.Invoke))
-                             ?.GetParameters().Select(p => p.ParameterType).ToArray();
+            static GenericInterpolation()
+            {
+                const string interpolation_method = nameof(Interpolation.ValueAt);
 
-            var valueAtMethod = typeof(Interpolation).GetMethod(interpolation_method, parameters)
-                                ?? typeof(TValue).GetMethod(interpolation_method, parameters)
-                                ?? throw new NotSupportedException(
-                                    $"Type {typeof(TValue)} has no interpolation function. Add a method with the name {interpolation_method} with the parameters of {nameof(InterpolationFunc<TValue>)} or interpolate the value manually.");
+                var parameters = typeof(InterpolationFunc<TValue>)
+                                 .GetMethod(nameof(InterpolationFunc<TValue>.Invoke))
+                                 ?.GetParameters().Select(p => p.ParameterType).ToArray();
 
-            FUNCTION = (InterpolationFunc<TValue>)valueAtMethod.CreateDelegate(typeof(InterpolationFunc<TValue>));
+                var valueAtMethod = typeof(Interpolation).GetMethod(interpolation_method, parameters)
+                                    ?? typeof(TValue).GetMethod(interpolation_method, parameters)
+                                    ?? throw new NotSupportedException(
+                                        $"Type {typeof(TValue)} has no interpolation function. Add a method with the name {interpolation_method} with the parameters of {nameof(InterpolationFunc<TValue>)} or interpolate the value manually.");
+
+                FUNCTION = (InterpolationFunc<TValue>)valueAtMethod.CreateDelegate(typeof(InterpolationFunc<TValue>));
+            }
         }
-
-        public static TValue ValueAt(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easing = Easing.None)
-            => FUNCTION(time, startValue, endValue, startTime, endTime, easing);
     }
 
     public delegate TValue InterpolationFunc<TValue>(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easingType);


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/3335

1. Makes `Interpolation` the common point of all interpolation functions. Without this the user would explicitly have to do something like `func = MarginPadding.ValueAt` for every type, whereas now it's always exactly `func = Interpolation.ValueAt`.
2. Allows the user to have a generic type of their own.