### PR TITLE
Explicitly define type interpolations via interfaces

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkInterpolation.cs
+++ b/osu.Framework.Benchmarks/BenchmarkInterpolation.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Graphics;
+using osu.Framework.Utils;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkInterpolation : BenchmarkTest
+    {
+        [Benchmark]
+        public MarginPadding InterpolateMarginPadding()
+        {
+            var first = new MarginPadding();
+            var second = new MarginPadding(10);
+
+            return Interpolation.ValueAt(0.5, first, second, 0, 1, Easing.OutQuint);
+        }
+
+        [Benchmark]
+        public float InterpolateFloatGeneric()
+        {
+            const float first = 0;
+            const float second = 10;
+
+            return Interpolation.ValueAt<float>(0.5, first, second, 0, 1, Easing.OutQuint);
+        }
+
+        [Benchmark]
+        public float InterpolateFloat()
+        {
+            const float first = 0;
+            const float second = 10;
+
+            return Interpolation.ValueAt(0.5, first, second, 0, 1, Easing.OutQuint);
+        }
+    }
+}

--- a/osu.Framework.Tests/MathUtils/TestInterpolation.cs
+++ b/osu.Framework.Tests/MathUtils/TestInterpolation.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Tests.MathUtils
         {
         }
 
-        private struct TestClassWithValueAt
+        private struct TestClassWithValueAt : IInterpolable<TestClassWithValueAt>
         {
             private readonly int i;
 
@@ -89,7 +89,8 @@ namespace osu.Framework.Tests.MathUtils
 
             public bool Equals(TestClassWithValueAt other) => i == other.i;
 
-            public static TestClassWithValueAt ValueAt(double time, TestClassWithValueAt startValue, TestClassWithValueAt endValue, double startTime, double endTime, Easing easingType) => new TestClassWithValueAt(Interpolation.ValueAt(time, startValue.i, endValue.i, startTime, endTime, easingType));
+            public TestClassWithValueAt ValueAt(double time, TestClassWithValueAt startValue, TestClassWithValueAt endValue, double startTime, double endTime, Easing easingType)
+                => new TestClassWithValueAt(Interpolation.ValueAt(time, startValue.i, endValue.i, startTime, endTime, easingType));
 
             public override string ToString() => $"{nameof(i)}: {i}";
         }

--- a/osu.Framework/Graphics/MarginPadding.cs
+++ b/osu.Framework/Graphics/MarginPadding.cs
@@ -3,7 +3,6 @@
 
 using osuTK;
 using System;
-using JetBrains.Annotations;
 using osu.Framework.Utils;
 
 namespace osu.Framework.Graphics
@@ -12,7 +11,7 @@ namespace osu.Framework.Graphics
     /// Holds data about the margin or padding of a <see cref="Drawable"/>.
     /// The margin describes the size of an empty area around its <see cref="Drawable"/>, while the padding describes the size of an empty area inside its container.
     /// </summary>
-    public struct MarginPadding : IEquatable<MarginPadding>
+    public struct MarginPadding : IInterpolable<MarginPadding>, IEquatable<MarginPadding>
     {
         /// <summary>
         /// The absolute size of the space that should be left empty above the <see cref="Drawable"/> if used as margin, or
@@ -95,16 +94,13 @@ namespace osu.Framework.Graphics
                 Bottom = -mp.Bottom,
             };
 
-        [UsedImplicitly]
-        public static MarginPadding ValueAt(double time, MarginPadding startValue, MarginPadding endValue, double startTime, double endTime, Easing easingType = Easing.None)
-        {
-            return new MarginPadding
+        public MarginPadding ValueAt(double time, MarginPadding startValue, MarginPadding endValue, double startTime, double endTime, Easing easingType)
+            => new MarginPadding
             {
                 Left = Interpolation.ValueAt(time, startValue.Left, endValue.Left, startTime, endTime, easingType),
                 Top = Interpolation.ValueAt(time, startValue.Top, endValue.Top, startTime, endTime, easingType),
                 Right = Interpolation.ValueAt(time, startValue.Right, endValue.Right, startTime, endTime, easingType),
                 Bottom = Interpolation.ValueAt(time, startValue.Bottom, endValue.Bottom, startTime, endTime, easingType),
             };
-        }
     }
 }

--- a/osu.Framework/Utils/IInterpolable.cs
+++ b/osu.Framework/Utils/IInterpolable.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+
+namespace osu.Framework.Utils
+{
+    /// <summary>
+    /// An interface that defines the interpolation of a value.
+    /// </summary>
+    /// <typeparam name="TValue">The type of value to be interpolated..</typeparam>
+    public interface IInterpolable<TValue>
+    {
+        /// <summary>
+        /// Interpolates between two <typeparamref name="TValue"/>s.
+        /// </summary>
+        /// <remarks>
+        /// This method MUST NOT modify the current object.
+        /// </remarks>
+        /// <param name="time">The current time.</param>
+        /// <param name="startValue">The <typeparamref name="TValue"/> at <paramref name="time"/> = <paramref name="startTime"/>.</param>
+        /// <param name="endValue">The <typeparamref name="TValue"/> at <paramref name="time"/> = <paramref name="endTime"/>.</param>
+        /// <param name="startTime">The start time.</param>
+        /// <param name="endTime">The end time.</param>
+        /// <param name="easingType">The easing to use.</param>
+        /// <returns>The interpolated value.</returns>
+        TValue ValueAt(double time, TValue startValue, TValue endValue, double startTime, double endTime, Easing easingType = Easing.None);
+    }
+}


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/3336

Interested on people's thoughts on this. It's not really required but it may ease implementation overhead, especially as this API is changed. Future changes will add an override for a general easing function.

It's a little bit hacky in that it's creating an uninitialised type and then calling a method on it, but maybe it's not too bad?

This is also one of those functions that is unlikely for consumers to have used just yet, since we have a pretty wide array of transforms/interpolations already.
In the case where a consumer did use it, they'll be provided with the helpful exception - "implement this interface on this type" where the interface has the correct function definition.