### PR TITLE
Fix stack traces not being logged when performance profiling is turned on

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -182,7 +182,7 @@ namespace osu.Framework.Graphics.Performance
                                     new TimeBar(),
                                 },
                             },
-                            frameTimeDisplay = new FrameTimeDisplay(monitor.Clock, monitor.Thread)
+                            frameTimeDisplay = new FrameTimeDisplay(monitor.Clock, thread)
                             {
                                 Anchor = Anchor.BottomRight,
                                 Origin = Anchor.BottomRight,

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -127,7 +127,7 @@ namespace osu.Framework.Platform
             Threads.ForEach(t => t.Exit());
             Threads.Where(t => t.Running).ForEach(t =>
             {
-                if (!t.Thread.Join(thread_join_timeout))
+                if (t.Thread?.Join(thread_join_timeout) == false)
                     Logger.Log($"Thread {t.Name} failed to exit in allocated time ({thread_join_timeout}ms).", LoggingTarget.Runtime, LogLevel.Important);
             });
 

--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -93,8 +93,9 @@ namespace osu.Framework.Statistics
                 {
                     try
                     {
-                        Logger.Log("Retrieving background stack trace...");
+                        Logger.Log($"Retrieving background stack trace on {targetThread.Name} thread...");
                         backgroundMonitorStackTrace = getStackTrace(targetThread);
+                        Logger.Log("Done!");
                     }
                     catch (Exception e)
                     {

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -29,6 +29,8 @@ namespace osu.Framework.Threading
         /// </summary>
         public EventHandler<UnhandledExceptionEventArgs> UnhandledException;
 
+        internal Action<Thread> ThreadChanged;
+
         protected Action OnNewFrame;
 
         /// <summary>
@@ -107,6 +109,8 @@ namespace osu.Framework.Threading
                 Name = PrefixedThreadNameFor(Name),
                 IsBackground = true,
             };
+
+            ThreadChanged?.Invoke(Thread);
 
             updateCulture();
         }
@@ -225,6 +229,7 @@ namespace osu.Framework.Threading
         protected virtual void Cleanup()
         {
             Thread = null;
+            ThreadChanged?.Invoke(Thread);
         }
 
         public void Exit() => exitRequested = true;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -29,8 +29,6 @@ namespace osu.Framework.Threading
         /// </summary>
         public EventHandler<UnhandledExceptionEventArgs> UnhandledException;
 
-        internal Action<Thread> ThreadChanged;
-
         protected Action OnNewFrame;
 
         /// <summary>
@@ -215,7 +213,6 @@ namespace osu.Framework.Threading
         protected virtual void Cleanup()
         {
             Thread = null;
-            ThreadChanged?.Invoke(null);
         }
 
         public void Exit()
@@ -237,7 +234,6 @@ namespace osu.Framework.Threading
             Thread = CreateRunningThread();
             if (Thread.Name == null)
                 Thread.Name = PrefixedThreadNameFor(Name);
-            ThreadChanged?.Invoke(Thread);
         }
 
         protected virtual void PerformExit()

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Statistics;
 using System.Collections.Generic;
+using System.Threading;
 using osu.Framework.Development;
 
 namespace osu.Framework.Threading
@@ -30,9 +31,19 @@ namespace osu.Framework.Threading
             ThreadSafety.IsInputThread = true;
         }
 
-        public override void Start()
+        public override bool Running => !Paused;
+
+        protected override Thread CreateRunningThread()
         {
             // InputThread does not get started. it is run manually by GameHost.
+            return Thread.CurrentThread;
+        }
+
+        protected override void PerformExit()
+        {
+            base.PerformExit();
+
+            Paused = true;
         }
     }
 }


### PR DESCRIPTION
Was about to use this in https://github.com/ppy/osu/issues/8185 and found that the threading changes meant we were sending a null thread to the `BackgroundStackTraceCollector`