### PR TITLE
Fix stack traces not being logged when performance profiling is turned off

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -182,7 +182,7 @@ namespace osu.Framework.Graphics.Performance
                                     new TimeBar(),
                                 },
                             },
-                            frameTimeDisplay = new FrameTimeDisplay(monitor.Clock, monitor.Thread)
+                            frameTimeDisplay = new FrameTimeDisplay(monitor.Clock, thread)
                             {
                                 Anchor = Anchor.BottomRight,
                                 Origin = Anchor.BottomRight,

--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -21,10 +21,11 @@ namespace osu.Framework.Statistics
         private IList<ClrStackFrame> backgroundMonitorStackTrace;
 
         private readonly StopwatchClock clock;
+        private readonly string threadName;
 
         private readonly Lazy<Logger> logger;
 
-        private readonly Thread targetThread;
+        private Thread targetThread;
 
         internal double LastConsumptionTime;
 
@@ -37,16 +38,19 @@ namespace osu.Framework.Statistics
         /// </summary>
         /// <param name="targetThread">The thread to monitor.</param>
         /// <param name="clock">The clock to use for elapsed time checks.</param>
-        public BackgroundStackTraceCollector(Thread targetThread, StopwatchClock clock)
+        /// <param name="threadName">A name used for tracking purposes. Can be used to track potentially changing threads under a single name.</param>
+        public BackgroundStackTraceCollector(Thread targetThread, StopwatchClock clock, string threadName = null)
         {
-            if (Debugger.IsAttached) return;
+            if (Debugger.IsAttached)
+                return;
 
             this.clock = clock;
+            this.threadName = threadName ?? targetThread?.Name;
             this.targetThread = targetThread;
 
             logger = new Lazy<Logger>(() =>
             {
-                var l = Logger.GetLogger($"performance-{targetThread.Name?.ToLower() ?? "unknown"}");
+                var l = Logger.GetLogger($"performance-{threadName?.ToLower() ?? "unknown"}");
                 l.OutputToListeners = false;
                 return l;
             });
@@ -78,23 +82,31 @@ namespace osu.Framework.Statistics
 
             var thread = new Thread(() => run((cancellation = new CancellationTokenSource()).Token))
             {
-                Name = $"{targetThread.Name}-StackTraceCollector",
+                Name = $"{threadName}-StackTraceCollector",
                 IsBackground = true
             };
 
             thread.Start();
         }
 
+        private bool isCollecting;
+
         private void run(CancellationToken cancellation)
         {
             while (!cancellation.IsCancellationRequested)
             {
-                if (targetThread.IsAlive && clock.ElapsedMilliseconds - LastConsumptionTime > spikeRecordThreshold / 2 && backgroundMonitorStackTrace == null)
+                var elapsed = clock.ElapsedMilliseconds - LastConsumptionTime;
+                var threshold = spikeRecordThreshold / 2;
+
+                if (targetThread.IsAlive && isCollecting && clock.ElapsedMilliseconds - LastConsumptionTime > spikeRecordThreshold / 2 && backgroundMonitorStackTrace == null)
                 {
                     try
                     {
-                        Logger.Log("Retrieving background stack trace...");
+                        Logger.Log($"Retrieving background stack trace on {threadName} thread ({elapsed:N0}ms over threshold of {threshold:N0}ms)...");
                         backgroundMonitorStackTrace = getStackTrace(targetThread);
+                        Logger.Log("Done!");
+
+                        Thread.Sleep(100);
                     }
                     catch (Exception e)
                     {
@@ -118,6 +130,8 @@ namespace osu.Framework.Statistics
         {
             if (targetThread == null) return;
 
+            isCollecting = true;
+
             var frames = backgroundMonitorStackTrace;
             backgroundMonitorStackTrace = null;
 
@@ -130,7 +144,7 @@ namespace osu.Framework.Statistics
 
             StringBuilder logMessage = new StringBuilder();
 
-            logMessage.AppendLine($@"| Slow frame on thread ""{targetThread.Name}""");
+            logMessage.AppendLine($@"| Slow frame on thread ""{threadName}""");
             logMessage.AppendLine(@"|");
             logMessage.AppendLine($@"| * Thread time  : {clock.CurrentTime:#0,#}ms");
             logMessage.AppendLine($@"| * Frame length : {elapsedFrameTime:#0,#}ms (allowable: {currentThreshold:#0,#}ms)");
@@ -148,6 +162,11 @@ namespace osu.Framework.Statistics
                 logMessage.AppendLine(@"| Call stack was not recorded.");
 
             logger.Value.Add(logMessage.ToString());
+        }
+
+        public void EndFrame()
+        {
+            isCollecting = false;
         }
 
         private static readonly Lazy<ClrInfo> clr_info = new Lazy<ClrInfo>(delegate
@@ -180,6 +199,7 @@ namespace osu.Framework.Statistics
             {
                 Enabled = false; // stops the thread if running.
                 isDisposed = true;
+                targetThread = null;
             }
         }
 

--- a/osu.Framework/Statistics/PerformanceMonitor.cs
+++ b/osu.Framework/Statistics/PerformanceMonitor.cs
@@ -4,8 +4,10 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Extensions.ObjectPool;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Utils;
 using osu.Framework.Threading;
 using osu.Framework.Timing;
@@ -20,11 +22,13 @@ namespace osu.Framework.Statistics
 
         private readonly InvokeOnDisposal[] endCollectionDelegates = new InvokeOnDisposal[FrameStatistics.NUM_PERFORMANCE_COLLECTION_TYPES];
 
-        private readonly BackgroundStackTraceCollector traceCollector;
+        private BackgroundStackTraceCollector traceCollector;
 
         private FrameStatistics currentFrame;
 
         private const int max_pending_frames = 10;
+
+        private readonly string threadName;
 
         internal readonly ConcurrentQueue<FrameStatistics> PendingFrames = new ConcurrentQueue<FrameStatistics>();
 
@@ -34,24 +38,35 @@ namespace osu.Framework.Statistics
 
         internal bool[] ActiveCounters { get; } = new bool[FrameStatistics.NUM_STATISTICS_COUNTER_TYPES];
 
+        private bool enablePerformanceProfiling;
+
         public bool EnablePerformanceProfiling
         {
-            get => traceCollector.Enabled;
-            set => traceCollector.Enabled = value;
+            set
+            {
+                enablePerformanceProfiling = value;
+                updateEnabledState();
+            }
         }
 
         private double consumptionTime;
 
+        private readonly IBindable<bool> isActive;
+
         internal readonly ThrottledFrameClock Clock;
 
-        internal readonly GameThread Thread;
+        private Thread thread;
 
         public double FrameAimTime => 1000.0 / (Clock?.MaximumUpdateHz ?? double.MaxValue);
 
         internal PerformanceMonitor(GameThread thread, IEnumerable<StatisticsCounterType> counters)
         {
             Clock = thread.Clock;
-            Thread = thread;
+            threadName = thread.Name;
+
+            isActive = thread.IsActive.GetBoundCopy();
+            isActive.BindValueChanged(_ => updateEnabledState());
+
             currentFrame = FramesPool.Get();
 
             foreach (var c in counters)
@@ -62,8 +77,23 @@ namespace osu.Framework.Statistics
                 var t = (PerformanceCollectionType)i;
                 endCollectionDelegates[i] = new InvokeOnDisposal(() => endCollecting(t));
             }
+        }
 
-            traceCollector = new BackgroundStackTraceCollector(thread.Thread, ourClock);
+        /// <summary>
+        /// Switch target thread to <see cref="Thread.CurrentThread"/>.
+        /// </summary>
+        public void MakeCurrent()
+        {
+            var current = Thread.CurrentThread;
+
+            if (current == thread)
+                return;
+
+            thread = Thread.CurrentThread;
+
+            traceCollector?.Dispose();
+            traceCollector = new BackgroundStackTraceCollector(thread, ourClock, threadName);
+            updateEnabledState();
         }
 
         /// <summary>
@@ -116,7 +146,7 @@ namespace osu.Framework.Statistics
                     var type = (StatisticsCounterType)i;
 
                     if (!globalStatistics.TryGetValue(type, out var global))
-                        globalStatistics[type] = global = GlobalStatistics.Get<long>(Thread.Name, type.ToString());
+                        globalStatistics[type] = global = GlobalStatistics.Get<long>(threadName, type.ToString());
 
                     global.Value = count;
                     currentFrame.Counts[type] = count;
@@ -151,9 +181,20 @@ namespace osu.Framework.Statistics
             averageFrameTime = Interpolation.Damp(averageFrameTime, Clock.ElapsedFrameTime, 0.01, dampRate);
 
             //check for dropped (stutter) frames
-            traceCollector.NewFrame(Clock.ElapsedFrameTime, Math.Max(10, Math.Max(1000 / Clock.MaximumUpdateHz, averageFrameTime) * 4));
+            traceCollector?.NewFrame(Clock.ElapsedFrameTime, Math.Max(10, Math.Max(1000 / Clock.MaximumUpdateHz, averageFrameTime) * 4));
 
             consumeStopwatchElapsedTime();
+        }
+
+        public void EndFrame()
+        {
+            traceCollector?.EndFrame();
+        }
+
+        private void updateEnabledState()
+        {
+            if (traceCollector != null)
+                traceCollector.Enabled = enablePerformanceProfiling && isActive.Value;
         }
 
         private double averageFrameTime;
@@ -162,7 +203,9 @@ namespace osu.Framework.Statistics
         {
             double last = consumptionTime;
 
-            consumptionTime = traceCollector.LastConsumptionTime = ourClock.CurrentTime;
+            consumptionTime = ourClock.CurrentTime;
+            if (traceCollector != null)
+                traceCollector.LastConsumptionTime = consumptionTime;
 
             return consumptionTime - last;
         }
@@ -178,7 +221,7 @@ namespace osu.Framework.Statistics
             if (!isDisposed)
             {
                 isDisposed = true;
-                traceCollector.Dispose();
+                traceCollector?.Dispose();
             }
         }
 

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -76,6 +76,10 @@ namespace osu.Framework.Threading
 
             Clock.Throttling = withThrottling;
 
+            Monitor.MakeCurrent();
+
+            updateCulture();
+
             initializedEvent.Set();
         }
 
@@ -169,6 +173,8 @@ namespace osu.Framework.Threading
 
                 using (Monitor?.BeginCollecting(PerformanceCollectionType.Sleep))
                     Clock.ProcessFrame();
+
+                Monitor?.EndFrame();
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Was about to use this in https://github.com/ppy/osu/issues/8185 and found that the threading changes meant we were sending a null thread to the `BackgroundStackTraceCollector`

Also
- Fixes stack traces getting logged when window is made inactive.
- Fixes stack traces not logging in single threaded execution.