### PR TITLE
Remove stray android project from rider config

### DIFF
--- a/.idea/.idea.osu-framework.Desktop/.idea/modules.xml
+++ b/.idea/.idea.osu-framework.Desktop/.idea/modules.xml
@@ -2,8 +2,6 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/.idea.osu-framework/SampleGame.Android.iml" filepath="$PROJECT_DIR$/.idea/.idea.osu-framework/SampleGame.Android.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/.idea.osu-framework/osu.Framework.Tests.Android.iml" filepath="$PROJECT_DIR$/.idea/.idea.osu-framework/osu.Framework.Tests.Android.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/.idea.osu-framework.Desktop/riderModule.iml" filepath="$PROJECT_DIR$/.idea/.idea.osu-framework.Desktop/riderModule.iml" />
     </modules>
   </component>


### PR DESCRIPTION
Shouldn't be in the desktop solution configuration.