### PR TITLE
Fix multiple issues with TextureAtlasVisualiser

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -359,10 +359,12 @@ namespace osu.Framework.Graphics.OpenGL
         /// </summary>
         /// <param name="texture">The texture to bind.</param>
         /// <param name="unit">The texture unit to bind it to.</param>
-        public static void BindTexture(TextureGL texture, TextureUnit unit = TextureUnit.Texture0)
+        public static bool BindTexture(TextureGL texture, TextureUnit unit = TextureUnit.Texture0)
         {
-            BindTexture(texture?.TextureId ?? 0, unit);
+            bool didBind = BindTexture(texture?.TextureId ?? 0, unit);
             last_bound_texture_is_atlas[GetTextureUnitId(unit)] = texture is TextureGLAtlas;
+
+            return didBind;
         }
 
         /// <summary>
@@ -370,22 +372,23 @@ namespace osu.Framework.Graphics.OpenGL
         /// </summary>
         /// <param name="textureId">The texture to bind.</param>
         /// <param name="unit">The texture unit to bind it to.</param>
-        public static void BindTexture(int textureId, TextureUnit unit = TextureUnit.Texture0)
+        public static bool BindTexture(int textureId, TextureUnit unit = TextureUnit.Texture0)
         {
             var index = GetTextureUnitId(unit);
 
-            if (last_bound_texture[index] != textureId)
-            {
-                FlushCurrentBatch();
+            if (last_bound_texture[index] == textureId)
+                return false;
 
-                GL.ActiveTexture(unit);
-                GL.BindTexture(TextureTarget.Texture2D, textureId);
+            FlushCurrentBatch();
 
-                last_bound_texture[index] = textureId;
-                last_bound_texture_is_atlas[GetTextureUnitId(unit)] = false;
+            GL.ActiveTexture(unit);
+            GL.BindTexture(TextureTarget.Texture2D, textureId);
 
-                FrameStatistics.Increment(StatisticsCounterType.TextureBinds);
-            }
+            last_bound_texture[index] = textureId;
+            last_bound_texture_is_atlas[GetTextureUnitId(unit)] = false;
+
+            FrameStatistics.Increment(StatisticsCounterType.TextureBinds);
+            return true;
         }
 
         private static BlendingParameters lastBlendingParameters;

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -359,6 +359,7 @@ namespace osu.Framework.Graphics.OpenGL
         /// </summary>
         /// <param name="texture">The texture to bind.</param>
         /// <param name="unit">The texture unit to bind it to.</param>
+        /// <returns>true if the provided texture was not already bound (causing a binding change).</returns>
         public static bool BindTexture(TextureGL texture, TextureUnit unit = TextureUnit.Texture0)
         {
             bool didBind = BindTexture(texture?.TextureId ?? 0, unit);
@@ -372,6 +373,7 @@ namespace osu.Framework.Graphics.OpenGL
         /// </summary>
         /// <param name="textureId">The texture to bind.</param>
         /// <param name="unit">The texture unit to bind it to.</param>
+        /// <returns>true if the provided texture was not already bound (causing a binding change).</returns>
         public static bool BindTexture(int textureId, TextureUnit unit = TextureUnit.Texture0)
         {
             var index = GetTextureUnitId(unit);

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Lists;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.OpenGL.Textures
@@ -15,7 +16,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <summary>
         /// Contains all currently-active <see cref="TextureGLAtlas"/>es.
         /// </summary>
-        private static readonly List<TextureGLAtlas> all_atlases = new List<TextureGLAtlas>();
+        private static readonly LockedWeakList<TextureGLAtlas> all_atlases = new LockedWeakList<TextureGLAtlas>();
 
         /// <summary>
         /// Invoked when a new <see cref="TextureGLAtlas"/> is created.
@@ -23,20 +24,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <remarks>
         /// Invocation from the draw or update thread cannot be assumed.
         /// </remarks>
-        public static event Action<TextureGLAtlas> TextureAdded;
-
-        /// <summary>
-        /// Invoked when a <see cref="TextureGLAtlas"/> is discarded.
-        /// </summary>
-        /// <remarks>
-        /// Invocation from the draw or update thread cannot be assumed.
-        /// </remarks>
-        public static event Action<TextureGLAtlas> TextureRemoved;
-
-        /// <summary>
-        /// The total amount of times this <see cref="TextureGLAtlas"/> was bound.
-        /// </summary>
-        public ulong BindCount { get; private set; }
+        public static event Action<TextureGLAtlas> TextureCreated;
 
         public TextureGLAtlas(int width, int height, bool manualMipmaps, All filteringMode = All.Linear)
             : base(width, height, manualMipmaps, filteringMode)
@@ -44,19 +32,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             lock (all_atlases)
                 all_atlases.Add(this);
 
-            TextureAdded?.Invoke(this);
-        }
-
-        public override bool Bind(TextureUnit unit = TextureUnit.Texture0)
-        {
-            if (base.Bind(unit))
-            {
-                // No lock since it doesn't matter if this is slightly out-of-date
-                BindCount++;
-                return true;
-            }
-
-            return false;
+            TextureCreated?.Invoke(this);
         }
 
         /// <summary>
@@ -74,8 +50,6 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
             lock (all_atlases)
                 all_atlases.Remove(this);
-
-            TextureRemoved?.Invoke(this);
         }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
@@ -29,8 +29,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         public TextureGLAtlas(int width, int height, bool manualMipmaps, All filteringMode = All.Linear)
             : base(width, height, manualMipmaps, filteringMode)
         {
-            lock (all_atlases)
-                all_atlases.Add(this);
+            all_atlases.Add(this);
 
             TextureCreated?.Invoke(this);
         }
@@ -38,18 +37,13 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         /// <summary>
         /// Retrieves all currently-active <see cref="TextureGLAtlas"/>es.
         /// </summary>
-        public static TextureGLAtlas[] GetAllAtlases()
-        {
-            lock (all_atlases)
-                return all_atlases.ToArray();
-        }
+        public static TextureGLAtlas[] GetAllAtlases() => all_atlases.ToArray();
 
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);
 
-            lock (all_atlases)
-                all_atlases.Remove(this);
+            all_atlases.Remove(this);
         }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -34,6 +34,11 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         private readonly All filteringMode;
         private TextureWrapMode internalWrapMode;
 
+        /// <summary>
+        /// The total amount of times this <see cref="TextureGLAtlas"/> was bound.
+        /// </summary>
+        public ulong BindCount { get; private set; }
+
         // ReSharper disable once InconsistentlySynchronizedField (no need to lock here. we don't really care if the value is stale).
         public override bool Loaded => textureId > 0 || uploadQueue.Count > 0;
 
@@ -320,7 +325,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             if (IsTransparent)
                 return false;
 
-            GLWrapper.BindTexture(this, unit);
+            if (GLWrapper.BindTexture(this, unit))
+                BindCount++;
 
             if (internalWrapMode != WrapMode)
                 updateWrapMode();

--- a/osu.Framework/Graphics/Visualisation/TextureAtlasVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureAtlasVisualiser.cs
@@ -26,7 +26,8 @@ namespace osu.Framework.Graphics.Visualisation
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Spacing = new Vector2(10),
+                Spacing = new Vector2(22),
+                Padding = new MarginPadding(10),
             };
         }
 
@@ -71,8 +72,8 @@ namespace osu.Framework.Graphics.Visualisation
             public TexturePanel(TextureGLAtlas atlasTexture)
             {
                 atlasReference = new WeakReference<TextureGLAtlas>(atlasTexture);
-                Width = 100;
-                AutoSizeAxes = Axes.Y;
+
+                Size = new Vector2(100, 132);
 
                 InternalChild = new FillFlowContainer
                 {
@@ -105,7 +106,7 @@ namespace osu.Framework.Graphics.Visualisation
                         {
                             Anchor = Anchor.TopCentre,
                             Origin = Anchor.TopCentre,
-                            Font = FontUsage.Default.With(size: 16)
+                            Font = FontUsage.Default.With(size: 16),
                         },
                     }
                 };

--- a/osu.Framework/Graphics/Visualisation/TextureAtlasVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureAtlasVisualiser.cs
@@ -119,7 +119,7 @@ namespace osu.Framework.Graphics.Visualisation
                 {
                     var atlas = AtlasTexture;
 
-                    if (atlas == null)
+                    if (atlas?.Available != true)
                     {
                         Expire();
                         return;

--- a/osu.Framework/Graphics/Visualisation/TextureAtlasVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureAtlasVisualiser.cs
@@ -3,14 +3,12 @@
 
 using System;
 using System.Linq;
-using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Graphics.Textures;
 using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
@@ -39,16 +37,16 @@ namespace osu.Framework.Graphics.Visualisation
             foreach (var tex in TextureGLAtlas.GetAllAtlases())
                 addTexture(tex);
 
-            TextureGLAtlas.TextureAdded += addTexture;
-            TextureGLAtlas.TextureRemoved += removeTexture;
+            TextureGLAtlas.TextureCreated += addTexture;
         }
 
         protected override void PopOut()
         {
             base.PopOut();
 
-            TextureGLAtlas.TextureAdded -= addTexture;
-            TextureGLAtlas.TextureRemoved -= removeTexture;
+            panelFlow.Clear();
+
+            TextureGLAtlas.TextureCreated -= addTexture;
         }
 
         private void addTexture(TextureGLAtlas texture) => Schedule(() =>
@@ -59,18 +57,20 @@ namespace osu.Framework.Graphics.Visualisation
             panelFlow.Add(new TexturePanel(texture));
         });
 
-        private void removeTexture(TextureGLAtlas texture) => Schedule(() => panelFlow.RemoveAll(p => p.AtlasTexture == texture));
-
         private class TexturePanel : CompositeDrawable
         {
-            public readonly TextureGLAtlas AtlasTexture;
+            private readonly WeakReference<TextureGLAtlas> atlasReference;
+
+            public TextureGLAtlas AtlasTexture => atlasReference.TryGetTarget(out var tex) ? tex : null;
 
             private readonly SpriteText titleText;
             private readonly SpriteText footerText;
 
+            private readonly UsageBackground usage;
+
             public TexturePanel(TextureGLAtlas atlasTexture)
             {
-                AtlasTexture = atlasTexture;
+                atlasReference = new WeakReference<TextureGLAtlas>(atlasTexture);
                 Width = 100;
                 AutoSizeAxes = Axes.Y;
 
@@ -95,30 +95,10 @@ namespace osu.Framework.Graphics.Visualisation
                             AutoSizeAxes = Axes.Y,
                             Children = new Drawable[]
                             {
-                                new UsageBackground(atlasTexture)
+                                usage = new UsageBackground(atlasReference)
                                 {
-                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(100)
                                 },
-                                new Container
-                                {
-                                    RelativeSizeAxes = Axes.X,
-                                    Height = 100,
-                                    Padding = new MarginPadding(5),
-                                    Children = new Drawable[]
-                                    {
-                                        new Box
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            Colour = Color4.Black
-                                        },
-                                        new Sprite
-                                        {
-                                            RelativeSizeAxes = Axes.Both,
-                                            FillMode = FillMode.Fit,
-                                            Texture = new Texture(atlasTexture),
-                                        }
-                                    }
-                                }
                             },
                         },
                         footerText = new SpriteText
@@ -137,8 +117,16 @@ namespace osu.Framework.Graphics.Visualisation
 
                 try
                 {
-                    titleText.Text = $"{AtlasTexture.Width}x{AtlasTexture.Height}";
-                    footerText.Text = $"{AtlasTexture.TextureId}";
+                    var atlas = AtlasTexture;
+
+                    if (atlas == null)
+                    {
+                        Expire();
+                        return;
+                    }
+
+                    titleText.Text = $"{atlas.TextureId}. {atlas.Width}x{atlas.Height} ";
+                    footerText.Text = Precision.AlmostBigger(usage.AverageUsagesPerFrame, 1) ? $"{usage.AverageUsagesPerFrame:N0} binds" : string.Empty;
                 }
                 catch { }
             }
@@ -146,13 +134,15 @@ namespace osu.Framework.Graphics.Visualisation
 
         private class UsageBackground : Box
         {
-            private readonly TextureGLAtlas atlasTexture;
+            private readonly WeakReference<TextureGLAtlas> atlasReference;
 
-            private float avgUsagesPerFrame;
+            private ulong lastBindCount;
 
-            public UsageBackground(TextureGLAtlas atlasTexture)
+            public float AverageUsagesPerFrame { get; private set; }
+
+            public UsageBackground(WeakReference<TextureGLAtlas> atlasReference)
             {
-                this.atlasTexture = atlasTexture;
+                this.atlasReference = atlasReference;
             }
 
             protected override DrawNode CreateDrawNode() => new UsageBackgroundDrawNode(this);
@@ -161,10 +151,9 @@ namespace osu.Framework.Graphics.Visualisation
             {
                 protected new UsageBackground Source => (UsageBackground)base.Source;
 
-                private ulong lastBindCount;
                 private ColourInfo drawColour;
 
-                private TextureGLAtlas atlasTexture;
+                private WeakReference<TextureGLAtlas> atlasReference;
 
                 public UsageBackgroundDrawNode(Box source)
                     : base(source)
@@ -175,30 +164,51 @@ namespace osu.Framework.Graphics.Visualisation
                 {
                     base.ApplyState();
 
-                    atlasTexture = Source.atlasTexture;
+                    atlasReference = Source.atlasReference;
                 }
 
                 public override void Draw(Action<TexturedVertex2D> vertexAction)
                 {
-                    if (!atlasTexture.Available)
+                    if (!atlasReference.TryGetTarget(out var texture))
                         return;
 
-                    ulong delta = atlasTexture.BindCount - lastBindCount;
+                    if (!texture.Available)
+                        return;
 
-                    Source.avgUsagesPerFrame = Source.avgUsagesPerFrame * 0.9f + delta * 0.1f;
+                    ulong delta = texture.BindCount - Source.lastBindCount;
+
+                    Source.AverageUsagesPerFrame = Source.AverageUsagesPerFrame * 0.9f + delta * 0.1f;
 
                     drawColour = DrawColourInfo.Colour;
-                    drawColour.ApplyChild(Interpolation.ValueAt(Source.avgUsagesPerFrame, Color4.Red.Opacity(0), Color4.Red, 0, 200));
+                    drawColour.ApplyChild(
+                        Precision.AlmostBigger(Source.AverageUsagesPerFrame, 1)
+                            ? Interpolation.ValueAt(Source.AverageUsagesPerFrame, Color4.DarkGray, Color4.Red, 0, 200)
+                            : Color4.Transparent);
 
                     base.Draw(vertexAction);
 
-                    lastBindCount = atlasTexture.BindCount;
+                    // intentionally after draw to avoid counting our own bind.
+                    Source.lastBindCount = texture.BindCount;
                 }
 
                 protected override void Blit(Action<TexturedVertex2D> vertexAction)
                 {
-                    DrawQuad(Texture, ScreenSpaceDrawQuad, drawColour, null, vertexAction,
-                        new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height));
+                    if (!atlasReference.TryGetTarget(out var texture))
+                        return;
+
+                    const float border_width = 4;
+
+                    // border
+                    DrawQuad(Texture, ScreenSpaceDrawQuad, drawColour, null, vertexAction);
+
+                    var shrunkenQuad = ScreenSpaceDrawQuad.AABBFloat.Shrink(border_width);
+
+                    // background
+                    DrawQuad(Texture, shrunkenQuad, Color4.Black, null, vertexAction);
+
+                    // atlas texture
+                    texture.Bind();
+                    DrawQuad(texture, shrunkenQuad, Color4.White, null, vertexAction);
                 }
 
                 protected internal override bool CanDrawOpaqueInterior => false;


### PR DESCRIPTION
- Fixes references being held indefinitely (even when not open)
- Fixed bind count being incorrect (was counting usages, not binds)
- Shows bind count as a number
- Changes colour range to show even low usages
- Removes unnecessary `TextureRemoved` logic (relies on `WeakReference` now)
- Renames `TextureAdded` to `TextureCreated`