### PR TITLE
Add ability to get bindings of an IBindable

### DIFF
--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -132,10 +132,10 @@ namespace osu.Framework.Bindables
 
         private WeakReference<Bindable<T>> weakReference => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<Bindable<T>>(this);
 
-        IEnumerable<IBindable> IBindable.Bindings => InternalBindings;
-        public IEnumerable<IBindable<T>> Bindings => InternalBindings;
+        IEnumerable<IBindable> IBindable.Bindings => Bindings;
+        IEnumerable<IBindable<T>> IBindable<T>.Bindings => Bindings;
 
-        protected LockedWeakList<Bindable<T>> InternalBindings { get; private set; }
+        protected LockedWeakList<Bindable<T>> Bindings { get; private set; }
 
         /// <summary>
         /// Creates a new bindable instance. This is used for deserialization of bindables.
@@ -225,13 +225,13 @@ namespace osu.Framework.Bindables
 
         private void addWeakReference(WeakReference<Bindable<T>> weakReference)
         {
-            if (InternalBindings == null)
-                InternalBindings = new LockedWeakList<Bindable<T>>();
+            if (Bindings == null)
+                Bindings = new LockedWeakList<Bindable<T>>();
 
-            InternalBindings.Add(weakReference);
+            Bindings.Add(weakReference);
         }
 
-        private void removeWeakReference(WeakReference<Bindable<T>> weakReference) => InternalBindings?.Remove(weakReference);
+        private void removeWeakReference(WeakReference<Bindable<T>> weakReference) => Bindings?.Remove(weakReference);
 
         /// <summary>
         /// Parse an object into this instance.
@@ -275,7 +275,7 @@ namespace osu.Framework.Bindables
 
             if (propagateToBindings && Bindings != null)
             {
-                foreach (var b in InternalBindings)
+                foreach (var b in Bindings)
                 {
                     if (b == source) continue;
 
@@ -294,7 +294,7 @@ namespace osu.Framework.Bindables
 
             if (propagateToBindings && Bindings != null)
             {
-                foreach (var b in InternalBindings)
+                foreach (var b in Bindings)
                 {
                     if (b == source) continue;
 
@@ -313,7 +313,7 @@ namespace osu.Framework.Bindables
 
             if (propagateToBindings && Bindings != null)
             {
-                foreach (var b in InternalBindings)
+                foreach (var b in Bindings)
                 {
                     if (b == source) continue;
 
@@ -344,13 +344,13 @@ namespace osu.Framework.Bindables
 
             // ToArray required as this may be called from an async disposal thread.
             // This can lead to deadlocks since each child is also enumerating its Bindings.
-            foreach (var b in InternalBindings.ToArray())
+            foreach (var b in Bindings.ToArray())
                 b.Unbind(this);
 
-            InternalBindings.Clear();
+            Bindings.Clear();
         }
 
-        protected void Unbind(Bindable<T> binding) => InternalBindings.Remove(binding.weakReference);
+        protected void Unbind(Bindable<T> binding) => Bindings.Remove(binding.weakReference);
 
         /// <summary>
         /// Calls <see cref="UnbindEvents"/> and <see cref="UnbindBindings"/>.
@@ -444,7 +444,7 @@ namespace osu.Framework.Bindables
 
             bool found = false;
 
-            foreach (var b in InternalBindings)
+            foreach (var b in Bindings)
             {
                 if (b != source)
                     found |= b.checkForLease(this);

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -41,10 +41,10 @@ namespace osu.Framework.Bindables
 
         private WeakReference<BindableList<T>> weakReference => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<BindableList<T>>(this);
 
-        IEnumerable<IBindable> IBindable.Bindings => bindings;
-        public IEnumerable<IBindableList<T>> Bindings => bindings;
+        IEnumerable<IBindable> IBindable.Bindings => Bindings;
+        IEnumerable<IBindableList<T>> IBindableList<T>.Bindings => Bindings;
 
-        private LockedWeakList<BindableList<T>> bindings;
+        protected internal LockedWeakList<BindableList<T>> Bindings;
 
         /// <summary>
         /// Creates a new <see cref="BindableList{T}"/>, optionally adding the items of the given collection.
@@ -77,9 +77,9 @@ namespace osu.Framework.Bindables
 
             collection[index] = item;
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -105,9 +105,9 @@ namespace osu.Framework.Bindables
 
             collection.Add(item);
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -141,9 +141,9 @@ namespace osu.Framework.Bindables
 
             collection.Insert(index, item);
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -174,9 +174,9 @@ namespace osu.Framework.Bindables
 
             collection.Clear();
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -216,9 +216,9 @@ namespace osu.Framework.Bindables
 
             collection.RemoveAt(index);
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -253,9 +253,9 @@ namespace osu.Framework.Bindables
             if (removedItems.Count == 0)
                 return;
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // Prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -283,9 +283,9 @@ namespace osu.Framework.Bindables
 
             collection.RemoveAt(index);
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -313,9 +313,9 @@ namespace osu.Framework.Bindables
             // RemoveAll is internally optimised
             collection.RemoveAll(match);
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -443,9 +443,9 @@ namespace osu.Framework.Bindables
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             bool beforePropagation = disabled;
 
-            if (propagateToBindings && bindings != null)
+            if (propagateToBindings && Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                     b.Disabled = disabled;
             }
 
@@ -470,13 +470,13 @@ namespace osu.Framework.Bindables
 
         public void UnbindBindings()
         {
-            if (bindings == null)
+            if (Bindings == null)
                 return;
 
-            foreach (var b in bindings)
+            foreach (var b in Bindings)
                 b.unbind(this);
 
-            bindings?.Clear();
+            Bindings?.Clear();
         }
 
         public void UnbindAll()
@@ -495,7 +495,7 @@ namespace osu.Framework.Bindables
         }
 
         private void unbind(BindableList<T> binding)
-            => bindings.Remove(binding.weakReference);
+            => Bindings.Remove(binding.weakReference);
 
         #endregion IUnbindable
 
@@ -521,9 +521,9 @@ namespace osu.Framework.Bindables
 
             collection.AddRange(items.Cast<T>());
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -552,9 +552,9 @@ namespace osu.Framework.Bindables
             collection.RemoveAt(oldIndex);
             collection.Insert(newIndex, item);
 
-            if (bindings != null)
+            if (Bindings != null)
             {
-                foreach (var b in bindings)
+                foreach (var b in Bindings)
                 {
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
@@ -599,7 +599,7 @@ namespace osu.Framework.Bindables
         {
             if (them == null)
                 throw new ArgumentNullException(nameof(them));
-            if (bindings?.Contains(weakReference) ?? false)
+            if (Bindings?.Contains(weakReference) ?? false)
                 throw new ArgumentException("An already bound collection can not be bound again.");
             if (them == this)
                 throw new ArgumentException("A collection can not be bound to itself");
@@ -614,13 +614,13 @@ namespace osu.Framework.Bindables
 
         private void addWeakReference(WeakReference<BindableList<T>> weakReference)
         {
-            if (bindings == null)
-                bindings = new LockedWeakList<BindableList<T>>();
+            if (Bindings == null)
+                Bindings = new LockedWeakList<BindableList<T>>();
 
-            bindings.Add(weakReference);
+            Bindings.Add(weakReference);
         }
 
-        private void removeWeakReference(WeakReference<BindableList<T>> weakReference) => bindings?.Remove(weakReference);
+        private void removeWeakReference(WeakReference<BindableList<T>> weakReference) => Bindings?.Remove(weakReference);
 
         IBindable IBindable.GetBoundCopy() => GetBoundCopy();
 

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -41,6 +41,9 @@ namespace osu.Framework.Bindables
 
         private WeakReference<BindableList<T>> weakReference => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<BindableList<T>>(this);
 
+        IEnumerable<IBindable> IBindable.Bindings => bindings;
+        public IEnumerable<IBindableList<T>> Bindings => bindings;
+
         private LockedWeakList<BindableList<T>> bindings;
 
         /// <summary>

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 
 namespace osu.Framework.Bindables
 {
@@ -10,6 +11,11 @@ namespace osu.Framework.Bindables
     /// </summary>
     public interface IBindable : IParseable, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
     {
+        /// <summary>
+        /// The list of all bindables that are bound to this <see cref="IBindable"/>.
+        /// </summary>
+        IEnumerable<IBindable> Bindings { get; }
+
         /// <summary>
         /// Binds ourselves to another bindable such that we receive any value limitations of the bindable we bind width.
         /// </summary>
@@ -54,6 +60,11 @@ namespace osu.Framework.Bindables
         /// The default value of this bindable. Used when querying <see cref="IHasDefaultValue.IsDefault">IsDefault</see>.
         /// </summary>
         T Default { get; }
+
+        /// <summary>
+        /// The list of all bindables that are bound to this <see cref="IBindable{T}"/>.
+        /// </summary>
+        new IEnumerable<IBindable<T>> Bindings { get; }
 
         /// <summary>
         /// Binds ourselves to another bindable such that we receive any values and value limitations of the bindable we bind width.

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// The list of all bindables that are bound to this <see cref="IBindable"/>.
         /// </summary>
-        IEnumerable<IBindable> Bindings { get; }
+        protected internal IEnumerable<IBindable> Bindings { get; }
 
         /// <summary>
         /// Binds ourselves to another bindable such that we receive any value limitations of the bindable we bind width.
@@ -64,7 +64,7 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// The list of all bindables that are bound to this <see cref="IBindable{T}"/>.
         /// </summary>
-        new IEnumerable<IBindable<T>> Bindings { get; }
+        protected internal new IEnumerable<IBindable<T>> Bindings { get; }
 
         /// <summary>
         /// Binds ourselves to another bindable such that we receive any values and value limitations of the bindable we bind width.

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -24,6 +24,11 @@ namespace osu.Framework.Bindables
         event Action<IEnumerable<T>> ItemsRemoved;
 
         /// <summary>
+        /// The list of all bindables that are bound to this <see cref="IBindableList{T}"/>.
+        /// </summary>
+        new IEnumerable<IBindableList<T>> Bindings { get; }
+
+        /// <summary>
         /// Binds self to another bindable such that we receive any values and value limitations of the bindable we bind width.
         /// </summary>
         /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// The list of all bindables that are bound to this <see cref="IBindableList{T}"/>.
         /// </summary>
-        new IEnumerable<IBindableList<T>> Bindings { get; }
+        protected internal new IEnumerable<IBindableList<T>> Bindings { get; }
 
         /// <summary>
         /// Binds self to another bindable such that we receive any values and value limitations of the bindable we bind width.


### PR DESCRIPTION
Adds an enumerable to get all bindings of an `IBindable` as read-only bindables (of type `IBindable` / `IBindable<T>`).

Required for #3361 to access the bindable's bindings for value change propagation.

# vNext
## Bindable bindings are now a member of `IBindable` and `IBindable<T>`
Any `IBindable`/`IBindable<T>` implementations must implement these members:
```csharp
IEnumerable<IBindable> Bindings { get; }
IEnumerable<IBindable<T>> Bindings { get; }
```