### PR TITLE
Introduce BindableProperty<T>

### DIFF
--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Bindables
     /// A generic implementation of a <see cref="IBindable"/>
     /// </summary>
     /// <typeparam name="T">The type of our stored <see cref="Value"/>.</typeparam>
-    public class Bindable<T> : IBindable<T>, ISerializableBindable
+    public class Bindable<T> : IBindable<T>, ISerializableBindable, IHasPropertyGuards
     {
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed (or manually via <see cref="TriggerValueChange"/>).
@@ -197,6 +197,12 @@ namespace osu.Framework.Bindables
 
             addWeakReference(them.weakReference);
             them.addWeakReference(weakReference);
+        }
+
+        void IHasPropertyGuards.CheckPropertyValueChange<TValue>(IBindableProperty<TValue> property, TValue value) => CheckPropertyValueChange(property, value);
+
+        protected virtual void CheckPropertyValueChange<TValue>(IBindableProperty<TValue> property, TValue value)
+        {
         }
 
         /// <summary>

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -41,6 +41,9 @@ namespace osu.Framework.Bindables
 
         private WeakReference<BindableList<T>> weakReference => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<BindableList<T>>(this);
 
+        IEnumerable<IBindable> IBindable.Bindings => bindings;
+        public IEnumerable<IBindableList<T>> Bindings => bindings;
+
         private LockedWeakList<BindableList<T>> bindings;
 
         /// <summary>

--- a/osu.Framework/Bindables/BindableProperty.cs
+++ b/osu.Framework/Bindables/BindableProperty.cs
@@ -38,6 +38,9 @@ namespace osu.Framework.Bindables
             get => value;
             set
             {
+                if (Source is IHasPropertyGuards pg)
+                    pg.CheckPropertyValueChange(this, value);
+
                 Set(value);
             }
         }

--- a/osu.Framework/Bindables/BindableProperty.cs
+++ b/osu.Framework/Bindables/BindableProperty.cs
@@ -1,0 +1,114 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Framework.Bindables
+{
+    /// <summary>
+    /// Represents a property that contains guards on setting a new value and propagates the change to all of <see cref="Source"/>'s bindings.
+    /// </summary>
+    /// <typeparam name="T">The property value type.</typeparam>
+    public class BindableProperty<T> : IBindableProperty<T>
+    {
+        public IBindable Source { get; }
+
+        /// <summary>
+        /// Invoked when a value has changed without any propagation rejection.
+        /// Used for invoking events indicating value changes.
+        /// </summary>
+        public Action<T, T> OnValueChange;
+
+        /// <summary>
+        /// Gets a <see cref="BindableProperty{T}"/> of a provided bindable equivalent to this property for propagating value to, or null if not found.
+        /// </summary>
+        private readonly Func<IBindable, BindableProperty<T>> getPropertyOf;
+
+        private T value;
+
+        object IBindableProperty.Value => Value;
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// This is guarded by <see cref="Source"/> checks to ensure changing value safely.
+        /// </remarks>
+        public T Value
+        {
+            get => value;
+            set
+            {
+                Set(value);
+            }
+        }
+
+        public BindableProperty(T initialValue, IBindable source, Func<IBindable, BindableProperty<T>> getPropertyOf)
+        {
+            Source = source;
+            this.getPropertyOf = getPropertyOf;
+
+            value = initialValue;
+        }
+
+        /// <summary>
+        /// Sets current value to <paramref name="newValue"/> and propagates the change to <see cref="Source"/>'s <see cref="IBindable.Bindings"/>.
+        /// </summary>
+        /// <remarks>
+        /// This sets the current value without checking from <see cref="Source"/>.
+        /// </remarks>
+        /// <param name="newValue">The new value, used for <see cref="OnValueChange"/> invocation and for propagation.</param>
+        public void Set(T newValue) => Set(value, newValue, Source, Source);
+
+        /// <summary>
+        /// Triggers <see cref="OnValueChange"/> from <paramref name="oldValue"/> to current value (<see cref="Value"/>) and propagates the change to <see cref="Source"/>'s <see cref="IBindable.Bindings"/>.
+        /// </summary>
+        /// <param name="oldValue">The old value, used for <see cref="OnValueChange"/> invocation and for propagation.</param>
+        /// <param name="propagateChange">Whether to propagate the change to <see cref="Source"/>'s <see cref="IBindable.Bindings"/>.</param>
+        public void TriggerChange(T oldValue, bool propagateChange = true) => TriggerChange(oldValue, Source, Source, propagateChange);
+
+        /// <summary>
+        /// Sets current value to <paramref name="newValue"/> and propagates the change to <see cref="Source"/>'s <see cref="IBindable.Bindings"/>.
+        /// </summary>
+        /// <remarks>
+        /// This sets the current value without checking from <see cref="Source"/>.
+        /// </remarks>
+        /// <param name="oldValue">The old value, used for <see cref="OnValueChange"/> invocation and for propagation.</param>
+        /// <param name="newValue">The new value, used for <see cref="OnValueChange"/> invocation and for propagation.</param>
+        /// <param name="propagationRoot">The root bindable of this propagation.</param>
+        /// <param name="triggeringBindable">The bindable triggering this change.</param>
+        protected virtual void Set(T oldValue, T newValue, IBindable propagationRoot, IBindable triggeringBindable)
+        {
+            if (EqualityComparer<T>.Default.Equals(oldValue, newValue))
+                return;
+
+            value = newValue;
+            TriggerChange(oldValue, propagationRoot, triggeringBindable);
+        }
+
+        /// <summary>
+        /// Triggers <see cref="OnValueChange"/> from <paramref name="oldValue"/> to current value (<see cref="Value"/>) and propagates the change to <see cref="Source"/>'s <see cref="IBindable.Bindings"/>.
+        /// </summary>
+        /// <param name="oldValue">The old value, used for <see cref="OnValueChange"/> invocation and for propagation.</param>
+        /// <param name="propagationRoot">The root bindable of this propagation.</param>
+        /// <param name="triggeringBindable">The bindable triggering this change.</param>
+        /// <param name="propagateChange">Whether to propagate the change to <see cref="Source"/>'s <see cref="IBindable.Bindings"/>.</param>
+        protected void TriggerChange(T oldValue, IBindable propagationRoot, IBindable triggeringBindable, bool propagateChange = true)
+        {
+            var beforePropagation = value;
+
+            if (Source.Bindings != null && propagateChange)
+            {
+                foreach (var b in Source.Bindings)
+                {
+                    if (ReferenceEquals(b, triggeringBindable)) continue;
+
+                    getPropertyOf(b)?.Set(oldValue, value, propagationRoot, Source);
+                }
+            }
+
+            // Check if the value hasn't changed during propagation to avoid firing already outdated events.
+            if (EqualityComparer<T>.Default.Equals(beforePropagation, value))
+                OnValueChange?.Invoke(oldValue, value);
+        }
+    }
+}

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 
 namespace osu.Framework.Bindables
 {
@@ -10,6 +11,11 @@ namespace osu.Framework.Bindables
     /// </summary>
     public interface IBindable : IParseable, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
     {
+        /// <summary>
+        /// The list of all bindables that are bound to this <see cref="IBindable"/>.
+        /// </summary>
+        IEnumerable<IBindable> Bindings { get; }
+
         /// <summary>
         /// Binds ourselves to another bindable such that we receive any value limitations of the bindable we bind width.
         /// </summary>
@@ -54,6 +60,11 @@ namespace osu.Framework.Bindables
         /// The default value of this bindable. Used when querying <see cref="IHasDefaultValue.IsDefault">IsDefault</see>.
         /// </summary>
         T Default { get; }
+
+        /// <summary>
+        /// The list of all bindables that are bound to this <see cref="IBindable{T}"/>.
+        /// </summary>
+        new IEnumerable<IBindable<T>> Bindings { get; }
 
         /// <summary>
         /// Binds ourselves to another bindable such that we receive any values and value limitations of the bindable we bind width.

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -24,6 +24,11 @@ namespace osu.Framework.Bindables
         event Action<IEnumerable<T>> ItemsRemoved;
 
         /// <summary>
+        /// The list of all bindables that are bound to this <see cref="IBindableList{T}"/>.
+        /// </summary>
+        new IEnumerable<IBindableList<T>> Bindings { get; }
+
+        /// <summary>
         /// Binds self to another bindable such that we receive any values and value limitations of the bindable we bind width.
         /// </summary>
         /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>

--- a/osu.Framework/Bindables/IBindableProperty.cs
+++ b/osu.Framework/Bindables/IBindableProperty.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Bindables
+{
+    /// <summary>
+    /// An interface representing a read-only <see cref="BindableProperty{T}"/>.
+    /// </summary>
+    public interface IBindableProperty
+    {
+        /// <summary>
+        /// The bindable source of this property.
+        /// </summary>
+        IBindable Source { get; }
+
+        /// <summary>
+        /// The current value of this property.
+        /// </summary>
+        object Value { get; }
+    }
+
+    /// <inheritdoc />
+    /// <typeparam name="T">The property value type.</typeparam>
+    public interface IBindableProperty<out T> : IBindableProperty
+    {
+        /// <summary>
+        /// The current value of this property.
+        /// </summary>
+        new T Value { get; }
+    }
+}

--- a/osu.Framework/Bindables/IHasPropertyGuards.cs
+++ b/osu.Framework/Bindables/IHasPropertyGuards.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Bindables
+{
+    /// <summary>
+    /// An interface which can be assigned to <see cref="IBindable"/>s to add property guards on <see cref="BindableProperty{T}.Value"/> setter.
+    /// </summary>
+    /// <remarks>
+    /// This interface only has protected methods to be executed internally inside <see cref="BindableProperty{T}"/>.
+    /// </remarks>
+    public interface IHasPropertyGuards
+    {
+        /// <summary>
+        /// The conditions required to allow changing <see cref="property"/>'s value to <see cref="value"/>.
+        /// Must throw exception inside the method for rejecting value change.
+        /// </summary>
+        protected internal void CheckPropertyValueChange<TValue>(IBindableProperty<TValue> property, TValue value)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Introducing `BindableProperty<T>`
`BindableProperty` is a class that wraps up value propagation logic of a certain property inside, all that is required from the consumer is to create an instance of it and provide the following:
 - `initialValue` (ctor param): The initial value of the property. (`OnValueChange` is not invoked on this)
- `OnValueChange`: An event to be invoked whenever a value has changed after it has been propagated to bindings.

Here's an example of adding a string bindable property:
```csharp
class MyBindable<T> : Bindable<T>
{
    public event Action<string, string> StringChanged;

    private BindableProperty<string> stringProperty;

    public MyBindable(string initialString)
    {
        stringProperty = new BindableProperty<string>(initialString, this, b => (b as MyBindable<T>)?.stringProperty)
        {
            OnValueChange = (oldValue, newValue) => StringChanged?.Invoke(oldValue, newValue)
        }
    }

    public string String
    {
        get => stringProperty.Value;
        set => stringProperty.Value = value;
    }

    public override void BindTo(Bindable<T> them)
    {
        if (them is MyBindable<T> other)
            String = other.String;

        base.BindTo(them);
    }
}
```