### PR TITLE
Throw when binding a BindableNumber<T> to a bindable with incompatible value

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -23,6 +23,15 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
+        public void TestBindToIncompatibleValueBindable()
+        {
+            BindableInt bindable1 = new BindableInt { MinValue = 100, MaxValue = 200, Value = 150 };
+            Bindable<int> bindable2 = new Bindable<int>(50);
+
+            Assert.Throws<InvalidOperationException>(() => bindable1.BindTo(bindable2));
+        }
+
+        [Test]
         public void TestPropagation()
         {
             Bindable<string> bindable1 = new Bindable<string>("default");

--- a/osu.Framework.Tests/Bindables/BindableNumberTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableNumberTest.cs
@@ -200,23 +200,6 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(bindable.Value, Is.EqualTo(3));
         }
 
-        /// <summary>
-        /// Ensures that the value is updated when you bind to a bindable with a value that doesn't respect the number properties.
-        /// </summary>
-        [Test]
-        public void TestValueUpdatedOnBindingToInvalidValueBindable()
-        {
-            var bindable = new BindableInt { MinValue = 50, MaxValue = 200, Value = 55 };
-            var remote = new Bindable<int>(15);
-
-            // The value on bindable should change in this sequence: 55 (initial) -> 15 ('remote' value on bind) -> 50 (value updated with number props)
-            // The value of remote should change in this sequence: 15 (initial) -> 50 (updated from 'bindable')
-            bindable.BindTo(remote);
-
-            Assert.That(remote.Value, Is.EqualTo(50));
-            Assert.That(remote.Value, Is.EqualTo(bindable.Value));
-        }
-
         private object createBindable(Type type) => Activator.CreateInstance(typeof(BindableNumber<>).MakeGenericType(type), Convert.ChangeType(0, type));
 
         private class BindableNumberWithDefaultMaxValue : BindableInt

--- a/osu.Framework.Tests/Bindables/BindableNumberTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableNumberTest.cs
@@ -200,6 +200,23 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(bindable.Value, Is.EqualTo(3));
         }
 
+        /// <summary>
+        /// Ensures that the value is updated when you bind to a bindable with a value that doesn't respect the number properties.
+        /// </summary>
+        [Test]
+        public void TestValueUpdatedOnBindingToInvalidValueBindable()
+        {
+            var bindable = new BindableInt { MinValue = 50, MaxValue = 200, Value = 55 };
+            var remote = new Bindable<int>(15);
+
+            // The value on bindable should change in this sequence: 55 (initial) -> 15 ('remote' value on bind) -> 50 (value updated with number props)
+            // The value of remote should change in this sequence: 15 (initial) -> 50 (updated from 'bindable')
+            bindable.BindTo(remote);
+
+            Assert.That(remote.Value, Is.EqualTo(50));
+            Assert.That(remote.Value, Is.EqualTo(bindable.Value));
+        }
+
         private object createBindable(Type type) => Activator.CreateInstance(typeof(BindableNumber<>).MakeGenericType(type), Convert.ChangeType(0, type));
 
         private class BindableNumberWithDefaultMaxValue : BindableInt

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -334,6 +334,13 @@ namespace osu.Framework.Bindables
             }
 
             base.BindTo(them);
+
+            if (!Value.Equals(them.Value))
+            {
+                throw new InvalidOperationException(
+                    $"Can not bind to a bindable with a value not compatible with this {nameof(BindableNumber<T>)} properties. "
+                    + $"Value: {them.Value}, {nameof(BindableNumber<T>)}'s properties: (range: [{MinValue} - {MaxValue}], precision: {Precision}).");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
- Covers binding a `BindableNumber` with defined properties to a normal `Bindable` with a value that isn't compatible with the `BindableNumber` properties. (precision / min-value / max-value)

Found this edge-case while fixing the bindable properties transferring behaviour and realized it didn't have a test, went ahead and wrote one.