### PR TITLE
Refresh audio DeviceInfo async from AudioThread

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -246,9 +246,6 @@ namespace osu.Framework.Audio
                 InitBass(deviceIndex);
             }
 
-            // Sync newly initialized device
-            syncAudioDevices();
-
             if (Bass.LastError != Errors.OK)
             {
                 Logger.Log($@"BASS failed to initialize with error code {Bass.LastError:D}: {Bass.LastError}.", LoggingTarget.Runtime, LogLevel.Important);

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -129,6 +129,11 @@ namespace osu.Framework.Audio
             CancellationToken token = cancellationTokenSource.Token;
             var thread = new Thread(() =>
             {
+                syncAudioDevices();
+                // If user has no audio devices at initialization, force one to be set.
+                if (audioDeviceNames.IsEmpty)
+                    scheduler.Add(() => setAudioDevice());
+
                 while (!token.IsCancellationRequested)
                 {
                     try

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Audio
         /// <summary>
         /// The thread audio operations (mainly Bass calls) are ran on.
         /// </summary>
-        internal readonly AudioThread Thread;
+        private readonly AudioThread thread;
 
         /// <summary>
         /// The names of all available audio devices.
@@ -81,7 +81,7 @@ namespace osu.Framework.Audio
         private ImmutableList<DeviceInfo> audioDevices = ImmutableList<DeviceInfo>.Empty;
         private ImmutableList<string> audioDeviceNames = ImmutableList<string>.Empty;
 
-        private Scheduler scheduler => Thread.Scheduler;
+        private Scheduler scheduler => thread.Scheduler;
 
         private Scheduler eventScheduler => EventScheduler ?? scheduler;
 
@@ -103,9 +103,9 @@ namespace osu.Framework.Audio
         /// <param name="sampleStore">The sample store containing all audio samples to be used in the future.</param>
         public AudioManager(AudioThread audioThread, ResourceStore<byte[]> trackStore, ResourceStore<byte[]> sampleStore)
         {
-            Thread = audioThread;
+            thread = audioThread;
 
-            Thread.RegisterManager(this);
+            thread.RegisterManager(this);
 
             AudioDevice.ValueChanged += onDeviceChanged;
 
@@ -141,7 +141,7 @@ namespace osu.Framework.Audio
                     {
                         try
                         {
-                            System.Threading.Thread.Sleep(1000);
+                            Thread.Sleep(1000);
                             syncAudioDevices();
                         }
                         catch
@@ -158,7 +158,7 @@ namespace osu.Framework.Audio
         protected override void Dispose(bool disposing)
         {
             cancelSource.Cancel();
-            Thread.UnregisterManager(this);
+            thread.UnregisterManager(this);
 
             OnNewDevice = null;
             OnLostDevice = null;

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using ManagedBass;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
@@ -141,7 +140,10 @@ namespace osu.Framework.Audio
                     {
                     }
                 }
-            }) { IsBackground = true };
+            })
+            {
+                IsBackground = true
+            };
             thread.Start();
         }
 


### PR DESCRIPTION
My attempt to fix: https://github.com/ppy/osu/issues/8185

This change starts up a new thread in the AudioManager that continuously polls for new audio DeviceInfo. Whenever new changes are detected, a task is scheduled to check to current device and whether it should be switched to a better one. (e.g. No Sound -> actual device)

Don't know if other people are actually affected by this latency problem, but I figured this device polling is non-critical and doesn't really need to be part of the main game threads.