### PR TITLE
Fix VideoTexture causing characters to disappear

### DIFF
--- a/osu.Framework/Graphics/Video/VideoTexture.cs
+++ b/osu.Framework/Graphics/Video/VideoTexture.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Graphics.Video
 
                 for (int i = 0; i < textureIds.Length; i++)
                 {
-                    GL.BindTexture(TextureTarget.Texture2D, textureIds[i]);
+                    GLWrapper.BindTexture(textureIds[i]);
 
                     if (i == 0)
                     {
@@ -84,7 +84,8 @@ namespace osu.Framework.Graphics.Video
 
             for (int i = 0; i < textureIds.Length; i++)
             {
-                GL.BindTexture(TextureTarget.Texture2D, textureIds[i]);
+                GLWrapper.BindTexture(textureIds[i]);
+
                 GL.PixelStore(PixelStoreParameter.UnpackRowLength, videoUpload.Frame->linesize[(uint)i]);
                 GL.TexSubImage2D(TextureTarget2d.Texture2D, 0, 0, 0, videoUpload.Frame->width / (i > 0 ? 2 : 1), videoUpload.Frame->height / (i > 0 ? 2 : 1),
                     PixelFormat.Red, PixelType.UnsignedByte, (IntPtr)videoUpload.Frame->data[(uint)i]);


### PR DESCRIPTION
This was causing the video texture to bind, bypassing GLWrapper, and then the atlas texture would try to bind but fail the "already bound" checks inside GLWrapper.

I'm not sure/don't think this (fixes) https://github.com/ppy/osu/issues/1488 since the issue is from 2017, but the uploading code and atlasing has changed a lot since then, so hopefully?