### PR TITLE
Add some sanity checks for audio management

### DIFF
--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using ManagedBass;
 using osu.Framework.Audio;
 using osu.Framework.IO.Stores;
@@ -93,7 +92,6 @@ namespace osu.Framework.Tests.Audio
         public override void Dispose()
         {
             Dispose(true);
-            Thread.Sleep(1000); // Ensure sync thread has been cancelled
             base.Dispose();
         }
     }

--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using ManagedBass;
 using osu.Framework.Audio;
 using osu.Framework.IO.Stores;
@@ -86,6 +87,12 @@ namespace osu.Framework.Tests.Audio
             current ??= CurrentDevice;
 
             AudioThreadTest.WaitForOrAssert(() => CurrentDevice != current, $"Timed out while waiting for the device to change from {current}.", timeoutMs);
+        }
+
+        public new void Dispose()
+        {
+            Dispose(true);
+            Thread.Sleep(1000); // Ensure sync thread has been cancelled
         }
     }
 }

--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using ManagedBass;
-using NUnit.Framework;
 using osu.Framework.Audio;
 using osu.Framework.IO.Stores;
 using osu.Framework.Threading;

--- a/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
+++ b/osu.Framework.Tests/Audio/AudioManagerWithDeviceLoss.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using ManagedBass;
+using NUnit.Framework;
 using osu.Framework.Audio;
 using osu.Framework.IO.Stores;
 using osu.Framework.Threading;
@@ -89,10 +90,12 @@ namespace osu.Framework.Tests.Audio
             AudioThreadTest.WaitForOrAssert(() => CurrentDevice != current, $"Timed out while waiting for the device to change from {current}.", timeoutMs);
         }
 
-        public new void Dispose()
+        // Override Dispose here because AudioManager schedules its Dispose on the AudioThread by default.
+        public override void Dispose()
         {
             Dispose(true);
             Thread.Sleep(1000); // Ensure sync thread has been cancelled
+            base.Dispose();
         }
     }
 }

--- a/osu.Framework.Tests/Audio/AudioThreadTest.cs
+++ b/osu.Framework.Tests/Audio/AudioThreadTest.cs
@@ -35,11 +35,11 @@ namespace osu.Framework.Tests.Audio
         [TearDown]
         public void TearDown()
         {
+            Manager?.Dispose();
+
             Assert.IsFalse(thread.Exited);
 
             thread.Exit();
-
-            Manager?.Dispose();
 
             WaitForOrAssert(() => thread.Exited, "Audio thread did not exit in time");
         }

--- a/osu.Framework.Tests/Audio/AudioThreadTest.cs
+++ b/osu.Framework.Tests/Audio/AudioThreadTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using ManagedBass;
 using NUnit.Framework;
 using osu.Framework.Audio.Track;
 using osu.Framework.IO.Stores;
@@ -20,14 +21,14 @@ namespace osu.Framework.Tests.Audio
         [SetUp]
         public virtual void SetUp()
         {
+            // If Bass is not in its default state, previous usage was not properly cleaned up.
+            Assert.AreEqual(Bass.DefaultDevice, Bass.CurrentDevice);
+
             thread = new AudioThread();
 
             var store = new NamespacedResourceStore<byte[]>(new DllResourceStore(@"osu.Framework.Tests.dll"), @"Resources");
 
             Manager = new AudioManagerWithDeviceLoss(thread, store, store);
-
-            // If manager is already loaded, previous instance was not cleaned up.
-            Assert.IsFalse(Manager.IsLoaded);
 
             thread.Start();
         }

--- a/osu.Framework.Tests/Audio/AudioThreadTest.cs
+++ b/osu.Framework.Tests/Audio/AudioThreadTest.cs
@@ -26,6 +26,9 @@ namespace osu.Framework.Tests.Audio
 
             Manager = new AudioManagerWithDeviceLoss(thread, store, store);
 
+            // If manager is already loaded, previous instance was not cleaned up.
+            Assert.IsFalse(Manager.IsLoaded);
+
             thread.Start();
         }
 

--- a/osu.Framework.Tests/Audio/AudioThreadTest.cs
+++ b/osu.Framework.Tests/Audio/AudioThreadTest.cs
@@ -22,7 +22,8 @@ namespace osu.Framework.Tests.Audio
         public virtual void SetUp()
         {
             // If Bass is not in its default state, previous usage was not properly cleaned up.
-            Assert.AreEqual(Bass.DefaultDevice, Bass.CurrentDevice);
+            while (Bass.CurrentDevice != Bass.DefaultDevice)
+                Bass.Free();
 
             thread = new AudioThread();
 

--- a/osu.Framework.Tests/Audio/DeviceLosingAudioTest.cs
+++ b/osu.Framework.Tests/Audio/DeviceLosingAudioTest.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Tests.Audio
             // seek track
             track.Seek(0);
 
-            Assert.IsFalse(track.IsRunning);
+            Assert.IsFalse(track.IsRunning, "Track started again");
             WaitForOrAssert(() => track.CurrentTime == 0, "Track did not seek correctly", 1000);
         }
     }

--- a/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
+++ b/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
@@ -12,6 +12,9 @@ namespace osu.Framework.Tests.Audio
         {
             base.SetUp();
 
+            // wait for any device to be initialized
+            Manager.WaitForDeviceChange(-1);
+
             // lose all devices
             Manager.SimulateDeviceLoss();
         }

--- a/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
+++ b/osu.Framework.Tests/Audio/DevicelessAudioTest.cs
@@ -36,12 +36,10 @@ namespace osu.Framework.Tests.Audio
 
             WaitForOrAssert(() => !track.IsRunning, "Track did not stop", 1000);
 
-            Assert.IsFalse(track.IsRunning);
-
             // seek track
             track.Seek(0);
 
-            Assert.IsFalse(track.IsRunning);
+            Assert.IsFalse(track.IsRunning, "Track started again");
             WaitForOrAssert(() => track.CurrentTime == 0, "Track did not seek correctly", 1000);
         }
     }

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Tests.Audio
         public void Setup()
         {
             // Initialize bass with no audio to make sure the test remains consistent even if there is no audio device.
-            Bass.Init(0);
+            Assert.IsTrue(Bass.Init(0), $"Failed to initialize Bass:{Bass.LastError}");
 
             resources = new DllResourceStore(typeof(TrackBassTest).Assembly);
 

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -27,7 +27,8 @@ namespace osu.Framework.Tests.Audio
         public void Setup()
         {
             // Initialize bass with no audio to make sure the test remains consistent even if there is no audio device.
-            Assert.IsTrue(Bass.Init(0), $"Failed to initialize Bass:{Bass.LastError}");
+            Bass.Init(0);
+            Assert.IsTrue(Bass.LastError == Errors.OK || Bass.LastError == Errors.Already);
 
             resources = new DllResourceStore(typeof(TrackBassTest).Assembly);
 

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -15,6 +15,7 @@ using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
 using osu.Framework.Threading;
+using ThreadState = System.Threading.ThreadState;
 
 namespace osu.Framework.Audio
 {
@@ -158,7 +159,8 @@ namespace osu.Framework.Audio
         {
             cancelSource.Cancel();
             thread.UnregisterManager(this);
-            syncThread.Join(); // Wait for thread to exit
+            if (syncThread.ThreadState != ThreadState.Unstarted)
+                syncThread.Join(); // Wait for thread to exit
 
             OnNewDevice = null;
             OnLostDevice = null;

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -144,8 +144,11 @@ namespace osu.Framework.Audio.Track
 
         void IBassAudio.UpdateDevice(int deviceIndex)
         {
-            Bass.ChannelSetDevice(activeStream, deviceIndex);
-            Trace.Assert(Bass.LastError == Errors.OK);
+            if (!Bass.ChannelSetDevice(activeStream, deviceIndex) && Bass.LastError == Errors.Already)
+                return;
+
+            // Errors.Init here means Free() was called on a device while attached to activeStream.
+            Trace.Assert(Bass.LastError == Errors.OK, $"Bass.ChannelSetDevice error:{Bass.LastError}");
 
             // Bass may leave us in an invalid state after the output device changes (this is true for "No sound" device)
             // if the observed state was playing before change, we should force things into a good state.

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -75,12 +75,16 @@ namespace osu.Framework.Threading
         {
             base.PerformExit();
 
+            List<AudioManager> managersCopy;
+
             lock (managers)
             {
-                foreach (var manager in managers)
-                    manager.Dispose();
+                managersCopy = new List<AudioManager>(managers);
                 managers.Clear();
             }
+
+            foreach (var manager in managersCopy)
+                manager.Dispose();
         }
     }
 }

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -81,11 +81,6 @@ namespace osu.Framework.Threading
                     manager.Dispose();
                 managers.Clear();
             }
-
-            // Safety net to ensure we have freed all devices before exiting.
-            // This is mainly required for device-lost scenarios.
-            // See https://github.com/ppy/osu-framework/pull/3378 for further discussion.
-            while (Bass.Free()) { }
         }
     }
 }


### PR DESCRIPTION
Sorry for so many PRs, but it should be good now. Not really fixing anything here just adding sanity checks.

Some takeaways:
- Do not call `Free` on the **active** device (Calling `Free` on an inactive device is fine). Active is defined as the device assigned by `Bass.ChannelSetDevice`.
- If a device was disabled and enabled again, it needs to be initialized again even though it will look to be already initialized from flags.
- If you switch from device A to B, then back to A again, you actually do not need to reinitialize A. Setting CurrentDevice to A is sufficient. (We don't differentiate this in the code and just re-init, but it seems to work fine)