### PR TITLE
Reduce allocations during dependency injection

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkDependencyContainer.cs
+++ b/osu.Framework.Benchmarks/BenchmarkDependencyContainer.cs
@@ -1,0 +1,75 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkDependencyContainer : GameBenchmark
+    {
+        private Game game;
+        private TestBdlReceiver bdlReceiver;
+        private TestCachedReceiver cachedReceiver;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            // Warm up caches to not pollute tests
+            game.Dependencies.Inject(bdlReceiver = new TestBdlReceiver());
+            game.Dependencies.Inject(cachedReceiver = new TestCachedReceiver());
+            game.Dependencies.Get(typeof(Game));
+            game.Dependencies.Get(typeof(CancellationToken?));
+        }
+
+        [Test]
+        [Benchmark]
+        public void Get() => game.Dependencies.Get(typeof(Game));
+
+        [Test]
+        [Benchmark]
+        public void GetNullable() => game.Dependencies.Get(typeof(CancellationToken?));
+
+        [Test]
+        [Benchmark]
+        public void InjectBdl() => game.Dependencies.Inject(bdlReceiver);
+
+        [Test]
+        [Benchmark]
+        public void InjectCached() => game.Dependencies.Inject(cachedReceiver);
+
+        protected override Game CreateGame() => game = new TestGame();
+
+        private class TestBdlReceiver : Drawable
+        {
+            [BackgroundDependencyLoader]
+            private void load(Game game, TextureStore textures, AudioManager audio)
+            {
+            }
+        }
+
+        private class TestCachedReceiver : Drawable
+        {
+            [Resolved]
+            private GameHost host { get; set; }
+
+            [Resolved]
+            private FrameworkConfigManager frameworkConfigManager { get; set; }
+
+            [Resolved]
+            private FrameworkDebugConfigManager frameworkDebugConfigManager { get; set; }
+        }
+
+        private class TestGame : Game
+        {
+        }
+    }
+}

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -143,10 +143,10 @@ namespace osu.Framework.Allocation
                 throw new ArgumentNullException(nameof(instance));
             }
 
-            info = info.WithType(Nullable.GetUnderlyingType(type) ?? type);
+            info = info.WithType(type.GetUnderlyingNullableType() ?? type);
 
             var instanceType = instance.GetType();
-            instanceType = Nullable.GetUnderlyingType(instanceType) ?? instanceType;
+            instanceType = instanceType.GetUnderlyingNullableType() ?? instanceType;
 
             if (instanceType.IsValueType && !allowValueTypes)
                 throw new ArgumentException($"{instanceType.ReadableName()} must be a class to be cached as a dependency.", nameof(instance));
@@ -167,7 +167,7 @@ namespace osu.Framework.Allocation
 
         public object Get(Type type, CacheInfo info)
         {
-            info = info.WithType(Nullable.GetUnderlyingType(type) ?? type);
+            info = info.WithType(type.GetUnderlyingNullableType() ?? type);
 
             if (cache.TryGetValue(info, out var existing))
                 return existing;

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.IO.Serialization;
 using osu.Framework.Lists;
 
@@ -237,7 +238,7 @@ namespace osu.Framework.Bindables
         /// <param name="input">The input which is to be parsed.</param>
         public virtual void Parse(object input)
         {
-            Type underlyingType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+            Type underlyingType = typeof(T).GetUnderlyingNullableType() ?? typeof(T);
 
             switch (input)
             {


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/3385

Master:
|       Method |        Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |------------:|---------:|---------:|-------:|------:|------:|----------:|
|          Get |    88.00 ns | 1.581 ns | 1.320 ns |      - |     - |     - |         - |
|  GetNullable |   715.65 ns | 2.539 ns | 2.375 ns | 0.0181 |     - |     - |      96 B |
|    InjectBdl |   894.11 ns | 4.200 ns | 3.724 ns | 0.1221 |     - |     - |     640 B |
| InjectCached | 1,045.52 ns | 9.256 ns | 8.206 ns | 0.0362 |     - |     - |     192 B |

This PR:
|       Method |        Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------- |------------:|---------:|---------:|-------:|------:|------:|----------:|
|          Get |    95.56 ns | 0.466 ns | 0.413 ns |      - |     - |     - |         - |
|  GetNullable |   172.63 ns | 0.498 ns | 0.466 ns |      - |     - |     - |         - |
|    InjectBdl |   618.43 ns | 2.455 ns | 2.177 ns | 0.0181 |     - |     - |      96 B |
| InjectCached | 1,069.04 ns | 6.246 ns | 5.842 ns | 0.0362 |     - |     - |     192 B |

`InjectCached` is still much slower/higher than I'd like it to be, but I'm not sure what's causing it/how to improve it. Good enough improvement for the time being I'd say (the BDL path was the hot one).

![](https://cdn.discordapp.com/attachments/191416004675371008/690020200199749634/unknown.png)

![](https://cdn.discordapp.com/attachments/191416004675371008/690020539758280818/unknown.png)

![](https://cdn.discordapp.com/attachments/191416004675371008/690021494201384995/unknown.png)
