### PR TITLE
Remove some minor delegate allocations

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -57,7 +57,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CollectionNeverQueried_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CommentTypo/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CompareOfFloatsByEqualityOperator/@EntryIndexedValue">HINT</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertClosureToMethodGroup/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertClosureToMethodGroup/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfDoToWhile/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfStatementToConditionalTernaryExpression/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfStatementToNullCoalescingExpression/@EntryIndexedValue">WARNING</s:String>

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -19,6 +19,7 @@ namespace osu.Framework.Graphics.Transforms
         {
             this.targetBindable = targetBindable;
 
+            // Lambda expression is used so that the delegate is cached (see: https://github.com/dotnet/roslyn/issues/5835)
             interpolationFunc = (double d, TValue value, TValue tValue, double time, double endTime, in TEasing type)
                 => Interpolation.ValueAt(d, value, tValue, time, endTime, in type);
 

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -18,7 +18,9 @@ namespace osu.Framework.Graphics.Transforms
         public TransformBindable(Bindable<TValue> targetBindable)
         {
             this.targetBindable = targetBindable;
-            interpolationFunc = Interpolation.ValueAt;
+
+            interpolationFunc = (double d, TValue value, TValue tValue, double time, double endTime, in TEasing type)
+                => Interpolation.ValueAt(d, value, tValue, time, endTime, in type);
 
             TargetMember = $"{targetBindable.GetHashCode()}.Value";
         }

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -162,6 +162,7 @@ namespace osu.Framework.Graphics.Transforms
             accessor = getAccessor(propertyOrFieldName);
             Trace.Assert(accessor.Read != null && accessor.Write != null, $"Failed to populate {nameof(accessor)}.");
 
+            // Lambda expression is used so that the delegate is cached (see: https://github.com/dotnet/roslyn/issues/5835)
             interpolationFunc = (double d, TValue value, TValue tValue, double time, double endTime, in TEasing type)
                 => Interpolation.ValueAt(d, value, tValue, time, endTime, in type);
         }

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -162,7 +162,8 @@ namespace osu.Framework.Graphics.Transforms
             accessor = getAccessor(propertyOrFieldName);
             Trace.Assert(accessor.Read != null && accessor.Write != null, $"Failed to populate {nameof(accessor)}.");
 
-            interpolationFunc = Interpolation.ValueAt;
+            interpolationFunc = (double d, TValue value, TValue tValue, double time, double endTime, in TEasing type)
+                => Interpolation.ValueAt(d, value, tValue, time, endTime, in type);
         }
 
         private TValue valueAt(double time)

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -159,8 +159,11 @@ namespace osu.Framework.Input.Bindings
                 && m.KeyCombination.IsPressed(pressedCombination, matchingMode));
 
             if (KeyCombination.IsModifierKey(newKey))
+            {
                 // if the current key pressed was a modifier, only handle modifier-only bindings.
+                // lambda expression is used so that the delegate is cached (see: https://github.com/dotnet/roslyn/issues/5835)
                 newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(key => KeyCombination.IsModifierKey(key)));
+            }
 
             // we want to always handle bindings with more keys before bindings with less.
             newlyPressed = newlyPressed.OrderByDescending(b => b.KeyCombination.Keys.Length).ToList();

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -160,7 +160,7 @@ namespace osu.Framework.Input.Bindings
 
             if (KeyCombination.IsModifierKey(newKey))
                 // if the current key pressed was a modifier, only handle modifier-only bindings.
-                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(KeyCombination.IsModifierKey));
+                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(key => KeyCombination.IsModifierKey(key)));
 
             // we want to always handle bindings with more keys before bindings with less.
             newlyPressed = newlyPressed.OrderByDescending(b => b.KeyCombination.Keys.Length).ToList();


### PR DESCRIPTION
This is the result of a custom analyser I've written to look for these cases. It's not ready for the public yet.

This is not a complete list of issues which would close https://github.com/ppy/osu-framework/issues/3389. Other cases involve restructuring how we're doing delegates to support a sender model or are otherwise more complex. Examples include:
1. `BufferedDrawNode` + `BufferedContainerDrawNode` (via the `InvokeOnDisposal`)
2. `AdjustableAudioComponent` (via `InvalidateState()`)

Master:
|                          Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| CreateSequenceWithDefaultEasing | 2.128 us | 0.0146 us | 0.0136 us | 0.4997 |     - |     - |   2.56 KB |

This PR:
|                          Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| CreateSequenceWithDefaultEasing | 2.061 us | 0.0122 us | 0.0108 us | 0.4616 |     - |     - |   2.38 KB |

(Reduction from the `TransformCustom` change)