### PR TITLE
Remove allocations from InvokeOnDisposal delegates

### DIFF
--- a/osu.Framework/Allocation/InvokeOnDisposal.cs
+++ b/osu.Framework/Allocation/InvokeOnDisposal.cs
@@ -39,4 +39,42 @@ namespace osu.Framework.Allocation
 
         #endregion
     }
+
+    /// <summary>
+    /// Instances of this class capture an action for later cleanup. When a method returns an instance of this class, the appropriate usage is:
+    /// <code>using (SomeMethod())
+    /// {
+    ///     // ...
+    /// }</code>
+    /// The using block will automatically dispose the returned instance, doing the necessary cleanup work.
+    /// </summary>
+    public class InvokeOnDisposal<T> : IDisposable
+    {
+        private readonly T sender;
+        private readonly Action<T> action;
+
+        /// <summary>
+        /// Constructs a new instance, capturing the given action to be run during disposal.
+        /// </summary>
+        /// <param name="sender">The sender which should appear in the <paramref name="action"/> callback.</param>
+        /// <param name="action">The action to invoke during disposal.</param>
+        public InvokeOnDisposal(T sender, Action<T> action)
+        {
+            this.sender = sender;
+            this.action = action ?? throw new ArgumentNullException(nameof(action));
+        }
+
+        #region IDisposable Support
+
+        /// <summary>
+        /// Disposes this instance, calling the initially captured action.
+        /// </summary>
+        public virtual void Dispose()
+        {
+            //no isDisposed check here so we can reuse these instances multiple times to save on allocations.
+            action(sender);
+        }
+
+        #endregion
+    }
 }

--- a/osu.Framework/Allocation/ValueInvokeOnDisposal.cs
+++ b/osu.Framework/Allocation/ValueInvokeOnDisposal.cs
@@ -41,4 +41,44 @@ namespace osu.Framework.Allocation
 
         #endregion
     }
+
+    /// <summary>
+    /// Instances of this struct capture an action for later cleanup. The appropriate usage is:
+    /// <code>using (SomeMethod())
+    /// {
+    ///     // ...
+    /// }</code>
+    /// The using block will automatically dispose the returned instance, doing the necessary cleanup work.
+    ///
+    /// This is a struct version of <see cref="InvokeOnDisposal"/> to be used when allocations are to be minimised.
+    /// </summary>
+    public readonly struct ValueInvokeOnDisposal<T> : IDisposable
+    {
+        private readonly T sender;
+        private readonly Action<T> action;
+
+        /// <summary>
+        /// Constructs a new instance, capturing the given action to be run during disposal.
+        /// </summary>
+        /// <param name="sender">The sender which should appear in the <paramref name="action"/> callback.</param>
+        /// <param name="action">The action to invoke during disposal.</param>
+        public ValueInvokeOnDisposal(T sender, Action<T> action)
+        {
+            this.sender = sender;
+            this.action = action ?? throw new ArgumentNullException(nameof(action));
+        }
+
+        #region IDisposable Support
+
+        /// <summary>
+        /// Disposes this instance, calling the initially captured action.
+        /// </summary>
+        public void Dispose()
+        {
+            //no isDisposed check here so we can reuse these instances multiple times to save on allocations.
+            action(sender);
+        }
+
+        #endregion
+    }
 }

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -136,17 +136,17 @@ namespace osu.Framework.Graphics
         /// </summary>
         /// <param name="frameBuffer">The <see cref="FrameBuffer"/> to bind.</param>
         /// <returns>A token that must be disposed upon finishing use of <paramref name="frameBuffer"/>.</returns>
-        protected ValueInvokeOnDisposal BindFrameBuffer(FrameBuffer frameBuffer)
+        protected IDisposable BindFrameBuffer(FrameBuffer frameBuffer)
         {
             // This setter will also take care of allocating a texture of appropriate size within the frame buffer.
             frameBuffer.Size = frameBufferSize;
 
             frameBuffer.Bind();
 
-            return new ValueInvokeOnDisposal(frameBuffer.Unbind);
+            return new ValueInvokeOnDisposal<FrameBuffer>(frameBuffer, b => b.Unbind());
         }
 
-        private ValueInvokeOnDisposal establishFrameBufferViewport()
+        private IDisposable establishFrameBufferViewport()
         {
             // Disable masking for generating the frame buffer since masking will be re-applied
             // when actually drawing later on anyways. This allows more information to be captured
@@ -167,7 +167,7 @@ namespace osu.Framework.Graphics
             GLWrapper.PushScissor(new RectangleI(0, 0, (int)frameBufferSize.X, (int)frameBufferSize.Y));
             GLWrapper.PushScissorOffset(screenSpaceMaskingRect.Location);
 
-            return new ValueInvokeOnDisposal(returnViewport);
+            return new ValueInvokeOnDisposal<BufferedDrawNode>(this, d => d.returnViewport());
         }
 
         private void returnViewport()

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1198,7 +1198,7 @@ namespace osu.Framework.Graphics.Containers
             foreach (var c in internalChildren)
                 disposalActions.Add(c.BeginAbsoluteSequence(newTransformStartTime, true));
 
-            return new InvokeOnDisposal<List<IDisposable>>(disposalActions, actions =>
+            return new ValueInvokeOnDisposal<List<IDisposable>>(disposalActions, actions =>
             {
                 foreach (var a in actions)
                     a.Dispose();

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1188,19 +1188,19 @@ namespace osu.Framework.Graphics.Containers
 
         protected ScheduledDelegate ScheduleAfterChildren(Action action) => SchedulerAfterChildren.AddDelayed(action, TransformDelay);
 
-        public override InvokeOnDisposal BeginAbsoluteSequence(double newTransformStartTime, bool recursive = false)
+        public override IDisposable BeginAbsoluteSequence(double newTransformStartTime, bool recursive = false)
         {
             var baseDisposalAction = base.BeginAbsoluteSequence(newTransformStartTime, recursive);
             if (!recursive)
                 return baseDisposalAction;
 
-            List<InvokeOnDisposal> disposalActions = new List<InvokeOnDisposal>(internalChildren.Count + 1) { baseDisposalAction };
+            List<IDisposable> disposalActions = new List<IDisposable>(internalChildren.Count + 1) { baseDisposalAction };
             foreach (var c in internalChildren)
                 disposalActions.Add(c.BeginAbsoluteSequence(newTransformStartTime, true));
 
-            return new InvokeOnDisposal(() =>
+            return new InvokeOnDisposal<List<IDisposable>>(disposalActions, actions =>
             {
-                foreach (var a in disposalActions)
+                foreach (var a in actions)
                     a.Dispose();
             });
         }

--- a/osu.Framework/Graphics/Transforms/ITransformable.cs
+++ b/osu.Framework/Graphics/Transforms/ITransformable.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Allocation;
+using System;
 using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.Transforms
 {
     public interface ITransformable
     {
-        InvokeOnDisposal BeginDelayedSequence(double delay, bool recursive = false);
+        IDisposable BeginDelayedSequence(double delay, bool recursive = false);
 
-        InvokeOnDisposal BeginAbsoluteSequence(double newTransformStartTime, bool recursive = false);
+        IDisposable BeginAbsoluteSequence(double newTransformStartTime, bool recursive = false);
 
         /// <summary>
         /// The current frame's time as observed by this class's <see cref="Transform"/>s.

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -366,7 +366,7 @@ namespace osu.Framework.Graphics.Transforms
             AddDelay(delay, recursive);
             double newTransformDelay = TransformDelay;
 
-            return new InvokeOnDisposal<(Transformable transformable, double delay, bool recursive, double newTransformDelay)>((this, delay, recursive, newTransformDelay), sender =>
+            return new ValueInvokeOnDisposal<(Transformable transformable, double delay, bool recursive, double newTransformDelay)>((this, delay, recursive, newTransformDelay), sender =>
             {
                 if (!Precision.AlmostEquals(sender.newTransformDelay, sender.transformable.TransformDelay))
                 {
@@ -391,7 +391,7 @@ namespace osu.Framework.Graphics.Transforms
             double oldTransformDelay = TransformDelay;
             double newTransformDelay = TransformDelay = newTransformStartTime - (Clock?.CurrentTime ?? 0);
 
-            return new InvokeOnDisposal<(Transformable transformable, double oldTransformDelay, double newTransformDelay)>((this, oldTransformDelay, newTransformDelay), sender =>
+            return new ValueInvokeOnDisposal<(Transformable transformable, double oldTransformDelay, double newTransformDelay)>((this, oldTransformDelay, newTransformDelay), sender =>
             {
                 if (!Precision.AlmostEquals(sender.newTransformDelay, sender.transformable.TransformDelay))
                 {

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -358,7 +358,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="delay">The offset in milliseconds from current time. Note that this stacks with other nested sequences.</param>
         /// <param name="recursive">Whether this should be applied to all children.</param>
         /// <returns>A <see cref="InvokeOnDisposal"/> to be used in a using() statement.</returns>
-        public InvokeOnDisposal BeginDelayedSequence(double delay, bool recursive = false)
+        public IDisposable BeginDelayedSequence(double delay, bool recursive = false)
         {
             if (delay == 0)
                 return null;
@@ -366,16 +366,16 @@ namespace osu.Framework.Graphics.Transforms
             AddDelay(delay, recursive);
             double newTransformDelay = TransformDelay;
 
-            return new InvokeOnDisposal(() =>
+            return new InvokeOnDisposal<(Transformable transformable, double delay, bool recursive, double newTransformDelay)>((this, delay, recursive, newTransformDelay), sender =>
             {
-                if (!Precision.AlmostEquals(newTransformDelay, TransformDelay))
+                if (!Precision.AlmostEquals(sender.newTransformDelay, sender.transformable.TransformDelay))
                 {
                     throw new InvalidOperationException(
-                        $"{nameof(TransformStartTime)} at the end of delayed sequence is not the same as at the beginning, but should be. " +
-                        $"(begin={newTransformDelay} end={TransformDelay})");
+                        $"{nameof(sender.transformable.TransformStartTime)} at the end of delayed sequence is not the same as at the beginning, but should be. " +
+                        $"(begin={sender.newTransformDelay} end={sender.transformable.TransformDelay})");
                 }
 
-                AddDelay(-delay, recursive);
+                AddDelay(-sender.delay, sender.recursive);
             });
         }
 
@@ -386,21 +386,21 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="recursive">Whether this should be applied to all children.</param>
         /// <returns>A <see cref="InvokeOnDisposal"/> to be used in a using() statement.</returns>
         /// <exception cref="InvalidOperationException">Absolute sequences should never be nested inside another existing sequence.</exception>
-        public virtual InvokeOnDisposal BeginAbsoluteSequence(double newTransformStartTime, bool recursive = false)
+        public virtual IDisposable BeginAbsoluteSequence(double newTransformStartTime, bool recursive = false)
         {
             double oldTransformDelay = TransformDelay;
             double newTransformDelay = TransformDelay = newTransformStartTime - (Clock?.CurrentTime ?? 0);
 
-            return new InvokeOnDisposal(() =>
+            return new InvokeOnDisposal<(Transformable transformable, double oldTransformDelay, double newTransformDelay)>((this, oldTransformDelay, newTransformDelay), sender =>
             {
-                if (!Precision.AlmostEquals(newTransformDelay, TransformDelay))
+                if (!Precision.AlmostEquals(sender.newTransformDelay, sender.transformable.TransformDelay))
                 {
                     throw new InvalidOperationException(
-                        $"{nameof(TransformStartTime)} at the end of absolute sequence is not the same as at the beginning, but should be. " +
-                        $"(begin={newTransformDelay} end={TransformDelay})");
+                        $"{nameof(sender.transformable.TransformStartTime)} at the end of absolute sequence is not the same as at the beginning, but should be. " +
+                        $"(begin={sender.newTransformDelay} end={sender.transformable.TransformDelay})");
                 }
 
-                TransformDelay = oldTransformDelay;
+                sender.transformable.TransformDelay = sender.oldTransformDelay;
             });
         }
 

--- a/osu.Framework/Platform/NativeMemoryTracker.cs
+++ b/osu.Framework/Platform/NativeMemoryTracker.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Platform
             getStatistic(source).Value += amount;
             GC.AddMemoryPressure(amount);
 
-            return new NativeMemoryLease(() => removeMemory(source, amount));
+            return new NativeMemoryLease((source, amount), sender => removeMemory(sender.source, sender.amount));
         }
 
         /// <summary>
@@ -43,10 +43,10 @@ namespace osu.Framework.Platform
         /// <summary>
         /// A leased on a native memory allocation. Should be disposed when the associated memory is freed.
         /// </summary>
-        public class NativeMemoryLease : InvokeOnDisposal
+        public class NativeMemoryLease : InvokeOnDisposal<(object source, long amount)>
         {
-            internal NativeMemoryLease(Action action)
-                : base(action)
+            internal NativeMemoryLease((object source, long amount) sender, Action<(object source, long amount)> action)
+                : base(sender, action)
             {
             }
 


### PR DESCRIPTION
Along with https://github.com/ppy/osu-framework/pull/3390:

|                          Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
| CreateSequenceWithDefaultEasing | 1.987 us | 0.0097 us | 0.0081 us | 0.4311 |     - |     - |   2.22 KB |

I also get ~0.16ms faster draw time on `TestSceneEffects`.

There is a minor breaking change, however I see no need to list it: the return type of `BeginAbsoluteSequence` and `BeginDelayedSequence` has been changed to `IDisposable`. I've left it out because osu! hasn't ever overridden these or used their return types.

