### PR TITLE
Handle TextureAtlas findPosition() edge cases

### DIFF
--- a/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
+++ b/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Tests.Graphics
         {
             TextureAtlas atlas = new TextureAtlas(1024, 1024);
             TextureGL texture = atlas.Add(width, height);
-            if(texture != null)
+            if (texture != null)
             {
                 Assert.AreEqual(texture.Width, width, message: $"Width: {texture.Width} != {width} for texture {width}x{height}");
                 Assert.AreEqual(texture.Height, height, message: $"Height: {texture.Height} != {height} for texture {width}x{height}");

--- a/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
+++ b/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
@@ -11,6 +11,28 @@ namespace osu.Framework.Tests.Graphics
     [TestFixture]
     public class TextureAtlasTest
     {
+        [TestCase(0, 0)]
+        [TestCase(1, 1)]
+        [TestCase(984, 20)]
+        [TestCase(985, 20)]
+        [TestCase(1020, 20)]
+        [TestCase(1024, 20)]
+        [TestCase(1025, 20)]
+        [TestCase(20, 984)]
+        [TestCase(20, 985)]
+        [TestCase(20, 1020)]
+        [TestCase(20, 1024)]
+        [TestCase(20, 1500)]
+        [TestCase(985, 985)]
+        [TestCase(1020, 985)]
+        [TestCase(1500, 985)]
+        [TestCase(1020, 1020)]
+        [TestCase(1500, 1500)]
+        public void TestAtlasAdd(int width, int height)
+        {
+            Assert.DoesNotThrow(() => testWithSize(width, height));
+        }
+
         private void testWithSize(int width, int height)
         {
             TextureAtlas atlas = new TextureAtlas(1024, 1024);
@@ -31,23 +53,6 @@ namespace osu.Framework.Tests.Graphics
                             (width > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE
                              && height > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE),
                     message: $"Returned texture is null, but should have fit: {width}x{height}");
-            }
-        }
-
-        [Test]
-        public void TestAtlasAdd()
-        {
-            var testSizes = new[]
-            {
-                (0, 0), (1, 1), (984, 20), (985, 20), (1020, 20), (1024, 20), (1025, 20),
-                (20, 984), (20, 985), (20, 1020), (20, 1024), (20, 1500),
-                (985, 985), (1020, 985), (1500, 985),
-                (1020, 1020), (1500, 1500)
-            };
-
-            foreach (var size in testSizes)
-            {
-                Assert.DoesNotThrow(() => testWithSize(size.Item1, size.Item2), $"Size {size.Item1}x{size.Item2} has thrown an exception");
             }
         }
     }

--- a/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
+++ b/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
@@ -28,9 +28,9 @@ namespace osu.Framework.Tests.Graphics
             else
             {
                 Assert.True(width > 1024 - TextureAtlas.PADDING || height > 1008 - TextureAtlas.PADDING ||
-                 (width > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE
+                            (width > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE
                              && height > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE),
-                     message: $"Returned texture is null, but should have fit: {width}x{height}");
+                    message: $"Returned texture is null, but should have fit: {width}x{height}");
             }
         }
 
@@ -44,6 +44,7 @@ namespace osu.Framework.Tests.Graphics
                 (985, 985), (1020, 985), (1500, 985),
                 (1020, 1020), (1500, 1500)
             };
+
             foreach (var size in testSizes)
             {
                 Assert.DoesNotThrow(() => testWithSize(size.Item1, size.Item2), $"Size {size.Item1}x{size.Item2} has thrown an exception");

--- a/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
+++ b/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
 using NUnit.Framework;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Primitives;
@@ -24,9 +27,9 @@ namespace osu.Framework.Tests.Graphics
             }
             else
             {
-                Assert.True(width > 1024 - TextureAtlas.PADDING || height > 1008 - TextureAtlas.PADDING || 
-                        (width > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE 
-                            && height > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE), 
+                Assert.True(width > 1024 - TextureAtlas.PADDING || height > 1008 - TextureAtlas.PADDING ||
+                        (width > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE
+                            && height > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE),
                         message: $"Returned texture is null, but should have fit: {width}x{height}");
             }
         }

--- a/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
+++ b/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
@@ -5,7 +5,6 @@ using NUnit.Framework;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Textures;
-using System;
 
 namespace osu.Framework.Tests.Graphics
 {
@@ -16,6 +15,7 @@ namespace osu.Framework.Tests.Graphics
         {
             TextureAtlas atlas = new TextureAtlas(1024, 1024);
             TextureGL texture = atlas.Add(width, height);
+
             if (texture != null)
             {
                 Assert.AreEqual(texture.Width, width, message: $"Width: {texture.Width} != {width} for texture {width}x{height}");
@@ -28,19 +28,22 @@ namespace osu.Framework.Tests.Graphics
             else
             {
                 Assert.True(width > 1024 - TextureAtlas.PADDING || height > 1008 - TextureAtlas.PADDING ||
-                        (width > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE
-                            && height > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE),
-                        message: $"Returned texture is null, but should have fit: {width}x{height}");
+                 (width > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE
+                             && height > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE),
+                     message: $"Returned texture is null, but should have fit: {width}x{height}");
             }
         }
 
         [Test]
         public void TestAtlasAdd()
         {
-            var testSizes = new[]{ (0, 0), (1, 1), (984, 20), (985, 20), (1020, 20), (1024, 20), (1025, 20),
-                                    (20, 984), (20, 985), (20, 1020), (20, 1024), (20, 1500),
-                                    (985, 985), (1020, 985), (1500, 985),
-                                    (1020, 1020), (1500, 1500) };
+            var testSizes = new[]
+            {
+                (0, 0), (1, 1), (984, 20), (985, 20), (1020, 20), (1024, 20), (1025, 20),
+                (20, 984), (20, 985), (20, 1020), (20, 1024), (20, 1500),
+                (985, 985), (1020, 985), (1500, 985),
+                (1020, 1020), (1500, 1500)
+            };
             foreach (var size in testSizes)
             {
                 Assert.DoesNotThrow(() => testWithSize(size.Item1, size.Item2), $"Size {size.Item1}x{size.Item2} has thrown an exception");

--- a/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
+++ b/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
@@ -1,0 +1,47 @@
+using NUnit.Framework;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Primitives;
+using osu.Framework.Graphics.Textures;
+using System;
+
+namespace osu.Framework.Tests.Graphics
+{
+    [TestFixture]
+    public class TextureAtlasTest
+    {
+        private void testWithSize(int width, int height)
+        {
+            TextureAtlas atlas = new TextureAtlas(1024, 1024);
+            TextureGL texture = atlas.Add(width, height);
+            if(texture != null)
+            {
+                Assert.AreEqual(texture.Width, width, message: $"Width: {texture.Width} != {width} for texture {width}x{height}");
+                Assert.AreEqual(texture.Height, height, message: $"Height: {texture.Height} != {height} for texture {width}x{height}");
+
+                RectangleF rect = texture.GetTextureRect(null);
+                Assert.LessOrEqual(rect.X + rect.Width, 1, message: $"Returned texture is wider than TextureAtlas for texture {width}x{height}");
+                Assert.LessOrEqual(rect.Y + rect.Height, 1, message: $"Returned texture is taller than TextureAtlas for texture {width}x{height}");
+            }
+            else
+            {
+                Assert.True(width > 1024 - TextureAtlas.PADDING || height > 1008 - TextureAtlas.PADDING || 
+                        (width > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE 
+                            && height > 1024 - TextureAtlas.PADDING - TextureAtlas.WHITE_PIXEL_SIZE), 
+                        message: $"Returned texture is null, but should have fit: {width}x{height}");
+            }
+        }
+
+        [Test]
+        public void TestAtlasAdd()
+        {
+            var testSizes = new[]{ (0, 0), (1, 1), (984, 20), (985, 20), (1020, 20), (1024, 20), (1025, 20),
+                                    (20, 984), (20, 985), (20, 1020), (20, 1024), (20, 1500),
+                                    (985, 985), (1020, 985), (1500, 985),
+                                    (1020, 1020), (1500, 1500) };
+            foreach (var size in testSizes)
+            {
+                Assert.DoesNotThrow(() => testWithSize(size.Item1, size.Item2), $"Size {size.Item1}x{size.Item2} has thrown an exception");
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Graphics.Textures
             {
                 var pos = findPosition(width, height);
 
-                if(pos == null) return null;
+                if (pos == null) return null;
 
                 Vector2I position = pos.Value;
                 RectangleI bounds = new RectangleI(position.X, position.Y, width, height);

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -74,6 +74,7 @@ namespace osu.Framework.Graphics.Textures
                 Logger.Log($"TextureAtlas initialised ({atlasWidth}x{atlasHeight})", LoggingTarget.Performance);
                 Reset();
             }
+
             if (currentPosition.Y + height > atlasHeight - PADDING)
             {
                 if (height > atlasHeight - PADDING - WHITE_PIXEL_SIZE
@@ -81,9 +82,11 @@ namespace osu.Framework.Graphics.Textures
                 {
                     return null;
                 }
+
                 Logger.Log($"TextureAtlas size exceeded {++exceedCount} time(s); generating new texture ({atlasWidth}x{atlasHeight})", LoggingTarget.Performance);
                 Reset();
             }
+
             if (currentPosition.X + width > atlasWidth - PADDING)
             {
                 int maxY = 0;

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Graphics.Textures
             lock (textureRetrievalLock)
             {
                 var pos = findPosition(width, height);
-                
+
                 if(pos == null) return null;
 
                 Vector2I position = pos.Value;

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Graphics.Textures
             currentPosition = new Vector2I(Math.Max(currentPosition.X, PADDING), PADDING);
         }
 
-        private Vector2I findPosition(int width, int height)
+        private Vector2I? findPosition(int width, int height)
         {
             if (AtlasTexture == null)
             {
@@ -76,6 +76,11 @@ namespace osu.Framework.Graphics.Textures
             }
             if (currentPosition.Y + height > atlasHeight - PADDING)
             {
+                if (height > atlasHeight - PADDING - WHITE_PIXEL_SIZE
+                    && width > atlasWidth - PADDING - WHITE_PIXEL_SIZE)
+                {
+                    return null;
+                }
                 Logger.Log($"TextureAtlas size exceeded {++exceedCount} time(s); generating new texture ({atlasWidth}x{atlasHeight})", LoggingTarget.Performance);
                 Reset();
             }
@@ -106,13 +111,16 @@ namespace osu.Framework.Graphics.Textures
         /// <returns>A texture, or null if the requested size exceeds the atlas' bounds.</returns>
         internal TextureGL Add(int width, int height)
         {
-            if (width > atlasWidth - PADDING || height > atlasHeight - PADDING
-                || (width > atlasWidth - PADDING - WHITE_PIXEL_SIZE && height > atlasHeight - PADDING - WHITE_PIXEL_SIZE))
+            if (width > atlasWidth - PADDING || height > atlasHeight - PADDING)
                 return null;
 
             lock (textureRetrievalLock)
             {
-                Vector2I position = findPosition(width, height);
+                var pos = findPosition(width, height);
+                
+                if(pos == null) return null;
+
+                Vector2I position = pos.Value;
                 RectangleI bounds = new RectangleI(position.X, position.Y, width, height);
                 subTextureBounds.Add(bounds);
 

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -106,7 +106,8 @@ namespace osu.Framework.Graphics.Textures
         /// <returns>A texture, or null if the requested size exceeds the atlas' bounds.</returns>
         internal TextureGL Add(int width, int height)
         {
-            if (width > atlasWidth - PADDING || height > atlasHeight - PADDING)
+            if (width > atlasWidth - PADDING || height > atlasHeight - PADDING
+                || (width > atlasWidth - PADDING - WHITE_PIXEL_SIZE && height > atlasHeight - PADDING - WHITE_PIXEL_SIZE))
                 return null;
 
             lock (textureRetrievalLock)

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -74,12 +74,12 @@ namespace osu.Framework.Graphics.Textures
                 Logger.Log($"TextureAtlas initialised ({atlasWidth}x{atlasHeight})", LoggingTarget.Performance);
                 Reset();
             }
-            else if (currentPosition.Y + height > atlasHeight - PADDING)
+            if (currentPosition.Y + height > atlasHeight - PADDING)
             {
                 Logger.Log($"TextureAtlas size exceeded {++exceedCount} time(s); generating new texture ({atlasWidth}x{atlasHeight})", LoggingTarget.Performance);
                 Reset();
             }
-            else if (currentPosition.X + width > atlasWidth - PADDING)
+            if (currentPosition.X + width > atlasWidth - PADDING)
             {
                 int maxY = 0;
 
@@ -91,6 +91,7 @@ namespace osu.Framework.Graphics.Textures
 
                 return findPosition(width, height);
             }
+            Logger.Log($"{currentPosition.X} {currentPosition.Y} {width}x{height} {atlasWidth - PADDING}", LoggingTarget.Performance);
 
             var result = currentPosition;
             currentPosition.X += width + PADDING;
@@ -106,7 +107,7 @@ namespace osu.Framework.Graphics.Textures
         /// <returns>A texture, or null if the requested size exceeds the atlas' bounds.</returns>
         internal TextureGL Add(int width, int height)
         {
-            if (width > atlasWidth || height > atlasHeight)
+            if (width > atlasWidth - PADDING || height > atlasHeight - PADDING)
                 return null;
 
             lock (textureRetrievalLock)

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -91,7 +91,6 @@ namespace osu.Framework.Graphics.Textures
 
                 return findPosition(width, height);
             }
-            Logger.Log($"{currentPosition.X} {currentPosition.Y} {width}x{height} {atlasWidth - PADDING}", LoggingTarget.Performance);
 
             var result = currentPosition;
             currentPosition.X += width + PADDING;


### PR DESCRIPTION
There are 2 bugs fixed by this PR:

 * `Add` didn't account for the padding. This would either cause an infinite loop or create an invalid texture when the texture width or height was between 1008 and 1024.

 * If a new textureatlas was created inside `findPosition` with `Reset`, the position checks would be skipped after the atlas is created. Since the 24x24 white pixel has been added, textures with a width between 984 and 1008 would skip the X position check and would be offset outside the texture by the white pixel. To fix this, I made sure that the position checks were always performed.