### PR TITLE
Expose less backend-specific types in IWindow

### DIFF
--- a/osu.Framework/Extensions/BridgingExtensions.cs
+++ b/osu.Framework/Extensions/BridgingExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Platform;
 using TKVector2 = osuTK.Vector2;
 using SNVector2 = System.Numerics.Vector2;
 using SDPoint = System.Drawing.Point;
@@ -40,53 +41,91 @@ namespace osu.Framework.Extensions
         public static SNVector2 ToSystemNumerics(this VPoint point) =>
             new SNVector2(point.X, point.Y);
 
-        public static TKWindowState ToOsuTK(this VWindowState state)
+        public static TKWindowState ToOsuTK(this WindowState state)
         {
             switch (state)
             {
-                case VWindowState.Normal:
+                case WindowState.Normal:
                     return TKWindowState.Normal;
 
-                case VWindowState.FullScreen:
+                case WindowState.Fullscreen:
+                case WindowState.FullscreenBorderless:
                     return TKWindowState.Fullscreen;
 
-                case VWindowState.Maximized:
+                case WindowState.Maximised:
                     return TKWindowState.Maximized;
 
-                case VWindowState.Minimized:
+                case WindowState.Minimised:
                     return TKWindowState.Minimized;
-
-                case VWindowState.BorderlessFullScreen:
-                    // WARNING: not supported by osuTK.WindowState
-                    return TKWindowState.Fullscreen;
-
-                case VWindowState.Hidden:
-                    // WARNING: not supported by osuTK.WindowState
-                    return TKWindowState.Normal;
             }
 
             return TKWindowState.Normal;
         }
 
-        public static VWindowState ToVeldrid(this TKWindowState state)
+        public static VWindowState ToVeldrid(this WindowState state)
+        {
+            switch (state)
+            {
+                case WindowState.Normal:
+                    return VWindowState.Normal;
+
+                case WindowState.Minimised:
+                    return VWindowState.Minimized;
+
+                case WindowState.Maximised:
+                    return VWindowState.Maximized;
+
+                case WindowState.Fullscreen:
+                    return VWindowState.FullScreen;
+
+                case WindowState.FullscreenBorderless:
+                    return VWindowState.BorderlessFullScreen;
+            }
+
+            return VWindowState.Normal;
+        }
+
+        public static WindowState ToFramework(this VWindowState state)
+        {
+            switch (state)
+            {
+                case VWindowState.Normal:
+                    return WindowState.Normal;
+
+                case VWindowState.Minimized:
+                    return WindowState.Minimised;
+
+                case VWindowState.Maximized:
+                    return WindowState.Maximised;
+
+                case VWindowState.FullScreen:
+                    return WindowState.Fullscreen;
+
+                case VWindowState.BorderlessFullScreen:
+                    return WindowState.FullscreenBorderless;
+            }
+
+            return WindowState.Normal;
+        }
+
+        public static WindowState ToFramework(this TKWindowState state)
         {
             switch (state)
             {
                 case TKWindowState.Normal:
-                    return VWindowState.Normal;
+                    return WindowState.Normal;
 
                 case TKWindowState.Minimized:
-                    return VWindowState.Minimized;
+                    return WindowState.Minimised;
 
                 case TKWindowState.Maximized:
-                    return VWindowState.Maximized;
+                    return WindowState.Maximised;
 
                 case TKWindowState.Fullscreen:
-                    return VWindowState.FullScreen;
+                    return WindowState.Fullscreen;
             }
 
-            // WARNING: some cases not supported by osuTK.WindowState
-            return VWindowState.Normal;
+            return WindowState.Normal;
         }
     }
 }

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKMouseHandler.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                     host.InputThread.Scheduler.Add(scheduled = new ScheduledDelegate(delegate
                     {
                         // we should be getting events if the mouse is inside the window.
-                        if (MouseInWindow || !host.Window.Visible || host.Window.WindowState == WindowState.Minimized) return;
+                        if (MouseInWindow || !host.Window.Visible || host.Window.WindowState == osuTK.WindowState.Minimized) return;
 
                         var cursorState = osuTK.Input.Mouse.GetCursorState();
 

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
@@ -46,7 +46,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                 {
                     host.InputThread.Scheduler.Add(scheduled = new ScheduledDelegate(delegate
                     {
-                        if (!host.Window.Visible || host.Window.WindowState == WindowState.Minimized)
+                        if (!host.Window.Visible || host.Window.WindowState == osuTK.WindowState.Minimized)
                             return;
 
                         if ((MouseInWindow || lastEachDeviceStates.Any(s => s != null && s.Buttons.HasAnyButtonPressed)) && host.Window.Focused)

--- a/osu.Framework/Platform/DesktopGameWindow.cs
+++ b/osu.Framework/Platform/DesktopGameWindow.cs
@@ -93,13 +93,13 @@ namespace osu.Framework.Platform
 
             sizeFullscreen.ValueChanged += e =>
             {
-                if (WindowState == WindowState.Fullscreen)
+                if (WindowState == osuTK.WindowState.Fullscreen)
                     ChangeResolution(CurrentDisplay, e.NewValue);
             };
 
             sizeWindowed.ValueChanged += newSize =>
             {
-                if (WindowState == WindowState.Normal)
+                if (WindowState == osuTK.WindowState.Normal)
                     ClientSize = sizeWindowed.Value;
             };
 
@@ -222,7 +222,7 @@ namespace osu.Framework.Platform
                         ChangeResolution(currentDisplay, sizeFullscreen.Value);
                         lastFullscreenDisplay = currentDisplay;
 
-                        WindowState = WindowState.Fullscreen;
+                        WindowState = osuTK.WindowState.Fullscreen;
                         break;
 
                     case Configuration.WindowMode.Borderless:
@@ -230,7 +230,7 @@ namespace osu.Framework.Platform
                             RestoreResolution(lastFullscreenDisplay);
                         lastFullscreenDisplay = null;
 
-                        WindowState = WindowState.Maximized;
+                        WindowState = osuTK.WindowState.Maximized;
                         WindowBorder = WindowBorder.Hidden;
 
                         // must add 1 to enter borderless
@@ -245,7 +245,7 @@ namespace osu.Framework.Platform
 
                         var newSize = sizeWindowed.Value;
 
-                        WindowState = WindowState.Normal;
+                        WindowState = osuTK.WindowState.Normal;
                         WindowBorder = WindowBorder.Resizable;
 
                         ClientSize = newSize;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -40,7 +40,6 @@ using osu.Framework.Graphics.Video;
 using osu.Framework.IO.Stores;
 using SixLabors.Memory;
 using PixelFormat = osuTK.Graphics.ES30.PixelFormat;
-using WindowState = osuTK.WindowState;
 
 namespace osu.Framework.Platform
 {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -305,7 +305,7 @@ namespace osu.Framework.Platform
                 var windowedSize = Config.Get<Size>(FrameworkSetting.WindowedSize);
                 Root.Size = new Vector2(windowedSize.Width, windowedSize.Height);
             }
-            else if (Window.WindowState != WindowState.Minimized)
+            else if (Window.WindowState != osuTK.WindowState.Minimized)
                 Root.Size = new Vector2(Window.ClientSize.Width, Window.ClientSize.Height);
 
             // Ensure we maintain a valid size for any children immediately scaling by the window size

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -386,7 +386,7 @@ namespace osu.Framework.Platform
         {
             Window.SwapBuffers();
 
-            if (Window.VSync == VSyncMode.On)
+            if (Window.VerticalSync)
                 // without glFinish, vsync is basically unplayable due to the extra latency introduced.
                 // we will likely want to give the user control over this in the future as an advanced setting.
                 GL.Finish();
@@ -823,7 +823,7 @@ namespace osu.Framework.Platform
         {
             if (Window == null) return;
 
-            DrawThread.Scheduler.Add(() => Window.VSync = frameSyncMode.Value == FrameSync.VSync ? VSyncMode.On : VSyncMode.Off);
+            DrawThread.Scheduler.Add(() => Window.VerticalSync = frameSyncMode.Value == FrameSync.VSync);
         }
 
         protected abstract IEnumerable<InputHandler> CreateAvailableInputHandlers();

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -118,7 +118,7 @@ namespace osu.Framework.Platform
                 }
             };
 
-            WindowStateChanged += (o, e) => isActive.Value = WindowState != WindowState.Minimized;
+            WindowStateChanged += (o, e) => isActive.Value = WindowState != osuTK.WindowState.Minimized;
 
             MakeCurrent();
 
@@ -315,7 +315,7 @@ namespace osu.Framework.Platform
         public bool Exists => Implementation.Exists;
         public IWindowInfo WindowInfo => Implementation.WindowInfo;
 
-        public virtual WindowState WindowState
+        public virtual osuTK.WindowState WindowState
         {
             get => Implementation.WindowState;
             set => Implementation.WindowState = value;

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -260,6 +260,12 @@ namespace osu.Framework.Platform
 
         public virtual VSyncMode VSync { get; set; }
 
+        public bool VerticalSync
+        {
+            get => VSync == VSyncMode.On;
+            set => VSync = value ? VSyncMode.On : VSyncMode.Off;
+        }
+
         public virtual void CycleMode()
         {
             var currentValue = WindowMode.Value;

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Controls the vertical sync mode of the screen.
         /// </summary>
-        VSyncMode VSync { get; set; }
+        bool VerticalSync { get; set; }
 
         /// <summary>
         /// Returns the default <see cref="WindowMode"/> for the implementation.

--- a/osu.Framework/Platform/IWindowBackend.cs
+++ b/osu.Framework/Platform/IWindowBackend.cs
@@ -3,9 +3,10 @@
 
 using System;
 using System.Collections.Generic;
-using System.Numerics;
+using System.Drawing;
 using osu.Framework.Input.StateChanges;
 using Veldrid;
+using Point = System.Drawing.Point;
 
 namespace osu.Framework.Platform
 {
@@ -29,12 +30,12 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Returns or sets the window's position in screen space.
         /// </summary>
-        Vector2 Position { get; set; }
+        Point Position { get; set; }
 
         /// <summary>
         /// Returns or sets the window's internal size, before scaling.
         /// </summary>
-        Vector2 Size { get; set; }
+        Size Size { get; set; }
 
         /// <summary>
         /// Returns the scale of window's drawable area.
@@ -143,7 +144,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Invoked when the window moves.
         /// </summary>
-        event Action<Vector2> Moved;
+        event Action<Point> Moved;
 
         /// <summary>
         /// Invoked when the user scrolls the mouse wheel over the window.

--- a/osu.Framework/Platform/IWindowBackend.cs
+++ b/osu.Framework/Platform/IWindowBackend.cs
@@ -5,8 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using osu.Framework.Input.StateChanges;
-using Veldrid;
-using Point = System.Drawing.Point;
 
 namespace osu.Framework.Platform
 {

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Platform.MacOS
             base.Swap();
 
             // It has been reported that this helps performance on macOS (https://github.com/ppy/osu/issues/7447)
-            if (Window.VSync != VSyncMode.On)
+            if (!Window.VerticalSync)
                 GL.Finish();
         }
 

--- a/osu.Framework/Platform/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl2WindowBackend.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
-using System.Numerics;
 using osu.Framework.Caching;
 using osu.Framework.Extensions;
 using osu.Framework.Input.StateChanges;
@@ -15,7 +14,7 @@ using Veldrid.Sdl2;
 using Key = osuTK.Input.Key;
 using MouseButton = osuTK.Input.MouseButton;
 using MouseEvent = Veldrid.MouseEvent;
-using Point = Veldrid.Point;
+using Point = System.Drawing.Point;
 using TKVector2 = osuTK.Vector2;
 
 namespace osu.Framework.Platform
@@ -68,36 +67,36 @@ namespace osu.Framework.Platform
 
         public bool Exists => implementation?.Exists ?? false;
 
-        private Vector2 position = Vector2.Zero;
+        private Point position = Point.Empty;
 
-        public Vector2 Position
+        public Point Position
         {
-            get => implementation == null ? position : new Vector2(implementation.X, implementation.Y);
+            get => implementation == null ? position : new Point(implementation.X, implementation.Y);
             set
             {
                 position = value;
 
                 scheduler.Add(() =>
                 {
-                    implementation.X = (int)value.X;
-                    implementation.Y = (int)value.Y;
+                    implementation.X = value.X;
+                    implementation.Y = value.Y;
                 });
             }
         }
 
-        private Vector2 size = new Vector2(default_width, default_height);
+        private Size size = new Size(default_width, default_height);
 
-        public Vector2 Size
+        public Size Size
         {
-            get => implementation == null ? size : new Vector2(implementation.Width, implementation.Height);
+            get => implementation == null ? size : new Size(implementation.Width, implementation.Height);
             set
             {
                 size = value;
 
                 scheduler.Add(() =>
                 {
-                    implementation.Width = (int)value.X;
-                    implementation.Height = (int)value.Y;
+                    implementation.Width = value.Width;
+                    implementation.Height = value.Height;
                 });
             }
         }
@@ -183,7 +182,7 @@ namespace osu.Framework.Platform
         public event Action Hidden;
         public event Action MouseEntered;
         public event Action MouseLeft;
-        public event Action<Vector2> Moved;
+        public event Action<Point> Moved;
         public event Action<MouseScrollRelativeInput> MouseWheel;
         public event Action<MousePositionAbsoluteInput> MouseMove;
         public event Action<MouseButtonInput> MouseDown;
@@ -208,7 +207,7 @@ namespace osu.Framework.Platform
         protected virtual void OnHidden() => Hidden?.Invoke();
         protected virtual void OnMouseEntered() => MouseEntered?.Invoke();
         protected virtual void OnMouseLeft() => MouseLeft?.Invoke();
-        protected virtual void OnMoved(Vector2 point) => Moved?.Invoke(point);
+        protected virtual void OnMoved(Point point) => Moved?.Invoke(point);
         protected virtual void OnMouseWheel(MouseScrollRelativeInput evt) => MouseWheel?.Invoke(evt);
         protected virtual void OnMouseMove(MousePositionAbsoluteInput args) => MouseMove?.Invoke(args);
         protected virtual void OnMouseDown(MouseButtonInput evt) => MouseDown?.Invoke(evt);
@@ -229,7 +228,7 @@ namespace osu.Framework.Platform
                                     SDL_WindowFlags.AllowHighDpi |
                                     getWindowFlags(WindowState);
 
-            implementation = new Sdl2Window(Title, (int)position.X, (int)position.Y, (int)size.X, (int)size.Y, flags, false);
+            implementation = new Sdl2Window(Title, position.X, position.Y, size.Width, size.Height, flags, false);
 
             // force a refresh of the size and position now that we can calculate the scale
             scale.Invalidate();
@@ -288,7 +287,8 @@ namespace osu.Framework.Platform
         /// <param name="key">The key to validate.</param>
         private bool isKeyValid(Veldrid.Key key) => key != Veldrid.Key.Unknown && key != Veldrid.Key.CapsLock;
 
-        private void implementation_OnMoved(Point point) => Moved?.Invoke(new Vector2(point.X, point.Y));
+        private void implementation_OnMoved(Veldrid.Point point) =>
+            OnMoved(new Point(point.X, point.Y));
 
         private void implementation_OnMouseWheel(MouseWheelEventArgs args) =>
             OnMouseWheel(new MouseScrollRelativeInput { Delta = new TKVector2(0, args.WheelDelta) });

--- a/osu.Framework/Platform/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl2WindowBackend.cs
@@ -136,12 +136,12 @@ namespace osu.Framework.Platform
 
         public WindowState WindowState
         {
-            get => implementation?.WindowState ?? windowState;
+            get => implementation?.WindowState.ToFramework() ?? windowState;
             set
             {
                 windowState = value;
 
-                scheduler.Add(() => implementation.WindowState = value);
+                scheduler.Add(() => implementation.WindowState = value.ToVeldrid());
             }
         }
 
@@ -319,7 +319,7 @@ namespace osu.Framework.Platform
 
         private void implementation_Resized()
         {
-            if (implementation.WindowState != windowState)
+            if (implementation.WindowState.ToFramework() != windowState)
                 OnWindowStateChanged();
 
             OnResized();
@@ -332,20 +332,17 @@ namespace osu.Framework.Platform
                 case WindowState.Normal:
                     return 0;
 
-                case WindowState.FullScreen:
+                case WindowState.Fullscreen:
                     return SDL_WindowFlags.Fullscreen;
 
-                case WindowState.Maximized:
+                case WindowState.Maximised:
                     return SDL_WindowFlags.Maximized;
 
-                case WindowState.Minimized:
+                case WindowState.Minimised:
                     return SDL_WindowFlags.Minimized;
 
-                case WindowState.BorderlessFullScreen:
+                case WindowState.FullscreenBorderless:
                     return SDL_WindowFlags.FullScreenDesktop;
-
-                case WindowState.Hidden:
-                    return SDL_WindowFlags.Hidden;
             }
 
             return 0;

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -439,13 +439,13 @@ namespace osu.Framework.Platform
 
         public int Width
         {
-            get => (int)Size.Value.Width;
+            get => Size.Value.Width;
             set => Size.Value = new Size(value, Size.Value.Height);
         }
 
         public int Height
         {
-            get => (int)Size.Value.Height;
+            get => Size.Value.Height;
             set => Size.Value = new Size(Size.Value.Width, value);
         }
 

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -12,7 +12,6 @@ using osu.Framework.Input.StateChanges;
 using osuTK;
 using osuTK.Input;
 using osuTK.Platform;
-using Vector2 = System.Numerics.Vector2;
 using WindowState = Veldrid.WindowState;
 
 namespace osu.Framework.Platform
@@ -71,12 +70,12 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Provides a bindable that controls the window's position.
         /// </summary>
-        public Bindable<Vector2> Position { get; } = new Bindable<Vector2>();
+        public Bindable<Point> Position { get; } = new Bindable<Point>();
 
         /// <summary>
         /// Provides a bindable that controls the window's unscaled internal size.
         /// </summary>
-        public Bindable<Vector2> Size { get; } = new Bindable<Vector2>();
+        public Bindable<Size> Size { get; } = new Bindable<Size>();
 
         /// <summary>
         /// Provides a bindable that controls the window's <see cref="WindowState"/>.
@@ -168,7 +167,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Invoked when the window moves.
         /// </summary>
-        public event Action<Vector2> Moved;
+        public event Action<Point> Moved;
 
         /// <summary>
         /// Invoked when the user scrolls the mouse wheel over the window.
@@ -224,7 +223,7 @@ namespace osu.Framework.Platform
         protected virtual void OnHidden() => Hidden?.Invoke();
         protected virtual void OnMouseEntered() => MouseEntered?.Invoke();
         protected virtual void OnMouseLeft() => MouseLeft?.Invoke();
-        protected virtual void OnMoved(Vector2 point) => Moved?.Invoke(point);
+        protected virtual void OnMoved(Point point) => Moved?.Invoke(point);
         protected virtual void OnMouseWheel(MouseScrollRelativeInput evt) => MouseWheel?.Invoke(evt);
         protected virtual void OnMouseMove(MousePositionAbsoluteInput evt) => MouseMove?.Invoke(evt);
         protected virtual void OnMouseDown(MouseButtonInput evt) => MouseDown?.Invoke(evt);
@@ -359,7 +358,7 @@ namespace osu.Framework.Platform
             OnResized();
         }
 
-        private void windowBackend_Moved(Vector2 point)
+        private void windowBackend_Moved(Point point)
         {
             if (!boundsChanging)
             {
@@ -371,7 +370,7 @@ namespace osu.Framework.Platform
             OnMoved(point);
         }
 
-        private void position_ValueChanged(ValueChangedEvent<Vector2> evt)
+        private void position_ValueChanged(ValueChangedEvent<Point> evt)
         {
             if (boundsChanging)
                 return;
@@ -381,7 +380,7 @@ namespace osu.Framework.Platform
             boundsChanging = false;
         }
 
-        private void size_ValueChanged(ValueChangedEvent<Vector2> evt)
+        private void size_ValueChanged(ValueChangedEvent<Size> evt)
         {
             if (boundsChanging)
                 return;
@@ -410,61 +409,61 @@ namespace osu.Framework.Platform
             get => new Rectangle(X, Y, Width, Height);
             set
             {
-                Position.Value = new Vector2(value.X, value.Y);
-                Size.Value = new Vector2(value.Width, value.Height);
+                Position.Value = value.Location;
+                Size.Value = value.Size;
             }
         }
 
         public Point Location
         {
-            get => Position.Value.ToSystemDrawingPoint();
-            set => Position.Value = value.ToSystemNumerics();
+            get => Position.Value;
+            set => Position.Value = value;
         }
 
         Size INativeWindow.Size
         {
-            get => Size.Value.ToSystemDrawingSize();
-            set => Size.Value = value.ToSystemNumerics();
+            get => Size.Value;
+            set => Size.Value = value;
         }
 
         public int X
         {
-            get => (int)Position.Value.X;
-            set => Position.Value = new Vector2(value, Position.Value.Y);
+            get => Position.Value.X;
+            set => Position.Value = new Point(value, Position.Value.Y);
         }
 
         public int Y
         {
-            get => (int)Position.Value.Y;
-            set => Position.Value = new Vector2(Position.Value.X, value);
+            get => Position.Value.Y;
+            set => Position.Value = new Point(Position.Value.X, value);
         }
 
         public int Width
         {
-            get => (int)Size.Value.X;
-            set => Size.Value = new Vector2(value, Size.Value.Y);
+            get => (int)Size.Value.Width;
+            set => Size.Value = new Size(value, Size.Value.Height);
         }
 
         public int Height
         {
-            get => (int)Size.Value.Y;
-            set => Size.Value = new Vector2(Size.Value.X, value);
+            get => (int)Size.Value.Height;
+            set => Size.Value = new Size(Size.Value.Width, value);
         }
 
         public Rectangle ClientRectangle
         {
-            get => new Rectangle(Position.Value.ToSystemDrawingPoint(), (Size.Value * Scale).ToSystemDrawingSize());
+            get => new Rectangle(Position.Value.X, Position.Value.Y, (int)(Size.Value.Width * Scale), (int)(Size.Value.Height * Scale));
             set
             {
-                Position.Value = new Vector2(value.X, value.Y);
-                Size.Value = new Vector2(value.Width / Scale, value.Height / Scale);
+                Position.Value = value.Location;
+                Size.Value = new Size((int)(value.Width / Scale), (int)(value.Height / Scale));
             }
         }
 
         Size INativeWindow.ClientSize
         {
-            get => (Size.Value * Scale).ToSystemDrawingSize();
-            set => Size.Value = value.ToSystemNumerics() / Scale;
+            get => new Size((int)(Size.Value.Width * Scale), (int)(Size.Value.Height * Scale));
+            set => Size.Value = new Size((int)(value.Width / Scale), (int)(value.Height / Scale));
         }
 
         public MouseCursor Cursor { get; set; }

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -12,7 +12,6 @@ using osu.Framework.Input.StateChanges;
 using osuTK;
 using osuTK.Input;
 using osuTK.Platform;
-using WindowState = Veldrid.WindowState;
 
 namespace osu.Framework.Platform
 {
@@ -399,7 +398,7 @@ namespace osu.Framework.Platform
         osuTK.WindowState INativeWindow.WindowState
         {
             get => WindowState.Value.ToOsuTK();
-            set => WindowState.Value = value.ToVeldrid();
+            set => WindowState.Value = value.ToFramework();
         }
 
         public WindowBorder WindowBorder { get; set; }

--- a/osu.Framework/Platform/WindowState.cs
+++ b/osu.Framework/Platform/WindowState.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform
+{
+    public enum WindowState
+    {
+        Normal,
+        Fullscreen,
+        FullscreenBorderless,
+        Maximised,
+        Minimised
+    }
+}

--- a/osu.Framework/Platform/WindowState.cs
+++ b/osu.Framework/Platform/WindowState.cs
@@ -3,12 +3,39 @@
 
 namespace osu.Framework.Platform
 {
+    /// <summary>
+    /// Enumerates the available window states in the operating system.
+    /// </summary>
     public enum WindowState
     {
+        /// <summary>
+        /// The window is movable and takes up a subsection of the screen.
+        /// This is the default state.
+        /// </summary>
         Normal,
+
+        /// <summary>
+        /// The window is running in exclusive fullscreen and is potentially using a
+        /// different resolution to the desktop.
+        /// </summary>
         Fullscreen,
+
+        /// <summary>
+        /// The window is running in non-exclusive fullscreen, where it expands to fill the screen
+        /// at the native desktop resolution.
+        /// </summary>
         FullscreenBorderless,
+
+        /// <summary>
+        /// The window is running in maximised mode, usually triggered by clicking the operating
+        /// system's maximise button.
+        /// </summary>
         Maximised,
+
+        /// <summary>
+        /// The window is running in minimised mode, usually triggered by clicking the operating
+        /// system's minimise button.
+        /// </summary>
         Minimised
     }
 }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -36,7 +36,6 @@
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.149" />
     <PackageReference Include="StbiSharp" Version="1.0.11" />
-    <PackageReference Include="Veldrid" Version="4.7.0" />
     <PackageReference Include="Veldrid.Sdl2" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp'">


### PR DESCRIPTION
Partially cleans up `IWindow` and `Window` to expose osu!framework and .NET standard types rather than osuTK and/or Veldrid types.

Breaking changes for consumers (but not osu!):
* `IWindow.WindowState` now uses a framework enum rather than osuTK.
* `IWindow.VerticalSync` is now a bool rather than an osuTK enum.

A future PR will also remove/replace `CurrentDisplay` and `AvailableResolutions` as they currently use osuTK types, but that's a larger job and a breaking change for osu!.