### PR TITLE
Better support custom clocks in VideoSprite and Animation

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -52,11 +52,11 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddStep("Reset clock", () => clock.CurrentTime = 0);
         }
 
-        private void loadNewAnimation()
+        private void loadNewAnimation(bool startFromCurrent = true)
         {
             AddStep("load animation", () =>
             {
-                animationContainer.Child = animation = new TestAnimation
+                animationContainer.Child = animation = new TestAnimation(startFromCurrent)
                 {
                     Repeat = false,
                 };
@@ -96,6 +96,42 @@ namespace osu.Framework.Tests.Visual.Sprites
             loadNewAnimation();
 
             AddAssert("Animation is near start", () => animation.PlaybackPosition < 1000);
+        }
+
+        [Test]
+        public void TestStartFromOngoingTime()
+        {
+            AddWaitStep("Wait some", 20);
+
+            loadNewAnimation(false);
+
+            AddAssert("Animation is not near start", () => animation.PlaybackPosition > 1000);
+        }
+
+        [Test]
+        public void TestSetCustomClockWithCurrentTime()
+        {
+            AddAssert("Animation is near start", () => animation.PlaybackPosition < 1000);
+
+            AddUntilStep("Animation is not near start", () => animation.PlaybackPosition > 1000);
+
+            AddStep("Set custom clock", () => animation.Clock = new FramedOffsetClock(null) { Offset = 10000 });
+
+            AddAssert("Animation is near start", () => animation.PlaybackPosition < 1000);
+        }
+
+        [Test]
+        public void TestSetCustomClockWithOngoingTime()
+        {
+            loadNewAnimation(false);
+
+            AddAssert("Animation is near start", () => animation.PlaybackPosition < 1000);
+
+            AddUntilStep("Animation is not near start", () => animation.PlaybackPosition > 1000);
+
+            AddStep("Set custom clock", () => animation.Clock = new FramedOffsetClock(null) { Offset = 10000 });
+
+            AddAssert("Animation is not near start", () => animation.PlaybackPosition > 1000);
         }
 
         [Test]
@@ -158,7 +194,8 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             public int FramesProcessed;
 
-            public TestAnimation()
+            public TestAnimation(bool startFromCurrent)
+                : base(startFromCurrent)
             {
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -88,6 +88,9 @@ namespace osu.Framework.Graphics.Animations
             sourceClock ??= Clock;
             base.Clock = offsetClock = new FramedOffsetClock(sourceClock); // set source here to avoid constructing unused StopwatchClock.
             updateOffsetSource();
+
+            if (CurrentFrameIndex > 0)
+                offsetClock.Offset += frameData[CurrentFrameIndex].DisplayStartTime;
         }
 
         private IFrameBasedClock sourceClock;
@@ -155,7 +158,8 @@ namespace osu.Framework.Graphics.Animations
             else if (frameIndex >= frameData.Count)
                 frameIndex = frameData.Count - 1;
 
-            offsetClock.Offset = frameData[frameIndex].DisplayStartTime - offsetClock.Source.CurrentTime;
+            if (IsLoaded)
+                offsetClock.Offset = frameData[frameIndex].DisplayStartTime - offsetClock.Source.CurrentTime;
             currentFrameCache.Invalidate();
         }
 


### PR DESCRIPTION
With the [recent change](https://github.com/ppy/osu-framework/pull/3405) to allow rewinding animations, support for `GotoFrame` was limited to when a custom clock was not in use.

This change allows `GotoFrame` and `startAtCurrentTime` to be used in combination with custom clocks. It also tidies up implementation to be (mostly, bar `GotoFrame`) shared between `Animation` and `VideoSprite`