### PR TITLE
Fix freeze (and failure to exit) when exception is thrown in single threaded mode

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -248,6 +248,10 @@ namespace osu.Framework.Platform
 
                 //we want to throw this exception on the input thread to interrupt window and also headless execution.
                 InputThread.Scheduler.Add(() => { captured.Throw(); });
+
+                // schedule an exit to the input thread.
+                // this is required for single threaded execution, else the draw thread may get stuck looping before the above schedule finishes.
+                PerformExit(false);
             }
 
             Logger.Error(exception, $"An {exception.Data["unhandled"]} error has occurred.", recursive: true);


### PR DESCRIPTION
This was occurring due to the draw thread looping forever when no update frames are available:

https://github.com/ppy/osu-framework/blob/e4b92fd3733698117bac3a4681af0f748a154bcd/osu.Framework/Platform/GameHost.cs#L329-L337

In conjunction with the exception being sheduled to the input thread (which will only run after the draw thread exits):

https://github.com/ppy/osu-framework/blob/e4b92fd3733698117bac3a4681af0f748a154bcd/osu.Framework/Platform/GameHost.cs#L249-L250

Can't unit test this unfortunately, since headless tests don't run the draw thread (where this is occurring).

- Closes #3350.