### PR TITLE
Fix first sprite on new atlas page overlapping white pixel

### DIFF
--- a/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
+++ b/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
@@ -59,5 +59,31 @@ namespace osu.Framework.Tests.Graphics
                     message: $"Returned texture is null, but should have fit: {width}x{height}");
             }
         }
+
+        [Test]
+        public void TestAtlasFirstRowAddRespectsWhitePixelSize()
+        {
+            const int atlas_size = 1024;
+
+            var atlas = new TextureAtlas(atlas_size, atlas_size);
+
+            TextureGL texture = atlas.Add(64, 64);
+
+            RectangleF rect = texture.GetTextureRect(null);
+            Assert.GreaterOrEqual(atlas_size * rect.X, TextureAtlas.WHITE_PIXEL_SIZE + TextureAtlas.PADDING, message: "Texture is placed on top of the white pixel");
+        }
+
+        [Test]
+        public void TestAtlasSecondRowAddRespectsWhitePixelSize()
+        {
+            const int atlas_size = 1024;
+
+            var atlas = new TextureAtlas(atlas_size, atlas_size);
+
+            TextureGL texture = atlas.Add(1024 - 2 * TextureAtlas.PADDING, 64);
+
+            RectangleF rect = texture.GetTextureRect(null);
+            Assert.GreaterOrEqual(atlas_size * rect.Y, TextureAtlas.WHITE_PIXEL_SIZE + TextureAtlas.PADDING, message: "Texture is placed on top of the white pixel");
+        }
     }
 }

--- a/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
+++ b/osu.Framework.Tests/Graphics/TextureAtlasTest.cs
@@ -71,6 +71,7 @@ namespace osu.Framework.Tests.Graphics
 
             RectangleF rect = texture.GetTextureRect(null);
             Assert.GreaterOrEqual(atlas_size * rect.X, TextureAtlas.WHITE_PIXEL_SIZE + TextureAtlas.PADDING, message: "Texture is placed on top of the white pixel");
+            Assert.GreaterOrEqual(atlas_size * rect.Y, TextureAtlas.PADDING, message: "Texture has insufficient padding");
         }
 
         [Test]
@@ -80,9 +81,10 @@ namespace osu.Framework.Tests.Graphics
 
             var atlas = new TextureAtlas(atlas_size, atlas_size);
 
-            TextureGL texture = atlas.Add(1024 - 2 * TextureAtlas.PADDING, 64);
+            TextureGL texture = atlas.Add(atlas_size - 2 * TextureAtlas.PADDING, 64);
 
             RectangleF rect = texture.GetTextureRect(null);
+            Assert.GreaterOrEqual(atlas_size * rect.X, TextureAtlas.PADDING, message: "Texture has insufficient padding");
             Assert.GreaterOrEqual(atlas_size * rect.Y, TextureAtlas.WHITE_PIXEL_SIZE + TextureAtlas.PADDING, message: "Texture is placed on top of the white pixel");
         }
     }

--- a/osu.Framework/Graphics/Textures/TextureAtlas.cs
+++ b/osu.Framework/Graphics/Textures/TextureAtlas.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Graphics.Textures
             using (var whiteTex = new TextureGLSub(bounds, AtlasTexture))
                 whiteTex.SetData(new TextureUpload(new Image<Rgba32>(SixLabors.ImageSharp.Configuration.Default, whiteTex.Width, whiteTex.Height, Rgba32.White)));
 
-            currentPosition = new Vector2I(Math.Max(currentPosition.X, PADDING), PADDING);
+            currentPosition = new Vector2I(PADDING + WHITE_PIXEL_SIZE, PADDING);
         }
 
         /// <summary>


### PR DESCRIPTION
Resolves ppy/osu#8547.

# Summary

Due to recent changes in the texture atlas area (cf6558b, in particular), a scenario could arise in which the first sprite to be added on a page of the texture atlas would receive a position that partially overlaps the white pixel in the upper left corner of the atlas.

The regression was caused by no longer using the `Add()` method to add the white pixel to the atlas, but by manually creating the upload and sub-texture. Due to this, inside of `Reset()` `currentPosition` would first be set to `(0, 0)`, and then to `(PADDING, PADDING)`. The previous way, using `Add()`, would silently mutate the value of `currentPosition` and therefore work fine.

To resolve, manually set the current position in the atlas to ensure space for the white pixel on the X axis and additionally the necessary padding on both X and Y axes.

# Remarks

I debugged this using RenderDoc. Here are the captured atlas pages before & after this change:

| current `master` | this PR |
| :-: | :-: |
| ![before](https://user-images.githubusercontent.com/20418176/78180528-32239b00-7463-11ea-825d-47ae2ea62543.png) | ![after](https://user-images.githubusercontent.com/20418176/78180540-39e33f80-7463-11ea-91fa-8592836aba82.png) |

(best viewed in two tabs, by navigating back and forth - makes it really visually obvious what the change is)

The fact that the cursor trail was the one sprite that was drawn over the white pixel was sort of lucky, as it made the regression quite obvious. All things considered this could have manifested in a way subtler way and be a major pain.

The coordinate math in the test looks sort of dodgy as it's floats, but it's division/multiplication by powers-of-two, so it *should* remain accurate. (I tested this, it does the sane thing in IEEE 754 by just operating on the exponent and leaving the mantissa alone.)