### PR TITLE
Fix transforms being applied on an animation from a parent's LoadComplete occurring at an incorrect point in time

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -52,21 +52,6 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddStep("Reset clock", () => clock.CurrentTime = 0);
         }
 
-        private void loadNewAnimation(bool startFromCurrent = true, Action<TestAnimation> postLoadAction = null)
-        {
-            AddStep("load animation", () =>
-            {
-                animationContainer.Child = animation = new TestAnimation(startFromCurrent)
-                {
-                    Repeat = false,
-                };
-
-                postLoadAction?.Invoke(animation);
-            });
-
-            AddUntilStep("Wait for animation to load", () => animation.IsLoaded);
-        }
-
         [Test]
         public void TestFrameSeeking()
         {
@@ -179,6 +164,35 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             AddWaitStep("Wait for playback", 10);
             AddUntilStep("Looped", () => animation.PlaybackPosition < animation.Duration - 1000);
+        }
+
+        private void loadNewAnimation(bool startFromCurrent = true, Action<TestAnimation> postLoadAction = null)
+        {
+            AddStep("load animation", () =>
+            {
+                animationContainer.Child = animation = new TestAnimation(startFromCurrent)
+                {
+                    Repeat = false,
+                };
+
+                postLoadAction?.Invoke(animation);
+            });
+
+            AddUntilStep("Wait for animation to load", () => animation.IsLoaded);
+        }
+
+        [Test]
+        public void TestTransformBeforeLoaded()
+        {
+            AddStep("set time to future", () => clock.CurrentTime += 10000);
+
+            loadNewAnimation(postLoadAction: a =>
+            {
+                a.Alpha = 0;
+                a.FadeInFromZero(10).Then().FadeOutFromOne(1000);
+            });
+
+            AddAssert("Is visible", () => animation.Alpha > 0);
         }
 
         protected override void Update()

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -166,6 +166,20 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddUntilStep("Looped", () => animation.PlaybackPosition < animation.Duration - 1000);
         }
 
+        [Test]
+        public void TestTransformBeforeLoaded()
+        {
+            AddStep("set time to future", () => clock.CurrentTime += 10000);
+
+            loadNewAnimation(postLoadAction: a =>
+            {
+                a.Alpha = 0;
+                a.FadeInFromZero(10).Then().FadeOutFromOne(1000);
+            });
+
+            AddAssert("Is visible", () => animation.Alpha > 0);
+        }
+
         private void loadNewAnimation(bool startFromCurrent = true, Action<TestAnimation> postLoadAction = null)
         {
             AddStep("load animation", () =>
@@ -179,20 +193,6 @@ namespace osu.Framework.Tests.Visual.Sprites
             });
 
             AddUntilStep("Wait for animation to load", () => animation.IsLoaded);
-        }
-
-        [Test]
-        public void TestTransformBeforeLoaded()
-        {
-            AddStep("set time to future", () => clock.CurrentTime += 10000);
-
-            loadNewAnimation(postLoadAction: a =>
-            {
-                a.Alpha = 0;
-                a.FadeInFromZero(10).Then().FadeOutFromOne(1000);
-            });
-
-            AddAssert("Is visible", () => animation.Alpha > 0);
         }
 
         protected override void Update()

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics.Containers;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Caching;
 using osu.Framework.Timing;
 using osuTK;
@@ -81,12 +82,19 @@ namespace osu.Framework.Graphics.Animations
 
         private FramedOffsetClock offsetClock;
 
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            // set in BDL to ensure external operations get placed correctly (ie. a transform applied from a parent's LoadComplete.
+            base.Clock = offsetClock = new FramedOffsetClock(sourceClock ??= Clock); // set source here to avoid constructing unused StopwatchClock.
+            updateOffsetSource();
+        }
+
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            sourceClock ??= Clock;
-            base.Clock = offsetClock = new FramedOffsetClock(sourceClock); // set source here to avoid constructing unused StopwatchClock.
+            // run a second time to re-zero the clock.
             updateOffsetSource();
 
             if (CurrentFrameIndex > 0)
@@ -102,7 +110,7 @@ namespace osu.Framework.Graphics.Animations
             {
                 sourceClock = value;
 
-                if (IsLoaded)
+                if (LoadState >= LoadState.Loading)
                     updateOffsetSource();
             }
         }

--- a/osu.Framework/Graphics/Video/VideoSprite.cs
+++ b/osu.Framework/Graphics/Video/VideoSprite.cs
@@ -144,20 +144,23 @@ namespace osu.Framework.Graphics.Video
             decoder.Looping = Loop;
             State.BindTo(decoder.State);
             decoder.StartDecoding();
+
+            // set in BDL to ensure external operations get placed correctly (ie. a transform applied from a parent's LoadComplete.
+            base.Clock = offsetClock = new FramedOffsetClock(sourceClock ??= Clock); // set source here to avoid constructing unused StopwatchClock.
+            updateOffsetSource();
         }
 
         #region Clock Implementation (shared between VideoSprite and Animation)
-
-        private FramedOffsetClock offsetClock;
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
 
-            sourceClock ??= Clock;
-            base.Clock = offsetClock = new FramedOffsetClock(sourceClock); // set source here to avoid constructing unused StopwatchClock.
+            // run a second time to re-zero the clock.
             updateOffsetSource();
         }
+
+        private FramedOffsetClock offsetClock;
 
         private IFrameBasedClock sourceClock;
 


### PR DESCRIPTION
Proof of concept for testing purposes. Needs testing and application to `VideoSprite` if we go with this.