### PR TITLE
Ensure animation starts at zero if stopped before load complete

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddStep("Reset clock", () => clock.CurrentTime = 0);
         }
 
-        private void loadNewAnimation(bool startFromCurrent = true)
+        private void loadNewAnimation(bool startFromCurrent = true, Action<TestAnimation> postLoadAction = null)
         {
             AddStep("load animation", () =>
             {
@@ -60,6 +60,8 @@ namespace osu.Framework.Tests.Visual.Sprites
                 {
                     Repeat = false,
                 };
+
+                postLoadAction?.Invoke(animation);
             });
 
             AddUntilStep("Wait for animation to load", () => animation.IsLoaded);
@@ -96,6 +98,13 @@ namespace osu.Framework.Tests.Visual.Sprites
             loadNewAnimation();
 
             AddAssert("Animation is near start", () => animation.PlaybackPosition < 1000);
+        }
+
+        [Test]
+        public void TestStoppedAnimationIsAtZero()
+        {
+            loadNewAnimation(postLoadAction: a => a.Stop());
+            AddAssert("Animation is at start", () => animation.PlaybackPosition == 0);
         }
 
         [Test]

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -110,6 +110,8 @@ namespace osu.Framework.Graphics.Animations
         private void updateOffsetSource()
         {
             offsetClock.ChangeSource(sourceClock);
+            offsetClock.ProcessFrame();
+
             if (startAtCurrentTime)
                 offsetClock.Offset = -sourceClock.CurrentTime;
         }


### PR DESCRIPTION
Clock not being processed meant it had an incorrect time reference.