### PR TITLE
Ensure animation starts at correct frame/time if seeked+stopped to frame before load complete

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -108,6 +108,13 @@ namespace osu.Framework.Tests.Visual.Sprites
         }
 
         [Test]
+        public void TestStoppedAnimationIsAtSpecifiedFrame()
+        {
+            loadNewAnimation(postLoadAction: a => a.GotoAndStop(2));
+            AddAssert("Animation is at specific frame", () => animation.PlaybackPosition == 500);
+        }
+
+        [Test]
         public void TestStartFromOngoingTime()
         {
             AddWaitStep("Wait some", 20);

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -90,7 +90,8 @@ namespace osu.Framework.Graphics.Animations
             updateOffsetSource();
 
             if (CurrentFrameIndex > 0)
-                offsetClock.Offset += frameData[CurrentFrameIndex].DisplayStartTime;
+                // there may be a seek pending from before LoadComplete.
+                gotoCurrentFrame();
         }
 
         private IFrameBasedClock sourceClock;
@@ -155,13 +156,15 @@ namespace osu.Framework.Graphics.Animations
         /// <param name="frameIndex">The zero-based index of the frame to display.</param>
         public void GotoFrame(int frameIndex)
         {
-            if (frameIndex < 0)
-                frameIndex = 0;
-            else if (frameIndex >= frameData.Count)
-                frameIndex = frameData.Count - 1;
+            CurrentFrameIndex = Math.Clamp(frameIndex, 0, frameData.Count);
 
             if (IsLoaded)
-                offsetClock.Offset = frameData[frameIndex].DisplayStartTime - offsetClock.Source.CurrentTime;
+                gotoCurrentFrame();
+        }
+
+        private void gotoCurrentFrame()
+        {
+            offsetClock.Offset = frameData[CurrentFrameIndex].DisplayStartTime - sourceClock.CurrentTime;
             currentFrameCache.Invalidate();
         }
 


### PR DESCRIPTION
- [x] Depends on #3419 (for clock sanity).

Would have been nice to do this using a `Schedule` in `GotoFrame` but it turns out schedulers don't work so well if the clock isn't running.