### PR TITLE
Fix animations incorrectly processing a parent clock

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -117,9 +117,13 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             AddUntilStep("Animation is not near start", () => animation.PlaybackPosition > 1000);
 
+            double posBefore = 0;
+
+            AddStep("store position", () => posBefore = animation.PlaybackPosition);
+
             AddStep("Set custom clock", () => animation.Clock = new FramedOffsetClock(null) { Offset = 10000 });
 
-            AddAssert("Animation is near start", () => animation.PlaybackPosition < 1000);
+            AddAssert("Animation continued playing at current position", () => animation.PlaybackPosition - posBefore < 1000);
         }
 
         [Test]
@@ -177,7 +181,7 @@ namespace osu.Framework.Tests.Visual.Sprites
         [Test]
         public void TestTransformBeforeLoaded()
         {
-            AddStep("set time to future", () => clock.CurrentTime += 10000);
+            AddStep("set time to future", () => clock.CurrentTime = 10000);
 
             loadNewAnimation(postLoadAction: a =>
             {
@@ -186,6 +190,19 @@ namespace osu.Framework.Tests.Visual.Sprites
             });
 
             AddAssert("Is visible", () => animation.Alpha > 0);
+        }
+
+        [Test]
+        public void TestStartFromFutureTimeWithInitialSeek()
+        {
+            AddStep("set time to future", () => clock.CurrentTime = 10000);
+
+            loadNewAnimation(false, a =>
+            {
+                a.PlaybackPosition = -10000;
+            });
+
+            AddAssert("Animation is at beginning", () => animation.PlaybackPosition < 1000);
         }
 
         private void loadNewAnimation(bool startFromCurrent = true, Action<TestAnimation> postLoadAction = null)

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -23,7 +23,8 @@ namespace osu.Framework.Tests.Visual.Sprites
         public override IReadOnlyList<Type> RequiredTypes => new[]
         {
             typeof(TextureAnimation),
-            typeof(Animation<>)
+            typeof(Animation<>),
+            typeof(AnimationClockComposite)
         };
 
         private ManualClock clock;

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -165,7 +165,7 @@ namespace osu.Framework.Tests.Visual.Sprites
         [Test]
         public void TestAnimationLoopsIfEnabled()
         {
-            AddStep("Set looping", () => animation.Repeat = true);
+            AddStep("Set looping", () => animation.Loop = true);
             AddStep("Seek to end", () => clock.CurrentTime = animation.Duration - 2000);
             AddUntilStep("Animation seeked", () => animation.PlaybackPosition >= animation.Duration - 1000);
 
@@ -193,7 +193,7 @@ namespace osu.Framework.Tests.Visual.Sprites
             {
                 animationContainer.Child = animation = new TestAnimation(startFromCurrent)
                 {
-                    Repeat = false,
+                    Loop = false,
                 };
 
                 postLoadAction?.Invoke(animation);

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -213,7 +213,7 @@ namespace osu.Framework.Tests.Visual.Sprites
             private bool? useRoundedShader;
 
             public TestVideoSpriteDrawNode(TestVideo source)
-                : base(source.Sprite)
+                : base(source)
             {
                 this.source = source;
             }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -20,7 +20,7 @@ using osu.Framework.Timing;
 
 namespace osu.Framework.Tests.Visual.Sprites
 {
-    public class TestSceneVideoSprite : FrameworkTestScene
+    public class TestSceneVideo : FrameworkTestScene
     {
         private readonly Container videoContainer;
         private readonly SpriteText timeText;
@@ -30,10 +30,10 @@ namespace osu.Framework.Tests.Visual.Sprites
 
         private readonly ManualClock clock;
 
-        private TestVideoSprite videoSprite;
+        private TestVideo video;
         private MemoryStream videoStream;
 
-        public TestSceneVideoSprite()
+        public TestSceneVideo()
         {
             Children = new Drawable[]
             {
@@ -66,7 +66,7 @@ namespace osu.Framework.Tests.Visual.Sprites
         {
             AddStep("Reset clock", () => clock.CurrentTime = 0);
             loadNewVideo();
-            AddUntilStep("Wait for video to load", () => videoSprite.IsLoaded);
+            AddUntilStep("Wait for video to load", () => video.IsLoaded);
             AddStep("Reset clock", () => clock.CurrentTime = 0);
         }
 
@@ -82,7 +82,7 @@ namespace osu.Framework.Tests.Visual.Sprites
 
                 localStream.Seek(0, SeekOrigin.Begin);
 
-                videoContainer.Child = videoSprite = new TestVideoSprite(localStream)
+                videoContainer.Child = video = new TestVideo(localStream)
                 {
                     Loop = false,
                 };
@@ -92,58 +92,58 @@ namespace osu.Framework.Tests.Visual.Sprites
         [Test]
         public void TestStartFromCurrentTime()
         {
-            AddAssert("Video is near start", () => videoSprite.PlaybackPosition < 1000);
+            AddAssert("Video is near start", () => video.PlaybackPosition < 1000);
 
             AddWaitStep("Wait some", 20);
 
             loadNewVideo();
 
-            AddAssert("Video is near start", () => videoSprite.PlaybackPosition < 1000);
+            AddAssert("Video is near start", () => video.PlaybackPosition < 1000);
         }
 
         [Test]
         public void TestJumpForward()
         {
             AddStep("Jump ahead by 10 seconds", () => clock.CurrentTime += 10000);
-            AddUntilStep("Video seeked", () => videoSprite.PlaybackPosition >= 10000);
+            AddUntilStep("Video seeked", () => video.PlaybackPosition >= 10000);
         }
 
         [Test]
         public void TestJumpBack()
         {
             AddStep("Jump ahead by 30 seconds", () => clock.CurrentTime += 30000);
-            AddUntilStep("Video seeked", () => videoSprite.PlaybackPosition >= 30000);
+            AddUntilStep("Video seeked", () => video.PlaybackPosition >= 30000);
 
             AddStep("Jump back by 10 seconds", () => clock.CurrentTime -= 10000);
-            AddUntilStep("Video seeked", () => videoSprite.PlaybackPosition < 30000);
+            AddUntilStep("Video seeked", () => video.PlaybackPosition < 30000);
         }
 
         [Test]
         public void TestVideoDoesNotLoopIfDisabled()
         {
-            AddStep("Seek to end", () => clock.CurrentTime = videoSprite.Duration);
-            AddUntilStep("Video seeked", () => videoSprite.PlaybackPosition >= videoSprite.Duration - 1000);
+            AddStep("Seek to end", () => clock.CurrentTime = video.Duration);
+            AddUntilStep("Video seeked", () => video.PlaybackPosition >= video.Duration - 1000);
 
             AddWaitStep("Wait for playback", 10);
-            AddAssert("Not looped", () => videoSprite.PlaybackPosition >= videoSprite.Duration - 1000);
+            AddAssert("Not looped", () => video.PlaybackPosition >= video.Duration - 1000);
         }
 
         [Test]
         public void TestVideoLoopsIfEnabled()
         {
-            AddStep("Set looping", () => videoSprite.Loop = true);
-            AddStep("Seek to end", () => clock.CurrentTime = videoSprite.Duration);
+            AddStep("Set looping", () => video.Loop = true);
+            AddStep("Seek to end", () => clock.CurrentTime = video.Duration);
 
             AddWaitStep("Wait for playback", 10);
-            AddUntilStep("Looped", () => videoSprite.PlaybackPosition < videoSprite.Duration - 1000);
+            AddUntilStep("Looped", () => video.PlaybackPosition < video.Duration - 1000);
         }
 
         [Test]
         public void TestShader()
         {
-            AddStep("Set colour", () => videoSprite.Colour = Color4Extensions.FromHex("#ea7948").Opacity(0.75f));
-            AddStep("Use normal shader", () => videoSprite.UseRoundedShader = false);
-            AddStep("Use rounded shader", () => videoSprite.UseRoundedShader = true);
+            AddStep("Set colour", () => video.Colour = Color4Extensions.FromHex("#ea7948").Opacity(0.75f));
+            AddStep("Use normal shader", () => video.UseRoundedShader = false);
+            AddStep("Use rounded shader", () => video.UseRoundedShader = true);
         }
 
         private int currentSecond;
@@ -157,35 +157,37 @@ namespace osu.Framework.Tests.Visual.Sprites
             if (clock != null)
                 clock.CurrentTime += Clock.ElapsedFrameTime;
 
-            if (videoSprite != null)
+            if (video != null)
             {
-                var newSecond = (int)(videoSprite.PlaybackPosition / 1000.0);
+                var newSecond = (int)(video.PlaybackPosition / 1000.0);
 
                 if (newSecond != currentSecond)
                 {
                     currentSecond = newSecond;
-                    fps = videoSprite.FramesProcessed - lastFramesProcessed;
-                    lastFramesProcessed = videoSprite.FramesProcessed;
+                    fps = video.FramesProcessed - lastFramesProcessed;
+                    lastFramesProcessed = video.FramesProcessed;
                 }
 
                 if (timeText != null)
                 {
-                    timeText.Text = $"aim time: {videoSprite.PlaybackPosition:N2} | "
-                                    + $"video time: {videoSprite.CurrentFrameTime:N2} | "
-                                    + $"duration: {videoSprite.Duration:N2} | "
-                                    + $"buffered {videoSprite.AvailableFrames} | "
+                    timeText.Text = $"aim time: {video.PlaybackPosition:N2} | "
+                                    + $"video time: {video.CurrentFrameTime:N2} | "
+                                    + $"duration: {video.Duration:N2} | "
+                                    + $"buffered {video.AvailableFrames} | "
                                     + $"FPS: {fps} | "
                                     + $"State: {decoderState.Value}";
                 }
             }
         }
 
-        private class TestVideoSprite : VideoSprite
+        private class TestVideo : Video
         {
-            public TestVideoSprite([NotNull] Stream stream, bool startAtCurrentTime = true)
+            public TestVideo([NotNull] Stream stream, bool startAtCurrentTime = true)
                 : base(stream, startAtCurrentTime)
             {
             }
+
+            public new VideoSprite Sprite => base.Sprite;
 
             private bool? useRoundedShader;
 
@@ -204,20 +206,23 @@ namespace osu.Framework.Tests.Visual.Sprites
 
         private class TestVideoSpriteDrawNode : VideoSpriteDrawNode
         {
+            private readonly TestVideo source;
+
             protected override bool RequiresRoundedShader => useRoundedShader ?? base.RequiresRoundedShader;
 
             private bool? useRoundedShader;
 
-            public TestVideoSpriteDrawNode(VideoSprite source)
-                : base(source)
+            public TestVideoSpriteDrawNode(TestVideo source)
+                : base(source.Sprite)
             {
+                this.source = source;
             }
 
             public override void ApplyState()
             {
                 base.ApplyState();
 
-                useRoundedShader = ((TestVideoSprite)Source).UseRoundedShader;
+                useRoundedShader = source.UseRoundedShader;
             }
         }
     }

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -86,7 +86,7 @@ namespace osu.Framework.Graphics.Animations
         private void load()
         {
             // set in BDL to ensure external operations get placed correctly (ie. a transform applied from a parent's LoadComplete.
-            base.Clock = offsetClock = new FramedOffsetClock(sourceClock ??= Clock); // set source here to avoid constructing unused StopwatchClock.
+            base.Clock = offsetClock = new FramedOffsetClock(sourceClock ??= Clock, false); // set source here to avoid constructing unused StopwatchClock.
             updateOffsetSource();
         }
 

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Animations
     /// Represents a generic, frame-based animation. Inherit this class if you need custom animations.
     /// </summary>
     /// <typeparam name="T">The type of content in the frames of the animation.</typeparam>
-    public abstract class Animation<T> : CompositeDrawable, IAnimation
+    public abstract class Animation<T> : CompositeDrawable, IFramedAnimation
     {
         /// <summary>
         /// The duration in milliseconds of a newly added frame, if no duration is explicitly specified when adding the frame.
@@ -31,7 +31,7 @@ namespace osu.Framework.Graphics.Animations
         {
             get
             {
-                if (Repeat)
+                if (Loop)
                     return Clock.CurrentTime % Duration;
 
                 return Math.Min(Clock.CurrentTime, Duration);
@@ -59,7 +59,7 @@ namespace osu.Framework.Graphics.Animations
         /// <summary>
         /// True if the animation should start over from the first frame after finishing. False if it should stop playing and keep displaying the last frame when finishing.
         /// </summary>
-        public bool Repeat { get; set; }
+        public bool Loop { get; set; }
 
         public T CurrentFrame => frameData[CurrentFrameIndex].Content;
 
@@ -75,7 +75,7 @@ namespace osu.Framework.Graphics.Animations
 
             frameData = new List<FrameData<T>>();
             IsPlaying = true;
-            Repeat = true;
+            Loop = true;
         }
 
         #region Clock Implementation (shared between VideoSprite and Animation)
@@ -157,6 +157,8 @@ namespace osu.Framework.Graphics.Animations
                 Height = value.Y;
             }
         }
+
+        public void Seek(double time) => offsetClock.Offset = time - sourceClock.CurrentTime;
 
         /// <summary>
         /// Displays the frame with the given zero-based frame index.

--- a/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
+++ b/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
@@ -1,0 +1,97 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Timing;
+
+namespace osu.Framework.Graphics.Animations
+{
+    public abstract class AnimationClockComposite : CompositeDrawable, IAnimation
+    {
+        private readonly bool startAtCurrentTime;
+
+        private ManualClock manualClock;
+
+        /// <summary>
+        /// Construct a new animation.
+        /// </summary>
+        /// <param name="startAtCurrentTime">Whether the current clock time should be assumed as the 0th animation frame.</param>
+        protected AnimationClockComposite(bool startAtCurrentTime = true)
+        {
+            this.startAtCurrentTime = startAtCurrentTime;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            base.AddInternal(new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Clock = new FramedClock(manualClock = new ManualClock()),
+                Child = CreateContent()
+            });
+        }
+
+        public override IFrameBasedClock Clock
+        {
+            get => base.Clock;
+            set
+            {
+                base.Clock = value;
+
+                manualClock.CurrentTime = !startAtCurrentTime ? Clock.CurrentTime : 0;
+            }
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            if (!startAtCurrentTime)
+                manualClock.CurrentTime = Clock.CurrentTime;
+        }
+
+        protected internal override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(CreateContent)} instead.");
+
+        /// <summary>
+        /// Create the content container for animation display.
+        /// </summary>
+        /// <returns></returns>
+        public abstract Drawable CreateContent();
+
+        protected override void Update()
+        {
+            base.Update();
+
+            if (IsPlaying)
+                manualClock.CurrentTime += Time.Elapsed;
+        }
+
+        /// <summary>
+        /// The current playback position of the animation, in milliseconds.
+        /// </summary>
+        public double PlaybackPosition
+        {
+            get
+            {
+                if (Loop)
+                    return manualClock.CurrentTime % Duration;
+
+                return Math.Min(manualClock.CurrentTime, Duration);
+            }
+        }
+
+        public double Duration { get; protected set; }
+
+        public bool IsPlaying { get; set; } = true;
+
+        public bool Loop { get; set; }
+
+        public void Seek(double time) => manualClock.CurrentTime = time;
+    }
+}

--- a/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
+++ b/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Containers;
@@ -65,7 +62,7 @@ namespace osu.Framework.Graphics.Animations
         /// <summary>
         /// Create the content container for animation display.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The container providing the content to be added into this <see cref="AnimationClockComposite"/>'s hierarchy.</returns>
         public abstract Drawable CreateContent();
 
         private double lastConsumedTime;

--- a/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
+++ b/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.Animations
     {
         private readonly bool startAtCurrentTime;
 
-        private ManualClock manualClock;
+        private readonly ManualClock manualClock = new ManualClock();
 
         /// <summary>
         /// Construct a new animation.
@@ -32,7 +32,7 @@ namespace osu.Framework.Graphics.Animations
             base.AddInternal(new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Clock = new FramedClock(manualClock = new ManualClock()),
+                Clock = new FramedClock(manualClock),
                 Child = CreateContent()
             });
         }
@@ -84,6 +84,7 @@ namespace osu.Framework.Graphics.Animations
 
                 return Math.Min(manualClock.CurrentTime, Duration);
             }
+            set => manualClock.CurrentTime = value;
         }
 
         public double Duration { get; protected set; }
@@ -92,6 +93,6 @@ namespace osu.Framework.Graphics.Animations
 
         public virtual bool Loop { get; set; }
 
-        public void Seek(double time) => manualClock.CurrentTime = time;
+        public void Seek(double time) => PlaybackPosition = time;
     }
 }

--- a/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
+++ b/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
@@ -90,7 +90,7 @@ namespace osu.Framework.Graphics.Animations
 
         public bool IsPlaying { get; set; } = true;
 
-        public bool Loop { get; set; }
+        public virtual bool Loop { get; set; }
 
         public void Seek(double time) => manualClock.CurrentTime = time;
     }

--- a/osu.Framework/Graphics/Animations/AnimationExtensions.cs
+++ b/osu.Framework/Graphics/Animations/AnimationExtensions.cs
@@ -4,7 +4,7 @@
 namespace osu.Framework.Graphics.Animations
 {
     /// <summary>
-    /// This class holds various extension methods for the <see cref="IAnimation"/> interface.
+    /// This class holds various extension methods for the <see cref="IFramedAnimation"/> interface.
     /// </summary>
     public static class AnimationExtensions
     {
@@ -13,7 +13,7 @@ namespace osu.Framework.Graphics.Animations
         /// </summary>
         /// <param name="animation">The animation that should seek the frame and stop playing.</param>
         /// <param name="frameIndex">The zero-based index of the frame to display.</param>
-        public static void GotoAndStop(this IAnimation animation, int frameIndex)
+        public static void GotoAndStop(this IFramedAnimation animation, int frameIndex)
         {
             animation.GotoFrame(frameIndex);
             animation.IsPlaying = false;
@@ -24,7 +24,7 @@ namespace osu.Framework.Graphics.Animations
         /// </summary>
         /// <param name="animation">The animation that should seek the frame and start playing.</param>
         /// <param name="frameIndex">The zero-based index of the frame to display.</param>
-        public static void GotoAndPlay(this IAnimation animation, int frameIndex)
+        public static void GotoAndPlay(this IFramedAnimation animation, int frameIndex)
         {
             animation.GotoFrame(frameIndex);
             animation.IsPlaying = true;
@@ -34,18 +34,18 @@ namespace osu.Framework.Graphics.Animations
         /// Resumes playing the animation.
         /// </summary>
         /// <param name="animation">The animation to play.</param>
-        public static void Play(this IAnimation animation) => animation.IsPlaying = true;
+        public static void Play(this IFramedAnimation animation) => animation.IsPlaying = true;
 
         /// <summary>
         /// Stops playing the animation.
         /// </summary>
         /// <param name="animation">The animation to stop playing.</param>
-        public static void Stop(this IAnimation animation) => animation.IsPlaying = false;
+        public static void Stop(this IFramedAnimation animation) => animation.IsPlaying = false;
 
         /// <summary>
         /// Restarts the animation.
         /// </summary>
         /// <param name="animation">The animation to restart.</param>
-        public static void Restart(this IAnimation animation) => animation.GotoAndPlay(0);
+        public static void Restart(this IFramedAnimation animation) => animation.GotoAndPlay(0);
     }
 }

--- a/osu.Framework/Graphics/Animations/DrawableAnimation.cs
+++ b/osu.Framework/Graphics/Animations/DrawableAnimation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Graphics.Containers;
 using osuTK;
 
 namespace osu.Framework.Graphics.Animations
@@ -10,11 +11,11 @@ namespace osu.Framework.Graphics.Animations
     /// </summary>
     public class DrawableAnimation : Animation<Drawable>
     {
-        protected override void DisplayFrame(Drawable content)
-        {
-            ClearInternal(false);
-            AddInternal(content);
-        }
+        private Container container;
+
+        protected override void DisplayFrame(Drawable content) => container.Child = content;
+
+        public override Drawable CreateContent() => container = new Container { RelativeSizeAxes = Axes.Both };
 
         protected override Vector2 GetFrameSize(Drawable content) => new Vector2(content.DrawWidth, content.DrawHeight);
     }

--- a/osu.Framework/Graphics/Animations/FramedAnimationExtensions.cs
+++ b/osu.Framework/Graphics/Animations/FramedAnimationExtensions.cs
@@ -6,7 +6,7 @@ namespace osu.Framework.Graphics.Animations
     /// <summary>
     /// This class holds various extension methods for the <see cref="IFramedAnimation"/> interface.
     /// </summary>
-    public static class AnimationExtensions
+    public static class FramedAnimationExtensions
     {
         /// <summary>
         /// Displays the frame with the given zero-based frame index and stops the animation at that frame.

--- a/osu.Framework/Graphics/Animations/IAnimation.cs
+++ b/osu.Framework/Graphics/Animations/IAnimation.cs
@@ -37,6 +37,6 @@ namespace osu.Framework.Graphics.Animations
         /// <summary>
         /// The current position of playback.
         /// </summary>
-        public double PlaybackPosition { get; }
+        public double PlaybackPosition { get; set; }
     }
 }

--- a/osu.Framework/Graphics/Animations/IAnimation.cs
+++ b/osu.Framework/Graphics/Animations/IAnimation.cs
@@ -9,12 +9,12 @@ namespace osu.Framework.Graphics.Animations
     public interface IAnimation
     {
         /// <summary>
-        /// The duration of the video that is being played. Can only be queried after the decoder has started decoding has loaded. This value may be an estimate by FFmpeg, depending on the video loaded.
+        /// The duration of the animation. Can only be queried after the decoder has started decoding has loaded. This value may be an estimate by FFmpeg, depending on the video loaded.
         /// </summary>
         public double Duration { get; }
 
         /// <summary>
-        /// True if the video has finished playing, false otherwise.
+        /// True if the animation has finished playing, false otherwise.
         /// </summary>
         public bool FinishedPlaying => !Loop && PlaybackPosition > Duration;
 
@@ -31,7 +31,7 @@ namespace osu.Framework.Graphics.Animations
         /// <summary>
         /// Seek the animation to a specific time value.
         /// </summary>
-        /// <param name="time"></param>
+        /// <param name="time">The time value to seek to.</param>
         void Seek(double time);
 
         /// <summary>

--- a/osu.Framework/Graphics/Animations/IAnimation.cs
+++ b/osu.Framework/Graphics/Animations/IAnimation.cs
@@ -4,34 +4,39 @@
 namespace osu.Framework.Graphics.Animations
 {
     /// <summary>
-    /// Represents a generic, frame-based animation.
+    /// An animation / playback sequence.
     /// </summary>
     public interface IAnimation
     {
         /// <summary>
-        /// The number of frames this animation has.
+        /// The duration of the video that is being played. Can only be queried after the decoder has started decoding has loaded. This value may be an estimate by FFmpeg, depending on the video loaded.
         /// </summary>
-        int FrameCount { get; }
+        public double Duration { get; }
 
         /// <summary>
-        /// The currently visible frame's index.
+        /// True if the video has finished playing, false otherwise.
         /// </summary>
-        int CurrentFrameIndex { get; }
+        public bool FinishedPlaying => !Loop && PlaybackPosition > Duration;
 
         /// <summary>
-        /// True if the animation is playing, false otherwise.
+        /// True if the animation is playing, false otherwise. Starts true.
         /// </summary>
         bool IsPlaying { get; set; }
 
         /// <summary>
         /// True if the animation should start over from the first frame after finishing. False if it should stop playing and keep displaying the last frame when finishing.
         /// </summary>
-        bool Repeat { get; set; }
+        bool Loop { get; set; }
 
         /// <summary>
-        /// Displays the frame with the given zero-based frame index.
+        /// Seek the animation to a specific time value.
         /// </summary>
-        /// <param name="frameIndex">The zero-based index of the frame to display.</param>
-        void GotoFrame(int frameIndex);
+        /// <param name="time"></param>
+        void Seek(double time);
+
+        /// <summary>
+        /// The current position of playback.
+        /// </summary>
+        public double PlaybackPosition { get; }
     }
 }

--- a/osu.Framework/Graphics/Animations/IAnimation.cs
+++ b/osu.Framework/Graphics/Animations/IAnimation.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Graphics.Animations
     public interface IAnimation
     {
         /// <summary>
-        /// The duration of the animation. Can only be queried after the decoder has started decoding has loaded. This value may be an estimate by FFmpeg, depending on the video loaded.
+        /// The duration of the animation.
         /// </summary>
         public double Duration { get; }
 

--- a/osu.Framework/Graphics/Animations/IAnimation.cs
+++ b/osu.Framework/Graphics/Animations/IAnimation.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Graphics.Animations
         public bool FinishedPlaying => !Loop && PlaybackPosition > Duration;
 
         /// <summary>
-        /// True if the animation is playing, false otherwise. Starts true.
+        /// True if the animation is playing, false otherwise. <c>true</c> by default.
         /// </summary>
         bool IsPlaying { get; set; }
 

--- a/osu.Framework/Graphics/Animations/IFramedAnimation.cs
+++ b/osu.Framework/Graphics/Animations/IFramedAnimation.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 namespace osu.Framework.Graphics.Animations
 {
     /// <summary>

--- a/osu.Framework/Graphics/Animations/IFramedAnimation.cs
+++ b/osu.Framework/Graphics/Animations/IFramedAnimation.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Animations
+{
+    /// <summary>
+    /// An animation with well-defined frames.
+    /// </summary>
+    public interface IFramedAnimation : IAnimation
+    {
+        /// <summary>
+        /// The number of frames this animation has.
+        /// </summary>
+        int FrameCount { get; }
+
+        /// <summary>
+        /// The currently visible frame's index.
+        /// </summary>
+        int CurrentFrameIndex { get; }
+
+        /// <summary>
+        /// Displays the frame with the given zero-based frame index.
+        /// </summary>
+        /// <param name="frameIndex">The zero-based index of the frame to display.</param>
+        void GotoFrame(int frameIndex);
+    }
+}

--- a/osu.Framework/Graphics/Animations/TextureAnimation.cs
+++ b/osu.Framework/Graphics/Animations/TextureAnimation.cs
@@ -12,23 +12,21 @@ namespace osu.Framework.Graphics.Animations
     /// </summary>
     public class TextureAnimation : Animation<Texture>
     {
-        private readonly Sprite textureHolder;
+        private Sprite textureHolder;
 
         public TextureAnimation(bool startAtCurrentTime = true)
             : base(startAtCurrentTime)
         {
-            InternalChild = textureHolder = new Sprite
-            {
-                RelativeSizeAxes = Axes.Both,
-                Anchor = Anchor.Centre,
-                Origin = Anchor.Centre,
-            };
         }
 
-        protected override void DisplayFrame(Texture content)
+        public override Drawable CreateContent() => textureHolder = new Sprite
         {
-            textureHolder.Texture = content;
-        }
+            RelativeSizeAxes = Axes.Both,
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+        };
+
+        protected override void DisplayFrame(Texture content) => textureHolder.Texture = content;
 
         protected override Vector2 GetFrameSize(Texture content) => new Vector2(content?.DisplayWidth ?? 0, content?.DisplayHeight ?? 0);
     }

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -56,7 +56,6 @@ namespace osu.Framework.Graphics.Video
         private VideoDecoder decoder;
 
         private readonly Stream stream;
-        private readonly bool startAtCurrentTime;
 
         private readonly Queue<DecodedFrame> availableFrames = new Queue<DecodedFrame>();
 
@@ -80,9 +79,7 @@ namespace osu.Framework.Graphics.Video
         /// Creates a new <see cref="Video"/>.
         /// </summary>
         /// <param name="filename">The video file.</param>
-        /// <param name="startAtCurrentTime">Whether the current clock time should be assumed as the 0th video frame.<br />
-        /// If <code>true</code>, the current clock time will be assumed as the 0th video frame. A custom <see cref="Clock"/> cannot be set.<br />
-        /// If <code>false</code>, a current clock time of 0 will be assumed as the 0th video frame. A custom <see cref="Clock"/> can be set.</param>
+        /// <param name="startAtCurrentTime">Whether the current clock time should be assumed as the 0th video frame.</param>
         public Video(string filename, bool startAtCurrentTime = true)
             : this(File.OpenRead(filename), startAtCurrentTime)
         {
@@ -94,13 +91,10 @@ namespace osu.Framework.Graphics.Video
         /// Creates a new <see cref="Video"/>.
         /// </summary>
         /// <param name="stream">The video file stream.</param>
-        /// <param name="startAtCurrentTime">Whether the current clock time should be assumed as the 0th video frame.<br />
-        /// If <code>true</code>, the current clock time will be assumed as the 0th video frame. A custom <see cref="Clock"/> cannot be set.<br />
-        /// If <code>false</code>, a current clock time of 0 will be assumed as the 0th video frame. A custom <see cref="Clock"/> can be set.</param>
+        /// <param name="startAtCurrentTime">Whether the current clock time should be assumed as the 0th video frame.</param>
         public Video([NotNull] Stream stream, bool startAtCurrentTime = true)
         {
             this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
-            this.startAtCurrentTime = startAtCurrentTime;
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Animations;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Graphics.Shaders;
+using osuTK;
 
 namespace osu.Framework.Graphics.Video
 {
@@ -73,7 +74,12 @@ namespace osu.Framework.Graphics.Video
 
         private bool isDisposed;
 
-        protected VideoSprite Sprite;
+        internal VideoSprite Sprite;
+
+        /// <summary>
+        /// YUV->RGB conversion matrix based on the video colorspace
+        /// </summary>
+        public Matrix3 ConversionMatrix => decoder.GetConversionMatrix();
 
         /// <summary>
         /// Creates a new <see cref="Video"/>.
@@ -85,7 +91,7 @@ namespace osu.Framework.Graphics.Video
         {
         }
 
-        public override Drawable CreateContent() => Sprite = new VideoSprite();
+        public override Drawable CreateContent() => Sprite = new VideoSprite(this);
 
         /// <summary>
         /// Creates a new <see cref="Video"/>.
@@ -104,9 +110,6 @@ namespace osu.Framework.Graphics.Video
             decoder.Looping = Loop;
             State.BindTo(decoder.State);
             decoder.StartDecoding();
-
-            // must be set post-construction (ie. can't be in CreateContent) due to load order.
-            Sprite.Decoder = decoder;
 
             Duration = decoder.Duration;
         }

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -1,0 +1,184 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using JetBrains.Annotations;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Animations;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Graphics.Shaders;
+
+namespace osu.Framework.Graphics.Video
+{
+    /// <summary>
+    /// Represents a sprite that plays back a video from a stream or a file.
+    /// </summary>
+    public class Video : AnimationClockComposite, IAnimation
+    {
+        /// <summary>
+        /// Whether this video is in a buffering state, waiting on decoder or underlying stream.
+        /// </summary>
+        public bool Buffering { get; private set; }
+
+        /// <summary>
+        /// True if the video should loop after finishing its playback, false otherwise.
+        /// </summary>
+        public override bool Loop
+        {
+            get => base.Loop;
+            set
+            {
+                if (decoder != null)
+                    decoder.Looping = value;
+
+                base.Loop = value;
+            }
+        }
+
+        /// <summary>
+        /// True if this VideoSprites decoding process has faulted.
+        /// </summary>
+        public bool IsFaulted => decoder?.IsFaulted ?? false;
+
+        /// <summary>
+        /// The current state of the <see cref="VideoDecoder"/>, as a bindable.
+        /// </summary>
+        public readonly IBindable<VideoDecoder.DecoderState> State = new Bindable<VideoDecoder.DecoderState>();
+
+        internal double CurrentFrameTime => lastFrame?.Time ?? 0;
+
+        internal int AvailableFrames => availableFrames.Count;
+
+        private VideoDecoder decoder;
+
+        private readonly Stream stream;
+        private readonly bool startAtCurrentTime;
+
+        private readonly Queue<DecodedFrame> availableFrames = new Queue<DecodedFrame>();
+
+        private DecodedFrame lastFrame;
+
+        /// <summary>
+        /// The total number of frames processed by this instance.
+        /// </summary>
+        public int FramesProcessed { get; private set; }
+
+        /// <summary>
+        /// The length in milliseconds that the decoder can be out of sync before a seek is automatically performed.
+        /// </summary>
+        private const float lenience_before_seek = 2500;
+
+        private bool isDisposed;
+
+        protected VideoSprite Sprite;
+
+        /// <summary>
+        /// Creates a new <see cref="Video"/>.
+        /// </summary>
+        /// <param name="filename">The video file.</param>
+        /// <param name="startAtCurrentTime">Whether the current clock time should be assumed as the 0th video frame.<br />
+        /// If <code>true</code>, the current clock time will be assumed as the 0th video frame. A custom <see cref="Clock"/> cannot be set.<br />
+        /// If <code>false</code>, a current clock time of 0 will be assumed as the 0th video frame. A custom <see cref="Clock"/> can be set.</param>
+        public Video(string filename, bool startAtCurrentTime = true)
+            : this(File.OpenRead(filename), startAtCurrentTime)
+        {
+        }
+
+        public override Drawable CreateContent() => Sprite = new VideoSprite();
+
+        /// <summary>
+        /// Creates a new <see cref="Video"/>.
+        /// </summary>
+        /// <param name="stream">The video file stream.</param>
+        /// <param name="startAtCurrentTime">Whether the current clock time should be assumed as the 0th video frame.<br />
+        /// If <code>true</code>, the current clock time will be assumed as the 0th video frame. A custom <see cref="Clock"/> cannot be set.<br />
+        /// If <code>false</code>, a current clock time of 0 will be assumed as the 0th video frame. A custom <see cref="Clock"/> can be set.</param>
+        public Video([NotNull] Stream stream, bool startAtCurrentTime = true)
+        {
+            this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
+            this.startAtCurrentTime = startAtCurrentTime;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost gameHost, ShaderManager shaders)
+        {
+            decoder = gameHost.CreateVideoDecoder(stream, Scheduler);
+            decoder.Looping = Loop;
+            State.BindTo(decoder.State);
+            decoder.StartDecoding();
+
+            // must be set post-construction (ie. can't be in CreateContent) due to load order.
+            Sprite.Decoder = decoder;
+
+            Duration = decoder.Duration;
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var nextFrame = availableFrames.Count > 0 ? availableFrames.Peek() : null;
+
+            if (nextFrame != null)
+            {
+                bool tooFarBehind = Math.Abs(PlaybackPosition - nextFrame.Time) > lenience_before_seek &&
+                                    (!Loop ||
+                                     Math.Abs(PlaybackPosition - decoder.Duration - nextFrame.Time) > lenience_before_seek &&
+                                     Math.Abs(PlaybackPosition + decoder.Duration - nextFrame.Time) > lenience_before_seek
+                                    );
+
+                // we are too far ahead or too far behind
+                if (tooFarBehind && decoder.CanSeek)
+                {
+                    Logger.Log($"Video too far out of sync ({nextFrame.Time}), seeking to {PlaybackPosition}");
+                    decoder.Seek(PlaybackPosition);
+                    decoder.ReturnFrames(availableFrames);
+                    availableFrames.Clear();
+                }
+            }
+
+            var frameTime = CurrentFrameTime;
+
+            while (availableFrames.Count > 0 && availableFrames.Peek().Time <= PlaybackPosition && Math.Abs(availableFrames.Peek().Time - PlaybackPosition) < lenience_before_seek)
+            {
+                if (lastFrame != null) decoder.ReturnFrames(new[] { lastFrame });
+                lastFrame = availableFrames.Dequeue();
+
+                var tex = lastFrame.Texture;
+
+                // Check if the new frame has been uploaded so we don't display an old frame
+                if ((tex?.TextureGL as VideoTexture)?.UploadComplete ?? false)
+                    Sprite.Texture = tex;
+            }
+
+            if (availableFrames.Count == 0)
+            {
+                foreach (var f in decoder.GetDecodedFrames())
+                    availableFrames.Enqueue(f);
+            }
+
+            Buffering = decoder.IsRunning && availableFrames.Count == 0;
+
+            if (frameTime != CurrentFrameTime)
+                FramesProcessed++;
+        }
+
+        protected override void Dispose(bool isDisposing)
+        {
+            if (isDisposed)
+                return;
+
+            base.Dispose(isDisposing);
+
+            isDisposed = true;
+            decoder?.Dispose();
+
+            foreach (var f in availableFrames)
+                f.Texture.Dispose();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Graphics.Video
     /// <summary>
     /// Represents a sprite that plays back a video from a stream or a file.
     /// </summary>
-    public class Video : AnimationClockComposite, IAnimation
+    public class Video : AnimationClockComposite
     {
         /// <summary>
         /// Whether this video is in a buffering state, waiting on decoder or underlying stream.

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -15,7 +15,7 @@ using osu.Framework.Graphics.Shaders;
 namespace osu.Framework.Graphics.Video
 {
     /// <summary>
-    /// Represents a sprite that plays back a video from a stream or a file.
+    /// Represents a composite that displays a video played back from a stream or a file.
     /// </summary>
     public class Video : AnimationClockComposite
     {
@@ -40,7 +40,7 @@ namespace osu.Framework.Graphics.Video
         }
 
         /// <summary>
-        /// True if this VideoSprites decoding process has faulted.
+        /// Whether the video decoding process has faulted.
         /// </summary>
         public bool IsFaulted => decoder?.IsFaulted ?? false;
 

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -121,8 +121,8 @@ namespace osu.Framework.Graphics.Video
             {
                 bool tooFarBehind = Math.Abs(PlaybackPosition - nextFrame.Time) > lenience_before_seek &&
                                     (!Loop ||
-                                     Math.Abs(PlaybackPosition - decoder.Duration - nextFrame.Time) > lenience_before_seek &&
-                                     Math.Abs(PlaybackPosition + decoder.Duration - nextFrame.Time) > lenience_before_seek
+                                     (Math.Abs(PlaybackPosition - decoder.Duration - nextFrame.Time) > lenience_before_seek &&
+                                      Math.Abs(PlaybackPosition + decoder.Duration - nextFrame.Time) > lenience_before_seek)
                                     );
 
                 // we are too far ahead or too far behind

--- a/osu.Framework/Graphics/Video/VideoSprite.cs
+++ b/osu.Framework/Graphics/Video/VideoSprite.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Sprites;
@@ -13,7 +10,7 @@ using osuTK;
 namespace osu.Framework.Graphics.Video
 {
     /// <summary>
-    /// A sprite which holds a video with a custom conversion matrix.
+    /// A sprite which holds a video with a custom conversion matrix. Use <see cref="Video"/> for loading and displaying a video.
     /// </summary>
     public class VideoSprite : Sprite
     {

--- a/osu.Framework/Graphics/Video/VideoSprite.cs
+++ b/osu.Framework/Graphics/Video/VideoSprite.cs
@@ -146,7 +146,7 @@ namespace osu.Framework.Graphics.Video
             decoder.StartDecoding();
 
             // set in BDL to ensure external operations get placed correctly (ie. a transform applied from a parent's LoadComplete.
-            base.Clock = offsetClock = new FramedOffsetClock(sourceClock ??= Clock); // set source here to avoid constructing unused StopwatchClock.
+            base.Clock = offsetClock = new FramedOffsetClock(sourceClock ??= Clock, false); // set source here to avoid constructing unused StopwatchClock.
             updateOffsetSource();
         }
 

--- a/osu.Framework/Graphics/Video/VideoSprite.cs
+++ b/osu.Framework/Graphics/Video/VideoSprite.cs
@@ -1,257 +1,36 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Graphics.Sprites;
-using osuTK;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using JetBrains.Annotations;
-using osu.Framework.Bindables;
-using osu.Framework.Graphics.Animations;
-using osu.Framework.Logging;
-using osu.Framework.Platform;
 using osu.Framework.Graphics.Shaders;
-using osu.Framework.Timing;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Platform;
+using osuTK;
 
 namespace osu.Framework.Graphics.Video
 {
     /// <summary>
-    /// Represents a sprite that plays back a video from a stream or a file.
+    /// A sprite which holds a video with a custom conversion matrix.
     /// </summary>
-    public class VideoSprite : Sprite, IAnimation
+    public class VideoSprite : Sprite
     {
-        /// <summary>
-        /// The duration of the video that is being played. Can only be queried after the decoder has started decoding has loaded. This value may be an estimate by FFmpeg, depending on the video loaded.
-        /// </summary>
-        public double Duration => decoder?.Duration ?? 0;
-
-        /// <summary>
-        /// Whether this video is in a buffering state, waiting on decoder or underlying stream.
-        /// </summary>
-        public bool Buffering { get; private set; }
-
-        private bool loop;
-
-        /// <summary>
-        /// True if the video should loop after finishing its playback, false otherwise.
-        /// </summary>
-        public bool Loop
-        {
-            get => loop;
-            set
-            {
-                if (decoder != null)
-                    decoder.Looping = value;
-
-                loop = value;
-            }
-        }
-
-        public bool IsPlaying { get; set; } = true;
-
-        public void Seek(double time) => offsetClock.Offset = time - sourceClock.CurrentTime;
-
-        /// <summary>
-        /// The current position of the video playback. The playback position is automatically calculated based on the clock of the VideoSprite.
-        /// To perform seeks, change the <see cref="Timing.IClock.CurrentTime"/> of the clock of this <see cref="VideoSprite"/>.
-        /// </summary>
-        public double PlaybackPosition
-        {
-            get
-            {
-                if (Loop)
-                    return Clock.CurrentTime % Duration;
-
-                return Math.Min(Clock.CurrentTime, Duration);
-            }
-        }
-
-        /// <summary>
-        /// True if this VideoSprites decoding process has faulted.
-        /// </summary>
-        public bool IsFaulted => decoder?.IsFaulted ?? false;
-
-        /// <summary>
-        /// The current state of the <see cref="VideoDecoder"/>, as a bindable.
-        /// </summary>
-        public readonly IBindable<VideoDecoder.DecoderState> State = new Bindable<VideoDecoder.DecoderState>();
-
-        internal double CurrentFrameTime => lastFrame?.Time ?? 0;
-
-        internal int AvailableFrames => availableFrames.Count;
-
-        private VideoDecoder decoder;
-
-        private readonly Stream stream;
-        private readonly bool startAtCurrentTime;
-
-        private readonly Queue<DecodedFrame> availableFrames = new Queue<DecodedFrame>();
-
-        private DecodedFrame lastFrame;
-
-        /// <summary>
-        /// The total number of frames processed by this instance.
-        /// </summary>
-        public int FramesProcessed { get; private set; }
-
-        /// <summary>
-        /// The length in milliseconds that the decoder can be out of sync before a seek is automatically performed.
-        /// </summary>
-        private const float lenience_before_seek = 2500;
-
-        private bool isDisposed;
-
-        /// <summary>
-        /// YUV->RGB conversion matrix based on the video colorspace
-        /// </summary>
-        public Matrix3 ConversionMatrix => decoder.GetConversionMatrix();
-
-        protected override DrawNode CreateDrawNode() => new VideoSpriteDrawNode(this);
-
-        /// <summary>
-        /// Creates a new <see cref="VideoSprite"/>.
-        /// </summary>
-        /// <param name="filename">The video file.</param>
-        /// <param name="startAtCurrentTime">Whether the current clock time should be assumed as the 0th video frame.<br />
-        /// If <code>true</code>, the current clock time will be assumed as the 0th video frame. A custom <see cref="Clock"/> cannot be set.<br />
-        /// If <code>false</code>, a current clock time of 0 will be assumed as the 0th video frame. A custom <see cref="Clock"/> can be set.</param>
-        public VideoSprite(string filename, bool startAtCurrentTime = true)
-            : this(File.OpenRead(filename), startAtCurrentTime)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="VideoSprite"/>.
-        /// </summary>
-        /// <param name="stream">The video file stream.</param>
-        /// <param name="startAtCurrentTime">Whether the current clock time should be assumed as the 0th video frame.<br />
-        /// If <code>true</code>, the current clock time will be assumed as the 0th video frame. A custom <see cref="Clock"/> cannot be set.<br />
-        /// If <code>false</code>, a current clock time of 0 will be assumed as the 0th video frame. A custom <see cref="Clock"/> can be set.</param>
-        public VideoSprite([NotNull] Stream stream, bool startAtCurrentTime = true)
-        {
-            this.stream = stream ?? throw new ArgumentNullException(nameof(stream));
-            this.startAtCurrentTime = startAtCurrentTime;
-        }
+        public VideoDecoder Decoder;
 
         [BackgroundDependencyLoader]
         private void load(GameHost gameHost, ShaderManager shaders)
         {
             TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.VIDEO);
             RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.VIDEO_ROUNDED);
-            decoder = gameHost.CreateVideoDecoder(stream, Scheduler);
-            decoder.Looping = Loop;
-            State.BindTo(decoder.State);
-            decoder.StartDecoding();
-
-            // set in BDL to ensure external operations get placed correctly (ie. a transform applied from a parent's LoadComplete.
-            base.Clock = offsetClock = new FramedOffsetClock(sourceClock ??= Clock, false); // set source here to avoid constructing unused StopwatchClock.
-            updateOffsetSource();
         }
 
-        #region Clock Implementation (shared between VideoSprite and Animation)
+        /// <summary>
+        /// YUV->RGB conversion matrix based on the video colorspace
+        /// </summary>
+        public Matrix3 ConversionMatrix => Decoder.GetConversionMatrix();
 
-        protected override void LoadComplete()
-        {
-            base.LoadComplete();
-
-            // run a second time to re-zero the clock.
-            updateOffsetSource();
-        }
-
-        private FramedOffsetClock offsetClock;
-
-        private IFrameBasedClock sourceClock;
-
-        public override IFrameBasedClock Clock
-        {
-            get => base.Clock;
-            set
-            {
-                sourceClock = value;
-
-                if (IsLoaded)
-                    updateOffsetSource();
-            }
-        }
-
-        private void updateOffsetSource()
-        {
-            offsetClock.ChangeSource(sourceClock);
-            offsetClock.ProcessFrame();
-
-            if (startAtCurrentTime)
-                offsetClock.Offset = -sourceClock.CurrentTime;
-        }
-
-        #endregion
-
-        protected override void Update()
-        {
-            base.Update();
-
-            if (!IsPlaying)
-                offsetClock.Offset -= Time.Elapsed;
-
-            var nextFrame = availableFrames.Count > 0 ? availableFrames.Peek() : null;
-
-            if (nextFrame != null)
-            {
-                bool tooFarBehind = Math.Abs(PlaybackPosition - nextFrame.Time) > lenience_before_seek &&
-                                    (!Loop ||
-                                     Math.Abs(PlaybackPosition - decoder.Duration - nextFrame.Time) > lenience_before_seek &&
-                                     Math.Abs(PlaybackPosition + decoder.Duration - nextFrame.Time) > lenience_before_seek
-                                    );
-
-                // we are too far ahead or too far behind
-                if (tooFarBehind && decoder.CanSeek)
-                {
-                    Logger.Log($"Video too far out of sync ({nextFrame.Time}), seeking to {PlaybackPosition}");
-                    decoder.Seek(PlaybackPosition);
-                    decoder.ReturnFrames(availableFrames);
-                    availableFrames.Clear();
-                }
-            }
-
-            var frameTime = CurrentFrameTime;
-
-            while (availableFrames.Count > 0 && availableFrames.Peek().Time <= PlaybackPosition && Math.Abs(availableFrames.Peek().Time - PlaybackPosition) < lenience_before_seek)
-            {
-                if (lastFrame != null) decoder.ReturnFrames(new[] { lastFrame });
-                lastFrame = availableFrames.Dequeue();
-
-                var tex = lastFrame.Texture;
-
-                // Check if the new frame has been uploaded so we don't display an old frame
-                if ((tex?.TextureGL as VideoTexture)?.UploadComplete ?? false)
-                    Texture = tex;
-            }
-
-            if (availableFrames.Count == 0)
-            {
-                foreach (var f in decoder.GetDecodedFrames())
-                    availableFrames.Enqueue(f);
-            }
-
-            Buffering = decoder.IsRunning && availableFrames.Count == 0;
-
-            if (frameTime != CurrentFrameTime)
-                FramesProcessed++;
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            if (isDisposed)
-                return;
-
-            base.Dispose(isDisposing);
-
-            isDisposed = true;
-            decoder?.Dispose();
-
-            foreach (var f in availableFrames)
-                f.Texture.Dispose();
-        }
+        protected override DrawNode CreateDrawNode() => new VideoSpriteDrawNode(this);
     }
 }

--- a/osu.Framework/Graphics/Video/VideoSprite.cs
+++ b/osu.Framework/Graphics/Video/VideoSprite.cs
@@ -5,16 +5,20 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
-using osuTK;
 
 namespace osu.Framework.Graphics.Video
 {
     /// <summary>
-    /// A sprite which holds a video with a custom conversion matrix. Use <see cref="Video"/> for loading and displaying a video.
+    /// A sprite which holds a video with a custom conversion matrix.
     /// </summary>
-    public class VideoSprite : Sprite
+    internal class VideoSprite : Sprite
     {
-        public VideoDecoder Decoder;
+        private readonly Video video;
+
+        public VideoSprite(Video video)
+        {
+            this.video = video;
+        }
 
         [BackgroundDependencyLoader]
         private void load(GameHost gameHost, ShaderManager shaders)
@@ -23,11 +27,6 @@ namespace osu.Framework.Graphics.Video
             RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.VIDEO_ROUNDED);
         }
 
-        /// <summary>
-        /// YUV->RGB conversion matrix based on the video colorspace
-        /// </summary>
-        public Matrix3 ConversionMatrix => Decoder.GetConversionMatrix();
-
-        protected override DrawNode CreateDrawNode() => new VideoSpriteDrawNode(this);
+        protected override DrawNode CreateDrawNode() => new VideoSpriteDrawNode(video);
     }
 }

--- a/osu.Framework/Graphics/Video/VideoSpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Video/VideoSpriteDrawNode.cs
@@ -8,10 +8,10 @@ using osu.Framework.Graphics.OpenGL.Vertices;
 
 namespace osu.Framework.Graphics.Video
 {
-    public class VideoSpriteDrawNode : SpriteDrawNode
+    internal class VideoSpriteDrawNode : SpriteDrawNode
     {
-        public VideoSpriteDrawNode(VideoSprite source)
-            : base(source)
+        public VideoSpriteDrawNode(Video source)
+            : base(source.Sprite)
         {
             yuvCoeff = source.ConversionMatrix;
         }

--- a/osu.Framework/Timing/FramedClock.cs
+++ b/osu.Framework/Timing/FramedClock.cs
@@ -18,8 +18,10 @@ namespace osu.Framework.Timing
         /// Construct a new FramedClock with an optional source clock.
         /// </summary>
         /// <param name="source">A source clock which will be used as the backing time source. If null, a StopwatchClock will be created. When provided, the CurrentTime of <paramref name="source"/> will be transferred instantly.</param>
-        public FramedClock(IClock source = null)
+        /// <param name="processSource">Whether the source clock's <see cref="ProcessFrame"/> method should be called during this clock's process call.</param>
+        public FramedClock(IClock source = null, bool processSource = true)
         {
+            this.processSource = processSource;
             ChangeSource(source ?? new StopwatchClock(true));
         }
 
@@ -39,6 +41,8 @@ namespace osu.Framework.Timing
 
         public bool IsRunning => Source?.IsRunning ?? false;
 
+        private readonly bool processSource;
+
         private double timeUntilNextCalculation;
         private double timeSinceLastCalculation;
         private int framesSinceLastCalculation;
@@ -53,7 +57,8 @@ namespace osu.Framework.Timing
 
         public virtual void ProcessFrame()
         {
-            (Source as IFrameBasedClock)?.ProcessFrame();
+            if (processSource && Source is IFrameBasedClock framedSource)
+                framedSource.ProcessFrame();
 
             if (timeUntilNextCalculation <= 0)
             {

--- a/osu.Framework/Timing/FramedOffsetClock.cs
+++ b/osu.Framework/Timing/FramedOffsetClock.cs
@@ -3,12 +3,21 @@
 
 namespace osu.Framework.Timing
 {
+    /// <summary>
+    /// A framed clock which allows an offset to be added or subtracted from an underlying source clock's time.
+    /// </summary>
     public class FramedOffsetClock : FramedClock
     {
-        private double offset;
-
         public override double CurrentTime => base.CurrentTime + offset;
 
+        private double offset;
+
+        /// <summary>
+        /// The offset to be applied.
+        /// </summary>
+        /// <remarks>
+        /// A positive offset will move time forward.
+        /// </remarks>
         public double Offset
         {
             get => offset;
@@ -19,8 +28,8 @@ namespace osu.Framework.Timing
             }
         }
 
-        public FramedOffsetClock(IClock source)
-            : base(source)
+        public FramedOffsetClock(IClock source, bool processSource = true)
+            : base(source, processSource)
         {
         }
     }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8581

Turns out that Animation was processing the "source" clock a second time. Because in some cases this was the game's thread clock, this cause it to try and sleep as it thought it was running too fast, causing a frame rate decrease when frame limiters were enabled.

Because the animation class' clock setup has caused so much trouble, I've decided to refactor this whole thing a bit.

- New class `AnimationClockComposite` manages clock logic. It now uses a `ManualClock` rather than `FramedOffsetClock`, which tidies up the code and makes the time incrementing feel less hacky.
- Split `IAnimation` into two interfaces (`IAnimation` and `IFramedAnimation`) to allow code share between `Animation` and `VideoSprite`.
- `Animation` / `VideoSprite` no longer have any custom clock logic.
- `VideoSprite` is now named `Video` (the "sprite" is nested within now). This is so it can share clock logic with `AnimationClockComposite`
- As a safety measure, added a `ctor` parameter to `FramedOffsetClock` to make future consumers aware of the processes-by-default behaviour. This is not required by this PR but I think it will prevent future trip-ups on the same behaviour.

I'm hoping this is the final refactor of these classes; they are feeling pretty nailed in now.

I'd like to add some kind of protection on (at least) `GameThread`'s clocks to avoid multiple processes in a single frame, but that can come in a separate PR.

# Breaking Changes

## VideoSprite is now Video

This was renamed for clarity, as it is now not a sprite itself. As a result, videos can now be seeked without using a custom clock.

## Animation.Repeat is now Animation.Loop

Now shares the same interface as VideoSprite

## Some helper methods are now only available via `IFrameAnimation` (instead of `IAnimation`)
