### PR TITLE
Share layout logic between Animation and Video

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideoLayout.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideoLayout.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Sprites
+{
+    public class TestSceneVideoLayout : GridTestScene
+    {
+        public TestSceneVideoLayout()
+            : base(1, 3)
+        {
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Cell(0, 0).Child = createTest("video - auto size", () => new TestVideo());
+            Cell(0, 1).Child = createTest("video - relative size + fit", () => new TestVideo
+            {
+                RelativeSizeAxes = Axes.Both,
+                FillMode = FillMode.Fit
+            });
+            Cell(0, 2).Child = createTest("video - fixed size", () => new TestVideo { Size = new Vector2(100, 50) });
+        }
+
+        private Drawable createTest(string name, Func<Drawable> animationCreationFunc) => new Container
+        {
+            RelativeSizeAxes = Axes.Both,
+            Padding = new MarginPadding(10),
+            Child = new GridContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Content = new[]
+                {
+                    new Drawable[]
+                    {
+                        new SpriteText
+                        {
+                            Anchor = Anchor.TopCentre,
+                            Origin = Anchor.TopCentre,
+                            Text = name
+                        },
+                    },
+                    new Drawable[]
+                    {
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Masking = true,
+                            BorderColour = Color4.OrangeRed,
+                            BorderThickness = 2,
+                            Children = new[]
+                            {
+                                new Box
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Alpha = 0,
+                                    AlwaysPresent = true
+                                },
+                                animationCreationFunc()
+                            }
+                        }
+                    },
+                },
+                RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) }
+            }
+        };
+    }
+}

--- a/osu.Framework.Tests/Visual/Sprites/TestVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestVideo.cs
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Threading;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Video;
+using osu.Framework.IO.Network;
+
+namespace osu.Framework.Tests.Visual.Sprites
+{
+    internal class TestVideo : Video
+    {
+        private static MemoryStream consumeVideoStream()
+        {
+            var wr = new WebRequest("https://assets.ppy.sh/media/landing.mp4");
+            wr.PerformAsync();
+
+            while (!wr.Completed)
+                Thread.Sleep(100);
+
+            var videoStream = new MemoryStream();
+            wr.ResponseStream.CopyTo(videoStream);
+            videoStream.Position = 0;
+            return videoStream;
+        }
+
+        public TestVideo(bool startAtCurrentTime = true)
+            : base(consumeVideoStream(), startAtCurrentTime)
+        {
+        }
+
+        private bool? useRoundedShader;
+
+        public bool? UseRoundedShader
+        {
+            get => useRoundedShader;
+            set
+            {
+                useRoundedShader = value;
+                Invalidate(Invalidation.DrawNode);
+            }
+        }
+
+        protected override DrawNode CreateDrawNode() => new TestVideoSpriteDrawNode(this);
+
+        private class TestVideoSpriteDrawNode : VideoSpriteDrawNode
+        {
+            private readonly TestVideo source;
+
+            protected override bool RequiresRoundedShader => useRoundedShader ?? base.RequiresRoundedShader;
+
+            private bool? useRoundedShader;
+
+            public TestVideoSpriteDrawNode(TestVideo source)
+                : base(source)
+            {
+                this.source = source;
+            }
+
+            public override void ApplyState()
+            {
+                base.ApplyState();
+
+                useRoundedShader = source.UseRoundedShader;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Caching;
-using osuTK;
 
 namespace osu.Framework.Graphics.Animations
 {
@@ -43,37 +42,6 @@ namespace osu.Framework.Graphics.Animations
         {
             frameData = new List<FrameData<T>>();
             Loop = true;
-        }
-
-        private bool hasCustomWidth;
-
-        public override float Width
-        {
-            set
-            {
-                base.Width = value;
-                hasCustomWidth = true;
-            }
-        }
-
-        private bool hasCustomHeight;
-
-        public override float Height
-        {
-            set
-            {
-                base.Height = value;
-                hasCustomHeight = true;
-            }
-        }
-
-        public override Vector2 Size
-        {
-            set
-            {
-                Width = value.X;
-                Height = value.Y;
-            }
         }
 
         /// <summary>
@@ -147,13 +115,6 @@ namespace osu.Framework.Graphics.Animations
         {
         }
 
-        /// <summary>
-        /// Retrieves the size of a given frame.
-        /// </summary>
-        /// <param name="content">The frame to retrieve the size of.</param>
-        /// <returns>The size of <paramref name="content"/>.</returns>
-        protected abstract Vector2 GetFrameSize(T content);
-
         protected override void Update()
         {
             base.Update();
@@ -192,20 +153,9 @@ namespace osu.Framework.Graphics.Animations
 
         private void updateCurrentFrame()
         {
-            var frame = CurrentFrame;
+            DisplayFrame(CurrentFrame);
 
-            if (RelativeSizeAxes != Axes.Both)
-            {
-                var frameSize = GetFrameSize(frame);
-
-                if ((RelativeSizeAxes & Axes.X) == 0 && !hasCustomWidth)
-                    base.Width = frameSize.X;
-
-                if ((RelativeSizeAxes & Axes.Y) == 0 && !hasCustomHeight)
-                    base.Height = frameSize.Y;
-            }
-
-            DisplayFrame(frame);
+            UpdateSizing();
 
             currentFrameCache.Validate();
         }

--- a/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
+++ b/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
@@ -8,7 +8,7 @@ using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.Animations
 {
-    public abstract class AnimationClockComposite : CompositeDrawable, IAnimation
+    public abstract class AnimationClockComposite : CustomisableSizeCompositeDrawable, IAnimation
     {
         private readonly bool startAtCurrentTime;
 

--- a/osu.Framework/Graphics/Animations/CustomisableSizeCompositeDrawable.cs
+++ b/osu.Framework/Graphics/Animations/CustomisableSizeCompositeDrawable.cs
@@ -1,0 +1,64 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Containers;
+using osuTK;
+
+namespace osu.Framework.Graphics.Animations
+{
+    /// <summary>
+    /// A drawable which handles sizing in a roughly expected way when wrapping a single direct child.
+    /// </summary>
+    public abstract class CustomisableSizeCompositeDrawable : CompositeDrawable
+    {
+        private bool hasCustomWidth;
+
+        public override float Width
+        {
+            set
+            {
+                base.Width = value;
+                hasCustomWidth = true;
+            }
+        }
+
+        private bool hasCustomHeight;
+
+        public override float Height
+        {
+            set
+            {
+                base.Height = value;
+                hasCustomHeight = true;
+            }
+        }
+
+        public override Vector2 Size
+        {
+            set
+            {
+                Width = value.X;
+                Height = value.Y;
+            }
+        }
+
+        /// <summary>
+        /// Retrieves the size of the target display content.
+        /// </summary>
+        /// <returns>The size of current content.</returns>
+        protected abstract Vector2 GetCurrentDisplaySize();
+
+        protected void UpdateSizing()
+        {
+            if (RelativeSizeAxes == Axes.Both) return;
+
+            var frameSize = GetCurrentDisplaySize();
+
+            if ((RelativeSizeAxes & Axes.X) == 0 && !hasCustomWidth)
+                base.Width = frameSize.X;
+
+            if ((RelativeSizeAxes & Axes.Y) == 0 && !hasCustomHeight)
+                base.Height = frameSize.Y;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Animations/CustomisableSizeCompositeDrawable.cs
+++ b/osu.Framework/Graphics/Animations/CustomisableSizeCompositeDrawable.cs
@@ -48,7 +48,7 @@ namespace osu.Framework.Graphics.Animations
         /// <returns>The size of current content.</returns>
         protected abstract Vector2 GetCurrentDisplaySize();
 
-        protected void UpdateSizing()
+        protected virtual void UpdateSizing()
         {
             if (RelativeSizeAxes == Axes.Both) return;
 

--- a/osu.Framework/Graphics/Animations/DrawableAnimation.cs
+++ b/osu.Framework/Graphics/Animations/DrawableAnimation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Graphics.Containers;
 using osuTK;
 
@@ -13,10 +14,16 @@ namespace osu.Framework.Graphics.Animations
     {
         private Container container;
 
-        protected override void DisplayFrame(Drawable content) => container.Child = content;
+        protected override void DisplayFrame(Drawable content)
+        {
+            // don't dispose previous frames as they may be displayed again.
+            container.Clear(false);
+
+            container.Child = content;
+        }
 
         public override Drawable CreateContent() => container = new Container { RelativeSizeAxes = Axes.Both };
 
-        protected override Vector2 GetFrameSize(Drawable content) => new Vector2(content.DrawWidth, content.DrawHeight);
+        protected override Vector2 GetCurrentDisplaySize() => container.Children.FirstOrDefault()?.DrawSize ?? Vector2.Zero;
     }
 }

--- a/osu.Framework/Graphics/Animations/TextureAnimation.cs
+++ b/osu.Framework/Graphics/Animations/TextureAnimation.cs
@@ -28,6 +28,14 @@ namespace osu.Framework.Graphics.Animations
 
         protected override void DisplayFrame(Texture content) => textureHolder.Texture = content;
 
+        protected override void UpdateSizing()
+        {
+            base.UpdateSizing();
+
+            // transfer fill mode to handle as one would expect.
+            textureHolder.FillMode = FillMode;
+        }
+
         protected override Vector2 GetCurrentDisplaySize() =>
             new Vector2(textureHolder.Texture?.DisplayWidth ?? 0, textureHolder.Texture?.DisplayHeight ?? 0);
     }

--- a/osu.Framework/Graphics/Animations/TextureAnimation.cs
+++ b/osu.Framework/Graphics/Animations/TextureAnimation.cs
@@ -28,6 +28,7 @@ namespace osu.Framework.Graphics.Animations
 
         protected override void DisplayFrame(Texture content) => textureHolder.Texture = content;
 
-        protected override Vector2 GetFrameSize(Texture content) => new Vector2(content?.DisplayWidth ?? 0, content?.DisplayHeight ?? 0);
+        protected override Vector2 GetCurrentDisplaySize() =>
+            new Vector2(textureHolder.Texture?.DisplayWidth ?? 0, textureHolder.Texture?.DisplayHeight ?? 0);
     }
 }

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -181,6 +181,14 @@ namespace osu.Framework.Graphics.Video
                 f.Texture.Dispose();
         }
 
+        protected override void UpdateSizing()
+        {
+            base.UpdateSizing();
+
+            // transfer fill mode to handle as one would expect.
+            Sprite.FillMode = FillMode;
+        }
+
         protected override Vector2 GetCurrentDisplaySize() =>
             new Vector2(Sprite.Texture?.DisplayWidth ?? 0, Sprite.Texture?.DisplayHeight ?? 0);
     }

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -91,7 +91,7 @@ namespace osu.Framework.Graphics.Video
         {
         }
 
-        public override Drawable CreateContent() => Sprite = new VideoSprite(this);
+        public override Drawable CreateContent() => Sprite = new VideoSprite(this) { RelativeSizeAxes = Axes.Both };
 
         /// <summary>
         /// Creates a new <see cref="Video"/>.
@@ -149,7 +149,10 @@ namespace osu.Framework.Graphics.Video
 
                 // Check if the new frame has been uploaded so we don't display an old frame
                 if ((tex?.TextureGL as VideoTexture)?.UploadComplete ?? false)
+                {
                     Sprite.Texture = tex;
+                    UpdateSizing();
+                }
             }
 
             if (availableFrames.Count == 0)
@@ -177,5 +180,8 @@ namespace osu.Framework.Graphics.Video
             foreach (var f in availableFrames)
                 f.Texture.Dispose();
         }
+
+        protected override Vector2 GetCurrentDisplaySize() =>
+            new Vector2(Sprite.Texture?.DisplayWidth ?? 0, Sprite.Texture?.DisplayHeight ?? 0);
     }
 }


### PR DESCRIPTION
Opening this reluctantly. Basically using what we know already "works" from Animation on video as well. Also fixes `FillMode` not working (never did). Wrapping drawables like this is still an area of the framework that falls over badly.

- Closes https://github.com/ppy/osu/issues/8600