### PR TITLE
Add temporary blending "fix" for BufferedContainer

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -347,7 +347,17 @@ namespace osu.Framework.Graphics.Containers
         public DrawColourInfo? FrameBufferDrawColour => base.DrawColourInfo;
 
         // Children should not receive the true colour to avoid colour doubling when the frame-buffers are rendered to the back-buffer.
-        public override DrawColourInfo DrawColourInfo => new DrawColourInfo(Color4.White, base.DrawColourInfo.Blending);
+        public override DrawColourInfo DrawColourInfo
+        {
+            get
+            {
+                // Todo: This is incorrect.
+                var blending = Blending;
+                blending.ApplyDefaultToInherited();
+
+                return new DrawColourInfo(Color4.White, blending);
+            }
+        }
 
         protected override void Dispose(bool isDisposing)
         {


### PR DESCRIPTION
"Regressed" from https://github.com/ppy/osu-framework/pull/3423, because blending is now handled correctly through multiple parents.

This is temporary because `BufferedContainer` blending is 100% messed up. It's incorrect because it's blending a pre-multiplied alpha texture as if it isn't pre-multiplied.
Over the last 3 days I've tried to get it to blend correctly, but it isn't an easy feat - premultiplying itself is theoretically very easy, but there's some weirdness going on inside the hierarchy of `BufferedContainer` that I need to investigate more.

For now, this restores the original behaviour prior to the PR mentioned above, in the hope that it'll be removed in a short while. This fixes the results screen.

Haven't written a test for this because there's really nothing of value to test here - it's completely incorrect.