### PR TITLE
Expose original instance for dynamic compilation

### DIFF
--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -27,12 +27,9 @@ namespace osu.Framework.Testing
 
         private string lastTouchedFile;
 
-        private T checkpointObject;
+        private T target;
 
-        public void Checkpoint(T obj)
-        {
-            checkpointObject = obj;
-        }
+        public void SetRecompilationTarget(T target) => this.target = target;
 
         private readonly List<string> requiredFiles = new List<string>();
         private List<string> requiredTypeNames = new List<string>();
@@ -89,25 +86,23 @@ namespace osu.Framework.Testing
         {
             lock (compileLock)
             {
-                if (checkpointObject == null || isCompiling)
+                if (target == null || isCompiling)
                     return;
 
-                var checkpointType = checkpointObject.GetType();
+                var targetType = target.GetType();
 
-                var reqTypes = checkpointObject.RequiredTypes.Select(t => removeGenerics(t.Name)).ToList();
+                var reqTypes = target.RequiredTypes.Select(t => removeGenerics(t.Name)).ToList();
 
                 // add ourselves
-                reqTypes.Add(removeGenerics(checkpointType.Name));
+                reqTypes.Add(removeGenerics(targetType.Name));
 
                 // add all parents
-                var derivedType = checkpointType;
+                var derivedType = targetType;
                 while ((derivedType = derivedType.BaseType) != null && derivedType != typeof(TestScene))
                     reqTypes.Add(removeGenerics(derivedType.Name));
 
-                var checkpointName = checkpointObject.GetType().Name;
-
                 // if we are a TestCase, add the class we are testing automatically.
-                reqTypes.Add(TestScene.RemovePrefix(removeGenerics(checkpointName)));
+                reqTypes.Add(TestScene.RemovePrefix(removeGenerics(target.GetType().Name)));
 
                 if (!reqTypes.Contains(Path.GetFileNameWithoutExtension(e.Name)))
                     return;
@@ -137,7 +132,7 @@ namespace osu.Framework.Testing
         /// <summary>
         /// Removes the "`1[T]" generic specification from type name output.
         /// </summary>
-        private string removeGenerics(string checkpointName) => checkpointName.Split('`').First();
+        private string removeGenerics(string targetName) => targetName.Split('`').First();
 
         private int currentVersion;
 
@@ -175,12 +170,12 @@ namespace osu.Framework.Testing
             while (!checkFileReady(lastTouchedFile))
                 Thread.Sleep(10);
 
-            Logger.Log($@"Recompiling {Path.GetFileName(checkpointObject.GetType().Name)}...", LoggingTarget.Runtime, LogLevel.Important);
+            Logger.Log($@"Recompiling {Path.GetFileName(target.GetType().Name)}...", LoggingTarget.Runtime, LogLevel.Important);
 
             CompilationStarted?.Invoke();
 
             // ensure we don't duplicate the dynamic suffix.
-            string assemblyNamespace = checkpointObject.GetType().Assembly.GetName().Name.Replace(".Dynamic", "");
+            string assemblyNamespace = target.GetType().Assembly.GetName().Name.Replace(".Dynamic", "");
 
             string assemblyVersion = $"{++currentVersion}.0.*";
             string dynamicNamespace = $"{assemblyNamespace}.Dynamic";
@@ -203,7 +198,7 @@ namespace osu.Framework.Testing
                 {
                     ms.Seek(0, SeekOrigin.Begin);
                     CompilationFinished?.Invoke(
-                        Assembly.Load(ms.ToArray()).GetModules()[0].GetTypes().LastOrDefault(t => t.FullName == checkpointObject.GetType().FullName)
+                        Assembly.Load(ms.ToArray()).GetModules()[0].GetTypes().LastOrDefault(t => t.FullName == target.GetType().FullName)
                     );
                 }
                 else

--- a/osu.Framework/Testing/IDynamicallyCompile.cs
+++ b/osu.Framework/Testing/IDynamicallyCompile.cs
@@ -17,7 +17,8 @@ namespace osu.Framework.Testing
         IReadOnlyList<Type> RequiredTypes { get; }
 
         /// <summary>
-        /// A reference to the original instance.
+        /// A reference to the original instance which dynamic compilation was based on.
+        /// Will reference self if already the original.
         /// </summary>
         object DynamicCompilationOriginal { get; }
     }

--- a/osu.Framework/Testing/IDynamicallyCompile.cs
+++ b/osu.Framework/Testing/IDynamicallyCompile.cs
@@ -15,5 +15,10 @@ namespace osu.Framework.Testing
         /// A list of types which may be edited and should be included during recompilation.
         /// </summary>
         IReadOnlyList<Type> RequiredTypes { get; }
+
+        /// <summary>
+        /// A reference to the original instance.
+        /// </summary>
+        object DynamicCompilationOriginal { get; }
     }
 }

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -404,6 +404,8 @@ namespace osu.Framework.Testing
                 CurrentTest.Dispose();
             }
 
+            var lastTest = CurrentTest;
+
             CurrentTest = null;
 
             if (testType == null && TestTypes.Count > 0)
@@ -423,12 +425,14 @@ namespace osu.Framework.Testing
             // if we are a dynamically compiled type (via DynamicClassCompiler) we should update the dropdown accordingly.
             if (isDynamicLoad)
             {
+                newTest.DynamicCompilationOriginal = lastTest?.DynamicCompilationOriginal ?? lastTest ?? newTest;
                 toolbar.AddAssembly($"{dynamic_prefix} ({testType.Name})", testType.Assembly);
             }
             else
+            {
                 TestTypes.RemoveAll(t => t.Assembly.FullName.Contains(dynamic_prefix));
-
-            newTest.DynamicCompilationOriginal = CurrentTest?.Original ?? CurrentTest;
+                newTest.DynamicCompilationOriginal = newTest;
+            }
 
             Assembly.Value = testType.Assembly;
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
@@ -415,13 +416,19 @@ namespace osu.Framework.Testing
 
             var newTest = (TestScene)Activator.CreateInstance(testType);
 
+            Debug.Assert(newTest != null);
+
             const string dynamic_prefix = "dynamic";
 
             // if we are a dynamically compiled type (via DynamicClassCompiler) we should update the dropdown accordingly.
             if (isDynamicLoad)
+            {
                 toolbar.AddAssembly($"{dynamic_prefix} ({testType.Name})", testType.Assembly);
+            }
             else
                 TestTypes.RemoveAll(t => t.Assembly.FullName.Contains(dynamic_prefix));
+
+            newTest.DynamicCompilationOriginal = CurrentTest?.Original ?? CurrentTest;
 
             Assembly.Value = testType.Assembly;
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -498,7 +498,7 @@ namespace osu.Framework.Testing
             if (!hadTestAttributeTest)
                 addSetUpSteps();
 
-            backgroundCompiler?.Checkpoint(CurrentTest);
+            backgroundCompiler?.SetRecompilationTarget(CurrentTest);
             runTests(onCompletion);
             updateButtons();
 

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -390,6 +390,8 @@ namespace osu.Framework.Testing
 
         public virtual IReadOnlyList<Type> RequiredTypes => Array.Empty<Type>();
 
+        public object DynamicCompilationOriginal { get; internal set; }
+
         internal void RunSetUpSteps()
         {
             addStepsAsSetupSteps = true;


### PR DESCRIPTION
For scenarios like needing access to the original assembly for accessing resources.