### PR TITLE
Fix position causing parent size invalidations

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1834,10 +1834,10 @@ namespace osu.Framework.Graphics
         private void invalidateParentSizeDependencies(Invalidation invalidation, Axes changedAxes)
         {
             // A parent source is faked so that the invalidation doesn't propagate upwards unnecessarily.
-            Invalidate(Invalidation.DrawSize, InvalidationSource.Parent);
+            Invalidate(invalidation, InvalidationSource.Parent);
 
             // The fast path, which performs an invalidation on the parent along with optimisations for bypassed sizing axes.
-            Parent?.InvalidateChildrenSizeDependencies(Invalidation.DrawSize, changedAxes, this);
+            Parent?.InvalidateChildrenSizeDependencies(invalidation, changedAxes, this);
         }
 
         #endregion


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/8663

For some reason it just wasn't using the parameter passed in...

Very unlikely this would actually cause a performance issues (e.g. in autosize or flow) except for some specific scenarios like the above PR.