### PR TITLE
Ensure no flattening for custom composite drawnodes

### DIFF
--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -232,8 +232,6 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         private long updateVersion;
 
-        protected override bool CanBeFlattened => false;
-
         public IShader TextureShader { get; private set; }
 
         public IShader RoundedTextureShader { get; private set; }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -228,6 +228,8 @@ namespace osu.Framework.Graphics.Containers
         [BackgroundDependencyLoader(true)]
         private void load(ShaderManager shaders, CancellationToken? cancellation)
         {
+            hasCustomDrawNode = GetType().GetMethod(nameof(CreateDrawNode))?.DeclaringType != typeof(CompositeDrawable);
+
             if (Shader == null)
                 Shader = shaders?.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
 
@@ -1009,6 +1011,8 @@ namespace osu.Framework.Graphics.Containers
 
         #region DrawNode
 
+        private bool hasCustomDrawNode;
+
         internal IShader Shader { get; private set; }
 
         protected override DrawNode CreateDrawNode() => new CompositeDrawableDrawNode(this);
@@ -1037,10 +1041,12 @@ namespace osu.Framework.Graphics.Containers
         /// In some cases, the <see cref="DrawNode"/> must always be generated and flattening should not occur.
         /// </summary>
         protected virtual bool CanBeFlattened =>
-            // Masking composite DrawNodes define the masking area for their children
+            // Masking composite DrawNodes define the masking area for their children.
             !Masking
-            // Proxied drawables have their DrawNodes drawn elsewhere in the scene graph
-            && !HasProxy;
+            // Proxied drawables have their DrawNodes drawn elsewhere in the scene graph.
+            && !HasProxy
+            // Custom draw nodes may provide custom drawing procedures.
+            && !hasCustomDrawNode;
 
         private const int amount_children_required_for_masking_check = 2;
 


### PR DESCRIPTION
Has caught me off-guard a few times since flattening is a non-explicit operation.

I've benchmarked the `.GetType().DeclaringType`, and imo it's insignificant:

```
                 Method |     Mean |     Error |    StdDev | Allocated |
----------------------- |---------:|----------:|----------:|----------:|
       GetDeclaringType | 76.75 ns | 0.3441 ns | 0.3219 ns |       0 B |
 GetDeclaringTypeCached | 29.61 ns | 0.6685 ns | 0.8210 ns |       0 B |
```
(per invocation)