### PR TITLE
Don't invalidate non-alive children when not required

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkInvalidationWithManyNotAlive.cs
+++ b/osu.Framework.Benchmarks/BenchmarkInvalidationWithManyNotAlive.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkInvalidationWithManyNotAlive : GameBenchmark
+    {
+        [Test]
+        [Benchmark]
+        public void RunFrame() => RunSingleFrame();
+
+        protected override Game CreateGame() => new TestGame();
+
+        private class TestGame : Game
+        {
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                var container = new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                };
+
+                for (int i = 0; i < 50000; i++)
+                {
+                    container.Add(new Box
+                    {
+                        Size = new Vector2(10),
+                        LifetimeStart = i > 10000 ? double.MaxValue : double.MinValue
+                    });
+                }
+
+                Add(container);
+
+                container.Spin(200, RotationDirection.Clockwise);
+            }
+        }
+    }
+}

--- a/osu.Framework.Benchmarks/BenchmarkMakeChildAlive.cs
+++ b/osu.Framework.Benchmarks/BenchmarkMakeChildAlive.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkMakeChildAlive : GameBenchmark
+    {
+        [Test]
+        [Benchmark]
+        public void RunFrame() => RunSingleFrame();
+
+        protected override Game CreateGame() => new TestGame();
+
+        private class TestGame : Game
+        {
+            private readonly Box child;
+
+            public TestGame()
+            {
+                child = new Box { RelativeSizeAxes = Axes.Both };
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+
+                Clear(false);
+                Add(child);
+            }
+        }
+    }
+}

--- a/osu.Framework.Benchmarks/BenchmarkSpinningParentWithManyAlive.cs
+++ b/osu.Framework.Benchmarks/BenchmarkSpinningParentWithManyAlive.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkSpinningParentWithManyAlive : GameBenchmark
+    {
+        [Test]
+        [Benchmark]
+        public void RunFrame() => RunSingleFrame();
+
+        protected override Game CreateGame() => new TestGame();
+
+        private class TestGame : Game
+        {
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                var container = new FillFlowContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                };
+
+                for (int i = 0; i < 10000; i++)
+                    container.Add(new Box { Size = new Vector2(10) });
+
+                Add(container);
+
+                container.Spin(200, RotationDirection.Clockwise);
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
+++ b/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
@@ -340,10 +340,10 @@ namespace osu.Framework.Tests.Layout
         }
 
         /// <summary>
-        /// Tests that non-alive children always receive non-layout invalidations (Parent & DrawNode).
+        /// Tests that non-alive children always receive Parent invalidations.
         /// </summary>
         [Test]
-        public void TestNonAliveChildReceivesParentAndDrawNodeInvalidations()
+        public void TestNonAliveChildReceivesParentInvalidations()
         {
             Container parent = null;
             bool invalidated = false;
@@ -372,14 +372,37 @@ namespace osu.Framework.Tests.Layout
             });
 
             AddAssert("child invalidated", () => invalidated);
+        }
 
-            AddStep("invalidate drawnode", () =>
+        /// <summary>
+        /// Tests that DrawNode invalidations never propagate.
+        /// </summary>
+        [Test]
+        public void TestDrawNodeInvalidationsNeverPropagate()
+        {
+            Container parent = null;
+            bool invalidated = false;
+
+            AddStep("create test", () =>
+            {
+                Drawable child;
+
+                Child = parent = new Container
+                {
+                    Size = new Vector2(200),
+                    Child = child = new Box { RelativeSizeAxes = Axes.Both }
+                };
+
+                child.Invalidated += _ => invalidated = true;
+            });
+
+            AddStep("invalidate parent", () =>
             {
                 invalidated = false;
                 parent.Invalidate(Invalidation.DrawNode);
             });
 
-            AddAssert("child invalidated", () => invalidated);
+            AddAssert("child not invalidated", () => !invalidated);
         }
 
         private class TestBox1 : Box

--- a/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
+++ b/osu.Framework.Tests/Layout/TestSceneContainerLayout.cs
@@ -339,6 +339,49 @@ namespace osu.Framework.Tests.Layout
             AddAssert("child size matches parent", () => child.DrawSize == parent.Size);
         }
 
+        /// <summary>
+        /// Tests that non-alive children always receive non-layout invalidations (Parent & DrawNode).
+        /// </summary>
+        [Test]
+        public void TestNonAliveChildReceivesParentAndDrawNodeInvalidations()
+        {
+            Container parent = null;
+            bool invalidated = false;
+
+            AddStep("create test", () =>
+            {
+                Drawable child;
+
+                Child = parent = new Container
+                {
+                    Size = new Vector2(200),
+                    Child = child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        LifetimeStart = double.MaxValue
+                    }
+                };
+
+                child.Invalidated += _ => invalidated = true;
+            });
+
+            AddStep("invalidate parent", () =>
+            {
+                invalidated = false;
+                parent.Invalidate(Invalidation.Parent);
+            });
+
+            AddAssert("child invalidated", () => invalidated);
+
+            AddStep("invalidate drawnode", () =>
+            {
+                invalidated = false;
+                parent.Invalidate(Invalidation.DrawNode);
+            });
+
+            AddAssert("child invalidated", () => invalidated);
+        }
+
         private class TestBox1 : Box
         {
             public override bool RemoveWhenNotAlive => false;

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -965,7 +965,7 @@ namespace osu.Framework.Graphics.Containers
             // Child invalidations should not propagate to other children.
             if (source == InvalidationSource.Child)
                 return anyInvalidated;
-                
+
             // DrawNode invalidations should not propagate to children.
             invalidation &= ~Invalidation.DrawNode;
             if (invalidation == Invalidation.None)

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -753,8 +753,8 @@ namespace osu.Framework.Graphics.Containers
 
             ChildBecameAlive?.Invoke(child);
 
-            // Invalidations on non-alive children are blocked, so they must be invalidated once when they become alive.
-            child.Invalidate(source: InvalidationSource.Parent);
+            // Layout invalidations on non-alive children are blocked, so they must be invalidated once when they become alive.
+            child.Invalidate(Invalidation.Layout, InvalidationSource.Parent);
 
             // Notify ourselves that a child has become alive.
             Invalidate(Invalidation.Presence, InvalidationSource.Child);
@@ -966,9 +966,15 @@ namespace osu.Framework.Graphics.Containers
             if (source == InvalidationSource.Child)
                 return anyInvalidated;
 
-            for (int i = 0; i < aliveInternalChildren.Count; ++i)
+            IReadOnlyList<Drawable> targetChildren = aliveInternalChildren;
+
+            // Non-layout flags must be propagated to all children. As such, it is simplest + quickest to propagate all other relevant flags along with them.
+            if ((invalidation & ~Invalidation.Layout) > 0)
+                targetChildren = internalChildren;
+
+            for (int i = 0; i < targetChildren.Count; ++i)
             {
-                Drawable c = aliveInternalChildren[i];
+                Drawable c = targetChildren[i];
 
                 Invalidation childInvalidation = invalidation;
                 if ((invalidation & Invalidation.RequiredParentSizeToFit) > 0)

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -753,6 +753,10 @@ namespace osu.Framework.Graphics.Containers
 
             ChildBecameAlive?.Invoke(child);
 
+            // Invalidations on non-alive children are blocked, so they must be invalidated once when they become alive.
+            child.Invalidate(source: InvalidationSource.Parent);
+
+            // Notify ourselves that a child has become alive.
             Invalidate(Invalidation.Presence, InvalidationSource.Child);
         }
 
@@ -785,6 +789,7 @@ namespace osu.Framework.Graphics.Containers
                 removed = true;
             }
 
+            // Notify ourselves that a child has died.
             Invalidate(Invalidation.Presence, InvalidationSource.Child);
 
             return removed;
@@ -961,9 +966,9 @@ namespace osu.Framework.Graphics.Containers
             if (source == InvalidationSource.Child)
                 return anyInvalidated;
 
-            for (int i = 0; i < internalChildren.Count; ++i)
+            for (int i = 0; i < aliveInternalChildren.Count; ++i)
             {
-                Drawable c = internalChildren[i];
+                Drawable c = aliveInternalChildren[i];
 
                 Invalidation childInvalidation = invalidation;
                 if ((invalidation & Invalidation.RequiredParentSizeToFit) > 0)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -318,7 +318,8 @@ namespace osu.Framework.Graphics
             // From a synchronous point of view, this is the first time the Drawable receives a parent.
             // If this Drawable calculated properties such as DrawInfo that depend on the parent state before this point, they must be re-validated in the now-correct state.
             // A "parent" source is faked since Child+Self states are always assumed valid if they only access local Drawable states (e.g. Colour but not DrawInfo).
-            Invalidate(invalidationList.Trim(Invalidation.All), InvalidationSource.Parent);
+            // Only layout flags are required, as non-layout flags are always propagated by the parent.
+            Invalidate(Invalidation.Layout, InvalidationSource.Parent);
 
             LoadComplete();
 
@@ -2588,6 +2589,11 @@ namespace osu.Framework.Graphics
         /// All possible things are affected.
         /// </summary>
         All = DrawNode | RequiredParentSizeToFit | Colour | DrawInfo | Presence,
+
+        /// <summary>
+        /// Only the layout flags.
+        /// </summary>
+        Layout = All & ~(DrawNode | Parent)
     }
 
     /// <summary>

--- a/osu.Framework/Graphics/InvalidationList.cs
+++ b/osu.Framework/Graphics/InvalidationList.cs
@@ -68,26 +68,14 @@ namespace osu.Framework.Graphics
                    | validate(ref childInvalidation, validation);
         }
 
-        /// <summary>
-        /// Trims off any <see cref="Invalidation"/> flags that should always invalidate.
-        /// </summary>
-        /// <remarks>
-        /// Some <see cref="Invalidation"/> flags act as "markers" to imply the layout hasn't changed but rather that a
-        /// significant change occurred in the scene graph such that the <see cref="DrawNode"/> should always be regenerated.
-        /// Such changes should always be alerted to the <see cref="Drawable"/> and its immediate hierarchy.
-        /// Trimming off the flags here will cause them to never block invalidation.
-        /// </remarks>
-        /// <param name="flags"></param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Invalidation Trim(Invalidation flags) => flags & ~(Invalidation.DrawNode | Invalidation.Parent);
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool invalidate(ref Invalidation target, Invalidation flags)
         {
             if ((target & flags) == flags)
                 return false;
 
-            target |= Trim(flags);
+            // Remove all non-layout flags, as they should always propagate and are thus not to be stored.
+            target |= flags & Invalidation.Layout;
             return true;
         }
 


### PR DESCRIPTION
It's unnecessary to propagate invalidations to non-alive children, as they are not part of the hierarchy yet. They don't receive any other updates, or even `LoadComplete` if they're not alive.

This provides a small benefit when there are many objects that aren't alive (e.g. hitobjects, currently) and when a parenting container changes (e.g. window size / screen scale).

```diff
  |         Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
  |--------------- |---------:|---------:|---------:|------:|------:|------:|----------:|
- |   ManyNotAlive | 17.67 ms | 0.107 ms | 0.100 ms |     - |     - |     - |     214 B |
+ |   ManyNotAlive | 15.72 ms | 0.312 ms | 0.321 ms |     - |     - |     - |     144 B |
- | MakeChildAlive | 992.7 us |  1.23 us |  1.15 us |     - |     - |     - |     115 B |
+ | MakeChildAlive | 987.1 us |  1.29 us |  1.21 us |     - |     - |     - |     112 B |
- |      ManyAlive | 11.69 ms | 0.035 ms | 0.029 ms |     - |     - |     - |     112 B |
+ |      ManyAlive | 11.45 ms | 0.037 ms | 0.035 ms |     - |     - |     - |     134 B |
```

I've also taken this time to remove the `InvalidationList.Trim()` method, because it was quite confusing as to what it actually did. I've replaced it with the `Invalidation.Layout` flag, which should be more self-explanatory.

I also highly suspect that the invalidation in `Drawable.loadComplete` isn't required after this change since I failed to make a reproduction of any failure scenario involving it. But I'll leave it there for now just for safety - it's essentially a no-op.