### PR TITLE
Never propagate DrawNode invalidations

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -961,6 +961,11 @@ namespace osu.Framework.Graphics.Containers
             if (source == InvalidationSource.Child)
                 return anyInvalidated;
 
+            // DrawNode invalidations should not propagate to children.
+            invalidation &= ~Invalidation.DrawNode;
+            if (invalidation == Invalidation.None)
+                return anyInvalidated;
+
             for (int i = 0; i < internalChildren.Count; ++i)
             {
                 Drawable c = internalChildren[i];

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2561,6 +2561,7 @@ namespace osu.Framework.Graphics
 
         /// <summary>
         /// <see cref="Graphics.DrawNode.ApplyState"/> has to be invoked on all old draw nodes.
+        /// This <see cref="Invalidation"/> flag never propagates to children.
         /// </summary>
         DrawNode = 1 << 4,
 


### PR DESCRIPTION
Across osu!framework and osu!, there is only one use case for `DrawNode` invalidations: notifying yourself that your own `DrawNode` should change.

For example, `Container` invalidates `DrawNode` to signal its own `DrawNode` of changes to edge effect/corner radius/masking states/etc. Similar for `BufferedContainer`, every time `ForceRedraw()` is called - potentially every frame.

Potentially breaking change, but no changes are required o!f-side or osu!-side, so I'm not making a breaking change entry for this.