### PR TITLE
Optimise conservative draw quad computations

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkSpinningParentWithManyAlive.cs
+++ b/osu.Framework.Benchmarks/BenchmarkSpinningParentWithManyAlive.cs
@@ -28,7 +28,8 @@ namespace osu.Framework.Benchmarks
                 {
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
-                    RelativeSizeAxes = Axes.Both,
+                    Size = new Vector2(200),
+                    Masking = true
                 };
 
                 for (int i = 0; i < 10000; i++)


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/3442 (tests)

Only needs to be computed when we know we're going to draw. This is inside `BoxDrawNode.ApplyState()`.

```diff
  |            Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
  |------------------ |---------:|----------:|----------:|------:|------:|------:|----------:|
- |         ManyAlive | 9.327 ms | 0.0518 ms | 0.0459 ms |     - |     - |     - |     128 B |
+ |         ManyAlive | 8.779 ms | 0.1085 ms | 0.0962 ms |     - |     - |     - |     112 B |
- | ManySpinningBoxes | 1.043 ms | 0.0053 ms | 0.0049 ms |     - |     - |     - |     133 B |
+ | ManySpinningBoxes | 987.1 us |   1.69 us |   1.58 us |     - |     - |     - |     113 B |
```

Changes in `ManyAlive` are due to the quad not being computed if `IsMaskedAway = true`.
Changes in `ManySpinningBoxes` are due to early condition on `EdgeSmoothness`, which didn't exist previously.