### PR TITLE
Remove atomic invalidation counter

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1732,10 +1732,8 @@ namespace osu.Framework.Graphics
                 Parent?.ValidateSuperTree(validationType);
         }
 
-        private static readonly AtomicCounter invalidation_counter = new AtomicCounter();
-
         // Make sure we start out with a value of 1 such that ApplyDrawNode is always called at least once
-        public long InvalidationID { get; private set; } = invalidation_counter.Increment();
+        public long InvalidationID { get; private set; } = 1;
 
         /// <summary>
         /// Invalidates the layout of this <see cref="Drawable"/>.
@@ -1791,7 +1789,7 @@ namespace osu.Framework.Graphics
             anyInvalidated |= OnInvalidate(invalidation, source);
 
             if (anyInvalidated)
-                InvalidationID = invalidation_counter.Increment();
+                InvalidationID++;
 
             Invalidated?.Invoke(this);
 


### PR DESCRIPTION
Theoretically this should have some performance impact, but it is not visible on any benchmarks whatsoever, so I haven't included any.

This is only ever accessed on the update thread (inside `Invalidate()`, `GenerateDrawNodeSubtree()` and `DrawNode.ApplyState()`).