### PR TITLE
Extract bindable propagations

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -5,6 +5,7 @@ using System;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Bindables.Bindings;
 using osu.Framework.Graphics;
 using osu.Framework.Timing;
 
@@ -28,16 +29,29 @@ namespace osu.Framework.Tests.Bindables
             Bindable<string> bindable1 = new Bindable<string>("default");
             Bindable<string> bindable2 = bindable1.GetBoundCopy();
             Bindable<string> bindable3 = bindable2.GetBoundCopy();
+            Bindable<string> bindable4 = bindable3.GetBoundCopy(BindingMode.OneWay);
 
             Assert.AreEqual("default", bindable1.Value);
-            Assert.AreEqual(bindable2.Value, bindable1.Value);
-            Assert.AreEqual(bindable3.Value, bindable1.Value);
+            Assert.AreEqual(bindable1.Value, bindable2.Value);
+            Assert.AreEqual(bindable1.Value, bindable3.Value);
+            Assert.AreEqual(bindable1.Value, bindable4.Value);
 
             bindable1.Value = "new value";
 
             Assert.AreEqual("new value", bindable1.Value);
-            Assert.AreEqual(bindable2.Value, bindable1.Value);
+            Assert.AreEqual(bindable1.Value, bindable2.Value);
+            Assert.AreEqual(bindable1.Value, bindable3.Value);
+            Assert.AreEqual(bindable1.Value, bindable4.Value);
+
+            bindable4.Value = "This change won't be propagated";
+            Assert.AreEqual("This change won't be propagated", bindable4.Value);
+            Assert.AreNotEqual(bindable3.Value, bindable4.Value);
+
+            bindable3.Value = "This change will be propagated";
+            Assert.AreEqual("This change will be propagated", bindable3.Value);
             Assert.AreEqual(bindable3.Value, bindable1.Value);
+            Assert.AreEqual(bindable3.Value, bindable2.Value);
+            Assert.AreEqual(bindable3.Value, bindable4.Value);
         }
 
         [Test]
@@ -46,12 +60,14 @@ namespace osu.Framework.Tests.Bindables
             Bindable<string> bindable1 = new Bindable<string>("default");
             Bindable<string> bindable2 = bindable1.GetBoundCopy();
             Bindable<string> bindable3 = bindable2.GetBoundCopy();
+            Bindable<string> bindable4 = bindable3.GetBoundCopy(BindingMode.OneWay);
 
             bindable1.Disabled = true;
 
             Assert.Throws<InvalidOperationException>(() => bindable1.Value = "new value");
             Assert.Throws<InvalidOperationException>(() => bindable2.Value = "new value");
             Assert.Throws<InvalidOperationException>(() => bindable3.Value = "new value");
+            Assert.Throws<InvalidOperationException>(() => bindable4.Value = "new value");
 
             bindable1.Disabled = false;
 
@@ -60,12 +76,23 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual("new value", bindable1.Value);
             Assert.AreEqual("new value", bindable2.Value);
             Assert.AreEqual("new value", bindable3.Value);
+            Assert.AreEqual("new value", bindable4.Value);
 
             bindable2.Value = "new value 2";
 
             Assert.AreEqual("new value 2", bindable1.Value);
             Assert.AreEqual("new value 2", bindable2.Value);
             Assert.AreEqual("new value 2", bindable3.Value);
+            Assert.AreEqual("new value 2", bindable4.Value);
+
+            bindable4.Disabled = true;
+
+            Assert.Throws<InvalidOperationException>(() => bindable4.Value = "new value");
+            Assert.False(bindable3.Disabled);
+
+            bindable3.Value = "not disabled";
+
+            Assert.AreEqual("not disabled", bindable3.Value);
         }
 
         [Test]
@@ -74,24 +101,28 @@ namespace osu.Framework.Tests.Bindables
             Bindable<string> bindable1 = new Bindable<string>("default");
             Bindable<string> bindable2 = bindable1.GetBoundCopy();
             Bindable<string> bindable3 = bindable2.GetBoundCopy();
+            Bindable<string> bindable4 = bindable3.GetBoundCopy(BindingMode.OneWay);
 
-            int changed1 = 0, changed2 = 0, changed3 = 0;
+            int changed1 = 0, changed2 = 0, changed3 = 0, changed4 = 0;
 
             bindable1.DefaultChanged += _ => changed1++;
             bindable2.DefaultChanged += _ => changed2++;
             bindable3.DefaultChanged += _ => changed3++;
+            bindable4.DefaultChanged += _ => changed4++;
 
             bindable1.Default = "new value";
 
             Assert.AreEqual(1, changed1);
             Assert.AreEqual(1, changed2);
             Assert.AreEqual(1, changed3);
+            Assert.AreEqual(1, changed4);
 
             bindable1.Default = "new value 2";
 
             Assert.AreEqual(2, changed1);
             Assert.AreEqual(2, changed2);
             Assert.AreEqual(2, changed3);
+            Assert.AreEqual(2, changed4);
 
             // should not re-fire, as the value hasn't changed.
             bindable1.Default = "new value 2";
@@ -99,6 +130,12 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(2, changed1);
             Assert.AreEqual(2, changed2);
             Assert.AreEqual(2, changed3);
+            Assert.AreEqual(2, changed4);
+
+            bindable4.Default = "new value 3";
+
+            Assert.AreEqual(2, changed3);
+            Assert.AreEqual(3, changed4);
         }
 
         [Test]
@@ -132,24 +169,28 @@ namespace osu.Framework.Tests.Bindables
             Bindable<string> bindable1 = new Bindable<string>("default");
             Bindable<string> bindable2 = bindable1.GetBoundCopy();
             Bindable<string> bindable3 = bindable2.GetBoundCopy();
+            Bindable<string> bindable4 = bindable3.GetBoundCopy(BindingMode.OneWay);
 
-            int changed1 = 0, changed2 = 0, changed3 = 0;
+            int changed1 = 0, changed2 = 0, changed3 = 0, changed4 = 0;
 
             bindable1.ValueChanged += _ => changed1++;
             bindable2.ValueChanged += _ => changed2++;
             bindable3.ValueChanged += _ => changed3++;
+            bindable4.ValueChanged += _ => changed4++;
 
             bindable1.Value = "new value";
 
             Assert.AreEqual(1, changed1);
             Assert.AreEqual(1, changed2);
             Assert.AreEqual(1, changed3);
+            Assert.AreEqual(1, changed4);
 
             bindable1.Value = "new value 2";
 
             Assert.AreEqual(2, changed1);
             Assert.AreEqual(2, changed2);
             Assert.AreEqual(2, changed3);
+            Assert.AreEqual(2, changed4);
 
             // should not re-fire, as the value hasn't changed.
             bindable1.Value = "new value 2";
@@ -157,6 +198,12 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(2, changed1);
             Assert.AreEqual(2, changed2);
             Assert.AreEqual(2, changed3);
+            Assert.AreEqual(2, changed4);
+
+            bindable4.Value = "new value 3";
+
+            Assert.AreEqual(2, changed3);
+            Assert.AreEqual(3, changed4);
         }
 
         [Test]
@@ -190,24 +237,33 @@ namespace osu.Framework.Tests.Bindables
             Bindable<string> bindable1 = new Bindable<string>("default");
             Bindable<string> bindable2 = bindable1.GetBoundCopy();
             Bindable<string> bindable3 = bindable2.GetBoundCopy();
+            Bindable<string> bindable4 = bindable3.GetBoundCopy(BindingMode.OneWay);
 
-            bool disabled1 = false, disabled2 = false, disabled3 = false;
+            bool disabled1 = false, disabled2 = false, disabled3 = false, disabled4 = false;
 
             bindable1.DisabledChanged += v => disabled1 = v;
             bindable2.DisabledChanged += v => disabled2 = v;
             bindable3.DisabledChanged += v => disabled3 = v;
+            bindable4.DisabledChanged += v => disabled4 = v;
 
             bindable1.Disabled = true;
 
             Assert.AreEqual(true, disabled1);
             Assert.AreEqual(true, disabled2);
             Assert.AreEqual(true, disabled3);
+            Assert.AreEqual(true, disabled4);
 
             bindable1.Disabled = false;
 
             Assert.AreEqual(false, disabled1);
             Assert.AreEqual(false, disabled2);
             Assert.AreEqual(false, disabled3);
+            Assert.AreEqual(false, disabled4);
+
+            bindable4.Disabled = true;
+
+            Assert.AreEqual(false, disabled3);
+            Assert.AreEqual(true, disabled4);
         }
 
         [Test]

--- a/osu.Framework/Bindables/BindableMarginPadding.cs
+++ b/osu.Framework/Bindables/BindableMarginPadding.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Globalization;
+using osu.Framework.Bindables.Bindings;
 using osu.Framework.Graphics;
 
 namespace osu.Framework.Bindables
@@ -28,7 +29,7 @@ namespace osu.Framework.Bindables
             set => base.Value = clamp(value, MinValue, MaxValue);
         }
 
-        public override void BindTo(Bindable<MarginPadding> them)
+        public override void BindTo(Bindable<MarginPadding> them, BindingMode mode = BindingMode.TwoWay)
         {
             if (them is BindableMarginPadding other)
             {
@@ -57,7 +58,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            base.BindTo(them);
+            base.BindTo(them, mode);
         }
 
         public override string ToString() => Value.ToString();

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using osu.Framework.Bindables.Bindings;
 
 namespace osu.Framework.Bindables
 {
@@ -265,7 +266,7 @@ namespace osu.Framework.Bindables
 
             if (propagateToBindings && Bindings != null)
             {
-                foreach (var b in Bindings)
+                foreach (var b in Bindings.Keys)
                 {
                     if (b == source) continue;
 
@@ -285,7 +286,7 @@ namespace osu.Framework.Bindables
 
             if (propagateToBindings && Bindings != null)
             {
-                foreach (var b in Bindings)
+                foreach (var b in Bindings.Keys)
                 {
                     if (b == source) continue;
 
@@ -305,7 +306,7 @@ namespace osu.Framework.Bindables
 
             if (propagateToBindings && Bindings != null)
             {
-                foreach (var b in Bindings)
+                foreach (var b in Bindings.Keys)
                 {
                     if (b == source) continue;
 
@@ -318,7 +319,7 @@ namespace osu.Framework.Bindables
                 MaxValueChanged?.Invoke(maxValue);
         }
 
-        public override void BindTo(Bindable<T> them)
+        public override void BindTo(Bindable<T> them, BindingMode mode = BindingMode.TwoWay)
         {
             if (them is BindableNumber<T> other)
             {
@@ -333,7 +334,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            base.BindTo(them);
+            base.BindTo(them, mode);
         }
 
         /// <summary>

--- a/osu.Framework/Bindables/BindableSize.cs
+++ b/osu.Framework/Bindables/BindableSize.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Drawing;
+using osu.Framework.Bindables.Bindings;
 
 namespace osu.Framework.Bindables
 {
@@ -27,7 +28,7 @@ namespace osu.Framework.Bindables
             set => base.Value = clamp(value, MinValue, MaxValue);
         }
 
-        public override void BindTo(Bindable<Size> them)
+        public override void BindTo(Bindable<Size> them, BindingMode mode = BindingMode.TwoWay)
         {
             if (them is BindableSize other)
             {
@@ -43,7 +44,7 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            base.BindTo(them);
+            base.BindTo(them, mode);
         }
 
         public override string ToString() => $"{Value.Width}x{Value.Height}";

--- a/osu.Framework/Bindables/Bindings/Binding.cs
+++ b/osu.Framework/Bindables/Bindings/Binding.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Bindables.Bindings
+{
+    /// <summary>
+    /// Denotes a binding between two <see cref="Bindable{T}"/> objects
+    /// </summary>
+    /// <typeparam name="T">The type of our stored <see cref="Bindable{T}.Value"/></typeparam>
+    public abstract class Binding<T>
+    {
+        /// <summary>
+        /// A binding source
+        /// </summary>
+        protected readonly WeakReference<Bindable<T>> Source;
+
+        /// <summary>
+        /// A binding target
+        /// </summary>
+        protected readonly WeakReference<Bindable<T>> Target;
+
+        /// <summary>
+        /// Creates a new <see cref="Binding{T}"/> instance.
+        /// </summary>
+        /// <param name="source">A binding source</param>
+        /// <param name="target">A binding target</param>
+        protected Binding(Bindable<T> source, Bindable<T> target)
+        {
+            Source = new WeakReference<Bindable<T>>(source);
+            Target = new WeakReference<Bindable<T>>(target);
+
+            target.Value = source.Value;
+            target.Default = source.Default;
+            target.Disabled = source.Disabled;
+        }
+
+        /// <summary>
+        /// Propagates <see cref="Bindable{T}.Value"/> changes between <see cref="Bindable{T}"/> objects
+        /// </summary>
+        /// <param name="previousValue">Previous <see cref="Bindable{T}.Value"/></param>
+        /// <param name="value">New <see cref="Bindable{T}.Value"/></param>
+        /// <param name="bypassChecks">Whether the checks will be skipped</param>
+        /// <param name="source"><see cref="Bindable{T}"/> which propagates the change to others</param>
+        public abstract void PropagateValueChange(T previousValue, T value, bool bypassChecks, Bindable<T> source);
+
+        /// <summary>
+        /// Propagates <see cref="Bindable{T}.Default"/> changes between <see cref="Bindable{T}"/> objects
+        /// </summary>
+        /// <param name="previousValue">Previous <see cref="Bindable{T}.Value"/></param>
+        /// <param name="value">New <see cref="Bindable{T}.Value"/></param>
+        /// <param name="bypassChecks">Whether the checks will be skipped</param>
+        /// <param name="source"><see cref="Bindable{T}"/> which propagates the change to others</param>
+        public abstract void PropagateDefaultChange(T previousValue, T value, bool bypassChecks, Bindable<T> source);
+
+        /// <summary>
+        /// Propagates <see cref="Bindable{T}.Disabled"/> changes between <see cref="Bindable{T}"/> objects
+        /// </summary>
+        /// <param name="source">New <see cref="Bindable{T}.Value"/></param>
+        /// <param name="bypassChecks">Whether the checks will be skipped</param>
+        public abstract void PropagateDisabledChange(Bindable<T> source, bool bypassChecks);
+    }
+}

--- a/osu.Framework/Bindables/Bindings/BindingMode.cs
+++ b/osu.Framework/Bindables/Bindings/BindingMode.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Bindables.Bindings
+{
+    /// <summary>
+    /// List of available change propagation strategies.
+    /// </summary>
+    public enum BindingMode
+    {
+        OneWay, TwoWay
+    }
+}

--- a/osu.Framework/Bindables/Bindings/OneWayBinding.cs
+++ b/osu.Framework/Bindables/Bindings/OneWayBinding.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Bindables.Bindings
+{
+    /// <summary>
+    /// A <see cref="Binding{T}"/> implementation where changes are propagated only from <see cref="Binding{T}.Source"/> to <see cref="Binding{T}.Target"/>
+    /// </summary>
+    /// <typeparam name="T">The type of our stored <see cref="Bindable{T}.Value"/></typeparam>
+    public class OneWayBinding<T> : Binding<T>
+    {
+        /// <summary>
+        /// Creates a new <see cref="OneWayBinding{T}"/> instance.
+        /// </summary>
+        /// <param name="source">A binding source</param>
+        /// <param name="target">A binding target</param>
+        public OneWayBinding(Bindable<T> source, Bindable<T> target)
+            : base(source, target)
+        {
+        }
+
+        /// <summary>
+        /// Propagates <see cref="Bindable{T}.Value"/> changes from <see cref="Binding{T}.Source"/> to <see cref="Binding{T}.Target"/>
+        /// </summary>
+        /// <param name="previousValue">Previous <see cref="Bindable{T}.Value"/></param>
+        /// <param name="value">New <see cref="Bindable{T}.Value"/></param>
+        /// <param name="bypassChecks">Whether the checks will be skipped</param>
+        /// <param name="source"><see cref="Bindable{T}"/> which propagates the change to others</param>
+        public override void PropagateValueChange(T previousValue, T value, bool bypassChecks, Bindable<T> source)
+        {
+            if (Source.TryGetTarget(out var bindingSource) && bindingSource == source && Target.TryGetTarget(out var bindingTarget))
+                bindingTarget.SetValue(previousValue, value, bypassChecks);
+        }
+
+        /// <summary>
+        /// Propagates <see cref="Bindable{T}.Default"/> changes from <see cref="Binding{T}.Source"/> to <see cref="Binding{T}.Target"/>
+        /// </summary>
+        /// <param name="previousValue">Previous <see cref="Bindable{T}.Value"/></param>
+        /// <param name="value">New <see cref="Bindable{T}.Value"/></param>
+        /// <param name="bypassChecks">Whether the checks will be skipped</param>
+        /// <param name="source"><see cref="Bindable{T}"/> which propagates the change to others</param>
+        public override void PropagateDefaultChange(T previousValue, T value, bool bypassChecks, Bindable<T> source)
+        {
+            if (Source.TryGetTarget(out var bindingSource) && bindingSource == source && Target.TryGetTarget(out var bindingTarget))
+                bindingTarget.SetDefaultValue(previousValue, value, bypassChecks);
+        }
+
+        /// <summary>
+        /// Propagates <see cref="Bindable{T}.Disabled"/> changes from <see cref="Binding{T}.Source"/> to <see cref="Binding{T}.Target"/>
+        /// </summary>
+        /// <param name="source">New <see cref="Bindable{T}.Value"/></param>
+        /// <param name="bypassChecks">Whether the checks will be skipped</param>
+        public override void PropagateDisabledChange(Bindable<T> source, bool bypassChecks)
+        {
+            if (Source.TryGetTarget(out var bindingSource) && bindingSource == source && Target.TryGetTarget(out var bindingTarget))
+                bindingTarget.SetDisabled(source.Disabled, bypassChecks);
+        }
+    }
+}

--- a/osu.Framework/Bindables/Bindings/TwoWayBinding.cs
+++ b/osu.Framework/Bindables/Bindings/TwoWayBinding.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+
+namespace osu.Framework.Bindables.Bindings
+{
+    /// <summary>
+    /// A <see cref="Binding{T}"/> implementation where changes are propagated bidirectional
+    /// </summary>
+    /// <typeparam name="T">The type of our stored <see cref="Bindable{T}.Value"/></typeparam>
+    public class TwoWayBinding<T> : Binding<T>
+    {
+        /// <summary>
+        /// Creates a new <see cref="TwoWayBinding{T}"/> instance.
+        /// </summary>
+        /// <param name="source">A binding source</param>
+        /// <param name="target">A binding target</param>
+        public TwoWayBinding(Bindable<T> source, Bindable<T> target)
+            : base(source, target)
+        {
+        }
+
+        /// <summary>
+        /// Propagates <see cref="Bindable{T}.Value"/> changes bidirectionally
+        /// </summary>
+        /// <param name="previousValue"></param>
+        /// <param name="value"></param>
+        /// <param name="bypassChecks"></param>
+        /// <param name="source"></param>
+        public override void PropagateValueChange(T previousValue, T value, bool bypassChecks, Bindable<T> source)
+        {
+            if (Source.TryGetTarget(out var bindingSource) && Target.TryGetTarget(out var bindingTarget))
+            {
+                if (!ReferenceEquals(bindingSource, source) && !EqualityComparer<T>.Default.Equals(bindingSource.Value, value))
+                    bindingSource.SetValue(previousValue, value, bypassChecks);
+                else if (!ReferenceEquals(bindingTarget, source) && !EqualityComparer<T>.Default.Equals(bindingTarget.Value, value))
+                    bindingTarget.SetValue(previousValue, value, bypassChecks);
+            }
+        }
+
+        /// <summary>
+        /// Propagates <see cref="Bindable{T}.Default"/> changes bidirectionally
+        /// </summary>
+        /// <param name="previousValue"></param>
+        /// <param name="value"></param>
+        /// <param name="bypassChecks"></param>
+        /// <param name="source"></param>
+        public override void PropagateDefaultChange(T previousValue, T value, bool bypassChecks, Bindable<T> source)
+        {
+            if (Source.TryGetTarget(out var bindingSource) && Target.TryGetTarget(out var bindingTarget))
+            {
+                if (!ReferenceEquals(bindingSource, source) && !EqualityComparer<T>.Default.Equals(bindingSource.Default, value))
+                    bindingSource.SetDefaultValue(previousValue, value, bypassChecks);
+                else
+                {
+                    if (!ReferenceEquals(bindingTarget, source) && !EqualityComparer<T>.Default.Equals(bindingTarget.Default, value))
+                        bindingTarget.SetDefaultValue(previousValue, value, bypassChecks);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Propagates <see cref="Bindable{T}.Disabled"/> changes bidirectionally
+        /// </summary>
+        /// <param name="source"></param>
+        /// <param name="bypassChecks"></param>
+        public override void PropagateDisabledChange(Bindable<T> source, bool bypassChecks)
+        {
+            if (Source.TryGetTarget(out var bindingSource) && Target.TryGetTarget(out var bindingTarget))
+            {
+                if (!ReferenceEquals(bindingSource, source) && bindingSource.Disabled != source.Disabled)
+                    bindingSource.SetDisabled(source.Disabled, bypassChecks);
+                else
+                {
+                    if (!ReferenceEquals(bindingTarget, source) && bindingTarget.Disabled != source.Disabled)
+                        bindingTarget.SetDisabled(source.Disabled, bypassChecks);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
As a XAML developer, I expect binding to be more powerful than it is now. For example, in UWP DataBinding supports multiple modes(one way, two way, one time) and converters(custom value processing during its propagation).

This PR extracts `Value`/`Default`/`Disabled` propagation to separate class hierarchy(`Binding<T>`). It allows us to implement various propagation algorithms without messing up the `Bindable<T>` itself.
In terms of design patterns, `Binding<T>` is a strategy. It encapsulates a propagation algorithm and theoretically can be passed to a `Bindable` from the outside.