### PR TITLE
Fix samples occasionally playing before volume adjustment can be applied

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -53,6 +53,8 @@ namespace osu.Framework.Audio.Sample
 
         public override void Play(bool restart = true)
         {
+            base.Play(restart);
+
             EnqueueAction(() =>
             {
                 if (!IsLoaded)
@@ -83,8 +85,6 @@ namespace osu.Framework.Audio.Sample
             // Needs to happen on the main thread such that
             // Played does not become true for a short moment.
             playing = true;
-
-            base.Play(restart);
         }
 
         protected override void UpdateState()


### PR DESCRIPTION
Stems from `SampleChannel`'s ctor `Action<SampleChannel> onPlay`, which is where the channel is added to its parent `AudioComponent` (and aggregate adjustments are bound). This was happening after the playback itself.

Closes https://github.com/ppy/osu/issues/8162.

Can be reproduced by adding a Thread.Sleep after the play call:

https://github.com/ppy/osu-framework/blob/78dbba4f63668da3dffe46d889fd41209105a2d2/osu.Framework/Audio/Sample/SampleChannelBass.cs#L80

Note that it will *not* reproduce in `TestSceneSamples` because this does not request new channels each playback, so it will only occur on the first playback (if that).