### PR TITLE
Rework dynamic compilation to use Roslyn-backed type resolution

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -25,6 +25,7 @@ using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Layout;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 
 namespace osu.Framework.Graphics.Containers
@@ -36,6 +37,7 @@ namespace osu.Framework.Graphics.Containers
     /// Additionally, <see cref="CompositeDrawable"/>s support various effects, such as masking, edge effect,
     /// padding, and automatic sizing depending on their children.
     /// </summary>
+    [ExcludeFromDynamicCompile]
     public abstract partial class CompositeDrawable : Drawable
     {
         #region Contruction and disposal

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -30,6 +30,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Layout;
+using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osuTK.Input;
 
@@ -47,6 +48,7 @@ namespace osu.Framework.Graphics
     /// Drawables are always rectangular in shape in their local coordinate system,
     /// which makes them quad-shaped in arbitrary (linearly transformed) coordinate systems.
     /// </summary>
+    [ExcludeFromDynamicCompile]
     public abstract partial class Drawable : Transformable, IDisposable, IDrawable
     {
         #region Construction and disposal

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -52,15 +52,14 @@ namespace osu.Framework.Testing
 #else
             referenceBuilder = new EmptyTypeReferenceBuilder();
 #endif
-
-            referenceBuilder.Initialise(Directory.GetFiles(getSolutionPath(di), "*.sln").First());
-
-            Task.Run(() =>
+            Task.Run(async () =>
             {
                 var basePath = getSolutionPath(di);
 
                 if (!Directory.Exists(basePath))
                     return;
+
+                await referenceBuilder.Initialise(Directory.GetFiles(getSolutionPath(di), "*.sln").First());
 
                 foreach (var dir in Directory.GetDirectories(basePath))
                 {

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -42,6 +42,8 @@ namespace osu.Framework.Testing
 #endif
             Task.Run(async () =>
             {
+                Logger.Log("Initialising dynamic compilation...");
+
                 var basePath = getSolutionPath(di);
 
                 if (!Directory.Exists(basePath))
@@ -68,6 +70,8 @@ namespace osu.Framework.Testing
 
                     watchers.Add(fsw);
                 }
+
+                Logger.Log("Dynamic compilation is now available.");
             });
         }
 

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -9,11 +9,8 @@ using System.Threading;
 using osu.Framework.Logging;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.MSBuild;
-using Microsoft.CodeAnalysis.Text;
 
 namespace osu.Framework.Testing
 {
@@ -34,20 +31,23 @@ namespace osu.Framework.Testing
 
         public void SetRecompilationTarget(T target) => this.target = target;
 
-        private readonly HashSet<string> requiredFiles = new HashSet<string>();
-
         private HashSet<string> assemblies;
 
         private readonly List<string> validDirectories = new List<string>();
 
-        private Solution solution;
+        private ITypeReferenceBuilder referenceBuilder;
 
         public void Start()
         {
-            MSBuildLocator.RegisterDefaults();
-
             var di = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
-            solution = MSBuildWorkspace.Create().OpenSolutionAsync(Path.Combine(getSolutionPath(di), "osu-framework.sln")).Result;
+
+#if NETCOREAPP
+            referenceBuilder = new RoslynTypeReferenceBuilder();
+#else
+            referenceBuilder = new EmptyTypeReferenceBuilder();
+#endif
+
+            referenceBuilder.Initialise(Directory.GetFiles(getSolutionPath(di), "*.sln").First());
 
             Task.Run(() =>
             {
@@ -97,243 +97,11 @@ namespace osu.Framework.Testing
                     return;
 
                 isCompiling = true;
-
-                var testProj = findTestProject();
-
-                var changedDoc = solution.GetDocumentIdsWithFilePath(args.FullPath)[0];
-                var changedProj = findProjectFromDocumentId(changedDoc);
-
-                Logger.Log("Updating solution...");
-
-                solution = solution.WithDocumentText(changedDoc, SourceText.From(File.ReadAllText(args.FullPath)));
-
-                Logger.Log("Compiling test project...");
-
-                // Find the syntax tree for the target TestScene.
-                var testProjCompilation = testProj.GetCompilationAsync().Result;
-                var testProjTargetType = testProjCompilation.GetTypeByMetadataName(target.GetType().FullName);
-
-                // The following goes through the following process. Given the test scene hierarchy (this graph is unknown to us by this point):
-                //
-                //                            P
-                //                          /  \
-                //                         /    \
-                //                        /      \
-                //                      C1       C2
-                //                    /   \      |
-                //                  C3    C4    C5
-                //                          \  /
-                //                           C6
-                //
-                // We generate a disjoint graph of connections between types and all their referenced types:
-                //
-                // P -> { C1, C2 }
-                // C1 -> { C3, C4 }
-                // C2 -> { C5 }
-                // C3 -> { }
-                // C4 -> { C6 }
-                // C5 -> { C6 }
-                // C6 -> { }
-                //
-                // Then we go through all the connections and assign parents, building a directed graph towards P.
-                //
-                // foreach conn in dict
-                //     foreach ref in connection
-                //         node := get_existing_node_or_create_new(ref)
-                //         node.parent := conn.node
-                //
-                // Then we find the changed type (e.g. C6) traverse the directed graph, adding each corresponding file as a required file.
-                //
-                // fun add_required_files(node):
-                //     add_file(node.file)
-                //     foreach parent in node
-                //         add_required_files(parent)
-                //
-                // We're then left with the set of required files that need to be recompiled.
-
-                // 1. Build the disjoint graph of connections.
-                Logger.Log("Finding all referenced types...");
-
-                var dict = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>();
-                getReferencedTypes(testProjTargetType, dict, compilations: new Dictionary<string, Compilation> { { testProj.Name, testProjCompilation } });
-
-                // 2. Merge disjoint graph by parents.
-                Logger.Log("Building reverse lookup graph...");
-
-                var revDict = new Dictionary<string, TypeNode>();
-
-                foreach (var kvp in dict)
-                {
-                    var parentNode = getNode(kvp.Key);
-                    foreach (var typeRef in kvp.Value)
-                        getNode(typeRef).Parents.Add(parentNode);
-                }
-
-                TypeNode getNode(INamedTypeSymbol typeSymbol)
-                {
-                    var stringTypeSymbol = typeSymbol.ToString();
-                    if (!revDict.TryGetValue(stringTypeSymbol, out var existing))
-                        revDict[stringTypeSymbol] = existing = new TypeNode(typeSymbol);
-                    return existing;
-                }
-
-                // 3. Traverse the directed graph and build the set of required files.
-                Logger.Log("Building required files...");
-
-                // Traverse the parent-hirerchy of the changed file
-                var changedTypeNode = revDict.Where(kvp =>
-                {
-                    foreach (var loc in kvp.Value.TypeSymbol.Locations)
-                    {
-                        var tree = loc.SourceTree;
-                        if (tree == null)
-                            return false;
-
-                        return tree.FilePath == args.FullPath;
-                    }
-
-                    return false;
-                }).First(); // Todo: FirstOrDefault() with a null check.
-
-                requiredFiles.Clear();
-
-                var seenNodes = new HashSet<TypeNode>();
-                addRequiredFiles(changedTypeNode.Value);
-
-                void addRequiredFiles(TypeNode node)
-                {
-                    if (seenNodes.Contains(node))
-                        return;
-
-                    seenNodes.Add(node);
-
-                    foreach (var loc in node.TypeSymbol.Locations)
-                    {
-                        if (loc.SourceTree != null)
-                            requiredFiles.Add(loc.SourceTree.FilePath);
-                    }
-
-                    foreach (var p in node.Parents)
-                        addRequiredFiles(p);
-                }
-
-                // Finally, recompile.
                 lastTouchedFile = args.FullPath;
 
-                Task.Run(recompile)
+                Task.Run(async () => recompile(await referenceBuilder.GetReferencedFiles(target.GetType(), args.FullPath)))
                     .ContinueWith(_ => isCompiling = false);
             }
-        }
-
-        private Project findTestProject()
-        {
-            var expectedAssemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
-            return solution.Projects.FirstOrDefault(p => p.AssemblyName == expectedAssemblyName);
-        }
-
-        private Project findProjectFromDocumentId(DocumentId document) => solution.Projects.SingleOrDefault(p => p.ContainsDocument(document));
-
-        private void getReferencedTypes(INamedTypeSymbol typeSymbol, Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> result, HashSet<string> checkedTypes = null,
-                                        Dictionary<string, Compilation> compilations = null, bool allowBaseTypes = false)
-        {
-            checkedTypes ??= new HashSet<string>();
-            compilations ??= new Dictionary<string, Compilation>();
-
-            var typeString = typeSymbol.ToString();
-
-            // If the type has already been checked, it doesn't need to be iterated over again.
-            if (checkedTypes.Contains(typeString))
-                return;
-
-            // Mark the current type as checked.
-            checkedTypes.Add(typeString);
-
-            if (typeSymbol.DeclaringSyntaxReferences.Length == 0)
-                return;
-
-            // Add storage for the type relationship.
-            var resultList = new List<INamedTypeSymbol>();
-            result[typeSymbol] = resultList;
-
-            // A type may exist in multiple syntax trees via partial classes.
-            foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
-            {
-                var syntaxTree = reference.SyntaxTree;
-
-                // Find the project which the syntax tree is contained in.
-                var project = solution.Projects.FirstOrDefault(p => p.Documents.Any(d => d.FilePath == syntaxTree.FilePath));
-                if (project == null)
-                    continue;
-
-                // Referenced types may exist in a separate project, however types referenced to the same project should come from a single compilation.
-                if (!compilations.TryGetValue(project.Name, out var compilation))
-                    compilations[project.Name] = compilation = project.GetCompilationAsync().Result;
-
-                // We need to re-retrieve the syntax tree on the correct compilation.
-                syntaxTree = compilation!.SyntaxTrees.Single(s => s.FilePath == syntaxTree.FilePath);
-
-                // Get the syntax model corresponding to the tree.
-                var semanticModel = compilation.GetSemanticModel(syntaxTree);
-
-                var descendantNodes = syntaxTree.GetRoot().DescendantNodes(n =>
-                {
-                    var kind = n.Kind();
-
-                    return kind != SyntaxKind.UsingDirective
-                           && kind != SyntaxKind.NamespaceKeyword
-                           && (allowBaseTypes || kind != SyntaxKind.BaseList);
-                });
-
-                // Find all the named type symbols in the syntax tree, and mark + recursively iterate through them.
-                foreach (var n in descendantNodes)
-                {
-                    switch (n.Kind())
-                    {
-                        case SyntaxKind.GenericName:
-                        case SyntaxKind.IdentifierName:
-                        {
-                            if (semanticModel.GetSymbolInfo(n).Symbol is INamedTypeSymbol t)
-                            {
-                                resultList.Add(t);
-                                getReferencedTypes(t, result, checkedTypes, compilations, true);
-                            }
-
-                            break;
-                        }
-
-                        case SyntaxKind.AsExpression:
-                        case SyntaxKind.IsExpression:
-                        case SyntaxKind.SizeOfExpression:
-                        case SyntaxKind.TypeOfExpression:
-                        case SyntaxKind.CastExpression:
-                        case SyntaxKind.ObjectCreationExpression:
-                        {
-                            if (semanticModel.GetTypeInfo(n).Type is INamedTypeSymbol t)
-                            {
-                                resultList.Add(t);
-                                getReferencedTypes(t, result, checkedTypes, compilations, true);
-                            }
-
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        private class TypeNode : IEquatable<TypeNode>
-        {
-            public readonly INamedTypeSymbol TypeSymbol;
-            public readonly HashSet<TypeNode> Parents = new HashSet<TypeNode>();
-
-            public TypeNode(INamedTypeSymbol typeSymbol)
-            {
-                TypeSymbol = typeSymbol;
-            }
-
-            public override int GetHashCode() => TypeSymbol.GetHashCode();
-
-            public bool Equals(TypeNode other) => TypeSymbol.Equals(other?.TypeSymbol);
         }
 
         private int currentVersion;
@@ -341,7 +109,7 @@ namespace osu.Framework.Testing
         private bool isCompiling;
         private readonly object compileLock = new object();
 
-        private void recompile()
+        private void recompile(IReadOnlyCollection<string> requiredFiles)
         {
             if (assemblies == null)
             {

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -27,13 +27,7 @@ namespace osu.Framework.Testing
 
         private T target;
 
-        public void SetRecompilationTarget(T target)
-        {
-            if (this.target?.GetType().FullName != target?.GetType().FullName)
-                referenceBuilder.Reset();
-
-            this.target = target;
-        }
+        public void SetRecompilationTarget(T target) => this.target = target;
 
         private ITypeReferenceBuilder referenceBuilder;
 

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Emit;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.Text;
@@ -35,8 +36,7 @@ namespace osu.Framework.Testing
 
         public void SetRecompilationTarget(T target) => this.target = target;
 
-        private readonly List<string> requiredFiles = new List<string>();
-        private List<string> requiredTypeNames = new List<string>();
+        private readonly HashSet<string> requiredFiles = new HashSet<string>();
 
         private HashSet<string> assemblies;
 
@@ -50,9 +50,7 @@ namespace osu.Framework.Testing
             MSBuildLocator.RegisterDefaults();
 
             var di = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
-
             solution = MSBuildWorkspace.Create().OpenSolutionAsync(Path.Combine(getSolutionPath(di), "osu-framework.sln")).Result;
-            emit();
 
             Task.Run(() =>
             {
@@ -101,30 +99,258 @@ namespace osu.Framework.Testing
                 if (target == null || isCompiling)
                     return;
 
-                solution = solution.WithDocumentText(solution.GetDocumentIdsWithFilePath(args.FullPath)[0], SourceText.From(File.ReadAllText(args.FullPath)));
+                isCompiling = true;
 
-                var targetType = target.GetType();
+                var testProj = findTestProject();
 
-                emit();
+                var changedDoc = solution.GetDocumentIdsWithFilePath(args.FullPath)[0];
+                var changedProj = findProjectFromDocumentId(changedDoc);
 
+                Logger.Log("Updating solution...");
+
+                solution = solution.WithDocumentText(changedDoc, SourceText.From(File.ReadAllText(args.FullPath)));
+
+                Logger.Log("Compiling test project...");
+
+                // Find the syntax tree for the target TestScene.
+                var testProjCompilation = testProj.GetCompilationAsync().Result;
+                var testProjTargetType = testProjCompilation.GetTypeByMetadataName(target.GetType().FullName);
+
+                // The following goes through the following process. Given the test scene hierarchy (this graph is unknown to us by this point):
+                //
+                //                            P
+                //                          /  \
+                //                         /    \
+                //                        /      \
+                //                      C1       C2
+                //                    /   \      |
+                //                  C3    C4    C5
+                //                          \  /
+                //                           C6
+                //
+                // We generate a disjoint graph of connections between types and all their referenced types:
+                //
+                // P -> { C1, C2 }
+                // C1 -> { C3, C4 }
+                // C2 -> { C5 }
+                // C3 -> { }
+                // C4 -> { C6 }
+                // C5 -> { C6 }
+                // C6 -> { }
+                //
+                // Then we go through all the connections and assign parents, building a directed graph towards P.
+                //
+                // foreach conn in dict
+                //     foreach ref in connection
+                //         node := get_existing_node_or_create_new(ref)
+                //         node.parent := conn.node
+                //
+                // Then we find the changed type (e.g. C6) traverse the directed graph, adding each corresponding file as a required file.
+                //
+                // fun add_required_files(node):
+                //     add_file(node.file)
+                //     foreach parent in node
+                //         add_required_files(parent)
+                //
+                // We're then left with the set of required files that need to be re-compilated.
+
+                // 1. Build the disjoint graph of connections.
+                Logger.Log("Finding all referenced types...");
+
+                var dict = new Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>>();
+                getReferencedTypes(testProjTargetType, dict, compilations: new Dictionary<string, Compilation> { { testProj.Name, testProjCompilation } });
+
+                // 2. Merge disjoint graph by parents.
+                Logger.Log("Building reverse lookup graph...");
+
+                var revDict = new Dictionary<string, TypeNode>();
+
+                foreach (var kvp in dict)
+                {
+                    var parentNode = getNode(kvp.Key);
+                    foreach (var typeRef in kvp.Value)
+                        getNode(typeRef).Parents.Add(parentNode);
+                }
+
+                TypeNode getNode(INamedTypeSymbol typeSymbol)
+                {
+                    var stringTypeSymbol = typeSymbol.ToString();
+                    if (!revDict.TryGetValue(stringTypeSymbol, out var existing))
+                        revDict[stringTypeSymbol] = existing = new TypeNode(typeSymbol);
+                    return existing;
+                }
+
+                // 3. Traverse the directed graph and build the set of required files.
+                Logger.Log("Building required files...");
+
+                // Traverse the parent-hirerchy of the changed file
+                var changedTypeNode = revDict.Where(kvp =>
+                {
+                    foreach (var loc in kvp.Value.TypeSymbol.Locations)
+                    {
+                        var tree = loc.SourceTree;
+                        if (tree == null)
+                            return false;
+
+                        return tree.FilePath == args.FullPath;
+                    }
+
+                    return false;
+                }).First(); // Todo: FirstOrDefault() with a null check.
+
+                requiredFiles.Clear();
+
+                var seenNodes = new HashSet<TypeNode>();
+                addRequiredFiles(changedTypeNode.Value);
+
+                void addRequiredFiles(TypeNode node)
+                {
+                    if (seenNodes.Contains(node))
+                        return;
+
+                    seenNodes.Add(node);
+
+                    foreach (var loc in node.TypeSymbol.Locations)
+                    {
+                        if (loc.SourceTree != null)
+                            requiredFiles.Add(loc.SourceTree.FilePath);
+                    }
+
+                    foreach (var p in node.Parents)
+                        addRequiredFiles(p);
+                }
+
+                // Finally, recompile.
                 lastTouchedFile = args.FullPath;
 
-                // isCompiling = true;
-                // Task.Run(recompile)
-                //     .ContinueWith(_ => isCompiling = false);
+                Task.Run(recompile)
+                    .ContinueWith(_ => isCompiling = false);
             }
         }
 
-        private void emit()
+        private Project findTestProject()
         {
-            var compilation = solution.Projects.ElementAt(0).GetCompilationAsync().Result;
-
-            var assemblyTypeVisitor = new AssemblyTypeVisitor();
-            compilation!.Assembly.Accept(assemblyTypeVisitor);
-
-            var typeReferenceVisitor = new TypeReferencesVisitor();
-            assemblyTypeVisitor.AllTypes[0].Accept(typeReferenceVisitor);
+            var expectedAssemblyName = Assembly.GetEntryAssembly()?.GetName().Name;
+            return solution.Projects.FirstOrDefault(p => p.AssemblyName == expectedAssemblyName);
         }
+
+        private Project findProjectFromDocumentId(DocumentId document) => solution.Projects.SingleOrDefault(p => p.ContainsDocument(document));
+
+        private void getReferencedTypes(INamedTypeSymbol typeSymbol, Dictionary<INamedTypeSymbol, List<INamedTypeSymbol>> result, HashSet<string> checkedTypes = null,
+                                        Dictionary<string, Compilation> compilations = null, bool allowBaseTypes = false)
+        {
+            checkedTypes ??= new HashSet<string>();
+            compilations ??= new Dictionary<string, Compilation>();
+
+            var typeString = typeSymbol.ToString();
+
+            // If the type has already been checked, it doesn't need to be iterated over again.
+            if (checkedTypes.Contains(typeString))
+                return;
+
+            // Mark the current type as checked.
+            checkedTypes.Add(typeString);
+
+            if (typeSymbol.DeclaringSyntaxReferences.Length == 0)
+                return;
+
+            // Add storage for the type relationship.
+            var resultList = new List<INamedTypeSymbol>();
+            result[typeSymbol] = resultList;
+
+            // A type may exist in multiple syntax trees via partial classes.
+            foreach (var reference in typeSymbol.DeclaringSyntaxReferences)
+            {
+                var syntaxTree = reference.SyntaxTree;
+
+                // Find the project which the syntax tree is contained in.
+                var project = solution.Projects.FirstOrDefault(p => p.Documents.Any(d => d.FilePath == syntaxTree.FilePath));
+                if (project == null)
+                    continue;
+
+                // Referenced types may exist in a separate project, however types referenced to the same project should come from a single compilation.
+                if (!compilations.TryGetValue(project.Name, out var compilation))
+                    compilations[project.Name] = compilation = project.GetCompilationAsync().Result;
+
+                // We need to re-retrieve the syntax tree on the correct compilation.
+                syntaxTree = compilation!.SyntaxTrees.Single(s => s.FilePath == syntaxTree.FilePath);
+
+                // Get the syntax model corresponding to the tree.
+                var semanticModel = compilation.GetSemanticModel(syntaxTree);
+
+                var descendantNodes = syntaxTree.GetRoot().DescendantNodes(n =>
+                {
+                    var kind = n.Kind();
+
+                    return kind != SyntaxKind.UsingDirective
+                           && kind != SyntaxKind.NamespaceKeyword
+                           && (allowBaseTypes || kind != SyntaxKind.BaseList);
+                });
+
+                // Find all the named type symbols in the syntax tree, and mark + recursively iterate through them.
+                foreach (var n in descendantNodes)
+                {
+                    switch (n.Kind())
+                    {
+                        case SyntaxKind.GenericName:
+                        case SyntaxKind.IdentifierName:
+                        {
+                            if (semanticModel.GetSymbolInfo(n).Symbol is INamedTypeSymbol t)
+                            {
+                                resultList.Add(t);
+                                getReferencedTypes(t, result, checkedTypes, compilations, true);
+                            }
+
+                            break;
+                        }
+
+                        case SyntaxKind.AsExpression:
+                        case SyntaxKind.IsExpression:
+                        case SyntaxKind.SizeOfExpression:
+                        case SyntaxKind.TypeOfExpression:
+                        case SyntaxKind.CastExpression:
+                        case SyntaxKind.ObjectCreationExpression:
+                        {
+                            if (semanticModel.GetTypeInfo(n).Type is INamedTypeSymbol t)
+                            {
+                                resultList.Add(t);
+                                getReferencedTypes(t, result, checkedTypes, compilations, true);
+                            }
+
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        private class TypeNode : IEquatable<TypeNode>
+        {
+            public readonly INamedTypeSymbol TypeSymbol;
+            public readonly HashSet<TypeNode> Parents = new HashSet<TypeNode>();
+
+            public TypeNode(INamedTypeSymbol typeSymbol)
+            {
+                TypeSymbol = typeSymbol;
+            }
+
+            public override int GetHashCode() => TypeSymbol.GetHashCode();
+
+            public bool Equals(TypeNode other) => TypeSymbol.Equals(other?.TypeSymbol);
+        }
+
+        // private Compilation emit()
+        // {
+        //     var compilation = solution.Projects.ElementAt(0).GetCompilationAsync().Result;
+        //
+        //     // var assemblyTypeVisitor = new AssemblyTypeVisitor();
+        //     // compilation!.Assembly.Accept(assemblyTypeVisitor);
+        //     //
+        //     // var typeReferenceVisitor = new TypeReferencesVisitor();
+        //     // assemblyTypeVisitor.AllTypes[0].Accept(typeReferenceVisitor);
+        //
+        //     return compilation;
+        // }
 
         public class AssemblyTypeVisitor : SymbolVisitor
         {
@@ -224,6 +450,8 @@ namespace osu.Framework.Testing
 
                 foreach (var param in symbol.Parameters)
                     param.Accept(this);
+
+                // Todo: This doesn't catch static references inside methods.
             }
         }
 

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -25,8 +25,6 @@ namespace osu.Framework.Testing
 
         private readonly List<FileSystemWatcher> watchers = new List<FileSystemWatcher>();
 
-        private string lastTouchedFile;
-
         private T target;
 
         public void SetRecompilationTarget(T target)
@@ -36,10 +34,6 @@ namespace osu.Framework.Testing
 
             this.target = target;
         }
-
-        private HashSet<string> assemblies;
-
-        private readonly List<string> validDirectories = new List<string>();
 
         private ITypeReferenceBuilder referenceBuilder;
 
@@ -67,9 +61,6 @@ namespace osu.Framework.Testing
                     if (!Directory.GetFiles(dir, "*.csproj").Any())
                         continue;
 
-                    lock (compileLock) // enumeration over this list occurs during compilation
-                        validDirectories.Add(dir);
-
                     var fsw = new FileSystemWatcher(dir, @"*.cs")
                     {
                         EnableRaisingEvents = true,
@@ -94,98 +85,98 @@ namespace osu.Framework.Testing
             return d.GetFiles().Any(f => f.Extension == ".sln") ? d.FullName : getSolutionPath(d.Parent);
         }
 
-        private void onChange(object sender, FileSystemEventArgs args)
-        {
-            lock (compileLock)
-            {
-                if (target == null || isCompiling)
-                    return;
-
-                isCompiling = true;
-                lastTouchedFile = args.FullPath;
-
-                Task.Run(async () => recompile(await referenceBuilder.GetReferencedFiles(target.GetType(), args.FullPath)))
-                    .ContinueWith(_ => isCompiling = false);
-            }
-        }
+        private void onChange(object sender, FileSystemEventArgs args) => Task.Run(async () => await recompileAsync(target?.GetType(), args.FullPath));
 
         private int currentVersion;
-
         private bool isCompiling;
-        private readonly object compileLock = new object();
 
-        private void recompile(IReadOnlyCollection<string> requiredFiles)
+        private async Task recompileAsync(Type targetType, string changedFile)
         {
-            if (assemblies == null)
+            if (targetType == null || isCompiling)
+                return;
+
+            isCompiling = true;
+
+            try
             {
-                assemblies = new HashSet<string>();
-                foreach (var ass in AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic))
-                    assemblies.Add(ass.Location);
-            }
+                while (!checkFileReady(changedFile))
+                    Thread.Sleep(10);
 
-            assemblies.Add(typeof(JetBrains.Annotations.NotNullAttribute).Assembly.Location);
+                CompilationStarted?.Invoke();
 
-            var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+                var requiredFiles = await referenceBuilder.GetReferencedFiles(targetType, changedFile);
+                var requiredAssemblies = await referenceBuilder.GetReferencedAssemblies(targetType, changedFile);
 
-            // ReSharper disable once RedundantExplicitArrayCreation this doesn't compile when the array is empty
-            var parseOptions = new CSharpParseOptions(preprocessorSymbols: new string[]
-            {
+                var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+
+                // ReSharper disable once RedundantExplicitArrayCreation this doesn't compile when the array is empty
+                var parseOptions = new CSharpParseOptions(preprocessorSymbols: new string[]
+                {
 #if DEBUG
-                "DEBUG",
+                    "DEBUG",
 #endif
 #if TRACE
-                "TRACE",
+                    "TRACE",
 #endif
 #if RELEASE
-                "RELEASE",
+                    "RELEASE",
 #endif
-            }, languageVersion: LanguageVersion.Latest);
-            var references = assemblies.Select(a => MetadataReference.CreateFromFile(a));
+                }, languageVersion: LanguageVersion.Latest);
 
-            while (!checkFileReady(lastTouchedFile))
-                Thread.Sleep(10);
+                var references = requiredAssemblies.Where(a => !string.IsNullOrEmpty(a))
+                                                   .Select(a => MetadataReference.CreateFromFile(a));
 
-            Logger.Log($@"Recompiling {Path.GetFileName(target.GetType().Name)}...", LoggingTarget.Runtime, LogLevel.Important);
+                Logger.Log($@"Recompiling {Path.GetFileName(targetType.Name)}...", LoggingTarget.Runtime, LogLevel.Important);
 
-            CompilationStarted?.Invoke();
+                // ensure we don't duplicate the dynamic suffix.
+                string assemblyNamespace = targetType.Assembly.GetName().Name?.Replace(".Dynamic", "");
 
-            // ensure we don't duplicate the dynamic suffix.
-            string assemblyNamespace = target.GetType().Assembly.GetName().Name.Replace(".Dynamic", "");
+                string assemblyVersion = $"{++currentVersion}.0.*";
+                string dynamicNamespace = $"{assemblyNamespace}.Dynamic";
 
-            string assemblyVersion = $"{++currentVersion}.0.*";
-            string dynamicNamespace = $"{assemblyNamespace}.Dynamic";
+                var compilation = CSharpCompilation.Create(
+                    dynamicNamespace,
+                    requiredFiles.Select(file => CSharpSyntaxTree.ParseText(File.ReadAllText(file), parseOptions, file))
+                                 // Compile the assembly with a new version so that it replaces the existing one
+                                 .Append(CSharpSyntaxTree.ParseText($"using System.Reflection; [assembly: AssemblyVersion(\"{assemblyVersion}\")]", parseOptions)),
+                    references,
+                    options
+                );
 
-            var compilation = CSharpCompilation.Create(
-                dynamicNamespace,
-                requiredFiles.Select(file => CSharpSyntaxTree.ParseText(File.ReadAllText(file), parseOptions, file))
-                             // Compile the assembly with a new version so that it replaces the existing one
-                             .Append(CSharpSyntaxTree.ParseText($"using System.Reflection; [assembly: AssemblyVersion(\"{assemblyVersion}\")]", parseOptions))
-                ,
-                references,
-                options
-            );
-
-            using (var ms = new MemoryStream())
-            {
-                var compilationResult = compilation.Emit(ms);
-
-                if (compilationResult.Success)
+                using (var ms = new MemoryStream())
                 {
-                    ms.Seek(0, SeekOrigin.Begin);
-                    CompilationFinished?.Invoke(
-                        Assembly.Load(ms.ToArray()).GetModules()[0].GetTypes().LastOrDefault(t => t.FullName == target.GetType().FullName)
-                    );
-                }
-                else
-                {
-                    foreach (var diagnostic in compilationResult.Diagnostics)
+                    var compilationResult = compilation.Emit(ms);
+
+                    if (compilationResult.Success)
                     {
-                        if (diagnostic.Severity < DiagnosticSeverity.Error)
-                            continue;
+                        ms.Seek(0, SeekOrigin.Begin);
+                        CompilationFinished?.Invoke(
+                            Assembly.Load(ms.ToArray()).GetModules()[0].GetTypes().LastOrDefault(t => t.FullName == targetType.FullName)
+                        );
+                    }
+                    else
+                    {
+                        var exceptions = new List<Exception>();
 
-                        CompilationFailed?.Invoke(new InvalidOperationException(diagnostic.ToString()));
+                        foreach (var diagnostic in compilationResult.Diagnostics)
+                        {
+                            if (diagnostic.Severity < DiagnosticSeverity.Error)
+                                continue;
+
+                            exceptions.Add(new InvalidOperationException(diagnostic.ToString()));
+                        }
+
+                        throw new AggregateException(exceptions.ToArray());
                     }
                 }
+            }
+            catch (Exception ex)
+            {
+                CompilationFailed?.Invoke(ex);
+            }
+            finally
+            {
+                isCompiling = false;
             }
         }
 

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -33,6 +33,7 @@ namespace osu.Framework.Testing
             if (this.target?.GetType().Name != target?.GetType().Name)
             {
                 requiredFiles.Clear();
+                referenceBuilder.Reset();
             }
 
             this.target = target;

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -149,7 +149,7 @@ namespace osu.Framework.Testing
                 //     foreach parent in node
                 //         add_required_files(parent)
                 //
-                // We're then left with the set of required files that need to be re-compilated.
+                // We're then left with the set of required files that need to be recompiled.
 
                 // 1. Build the disjoint graph of connections.
                 Logger.Log("Finding all referenced types...");

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -29,7 +29,13 @@ namespace osu.Framework.Testing
 
         private T target;
 
-        public void SetRecompilationTarget(T target) => this.target = target;
+        public void SetRecompilationTarget(T target)
+        {
+            if (this.target?.GetType().FullName != target?.GetType().FullName)
+                referenceBuilder.Reset();
+
+            this.target = target;
+        }
 
         private HashSet<string> assemblies;
 

--- a/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
@@ -13,5 +13,9 @@ namespace osu.Framework.Testing
 
         public async Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile)
             => await Task.FromResult(Array.Empty<string>());
+
+        public void Reset()
+        {
+        }
     }
 }

--- a/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Testing
+{
+    public class EmptyTypeReferenceBuilder : ITypeReferenceBuilder
+    {
+        public Task Initialise(string solutionFile) => Task.CompletedTask;
+
+        public async Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile)
+            => await Task.FromResult(Array.Empty<string>());
+    }
+}

--- a/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
@@ -14,6 +14,9 @@ namespace osu.Framework.Testing
         public async Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile)
             => await Task.FromResult(Array.Empty<string>());
 
+        public async Task<IReadOnlyCollection<string>> GetReferencedAssemblies(Type testType, string changedFile)
+            => await Task.FromResult(Array.Empty<string>());
+
         public void Reset()
         {
         }

--- a/osu.Framework/Testing/ExcludeFromDynamicCompileAttribute.cs
+++ b/osu.Framework/Testing/ExcludeFromDynamicCompileAttribute.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Testing
+{
+    /// <summary>
+    /// Indicates that a type should be excluded from dynamic compilation. Does not affect derived types.
+    /// </summary>
+    /// <remarks>
+    /// This should be used as sparingly as possible for cases where compiling a type changes fundamental testing components (e.g. <see cref="TestBrowser"/>).
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = false)]
+    public class ExcludeFromDynamicCompileAttribute : Attribute
+    {
+    }
+}

--- a/osu.Framework/Testing/ITypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/ITypeReferenceBuilder.cs
@@ -1,0 +1,16 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Testing
+{
+    public interface ITypeReferenceBuilder
+    {
+        Task Initialise(string solutionFile);
+
+        Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile);
+    }
+}

--- a/osu.Framework/Testing/ITypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/ITypeReferenceBuilder.cs
@@ -12,5 +12,7 @@ namespace osu.Framework.Testing
         Task Initialise(string solutionFile);
 
         Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile);
+
+        void Reset();
     }
 }

--- a/osu.Framework/Testing/ITypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/ITypeReferenceBuilder.cs
@@ -9,12 +9,31 @@ namespace osu.Framework.Testing
 {
     public interface ITypeReferenceBuilder
     {
+        /// <summary>
+        /// Initialises this <see cref="ITypeReferenceBuilder"/> with a given solution file.
+        /// </summary>
+        /// <param name="solutionFile">The solution file.</param>
         Task Initialise(string solutionFile);
 
+        /// <summary>
+        /// Retrieves all files referenced by the type hierarchy joining a given <see cref="Type"/> to a given file.
+        /// </summary>
+        /// <param name="testType">The <see cref="Type"/>.</param>
+        /// <param name="changedFile">The file.</param>
+        /// <returns>The file names containing all types referenced between <paramref name="testType"/> and <see cref="changedFile"/>.</returns>
         Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile);
 
+        /// <summary>
+        /// Retrieves all assemblies referenced by the type hierarchy joining a given <see cref="Type"/> to a given file.
+        /// </summary>
+        /// <param name="testType">The <see cref="Type"/>.</param>
+        /// <param name="changedFile">The file.</param>
+        /// <returns>The file names containing all assemblies referenced between <see cref="testType"/> and <see cref="changedFile"/>.</returns>
         Task<IReadOnlyCollection<string>> GetReferencedAssemblies(Type testType, string changedFile);
 
+        /// <summary>
+        /// Resets this <see cref="ITypeReferenceBuilder"/>.
+        /// </summary>
         void Reset();
     }
 }

--- a/osu.Framework/Testing/ITypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/ITypeReferenceBuilder.cs
@@ -13,6 +13,8 @@ namespace osu.Framework.Testing
 
         Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile);
 
+        Task<IReadOnlyCollection<string>> GetReferencedAssemblies(Type testType, string changedFile);
+
         void Reset();
     }
 }

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -47,10 +47,7 @@ namespace osu.Framework.Testing
             Logger.Log("Retrieving required files...");
             var changedType = directedGraph
                               .Select(kvp => kvp.Key)
-                              .FirstOrDefault(t => t.Symbol.Locations.Any(l => l.SourceTree?.FilePath == changedFile));
-
-            if (changedType.Symbol == null)
-                return Array.Empty<string>();
+                              .Where(t => t.Symbol.Locations.Any(l => l.SourceTree?.FilePath == changedFile));
 
             return getRequiredFiles(changedType, directedGraph);
         }
@@ -201,13 +198,15 @@ namespace osu.Framework.Testing
             }
         }
 
-        private HashSet<string> getRequiredFiles(TypeReference start, IReadOnlyDictionary<TypeReference, TypeNode> directedGraph)
+        private HashSet<string> getRequiredFiles(IEnumerable<TypeReference> sources, IReadOnlyDictionary<TypeReference, TypeNode> directedGraph)
         {
             var result = new HashSet<string>();
 
             var seenTypes = new HashSet<TypeNode>();
             var searchQueue = new Queue<TypeNode>();
-            searchQueue.Enqueue(directedGraph[start]);
+
+            foreach (var reference in sources)
+                searchQueue.Enqueue(directedGraph[reference]);
 
             while (searchQueue.Count > 0)
             {

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -1,0 +1,301 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#if NETCOREAPP
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.MSBuild;
+using Microsoft.CodeAnalysis.Text;
+using osu.Framework.Logging;
+
+namespace osu.Framework.Testing
+{
+    public class RoslynTypeReferenceBuilder : ITypeReferenceBuilder
+    {
+        private readonly Dictionary<Project, Compilation> compilationCache = new Dictionary<Project, Compilation>();
+        private readonly Dictionary<SyntaxTree, SemanticModel> semanticModelCache = new Dictionary<SyntaxTree, SemanticModel>();
+
+        private Solution solution;
+
+        public async Task Initialise(string solutionFile)
+        {
+            MSBuildLocator.RegisterDefaults();
+            solution = await MSBuildWorkspace.Create().OpenSolutionAsync(solutionFile);
+        }
+
+        public async Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile)
+        {
+            clearCaches();
+            updateFile(changedFile);
+
+            var compiledTestProject = await compileProjectAsync(findTestProject());
+            var compiledTestType = compiledTestProject.GetTypeByMetadataName(testType.FullName);
+
+            Logger.Log("Finding all referenced types...");
+            var disjointGraph = await getReferencedTypesRecursiveAsync(TypeReference.FromSymbol(compiledTestType));
+
+            Logger.Log("Building type graph...");
+            var directedGraph = getDirectedGraph(disjointGraph);
+
+            Logger.Log("Retrieving required files...");
+            var changedType = directedGraph
+                              .Select(kvp => kvp.Key)
+                              .FirstOrDefault(t => t.Symbol.Locations.Any(l => l.SourceTree?.FilePath == changedFile));
+
+            if (changedType.Symbol == null)
+                return Array.Empty<string>();
+
+            return getRequiredFiles(changedType, directedGraph);
+        }
+
+        private void clearCaches()
+        {
+            compilationCache.Clear();
+            semanticModelCache.Clear();
+        }
+
+        private void updateFile(string file)
+        {
+            Logger.Log($"Updating file {file} in solution...");
+
+            var changedDoc = solution.GetDocumentIdsWithFilePath(file)[0];
+            solution = solution.WithDocumentText(changedDoc, SourceText.From(File.ReadAllText(file)));
+        }
+
+        private async Task<Dictionary<TypeReference, IReadOnlyCollection<TypeReference>>> getReferencedTypesRecursiveAsync(TypeReference rootReference)
+        {
+            // There exists a graph of types from the root type symbol which we want to find.
+            //
+            //                            P
+            //                          /  \
+            //                         /    \
+            //                        /      \
+            //                      C1       C2 ---
+            //                    /   \      |    /
+            //                  C3    C4    C5   /
+            //                          \  /    /
+            //                           C6 ---
+            //
+            // We do this by constructing a disjoint graph between types and all their referenced types. This is done via a BFS, leading to the following:
+            //
+            // P -> { C1, C2 }
+            // C1 -> { C3, C4 }
+            // C2 -> { C5, C6 }
+            // C3 -> { }
+            // C4 -> { C6 }
+            // C5 -> { C6 }
+            // C6 -> { C2 }
+
+            var result = new Dictionary<TypeReference, IReadOnlyCollection<TypeReference>>();
+
+            var searchQueue = new Queue<TypeReference>();
+            searchQueue.Enqueue(rootReference);
+
+            while (searchQueue.Count > 0)
+            {
+                var toCheck = searchQueue.Dequeue();
+                var referencedTypes = await getReferencedTypesAsync(toCheck, !toCheck.Equals(rootReference));
+
+                result[toCheck] = referencedTypes;
+
+                foreach (var referenced in referencedTypes)
+                {
+                    // We don't want to cycle over types that have already been explored.
+                    if (!result.ContainsKey(referenced))
+                    {
+                        // Used for de-duping, so it must be added to the dictionary immediately.
+                        result[referenced] = null;
+                        searchQueue.Enqueue(referenced);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private async Task<HashSet<TypeReference>> getReferencedTypesAsync(TypeReference typeReference, bool includeBaseType)
+        {
+            var result = new HashSet<TypeReference>();
+
+            foreach (var reference in typeReference.Symbol.DeclaringSyntaxReferences)
+            {
+                var syntaxTree = reference.SyntaxTree;
+                var semanticModel = await getSemanticModelAsync(reference.SyntaxTree);
+                var root = await syntaxTree.GetRootAsync();
+
+                var descendantNodes = root.DescendantNodes(n =>
+                {
+                    var kind = n.Kind();
+
+                    return kind != SyntaxKind.UsingDirective
+                           && kind != SyntaxKind.NamespaceKeyword
+                           && (includeBaseType || kind != SyntaxKind.BaseList);
+                });
+
+                // Find all the named type symbols in the syntax tree, and mark + recursively iterate through them.
+                foreach (var node in descendantNodes)
+                {
+                    switch (node.Kind())
+                    {
+                        case SyntaxKind.GenericName:
+                        case SyntaxKind.IdentifierName:
+                        {
+                            if (semanticModel.GetSymbolInfo(node).Symbol is INamedTypeSymbol t)
+                                result.Add(TypeReference.FromSymbol(t));
+
+                            break;
+                        }
+
+                        case SyntaxKind.AsExpression:
+                        case SyntaxKind.IsExpression:
+                        case SyntaxKind.SizeOfExpression:
+                        case SyntaxKind.TypeOfExpression:
+                        case SyntaxKind.CastExpression:
+                        case SyntaxKind.ObjectCreationExpression:
+                        {
+                            if (semanticModel.GetTypeInfo(node).Type is INamedTypeSymbol t)
+                                result.Add(TypeReference.FromSymbol(t));
+
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        private Dictionary<TypeReference, TypeNode> getDirectedGraph(IReadOnlyDictionary<TypeReference, IReadOnlyCollection<TypeReference>> disjointGraph)
+        {
+            // Build an upwards directed graph by assigning parents to all the connections.
+            //
+            // foreach conn in dict
+            //     foreach ref in connection
+            //         node := get_existing_node_or_create_new(ref)
+            //         node.parent := conn.node
+            //
+
+            var result = new Dictionary<TypeReference, TypeNode>();
+
+            foreach (var kvp in disjointGraph)
+            {
+                var parentNode = getNode(kvp.Key);
+                foreach (var typeRef in kvp.Value)
+                    getNode(typeRef).Parents.Add(parentNode);
+            }
+
+            return result;
+
+            TypeNode getNode(TypeReference typeSymbol)
+            {
+                if (!result.TryGetValue(typeSymbol, out var existing))
+                    result[typeSymbol] = existing = new TypeNode(typeSymbol);
+                return existing;
+            }
+        }
+
+        private HashSet<string> getRequiredFiles(TypeReference start, IReadOnlyDictionary<TypeReference, TypeNode> directedGraph)
+        {
+            var result = new HashSet<string>();
+
+            var seenTypes = new HashSet<TypeNode>();
+            var searchQueue = new Queue<TypeNode>();
+            searchQueue.Enqueue(directedGraph[start]);
+
+            while (searchQueue.Count > 0)
+            {
+                var toCheck = searchQueue.Dequeue();
+
+                seenTypes.Add(toCheck);
+
+                foreach (var location in toCheck.Reference.Symbol.Locations)
+                {
+                    var syntaxTree = location.SourceTree;
+                    if (syntaxTree != null)
+                        result.Add(syntaxTree.FilePath);
+                }
+
+                foreach (var parent in toCheck.Parents)
+                {
+                    if (!seenTypes.Contains(parent))
+                        searchQueue.Enqueue(parent);
+                }
+            }
+
+            return result;
+        }
+
+        private async Task<Compilation> compileProjectAsync(Project project)
+        {
+            if (compilationCache.TryGetValue(project, out var existing))
+                return existing;
+
+            Logger.Log($"Compiling project {project.Name}...");
+            return compilationCache[project] = await project.GetCompilationAsync();
+        }
+
+        private async Task<SemanticModel> getSemanticModelAsync(SyntaxTree syntaxTree)
+        {
+            if (semanticModelCache.TryGetValue(syntaxTree, out var existing))
+                return existing;
+
+            var project = solution.Projects.FirstOrDefault(p => p.Documents.Any(d => d.FilePath == syntaxTree.FilePath));
+            return semanticModelCache[syntaxTree] = (await compileProjectAsync(project)).GetSemanticModel(syntaxTree, true);
+        }
+
+        private Project findTestProject()
+        {
+            var executingAssembly = Assembly.GetEntryAssembly()?.GetName().Name;
+            return solution.Projects.FirstOrDefault(p => p.AssemblyName == executingAssembly);
+        }
+
+        private readonly struct TypeReference : IEquatable<TypeReference>
+        {
+            public readonly INamedTypeSymbol Symbol;
+
+            public TypeReference(INamedTypeSymbol symbol)
+            {
+                Symbol = symbol;
+            }
+
+            public bool Equals(TypeReference other)
+                => Symbol.ContainingNamespace.ToString() == other.Symbol.ContainingNamespace.ToString()
+                   && Symbol.ToString() == other.Symbol.ToString();
+
+            public override int GetHashCode()
+            {
+                var hash = new HashCode();
+                hash.Add(Symbol.ToString(), StringComparer.Ordinal);
+                return hash.ToHashCode();
+            }
+
+            public static TypeReference FromSymbol(INamedTypeSymbol symbol) => new TypeReference(symbol);
+        }
+
+        private class TypeNode : IEquatable<TypeNode>
+        {
+            public readonly TypeReference Reference;
+            public readonly List<TypeNode> Parents = new List<TypeNode>();
+
+            public TypeNode(TypeReference reference)
+            {
+                Reference = reference;
+            }
+
+            public bool Equals(TypeNode other)
+                => other != null
+                   && Reference.Equals(other.Reference);
+
+            public override int GetHashCode() => Reference.GetHashCode();
+        }
+    }
+}
+
+#endif

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -75,6 +75,8 @@ namespace osu.Framework.Testing
                     var syntaxTree = compilation.SyntaxTrees.First(tree => tree.FilePath == typePath);
 
                     var referencedTypes = await getReferencedTypesAsync(await getSemanticModelAsync(syntaxTree), compiledTestType.Locations.Any(l => l.SourceTree?.FilePath == changedFile));
+                    referenceMap[TypeReference.FromSymbol(t.Symbol)] = referencedTypes;
+
                     foreach (var referenced in referencedTypes)
                         await getReferencedTypesRecursiveAsync(referenced, referenced.Symbol.Locations.Any(l => l.SourceTree?.FilePath == changedFile));
                 }

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -221,8 +221,7 @@ namespace osu.Framework.Testing
                     case SyntaxKind.IdentifierName:
                     {
                         if (semanticModel.GetSymbolInfo(node).Symbol is INamedTypeSymbol t)
-                            result.Add(TypeReference.FromSymbol(t));
-
+                            addTypeSymbol(t);
                         break;
                     }
 
@@ -234,14 +233,21 @@ namespace osu.Framework.Testing
                     case SyntaxKind.ObjectCreationExpression:
                     {
                         if (semanticModel.GetTypeInfo(node).Type is INamedTypeSymbol t)
-                            result.Add(TypeReference.FromSymbol(t));
-
+                            addTypeSymbol(t);
                         break;
                     }
                 }
             }
 
             return result;
+
+            void addTypeSymbol(INamedTypeSymbol typeSymbol)
+            {
+                if (typeSymbol.GetAttributes().Any(attrib => attrib.AttributeClass.Name.Contains(nameof(ExcludeFromDynamicCompileAttribute))))
+                    return;
+
+                result.Add(TypeReference.FromSymbol(typeSymbol));
+            }
         }
 
         /// <summary>

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -95,6 +95,19 @@ namespace osu.Framework.Testing
             return getRequiredFiles(getTypesFromFile(changedFile), directedGraph);
         }
 
+        public async Task<IReadOnlyCollection<string>> GetReferencedAssemblies(Type testType, string changedFile) => await Task.Run(() =>
+        {
+            // Todo: This is temporary, and is potentially missing assemblies.
+
+            var assemblies = new HashSet<string>();
+
+            foreach (var ass in AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic))
+                assemblies.Add(ass.Location);
+            assemblies.Add(typeof(JetBrains.Annotations.NotNullAttribute).Assembly.Location);
+
+            return assemblies;
+        });
+
         public void Reset()
         {
             clearCaches();

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -306,6 +306,9 @@ namespace osu.Framework.Testing
             compilingNotice.FadeOut(800, Easing.InQuint);
             compilingNotice.FadeColour(Color4.YellowGreen, 100);
 
+            if (newType == null)
+                return;
+
             int i = TestTypes.FindIndex(t => t.Name == newType.Name && t.Assembly.GetName().Name == newType.Assembly.GetName().Name);
 
             if (i < 0)

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -23,6 +23,7 @@ using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Testing
 {
+    [ExcludeFromDynamicCompile]
     [TestFixture]
     public abstract class TestScene : Container, IDynamicallyCompile
     {

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;netcoreapp3.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyTitle>osu!framework</AssemblyTitle>
@@ -28,11 +28,11 @@
     <PackageReference Include="SharpFNT" Version="1.1.1" />
     <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" Condition="'$(TargetFrameworks)' != 'netstandard2.1'" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" Condition="'$(TargetFrameworks)' != 'netstandard2.1'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.5.0" Condition="'$(TargetFrameworks)' != 'netstandard2.1'" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.5.0" Condition="'$(TargetFrameworks)' != 'netstandard2.1'" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.122004" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="ManagedBass" Version="2.0.4" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -28,11 +28,7 @@
     <PackageReference Include="SharpFNT" Version="1.1.1" />
     <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" Condition="'$(TargetFrameworks)' != 'netstandard2.1'" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" Condition="'$(TargetFrameworks)' != 'netstandard2.1'" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.5.0" Condition="'$(TargetFrameworks)' != 'netstandard2.1'" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.5.0" Condition="'$(TargetFrameworks)' != 'netstandard2.1'" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.122004" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="ManagedBass" Version="2.0.4" />
@@ -47,5 +43,10 @@
     <!-- DO NOT use ProjectReference for native packaging project.
          See https://github.com/NuGet/Home/issues/4514 and https://github.com/dotnet/sdk/issues/765 . -->
     <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2020.213.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.5.0">
+      <NoWarn>NU1701</NoWarn> <!-- Requires .NETFramework for MSBuild, but we use Microsoft.Build.Locator which allows this package to work in .NETCoreApp. -->
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFrameworks>netstandard2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;netstandard2.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyTitle>osu!framework</AssemblyTitle>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup Label="Project">
-    <TargetFrameworks>netcoreapp3.0;netstandard2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyTitle>osu!framework</AssemblyTitle>
@@ -28,7 +28,11 @@
     <PackageReference Include="SharpFNT" Version="1.1.1" />
     <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.5.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.122004" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="ManagedBass" Version="2.0.4" />


### PR DESCRIPTION
This is a complete rework of the type performed during dynamic compilation. It follows the following process with some optimisations in-between, which I hope to have documented in a somewhat readable way in code:

1. Map all types to the types which they reference.
2. Build a directed graph from the changed file towards the test scene type by following the map generated in (1).
3. Find all files corresponding to the types by following the graph in (2) by-parent.

Performance wise this is slightly slower on first initialisation (building the map in step (1)), but further changes are about as quick as they were previously. Step (1) could could probably be done in the background rather than on change, but I haven't done that in this PR.

Scenarios I've tested:
1. Changing `AnimationClockComposite` while in `TestSceneAnimation`.
2. Changing `Video` while in `TestSceneAnimation`.
3. Changing `Video` while in `TestSceneVideo`.
4. Changing `Menu` while in `TestSceneNestedMenus`.
5. Changing `TabItem<T>` while in `TestSceneTabControl`.
6. osu!-side: Changing `LegacyDrumRoll` while in `TestSceneDrawableDrumRoll`.

All with `RequiredTypes` removed.

I haven't removed `RequiredTypes` in this PR since it touches quite a lot of files. That can be done in a separate PR.