### PR TITLE
Fix dropdown with nothing selected throwing on pre-selecting afterwards

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -367,8 +367,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             internal new DropdownMenuItem<string> SelectedItem => base.SelectedItem;
 
-            public int SelectedIndex => SelectedItem == null ? NULL_ITEM_INDEX : Menu.DrawableMenuItems.Select(d => d.Item).ToList().IndexOf(SelectedItem);
-            public int PreselectedIndex => Menu.PreselectedItem == null ? NULL_ITEM_INDEX : Menu.DrawableMenuItems.ToList().IndexOf(Menu.PreselectedItem);
+            public int SelectedIndex => Menu.DrawableMenuItems.Select(d => d.Item).ToList().IndexOf(SelectedItem);
+            public int PreselectedIndex => Menu.DrawableMenuItems.ToList().IndexOf(Menu.PreselectedItem);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneDropdown.cs
@@ -88,7 +88,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void Basic()
+        public void TestBasic()
         {
             var i = items_to_add;
 
@@ -166,9 +166,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
             drawable.HasFocus = tempHasFocus;
         }
 
-        [Test]
-        public void KeyboardSelection()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestKeyboardSelection(bool cleanSelection)
         {
+            if (cleanSelection)
+                AddStep("Clean selection", () => testDropdown.Current.Value = null);
+
             AddStep("Select next item", () =>
             {
                 previousIndex = testDropdown.SelectedIndex;
@@ -183,7 +187,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 performKeypress(testDropdown.Header, Key.Up);
             });
 
-            AddAssert("Previous item is selected", () => testDropdown.SelectedIndex == previousIndex - 1);
+            AddAssert("Previous item is selected", () => testDropdown.SelectedIndex == Math.Max(0, previousIndex - 1));
 
             AddStep("Select last item",
                 () => performPlatformAction(new PlatformAction(PlatformActionType.ListEnd, PlatformActionMethod.Move), platformActionContainerKeyboardSelection, testDropdown.Header));
@@ -204,9 +208,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("Select first item when empty", () => performKeypress(emptyDropdown.Header, Key.PageDown));
         }
 
-        [Test]
-        public void KeyboardPreselection()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestKeyboardPreselection(bool cleanSelection)
         {
+            if (cleanSelection)
+                AddStep("Clean selection", () => testDropdownMenu.Current.Value = null);
+
             clickKeyboardPreselectionDropdown();
             assertDropdownIsOpen();
 
@@ -224,7 +232,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 performKeypress(testDropdownMenu.Menu, Key.Up);
             });
 
-            AddAssert("Previous item is preselected", () => testDropdownMenu.PreselectedIndex == previousIndex - 1);
+            AddAssert("Previous item is preselected", () => testDropdownMenu.PreselectedIndex == Math.Max(0, previousIndex - 1));
 
             AddStep("Preselect last visible item", () =>
             {
@@ -327,7 +335,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void SelectNull()
+        public void TestSelectNull()
         {
             AddStep("select item 1", () => testDropdown.Current.Value = testDropdown.Items.ElementAt(1));
             AddAssert("item 1 is selected", () => testDropdown.Current.Value == testDropdown.Items.ElementAt(1));
@@ -359,8 +367,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             internal new DropdownMenuItem<string> SelectedItem => base.SelectedItem;
 
-            public int SelectedIndex => Menu.DrawableMenuItems.Select(d => d.Item).ToList().IndexOf(SelectedItem);
-            public int PreselectedIndex => Menu.DrawableMenuItems.ToList().IndexOf(Menu.PreselectedItem);
+            public int SelectedIndex => SelectedItem == null ? NULL_ITEM_INDEX : Menu.DrawableMenuItems.Select(d => d.Item).ToList().IndexOf(SelectedItem);
+            public int PreselectedIndex => Menu.PreselectedItem == null ? NULL_ITEM_INDEX : Menu.DrawableMenuItems.ToList().IndexOf(Menu.PreselectedItem);
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -23,6 +23,11 @@ namespace osu.Framework.Graphics.UserInterface
     /// <typeparam name="T">Type of value to select.</typeparam>
     public abstract class Dropdown<T> : CompositeDrawable, IHasCurrentValue<T>
     {
+        /// <summary>
+        /// The index used to indicate selecting nothing for the dropdown.
+        /// </summary>
+        internal const int NULL_ITEM_INDEX = -1;
+
         protected internal DropdownHeader Header;
         protected internal DropdownMenu Menu;
 
@@ -218,7 +223,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void preselectionConfirmed(int selectedIndex)
         {
-            SelectedItem = MenuItems.ElementAt(selectedIndex);
+            SelectedItem = selectedIndex == NULL_ITEM_INDEX ? null : MenuItems.ElementAt(selectedIndex);
             Menu.State = MenuState.Closed;
         }
 
@@ -356,8 +361,8 @@ namespace osu.Framework.Graphics.UserInterface
             protected internal IEnumerable<DrawableDropdownMenuItem> DrawableMenuItems => Children.OfType<DrawableDropdownMenuItem>();
             protected internal IEnumerable<DrawableDropdownMenuItem> VisibleMenuItems => DrawableMenuItems.Where(item => !item.IsMaskedAway);
 
-            public DrawableDropdownMenuItem PreselectedItem => Children.OfType<DrawableDropdownMenuItem>().FirstOrDefault(c => c.IsPreSelected)
-                                                               ?? Children.OfType<DrawableDropdownMenuItem>().FirstOrDefault(c => c.IsSelected);
+            public DrawableDropdownMenuItem PreselectedItem => DrawableMenuItems.FirstOrDefault(c => c.IsPreSelected)
+                                                               ?? DrawableMenuItems.FirstOrDefault(c => c.IsSelected);
 
             public event Action<int> PreselectionConfirmed;
 
@@ -525,9 +530,8 @@ namespace osu.Framework.Graphics.UserInterface
                 if (!drawableMenuItemsList.Any())
                     return base.OnKeyDown(e);
 
-                var currentPreselected = drawableMenuItemsList.FirstOrDefault(i => i.IsPreSelected) ?? drawableMenuItemsList.First(i => i.IsSelected);
-
-                var targetPreselectionIndex = drawableMenuItemsList.IndexOf(currentPreselected);
+                var currentPreselected = PreselectedItem;
+                var targetPreselectionIndex = currentPreselected == null ? NULL_ITEM_INDEX : drawableMenuItemsList.IndexOf(currentPreselected);
 
                 switch (e.Key)
                 {

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -23,11 +23,6 @@ namespace osu.Framework.Graphics.UserInterface
     /// <typeparam name="T">Type of value to select.</typeparam>
     public abstract class Dropdown<T> : CompositeDrawable, IHasCurrentValue<T>
     {
-        /// <summary>
-        /// The index used to indicate selecting nothing for the dropdown.
-        /// </summary>
-        internal const int NULL_ITEM_INDEX = -1;
-
         protected internal DropdownHeader Header;
         protected internal DropdownMenu Menu;
 
@@ -223,7 +218,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void preselectionConfirmed(int selectedIndex)
         {
-            SelectedItem = selectedIndex == NULL_ITEM_INDEX ? null : MenuItems.ElementAt(selectedIndex);
+            SelectedItem = MenuItems.ElementAtOrDefault(selectedIndex);
             Menu.State = MenuState.Closed;
         }
 
@@ -531,7 +526,7 @@ namespace osu.Framework.Graphics.UserInterface
                     return base.OnKeyDown(e);
 
                 var currentPreselected = PreselectedItem;
-                var targetPreselectionIndex = currentPreselected == null ? NULL_ITEM_INDEX : drawableMenuItemsList.IndexOf(currentPreselected);
+                var targetPreselectionIndex = drawableMenuItemsList.IndexOf(currentPreselected);
 
                 switch (e.Key)
                 {


### PR DESCRIPTION
Technically closes #3498, but will be more corrected with ppy/osu#8912 being fixed.

There may normally be dropdowns with no items selected inside them, this is aiming to fix the exception thrown when pre-selecting by pressing on the keyboard there.