### PR TITLE
Continue initialising InputHandlers if one fails

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -658,7 +658,7 @@ namespace osu.Framework.Platform
                 if (!handler.Initialize(this))
                 {
                     handler.Enabled.Value = false;
-                    break;
+                    continue;
                 }
 
                 (handler as IHasCursorSensitivity)?.Sensitivity.BindTo(cursorSensitivity);


### PR DESCRIPTION
Currently if an `InputHandler` fails initialisation, no other input handlers will be initialised.  As discussed in Discord, it is preferred that all input handlers get a chance to initialise themselves.