### PR TITLE
Fix "open in explorer" occurring twice for windows directories

### DIFF
--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -27,7 +27,10 @@ namespace osu.Framework.Platform.Windows
         public override void OpenFileExternally(string filename)
         {
             if (Directory.Exists(filename))
+            {
                 Process.Start("explorer.exe", filename);
+                return;
+            }
 
             base.OpenFileExternally(filename);
         }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/8984
- Regressed with https://github.com/ppy/osu-framework/commit/3f9cb216a2be06137811e1a5461dcfd6db218cce#diff-ba0efd388bc6a3ecfc4e4ffad10d9c89 due to missing return.