### PR TITLE
Disable dynamic recompilation on Android

### DIFF
--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -251,7 +251,7 @@ namespace osu.Framework.Testing
 
             searchTextBox.Current.ValueChanged += e => leftFlowContainer.SearchTerm = e.NewValue;
 
-            if (RuntimeInfo.SupportsJIT)
+            if (!RuntimeInfo.IsMobile)
             {
                 backgroundCompiler = new DynamicClassCompiler<TestScene>();
                 backgroundCompiler.CompilationStarted += compileStarted;

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -251,7 +251,7 @@ namespace osu.Framework.Testing
 
             searchTextBox.Current.ValueChanged += e => leftFlowContainer.SearchTerm = e.NewValue;
 
-            if (!RuntimeInfo.IsMobile)
+            if (RuntimeInfo.IsDesktop)
             {
                 backgroundCompiler = new DynamicClassCompiler<TestScene>();
                 backgroundCompiler.CompilationStarted += compileStarted;


### PR DESCRIPTION
Side effect of testing ppy/osu#9011.

# Summary

Disable dynamic recompilation in Android visual test runs, as in its current state it causes the test browser to hang on startup. First, `DynamicClassCompiler.Start()` would silently fail [due to `AppDomain.CurrentDomain.BaseDirectory` being null](https://github.com/ppy/osu-framework/blob/7373bed57a480512ff8408b2c9530ca6c8a32260/osu.Framework/Testing/DynamicClassCompiler.cs#L46) (that exception is swallowed [here](https://github.com/ppy/osu-framework/blob/6bfb8880ed6e0b5f60b35657d0b1d8293f9ae548/osu.Framework/Testing/TestBrowser.cs#L261-L268)):

```
System.ArgumentNullException: Value cannot be null.
Parameter name: path
  at System.IO.Path.InsecureGetFullPath (System.String path) [0x00003] in /Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/mcs/class/corlib/System.IO/Path.cs:369 
  at System.IO.Path.GetFullPath (System.String path) [0x00000] in /Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/mcs/class/corlib/System.IO/Path.cs:288 
  at System.IO.DirectoryInfo..ctor (System.String path) [0x00006] in /Users/builder/jenkins/workspace/archive-mono/2019-08/android/release/external/corefx/src/System.IO.FileSystem/src/System/IO/DirectoryInfo.cs:19 
  at (wrapper remoting-invoke-with-check) System.IO.DirectoryInfo..ctor(string)
  at osu.Framework.Testing.DynamicClassCompiler`1[T].Start () [0x0000e] in D:\Open Source\osu-framework\osu.Framework\Testing\DynamicClassCompiler.cs:46 
  at osu.Framework.Testing.TestBrowser.load (osu.Framework.Platform.Storage storage, osu.Framework.Platform.GameHost host, osu.Framework.Configuration.FrameworkConfigManager frameworkConfig, osu.Framework.IO.Stores.FontStore fonts, osu.Framework.Game game, osu.Framework.Audio.AudioManager audio) [0x00448] in D:\Open Source\osu-framework\osu.Framework\Testing\TestBrowser.cs:263 
```

then leading to [a nullref at `SetRecompilationTarget()`](https://github.com/ppy/osu-framework/blob/7373bed57a480512ff8408b2c9530ca6c8a32260/osu.Framework/Testing/DynamicClassCompiler.cs#L36):

```
2020-05-13 20:55:32.838 I/mono-stdout( 4538): [runtime] 2020-05-13 18:55:32 [error]: An unhandled error has occurred.
2020-05-13 20:55:32.838 I/mono-stdout( 4538): [runtime] 2020-05-13 18:55:32 [error]: System.NullReferenceException: Object reference not set to an instance of an object
2020-05-13 20:55:32.838 I/mono-stdout( 4538): [runtime] 2020-05-13 18:55:32 [error]: at osu.Framework.Testing.DynamicClassCompiler`1[T].SetRecompilationTarget (T target) [0x0006e] in <034ed805a4d046929015dd94207fd806>:0
2020-05-13 20:55:32.838 I/mono-stdout( 4538): [runtime] 2020-05-13 18:55:32 [error]: at osu.Framework.Testing.TestBrowser.finishLoad (osu.Framework.Testing.TestScene newTest, System.Action onCompletion) [0x0027a] in <034ed805a4d046929015dd94207fd806>:0
```

which hangs the entire test browser.

# Remarks

The recompilation was previously disabled on iOS by the use of `SupportsJIT`. The disable is now extended to Android by using `IsDesktop`, which is probably the better choice anyway (as the availability of recompilation has as much to do with JIT as it does with availability of the source, which is obviously not available on mobile platforms).