### PR TITLE
Fix libbass_fx load errors during tests on linux

### DIFF
--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.IO;
-using osu.Framework.Platform.Linux.Native;
 using osu.Framework.Platform.Linux.Sdl;
 using osuTK;
 
@@ -14,14 +13,6 @@ namespace osu.Framework.Platform.Linux
         internal LinuxGameHost(string gameName, bool bindIPC = false, ToolkitOptions toolkitOptions = default, bool portableInstallation = false, bool useSdl = false)
             : base(gameName, bindIPC, toolkitOptions, portableInstallation, useSdl)
         {
-        }
-
-        protected override void SetupForRun()
-        {
-            base.SetupForRun();
-
-            // required for the time being to address libbass_fx.so load failures (see https://github.com/ppy/osu/issues/2852)
-            Library.Load("libbass.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
         }
 
         protected override IWindow CreateWindow() =>

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using ManagedBass;
 using osu.Framework.Audio;
 using osu.Framework.Development;
+using osu.Framework.Platform.Linux.Native;
 
 namespace osu.Framework.Threading
 {
@@ -16,6 +17,12 @@ namespace osu.Framework.Threading
             : base(name: "Audio")
         {
             OnNewFrame = onNewFrame;
+
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux)
+            {
+                // required for the time being to address libbass_fx.so load failures (see https://github.com/ppy/osu/issues/2852)
+                Library.Load("libbass.so", Library.LoadFlags.RTLD_LAZY | Library.LoadFlags.RTLD_GLOBAL);
+            }
         }
 
         public override bool IsCurrent => ThreadSafety.IsAudioThread;


### PR DESCRIPTION
Anything that touched bass would fail with:
```
Reason: Test host process crashed : /usr/share/dotnet/dotnet: symbol lookup error: /home/smgi/Repos/osu/osu.Game.Rulesets.Mania.Tests/bin/Debug/netcoreapp3.1/runtimes/linux-x64/native/libbass_fx.so: undefined symbol: BASS_GetVersion
```
This also affected nunit tests since they use `HeadlessGameHost` (not `LinuxGameHost`).