### PR TITLE
Restore RequiredTypes as an obsolete property

### DIFF
--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TestSceneTemplateGameGame.cs
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TestSceneTemplateGameGame.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
@@ -12,11 +10,6 @@ namespace TemplateGame.Game.Tests.Visual
         // You can make changes to classes associated with the tests and they will recompile and update immediately.
 
         private TemplateGameGame game;
-
-        public override IReadOnlyList<Type> RequiredTypes => new[]
-        {
-            typeof(TemplateGameGame),
-        };
 
         [BackgroundDependencyLoader]
         private void load(GameHost host)

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
@@ -391,6 +392,9 @@ namespace osu.Framework.Testing
                 Assertion = assert,
             });
         });
+
+        [Obsolete("Required types are now determined automatically.")] // can be removed 20201115
+        public virtual IReadOnlyList<Type> RequiredTypes => Array.Empty<Type>();
 
         internal void RunSetUpSteps()
         {


### PR DESCRIPTION
I consider this a breaking change since it affects every project in existence (it was included in the template).