### PR TITLE
Fix ModelBackedDrawable not working inside BufferedContainer

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneModelBackedDrawable.cs
@@ -142,6 +142,31 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddUntilStep("null model shown", () => backedDrawable.DisplayedDrawable is TestNullDrawableModel);
         }
 
+        [Test]
+        public void TestInsideBufferedContainer()
+        {
+            TestDrawableModel drawableModel = null;
+
+            AddStep("setup", () =>
+            {
+                Child = new BufferedContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(200),
+                    Child = backedDrawable = new TestModelBackedDrawable
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        HasIntermediate = false,
+                        ShowNullModel = false,
+                        Model = new TestModel(drawableModel = new TestDrawableModel(1).With(d => d.AllowLoad.Set()))
+                    }
+                };
+            });
+
+            assertDrawableVisibility(1, () => drawableModel);
+        }
+
         private void assertIntermediateVisibility(bool hasIntermediate, Func<Drawable> getLastFunc)
         {
             if (hasIntermediate)

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -263,6 +263,15 @@ namespace osu.Framework.Graphics.Containers
 
         protected override DrawNode CreateDrawNode() => new BufferedContainerDrawNode(this, sharedData);
 
+        public override bool UpdateSubTreeMasking(Drawable source, RectangleF maskingBounds)
+        {
+            var result = base.UpdateSubTreeMasking(source, maskingBounds);
+
+            childrenUpdateVersion = updateVersion;
+
+            return result;
+        }
+
         protected override RectangleF ComputeChildMaskingBounds(RectangleF maskingBounds) => ScreenSpaceDrawQuad.AABBFloat; // Make sure children never get masked away
 
         private Vector2 lastScreenSpaceSize;
@@ -311,13 +320,6 @@ namespace osu.Framework.Graphics.Containers
 
                 screenSpaceSizeBacking.Validate();
             }
-        }
-
-        protected override void UpdateAfterChildren()
-        {
-            base.UpdateAfterChildren();
-
-            childrenUpdateVersion = updateVersion;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/3222

`childrenUpdateVersion` was set too soon, which blocked `UpdateSubTreeMasking` from proceeding to children.

Unsure 100% on the placement here, I feel like it really should be inside `GenerateDrawNodeSubtree` but I'm considering cases like `FrameStabilityContainer` which potentially trigger multiple updates per-frame without drawnode generation.