### PR TITLE
Dispose of font stores in base game

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -345,6 +345,12 @@ namespace osu.Framework
             Audio?.Dispose();
             Audio = null;
 
+            Fonts?.Dispose();
+            Fonts = null;
+
+            localFonts?.Dispose();
+            localFonts = null;
+
             base.Dispose(isDisposing);
         }
     }


### PR DESCRIPTION
Resolves the framework side of ppy/osu#8420.

# Summary

Due to semantics of file removal on Windows, the post-test host cleanup logic would leave behind font cache files, as they were being held open by `RawCachingGlyphStore`s. This meant that each new game host instantiated would leave behind a 1 MB file that wouldn't be cleaned up, summing up to gigabytes in leftover files after a full test suite run.

To resolve, dispose of both font stores in `Game`. I have confirmed that this leads to the cache files being cleaned up on Windows, and additionally that this change should not regress game-side tests.

# Remarks

I have refrained from touching the other disposable resources in `Game` as per the "if it isn't broken, don't fix it" philosophy. In fact I recall that doing so would cause game-side failures, and I'd rather not get into investigating that right now.

Note that framework test runs aren't completely cleaned up still after this change. There's still a few cases (especially in headless tests) that leave behind files, such as `.ini` configs or log files, but their total size is about ~300 kB per full test suite run, so the remaining issues are nowhere near the order of magnitude of the previous state of affairs.