### PR TITLE
Improve WeakList<> performance in degenerate scenarios

### DIFF
--- a/osu.Framework.Tests/Lists/TestWeakList.cs
+++ b/osu.Framework.Tests/Lists/TestWeakList.cs
@@ -37,6 +37,18 @@ namespace osu.Framework.Tests.Lists
         }
 
         [Test]
+        public void TestEnumerate()
+        {
+            var obj = new object();
+            var list = new WeakList<object> { obj };
+
+            Assert.That(list.Count(), Is.EqualTo(1));
+            Assert.That(list, Does.Contain(obj));
+
+            GC.KeepAlive(obj);
+        }
+
+        [Test]
         public void TestRemove()
         {
             var obj = new object();

--- a/osu.Framework.Tests/Lists/TestWeakList.cs
+++ b/osu.Framework.Tests/Lists/TestWeakList.cs
@@ -66,6 +66,86 @@ namespace osu.Framework.Tests.Lists
         }
 
         [Test]
+        public void TestRemoveObjectsAtSides()
+        {
+            var objects = new List<object>
+            {
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+            };
+
+            var list = new WeakList<object>();
+            foreach (var o in objects)
+                list.Add(o);
+
+            list.Remove(objects[0]);
+            list.Remove(objects[1]);
+            list.Remove(objects[4]);
+            list.Remove(objects[5]);
+
+            Assert.That(list.Count(), Is.EqualTo(2));
+            Assert.That(list, Does.Contain(objects[2]));
+            Assert.That(list, Does.Contain(objects[3]));
+        }
+
+        [Test]
+        public void TestRemoveObjectsAtCentre()
+        {
+            var objects = new List<object>
+            {
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+            };
+
+            var list = new WeakList<object>();
+            foreach (var o in objects)
+                list.Add(o);
+
+            list.Remove(objects[2]);
+            list.Remove(objects[3]);
+
+            Assert.That(list.Count(), Is.EqualTo(4));
+            Assert.That(list, Does.Contain(objects[0]));
+            Assert.That(list, Does.Contain(objects[1]));
+            Assert.That(list, Does.Contain(objects[4]));
+            Assert.That(list, Does.Contain(objects[5]));
+        }
+
+        [Test]
+        public void TestAddAfterRemoveFromEnd()
+        {
+            var objects = new List<object>
+            {
+                new object(),
+                new object(),
+                new object(),
+            };
+
+            var newLastObject = new object();
+
+            var list = new WeakList<object>();
+            foreach (var o in objects)
+                list.Add(o);
+
+            list.Remove(objects[2]);
+            list.Add(newLastObject);
+
+            Assert.That(list.Count(), Is.EqualTo(3));
+            Assert.That(list, Does.Contain(objects[0]));
+            Assert.That(list, Does.Contain(objects[0]));
+            Assert.That(list, Does.Not.Contain(objects[2]));
+            Assert.That(list, Does.Contain(newLastObject));
+        }
+
+        [Test]
         public void TestCountIsZeroAfterClear()
         {
             var obj = new object();
@@ -79,6 +159,29 @@ namespace osu.Framework.Tests.Lists
             Assert.That(list.Contains(weakRef), Is.False);
 
             GC.KeepAlive(obj);
+        }
+
+        [Test]
+        public void TestAddAfterClear()
+        {
+            var objects = new List<object>
+            {
+                new object(),
+                new object(),
+                new object(),
+            };
+
+            var newObject = new object();
+
+            var list = new WeakList<object>();
+            foreach (var o in objects)
+                list.Add(o);
+
+            list.Clear();
+            list.Add(newObject);
+
+            Assert.That(list.Count(), Is.EqualTo(1));
+            Assert.That(list, Does.Contain(newObject));
         }
 
         [Test]

--- a/osu.Framework/Lists/IWeakList.cs
+++ b/osu.Framework/Lists/IWeakList.cs
@@ -37,6 +37,12 @@ namespace osu.Framework.Lists
         bool Remove(WeakReference<T> weakReference);
 
         /// <summary>
+        /// Removes an item at an index from this list.
+        /// </summary>
+        /// <param name="index">The index of the item to remove.</param>
+        void RemoveAt(int index);
+
+        /// <summary>
         /// Searches for an item in the list.
         /// </summary>
         /// <param name="item">The item to search for.</param>

--- a/osu.Framework/Lists/IWeakList.cs
+++ b/osu.Framework/Lists/IWeakList.cs
@@ -21,14 +21,15 @@ namespace osu.Framework.Lists
         /// <summary>
         /// Adds a weak reference to this list.
         /// </summary>
-        /// <param name="weakReference"></param>
+        /// <param name="weakReference">The weak reference to add.</param>
         void Add(WeakReference<T> weakReference);
 
         /// <summary>
         /// Removes an item from this list.
         /// </summary>
-        /// <param name="item"></param>
-        void Remove(T item);
+        /// <param name="item">The item to remove.</param>
+        /// <returns>Whether the item was removed.</returns>
+        bool Remove(T item);
 
         /// <summary>
         /// Removes a weak reference from this list.

--- a/osu.Framework/Lists/LockedWeakList.cs
+++ b/osu.Framework/Lists/LockedWeakList.cs
@@ -40,6 +40,12 @@ namespace osu.Framework.Lists
                 return list.Remove(weakReference);
         }
 
+        public void RemoveAt(int index)
+        {
+            lock (list)
+                list.RemoveAt(index);
+        }
+
         public bool Contains(T item)
         {
             lock (list)

--- a/osu.Framework/Lists/LockedWeakList.cs
+++ b/osu.Framework/Lists/LockedWeakList.cs
@@ -28,10 +28,10 @@ namespace osu.Framework.Lists
                 list.Add(weakReference);
         }
 
-        public void Remove(T item)
+        public bool Remove(T item)
         {
             lock (list)
-                list.Remove(item);
+                return list.Remove(item);
         }
 
         public bool Remove(WeakReference<T> weakReference)

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -20,22 +20,16 @@ namespace osu.Framework.Lists
         private int listStart;
         private int listEnd;
 
-        public void Add(T obj)
+        public void Add(T obj) => add(new InvalidatableWeakReference(obj));
+
+        public void Add(WeakReference<T> weakReference) => add(new InvalidatableWeakReference(weakReference));
+
+        private void add(in InvalidatableWeakReference item)
         {
             if (listEnd < list.Count)
-                list[listEnd] = new InvalidatableWeakReference(obj);
+                list[listEnd] = item;
             else
-                list.Add(new InvalidatableWeakReference(obj));
-
-            listEnd++;
-        }
-
-        public void Add(WeakReference<T> weakReference)
-        {
-            if (listEnd < list.Count)
-                list[listEnd] = new InvalidatableWeakReference(weakReference);
-            else
-                list.Add(new InvalidatableWeakReference(weakReference));
+                list.Add(item);
 
             listEnd++;
         }
@@ -49,13 +43,7 @@ namespace osu.Framework.Lists
                 if (enumerator.Current != item)
                     continue;
 
-                if (enumerator.CurrentIndex == listStart)
-                    listStart++;
-                else if (enumerator.CurrentIndex == listEnd)
-                    listEnd--;
-
-                list[enumerator.CurrentIndex] = default;
-
+                RemoveAt(enumerator.CurrentIndex);
                 break;
             }
         }
@@ -69,17 +57,21 @@ namespace osu.Framework.Lists
                 if (enumerator.CurrentReference != weakReference)
                     continue;
 
-                if (enumerator.CurrentIndex == listStart)
-                    listStart++;
-                else if (enumerator.CurrentIndex == listEnd)
-                    listEnd--;
-
-                list[enumerator.CurrentIndex] = default;
-
+                RemoveAt(enumerator.CurrentIndex);
                 return true;
             }
 
             return false;
+        }
+
+        public void RemoveAt(int index)
+        {
+            list[index] = default;
+
+            if (index == listStart)
+                listStart++;
+            else if (index == listEnd)
+                listEnd--;
         }
 
         public bool Contains(T item)

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Lists
             listEnd++;
         }
 
-        public void Remove(T item)
+        public bool Remove(T item)
         {
             var enumerator = GetEnumeratorNoTrim();
 
@@ -44,8 +44,10 @@ namespace osu.Framework.Lists
                     continue;
 
                 RemoveAt(enumerator.CurrentIndex);
-                break;
+                return true;
             }
+
+            return false;
         }
 
         public bool Remove(WeakReference<T> weakReference)

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -127,7 +127,7 @@ namespace osu.Framework.Lists
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Enumerator GetEnumeratorNoTrim() => new Enumerator(this);
+        internal Enumerator GetEnumeratorNoTrim() => new Enumerator(this);
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
 

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -151,12 +151,8 @@ namespace osu.Framework.Lists
                     // Check to make sure the object can be retrieved.
                     if (weakReference == null || !weakReference.TryGetTarget(out currentObject))
                     {
-                        // If the object can't be retrieved and we're at the start or the end of the list, increment the pointers to optimise for future enumerations.
-                        if (CurrentIndex == weakList.listStart)
-                            weakList.listStart++;
-                        else if (CurrentIndex == weakList.listEnd)
-                            weakList.listEnd--;
-
+                        // If it can't be retrieved, mark for removal. This will occur on the _next_ enumeration (see: GetEnumerator()).
+                        weakList.RemoveAt(CurrentIndex);
                         continue;
                     }
 


### PR DESCRIPTION
Specifically, cases where items are sequentially removed from either end (`RemoveAllIteratively`).

Removal of items is done lazily - items are effectively "nulled" and removed on the next `GetEnumerator()` call. This could lead subsequent removals without an interleaved `GetEnumerator()` call into a very bad O(n^2) scenario.

The solution is to store an enumeration range such that sequential removals only operate on the subset of the range that is relevant after the removal.

```diff
  |               Method | ItemCount |          Mean |        Error |       StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
  |--------------------- |---------- |--------------:| ------------:| ------------:|------:|--------:|-------:|-------:|------:|----------:|
- |                  Add |         1 |      207.0 ns |      3.06 ns |      2.86 ns |  1.00 |    0.00 | 0.0041 |      - |     - |     136 B |
+ |                  Add |         1 |      227.3 ns |      2.18 ns |      1.93 ns |  1.00 |    0.00 | 0.0043 |      - |     - |     144 B |
- |            RemoveOne |         1 |      209.9 ns |      1.05 ns |      0.87 ns |  1.01 |    0.01 | 0.0041 |      - |     - |     136 B |
+ |            RemoveOne |         1 |      265.8 ns |      5.27 ns |      4.93 ns |  1.17 |    0.02 | 0.0043 |      - |     - |     144 B |
- | RemoveAllIteratively |         1 |      214.4 ns |      2.36 ns |      2.20 ns |  1.04 |    0.02 | 0.0041 |      - |     - |     136 B |
+ | RemoveAllIteratively |         1 |      266.8 ns |      3.61 ns |      3.37 ns |  1.17 |    0.02 | 0.0043 |      - |     - |     144 B |
- |                Clear |         1 |      198.6 ns |      0.91 ns |      0.81 ns |  0.96 |    0.01 | 0.0041 |      - |     - |     136 B |
+ |                Clear |         1 |      229.4 ns |      1.58 ns |      1.48 ns |  1.01 |    0.01 | 0.0043 |      - |     - |     144 B |
- |             Contains |         1 |      239.9 ns |      4.42 ns |      4.14 ns |  1.16 |    0.02 | 0.0041 |      - |     - |     136 B |
+ |             Contains |         1 |      262.0 ns |      1.33 ns |      1.18 ns |  1.15 |    0.01 | 0.0043 |      - |     - |     144 B |
- |      AddAndEnumerate |         1 |      454.4 ns |      4.01 ns |      3.75 ns |  2.20 |    0.04 | 0.0076 |      - |     - |     264 B |
+ |      AddAndEnumerate |         1 |      456.2 ns |      8.63 ns |      8.07 ns |  2.00 |    0.04 | 0.0081 |      - |     - |     280 B |
- |    ClearAndEnumerate |         1 |      339.5 ns |      3.66 ns |      3.42 ns |  1.64 |    0.03 | 0.0052 |      - |     - |     176 B |
+ |    ClearAndEnumerate |         1 |      350.9 ns |      6.89 ns |      6.77 ns |  1.54 |    0.03 | 0.0057 |      - |     - |     192 B |
- |                      |           |               |              |              |       |         |        |        |       |           |
- |                  Add |        10 |    1,881.8 ns |     16.60 ns |     14.72 ns |  1.00 |    0.00 | 0.0153 |      - |     - |     592 B |
+ |                  Add |        10 |    2,019.0 ns |     16.14 ns |     15.10 ns |  1.00 |    0.00 | 0.0172 |      - |     - |     600 B |
- |            RemoveOne |        10 |    2,008.0 ns |      7.08 ns |      5.91 ns |  1.07 |    0.01 | 0.0172 |      - |     - |     592 B |
+ |            RemoveOne |        10 |    2,015.6 ns |     24.73 ns |     21.93 ns |  1.00 |    0.02 | 0.0153 |      - |     - |     600 B |
- | RemoveAllIteratively |        10 |    1,965.5 ns |     33.12 ns |     30.98 ns |  1.05 |    0.02 | 0.0153 |      - |     - |     592 B |
+ | RemoveAllIteratively |        10 |    2,217.6 ns |      9.66 ns |      9.04 ns |  1.10 |    0.01 | 0.0153 |      - |     - |     600 B |
- |                Clear |        10 |    1,995.8 ns |     13.77 ns |     12.21 ns |  1.06 |    0.01 | 0.0172 |      - |     - |     592 B |
+ |                Clear |        10 |    1,969.3 ns |     17.68 ns |     16.54 ns |  0.98 |    0.01 | 0.0172 |      - |     - |     600 B |
- |             Contains |        10 |    1,995.4 ns |     18.49 ns |     17.30 ns |  1.06 |    0.01 | 0.0153 |      - |     - |     592 B |
+ |             Contains |        10 |    2,010.9 ns |     22.47 ns |     21.02 ns |  1.00 |    0.01 | 0.0153 |      - |     - |     600 B |
- |      AddAndEnumerate |        10 |    2,531.8 ns |     24.27 ns |     22.70 ns |  1.35 |    0.01 | 0.0267 |      - |     - |     968 B |
+ |      AddAndEnumerate |        10 |    2,563.8 ns |     25.72 ns |     24.06 ns |  1.27 |    0.02 | 0.0267 |      - |     - |     984 B |
- |    ClearAndEnumerate |        10 |    1,925.4 ns |      8.37 ns |      7.83 ns |  1.02 |    0.01 | 0.0153 |      - |     - |     632 B |
+ |    ClearAndEnumerate |        10 |    2,124.1 ns |     31.15 ns |     29.14 ns |  1.05 |    0.02 | 0.0191 |      - |     - |     648 B |
- |                      |           |               |              |              |       |         |        |        |       |           |
- |                  Add |       100 |   17,318.5 ns |    201.34 ns |    188.33 ns |  1.00 |    0.00 | 0.1221 |      - |     - |    4616 B |
+ |                  Add |       100 |   17,062.2 ns |    192.91 ns |    180.45 ns |  1.00 |    0.00 | 0.1221 |      - |     - |    4624 B |
- |            RemoveOne |       100 |   16,947.0 ns |    239.75 ns |    212.53 ns |  0.98 |    0.01 | 0.1221 |      - |     - |    4616 B |
+ |            RemoveOne |       100 |   18,390.1 ns |    245.30 ns |    229.45 ns |  1.08 |    0.02 | 0.1221 |      - |     - |    4624 B |
- | RemoveAllIteratively |       100 |   24,291.9 ns |    485.49 ns |    519.47 ns |  1.40 |    0.03 | 0.1221 |      - |     - |    4616 B |
+ | RemoveAllIteratively |       100 |   20,157.9 ns |    299.70 ns |    280.34 ns |  1.18 |    0.01 | 0.1221 |      - |     - |    4624 B |
- |                Clear |       100 |   17,301.9 ns |    337.04 ns |    360.63 ns |  1.00 |    0.02 | 0.1221 |      - |     - |    4616 B |
+ |                Clear |       100 |   17,761.8 ns |    224.81 ns |    210.29 ns |  1.04 |    0.02 | 0.1221 |      - |     - |    4624 B |
- |             Contains |       100 |   17,823.1 ns |    237.75 ns |    198.53 ns |  1.03 |    0.02 | 0.1221 |      - |     - |    4616 B |
+ |             Contains |       100 |   18,868.9 ns |    327.09 ns |    305.96 ns |  1.11 |    0.02 | 0.1221 |      - |     - |    4624 B |
- |      AddAndEnumerate |       100 |   20,000.2 ns |    268.11 ns |    250.79 ns |  1.15 |    0.02 | 0.1831 |      - |     - |    6736 B |
+ |      AddAndEnumerate |       100 |   20,131.5 ns |    349.09 ns |    326.54 ns |  1.18 |    0.02 | 0.1831 |      - |     - |    6752 B |
- |    ClearAndEnumerate |       100 |   18,011.5 ns |    347.24 ns |    451.51 ns |  1.03 |    0.03 | 0.1221 |      - |     - |    4656 B |
+ |    ClearAndEnumerate |       100 |   18,199.3 ns |    231.95 ns |    216.97 ns |  1.07 |    0.01 | 0.1221 |      - |     - |    4672 B |
- |                      |           |               |              |              |       |         |        |        |       |           |
- |                  Add |      1000 |  162,337.4 ns |  2,794.20 ns |  2,613.70 ns |  1.00 |    0.00 | 0.9766 |      - |     - |   40624 B |
+ |                  Add |      1000 |  164,507.5 ns |  2,973.34 ns |  2,781.26 ns |  1.00 |    0.00 | 0.9766 |      - |     - |   40634 B |
- |            RemoveOne |      1000 |  168,187.2 ns |  1,806.57 ns |  1,508.57 ns |  1.03 |    0.02 | 0.9766 |      - |     - |   40625 B |
+ |            RemoveOne |      1000 |  171,714.5 ns |  3,395.22 ns |  6,122.28 ns |  1.07 |    0.04 | 0.9766 |      - |     - |   40632 B |
- | RemoveAllIteratively |      1000 |  719,680.4 ns |  2,989.08 ns |  2,795.99 ns |  4.43 |    0.07 | 0.9766 |      - |     - |   40625 B |
+ | RemoveAllIteratively |      1000 |  191,837.6 ns |  1,906.30 ns |  1,783.15 ns |  1.17 |    0.02 | 0.9766 |      - |     - |   40632 B |
- |                Clear |      1000 |  161,095.3 ns |  1,892.51 ns |  1,770.26 ns |  0.99 |    0.02 | 0.9766 |      - |     - |   40626 B |
+ |                Clear |      1000 |  163,225.7 ns |  3,128.09 ns |  3,956.03 ns |  1.00 |    0.03 | 0.9766 |      - |     - |   40632 B |
- |             Contains |      1000 |  171,346.6 ns |  1,645.03 ns |  1,538.76 ns |  1.06 |    0.02 | 0.9766 |      - |     - |   40626 B |
+ |             Contains |      1000 |  179,636.8 ns |  3,008.97 ns |  2,814.59 ns |  1.09 |    0.03 | 0.9766 |      - |     - |   40633 B |
- |      AddAndEnumerate |      1000 |  198,525.6 ns |  3,672.92 ns |  3,607.29 ns |  1.22 |    0.03 | 1.7090 |      - |     - |   57272 B |
+ |      AddAndEnumerate |      1000 |  201,681.5 ns |  3,373.97 ns |  2,817.42 ns |  1.23 |    0.03 | 1.7090 |      - |     - |   57289 B |
- |    ClearAndEnumerate |      1000 |  162,947.7 ns |  1,381.78 ns |  1,292.52 ns |  1.00 |    0.02 | 0.9766 |      - |     - |   40665 B |
+ |    ClearAndEnumerate |      1000 |  163,208.1 ns |  1,809.39 ns |  1,603.98 ns |  0.99 |    0.01 | 0.9766 |      - |     - |   40681 B | 
```

Vs `List<T>`:
```
|               Method | ItemCount |          Mean |        Error |       StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|--------------------- |---------- |--------------:|-------------:|-------------:|------:|--------:|-------:|-------:|------:|----------:|
|                  Add |         1 |      36.49 ns |     0.290 ns |     0.271 ns |  1.00 |    0.00 | 0.0026 |      - |     - |      88 B |
|            RemoveOne |         1 |      49.67 ns |     0.631 ns |     0.590 ns |  1.36 |    0.02 | 0.0026 |      - |     - |      88 B |
| RemoveAllIteratively |         1 |      53.26 ns |     0.729 ns |     0.682 ns |  1.46 |    0.02 | 0.0026 |      - |     - |      88 B |
|                Clear |         1 |      44.87 ns |     0.605 ns |     0.566 ns |  1.23 |    0.02 | 0.0026 |      - |     - |      88 B |
|             Contains |         1 |      48.22 ns |     0.602 ns |     0.563 ns |  1.32 |    0.02 | 0.0026 |      - |     - |      88 B |
|      AddAndEnumerate |         1 |      71.70 ns |     0.377 ns |     0.352 ns |  1.97 |    0.02 | 0.0036 |      - |     - |     120 B |
|    ClearAndEnumerate |         1 |      53.11 ns |     0.816 ns |     0.763 ns |  1.46 |    0.03 | 0.0026 |      - |     - |      88 B |
|                      |           |               |              |              |       |         |        |        |       |           |
|                  Add |        10 |     167.25 ns |     1.762 ns |     1.648 ns |  1.00 |    0.00 | 0.0098 |      - |     - |     328 B |
|            RemoveOne |        10 |     183.31 ns |     1.868 ns |     1.748 ns |  1.10 |    0.01 | 0.0098 |      - |     - |     328 B |
| RemoveAllIteratively |        10 |     464.38 ns |     5.340 ns |     4.995 ns |  2.78 |    0.04 | 0.0095 |      - |     - |     328 B |
|                Clear |        10 |     169.64 ns |     3.095 ns |     2.895 ns |  1.01 |    0.02 | 0.0098 |      - |     - |     328 B |
|             Contains |        10 |     182.89 ns |     1.759 ns |     1.469 ns |  1.09 |    0.01 | 0.0098 |      - |     - |     328 B |
|      AddAndEnumerate |        10 |     213.92 ns |     3.761 ns |     3.518 ns |  1.28 |    0.02 | 0.0129 |      - |     - |     432 B |
|    ClearAndEnumerate |        10 |     189.38 ns |     3.388 ns |     3.169 ns |  1.13 |    0.02 | 0.0098 |      - |     - |     328 B |
|                      |           |               |              |              |       |         |        |        |       |           |
|                  Add |       100 |     849.33 ns |    14.759 ns |    13.805 ns |  1.00 |    0.00 | 0.0648 |      - |     - |    2192 B |
|            RemoveOne |       100 |     863.62 ns |    16.730 ns |    17.901 ns |  1.02 |    0.03 | 0.0648 |      - |     - |    2192 B |
| RemoveAllIteratively |       100 |   4,620.48 ns |    58.899 ns |    52.212 ns |  5.45 |    0.13 | 0.0610 |      - |     - |    2192 B |
|                Clear |       100 |     888.57 ns |    10.352 ns |     9.683 ns |  1.05 |    0.01 | 0.0648 |      - |     - |    2192 B |
|             Contains |       100 |     892.48 ns |     4.814 ns |     4.020 ns |  1.05 |    0.02 | 0.0648 |      - |     - |    2192 B |
|      AddAndEnumerate |       100 |     935.74 ns |     4.272 ns |     3.996 ns |  1.10 |    0.02 | 0.0896 |      - |     - |    3016 B |
|    ClearAndEnumerate |       100 |     907.35 ns |    10.259 ns |     9.596 ns |  1.07 |    0.02 | 0.0648 |      - |     - |    2192 B |
|                      |           |               |              |              |       |         |        |        |       |           |
|                  Add |      1000 |   6,515.83 ns |    73.826 ns |    65.445 ns |  1.00 |    0.00 | 0.4959 | 0.0153 |     - |   16600 B |
|            RemoveOne |      1000 |   9,361.82 ns |    41.383 ns |    38.710 ns |  1.44 |    0.01 | 0.4883 | 0.0153 |     - |   16600 B |
| RemoveAllIteratively |      1000 | 117,623.08 ns | 1,630.781 ns | 1,525.434 ns | 18.04 |    0.30 | 0.4883 |      - |     - |   16600 B |
|                Clear |      1000 |   5,796.35 ns |   114.192 ns |   170.918 ns |  0.89 |    0.03 | 0.4959 | 0.0153 |     - |   16600 B |
|             Contains |      1000 |   8,693.15 ns |   123.574 ns |   115.591 ns |  1.34 |    0.02 | 0.4883 | 0.0153 |     - |   16600 B |
|      AddAndEnumerate |      1000 |   7,141.65 ns |   103.790 ns |    92.008 ns |  1.10 |    0.02 | 0.7324 | 0.0381 |     - |   24624 B |
|    ClearAndEnumerate |      1000 |   6,538.84 ns |   127.204 ns |   190.393 ns |  1.00 |    0.03 | 0.4959 | 0.0153 |     - |   16600 B |
```

Most losses in raw mean value vs `List<T>` are due to `Add()` and the creation of weak references before each method, which is why there's a baseline column on `Add()`.

This should hopefully improve performance of bindable unbinding on disposal (which are generally sequential /  partly sequential).

Requesting high scrutiny on this one.