### PR TITLE
Fix audio devices potentially getting initialized more than once

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -246,7 +246,7 @@ namespace osu.Framework.Audio
                 return false;
 
             // same device
-            if (device.IsInitialized && deviceIndex == Bass.CurrentDevice)
+            if (deviceIndex == Bass.CurrentDevice)
                 return true;
 
             // initialize new device


### PR DESCRIPTION
As found by the CI https://ci.appveyor.com/project/peppy/osu-framework/builds/32962217/tests
<img width="947" alt="image" src="https://user-images.githubusercontent.com/22781491/82403968-c2945a00-9a68-11ea-90cf-f7c69e0b0ba5.png">


## The problem

The problem found by the CI is because calling `setAudioDevice()` twice in a row without `syncAudioDevices()` being invoked (`audioDevices` list must've been filled up first) will cause the audio device to be initialized again and will call `UpdateDevice(index)` with the same index, thus a `Bass.ChannelSetDevice(handle, index)` operation will fail with `Errors.Already`.

This PR fixes the issue by enforcing a list synchronization before performing any initialization steps and checks, also removes unnecessary `device.IsInitialized` check as `deviceIndex == Bass.CurrentDevice` pretty much does its job.
```diff
- if (device.IsInitialized && deviceIndex == Bass.CurrentDevice)
+ if (deviceIndex == Bass.CurrentDevice)
```

I've left the synchronization schedule another `setAudioDevice()` call even though this is called from `setAudioDevice(int)` itself, intended to fix a possible case of `Bass.CurrentDevice` and the requested device to set from the root `setAudioDevice(int)` both becoming disabled after synchronization. (by returning on the root `setAudioDevice(int)` and let the scheduled call from synchronization method change the current device to the default one or no-sound)

## The cause
Currently happening because of a race between an internal thread inside `AudioManager` where `syncAudioDevices()` method is invoked from and the `AudioThread` where a `setAudioDevice()` call is scheduled to from binding with the config bindable.

Here's a diagram illustrating how the race is happening:
![setAudioDevicesCalledTwiceBeforeNextSyncAudioDevice()](https://user-images.githubusercontent.com/22781491/82401982-eef9a780-9a63-11ea-809e-8ed3d0b54569.png)

This race will only happen if `syncAudioDevices()` is called first and updated the `audioDevices` list, making [the `setAudioDevice()` call from config-binding](https://github.com/ppy/osu-framework/blob/1a98edd0cb96bfdfc7da2a3853a369eea8c74898/osu.Framework/Audio/AudioManager.cs#L175) a successful one, [after that](https://github.com/ppy/osu-framework/blob/1a98edd0cb96bfdfc7da2a3853a369eea8c74898/osu.Framework/Audio/AudioManager.cs#L343) another [`setAudioDevice()` call will be scheduled](https://github.com/ppy/osu-framework/blob/1a98edd0cb96bfdfc7da2a3853a369eea8c74898/osu.Framework/Audio/AudioManager.cs#L180-L184) and [its thread will sleep for a whole second](https://github.com/ppy/osu-framework/blob/1a98edd0cb96bfdfc7da2a3853a369eea8c74898/osu.Framework/Audio/AudioManager.cs#L147) before invoking `syncAudioDevices()` again, therefore invoking the scheduled `setAudioDevice()` call before the next sync call and fails with the problem mentioned above.