### PR TITLE
Add pdb to DynamicClassCompiler to show more info in stack trace

### DIFF
--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -155,18 +155,18 @@ namespace osu.Framework.Testing
                     options
                 );
 
-                using (var symbols = new MemoryStream())
-                using (var ms = new MemoryStream())
+                using (var pdbStream = new MemoryStream())
+                using (var peStream = new MemoryStream())
                 {
-                    var compilationResult = compilation.Emit(ms, symbols);
+                    var compilationResult = compilation.Emit(peStream, pdbStream);
 
                     if (compilationResult.Success)
                     {
-                        ms.Seek(0, SeekOrigin.Begin);
-                        symbols.Seek(0, SeekOrigin.Begin);
+                        peStream.Seek(0, SeekOrigin.Begin);
+                        pdbStream.Seek(0, SeekOrigin.Begin);
 
                         CompilationFinished?.Invoke(
-                            Assembly.Load(ms.ToArray(), symbols.ToArray()).GetModules()[0].GetTypes().LastOrDefault(t => t.FullName == targetType.FullName)
+                            Assembly.Load(peStream.ToArray(), pdbStream.ToArray()).GetModules()[0].GetTypes().LastOrDefault(t => t.FullName == targetType.FullName)
                         );
                     }
                     else

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using System.Text;
 
 namespace osu.Framework.Testing
 {
@@ -147,22 +148,25 @@ namespace osu.Framework.Testing
 
                 var compilation = CSharpCompilation.Create(
                     dynamicNamespace,
-                    requiredFiles.Select(file => CSharpSyntaxTree.ParseText(File.ReadAllText(file), parseOptions, file))
+                    requiredFiles.Select(file => CSharpSyntaxTree.ParseText(File.ReadAllText(file, Encoding.UTF8), parseOptions, file, encoding: Encoding.UTF8))
                                  // Compile the assembly with a new version so that it replaces the existing one
                                  .Append(CSharpSyntaxTree.ParseText($"using System.Reflection; [assembly: AssemblyVersion(\"{assemblyVersion}\")]", parseOptions)),
                     references,
                     options
                 );
 
+                using (var symbols = new MemoryStream())
                 using (var ms = new MemoryStream())
                 {
-                    var compilationResult = compilation.Emit(ms);
+                    var compilationResult = compilation.Emit(ms, symbols);
 
                     if (compilationResult.Success)
                     {
                         ms.Seek(0, SeekOrigin.Begin);
+                        symbols.Seek(0, SeekOrigin.Begin);
+
                         CompilationFinished?.Invoke(
-                            Assembly.Load(ms.ToArray()).GetModules()[0].GetTypes().LastOrDefault(t => t.FullName == targetType.FullName)
+                            Assembly.Load(ms.ToArray(), symbols.ToArray()).GetModules()[0].GetTypes().LastOrDefault(t => t.FullName == targetType.FullName)
                         );
                     }
                     else


### PR DESCRIPTION
Currently after your code have been dynamically compiled and if it throws an exception then you will see stack trace but without file and line where this exception happened.

Adding pdb stream to compilation will show that information even after dynamic assembly been created.

You can see the difference in image below.

![image](https://user-images.githubusercontent.com/44163588/82763285-350d8d00-9e0f-11ea-9ff4-ab8672659707.png)
