### PR TITLE
Fix WeakList<T> failure cases

### DIFF
--- a/osu.Framework.Tests/Lists/TestWeakList.cs
+++ b/osu.Framework.Tests/Lists/TestWeakList.cs
@@ -158,6 +158,83 @@ namespace osu.Framework.Tests.Lists
         }
 
         [Test]
+        public void TestRemoveAllUsingRemoveAtFromStart()
+        {
+            var objects = new List<object>
+            {
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+            };
+
+            var list = new WeakList<object>();
+            foreach (var o in objects)
+                list.Add(o);
+
+            for (int i = 0; i < objects.Count; i++)
+                list.RemoveAt(0);
+
+            Assert.That(list.Count(), Is.Zero);
+        }
+
+        [Test]
+        public void TestRemoveAllUsingRemoveAtFromEnd()
+        {
+            var objects = new List<object>
+            {
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+            };
+
+            var list = new WeakList<object>();
+            foreach (var o in objects)
+                list.Add(o);
+
+            for (int i = 0; i < objects.Count; i++)
+                list.RemoveAt(list.Count() - 1);
+
+            Assert.That(list.Count(), Is.Zero);
+        }
+
+        [Test]
+        public void TestRemoveAllUsingRemoveAtFromBothSides()
+        {
+            var objects = new List<object>
+            {
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+                new object(),
+            };
+
+            var list = new WeakList<object>();
+            foreach (var o in objects)
+                list.Add(o);
+
+            for (int i = 0; i < objects.Count; i++)
+            {
+                if (i % 2 == 0)
+                    list.RemoveAt(0);
+                else
+                    list.RemoveAt(list.Count() - 1);
+            }
+
+            Assert.That(list.Count(), Is.Zero);
+        }
+
+        [Test]
         public void TestCountIsZeroAfterClear()
         {
             var obj = new object();

--- a/osu.Framework/Lists/LockedWeakList.cs
+++ b/osu.Framework/Lists/LockedWeakList.cs
@@ -82,10 +82,10 @@ namespace osu.Framework.Lists
             {
                 this.list = list;
 
-                listEnumerator = list.GetEnumerator();
-
                 lockTaken = false;
                 Monitor.Enter(list, ref lockTaken);
+
+                listEnumerator = list.GetEnumerator();
             }
 
             public bool MoveNext() => listEnumerator.MoveNext();

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Lists
                 if (enumerator.Current != item)
                     continue;
 
-                RemoveAt(enumerator.CurrentIndex);
+                RemoveAt(enumerator.CurrentOffset);
                 return true;
             }
 
@@ -59,7 +59,7 @@ namespace osu.Framework.Lists
                 if (enumerator.CurrentReference != weakReference)
                     continue;
 
-                RemoveAt(enumerator.CurrentIndex);
+                RemoveAt(enumerator.CurrentOffset);
                 return true;
             }
 
@@ -68,6 +68,12 @@ namespace osu.Framework.Lists
 
         public void RemoveAt(int index)
         {
+            // Move the index to the valid range of the list.
+            index += listStart;
+
+            if (index < listStart || index >= listEnd)
+                throw new ArgumentOutOfRangeException(nameof(index));
+
             list[index] = default;
 
             if (index == listStart)
@@ -130,42 +136,55 @@ namespace osu.Framework.Lists
         public struct Enumerator : IEnumerator<T>
         {
             private WeakList<T> weakList;
-
             private T currentObject;
 
             internal Enumerator(WeakList<T> weakList)
             {
                 this.weakList = weakList;
 
-                CurrentIndex = weakList.listStart - 1; // The first MoveNext() should bring the iterator to the start
+                CurrentOffset = -1; // The first MoveNext() should bring the iterator to the start
                 CurrentReference = null;
                 currentObject = null;
             }
 
             public bool MoveNext()
             {
-                while (++CurrentIndex < weakList.listEnd)
+                while (true)
                 {
-                    var weakReference = weakList.list[CurrentIndex].Reference;
+                    ++CurrentOffset;
 
-                    // Check to make sure the object can be retrieved.
-                    if (weakReference == null || !weakReference.TryGetTarget(out currentObject))
+                    int index = weakList.listStart + CurrentOffset;
+
+                    // Check whether we're still within the valid range of the list.
+                    if (index >= weakList.listEnd)
+                        return false;
+
+                    var weakReference = weakList.list[index].Reference;
+
+                    // Check whether the reference exists.
+                    if (weakReference == null)
                     {
-                        // If it can't be retrieved, mark for removal. This will occur on the _next_ enumeration (see: GetEnumerator()).
-                        weakList.RemoveAt(CurrentIndex);
+                        // If the reference doesn't exist, it must have previously been removed and can be skipped.
+                        continue;
+                    }
+
+                    // Check whether the object can be retrieved.
+                    if (!weakReference.TryGetTarget(out currentObject))
+                    {
+                        // If the object can't be retrieved, mark the reference for removal.
+                        // The removal will occur on the _next_ enumeration (see: GetEnumerator()).
+                        weakList.RemoveAt(CurrentOffset);
                         continue;
                     }
 
                     CurrentReference = weakReference;
                     return true;
                 }
-
-                return false;
             }
 
             public void Reset()
             {
-                CurrentIndex = weakList.listStart - 1;
+                CurrentOffset = -1;
                 CurrentReference = null;
                 currentObject = null;
             }
@@ -174,7 +193,7 @@ namespace osu.Framework.Lists
 
             internal WeakReference<T> CurrentReference { get; private set; }
 
-            internal int CurrentIndex { get; private set; }
+            internal int CurrentOffset { get; private set; }
 
             readonly object IEnumerator.Current => Current;
 

--- a/osu.Framework/Lists/WeakList.cs
+++ b/osu.Framework/Lists/WeakList.cs
@@ -17,8 +17,8 @@ namespace osu.Framework.Lists
         where T : class
     {
         private readonly List<InvalidatableWeakReference> list = new List<InvalidatableWeakReference>();
-        private int listStart;
-        private int listEnd;
+        private int listStart; // The inclusive starting index in the list.
+        private int listEnd; // The exclusive ending index in the list.
 
         public void Add(T obj) => add(new InvalidatableWeakReference(obj));
 
@@ -72,7 +72,7 @@ namespace osu.Framework.Lists
 
             if (index == listStart)
                 listStart++;
-            else if (index == listEnd)
+            else if (index == listEnd - 1)
                 listEnd--;
         }
 


### PR DESCRIPTION
There's 2 fixes here:

First, `RemoveAt()` was broken.
1. It didn't include the start offset, meaning `RemoveAt(0)`, `RemoveAt(0)`, ..., would be a no-op after the first operation. This is a new function and doesn't affect, e.g. `Remove()` which used this method.
2. It would never decrement the end index when removing from the end. This could only really affect performance, and even then it would only be for cases where you constantly iterate over the whole list (like, I guess... `.Contains()` with an item that doesn't exist after a `.RemoveAt()`?).

I don't believe either of the above could cause the failure seen in https://ci.appveyor.com/project/peppy/osu/builds/33061305, because even with the above issues, `listEnd` is guaranteed to be less than or equal to the list count. There's only 3 places where it's changed:
1. https://github.com/ppy/osu-framework/blob/d7c13699a75f048c79a38a57f5c97f405090ac15/osu.Framework/Lists/WeakList.cs#L29-L34 (keeps `listEnd <= list.Count` at all times)
2. https://github.com/ppy/osu-framework/blob/d7c13699a75f048c79a38a57f5c97f405090ac15/osu.Framework/Lists/WeakList.cs#L75-L76 (doesn't actually work, see (2) above)
3. https://github.com/ppy/osu-framework/blob/d7c13699a75f048c79a38a57f5c97f405090ac15/osu.Framework/Lists/WeakList.cs#L118 (sets `listEnd = list.Count`)

So I think the issue with the CI link is actually a threading one. I don't know how this is possible, however I have found one place where mutation was occurring just slightly outside of a lock, directly inside `LockedWeakList<T>.GetEnumerator()`.
It may be possible that some really wacky series of events happened there, it may even have something to do with an omission of `volatile` on `List<T>.Count`... It's the only way I can imagine `listEnd` being set _higher_ than the true count of elements in the list.

Note that this does not fix the issue where Bindables are directly enumerating from the list and may behave unexpectedly if bound bindables make any modifications. It's possible to fix that with the model of this list, but it's probably best left for a separate PR.