### PR TITLE
Fix dynamic compilation not working for testscenes

### DIFF
--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -349,7 +349,7 @@ namespace osu.Framework.Testing
                 var node = directedGraph[s];
 
                 // This shouldn't be super tight (e.g. log_2), but tight enough that a significant number of nodes do get excluded.
-                double range = Math.Log(node.ExpansionFactor, 1.25d);
+                double range = Math.Log(Math.Max(1, node.ExpansionFactor), 1.25d);
 
                 var exclusionRange = (
                     min: range,


### PR DESCRIPTION
`Log(0) = Infinity`

With expansion factor 0, this becomes `exclusionRange = (-Inf .. +Inf)`.

This entire method is going to be rewritten - I don't like the concept of this expansion factor anymore, so just treat it as a hotfix for now.