### PR TITLE
Ignore static classes in dynamic compilation

### DIFF
--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.Text;
 using osu.Framework.Logging;
@@ -222,8 +223,14 @@ namespace osu.Framework.Testing
             {
                 var kind = n.Kind();
 
+                // Ignored:
+                // - Entire using lines.
+                // - Namespace names (not entire namespaces).
+                // - Entire static classes.
+
                 return kind != SyntaxKind.UsingDirective
-                       && kind != SyntaxKind.NamespaceKeyword;
+                       && kind != SyntaxKind.NamespaceKeyword
+                       && (kind != SyntaxKind.ClassDeclaration || ((ClassDeclarationSyntax)n).Modifiers.All(m => m.Kind() != SyntaxKind.StaticKeyword));
             });
 
             // Find all the named type symbols in the syntax tree, and mark + recursively iterate through them.


### PR DESCRIPTION
Since static classes are more often than not used to provide extension methods, they can't be re-compiled otherwise they lead to ambiguous names.
Technically this is also true for all statics, but there's no way to avoid that, and will be documented as a failure case.