### PR TITLE
Add test covering removing twice from a BindableList not firing events

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -751,6 +751,23 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
+        public void TestRemoveDoesntNotifySubscribersOnNoOp()
+        {
+            const string item = "item";
+            bindableStringList.Add(item);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+
+            bindableStringList.Remove(item);
+
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringList.Remove(item);
+
+            Assert.That(triggeredArgs, Is.Null);
+        }
+
+        [Test]
         public void TestRemoveNotifiesSubscribers()
         {
             const string item = "item";


### PR DESCRIPTION
Not actually an issue, but I wrote a test to confirm it was working correctly, and seems like it's worthwhile having.