### PR TITLE
Replace returning host assembly with NUnit current test assembly

### DIFF
--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Development
             {
                 Debug.Assert(IsNUnitRunning);
 
-                var testName = TestContext.CurrentContext.Test.FullName;
+                var testName = TestContext.CurrentContext.Test.ClassName;
                 return AppDomain.CurrentDomain.GetAssemblies().First(asm => asm.GetType(testName) != null);
             }
         );

--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -12,8 +12,6 @@ namespace osu.Framework.Development
 {
     public static class DebugUtils
     {
-        internal static Assembly HostAssembly { get; set; }
-
         public static bool IsNUnitRunning => is_nunit_running.Value;
 
         private static readonly Lazy<bool> is_nunit_running = new Lazy<bool>(() =>
@@ -22,6 +20,15 @@ namespace osu.Framework.Development
 
                 // when running under nunit + netcore, entry assembly becomes nunit itself (testhost, Version=15.0.0.0), which isn't what we want.
                 return entry == null || entry.Location.Contains("testhost");
+            }
+        );
+
+        private static readonly Lazy<Assembly> nunit_test_assembly = new Lazy<Assembly>(() =>
+            {
+                Debug.Assert(IsNUnitRunning);
+
+                var testName = TestContext.CurrentContext.Test.FullName;
+                return AppDomain.CurrentDomain.GetAssemblies().First(asm => asm.GetType(testName) != null);
             }
         );
 
@@ -41,20 +48,21 @@ namespace osu.Framework.Development
         private static bool isDebugAssembly(Assembly assembly) => assembly?.GetCustomAttributes(false).OfType<DebuggableAttribute>().Any(da => da.IsJITTrackingEnabled) ?? false;
 
         /// <summary>
-        /// Get the entry assembly, even when running under nUnit.
-        /// Will fall back to calling assembly if there is no Entry assembly.
+        /// Gets the entry assembly, or calling assembly otherwise.
+        /// When running under NUnit, the assembly of the current test will be returned instead.
         /// </summary>
         /// <returns>The entry assembly (usually obtained via <see cref="Assembly.GetEntryAssembly()"/>.</returns>
         public static Assembly GetEntryAssembly()
         {
-            if (IsNUnitRunning && HostAssembly != null)
-                return HostAssembly;
+            if (IsNUnitRunning)
+                return nunit_test_assembly.Value;
 
-            return Assembly.GetEntryAssembly() ?? HostAssembly ?? Assembly.GetCallingAssembly();
+            return Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
         }
 
         /// <summary>
-        /// Get the entry path, even when running under nUnit.
+        /// Gets the absolute path to the directory containing the assembly determined by <see cref="GetEntryAssembly"/>.
+        /// When running under NUnit, the directory containing the current test assembly will be returned instead.
         /// </summary>
         /// <returns>The entry assembly (usually obtained via the entry assembly's <see cref="Assembly.Location"/>.</returns>
         public static string GetEntryPath() =>

--- a/osu.Framework/Development/DebugUtils.cs
+++ b/osu.Framework/Development/DebugUtils.cs
@@ -62,10 +62,8 @@ namespace osu.Framework.Development
 
         /// <summary>
         /// Gets the absolute path to the directory containing the assembly determined by <see cref="GetEntryAssembly"/>.
-        /// When running under NUnit, the directory containing the current test assembly will be returned instead.
         /// </summary>
-        /// <returns>The entry assembly (usually obtained via the entry assembly's <see cref="Assembly.Location"/>.</returns>
-        public static string GetEntryPath() =>
-            IsNUnitRunning ? TestContext.CurrentContext.TestDirectory : Path.GetDirectoryName(GetEntryAssembly().Location);
+        /// <returns>The entry path (usually obtained via the entry assembly's <see cref="Assembly.Location"/> directory.</returns>
+        public static string GetEntryPath() => Path.GetDirectoryName(GetEntryAssembly().Location);
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -481,8 +481,6 @@ namespace osu.Framework.Platform
                 SixLabors.ImageSharp.Configuration.Default.MemoryAllocator = ArrayPoolMemoryAllocator.CreateWithModeratePooling();
             }
 
-            DebugUtils.HostAssembly = game.GetType().Assembly;
-
             if (ExecutionState != ExecutionState.Idle)
                 throw new InvalidOperationException("A game that has already been run cannot be restarted.");
 


### PR DESCRIPTION
Makes more sense to return the assembly containing the current running test as the entry assembly, instead of the game assembly. 

Also an upside with this change is that `DebugUtils.GetEntryAssembly()` will now return the exact same assembly value for normal runs on nunit runs as can be seen in the below results.

---

Only slightly improves code quality by avoiding use of mutable static members, not needed for any other PR but worth submitting this change for the sake of code quality.

Tested assembly values manually on different projects:
```
osu.Framework.Tests (normal run)
- Assembly.GetEntryAssembly(): /Users/salman/Desktop/osu-framework/osu.Framework.Tests/bin/Debug/netcoreapp3.1/osu.Framework.Tests.dll
- Assembly.GetCallingAssembly(): /Users/salman/Desktop/osu-framework/osu.Framework.Tests/bin/Debug/netcoreapp3.1/osu.Framework.dll

osu.Framework.Tests (NUnit run)
- nunit_test_assembly: /Users/salman/Desktop/osu-framework/osu.Framework.Tests/bin/Debug/netcoreapp3.1/osu.Framework.Tests.dll
- Assembly.GetEntryAssembly(): /Users/salman/Desktop/osu-framework/osu.Framework.Tests/bin/Debug/netcoreapp3.1/testhost.dll
- Assembly.GetCallingAssembly(): /Users/salman/Desktop/osu-framework/osu.Framework.Tests/bin/Debug/netcoreapp3.1/osu.Framework.dll

osu.Game.Tests (normal run)
- Assembly.GetEntryAssembly(): /Users/salman/Desktop/osu/osu.Game.Tests/bin/Debug/netcoreapp3.1/osu.Game.Tests.dll
- Assembly.GetCallingAssembly(): /Users/salman/Desktop/osu/osu.Game.Tests/bin/Debug/netcoreapp3.1/osu.Framework.dll

osu.Game.Tests (NUnit run)
- nunit_test_assembly: /Users/salman/Desktop/osu/osu.Game.Tests/bin/Debug/netcoreapp3.1/osu.Game.Tests.dll
- Assembly.GetEntryAssembly(): /Users/salman/Desktop/osu/osu.Game.Tests/bin/Debug/netcoreapp3.1/testhost.dll
- Assembly.GetCallingAssembly(): /Users/salman/Desktop/osu/osu.Game.Tests/bin/Debug/netcoreapp3.1/osu.Framework.dll

osu.Game.Rulesets.Tau.Tests (normal run)
- Assembly.GetEntryAssembly(): /Users/salman/Desktop/tau/osu.Game.Rulesets.tau.Tests/bin/Debug/netcoreapp3.0/osu.Game.Rulesets.tau.Tests.dll
- Assembly.GetCallingAssembly(): /Users/salman/Desktop/tau/osu.Game.Rulesets.tau.Tests/bin/Debug/netcoreapp3.0/osu.Framework.dll

osu.Game.Rulesets.Tau.Tests (NUnit run)
- nunit_test_assembly: /Users/salman/Desktop/tau/osu.Game.Rulesets.tau.Tests/bin/Debug/netcoreapp3.0/osu.Game.Rulesets.tau.Tests.dll
- Assembly.GetEntryAssembly(): /Users/salman/Desktop/tau/osu.Game.Rulesets.tau.Tests/bin/Debug/netcoreapp3.0/testhost.dll
- Assembly.GetCallingAssembly(): /Users/salman/Desktop/tau/osu.Game.Rulesets.tau.Tests/bin/Debug/netcoreapp3.0/osu.Framework.dll
```