### PR TITLE
Replace any potential usage of Environment.CurrentDirectory with an immutable static property

### DIFF
--- a/osu.Framework.Tests/Platform/PortableInstallationTest.cs
+++ b/osu.Framework.Tests/Platform/PortableInstallationTest.cs
@@ -11,7 +11,7 @@ namespace osu.Framework.Tests.Platform
     [TestFixture]
     public class PortableInstallationTest
     {
-        private Storage startupStorage => RuntimeInfo.StartupStorage;
+        private readonly Storage startupStorage = new NativeStorage(RuntimeInfo.StartupDirectory);
 
         [Test]
         public void TestPortableInstall()

--- a/osu.Framework.Tests/Platform/PortableInstallationTest.cs
+++ b/osu.Framework.Tests/Platform/PortableInstallationTest.cs
@@ -11,49 +11,51 @@ namespace osu.Framework.Tests.Platform
     [TestFixture]
     public class PortableInstallationTest
     {
+        private Storage startupStorage => RuntimeInfo.StartupStorage;
+
         [Test]
         public void TestPortableInstall()
         {
-            Assert.IsFalse(File.Exists(FrameworkConfigManager.FILENAME));
+            Assert.IsFalse(startupStorage.Exists(FrameworkConfigManager.FILENAME));
 
             using (var portable = new HeadlessGameHost(@"portable", portableInstallation: true))
             {
                 portable.Run(new TestGame());
-                Assert.AreEqual(Path.GetFullPath(FrameworkConfigManager.FILENAME), portable.Storage.GetFullPath(FrameworkConfigManager.FILENAME));
+                Assert.AreEqual(startupStorage.GetFullPath(FrameworkConfigManager.FILENAME), portable.Storage.GetFullPath(FrameworkConfigManager.FILENAME));
             }
 
             // portable mode should write the configuration
-            Assert.IsTrue(File.Exists(FrameworkConfigManager.FILENAME));
+            Assert.IsTrue(startupStorage.Exists(FrameworkConfigManager.FILENAME));
 
             // subsequent startups should detect the portable config and continue running in portable mode, even though it is not explicitly specified
             using (var portable = new HeadlessGameHost(@"portable"))
             {
                 portable.Run(new TestGame());
-                Assert.AreEqual(Path.GetFullPath(FrameworkConfigManager.FILENAME), portable.Storage.GetFullPath(FrameworkConfigManager.FILENAME));
+                Assert.AreEqual(startupStorage.GetFullPath(FrameworkConfigManager.FILENAME), portable.Storage.GetFullPath(FrameworkConfigManager.FILENAME));
             }
 
-            Assert.IsTrue(File.Exists(FrameworkConfigManager.FILENAME));
+            Assert.IsTrue(startupStorage.Exists(FrameworkConfigManager.FILENAME));
         }
 
         [Test]
         public void TestNonPortableInstall()
         {
-            Assert.IsFalse(File.Exists(FrameworkConfigManager.FILENAME));
+            Assert.IsFalse(startupStorage.Exists(FrameworkConfigManager.FILENAME));
 
             using (var portable = new HeadlessGameHost(@"non-portable"))
             {
                 portable.Run(new TestGame());
-                Assert.AreEqual(Path.GetFullPath(Path.Combine("headless", "non-portable", FrameworkConfigManager.FILENAME)), portable.Storage.GetFullPath(FrameworkConfigManager.FILENAME));
+                Assert.AreEqual(startupStorage.GetFullPath(Path.Combine("headless", "non-portable", FrameworkConfigManager.FILENAME)), portable.Storage.GetFullPath(FrameworkConfigManager.FILENAME));
             }
 
-            Assert.IsFalse(File.Exists(FrameworkConfigManager.FILENAME));
+            Assert.IsFalse(startupStorage.Exists(FrameworkConfigManager.FILENAME));
         }
 
         [TearDown]
         [SetUp]
         public void TearDown()
         {
-            File.Delete(FrameworkConfigManager.FILENAME);
+            startupStorage.Delete(FrameworkConfigManager.FILENAME);
         }
 
         private class TestGame : Game

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,8 +35,8 @@ namespace osu.Framework.Platform
 
         protected sealed override Storage CreateGameStorage()
         {
-            if (IsPortableInstallation || File.Exists(FrameworkConfigManager.FILENAME))
-                return GetStorage(Environment.CurrentDirectory);
+            if (IsPortableInstallation || RuntimeInfo.StartupStorage.Exists(FrameworkConfigManager.FILENAME))
+                return GetStorage(RuntimeInfo.StartupDirectory);
 
             return base.CreateGameStorage();
         }

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -35,7 +36,7 @@ namespace osu.Framework.Platform
 
         protected sealed override Storage CreateGameStorage()
         {
-            if (IsPortableInstallation || RuntimeInfo.StartupStorage.Exists(FrameworkConfigManager.FILENAME))
+            if (IsPortableInstallation || File.Exists(Path.Combine(RuntimeInfo.StartupDirectory, FrameworkConfigManager.FILENAME)))
                 return GetStorage(RuntimeInfo.StartupDirectory);
 
             return base.CreateGameStorage();

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -510,13 +510,9 @@ namespace osu.Framework.Platform
                 Trace.Listeners.Add(new ThrowingTraceListener());
 
                 var assembly = DebugUtils.GetEntryAssembly();
-                string assemblyPath = DebugUtils.GetEntryPath();
 
                 Logger.GameIdentifier = Name;
                 Logger.VersionIdentifier = assembly.GetName().Version.ToString();
-
-                if (assemblyPath != null)
-                    Environment.CurrentDirectory = assemblyPath;
 
                 Dependencies.CacheAs(this);
 

--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Runtime.InteropServices;
 using osu.Framework.Development;
-using osu.Framework.Platform;
 
 namespace osu.Framework
 {
@@ -14,13 +13,6 @@ namespace osu.Framework
         /// The absolute path to the startup directory of this game.
         /// </summary>
         public static string StartupDirectory { get; } = DebugUtils.GetEntryPath();
-
-        /// <summary>
-        /// A storage pointing at the <see cref="StartupDirectory"/> path.
-        /// </summary>
-        public static Storage StartupStorage => startup_storage.Value;
-
-        private static readonly Lazy<Storage> startup_storage = new Lazy<Storage>(() => new NativeStorage(StartupDirectory));
 
         /// <summary>
         /// Returns the absolute path of osu.Framework.dll.

--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -3,11 +3,25 @@
 
 using System;
 using System.Runtime.InteropServices;
+using osu.Framework.Development;
+using osu.Framework.Platform;
 
 namespace osu.Framework
 {
     public static class RuntimeInfo
     {
+        /// <summary>
+        /// The absolute path to the startup directory of this game.
+        /// </summary>
+        public static string StartupDirectory { get; } = DebugUtils.GetEntryPath();
+
+        /// <summary>
+        /// A storage pointing at the <see cref="StartupDirectory"/> path.
+        /// </summary>
+        public static Storage StartupStorage => startup_storage.Value;
+
+        private static readonly Lazy<Storage> startup_storage = new Lazy<Storage>(() => new NativeStorage(StartupDirectory));
+
         /// <summary>
         /// Returns the absolute path of osu.Framework.dll.
         /// </summary>


### PR DESCRIPTION
Using `Environment.CurrentDirectory` for storing / reading files is dangerous as the current directory is mutable and can be changed when performing certain operations (like opening solutions in roslyn type reference builder for example).

This fixes the issue by introducing a new immutable static `StartupDirectory` property (and `StartupStorage` for components that perform disk mutation operations in the startup directory) to use in place of `Environment.CurrentDirectory` uses.