### PR TITLE
Fix DSPFC not considering parent padding correctly

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneDrawSizePreservingFillContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneDrawSizePreservingFillContainer.cs
@@ -1,9 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
 
@@ -14,6 +16,7 @@ namespace osu.Framework.Tests.Visual.Containers
         public TestSceneDrawSizePreservingFillContainer()
         {
             DrawSizePreservingFillContainer fillContainer;
+
             Child = new Container
             {
                 Anchor = Anchor.Centre,
@@ -55,6 +58,50 @@ namespace osu.Framework.Tests.Visual.Containers
             AddSliderStep("Height", 50, 650, 500, v => Child.Height = v);
 
             AddStep("Override Size to 1x1", () => Child.Size = Vector2.One);
+        }
+
+        [Test]
+        public void TestParentPadding()
+        {
+            Box fullBox = null;
+            Box innerBox = null;
+
+            AddStep("create container", () =>
+            {
+                Child = new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(512, 384),
+                    Children = new Drawable[]
+                    {
+                        fullBox = new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Color4.Red,
+                        },
+                        new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Padding = new MarginPadding { Left = 100 },
+                            Children = new Drawable[]
+                            {
+                                new DrawSizePreservingFillContainer
+                                {
+                                    Child = innerBox = new Box
+                                    {
+                                        Size = new Vector2(1024, 768),
+                                        Colour = Color4.Pink,
+                                        Alpha = 0.3f
+                                    }
+                                },
+                            }
+                        },
+                    }
+                };
+            });
+
+            AddAssert("inner box stops at edge of right box", () => Precision.AlmostEquals(fullBox.ScreenSpaceDrawQuad.TopRight, innerBox.ScreenSpaceDrawQuad.TopRight));
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
+++ b/osu.Framework/Graphics/Containers/DrawSizePreservingFillContainer.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Containers
         {
             base.Update();
 
-            Vector2 drawSizeRatio = Vector2.Divide(Parent.DrawSize, TargetDrawSize);
+            Vector2 drawSizeRatio = Vector2.Divide(Parent.ChildSize, TargetDrawSize);
 
             switch (Strategy)
             {


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/3592

As mentioned in the issue thread, `ChildSize` is the correct solution here.

Previous:
![image](https://user-images.githubusercontent.com/1329837/83374122-9df39700-a405-11ea-8b45-b67aceee3aa5.png)

Now:
![image](https://user-images.githubusercontent.com/1329837/83374144-ae0b7680-a405-11ea-8609-d74eb240e14a.png)

(Padding on the left side).