### PR TITLE
Fix changing Size/Position not invalidating self correctly

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -298,7 +298,8 @@ namespace osu.Framework.Graphics
                 double allowedDuration = blocking ? 16 : 100;
 
                 if (loadDuration > allowedDuration)
-                    Logger.Log($@"{ToString()} took {loadDuration:0.00}ms to load" + (blocking ? " (and blocked the update thread)" : " (async)"), LoggingTarget.Performance, blocking ? LogLevel.Important : LogLevel.Verbose);
+                    Logger.Log($@"{ToString()} took {loadDuration:0.00}ms to load" + (blocking ? " (and blocked the update thread)" : " (async)"), LoggingTarget.Performance,
+                        blocking ? LogLevel.Important : LogLevel.Verbose);
             }
         }
 
@@ -1744,7 +1745,17 @@ namespace osu.Framework.Graphics
         /// <param name="invalidation">The flags to invalidate with.</param>
         /// <param name="source">The source that triggered the invalidation.</param>
         /// <returns>If any layout was invalidated.</returns>
-        public bool Invalidate(Invalidation invalidation = Invalidation.All, InvalidationSource source = InvalidationSource.Self)
+        public bool Invalidate(Invalidation invalidation = Invalidation.All, InvalidationSource source = InvalidationSource.Self) => invalidate(invalidation, source);
+
+        /// <summary>
+        /// Invalidates the layout of this <see cref="Drawable"/>.
+        /// </summary>
+        /// <param name="invalidation">The flags to invalidate with.</param>
+        /// <param name="source">The source that triggered the invalidation.</param>
+        /// <param name="propagateToParent">Whether to propagate the invalidation to the parent of this <see cref="Drawable"/>.
+        /// Only has an effect if <paramref name="source"/> is <see cref="InvalidationSource.Self"/>.</param>
+        /// <returns>If any layout was invalidated.</returns>
+        private bool invalidate(Invalidation invalidation = Invalidation.All, InvalidationSource source = InvalidationSource.Self, bool propagateToParent = true)
         {
             if (source != InvalidationSource.Child && source != InvalidationSource.Parent && source != InvalidationSource.Self)
                 throw new InvalidOperationException($"A {nameof(Drawable)} can only be invalidated with a singular {nameof(source)} (child, parent, or self).");
@@ -1762,7 +1773,7 @@ namespace osu.Framework.Graphics
             // If the invalidation originated locally, propagate to the immediate parent.
             // Note: This is done _before_ invalidation is blocked below, since the parent always needs to be aware of changes even if the Drawable's invalidation state hasn't changed.
             // This is for only propagating once, otherwise it would propagate all the way to the root Drawable.
-            if (source == InvalidationSource.Self)
+            if (propagateToParent && source == InvalidationSource.Self)
                 Parent?.Invalidate(invalidation, InvalidationSource.Child);
 
             // Perform the invalidation.
@@ -1834,8 +1845,8 @@ namespace osu.Framework.Graphics
         /// <param name="changedAxes">The <see cref="Axes"/> that were affected.</param>
         private void invalidateParentSizeDependencies(Invalidation invalidation, Axes changedAxes)
         {
-            // A parent source is faked so that the invalidation doesn't propagate upwards unnecessarily.
-            Invalidate(invalidation, InvalidationSource.Parent);
+            // We're invalidating the parent manually, so we should not propagate it upwards.
+            invalidate(invalidation, InvalidationSource.Self, false);
 
             // The fast path, which performs an invalidation on the parent along with optimisations for bypassed sizing axes.
             Parent?.InvalidateChildrenSizeDependencies(invalidation, changedAxes, this);

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -298,8 +298,10 @@ namespace osu.Framework.Graphics
                 double allowedDuration = blocking ? 16 : 100;
 
                 if (loadDuration > allowedDuration)
+                {
                     Logger.Log($@"{ToString()} took {loadDuration:0.00}ms to load" + (blocking ? " (and blocked the update thread)" : " (async)"), LoggingTarget.Performance,
                         blocking ? LogLevel.Important : LogLevel.Verbose);
+                }
             }
         }
 


### PR DESCRIPTION
An optimisation that led to incorrectness :/

Noticed because of `TestSceneExpandedPanelMiddleContent` osu!-side.

Before:
![image](https://user-images.githubusercontent.com/1329837/83756346-e92dd400-a6a9-11ea-9813-c2fd9357938a.png)

After:
![image](https://user-images.githubusercontent.com/1329837/83756268-c8657e80-a6a9-11ea-905e-1ab4cb2cdd0a.png)

(Note position of the "Played on" text at the bottom)

Not suuuuuuuper keen on the extra parameter, but it's all pretty local so... Definitely don't want to expose it publicly since this is the only case it's ever used.