### PR TITLE
Fix TabControl's updated switching-on-removal logic not considering IsSwitchable

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -251,7 +251,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             if (tab == SelectedTab)
             {
-                if (Items.Count == 1)
+                if (TabMap.Values.Count(t => t.IsSwitchable) == 1)
                     SelectedTab = null;
                 else
                 {

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -38,7 +38,14 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// A collection of all tabs which are valid switch targets.
         /// </summary>
-        public TabItem<T>[] SwitchableTabs => TabContainer.AllTabItems.Where(tab => tab.IsSwitchable).ToArray();
+        protected internal IEnumerable<TabItem<T>> SwitchableTabs => AllTabs.Where(tab => tab.IsSwitchable);
+
+        protected internal IEnumerable<TabItem<T>> AllTabs => TabContainer.AllTabItems;
+
+        /// <summary>
+        /// All items which are currently present and visible in the tab control.
+        /// </summary>
+        public IEnumerable<T> VisibleItems => TabContainer.TabItems.Select(t => t.Value).Distinct();
 
         private readonly List<T> items = new List<T>();
 
@@ -58,8 +65,6 @@ namespace osu.Framework.Graphics.UserInterface
                     AddItem(item);
             }
         }
-
-        public IEnumerable<T> VisibleItems => TabContainer.TabItems.Select(t => t.Value).Distinct();
 
         /// <summary>
         /// When true, tabs selected from the overflow dropdown will be moved to the front of the list (after pinned items).
@@ -98,6 +103,9 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// A mapping of tabs to their items.
         /// </summary>
+        /// <remarks>
+        /// There is no guaranteed order. To retrieve ordered tabs, use <see cref="SwitchableTabs"/> or <see cref="AllTabs"/> instead.
+        /// </remarks>
         protected IReadOnlyDictionary<T, TabItem<T>> TabMap => tabMap;
 
         private readonly Dictionary<T, TabItem<T>> tabMap = new Dictionary<T, TabItem<T>>();
@@ -256,12 +264,12 @@ namespace osu.Framework.Graphics.UserInterface
 
             if (tab == SelectedTab)
             {
-                if (SwitchableTabs.Length < 2)
+                if (SwitchableTabs.Count() < 2)
                     SelectedTab = null;
                 else
                 {
                     // check all tabs as to include self (in correct iteration order)
-                    bool anySwitchableTabsToRight = TabContainer.AllTabItems.SkipWhile(t => t != tab).Skip(1).Any(t => t.IsSwitchable);
+                    bool anySwitchableTabsToRight = AllTabs.SkipWhile(t => t != tab).Skip(1).Any(t => t.IsSwitchable);
                     SwitchTab(anySwitchableTabsToRight ? 1 : -1);
                 }
             }

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// A collection of all tabs which are valid switch targets.
         /// </summary>
-        public TabItem<T>[] SwitchableTabs => tabMap.Values.Where(tab => tab.IsSwitchable).ToArray();
+        public TabItem<T>[] SwitchableTabs => TabContainer.AllTabItems.Where(tab => tab.IsSwitchable).ToArray();
 
         private readonly List<T> items = new List<T>();
 
@@ -261,7 +261,7 @@ namespace osu.Framework.Graphics.UserInterface
                 else
                 {
                     // check all tabs as to include self (in correct iteration order)
-                    bool anySwitchableTabsToRight = tabMap.Values.SkipWhile(t => t != tab).Skip(1).Any(t => t.IsSwitchable);
+                    bool anySwitchableTabsToRight = TabContainer.AllTabItems.SkipWhile(t => t != tab).Skip(1).Any(t => t.IsSwitchable);
                     SwitchTab(anySwitchableTabsToRight ? 1 : -1);
                 }
             }
@@ -315,12 +315,11 @@ namespace osu.Framework.Graphics.UserInterface
         /// <param name="wrap">If <c>true</c>, moving past the start or the end of the tab list will wrap to the opposite end.</param>
         public virtual void SwitchTab(int direction, bool wrap = true)
         {
-            if (Math.Abs(direction) != 1)
-                throw new ArgumentException("value must be -1 or 1", nameof(direction));
+            if (Math.Abs(direction) != 1) throw new ArgumentException("value must be -1 or 1", nameof(direction));
 
             // the current selected tab may be an non-switchable tab, so search all tabs for a candidate.
             // this is done to ensure ordering (ie. if an non-switchable tab is in the middle).
-            var allTabs = tabMap.Values.Where(t => t.IsSwitchable || t == SelectedTab);
+            var allTabs = TabContainer.AllTabItems.Where(t => t.IsSwitchable || t == SelectedTab);
 
             if (direction < 0)
                 allTabs = allTabs.Reverse();

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -35,6 +35,11 @@ namespace osu.Framework.Graphics.UserInterface
             set => current.Current = value;
         }
 
+        /// <summary>
+        /// A collection of all tabs which are valid switch targets.
+        /// </summary>
+        public TabItem<T>[] SwitchableTabs => TabContainer.AllTabItems.Where(tab => tab.IsSwitchable).ToArray();
+
         private readonly List<T> items = new List<T>();
 
         /// <summary>
@@ -251,7 +256,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             if (tab == SelectedTab)
             {
-                if (TabMap.Values.Count(t => t.IsSwitchable) == 1)
+                if (SwitchableTabs.Length == 1)
                     SelectedTab = null;
                 else
                 {
@@ -312,7 +317,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (Math.Abs(direction) != 1)
                 throw new ArgumentException("value must be -1 or 1", nameof(direction));
 
-            TabItem<T>[] switchableTabs = TabContainer.AllTabItems.Where(tab => tab.IsSwitchable).ToArray();
+            TabItem<T>[] switchableTabs = SwitchableTabs;
             int tabCount = switchableTabs.Length;
 
             if (tabCount == 0)


### PR DESCRIPTION
Allow's osu!'s `ChannelTabControl` to work again. Without this check, it was possible that the switch call would re-select the tab to be removed.