### PR TITLE
Add trackpad scrolling support for iPadOS

### DIFF
--- a/osu.Framework.iOS/Input/IOSMouseHandler.cs
+++ b/osu.Framework.iOS/Input/IOSMouseHandler.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.iOS.Input
                 MaximumNumberOfTouches = 0 // Only enables this for 2 finger swipe, disabling clicking and dragging.
             };
             view.AddGestureRecognizer(panGestureRecognizer);
-            
+
             return true;
         }
 
@@ -75,9 +75,9 @@ namespace osu.Framework.iOS.Input
                 previousPanTranslation = translation;
 
             CGPoint delta = new CGPoint(
-                    translation.X - previousPanTranslation.X,
-                    translation.Y - previousPanTranslation.Y
-                );
+                translation.X - previousPanTranslation.X,
+                translation.Y - previousPanTranslation.Y
+            );
 
             PendingInputs.Enqueue(new MouseScrollRelativeInput
             {

--- a/osu.Framework.iOS/Input/IOSMouseHandler.cs
+++ b/osu.Framework.iOS/Input/IOSMouseHandler.cs
@@ -67,6 +67,8 @@ namespace osu.Framework.iOS.Input
             });
         }
 
+        private const float scroll_rate_adjust = 0.1f;
+
         private void panOffsetUpdated()
         {
             CGPoint translation = panGestureRecognizer.TranslationInView(view);
@@ -89,7 +91,7 @@ namespace osu.Framework.iOS.Input
             PendingInputs.Enqueue(new MouseScrollRelativeInput
             {
                 IsPrecise = true,
-                Delta = delta
+                Delta = delta * scroll_rate_adjust
             });
         }
     }

--- a/osu.Framework.iOS/Input/IOSMouseHandler.cs
+++ b/osu.Framework.iOS/Input/IOSMouseHandler.cs
@@ -37,25 +37,24 @@ namespace osu.Framework.iOS.Input
             if (!UIDevice.CurrentDevice.CheckSystemVersion(13, 4))
                 return false;
 
-            pointerInteraction = new UIPointerInteraction(mouseDelegate = new IOSMouseDelegate());
+            view.AddInteraction(pointerInteraction = new UIPointerInteraction(mouseDelegate = new IOSMouseDelegate()));
             mouseDelegate.LocationUpdated += locationUpdated;
-            view.AddInteraction(pointerInteraction);
 
-            panGestureRecognizer = new UIPanGestureRecognizer(panOffsetUpdated)
+            view.AddGestureRecognizer(panGestureRecognizer = new UIPanGestureRecognizer(panOffsetUpdated)
             {
                 AllowedScrollTypesMask = UIScrollTypeMask.Continuous,
                 MaximumNumberOfTouches = 0 // Only handle drags when no "touches" are active (ie. no buttons are in a pressed state)
-            };
-            view.AddGestureRecognizer(panGestureRecognizer);
+            });
 
             return true;
         }
 
         protected override void Dispose(bool disposing)
         {
+            base.Dispose(disposing);
+
             view.RemoveInteraction(pointerInteraction);
             view.RemoveGestureRecognizer(panGestureRecognizer);
-            base.Dispose(disposing);
         }
 
         private void locationUpdated(CGPoint location)

--- a/osu.Framework.iOS/Input/IOSMouseHandler.cs
+++ b/osu.Framework.iOS/Input/IOSMouseHandler.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.iOS.Input
             panGestureRecognizer = new UIPanGestureRecognizer(panOffsetUpdated)
             {
                 AllowedScrollTypesMask = UIScrollTypeMask.Continuous,
-                MaximumNumberOfTouches = 0 // Only enables this for 2 finger swipe, disabling clicking and dragging.
+                MaximumNumberOfTouches = 0 // Only handle drags when no "touches" are active (ie. no buttons are in a pressed state)
             };
             view.AddGestureRecognizer(panGestureRecognizer);
 

--- a/osu.Framework.iOS/Input/IOSMouseHandler.cs
+++ b/osu.Framework.iOS/Input/IOSMouseHandler.cs
@@ -43,7 +43,8 @@ namespace osu.Framework.iOS.Input
 
             panGestureRecognizer = new UIPanGestureRecognizer(panOffsetUpdated)
             {
-                AllowedScrollTypesMask = UIScrollTypeMask.Continuous
+                AllowedScrollTypesMask = UIScrollTypeMask.Continuous,
+                MaximumNumberOfTouches = 0 // Only enables this for 2 finger swipe, disabling clicking and dragging.
             };
             view.AddGestureRecognizer(panGestureRecognizer);
             

--- a/osu.Framework.iOS/Input/IOSMouseHandler.cs
+++ b/osu.Framework.iOS/Input/IOSMouseHandler.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.iOS.Input
         private readonly IOSGameView view;
         private UIPointerInteraction pointerInteraction;
         private UIPanGestureRecognizer panGestureRecognizer;
-        private CGPoint previousPanTranslation;
+        private CGPoint lastScrollTranslation;
 
         [UsedImplicitly]
         private IOSMouseDelegate mouseDelegate;
@@ -71,21 +71,27 @@ namespace osu.Framework.iOS.Input
         private void panOffsetUpdated()
         {
             CGPoint translation = panGestureRecognizer.TranslationInView(view);
-            if (panGestureRecognizer.State == UIGestureRecognizerState.Began)
-                previousPanTranslation = translation;
 
-            CGPoint delta = new CGPoint(
-                translation.X - previousPanTranslation.X,
-                translation.Y - previousPanTranslation.Y
-            );
+            Vector2 delta;
+
+            if (panGestureRecognizer.State == UIGestureRecognizerState.Began)
+            {
+                // consume initial value.
+                delta = new Vector2((float)translation.X, (float)translation.Y);
+            }
+            else
+            {
+                // only consider relative change from previous value.
+                delta = new Vector2((float)(translation.X - lastScrollTranslation.X), (float)(translation.Y - lastScrollTranslation.Y));
+            }
+
+            lastScrollTranslation = translation;
 
             PendingInputs.Enqueue(new MouseScrollRelativeInput
             {
                 IsPrecise = true,
-                Delta = new Vector2((float)delta.X, (float)delta.Y)
+                Delta = delta
             });
-
-            previousPanTranslation = translation;
         }
     }
 


### PR DESCRIPTION
Closes #3621 

This PR extends the trackpad mouse support on iPadOS by adding a `UIPanGestureRecognizer` object to the main game view, which then converts any scrolling offsets into `MouseScrollRelativeInput` events. Tested and confirmed working in the Test Browser.

It doesn't behave like a native iOS scroll view in that when you over scroll, the content will snap back on its own. If this ends up not being desirable, an alternative might be to make this code simulate a soft mouse click and drag event (Depending on how easy that is to do).

Additionally, the scrolling is quite fast, so it might be necessary to add some damping to it.