### PR TITLE
Disable opacity checks on mobile platforms

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -157,7 +157,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         {
             // TODO: Investigate performance issues and remove this once we are certain there's no overhead.
             if (RuntimeInfo.IsMobile)
-                return Opacity.Transparent;
+                return Opacity.Mixed;
 
             if (upload.Data.Length == 0)
                 return Opacity.Transparent;

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -155,29 +155,29 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         protected static Opacity ComputeOpacity(ITextureUpload upload)
         {
-            // TODO: Investigate performance issues and remove this once we are certain there's no overhead.
-            if (RuntimeInfo.IsMobile)
-                return Opacity.Mixed;
+            // TODO: Investigate performance issues and revert functionality once we are sure there is no overhead.
+            // see https://github.com/ppy/osu/issues/9307
+            return Opacity.Mixed;
 
-            if (upload.Data.Length == 0)
-                return Opacity.Transparent;
-
-            bool isTransparent = true;
-            bool isOpaque = true;
-
-            for (int i = 0; i < upload.Data.Length; ++i)
-            {
-                isTransparent &= upload.Data[i].A == 0;
-                isOpaque &= upload.Data[i].A == 255;
-
-                if (!isTransparent && !isOpaque)
-                    return Opacity.Mixed;
-            }
-
-            if (isTransparent)
-                return Opacity.Transparent;
-
-            return Opacity.Opaque;
+            // if (upload.Data.Length == 0)
+            //     return Opacity.Transparent;
+            //
+            // bool isTransparent = true;
+            // bool isOpaque = true;
+            //
+            // for (int i = 0; i < upload.Data.Length; ++i)
+            // {
+            //     isTransparent &= upload.Data[i].A == 0;
+            //     isOpaque &= upload.Data[i].A == 255;
+            //
+            //     if (!isTransparent && !isOpaque)
+            //         return Opacity.Mixed;
+            // }
+            //
+            // if (isTransparent)
+            //     return Opacity.Transparent;
+            //
+            // return Opacity.Opaque;
         }
 
         protected void UpdateOpacity(ITextureUpload upload, ref Opacity? uploadOpacity)

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -155,6 +155,10 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         protected static Opacity ComputeOpacity(ITextureUpload upload)
         {
+            // TODO: Investigate performance issues and remove this once we are certain there's no overhead.
+            if (RuntimeInfo.IsMobile)
+                return Opacity.Transparent;
+
             if (upload.Data.Length == 0)
                 return Opacity.Transparent;
 


### PR DESCRIPTION
Has caused a *huge* degradation in performance. Likely affects desktop too, just in a less noticeable way. I know it did on osu-stable (we use `unsafe` to get around this). I'm open to disabling this across desktop as well, until a better solution is applied with benchmarking.

Closes https://github.com/ppy/osu/issues/9307