### PR TITLE
Remove GDEdit

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,6 @@ The BASS audio library (a dependency of this framework) is a commercial product.
 
 [osu!](https://github.com/ppy/osu) – rhythm is just a *click* away!
 
-[GDEdit](https://github.com/gd-edit/GDE) - A third-party Geometry Dash editor.
-
 <!--
 We love to see people using our framework! Add your project here via a PR!
 


### PR DESCRIPTION
As the project has been recently disbanded due to lack of motivation, it would be best to remove this now as the project no longer exists.