### PR TITLE
Always change the Android WindowManager flags on the UI thread.

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -60,10 +60,13 @@ namespace osu.Framework.Android
             {
                 host.AllowScreenSuspension.BindValueChanged(allow =>
                 {
-                    if (allow.NewValue)
-                        Window.AddFlags(WindowManagerFlags.KeepScreenOn);
-                    else
-                        Window.ClearFlags(WindowManagerFlags.KeepScreenOn);
+                    RunOnUiThread(() =>
+                    {
+                        if (allow.NewValue)
+                            Window.AddFlags(WindowManagerFlags.KeepScreenOn);
+                        else
+                            Window.ClearFlags(WindowManagerFlags.KeepScreenOn);
+                    });
                 }, true);
             };
         }


### PR DESCRIPTION
# Summary

Closes ppy/osu#9321

This simply wraps the mutation of the WindowManager flags (which should always be done on the Android UI thread) into a closure that will always run on the UI thread through `RunOnUiThread()` and should fix the crashes occuring in multithreaded mode.