### PR TITLE
Fix crashes on iOS versions lower than 13.4

### DIFF
--- a/osu.Framework.iOS/Input/IOSMouseHandler.cs
+++ b/osu.Framework.iOS/Input/IOSMouseHandler.cs
@@ -53,8 +53,11 @@ namespace osu.Framework.iOS.Input
         {
             base.Dispose(disposing);
 
-            view.RemoveInteraction(pointerInteraction);
-            view.RemoveGestureRecognizer(panGestureRecognizer);
+            if (pointerInteraction != null)
+                view.RemoveInteraction(pointerInteraction);
+
+            if (panGestureRecognizer != null)
+                view.RemoveGestureRecognizer(panGestureRecognizer);
         }
 
         private void locationUpdated(CGPoint location)


### PR DESCRIPTION
We discovered a crash occurring on iOS versions lower than 13.4 due to the fact that `IOSMouseHandler` properly checks the version upon initialisation, but neglects to do that during disposal. Sorry about that!