### PR TITLE
Add virtual sample channel

### DIFF
--- a/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using NUnit.Framework;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Development;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Audio
+{
+    [TestFixture]
+    public class SampleChannelVirtualTest
+    {
+        private SampleChannelVirtual channel;
+
+        [SetUp]
+        public void Setup()
+        {
+            channel = new SampleChannelVirtual();
+            updateTrack();
+        }
+
+        [Test]
+        public void TestStart()
+        {
+            Assert.IsFalse(channel.Played);
+            Assert.IsFalse(channel.HasCompleted);
+
+            channel.Play();
+            updateTrack();
+
+            Thread.Sleep(50);
+
+            Assert.IsTrue(channel.Played);
+            Assert.IsTrue(channel.HasCompleted);
+        }
+
+        private void updateTrack() => RunOnAudioThread(() => channel.Update());
+
+        /// <summary>
+        /// Certain actions are invoked on the audio thread.
+        /// Here we simulate this process on a correctly named thread to avoid endless blocking.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        public static void RunOnAudioThread(Action action)
+        {
+            var resetEvent = new ManualResetEvent(false);
+
+            new Thread(() =>
+            {
+                ThreadSafety.IsAudioThread = true;
+
+                action();
+
+                resetEvent.Set();
+            })
+            {
+                Name = GameThread.PrefixedThreadNameFor("Audio")
+            }.Start();
+
+            if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException();
+        }
+    }
+}

--- a/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/SampleChannelVirtualTest.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Tests.Audio
         public void Setup()
         {
             channel = new SampleChannelVirtual();
-            updateTrack();
+            updateChannel();
         }
 
         [Test]
@@ -29,7 +29,7 @@ namespace osu.Framework.Tests.Audio
             Assert.IsFalse(channel.HasCompleted);
 
             channel.Play();
-            updateTrack();
+            updateChannel();
 
             Thread.Sleep(50);
 
@@ -37,7 +37,7 @@ namespace osu.Framework.Tests.Audio
             Assert.IsTrue(channel.HasCompleted);
         }
 
-        private void updateTrack() => RunOnAudioThread(() => channel.Update());
+        private void updateChannel() => RunOnAudioThread(() => channel.Update());
 
         /// <summary>
         /// Certain actions are invoked on the audio thread.

--- a/osu.Framework/Audio/Sample/SampleChannelVirtual.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelVirtual.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Audio.Sample
+{
+    /// <summary>
+    /// A <see cref="SampleChannel"/> which explicitly plays no audio.
+    /// Aimed for scenarios in which a non-null <see cref="SampleChannel"/> is needed, but one that doesn't necessarily play any sound.
+    /// </summary>
+    public sealed class SampleChannelVirtual : SampleChannel
+    {
+        public SampleChannelVirtual()
+            : base(new SampleVirtual(), _ => { })
+        {
+        }
+
+        public override bool Playing => false;
+
+        protected override void UpdateState()
+        {
+            // empty override to avoid affecting sample channel count in frame statistics
+        }
+
+        private class SampleVirtual : Sample
+        {
+        }
+    }
+}

--- a/osu.Framework/Audio/Sample/SampleChannelVirtual.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelVirtual.cs
@@ -16,11 +16,6 @@ namespace osu.Framework.Audio.Sample
 
         public override bool Playing => false;
 
-        protected override void UpdateState()
-        {
-            // empty override to avoid affecting sample channel count in frame statistics
-        }
-
         private class SampleVirtual : Sample
         {
         }


### PR DESCRIPTION
Step 1 towards addressing ppy/osu#8595.

# Summary

This PR adds a `SampleChannelVirtual`, which analogously to `TrackVirtual` fulfills the code contract of being a sample channel, but in reality does nothing in terms of audio playback. Consumers can use it as an alternative to a null sample channel.

Adding it to framework was suggested by @frenzibyte and I would tend to agree with that suggestion as it keeps things consistent.

# Remarks

I haven't added any tests, but this seems pointless to test as it's a do-nothing class.

I opted for this solution so as not to have to change the game-side skin lookup fallback logic which is complex enough as-is without adding another layer on top.

Not 100% on the `UpdateState()` override. It made sense to me at the time.