### PR TITLE
Don't activate run tool window on rider run

### DIFF
--- a/.idea/.idea.osu-framework.Desktop/.idea/runConfigurations/SampleGame.xml
+++ b/.idea/.idea.osu-framework.Desktop/.idea/runConfigurations/SampleGame.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="SampleGame" type="DotNetProject" factoryName=".NET Project">
+  <configuration default="false" name="SampleGame" type="DotNetProject" factoryName=".NET Project" activateToolWindowBeforeRun="false">
     <option name="EXE_PATH" value="$PROJECT_DIR$/SampleGame.Desktop/bin/Debug/netcoreapp3.1/SampleGame.Desktop.dll" />
     <option name="PROGRAM_PARAMETERS" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/SampleGame.Desktop/bin/Debug/netcoreapp3.1" />
@@ -14,7 +14,7 @@
     <option name="PROJECT_KIND" value="DotNetCore" />
     <option name="PROJECT_TFM" value=".NETCoreApp,Version=v3.1" />
     <method v="2">
-      <option name="Build" enabled="true" />
+      <option name="Build" />
     </method>
   </configuration>
 </component>

--- a/.idea/.idea.osu-framework.Desktop/.idea/runConfigurations/VisualTests.xml
+++ b/.idea/.idea.osu-framework.Desktop/.idea/runConfigurations/VisualTests.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="VisualTests" type="DotNetProject" factoryName=".NET Project">
+  <configuration default="false" name="VisualTests" type="DotNetProject" factoryName=".NET Project" activateToolWindowBeforeRun="false">
     <option name="EXE_PATH" value="$PROJECT_DIR$/osu.Framework.Tests/bin/Debug/netcoreapp3.1/osu.Framework.Tests.dll" />
     <option name="PROGRAM_PARAMETERS" value="" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/osu.Framework.Tests/bin/Debug/netcoreapp3.1" />
@@ -14,7 +14,7 @@
     <option name="PROJECT_KIND" value="DotNetCore" />
     <option name="PROJECT_TFM" value=".NETCoreApp,Version=v3.1" />
     <method v="2">
-      <option name="Build" enabled="true" />
+      <option name="Build" />
     </method>
   </configuration>
 </component>


### PR DESCRIPTION
Been meaning to PR this for a while so I don't need to keep the changes locally. The run window popping up is really annoying in my opinion, so as long as there is consensus I'd like to push this change out across all non-CLI project configurations.