### PR TITLE
Split out bass amplitude computation to separate class

### DIFF
--- a/osu.Framework.Tests/Visual/Audio/TestSceneTrackAmplitudes.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneTrackAmplitudes.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Allocation;
+using osu.Framework.Audio.Track;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Audio;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Tests.Visual.Audio
+{
+    public class TestSceneTrackAmplitudes : FrameworkTestScene
+    {
+        private DrawableTrack track;
+
+        [BackgroundDependencyLoader]
+        private void load(ITrackStore tracks)
+        {
+            new Container
+            {
+                RelativeSizeAxes = Axes.Both,
+                Children = new Drawable[]
+                {
+                    track = new DrawableTrack(tracks.Get("sample-track.mp3"))
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            track.Looping = true;
+            track.Start();
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Audio/TestSceneTrackAmplitudes.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneTrackAmplitudes.cs
@@ -1,11 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
 
 namespace osu.Framework.Tests.Visual.Audio
 {
@@ -13,16 +15,69 @@ namespace osu.Framework.Tests.Visual.Audio
     {
         private DrawableTrack track;
 
+        private Box leftChannel;
+        private Box rightChannel;
+
+        private TrackBass bassTrack;
+
+        private Container amplitudeBoxes;
+
         [BackgroundDependencyLoader]
         private void load(ITrackStore tracks)
         {
-            new Container
+            bassTrack = (TrackBass)tracks.Get("sample-track.mp3");
+            var length = bassTrack.CurrentAmplitudes.FrequencyAmplitudes.Length;
+
+            Children = new Drawable[]
             {
-                RelativeSizeAxes = Axes.Both,
-                Children = new Drawable[]
+                track = new DrawableTrack(bassTrack),
+                new GridContainer
                 {
-                    track = new DrawableTrack(tracks.Get("sample-track.mp3"))
-                }
+                    RelativeSizeAxes = Axes.Both,
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Children = new Drawable[]
+                                {
+                                    leftChannel = new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.CentreRight,
+                                    },
+                                    rightChannel = new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.CentreLeft,
+                                    }
+                                }
+                            },
+                        },
+                        new Drawable[]
+                        {
+                            amplitudeBoxes = new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                ChildrenEnumerable =
+                                    Enumerable.Range(0, length)
+                                              .Select(i => new Box
+                                              {
+                                                  RelativeSizeAxes = Axes.Both,
+                                                  RelativePositionAxes = Axes.X,
+                                                  Anchor = Anchor.BottomLeft,
+                                                  Origin = Anchor.BottomLeft,
+                                                  Width = 1f / length,
+                                                  X = (float)i / length
+                                              })
+                            },
+                        }
+                    }
+                },
             };
         }
 
@@ -31,7 +86,21 @@ namespace osu.Framework.Tests.Visual.Audio
             base.LoadComplete();
 
             track.Looping = true;
-            track.Start();
+            AddStep("start track", () => track.Start());
+            AddStep("stop track", () => track.Stop());
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var amplitudes = bassTrack.CurrentAmplitudes;
+
+            rightChannel.Width = amplitudes.RightChannel * 0.5f;
+            leftChannel.Width = amplitudes.LeftChannel * 0.5f;
+
+            for (int i = 0; i < amplitudes.FrequencyAmplitudes.Length; i++)
+                amplitudeBoxes[i].Height = amplitudes.FrequencyAmplitudes[i];
         }
     }
 }

--- a/osu.Framework/Audio/BassAmplitudeProcessor.cs
+++ b/osu.Framework/Audio/BassAmplitudeProcessor.cs
@@ -2,13 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using ManagedBass;
+using osu.Framework.Audio.Track;
 
-namespace osu.Framework.Audio.Track
+namespace osu.Framework.Audio
 {
     /// <summary>
     /// Computes and caches amplitudes for a bass channel.
     /// </summary>
-    public class BassAmplitudes
+    public class BassAmplitudeProcessor
     {
         private int channel;
 
@@ -20,7 +21,7 @@ namespace osu.Framework.Audio.Track
 
         private static readonly TrackAmplitudes empty = new TrackAmplitudes { FrequencyAmplitudes = new float[size] };
 
-        public BassAmplitudes(int channel)
+        public BassAmplitudeProcessor(int channel)
         {
             this.channel = channel;
 

--- a/osu.Framework/Audio/Track/BassAmplitudes.cs
+++ b/osu.Framework/Audio/Track/BassAmplitudes.cs
@@ -20,7 +20,9 @@ namespace osu.Framework.Audio.Track
 
         public TrackAmplitudes CurrentAmplitudes => currentAmplitudes;
 
-        private static readonly TrackAmplitudes empty = new TrackAmplitudes { FrequencyAmplitudes = new float[256] };
+        private const int size = 256; // should be half of the FFT length provided to ChannelGetData.
+
+        private static readonly TrackAmplitudes empty = new TrackAmplitudes { FrequencyAmplitudes = new float[size] };
 
         public BassAmplitudes(int channel)
         {
@@ -54,7 +56,7 @@ namespace osu.Framework.Audio.Track
                 currentAmplitudes.LeftChannel = leftChannel;
                 currentAmplitudes.RightChannel = rightChannel;
 
-                float[] tempFrequencyData = new float[256];
+                float[] tempFrequencyData = new float[size];
                 Bass.ChannelGetData(channel, tempFrequencyData, (int)DataFlags.FFT512);
                 currentAmplitudes.FrequencyAmplitudes = tempFrequencyData;
             }

--- a/osu.Framework/Audio/Track/BassAmplitudes.cs
+++ b/osu.Framework/Audio/Track/BassAmplitudes.cs
@@ -20,6 +20,8 @@ namespace osu.Framework.Audio.Track
 
         public TrackAmplitudes CurrentAmplitudes => currentAmplitudes;
 
+        private static readonly TrackAmplitudes empty = new TrackAmplitudes { FrequencyAmplitudes = new float[256] };
+
         public BassAmplitudes(int channel)
         {
             this.channel = channel;
@@ -60,7 +62,7 @@ namespace osu.Framework.Audio.Track
             {
                 currentAmplitudes.LeftChannel = 0;
                 currentAmplitudes.RightChannel = 0;
-                currentAmplitudes.FrequencyAmplitudes = new float[256];
+                currentAmplitudes.FrequencyAmplitudes = empty.FrequencyAmplitudes;
             }
         }
     }

--- a/osu.Framework/Audio/Track/BassAmplitudes.cs
+++ b/osu.Framework/Audio/Track/BassAmplitudes.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using ManagedBass;
+
+namespace osu.Framework.Audio.Track
+{
+    /// <summary>
+    /// Computes and caches amplitudes for a bass channel.
+    /// </summary>
+    public class BassAmplitudes
+    {
+        private int channel;
+
+        private TrackAmplitudes currentAmplitudes;
+
+        public TrackAmplitudes CurrentAmplitudes => currentAmplitudes;
+
+        public BassAmplitudes(int channel)
+        {
+            this.channel = channel;
+        }
+
+        public void SetChannel(int channel)
+        {
+            if (this.channel != 0)
+                // just for simple thread safety. limitation can be easily removed later if required.
+                throw new InvalidOperationException("Can only set channel to non-zero value once");
+
+            if (channel == 0)
+                throw new ArgumentException("Channel must be non-zero", nameof(channel));
+
+            this.channel = channel;
+        }
+
+        public void Update()
+        {
+            if (channel == 0)
+                return;
+
+            bool active = Bass.ChannelIsActive(channel) == PlaybackState.Playing;
+
+            var leftChannel = active ? Bass.ChannelGetLevelLeft(channel) / 32768f : -1;
+            var rightChannel = active ? Bass.ChannelGetLevelRight(channel) / 32768f : -1;
+
+            if (leftChannel >= 0 && rightChannel >= 0)
+            {
+                currentAmplitudes.LeftChannel = leftChannel;
+                currentAmplitudes.RightChannel = rightChannel;
+
+                float[] tempFrequencyData = new float[256];
+                Bass.ChannelGetData(channel, tempFrequencyData, (int)DataFlags.FFT512);
+                currentAmplitudes.FrequencyAmplitudes = tempFrequencyData;
+            }
+            else
+            {
+                currentAmplitudes.LeftChannel = 0;
+                currentAmplitudes.RightChannel = 0;
+                currentAmplitudes.FrequencyAmplitudes = new float[256];
+            }
+        }
+    }
+}

--- a/osu.Framework/Audio/Track/BassAmplitudes.cs
+++ b/osu.Framework/Audio/Track/BassAmplitudes.cs
@@ -27,6 +27,8 @@ namespace osu.Framework.Audio.Track
         public BassAmplitudes(int channel)
         {
             this.channel = channel;
+
+            setEmpty();
         }
 
         public void SetChannel(int channel)
@@ -61,11 +63,14 @@ namespace osu.Framework.Audio.Track
                 currentAmplitudes.FrequencyAmplitudes = tempFrequencyData;
             }
             else
-            {
-                currentAmplitudes.LeftChannel = 0;
-                currentAmplitudes.RightChannel = 0;
-                currentAmplitudes.FrequencyAmplitudes = empty.FrequencyAmplitudes;
-            }
+                setEmpty();
+        }
+
+        private void setEmpty()
+        {
+            currentAmplitudes.LeftChannel = 0;
+            currentAmplitudes.RightChannel = 0;
+            currentAmplitudes.FrequencyAmplitudes = empty.FrequencyAmplitudes;
         }
     }
 }

--- a/osu.Framework/Audio/Track/BassAmplitudes.cs
+++ b/osu.Framework/Audio/Track/BassAmplitudes.cs
@@ -1,10 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
-using System;
 using ManagedBass;
 
 namespace osu.Framework.Audio.Track
@@ -33,25 +29,20 @@ namespace osu.Framework.Audio.Track
 
         public void SetChannel(int channel)
         {
-            if (this.channel != 0)
-                // just for simple thread safety. limitation can be easily removed later if required.
-                throw new InvalidOperationException("Can only set channel to non-zero value once");
-
-            if (channel == 0)
-                throw new ArgumentException("Channel must be non-zero", nameof(channel));
-
             this.channel = channel;
         }
 
         public void Update()
         {
-            if (channel == 0)
+            int ch = channel;
+
+            if (ch == 0)
                 return;
 
-            bool active = Bass.ChannelIsActive(channel) == PlaybackState.Playing;
+            bool active = Bass.ChannelIsActive(ch) == PlaybackState.Playing;
 
-            var leftChannel = active ? Bass.ChannelGetLevelLeft(channel) / 32768f : -1;
-            var rightChannel = active ? Bass.ChannelGetLevelRight(channel) / 32768f : -1;
+            var leftChannel = active ? Bass.ChannelGetLevelLeft(ch) / 32768f : -1;
+            var rightChannel = active ? Bass.ChannelGetLevelRight(ch) / 32768f : -1;
 
             if (leftChannel >= 0 && rightChannel >= 0)
             {
@@ -59,7 +50,7 @@ namespace osu.Framework.Audio.Track
                 currentAmplitudes.RightChannel = rightChannel;
 
                 float[] tempFrequencyData = new float[size];
-                Bass.ChannelGetData(channel, tempFrequencyData, (int)DataFlags.FFT512);
+                Bass.ChannelGetData(ch, tempFrequencyData, (int)DataFlags.FFT512);
                 currentAmplitudes.FrequencyAmplitudes = tempFrequencyData;
             }
             else

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Audio.Track
         /// LeftChannel and RightChannel represent the maximum current amplitude of all of the left and right channels respectively.
         /// The most recent values are returned. Synchronisation between channels should not be expected.
         /// </summary>
-        public virtual TrackAmplitudes CurrentAmplitudes => new TrackAmplitudes();
+        public virtual TrackAmplitudes CurrentAmplitudes { get; } = new TrackAmplitudes();
 
         protected override void UpdateState()
         {

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -106,7 +106,7 @@ namespace osu.Framework.Audio.Track
 
                     isLoaded = true;
 
-                    bassAmplitudes?.SetChannel(activeStream);
+                    bassAmplitudeProcessor?.SetChannel(activeStream);
                 }
             });
 
@@ -166,7 +166,7 @@ namespace osu.Framework.Audio.Track
             }
         }
 
-        private BassAmplitudes bassAmplitudes;
+        private BassAmplitudeProcessor bassAmplitudeProcessor;
 
         protected override void UpdateState()
         {
@@ -180,7 +180,7 @@ namespace osu.Framework.Audio.Track
 
             Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, bytePosition) * 1000);
 
-            bassAmplitudes?.Update();
+            bassAmplitudeProcessor?.Update();
 
             base.UpdateState();
         }
@@ -307,6 +307,6 @@ namespace osu.Framework.Audio.Track
 
         public override int? Bitrate => bitrate;
 
-        public override TrackAmplitudes CurrentAmplitudes => (bassAmplitudes ??= new BassAmplitudes(activeStream)).CurrentAmplitudes;
+        public override TrackAmplitudes CurrentAmplitudes => (bassAmplitudeProcessor ??= new BassAmplitudeProcessor(activeStream)).CurrentAmplitudes;
     }
 }


### PR DESCRIPTION
Feels better from a code quality perspective, but may also pave the way to using this in `SampleChannel` (something I am currently looking in to.

- [x] Depends on https://github.com/ppy/osu-framework/pull/3646

