### PR TITLE
Allow retrieving SampleChannel amplitudes

### DIFF
--- a/osu.Framework.Tests/Visual/Audio/TestSceneSampleAmplitudes.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneSampleAmplitudes.cs
@@ -1,4 +1,3 @@
-
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 

--- a/osu.Framework.Tests/Visual/Audio/TestSceneSampleAmplitudes.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneSampleAmplitudes.cs
@@ -1,0 +1,109 @@
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Audio.Track;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Audio;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Framework.Tests.Visual.Audio
+{
+    public class TestSceneSampleAmplitudes : FrameworkTestScene
+    {
+        private DrawableSample sample;
+
+        private Box leftChannel;
+        private Box rightChannel;
+
+        private SampleChannelBass bassSample;
+
+        private Container amplitudeBoxes;
+
+        [BackgroundDependencyLoader]
+        private void load(ISampleStore samples)
+        {
+            bassSample = (SampleChannelBass)samples.Get("long.mp3");
+
+            var length = bassSample.CurrentAmplitudes.FrequencyAmplitudes.Length;
+
+            Children = new Drawable[]
+            {
+                sample = new DrawableSample(bassSample),
+                new GridContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                Children = new Drawable[]
+                                {
+                                    leftChannel = new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.CentreRight,
+                                    },
+                                    rightChannel = new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both,
+                                        Anchor = Anchor.Centre,
+                                        Origin = Anchor.CentreLeft,
+                                    }
+                                }
+                            },
+                        },
+                        new Drawable[]
+                        {
+                            amplitudeBoxes = new Container
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                ChildrenEnumerable =
+                                    Enumerable.Range(0, length)
+                                              .Select(i => new Box
+                                              {
+                                                  RelativeSizeAxes = Axes.Both,
+                                                  RelativePositionAxes = Axes.X,
+                                                  Anchor = Anchor.BottomLeft,
+                                                  Origin = Anchor.BottomLeft,
+                                                  Width = 1f / length,
+                                                  X = (float)i / length
+                                              })
+                            },
+                        }
+                    }
+                },
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            sample.Looping = true;
+            AddStep("start sample", () => sample.Play());
+            AddStep("stop sample", () => sample.Stop());
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+
+            var amplitudes = bassSample.CurrentAmplitudes;
+
+            rightChannel.Width = amplitudes.RightChannel * 0.5f;
+            leftChannel.Width = amplitudes.LeftChannel * 0.5f;
+
+            for (int i = 0; i < amplitudes.FrequencyAmplitudes.Length; i++)
+                amplitudeBoxes[i].Height = amplitudes.FrequencyAmplitudes[i];
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Audio/TestSceneSampleAmplitudes.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneSampleAmplitudes.cs
@@ -101,8 +101,10 @@ namespace osu.Framework.Tests.Visual.Audio
             rightChannel.Width = amplitudes.RightChannel * 0.5f;
             leftChannel.Width = amplitudes.LeftChannel * 0.5f;
 
-            for (int i = 0; i < amplitudes.FrequencyAmplitudes.Length; i++)
-                amplitudeBoxes[i].Height = amplitudes.FrequencyAmplitudes[i];
+            var freqAmplitudes = amplitudes.FrequencyAmplitudes.Span;
+
+            for (int i = 0; i < freqAmplitudes.Length; i++)
+                amplitudeBoxes[i].Height = freqAmplitudes[i];
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Audio/TestSceneTrackAmplitudes.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneTrackAmplitudes.cs
@@ -99,8 +99,10 @@ namespace osu.Framework.Tests.Visual.Audio
             rightChannel.Width = amplitudes.RightChannel * 0.5f;
             leftChannel.Width = amplitudes.LeftChannel * 0.5f;
 
-            for (int i = 0; i < amplitudes.FrequencyAmplitudes.Length; i++)
-                amplitudeBoxes[i].Height = amplitudes.FrequencyAmplitudes[i];
+            var freqAmplitudes = amplitudes.FrequencyAmplitudes.Span;
+
+            for (int i = 0; i < freqAmplitudes.Length; i++)
+                amplitudeBoxes[i].Height = freqAmplitudes[i];
         }
     }
 }

--- a/osu.Framework/Audio/BassAmplitudeProcessor.cs
+++ b/osu.Framework/Audio/BassAmplitudeProcessor.cs
@@ -13,13 +13,13 @@ namespace osu.Framework.Audio
     {
         private int channel;
 
-        private TrackAmplitudes currentAmplitudes;
+        private ChannelAmplitudes currentAmplitudes;
 
-        public TrackAmplitudes CurrentAmplitudes => currentAmplitudes;
+        public ChannelAmplitudes CurrentAmplitudes => currentAmplitudes;
 
         private const int size = 256; // should be half of the FFT length provided to ChannelGetData.
 
-        private static readonly TrackAmplitudes empty = new TrackAmplitudes { FrequencyAmplitudes = new float[size] };
+        private static readonly ChannelAmplitudes empty = new ChannelAmplitudes { FrequencyAmplitudes = new float[size] };
 
         public BassAmplitudeProcessor(int channel)
         {

--- a/osu.Framework/Audio/BassAmplitudeProcessor.cs
+++ b/osu.Framework/Audio/BassAmplitudeProcessor.cs
@@ -13,19 +13,11 @@ namespace osu.Framework.Audio
     {
         private int channel;
 
-        private ChannelAmplitudes currentAmplitudes;
-
-        public ChannelAmplitudes CurrentAmplitudes => currentAmplitudes;
-
-        private const int size = 256; // should be half of the FFT length provided to ChannelGetData.
-
-        private static readonly ChannelAmplitudes empty = new ChannelAmplitudes { FrequencyAmplitudes = new float[size] };
+        public ChannelAmplitudes CurrentAmplitudes { get; private set; } = ChannelAmplitudes.Empty;
 
         public BassAmplitudeProcessor(int channel)
         {
             this.channel = channel;
-
-            setEmpty();
         }
 
         public void SetChannel(int channel)
@@ -47,22 +39,12 @@ namespace osu.Framework.Audio
 
             if (leftChannel >= 0 && rightChannel >= 0)
             {
-                currentAmplitudes.LeftChannel = leftChannel;
-                currentAmplitudes.RightChannel = rightChannel;
-
-                float[] tempFrequencyData = new float[size];
-                Bass.ChannelGetData(ch, tempFrequencyData, (int)DataFlags.FFT512);
-                currentAmplitudes.FrequencyAmplitudes = tempFrequencyData;
+                float[] frequencyData = new float[ChannelAmplitudes.AMPLITUDES_SIZE];
+                Bass.ChannelGetData(ch, frequencyData, (int)DataFlags.FFT512);
+                CurrentAmplitudes = new ChannelAmplitudes(leftChannel, rightChannel, frequencyData);
             }
             else
-                setEmpty();
-        }
-
-        private void setEmpty()
-        {
-            currentAmplitudes.LeftChannel = 0;
-            currentAmplitudes.RightChannel = 0;
-            currentAmplitudes.FrequencyAmplitudes = empty.FrequencyAmplitudes;
+                CurrentAmplitudes = ChannelAmplitudes.Empty;
         }
     }
 }

--- a/osu.Framework/Audio/IHasAmplitudes.cs
+++ b/osu.Framework/Audio/IHasAmplitudes.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Audio.Track;
+
+namespace osu.Framework.Audio
+{
+    public interface IHasAmplitudes
+    {
+        /// <summary>
+        /// Current amplitude of stereo channels where 1 is full volume and 0 is silent.
+        /// LeftChannel and RightChannel represent the maximum current amplitude of all of the left and right channels respectively.
+        /// The most recent values are returned. Synchronisation between channels should not be expected.
+        /// </summary>
+        ChannelAmplitudes CurrentAmplitudes { get; }
+    }
+}

--- a/osu.Framework/Audio/Sample/ISampleChannel.cs
+++ b/osu.Framework/Audio/Sample/ISampleChannel.cs
@@ -6,7 +6,7 @@ namespace osu.Framework.Audio.Sample
     /// <summary>
     /// A channel playing back an audio sample.
     /// </summary>
-    public interface ISampleChannel
+    public interface ISampleChannel : IHasAmplitudes
     {
         /// <summary>
         /// Start playback.

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -54,6 +54,6 @@ namespace osu.Framework.Audio.Sample
 
         public override bool IsAlive => base.IsAlive && !Played;
 
-        public virtual ChannelAmplitudes CurrentAmplitudes { get; } = new ChannelAmplitudes();
+        public virtual ChannelAmplitudes CurrentAmplitudes { get; } = ChannelAmplitudes.Empty;
     }
 }

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Statistics;
 using System;
+using osu.Framework.Audio.Track;
 
 namespace osu.Framework.Audio.Sample
 {
@@ -52,5 +53,12 @@ namespace osu.Framework.Audio.Sample
         public virtual bool Played => WasStarted && !Playing;
 
         public override bool IsAlive => base.IsAlive && !Played;
+
+        /// <summary>
+        /// Current amplitude of stereo channels where 1 is full volume and 0 is silent.
+        /// LeftChannel and RightChannel represent the maximum current amplitude of all of the left and right channels respectively.
+        /// The most recent values are returned. Synchronisation between channels should not be expected.
+        /// </summary>
+        public virtual TrackAmplitudes CurrentAmplitudes { get; } = new TrackAmplitudes();
     }
 }

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -54,11 +54,6 @@ namespace osu.Framework.Audio.Sample
 
         public override bool IsAlive => base.IsAlive && !Played;
 
-        /// <summary>
-        /// Current amplitude of stereo channels where 1 is full volume and 0 is silent.
-        /// LeftChannel and RightChannel represent the maximum current amplitude of all of the left and right channels respectively.
-        /// The most recent values are returned. Synchronisation between channels should not be expected.
-        /// </summary>
         public virtual ChannelAmplitudes CurrentAmplitudes { get; } = new ChannelAmplitudes();
     }
 }

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -59,6 +59,6 @@ namespace osu.Framework.Audio.Sample
         /// LeftChannel and RightChannel represent the maximum current amplitude of all of the left and right channels respectively.
         /// The most recent values are returned. Synchronisation between channels should not be expected.
         /// </summary>
-        public virtual TrackAmplitudes CurrentAmplitudes { get; } = new TrackAmplitudes();
+        public virtual ChannelAmplitudes CurrentAmplitudes { get; } = new ChannelAmplitudes();
     }
 }

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -3,6 +3,7 @@
 
 using System;
 using ManagedBass;
+using osu.Framework.Audio.Track;
 
 namespace osu.Framework.Audio.Sample
 {
@@ -14,6 +15,8 @@ namespace osu.Framework.Audio.Sample
         public override bool IsLoaded => Sample.IsLoaded;
 
         private float initialFrequency;
+
+        private BassAmplitudeProcessor bassAmplitudeProcessor;
 
         public SampleChannelBass(Sample sample, Action<SampleChannel> onPlay)
             : base(sample, onPlay)
@@ -69,9 +72,12 @@ namespace osu.Framework.Audio.Sample
                 // We are creating a new channel for every playback, since old channels may
                 // be overridden when too many other channels are created from the same sample.
                 channel = ((SampleBass)Sample).CreateChannel();
+
                 Bass.ChannelSetAttribute(channel, ChannelAttribute.NoRamp, 1);
                 Bass.ChannelGetAttribute(channel, ChannelAttribute.Frequency, out initialFrequency);
                 setLoopFlag(Looping);
+
+                bassAmplitudeProcessor?.SetChannel(channel);
             });
 
             InvalidateState();
@@ -91,6 +97,8 @@ namespace osu.Framework.Audio.Sample
         {
             playing = channel != 0 && Bass.ChannelIsActive(channel) != 0;
             base.UpdateState();
+
+            bassAmplitudeProcessor?.Update();
         }
 
         public override void Stop()
@@ -108,6 +116,8 @@ namespace osu.Framework.Audio.Sample
         }
 
         public override bool Playing => playing;
+
+        public override TrackAmplitudes CurrentAmplitudes => (bassAmplitudeProcessor ??= new BassAmplitudeProcessor(channel)).CurrentAmplitudes;
 
         private void setLoopFlag(bool value) => EnqueueAction(() =>
         {

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Audio.Sample
 
         public override bool Playing => playing;
 
-        public override TrackAmplitudes CurrentAmplitudes => (bassAmplitudeProcessor ??= new BassAmplitudeProcessor(channel)).CurrentAmplitudes;
+        public override ChannelAmplitudes CurrentAmplitudes => (bassAmplitudeProcessor ??= new BassAmplitudeProcessor(channel)).CurrentAmplitudes;
 
         private void setLoopFlag(bool value) => EnqueueAction(() =>
         {

--- a/osu.Framework/Audio/Track/ChannelAmplitudes.cs
+++ b/osu.Framework/Audio/Track/ChannelAmplitudes.cs
@@ -5,18 +5,34 @@ using System;
 
 namespace osu.Framework.Audio.Track
 {
-    public struct ChannelAmplitudes
+    public readonly struct ChannelAmplitudes
     {
-        public float LeftChannel;
-        public float RightChannel;
+        /// <summary>
+        /// The length of the <see cref="FrequencyAmplitudes"/> data.
+        /// </summary>
+        public const int AMPLITUDES_SIZE = 256;
 
-        public readonly float Maximum => Math.Max(LeftChannel, RightChannel);
+        public readonly float LeftChannel;
+        public readonly float RightChannel;
 
-        public readonly float Average => (LeftChannel + RightChannel) / 2;
+        public float Maximum => Math.Max(LeftChannel, RightChannel);
+
+        public float Average => (LeftChannel + RightChannel) / 2;
 
         /// <summary>
         /// 256 length array of bins containing the average frequency of both channels at every ~78Hz step of the audible spectrum (0Hz - 20,000Hz).
         /// </summary>
-        public float[] FrequencyAmplitudes;
+        public readonly ReadOnlyMemory<float> FrequencyAmplitudes;
+
+        private static readonly float[] empty_array = new float[AMPLITUDES_SIZE];
+
+        public ChannelAmplitudes(float leftChannel = 0, float rightChannel = 0, float[] amplitudes = null)
+        {
+            LeftChannel = leftChannel;
+            RightChannel = rightChannel;
+            FrequencyAmplitudes = amplitudes ?? empty_array;
+        }
+
+        public static ChannelAmplitudes Empty { get; } = new ChannelAmplitudes(0);
     }
 }

--- a/osu.Framework/Audio/Track/ChannelAmplitudes.cs
+++ b/osu.Framework/Audio/Track/ChannelAmplitudes.cs
@@ -5,6 +5,9 @@ using System;
 
 namespace osu.Framework.Audio.Track
 {
+    /// <summary>
+    /// A collection of information providing per-channel and per-frequency amplitudes of an audio channel.
+    /// </summary>
     public readonly struct ChannelAmplitudes
     {
         /// <summary>
@@ -12,11 +15,24 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         public const int AMPLITUDES_SIZE = 256;
 
+        /// <summary>
+        /// The amplitude of the left channel (0..1).
+        /// </summary>
         public readonly float LeftChannel;
+
+        /// <summary>
+        /// The amplitude of the right channel (0..1).
+        /// </summary>
         public readonly float RightChannel;
 
+        /// <summary>
+        /// The maximum amplitude of the left and right channels (0..1).
+        /// </summary>
         public float Maximum => Math.Max(LeftChannel, RightChannel);
 
+        /// <summary>
+        /// The average amplitude of the left and right channels (0..1).
+        /// </summary>
         public float Average => (LeftChannel + RightChannel) / 2;
 
         /// <summary>

--- a/osu.Framework/Audio/Track/ChannelAmplitudes.cs
+++ b/osu.Framework/Audio/Track/ChannelAmplitudes.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace osu.Framework.Audio.Track
 {
-    public struct TrackAmplitudes
+    public struct ChannelAmplitudes
     {
         public float LeftChannel;
         public float RightChannel;

--- a/osu.Framework/Audio/Track/ITrack.cs
+++ b/osu.Framework/Audio/Track/ITrack.cs
@@ -6,7 +6,7 @@ namespace osu.Framework.Audio.Track
     /// <summary>
     /// An audio track.
     /// </summary>
-    public interface ITrack
+    public interface ITrack : IHasAmplitudes
     {
         /// <summary>
         /// States if this track should repeat.

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -112,7 +112,7 @@ namespace osu.Framework.Audio.Track
 
         public override bool HasCompleted => IsLoaded && !IsRunning && CurrentTime >= Length;
 
-        public virtual ChannelAmplitudes CurrentAmplitudes { get; } = new ChannelAmplitudes();
+        public virtual ChannelAmplitudes CurrentAmplitudes { get; } = ChannelAmplitudes.Empty;
 
         protected override void UpdateState()
         {

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Audio.Track
         /// LeftChannel and RightChannel represent the maximum current amplitude of all of the left and right channels respectively.
         /// The most recent values are returned. Synchronisation between channels should not be expected.
         /// </summary>
-        public virtual TrackAmplitudes CurrentAmplitudes { get; } = new TrackAmplitudes();
+        public virtual ChannelAmplitudes CurrentAmplitudes { get; } = new ChannelAmplitudes();
 
         protected override void UpdateState()
         {

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -112,11 +112,6 @@ namespace osu.Framework.Audio.Track
 
         public override bool HasCompleted => IsLoaded && !IsRunning && CurrentTime >= Length;
 
-        /// <summary>
-        /// Current amplitude of stereo channels where 1 is full volume and 0 is silent.
-        /// LeftChannel and RightChannel represent the maximum current amplitude of all of the left and right channels respectively.
-        /// The most recent values are returned. Synchronisation between channels should not be expected.
-        /// </summary>
         public virtual ChannelAmplitudes CurrentAmplitudes { get; } = new ChannelAmplitudes();
 
         protected override void UpdateState()

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -307,6 +307,6 @@ namespace osu.Framework.Audio.Track
 
         public override int? Bitrate => bitrate;
 
-        public override TrackAmplitudes CurrentAmplitudes => (bassAmplitudeProcessor ??= new BassAmplitudeProcessor(activeStream)).CurrentAmplitudes;
+        public override ChannelAmplitudes CurrentAmplitudes => (bassAmplitudeProcessor ??= new BassAmplitudeProcessor(activeStream)).CurrentAmplitudes;
     }
 }

--- a/osu.Framework/Graphics/Audio/DrawableSample.cs
+++ b/osu.Framework/Graphics/Audio/DrawableSample.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Audio.Sample;
+using osu.Framework.Audio.Track;
 
 namespace osu.Framework.Graphics.Audio
 {
@@ -36,5 +37,7 @@ namespace osu.Framework.Graphics.Audio
             get => channel.Looping;
             set => channel.Looping = value;
         }
+
+        public ChannelAmplitudes CurrentAmplitudes => channel.CurrentAmplitudes;
     }
 }

--- a/osu.Framework/Graphics/Audio/DrawableTrack.cs
+++ b/osu.Framework/Graphics/Audio/DrawableTrack.cs
@@ -56,5 +56,7 @@ namespace osu.Framework.Graphics.Audio
         public void Start() => track.Start();
 
         public void Stop() => track.Stop();
+
+        public ChannelAmplitudes CurrentAmplitudes => track.CurrentAmplitudes;
     }
 }


### PR DESCRIPTION
- [x] Depends on #3647 

Not sure about the renaming breaking backwards compatibility. Can't add a temporary obsoleted class due to it being a struct.