### PR TITLE
Fix black square around triangle sprites due to front-to-back

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackTriangle.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackTriangle.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    public class TestSceneFrontToBackTriangle : FrameworkTestScene
+    {
+        public TestSceneFrontToBackTriangle()
+        {
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Color4.LightPink
+                },
+                new Triangle
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(200),
+                    Colour = Color4.Red
+                }
+            };
+        }
+    }
+}

--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -48,20 +48,14 @@ namespace osu.Framework.Graphics.Shapes
                     new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height), TextureCoords);
             }
 
-            protected override void DrawOpaqueInterior(Action<TexturedVertex2D> vertexAction)
+            protected override void BlitOpaqueInterior(Action<TexturedVertex2D> vertexAction)
             {
-                base.DrawOpaqueInterior(vertexAction);
-
-                TextureShader.Bind();
-
                 var triangle = toTriangle(ConservativeScreenSpaceDrawQuad);
 
                 if (GLWrapper.IsMaskingActive)
                     DrawClipped(ref triangle, Texture, DrawColourInfo.Colour, vertexAction: vertexAction);
                 else
                     DrawTriangle(Texture, triangle, DrawColourInfo.Colour, vertexAction: vertexAction);
-
-                TextureShader.Unbind();
             }
         }
     }

--- a/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
@@ -63,6 +63,14 @@ namespace osu.Framework.Graphics.Sprites
                 null, TextureCoords);
         }
 
+        protected virtual void BlitOpaqueInterior(Action<TexturedVertex2D> vertexAction)
+        {
+            if (GLWrapper.IsMaskingActive)
+                DrawClipped(ref ConservativeScreenSpaceDrawQuad, Texture, DrawColourInfo.Colour, vertexAction: vertexAction);
+            else
+                DrawQuad(Texture, ConservativeScreenSpaceDrawQuad, DrawColourInfo.Colour, vertexAction: vertexAction, textureCoords: TextureCoords);
+        }
+
         public override void Draw(Action<TexturedVertex2D> vertexAction)
         {
             base.Draw(vertexAction);
@@ -83,12 +91,12 @@ namespace osu.Framework.Graphics.Sprites
         {
             base.DrawOpaqueInterior(vertexAction);
 
+            if (Texture?.Available != true)
+                return;
+
             TextureShader.Bind();
 
-            if (GLWrapper.IsMaskingActive)
-                DrawClipped(ref ConservativeScreenSpaceDrawQuad, Texture, DrawColourInfo.Colour, vertexAction: vertexAction);
-            else
-                DrawQuad(Texture, ConservativeScreenSpaceDrawQuad, DrawColourInfo.Colour, vertexAction: vertexAction, textureCoords: TextureCoords);
+            BlitOpaqueInterior(vertexAction);
 
             TextureShader.Unbind();
         }


### PR DESCRIPTION
* Closes ppy/osu#9351

Not a super huge fan of this but at least it's consistent with `Draw()`/`Blit()`...

Also adds the texture availability check, both to be consistent with `Draw()` and to prevent the potential error there.