### PR TITLE
Fix potential ObjectDisposedException in DelayedLoadUnloadWrapper

### DIFF
--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -84,6 +84,14 @@ namespace osu.Framework.Graphics.Containers
             });
         }
 
+        private readonly object unloadLock = new object();
+
+        protected override void Dispose(bool isDisposing)
+        {
+            lock (unloadClock)
+                base.Dispose(isDisposing);
+        }
+
         protected override void CancelTasks()
         {
             base.CancelTasks();
@@ -109,7 +117,11 @@ namespace osu.Framework.Graphics.Containers
             else
                 timeHidden += unloadClock.ElapsedFrameTime;
 
-            if (ShouldUnloadContent)
+            if (!ShouldUnloadContent)
+                return;
+
+            // This code is running on the game's scheduler meanwhile an async disposal may have already been triggered from elsewhere in the hierarchy.
+            lock (unloadLock)
             {
                 Debug.Assert(contentLoaded);
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -88,7 +88,7 @@ namespace osu.Framework.Graphics.Containers
 
         protected override void Dispose(bool isDisposing)
         {
-            lock (unloadClock)
+            lock (unloadLock)
                 base.Dispose(isDisposing);
         }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/3306

Couldn't actually replicate this one (hence no test). It's actually quite hard to do so because you have to juggle 3 schedules: the one inside `DLW.OnInvalidate()`, the one for `checkForUnload()`, and then another one to actually trigger the disposal at the correct time. Then you have to deal with `perUpdateTasks` vs non-`perUpdateTasks` in the `Scheduler` and it gets very implementation-specific.

But I can imagine why this could occur.