### PR TITLE
Add improved state handling for right-click on iPadOS

### DIFF
--- a/osu.Framework.iOS/Input/IOSMouseHandler.cs
+++ b/osu.Framework.iOS/Input/IOSMouseHandler.cs
@@ -13,6 +13,10 @@ using UIKit;
 
 namespace osu.Framework.iOS.Input
 {
+    /// <summary>
+    /// Handles scroll and positional updates for external cursor-based input devices.
+    /// Click / touch handling is still provided by <see cref="IOSTouchHandler"/>.
+    /// </summary>
     public class IOSMouseHandler : InputHandler
     {
         private readonly IOSGameView view;

--- a/osu.Framework.iOS/Input/IOSTouchHandler.cs
+++ b/osu.Framework.iOS/Input/IOSTouchHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Diagnostics;
 using Foundation;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
@@ -15,7 +16,7 @@ namespace osu.Framework.iOS.Input
     {
         private readonly IOSGameView view;
 
-        private UIEventButtonMask lastButtonMask = UIEventButtonMask.Primary;
+        private UIEventButtonMask? lastButtonMask;
 
         private readonly bool indirectPointerSupported = UIDevice.CurrentDevice.CheckSystemVersion(13, 4);
 
@@ -31,79 +32,71 @@ namespace osu.Framework.iOS.Input
                 handleUITouch((UITouch)t, evt);
         }
 
-        private void handleUITouch(UITouch touch, UIEvent evt)
+        private void handleUITouch(UITouch touch, UIEvent e)
         {
+            // always update position.
             var location = touch.LocationInView(null);
 
-            // Indirect pointer means the touch came from a mouse cursor, and wasn't a physical touch on the screen
-            bool isIndirect = (indirectPointerSupported && touch.Type == UITouchType.IndirectPointer);
-
-            PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = new Vector2((float)location.X * view.Scale, (float)location.Y * view.Scale) });
-
-            switch (touch.Phase)
+            PendingInputs.Enqueue(new MousePositionAbsoluteInput
             {
-                case UITouchPhase.Began:
-                    if (isIndirect)
-                    {
-                        lastButtonMask = evt.ButtonMask;
-                        MouseButton mouseButton = isRightClick(lastButtonMask) ? MouseButton.Right : MouseButton.Left;
-                        PendingInputs.Enqueue(new MouseButtonInput(mouseButton, true));
-                    }
-                    else
+                Position = new Vector2((float)location.X * view.Scale, (float)location.Y * view.Scale)
+            });
+
+            if (indirectPointerSupported && touch.Type == UITouchType.IndirectPointer)
+            {
+                // Indirect pointer means the touch came from a mouse cursor, and wasn't a physical touch on the screen
+                switch (touch.Phase)
+                {
+                    case UITouchPhase.Began:
+                    case UITouchPhase.Moved:
+                        // only one button can be in a "down" state at once. all previous buttons are automatically released.
+                        // we need to handle this assumption at our end.
+                        if (lastButtonMask != null && lastButtonMask != e.ButtonMask)
+                            PendingInputs.Enqueue(new MouseButtonInput(buttonFromMask(lastButtonMask.Value), false));
+
+                        PendingInputs.Enqueue(new MouseButtonInput(buttonFromMask(e.ButtonMask), true));
+                        lastButtonMask = e.ButtonMask;
+                        break;
+
+                    case UITouchPhase.Cancelled:
+                    case UITouchPhase.Ended:
+                        Debug.Assert(lastButtonMask != null);
+
+                        PendingInputs.Enqueue(new MouseButtonInput(buttonFromMask(lastButtonMask.Value), false));
+                        lastButtonMask = null;
+                        break;
+                }
+            }
+            else
+            {
+                // simple logic before multiple button support was introduced.
+                // TODO: going forward, this should also handle multi-touch input.
+                switch (touch.Phase)
+                {
+                    case UITouchPhase.Began:
                         PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Left, true));
+                        break;
 
-                    break;
-
-                case UITouchPhase.Moved:
-                    if (isIndirect)
-                        transitionRightClick(evt);
-                    else
-                        PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Left, true));
-
-                    break;
-
-                case UITouchPhase.Cancelled:
-                case UITouchPhase.Ended:
-                    if (isIndirect)
-                    {
-                        MouseButton mouseButton = isRightClick(lastButtonMask) ? MouseButton.Right : MouseButton.Left;
-                        PendingInputs.Enqueue(new MouseButtonInput(mouseButton, false));
-                    }
-                    else
+                    case UITouchPhase.Cancelled:
+                    case UITouchPhase.Ended:
                         PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Left, false));
-
-                    break;
+                        break;
+                }
             }
         }
 
-        private void transitionRightClick(UIEvent evt)
+        private MouseButton buttonFromMask(UIEventButtonMask buttonMask)
         {
-            if (!indirectPointerSupported)
-                return;
+            Debug.Assert(indirectPointerSupported);
 
-            MouseButton activeButton = isRightClick(evt.ButtonMask) ? MouseButton.Right : MouseButton.Left;
-            MouseButton inactiveButton = activeButton == MouseButton.Right ? MouseButton.Left : MouseButton.Right;
-
-            // A single UITouch object represents the mouse cursor on iPadOS 13.4.
-            // If the user clicks both left and right buttons on a physical mouse, this doesn't generate more
-            // touch objects; it just changes the button mask value for the one touch object without calling "Began" or "Ended".
-            // If the stored mask value doesn't match the active one, this means the user alternated buttons, so unclick
-            // the previous button, and click the new button
-            if (lastButtonMask != evt.ButtonMask)
+            switch (buttonMask)
             {
-                PendingInputs.Enqueue(new MouseButtonInput(inactiveButton, false));
-                lastButtonMask = evt.ButtonMask;
+                default:
+                    return MouseButton.Left;
+
+                case UIEventButtonMask.Secondary:
+                    return MouseButton.Right;
             }
-
-            PendingInputs.Enqueue(new MouseButtonInput(activeButton, true));
-        }
-
-        private bool isRightClick(UIEventButtonMask buttonMask)
-        {
-            if (!indirectPointerSupported)
-                return false;
-
-            return (buttonMask == UIEventButtonMask.Secondary);
         }
 
         protected override void Dispose(bool disposing)

--- a/osu.Framework.iOS/Input/IOSTouchHandler.cs
+++ b/osu.Framework.iOS/Input/IOSTouchHandler.cs
@@ -32,15 +32,17 @@ namespace osu.Framework.iOS.Input
 
         private void handleUITouch(UITouch touch, UIEvent evt)
         {
-            var location = touch.LocationInView(null);
+            // Indirect pointer means the touch came from a mouse cursor, and wasn't a physcial touch on the screen
+            bool indirectTouch = (rightClickSupport && touch.Type == UITouchType.IndirectPointer);
+            bool rightClickEvent = (rightClickSupport && evt.ButtonMask == UIEventButtonMask.Secondary);
 
+            var location = touch.LocationInView(null);
             PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = new Vector2((float)location.X * view.Scale, (float)location.Y * view.Scale) });
 
             switch (touch.Phase)
             {
-                case UITouchPhase.Moved:
                 case UITouchPhase.Began:
-                    if (rightClickSupport && evt.ButtonMask == UIEventButtonMask.Secondary)
+                    if (indirectTouch && rightClickEvent)
                     {
                         pendingRightClickTouches.Add(touch);
                         PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, true));
@@ -49,10 +51,46 @@ namespace osu.Framework.iOS.Input
                         PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Left, true));
 
                     break;
+                case UITouchPhase.Moved:
+                    if (!indirectTouch)
+                        PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Left, true));
+                    else
+                    {
+                        // A single UITouch object represents the mouse cursor on iPadOS 13.4.
+                        // If the user clicks both left and right buttons on a physical mouse, this doesn't generate more
+                        // touch objects; it just changes the button mask value for the one touch object without calling "Began" or "Ended".
+                        // Without accounting for this, the mouse button input can sometimes be left in a "stuck" state. 
+          
+                        if (rightClickEvent)
+                        {
+                            // If a right-click event occurred, and the touch wasn't already saved in the right-click set,
+                            // the user has transitioned from left-click to right-click.
+                            if (!pendingRightClickTouches.Contains(touch))
+                            {
+                                PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Left, false));
+                                pendingRightClickTouches.Add(touch);
+                            }
 
+                            PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, true));
+                        }
+                        else
+                        {
+                            // If a left-click event has occurred, but the touch event was already saved in the right-click set,
+                            // the user has transitioned from a right-click event to a left-click.
+                            if (pendingRightClickTouches.Contains(touch))
+                            {
+                                PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, false));
+                                pendingRightClickTouches.Remove(touch);
+                            }
+
+                            PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Left, true));
+                        }
+                    }
+
+                    break;
                 case UITouchPhase.Cancelled:
                 case UITouchPhase.Ended:
-                    if (pendingRightClickTouches.Contains(touch))
+                    if (indirectTouch && pendingRightClickTouches.Contains(touch))
                     {
                         pendingRightClickTouches.Remove(touch);
                         PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, false));

--- a/osu.Framework.iOS/Input/IOSTouchHandler.cs
+++ b/osu.Framework.iOS/Input/IOSTouchHandler.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.iOS.Input
         {
             var location = touch.LocationInView(null);
 
-            // Indirect pointer means the touch came from a mouse cursor, and wasn't a physcial touch on the screen
+            // Indirect pointer means the touch came from a mouse cursor, and wasn't a physical touch on the screen
             bool isIndirect = (indirectPointerSupported && touch.Type == UITouchType.IndirectPointer);
 
             PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = new Vector2((float)location.X * view.Scale, (float)location.Y * view.Scale) });

--- a/osu.Framework.iOS/Input/IOSTouchHandler.cs
+++ b/osu.Framework.iOS/Input/IOSTouchHandler.cs
@@ -59,8 +59,8 @@ namespace osu.Framework.iOS.Input
                         // A single UITouch object represents the mouse cursor on iPadOS 13.4.
                         // If the user clicks both left and right buttons on a physical mouse, this doesn't generate more
                         // touch objects; it just changes the button mask value for the one touch object without calling "Began" or "Ended".
-                        // Without accounting for this, the mouse button input can sometimes be left in a "stuck" state. 
-          
+                        // Without accounting for this, the mouse button input can sometimes be left in a "stuck" state.
+
                         if (rightClickEvent)
                         {
                             // If a right-click event occurred, and the touch wasn't already saved in the right-click set,


### PR DESCRIPTION
This PR is a refinement on top of #3642. 

In my testing, I noticed that if a user had a physical mouse and clicked both buttons down at the same time, the "Unclick" mouse event for the left button wouldn't be called, and the cursor was consistently getting stuck in a "left button still clicked" state.

I discovered today that this was because I had assumed clicking the left and right buttons generated separate streams of  `UITouch` objects, but I found that actually only one `UITouch` object is ever used when a user is clicking a physical mouse, and that single touch object simply transitions between "left-click" and "right-click" states on demand.

This PR does two things:
1) Properly silos all of the custom right-click logic, so regular screen taps aren't affected by it.
2) Detects when the state of the `UITouch` object has changed mid-flight, and performs the necessary "unclick" and "click" events to transition the mouse state in the framework to match the physical mouse.

Tested with both the Magic Keyboard and a Logitech gaming mouse and confirmed working on both.