### PR TITLE
Fix PassThroughInputManager potentially not receiving release events

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -89,6 +89,21 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Test]
+        public void TestUpReceivedOnDownFromSync()
+        {
+            addTestInputManagerStep();
+            AddStep("UseParentInput = false", () => testInputManager.UseParentInput = false);
+            AddStep("press keyboard", () => InputManager.PressKey(Key.A));
+            AddAssert("key not pressed", () => !testInputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed);
+
+            AddStep("UseParentInput = true", () => testInputManager.UseParentInput = true);
+            AddAssert("key pressed", () => testInputManager.CurrentState.Keyboard.Keys.Single() == Key.A);
+
+            AddStep("release keyboard", () => InputManager.ReleaseKey(Key.A));
+            AddAssert("key released", () => !testInputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed);
+        }
+
+        [Test]
         public void MouseDownNoSync()
         {
             addTestInputManagerStep();

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -49,13 +49,10 @@ namespace osu.Framework.Input
             if (!PropagateNonPositionalInputSubTree) return false;
 
             if (!allowBlocking)
-            {
                 base.BuildNonPositionalInputQueue(queue, false);
-                return false;
-            }
-
-            if (UseParentInput)
+            else
                 queue.Add(this);
+
             return false;
         }
 
@@ -63,8 +60,7 @@ namespace osu.Framework.Input
         {
             if (!PropagatePositionalInputSubTree) return false;
 
-            if (UseParentInput)
-                queue.Add(this);
+            queue.Add(this);
             return false;
         }
 


### PR DESCRIPTION
All event managers propagate release events to the handler drawable and all of what its in front of it built in to the queue. And for `TouchEventManager` which propagates touch move events to the queue of `TouchDownEvent` (test coverage about that coming in dependent PR), the pass-through input manager must always stick itself to the queue.

The test case provided for this will not produce different results based on the fix due to the manager actually tries to synchronize itself with the parent manager per-frame because of "some non-positional events" being blocked, which I think this fix would render that redundant, but decided to separate that change into another PR as it also kinda changes behaviour.