### PR TITLE
Remove PassThroughInputManager per-update synchronization

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -89,6 +89,21 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Test]
+        public void TestUpReceivedOnDownFromSync()
+        {
+            addTestInputManagerStep();
+            AddStep("UseParentInput = false", () => testInputManager.UseParentInput = false);
+            AddStep("press keyboard", () => InputManager.PressKey(Key.A));
+            AddAssert("key not pressed", () => !testInputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed);
+
+            AddStep("UseParentInput = true", () => testInputManager.UseParentInput = true);
+            AddAssert("key pressed", () => testInputManager.CurrentState.Keyboard.Keys.Single() == Key.A);
+
+            AddStep("release keyboard", () => InputManager.ReleaseKey(Key.A));
+            AddAssert("key released", () => !testInputManager.CurrentState.Keyboard.Keys.HasAnyButtonPressed);
+        }
+
+        [Test]
         public void MouseDownNoSync()
         {
             addTestInputManagerStep();

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -122,14 +122,6 @@ namespace osu.Framework.Input
             Sync();
         }
 
-        protected override void Update()
-        {
-            base.Update();
-
-            // Some non-positional events are blocked. Sync every frame.
-            if (UseParentInput) Sync(true);
-        }
-
         /// <summary>
         /// Sync input state to parent <see cref="InputManager"/>'s <see cref="InputState"/>.
         /// Call this when parent <see cref="InputManager"/> changed somehow.

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -49,13 +49,10 @@ namespace osu.Framework.Input
             if (!PropagateNonPositionalInputSubTree) return false;
 
             if (!allowBlocking)
-            {
                 base.BuildNonPositionalInputQueue(queue, false);
-                return false;
-            }
-
-            if (UseParentInput)
+            else
                 queue.Add(this);
+
             return false;
         }
 
@@ -63,8 +60,7 @@ namespace osu.Framework.Input
         {
             if (!PropagatePositionalInputSubTree) return false;
 
-            if (UseParentInput)
-                queue.Add(this);
+            queue.Add(this);
             return false;
         }
 


### PR DESCRIPTION
- [ ] Depends on #3660 (to replace this)

Seems to be unnecessary now after the aforementioned PR is merged, although there's a behaviour change here which is that some input may not be synchronized when there's a drawable in front of the manager absorbing their corresponding event (excluding `MouseMoveEvent` because of using `IRequireHighFrequencyMousePosition`).

Not quite sure if that's the only behaviour change this will result in though, but testing with osu! in both desktop and mobile it seems to be working correctly, especially on gameplay.