### PR TITLE
Disallow mouse input from primary touch on PassThroughInputManagers

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -128,6 +128,11 @@ namespace osu.Framework.Input
 
         private readonly Dictionary<JoystickAxisSource, JoystickAxisEventManager> joystickAxisEventManagers = new Dictionary<JoystickAxisSource, JoystickAxisEventManager>();
 
+        /// <summary>
+        /// Whether to produce mouse input on any primary touch input.
+        /// </summary>
+        protected virtual bool MapMouseToPrimaryTouch => true;
+
         protected InputManager()
         {
             CurrentState = CreateInitialState();
@@ -593,8 +598,7 @@ namespace osu.Framework.Input
                 case TouchStateChangeEvent touchChange:
                     HandleTouchStateChange(touchChange);
 
-                    // primary touch mapped to mouse.
-                    if (touchChange.Touch.Source == TouchSource.Touch1)
+                    if (MapMouseToPrimaryTouch && touchChange.Touch.Source == TouchSource.Touch1)
                     {
                         new MousePositionAbsoluteInput { Position = touchChange.Touch.Position }.Apply(CurrentState, this);
                         new MouseButtonInput(MouseButton.Left, touchChange.State.Touch.IsActive(touchChange.Touch.Source)).Apply(CurrentState, this);

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -569,6 +569,21 @@ namespace osu.Framework.Input
                 manager.HandleButtonStateChange(e.State, active ? ButtonStateChangeKind.Pressed : ButtonStateChangeKind.Released);
         }
 
+        /// <summary>
+        /// Handles primary touch state change event to produce mouse input from.
+        /// </summary>
+        /// <param name="e">The primary touch state change event.</param>
+        /// <returns>Whether mouse input has been performed accordingly.</returns>
+        protected virtual bool HandleMouseTouchStateChange(TouchStateChangeEvent e)
+        {
+            if (!MapMouseToPrimaryTouch)
+                return false;
+
+            new MousePositionAbsoluteInput { Position = e.Touch.Position }.Apply(CurrentState, this);
+            new MouseButtonInput(MouseButton.Left, e.State.Touch.IsActive(e.Touch.Source)).Apply(CurrentState, this);
+            return true;
+        }
+
         protected virtual void HandleJoystickButtonStateChange(ButtonStateChangeEvent<JoystickButton> joystickButtonStateChange)
             => GetButtonEventManagerFor(joystickButtonStateChange.Button).HandleButtonStateChange(joystickButtonStateChange.State, joystickButtonStateChange.Kind);
 
@@ -598,11 +613,8 @@ namespace osu.Framework.Input
                 case TouchStateChangeEvent touchChange:
                     HandleTouchStateChange(touchChange);
 
-                    if (MapMouseToPrimaryTouch && touchChange.Touch.Source == TouchSource.Touch1)
-                    {
-                        new MousePositionAbsoluteInput { Position = touchChange.Touch.Position }.Apply(CurrentState, this);
-                        new MouseButtonInput(MouseButton.Left, touchChange.State.Touch.IsActive(touchChange.Touch.Source)).Apply(CurrentState, this);
-                    }
+                    if (touchChange.Touch.Source == TouchSource.Touch1)
+                        HandleMouseTouchStateChange(touchChange);
 
                     return;
 

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -25,6 +25,8 @@ namespace osu.Framework.Input
     /// </remarks>
     public class PassThroughInputManager : CustomInputManager, IRequireHighFrequencyMousePosition
     {
+        protected override bool MapMouseToPrimaryTouch => !UseParentInput;
+
         /// <summary>
         /// If there's an InputManager above us, decide whether we should use their available state.
         /// </summary>

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.StateChanges;
+using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
 using osuTK;
 using osuTK.Input;
@@ -25,8 +26,6 @@ namespace osu.Framework.Input
     /// </remarks>
     public class PassThroughInputManager : CustomInputManager, IRequireHighFrequencyMousePosition
     {
-        protected override bool MapMouseToPrimaryTouch => !UseParentInput;
-
         /// <summary>
         /// If there's an InputManager above us, decide whether we should use their available state.
         /// </summary>
@@ -81,6 +80,15 @@ namespace osu.Framework.Input
             }
 
             return pendingInputs;
+        }
+
+        protected override bool HandleMouseTouchStateChange(TouchStateChangeEvent e)
+        {
+            // The parent manager will propagate mouse events from primary touch input if we are using it.
+            if (UseParentInput)
+                return false;
+
+            return base.HandleMouseTouchStateChange(e);
         }
 
         protected override bool Handle(UIEvent e)


### PR DESCRIPTION
Actually doesn't seem testable as there's no way to distinguish between whether a redundant input has been applied and whether not, as mouse input from touch will be produced in order from bottom-child up to top-parent.

But makes sense either way to put this toggle for things to be as expected.