### PR TITLE
Add a copy constructor to InputState

### DIFF
--- a/osu.Framework/Input/States/InputState.cs
+++ b/osu.Framework/Input/States/InputState.cs
@@ -3,14 +3,53 @@
 
 namespace osu.Framework.Input.States
 {
+    /// <summary>
+    /// An object that stores all input states.
+    /// </summary>
     public class InputState
     {
+        /// <summary>
+        /// The mouse state.
+        /// </summary>
         public readonly MouseState Mouse;
+
+        /// <summary>
+        /// The keyboard state.
+        /// </summary>
         public readonly KeyboardState Keyboard;
+
+        /// <summary>
+        /// The touch state.
+        /// </summary>
         public readonly TouchState Touch;
+
+        /// <summary>
+        /// The joystick state.
+        /// </summary>
         public readonly JoystickState Joystick;
+
+        /// <summary>
+        /// The midi state.
+        /// </summary>
         public readonly MidiState Midi;
 
+        /// <summary>
+        /// Creates a new <see cref="InputState"/> using the individual input states from another <see cref="InputState"/>.
+        /// </summary>
+        /// <param name="other">The <see cref="InputState"/> to take the individual input states from.</param>
+        public InputState(InputState other)
+            : this(other.Mouse, other.Keyboard, other.Touch, other.Joystick, other.Midi)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="InputState"/> using given individual input states.
+        /// </summary>
+        /// <param name="mouse">The mouse state.</param>
+        /// <param name="keyboard">The keyboard state.</param>
+        /// <param name="touch">The touch state.</param>
+        /// <param name="joystick">The joystick state.</param>
+        /// <param name="midi">The midi state.</param>
         public InputState(MouseState mouse = null, KeyboardState keyboard = null, TouchState touch = null, JoystickState joystick = null, MidiState midi = null)
         {
             Mouse = mouse ?? new MouseState();

--- a/osu.Framework/Input/States/InputState.cs
+++ b/osu.Framework/Input/States/InputState.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Input.States
         /// <summary>
         /// Creates a new <see cref="InputState"/> using the individual input states from another <see cref="InputState"/>.
         /// </summary>
-        /// <param name="other">The <see cref="InputState"/> to take the individual input states from.</param>
+        /// <param name="other">The <see cref="InputState"/> to take the individual input states from. Note that states are not cloned and will remain as references to the same objects.</param>
         public InputState(InputState other)
             : this(other.Mouse, other.Keyboard, other.Touch, other.Joystick, other.Midi)
         {


### PR DESCRIPTION
Noticed while updating osu!-side dependencies that:
1. `touch` was injected before `joystick` - build-time error.
2. `midi` wasn't passed through.

It's not a huge deal, but it's probably safer for the user to be able to specify the `InputState` to be copied from.