### PR TITLE
Schedule lifetime change callbacks after children

### DIFF
--- a/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
+++ b/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
@@ -210,7 +210,11 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private void childLifetimeChanged(Drawable child)
+        /// <remarks>
+        /// All executions of this callback are deferred until all children of this <see cref="LifetimeManagementContainer"/> are processed
+        /// to avoid mutating <see cref="CompositeDrawable.AliveInternalChildren"/> while they're being enumerated inside <see cref="Drawable.UpdateSubTree"/>.
+        /// </remarks>
+        private void childLifetimeChanged(Drawable child) => ScheduleAfterChildren(() =>
         {
             if (!childStateMap.TryGetValue(child, out var entry)) return;
 
@@ -218,7 +222,7 @@ namespace osu.Framework.Graphics.Containers
             entry.UpdateLifetime();
 
             updateChildEntry(entry, true);
-        }
+        });
 
         protected internal override void AddInternal(Drawable drawable)
         {


### PR DESCRIPTION
Resolves ppy/osu#8145 (*finally*).

# Summary

As outlined in the issue thread, a storyboard usage of `LifetimeManagementContainer` revealed that setting `LifetimeStart` and `LifetimeEnd` inside a child's `Update()` was unsafe, as it was mutating `AliveInternalChildren` while they were being enumerated inside of `UpdateSubTree()` through the `childLifetimeChanged` callback.

Resolve by deferring all `childLifetimeChanged` executions until all alive children are processed during an update frame.

Here are two videos, demonstrating the manifestation of the bug on the map affected game-side and its resolution with this PR:

* [before](https://streamable.com/xxk4cq) - note the zombie samples highlighted in the draw visualiser and the lack of kick drum playback when they appear,
* [after](https://streamable.com/wa3qc0) - note the presence of the kick drums and no left-over alive children in the storyboard layer.

# Remarks

Mini-rant: in retrospect the signs this was going to be this sort of issue were there all along, but for some reason I could not understand the presentation of this bug for the longest time (I stared at it on and off for like two weeks). I was thinking this was a BASS sample concurrency issue several times and almost gave up on debugging this like three times along the way. Not sure if this was just me being bird-brained or just a nasty bug.

(That piano intro song is burned in my brain now from how many times I replayed it.)

Glad I caught it, though.