### PR TITLE
Distinguish mouse events from touch input via bool property

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
@@ -289,12 +289,37 @@ namespace osu.Framework.Tests.Visual.Input
             });
         }
 
+        [Test]
+        public void TestMouseEventFromTouchIndication()
+        {
+            InputReceptor primaryReceptor = null;
+
+            AddStep("retrieve primary receptor", () => primaryReceptor = receptors[(int)TouchSource.Touch1]);
+            AddStep("setup handlers to avoid mouse-from-touch events", () =>
+            {
+                primaryReceptor.HandleMouse = me => !me.FromTouchSource;
+            });
+
+            AddStep("perform input on primary touch", () =>
+            {
+                InputManager.BeginTouch(new Touch(TouchSource.Touch1, getTouchDownPos(TouchSource.Touch1)));
+                InputManager.MoveTouchTo(new Touch(TouchSource.Touch1, getTouchMovePos(TouchSource.Touch1)));
+                InputManager.EndTouch(new Touch(TouchSource.Touch1, getTouchUpPos(TouchSource.Touch1)));
+            });
+            AddAssert("no mouse event received", () => primaryReceptor.MouseEvents.Count == 0);
+
+            AddStep("perform mouse move input", () => InputManager.MoveMouseTo(getTouchDownPos(TouchSource.Touch1)));
+            AddAssert("mouse event received", () => primaryReceptor.MouseEvents.Single() is MouseMoveEvent);
+        }
+
         private class InputReceptor : CompositeDrawable
         {
             public readonly TouchSource AssociatedSource;
 
             public readonly Queue<TouchEvent> TouchEvents = new Queue<TouchEvent>();
             public readonly Queue<MouseEvent> MouseEvents = new Queue<MouseEvent>();
+
+            public Func<MouseEvent, bool> HandleMouse;
 
             public InputReceptor(TouchSource source)
             {
@@ -329,12 +354,17 @@ namespace osu.Framework.Tests.Visual.Input
                     case MouseMoveEvent _:
                     case DragEvent _:
                     case MouseUpEvent _:
-                        MouseEvents.Enqueue((MouseEvent)e);
-                        return !(e is MouseUpEvent);
+                        if (HandleMouse?.Invoke((MouseEvent)e) != false)
+                        {
+                            MouseEvents.Enqueue((MouseEvent)e);
+                            return true;
+                        }
+
+                        break;
 
                     // not worth enqueuing, just handle for receiving drag.
-                    case DragStartEvent _:
-                        return true;
+                    case DragStartEvent dse:
+                        return HandleMouse?.Invoke(dse) ?? true;
                 }
 
                 return false;

--- a/osu.Framework/Input/Events/MouseEvent.cs
+++ b/osu.Framework/Input/Events/MouseEvent.cs
@@ -13,6 +13,11 @@ namespace osu.Framework.Input.Events
     public abstract class MouseEvent : UIEvent
     {
         /// <summary>
+        /// Whether this event has been raised from a primary touch input source.
+        /// </summary>
+        public bool FromTouchSource => CurrentState.Mouse.FromTouchSource;
+
+        /// <summary>
         /// Whether a specific mouse button is pressed.
         /// </summary>
         public bool IsPressed(MouseButton button) => CurrentState.Mouse.Buttons.IsPressed(button);

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -579,8 +579,17 @@ namespace osu.Framework.Input
             if (!MapMouseToPrimaryTouch)
                 return false;
 
-            new MousePositionAbsoluteInput { Position = e.Touch.Position }.Apply(CurrentState, this);
-            new MouseButtonInput(MouseButton.Left, e.State.Touch.IsActive(e.Touch.Source)).Apply(CurrentState, this);
+            new MousePositionAbsoluteInput
+            {
+                FromTouchSource = true,
+                Position = e.Touch.Position,
+            }.Apply(CurrentState, this);
+
+            new MouseButtonInput(MouseButton.Left, e.State.Touch.IsActive(e.Touch.Source))
+            {
+                FromTouchSource = true,
+            }.Apply(CurrentState, this);
+
             return true;
         }
 

--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -71,9 +71,11 @@ namespace osu.Framework.Input.StateChanges
                 if (buttonStates.SetPressed(entry.Button, entry.IsPressed))
                 {
                     var buttonStateChange = CreateEvent(state, entry.Button, entry.IsPressed ? ButtonStateChangeKind.Pressed : ButtonStateChangeKind.Released);
-                    handler.HandleInputStateChange(buttonStateChange);
+                    HandleInputStateChange(buttonStateChange, handler);
                 }
             }
         }
+
+        protected virtual void HandleInputStateChange(ButtonStateChangeEvent<TButton> e, IInputStateChangeHandler handler) => handler.HandleInputStateChange(e);
     }
 }

--- a/osu.Framework/Input/StateChanges/IMouseInput.cs
+++ b/osu.Framework/Input/StateChanges/IMouseInput.cs
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Input.StateChanges
+{
+    public interface IMouseInput : IInput
+    {
+        /// <summary>
+        /// Whether this input is performed from a primary touch input source.
+        /// </summary>
+        public bool FromTouchSource { get; set; }
+    }
+}

--- a/osu.Framework/Input/StateChanges/IMouseInput.cs
+++ b/osu.Framework/Input/StateChanges/IMouseInput.cs
@@ -8,6 +8,6 @@ namespace osu.Framework.Input.StateChanges
         /// <summary>
         /// Whether this input is performed from a primary touch input source.
         /// </summary>
-        public bool FromTouchSource { get; set; }
+        bool FromTouchSource { get; set; }
     }
 }

--- a/osu.Framework/Input/StateChanges/MouseButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseButtonInput.cs
@@ -2,13 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
 using osuTK.Input;
 
 namespace osu.Framework.Input.StateChanges
 {
-    public class MouseButtonInput : ButtonInput<MouseButton>
+    public class MouseButtonInput : ButtonInput<MouseButton>, IMouseInput
     {
+        public bool FromTouchSource { get; set; }
+
         public MouseButtonInput(IEnumerable<ButtonInputEntry<MouseButton>> entries)
             : base(entries)
         {
@@ -25,5 +28,11 @@ namespace osu.Framework.Input.StateChanges
         }
 
         protected override ButtonStates<MouseButton> GetButtonStates(InputState state) => state.Mouse.Buttons;
+
+        protected override void HandleInputStateChange(ButtonStateChangeEvent<MouseButton> stateChangeEvent, IInputStateChangeHandler handler)
+        {
+            stateChangeEvent.State.Mouse.FromTouchSource = FromTouchSource;
+            base.HandleInputStateChange(stateChangeEvent, handler);
+        }
     }
 }

--- a/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
@@ -14,8 +14,10 @@ namespace osu.Framework.Input.StateChanges
     /// <remarks>
     /// This is the first input received from any pointing device.
     /// </remarks>
-    public class MousePositionAbsoluteInput : IInput
+    public class MousePositionAbsoluteInput : IMouseInput
     {
+        public bool FromTouchSource { get; set; }
+
         /// <summary>
         /// The position which will be assigned to the current position.
         /// </summary>

--- a/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
@@ -29,6 +29,8 @@ namespace osu.Framework.Input.StateChanges
 
             if (!mouse.IsPositionValid || mouse.Position != Position)
             {
+                mouse.FromTouchSource = FromTouchSource;
+
                 var lastPosition = mouse.IsPositionValid ? mouse.Position : Position;
                 mouse.IsPositionValid = true;
                 mouse.Position = Position;

--- a/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
@@ -27,6 +27,8 @@ namespace osu.Framework.Input.StateChanges
 
             if (mouse.IsPositionValid && Delta != Vector2.Zero)
             {
+                mouse.FromTouchSource = FromTouchSource;
+
                 var lastPosition = mouse.Position;
                 mouse.Position += Delta;
                 handler.HandleInputStateChange(new MousePositionChangeEvent(state, this, lastPosition));

--- a/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
@@ -11,8 +11,10 @@ namespace osu.Framework.Input.StateChanges
     /// Denotes a relative change of mouse position.
     /// Pointing devices such as mice provide relative positional input.
     /// </summary>
-    public class MousePositionRelativeInput : IInput
+    public class MousePositionRelativeInput : IMouseInput
     {
+        public bool FromTouchSource { get; set; }
+
         /// <summary>
         /// The change in position. This will be added to the current position.
         /// When the current position is not valid, no changes will be made.

--- a/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
@@ -34,6 +34,8 @@ namespace osu.Framework.Input.StateChanges
 
             if (Delta != Vector2.Zero)
             {
+                mouse.FromTouchSource = FromTouchSource;
+
                 var lastScroll = mouse.Scroll;
                 mouse.Scroll += Delta;
                 handler.HandleInputStateChange(new MouseScrollChangeEvent(state, this, lastScroll, IsPrecise));

--- a/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
@@ -11,8 +11,10 @@ namespace osu.Framework.Input.StateChanges
     /// Denotes a relative change of mouse scroll.
     /// Pointing devices such as mice provide relative scroll input.
     /// </summary>
-    public class MouseScrollRelativeInput : IInput
+    public class MouseScrollRelativeInput : IMouseInput
     {
+        public bool FromTouchSource { get; set; }
+
         /// <summary>
         /// The change in scroll. This is added to the current scroll.
         /// </summary>

--- a/osu.Framework/Input/States/MouseState.cs
+++ b/osu.Framework/Input/States/MouseState.cs
@@ -9,6 +9,11 @@ namespace osu.Framework.Input.States
 {
     public class MouseState
     {
+        /// <summary>
+        /// Whether the last mouse input has been performed from a touch input source.
+        /// </summary>
+        public bool FromTouchSource { get; set; }
+
         public readonly ButtonStates<MouseButton> Buttons = new ButtonStates<MouseButton>();
 
         public Vector2 Scroll { get; set; }
@@ -23,7 +28,7 @@ namespace osu.Framework.Input.States
         public override string ToString()
         {
             string position = IsPositionValid ? $"({Position.X:F0},{Position.Y:F0})" : "(Invalid)";
-            return $@"{GetType().ReadableName()} {position} {Buttons} Scroll ({Scroll.X:F2},{Scroll.Y:F2})";
+            return $@"{GetType().ReadableName()} {position} {Buttons} Scroll ({Scroll.X:F2},{Scroll.Y:F2}) {(FromTouchSource ? "(State from touch source)" : "")}";
         }
     }
 }


### PR DESCRIPTION
Addresses a discussion in #3667, around combining touch and mouse input handling like cursor containers, magically required for dependent PR which made me work on it first.

The way implemented here is likely the best way to get proper values on this, there were other ways like directly passing the `IInput` to all button event managers and reading the value from there, or passing the bool to the `InputStateChangeEvent` and pass that class into the button event managers. But I'm confident with the way I wrote it now, consistent with the rest of current mouse state properties in the event, easy to pass, and simplifies the changes.

EDIT: Forgot to note, but I've decided to put a bool property instead of marker interface as that one would really pollute the `MouseButtonEventManager` class with checks through whether `XXXFromTouchEvent` should be propagated or the original one.