### PR TITLE
Add option to disable TabControl switch-on-remove behaviour

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -27,6 +27,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         private StyledTabControl removeAllTabControl;
         private StyledMultilineTabControl multilineTabControl;
         private StyledTabControl simpleTabcontrol;
+        private StyledTabControl simpleTabcontrolNoSwitchOnRemove;
 
         public TestSceneTabControl()
         {
@@ -48,6 +49,11 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     simpleTabcontrol = new StyledTabControl
                     {
                         Size = new Vector2(200, 30),
+                    },
+                    simpleTabcontrolNoSwitchOnRemove = new StyledTabControl
+                    {
+                        Size = new Vector2(200, 30),
+                        SwitchTabOnRemove = false
                     },
                     multilineTabControl = new StyledMultilineTabControl
                     {
@@ -82,6 +88,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             foreach (var item in items)
             {
                 simpleTabcontrol.AddItem(item);
+                simpleTabcontrolNoSwitchOnRemove.AddItem(item);
                 multilineTabControl.AddItem(item);
                 switchingTabControl.AddItem(item);
                 withoutDropdownTabControl.AddItem(item);
@@ -258,6 +265,17 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 itemsForDelete.ForEach(item => simpleTabcontrol.RemoveItem(item));
             });
             AddAssert("Ensure selected tab is null", () => simpleTabcontrol.SelectedTab == null);
+        }
+
+        /// <summary>
+        /// Tests that the selection is not switched on a <see cref="TabControl{T}"/> that has <see cref="TabControl{T}.SwitchTabOnRemove"/> set to <c>false</c>.
+        /// </summary>
+        [Test]
+        public void TestRemovingSelectedTabDoesNotSwitchSelectionIfNotSwitchTabOnRemove()
+        {
+            AddStep("Select tab 2", () => simpleTabcontrolNoSwitchOnRemove.Current.Value = TestEnum.Test2);
+            AddStep("Remove tab 2", () => simpleTabcontrolNoSwitchOnRemove.RemoveItem(TestEnum.Test2));
+            AddAssert("Ensure has not switched", () => simpleTabcontrolNoSwitchOnRemove.SelectedTab.Value == TestEnum.Test2);
         }
 
         [Test]

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Graphics.UserInterface
         public bool AutoSort { set; get; }
 
         /// <summary>
-        /// The <see cref="Dropdown"/> which is displayed when tabs overflow the visible bounds of this <see cref="TabControl{T}"/>.
+        /// The <see cref="Dropdown{T}"/> which is displayed when tabs overflow the visible bounds of this <see cref="TabControl{T}"/>.
         /// </summary>
         [CanBeNull]
         protected readonly Dropdown<T> Dropdown;
@@ -268,7 +268,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// Adds an arbitrary <see cref="TabItem{T}"/> to the <see cref="TabControl{T}"/>.
         /// </summary>
         /// <param name="tab">The tab to add.</param>
-        /// <param name="addToDropdown">Whether the tab should be added to the dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
+        /// <param name="addToDropdown">Whether the tab should be added to the <see cref="Dropdown"/> if supported by the <see cref="TabControl{T}"/> implementation.</param>
         protected virtual void AddTabItem(TabItem<T> tab, bool addToDropdown = true)
         {
             tab.PinnedChanged += performTabSort;
@@ -290,7 +290,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// If the current tab is removed and <see cref="SwitchTabOnRemove"/> is <c>true</c>, then selection will change to a new tab if possible or be cleared if there are no tabs remaining in the <see cref="TabControl{T}"/>.
         /// </remarks>
         /// <param name="tab">The tab to remove.</param>
-        /// <param name="removeFromDropdown">Whether the tab should be removed from the dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
+        /// <param name="removeFromDropdown">Whether the tab should be removed from the <see cref="Dropdown"/> if supported by the <see cref="TabControl{T}"/> implementation.</param>
         protected virtual void RemoveTabItem(TabItem<T> tab, bool removeFromDropdown = true)
         {
             if (!tab.IsRemovable)
@@ -424,7 +424,6 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Creates the <see cref="TabFillFlowContainer"/> to contain the <see cref="TabItem{T}"/>s.
         /// </summary>
-        /// <returns></returns>
         protected virtual TabFillFlowContainer CreateTabFlow() => new TabFillFlowContainer
         {
             Direction = FillDirection.Full,

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -36,10 +36,13 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// A collection of all tabs which are valid switch targets.
+        /// A collection of all tabs which are valid switch targets, sorted by their order of appearance.
         /// </summary>
         protected internal IEnumerable<TabItem<T>> SwitchableTabs => AllTabs.Where(tab => tab.IsSwitchable);
 
+        /// <summary>
+        /// The collection of all tabs, sorted by their order of appearance.
+        /// </summary>
         protected internal IEnumerable<TabItem<T>> AllTabs => TabContainer.AllTabItems;
 
         /// <summary>
@@ -71,14 +74,24 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         public bool AutoSort { set; get; }
 
-        protected Dropdown<T> Dropdown;
-
-        protected readonly TabFillFlowContainer TabContainer;
-
-        protected TabItem<T> SelectedTab;
+        /// <summary>
+        /// The <see cref="Dropdown"/> which is displayed when tabs overflow the visible bounds of this <see cref="TabControl{T}"/>.
+        /// </summary>
+        [CanBeNull]
+        protected readonly Dropdown<T> Dropdown;
 
         /// <summary>
-        /// When true, tabs can be switched back and forth using PlatformAction.DocumentPrevious and PlatformAction.DocumentNext respectively.
+        /// The flow of <see cref="TabItem{T}"/>s.
+        /// </summary>
+        protected readonly TabFillFlowContainer TabContainer;
+
+        /// <summary>
+        /// The currently-selected <see cref="TabItem{T}"/>.
+        /// </summary>
+        protected TabItem<T> SelectedTab { get; private set; }
+
+        /// <summary>
+        /// When true, tabs can be switched back and forth using <see cref="PlatformActionType.DocumentPrevious"/> and <see cref="PlatformActionType.DocumentNext"/> respectively.
         /// </summary>
         public bool IsSwitchable { get; set; }
 
@@ -96,18 +109,24 @@ namespace osu.Framework.Graphics.UserInterface
         /// </item>
         /// </list>
         /// </remarks>
-        protected virtual bool SwitchTabOnRemove => true;
+        protected bool SwitchTabOnRemove { get; set; } = true;
 
         /// <summary>
         /// Creates an optional overflow dropdown.
         /// When implementing this dropdown make sure:
-        ///  - It is made to be anchored to the right-hand side of its parent.
-        ///  - The dropdown's header does *not* have a relative x axis.
+        /// <list type="bullet">
+        /// <item>
+        /// <description>It is made to be anchored to the right-hand side of its parent.</description>
+        /// </item>
+        /// <item>
+        /// <description>The dropdown's header does *not* have a relative x axis.</description>
+        /// </item>
+        /// </list>
         /// </summary>
         protected abstract Dropdown<T> CreateDropdown();
 
         /// <summary>
-        /// Creates a tab item.
+        /// Creates a <see cref="TabItem{T}"/> for a given <typeparamref name="T"/> value.
         /// </summary>
         protected abstract TabItem<T> CreateTabItem(T value);
 
@@ -128,6 +147,9 @@ namespace osu.Framework.Graphics.UserInterface
 
         private bool firstSelection = true;
 
+        /// <summary>
+        /// Creates a new <see cref="TabControl{T}"/>.
+        /// </summary>
         protected TabControl()
         {
             Dropdown = CreateDropdown();
@@ -169,9 +191,9 @@ namespace osu.Framework.Graphics.UserInterface
             }
         }
 
-        // Default to first selection in list
         protected override void LoadComplete()
         {
+            // Default to first selection in list
             if (firstSelection && !Current.Disabled && Items.Any())
                 Current.Value = Items.First();
 
@@ -179,7 +201,7 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Pin an item to the start of the list.
+        /// Pins an item to the start of the <see cref="TabControl{T}"/>.
         /// </summary>
         /// <param name="item">The item to pin.</param>
         public void PinItem(T item)
@@ -191,7 +213,7 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Unpin an item and return it to the start of unpinned items.
+        /// Unpins an item and returns it to the start of unpinned items.
         /// </summary>
         /// <param name="item">The item to unpin.</param>
         public void UnpinItem(T item)
@@ -203,13 +225,13 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Add a new item to the control.
+        /// Adds a new item to the <see cref="TabControl{T}"/>.
         /// </summary>
         /// <param name="item">The item to add.</param>
         public void AddItem(T item) => addTab(item);
 
         /// <summary>
-        /// Removes an item from the control.
+        /// Removes an item from the <see cref="TabControl{T}"/>.
         /// </summary>
         /// <remarks>
         /// If the current tab is removed and <see cref="SwitchTabOnRemove"/> is <c>true</c>, then selection will change to a new tab if possible or be cleared if there are no tabs remaining in the <see cref="TabControl{T}"/>.
@@ -218,7 +240,7 @@ namespace osu.Framework.Graphics.UserInterface
         public void RemoveItem(T item) => removeTab(item);
 
         /// <summary>
-        /// Removes all items from the control.
+        /// Removes all items from the <see cref="TabControl{T}"/>.
         /// </summary>
         public void Clear() => Items = Array.Empty<T>();
 
@@ -243,10 +265,10 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Adds an arbitrary <see cref="TabItem{T}"/> to the control.
+        /// Adds an arbitrary <see cref="TabItem{T}"/> to the <see cref="TabControl{T}"/>.
         /// </summary>
         /// <param name="tab">The tab to add.</param>
-        /// <param name="addToDropdown">Whether the tab should be added to the Dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
+        /// <param name="addToDropdown">Whether the tab should be added to the dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
         protected virtual void AddTabItem(TabItem<T> tab, bool addToDropdown = true)
         {
             tab.PinnedChanged += performTabSort;
@@ -268,7 +290,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// If the current tab is removed and <see cref="SwitchTabOnRemove"/> is <c>true</c>, then selection will change to a new tab if possible or be cleared if there are no tabs remaining in the <see cref="TabControl{T}"/>.
         /// </remarks>
         /// <param name="tab">The tab to remove.</param>
-        /// <param name="removeFromDropdown">Whether the tab should be removed from the Dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
+        /// <param name="removeFromDropdown">Whether the tab should be removed from the dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
         protected virtual void RemoveTabItem(TabItem<T> tab, bool removeFromDropdown = true)
         {
             if (!tab.IsRemovable)
@@ -307,6 +329,10 @@ namespace osu.Framework.Graphics.UserInterface
                 Dropdown?.ShowItem(tab.Value);
         }
 
+        /// <summary>
+        /// Selects a <see cref="TabItem{T}"/>.
+        /// </summary>
+        /// <param name="tab">The tab to select.</param>
         protected virtual void SelectTab(TabItem<T> tab)
         {
             selectTab(tab);
@@ -395,6 +421,10 @@ namespace osu.Framework.Graphics.UserInterface
         {
         }
 
+        /// <summary>
+        /// Creates the <see cref="TabFillFlowContainer"/> to contain the <see cref="TabItem{T}"/>s.
+        /// </summary>
+        /// <returns></returns>
         protected virtual TabFillFlowContainer CreateTabFlow() => new TabFillFlowContainer
         {
             Direction = FillDirection.Full,

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -83,6 +83,22 @@ namespace osu.Framework.Graphics.UserInterface
         public bool IsSwitchable { get; set; }
 
         /// <summary>
+        /// Whether a new tab should be automatically switched to when the current tab is removed.
+        /// </summary>
+        /// <remarks>
+        /// When <c>true</c>:
+        /// <list type="bullet">
+        /// <item>
+        /// <description>If the current tab is not the only tab in the <see cref="TabControl{T}"/>, then the next or previous tab will be selected depending on the current tab's position.</description>
+        /// </item>
+        /// <item>
+        /// <description>If the current tab is the only tab in the <see cref="TabControl{T}"/>, then selection will be cleared.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        protected virtual bool SwitchTabOnRemove => true;
+
+        /// <summary>
         /// Creates an optional overflow dropdown.
         /// When implementing this dropdown make sure:
         ///  - It is made to be anchored to the right-hand side of its parent.
@@ -195,6 +211,9 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Removes an item from the control.
         /// </summary>
+        /// <remarks>
+        /// If the current tab is removed and <see cref="SwitchTabOnRemove"/> is <c>true</c>, then selection will change to a new tab if possible or be cleared if there are no tabs remaining in the <see cref="TabControl{T}"/>.
+        /// </remarks>
         /// <param name="item">The item to remove.</param>
         public void RemoveItem(T item) => removeTab(item);
 
@@ -246,14 +265,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// Removes a <see cref="TabItem{T}"/> from this <see cref="TabControl{T}"/>.
         /// </summary>
         /// <remarks>
-        /// <para>
-        /// If <paramref name="tab"/> is currently selected and is not the only tab in the <see cref="TabControl{T}"/>,
-        /// then selection will switch to the next or previous one depending on <paramref name="tab"/>'s position.
-        /// </para>
-        /// <para>
-        /// If <paramref name="tab"/> is currently selected and is the only tab in the <see cref="TabControl{T}"/>,
-        /// then selection will be cleared.
-        /// </para>
+        /// If the current tab is removed and <see cref="SwitchTabOnRemove"/> is <c>true</c>, then selection will change to a new tab if possible or be cleared if there are no tabs remaining in the <see cref="TabControl{T}"/>.
         /// </remarks>
         /// <param name="tab">The tab to remove.</param>
         /// <param name="removeFromDropdown">Whether the tab should be removed from the Dropdown if supported by the <see cref="TabControl{T}"/> implementation.</param>
@@ -262,7 +274,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (!tab.IsRemovable)
                 throw new InvalidOperationException($"Cannot remove non-removable tab {tab}. Ensure {nameof(TabItem.IsRemovable)} is set appropriately.");
 
-            if (tab == SelectedTab)
+            if (SwitchTabOnRemove && tab == SelectedTab)
             {
                 if (SwitchableTabs.Count() < 2)
                     SelectedTab = null;

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -109,7 +109,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// </item>
         /// </list>
         /// </remarks>
-        protected bool SwitchTabOnRemove { get; set; } = true;
+        public bool SwitchTabOnRemove { get; set; } = true;
 
         /// <summary>
         /// Creates an optional overflow dropdown.


### PR DESCRIPTION
In investigating https://github.com/ppy/osu/issues/9324 I initially took the path of making `Remove` return a `bool`. While that could still be done it isn't enough to resolve the issue, since the issue occurs _while_ we're in the removal process (i.e. `bindable callback -> remove -> switch -> bindable callback -> remove`), and would also require a schedule of the callback. I think that's pretty hacky.

So probably the easiest way to do this is just adding an option to disable this behaviour altogether for cases like `BreadcrumbControl` that are `TabControl`s only in appearance and don't need such functionality.

Have also used this opportunity to document the rest of the class, as one of the goals I'm hoping to achieve is documenting any classes I touch framework-side.