### PR TITLE
Add DrawablePool for avoiding allocation overhead of drawables

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -140,6 +140,24 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddUntilStep("drawable was disposed", () => drawable.IsDisposed);
         }
 
+        [Test]
+        public void TestAllDrawablesComeReady()
+        {
+            const int pool_size = 10;
+            List<Drawable> retrieved = new List<Drawable>();
+
+            resetWithNewPool(() => new TestPool(TimePerAction * 20, 10, pool_size));
+
+            AddStep("get many pooled drawables", () =>
+            {
+                retrieved.Clear();
+                for (int i = 0; i < pool_size * 2; i++)
+                    retrieved.Add(pool.Get());
+            });
+
+            AddAssert("all drawables in ready state", () => retrieved.All(d => d.LoadState == LoadState.Ready));
+        }
+
         [TestCase(10)]
         [TestCase(20)]
         public void TestPoolUsageExceedsMaximum(int maxPoolSize)

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -31,8 +31,6 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             for (int i = 0; i < 3; i++)
                 AddAssert("check drawable is in ready state", () => pool.Get().LoadState == LoadState.Ready);
-
-            AddAssert("check drawable is not in ready state", () => pool.Get().LoadState < LoadState.Ready);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -115,6 +115,19 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddUntilStep("free was run", () => drawable2.FreedCount == 2);
         }
 
+        [Test]
+        public void TestUsePoolableDrawableWithoutPool()
+        {
+            TestDrawable drawable = null;
+
+            AddStep("consume item", () => Add(drawable = new TestDrawable()));
+
+            AddAssert("prepare was run", () => drawable.PreparedCount == 1);
+            AddUntilStep("free was run", () => drawable.FreedCount == 1);
+
+            AddUntilStep("drawable was disposed", () => drawable.IsDisposed);
+        }
+
         [TestCase(10)]
         [TestCase(20)]
         public void TestPoolUsageExceedsMaximum(int maxPoolSize)

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -24,6 +24,18 @@ namespace osu.Framework.Tests.Visual.Drawables
         private readonly HashSet<TestDrawable> consumed = new HashSet<TestDrawable>();
 
         [Test]
+        public void TestPoolInitialDrawableLoadedAheadOfTime()
+        {
+            const int pool_size = 3;
+            resetWithNewPool(() => new TestPool(TimePerAction, pool_size));
+
+            for (int i = 0; i < 3; i++)
+                AddAssert("check drawable is in ready state", () => pool.Get().LoadState == LoadState.Ready);
+
+            AddAssert("check drawable is not in ready state", () => pool.Get().LoadState < LoadState.Ready);
+        }
+
+        [Test]
         public void TestPoolUsageWithinLimits()
         {
             const int pool_size = 10;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -1,0 +1,187 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Pooling;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using osu.Framework.Utils;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    public class TestSceneDrawablePool : TestScene
+    {
+        private DrawablePool<TestDrawable> pool;
+        private SpriteText count;
+
+        private readonly HashSet<TestDrawable> consumed = new HashSet<TestDrawable>();
+
+        [Test]
+        public void TestPoolUsageWithinLimits()
+        {
+            const int pool_size = 10;
+
+            resetWithNewPool(() => new TestPool(TimePerAction, pool_size));
+
+            AddRepeatStep("get new pooled drawable", consumeDrawable, 50);
+
+            AddUntilStep("all returned to pool", () => pool.CountAvailable == pool_size);
+
+            AddAssert("consumed drawables report returned to pool", () => consumed.All(d => d.IsInPool));
+            AddAssert("consumed drawables not disposed", () => consumed.All(d => !d.IsDisposed));
+
+            AddAssert("consumed less than pool size", () => consumed.Count < pool_size);
+        }
+
+        [Test]
+        public void TestPoolUsageExceedsLimits()
+        {
+            const int pool_size = 10;
+
+            resetWithNewPool(() => new TestPool(TimePerAction * 20, pool_size));
+
+            AddRepeatStep("get new pooled drawable", consumeDrawable, 50);
+
+            AddUntilStep("all returned to pool", () => pool.CountAvailable == consumed.Count);
+
+            AddAssert("pool grew in size", () => pool.CountAvailable > pool_size);
+
+            AddAssert("consumed drawables report returned to pool", () => consumed.All(d => d.IsInPool));
+            AddAssert("consumed drawables not disposed", () => consumed.All(d => !d.IsDisposed));
+        }
+
+        [TestCase(10)]
+        [TestCase(20)]
+        public void TestPoolInitialSize(int initialPoolSize)
+        {
+            resetWithNewPool(() => new TestPool(TimePerAction * 20, initialPoolSize));
+
+            AddUntilStep("available count is correct", () => pool.CountAvailable == initialPoolSize);
+        }
+
+        [TestCase(10)]
+        [TestCase(20)]
+        public void TestPoolUsageExceedsMaximum(int maxPoolSize)
+        {
+            resetWithNewPool(() => new TestPool(TimePerAction * 20, 10, maxPoolSize));
+
+            AddRepeatStep("get new pooled drawable", consumeDrawable, 50);
+
+            AddUntilStep("pool size hit maximum", () => pool.CountAvailable == maxPoolSize);
+            AddUntilStep("count in pool is correct", () => consumed.Count(d => d.IsInPool) == maxPoolSize);
+            AddAssert("non-returned drawables disposed", () => consumed.Where(d => !d.IsInPool).All(d => d.IsDisposed));
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            if (count != null)
+                count.Text = $"available: {pool.CountAvailable} consumed: {consumed.Count} disposed: {consumed.Count(d => d.IsDisposed)}";
+        }
+
+        private static int displayCount;
+
+        private void consumeDrawable()
+        {
+            var drawable = pool.Get();
+            consumed.Add(drawable);
+
+            drawable.RelativePositionAxes = Axes.Both;
+            drawable.Position = new Vector2(RNG.NextSingle(), RNG.NextSingle());
+            drawable.DisplayString = (++displayCount).ToString();
+
+            Add(drawable);
+        }
+
+        private void resetWithNewPool(Func<DrawablePool<TestDrawable>> createPool)
+        {
+            AddStep("reset stats", () => consumed.Clear());
+
+            AddStep("create pool", () =>
+            {
+                pool = createPool();
+
+                Children = new Drawable[]
+
+                {
+                    pool,
+                    count = new SpriteText(),
+                };
+            });
+        }
+
+        private class TestPool : DrawablePool<TestDrawable>
+        {
+            private readonly double fadeTime;
+
+            public TestPool(double fadeTime, int initialSize, int? maximumSize = null)
+                : base(initialSize, maximumSize)
+            {
+                this.fadeTime = fadeTime;
+            }
+
+            protected override TestDrawable CreateNewDrawable()
+            {
+                return new TestDrawable(fadeTime);
+            }
+        }
+
+        private class TestDrawable : PoolableDrawable
+        {
+            private readonly double fadeTime;
+
+            private readonly SpriteText text;
+
+            public string DisplayString
+            {
+                set => text.Text = value;
+            }
+
+            public TestDrawable()
+                : this(1000)
+            {
+            }
+
+            public TestDrawable(double fadeTime)
+            {
+                this.fadeTime = fadeTime;
+
+                Size = new Vector2(50);
+                Origin = Anchor.Centre;
+
+                InternalChildren = new Drawable[]
+                {
+                    new Box
+                    {
+                        Colour = Color4.Green,
+                        RelativeSizeAxes = Axes.Both,
+                    },
+                    text = new SpriteText
+                    {
+                        Text = "-",
+                        Font = FontUsage.Default.With(size: 40),
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre,
+                    },
+                };
+            }
+
+            public new bool IsDisposed => base.IsDisposed;
+
+            protected override void PrepareForUse()
+            {
+                this.FadeOutFromOne(fadeTime);
+                this.RotateTo(0).RotateTo(80, fadeTime);
+
+                Expire();
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -146,10 +146,17 @@ namespace osu.Framework.Tests.Visual.Drawables
         {
             resetWithNewPool(() => new TestPool(TimePerAction * 20, 10, maxPoolSize));
 
-            AddRepeatStep("get new pooled drawable", () => consumeDrawable(), 50);
+            AddStep("get many pooled drawables", () =>
+            {
+                for (int i = 0; i < maxPoolSize * 2; i++)
+                    consumeDrawable();
+            });
 
-            AddUntilStep("pool size hit maximum", () => pool.CountAvailable == maxPoolSize);
+            AddAssert("pool saturated", () => pool.CountAvailable == 0);
+
+            AddUntilStep("pool size returned to correct maximum", () => pool.CountAvailable == maxPoolSize);
             AddUntilStep("count in pool is correct", () => consumed.Count(d => d.IsInPool) == maxPoolSize);
+            AddAssert("excess drawables were used", () => consumed.Any(d => !d.IsInPool));
             AddAssert("non-returned drawables disposed", () => consumed.Where(d => !d.IsInPool).All(d => d.IsDisposed));
         }
 

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -70,7 +70,10 @@ namespace osu.Framework.Graphics.Pooling
         public T Get(Action<T> setupAction = null)
         {
             if (!pool.TryPop(out var drawable))
+            {
                 drawable = create();
+                LoadComponent(drawable);
+            }
 
             setupAction?.Invoke(drawable);
             drawable.Assign();

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -70,9 +70,9 @@ namespace osu.Framework.Graphics.Pooling
         }
 
         /// <summary>
-        /// Get a drawable
+        /// Get a drawable from this pool.
         /// </summary>
-        /// <param name="setupAction"></param>
+        /// <param name="setupAction">An optional action to be performed on this drawable immediately after retrieval. Should generally be used to prepare the drawable into a usable state.</param>
         /// <returns></returns>
         public T Get(Action<T> setupAction = null)
         {

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -58,6 +58,9 @@ namespace osu.Framework.Graphics.Pooling
             if (!(pooledDrawable is T))
                 throw new ArgumentException("Invalid type", nameof(pooledDrawable));
 
+            if (Parent != null)
+                throw new InvalidOperationException("Drawable was attempted to be returned to pool while still in a hierarchy");
+
             if (pooledDrawable.IsInUse)
             {
                 // if the return operation didn't come from the drawable, redirect to ensure consistent behaviour.

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -1,0 +1,99 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Allocation;
+
+namespace osu.Framework.Graphics.Pooling
+{
+    /// <summary>
+    /// A component which provides a pool of reusable drawables.
+    /// Should be used to reduce allocation and construction overhead of individual drawables.
+    /// </summary>
+    /// <typeparam name="T">The type of drawable to be pooled.</typeparam>
+    public class DrawablePool<T> : Component, IDrawablePool where T : PoolableDrawable, new()
+    {
+        private readonly int initialSize;
+        private readonly int? maximumSize;
+
+        /// <summary>
+        /// The number of drawables currently available for consumption.
+        /// </summary>
+        public int CountAvailable => pool.Count;
+
+        private readonly Stack<T> pool = new Stack<T>();
+
+        /// <summary>
+        /// create a new pool instance.
+        /// </summary>
+        /// <param name="initialSize">The number of drawables to be prepared for initial consumption.</param>
+        /// <param name="maximumSize">An optional maximum size after which the pool will no longer be expanded.</param>
+        public DrawablePool(int initialSize, int? maximumSize = null)
+        {
+            this.maximumSize = maximumSize;
+            this.initialSize = initialSize;
+        }
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            for (int i = 0; i < initialSize; i++)
+                push(create());
+        }
+
+        /// <summary>
+        /// Return a drawable after use.
+        /// </summary>
+        /// <param name="pooledDrawable">The drawable to return. Should have originally come from this pool.</param>
+        public void Return(Drawable pooledDrawable)
+        {
+            if (!(pooledDrawable is T))
+                throw new ArgumentException("Invalid type", nameof(pooledDrawable));
+
+            //TODO: check the drawable was sourced from this pool for safety.
+            push((T)pooledDrawable);
+        }
+
+        /// <summary>
+        /// Get a drawable
+        /// </summary>
+        /// <param name="setupAction"></param>
+        /// <returns></returns>
+        public T Get(Action<T> setupAction = null)
+        {
+            if (!pool.TryPop(out var drawable))
+                drawable = create();
+
+            setupAction?.Invoke(drawable);
+            drawable.Assign();
+
+            return drawable;
+        }
+
+        /// <summary>
+        /// Create a new drawable to be consumed or added to the pool.
+        /// </summary>
+        protected virtual T CreateNewDrawable() => new T();
+
+        private T create()
+        {
+            var drawable = CreateNewDrawable();
+            drawable.SetPool(this);
+            return drawable;
+        }
+
+        private bool push(T poolableDrawable)
+        {
+            if (CountAvailable >= maximumSize)
+            {
+                // if the drawable can't be returned to the pool, mark it as such so it can be disposed of.
+                poolableDrawable.SetPool(null);
+                return false;
+            }
+
+            pool.Push(poolableDrawable);
+            return true;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -107,6 +107,11 @@ namespace osu.Framework.Graphics.Pooling
             {
                 // if the drawable can't be returned to the pool, mark it as such so it can be disposed of.
                 poolableDrawable.SetPool(null);
+
+                // then attempt disposal.
+                if (poolableDrawable.DisposeOnDeathRemoval)
+                    DisposeChildAsync(poolableDrawable);
+
                 return false;
             }
 

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Graphics.Pooling
                 // if the return operation didn't come from the drawable, redirect to ensure consistent behaviour.
                 pooledDrawable.Return();
                 return;
-            };
+            }
 
             //TODO: check the drawable was sourced from this pool for safety.
             push((T)pooledDrawable);

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Graphics.Pooling
 {
@@ -11,8 +12,12 @@ namespace osu.Framework.Graphics.Pooling
     /// A component which provides a pool of reusable drawables.
     /// Should be used to reduce allocation and construction overhead of individual drawables.
     /// </summary>
+    /// <remarks>
+    /// The <see cref="initialSize"/> drawables will be prepared ahead-of-time during this pool's asynchronous load procedure.
+    /// Drawables exceeding the pool's available size will not be asynchronously loaded as it is assumed they are immediately required for consumption.
+    /// </remarks>
     /// <typeparam name="T">The type of drawable to be pooled.</typeparam>
-    public class DrawablePool<T> : Component, IDrawablePool where T : PoolableDrawable, new()
+    public class DrawablePool<T> : CompositeDrawable, IDrawablePool where T : PoolableDrawable, new()
     {
         private readonly int initialSize;
         private readonly int? maximumSize;
@@ -40,6 +45,8 @@ namespace osu.Framework.Graphics.Pooling
         {
             for (int i = 0; i < initialSize; i++)
                 push(create());
+
+            LoadComponents(pool.ToArray());
         }
 
         /// <summary>
@@ -80,6 +87,7 @@ namespace osu.Framework.Graphics.Pooling
         {
             var drawable = CreateNewDrawable();
             drawable.SetPool(this);
+
             return drawable;
         }
 

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -53,10 +53,17 @@ namespace osu.Framework.Graphics.Pooling
         /// Return a drawable after use.
         /// </summary>
         /// <param name="pooledDrawable">The drawable to return. Should have originally come from this pool.</param>
-        public void Return(Drawable pooledDrawable)
+        public void Return(PoolableDrawable pooledDrawable)
         {
             if (!(pooledDrawable is T))
                 throw new ArgumentException("Invalid type", nameof(pooledDrawable));
+
+            if (pooledDrawable.IsInUse)
+            {
+                // if the return operation didn't come from the drawable, redirect to ensure consistent behaviour.
+                pooledDrawable.Return();
+                return;
+            };
 
             //TODO: check the drawable was sourced from this pool for safety.
             push((T)pooledDrawable);

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Graphics.Pooling
         private readonly Stack<T> pool = new Stack<T>();
 
         /// <summary>
-        /// create a new pool instance.
+        /// Create a new pool instance.
         /// </summary>
         /// <param name="initialSize">The number of drawables to be prepared for initial consumption.</param>
         /// <param name="maximumSize">An optional maximum size after which the pool will no longer be expanded.</param>
@@ -76,7 +76,7 @@ namespace osu.Framework.Graphics.Pooling
         /// Get a drawable from this pool.
         /// </summary>
         /// <param name="setupAction">An optional action to be performed on this drawable immediately after retrieval. Should generally be used to prepare the drawable into a usable state.</param>
-        /// <returns></returns>
+        /// <returns>The drawable.</returns>
         public T Get(Action<T> setupAction = null)
         {
             if (!pool.TryPop(out var drawable))

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.Graphics.Pooling
             if (!(pooledDrawable is T))
                 throw new ArgumentException("Invalid type", nameof(pooledDrawable));
 
-            if (Parent != null)
+            if (pooledDrawable.Parent != null)
                 throw new InvalidOperationException("Drawable was attempted to be returned to pool while still in a hierarchy");
 
             if (pooledDrawable.IsInUse)

--- a/osu.Framework/Graphics/Pooling/IDrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/IDrawablePool.cs
@@ -9,6 +9,6 @@ namespace osu.Framework.Graphics.Pooling
         /// Return a drawable after use.
         /// </summary>
         /// <param name="pooledDrawable">The drwable to return. Should have originally come from this pool.</param>
-        void Return(Drawable pooledDrawable);
+        void Return(PoolableDrawable pooledDrawable);
     }
 }

--- a/osu.Framework/Graphics/Pooling/IDrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/IDrawablePool.cs
@@ -1,0 +1,14 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Pooling
+{
+    public interface IDrawablePool
+    {
+        /// <summary>
+        /// Return a drawable after use.
+        /// </summary>
+        /// <param name="pooledDrawable">The drwable to return. Should have originally come from this pool.</param>
+        void Return(Drawable pooledDrawable);
+    }
+}

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -31,11 +31,6 @@ namespace osu.Framework.Graphics.Pooling
 
         public override bool IsPresent => waitingForPrepare || base.IsPresent;
 
-        public void SetPool(IDrawablePool pool)
-        {
-            this.pool = pool;
-        }
-
         /// <summary>
         /// Perform any initialisation on new usage of this drawable.
         /// </summary>
@@ -48,6 +43,22 @@ namespace osu.Framework.Graphics.Pooling
         /// </summary>
         protected virtual void FreeAfterUse()
         {
+        }
+
+        /// <summary>
+        /// Set the associated pool this drawable is currently associated with.
+        /// </summary>
+        /// <param name="pool">The target pool, or null to disassociate from all pools (and cause the drawable to be disposed as if it was not pooled). </param>
+        /// <exception cref="InvalidOperationException">Thrown if this drawable is still in use, or is already in another pool.</exception>
+        internal void SetPool(IDrawablePool pool)
+        {
+            if (IsInUse)
+                throw new InvalidOperationException($"This {nameof(PoolableDrawable)} is already in use");
+
+            if (pool != null && this.pool != null)
+                throw new InvalidOperationException($"This {nameof(PoolableDrawable)} is already in a pool");
+
+            this.pool = pool;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Graphics.Pooling
         private IDrawablePool pool;
 
         /// <summary>
-        /// A flag to keep the drawable present to guarantee <see cref="prepare"/> can be performed as a scheduled call.
+        /// A flag to keep the drawable present to guarantee the prepare call can be performed as a scheduled call.
         /// </summary>
         private bool waitingForPrepare;
 

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -24,6 +24,11 @@ namespace osu.Framework.Graphics.Pooling
 
         private IDrawablePool pool;
 
+        private bool waitingForPrepare;
+
+        // ensure we are able to schedule the prepare call even if not visible.
+        public override bool IsPresent => waitingForPrepare || base.IsPresent;
+
         public void SetPool(IDrawablePool pool)
         {
             this.pool = pool;
@@ -40,7 +45,14 @@ namespace osu.Framework.Graphics.Pooling
             LifetimeStart = double.MinValue;
             LifetimeEnd = double.MaxValue;
 
-            Schedule(PrepareForUse);
+            waitingForPrepare = true;
+            Schedule(prepare);
+        }
+
+        private void prepare()
+        {
+            waitingForPrepare = false;
+            PrepareForUse();
         }
 
         /// <summary>
@@ -66,6 +78,7 @@ namespace osu.Framework.Graphics.Pooling
                     FreeAfterUse();
                     pool?.Return(this);
                     IsInUse = false;
+                    waitingForPrepare = false;
                 }
             }
 

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Diagnostics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
@@ -28,20 +29,18 @@ namespace osu.Framework.Graphics.Pooling
             this.pool = pool;
         }
 
-        public void Assign()
+        internal void Assign()
         {
-            Debug.Assert(pool != null);
-            Debug.Assert(!IsInUse);
+            if (IsInUse)
+                throw new InvalidOperationException($"This {nameof(PoolableDrawable)} is already in use");
 
+            Debug.Assert(pool != null);
             IsInUse = true;
 
             LifetimeStart = double.MinValue;
             LifetimeEnd = double.MaxValue;
 
-            if (IsLoaded)
-                PrepareForUse();
-            else
-                Schedule(PrepareForUse);
+            Schedule(PrepareForUse);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Diagnostics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
 
@@ -53,7 +52,7 @@ namespace osu.Framework.Graphics.Pooling
         internal void SetPool(IDrawablePool pool)
         {
             if (IsInUse)
-                throw new InvalidOperationException($"This {nameof(PoolableDrawable)} is already in use");
+                throw new InvalidOperationException($"This {nameof(PoolableDrawable)} is still in use");
 
             if (pool != null && this.pool != null)
                 throw new InvalidOperationException($"This {nameof(PoolableDrawable)} is already in a pool");
@@ -93,9 +92,10 @@ namespace osu.Framework.Graphics.Pooling
             {
                 if (IsInUse && Parent == null)
                 {
+                    IsInUse = false;
+
                     FreeAfterUse();
                     pool?.Return(this);
-                    IsInUse = false;
                     waitingForPrepare = false;
                 }
             }

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -110,8 +110,8 @@ namespace osu.Framework.Graphics.Pooling
 
         private void prepare()
         {
-            waitingForPrepare = false;
             PrepareForUse();
+            waitingForPrepare = false;
         }
 
         protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -1,0 +1,76 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Layout;
+
+namespace osu.Framework.Graphics.Pooling
+{
+    public class PoolableDrawable : CompositeDrawable
+    {
+        public override bool DisposeOnDeathRemoval => pool == null;
+
+        /// <summary>
+        /// Whether this pooled drawable is currently in use.
+        /// </summary>
+        public bool IsInUse { get; private set; }
+
+        /// <summary>
+        /// Whether this drawable is currently managed by a pool.
+        /// </summary>
+        public bool IsInPool => pool != null;
+
+        private IDrawablePool pool;
+
+        public void SetPool(IDrawablePool pool)
+        {
+            this.pool = pool;
+        }
+
+        public void Assign()
+        {
+            Debug.Assert(pool != null);
+            Debug.Assert(!IsInUse);
+
+            IsInUse = true;
+
+            LifetimeStart = double.MinValue;
+            LifetimeEnd = double.MaxValue;
+
+            if (IsLoaded)
+                PrepareForUse();
+            else
+                Schedule(PrepareForUse);
+        }
+
+        /// <summary>
+        /// Perform any initialisation on new usage of this drawable.
+        /// </summary>
+        protected virtual void PrepareForUse()
+        {
+        }
+
+        /// <summary>
+        /// Perform any clean-up required before returning this drawable to a pool.
+        /// </summary>
+        protected virtual void FreeAfterUse()
+        {
+        }
+
+        protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
+        {
+            if (invalidation.HasFlag(Invalidation.Parent))
+            {
+                if (IsInUse && Parent == null)
+                {
+                    FreeAfterUse();
+                    pool?.Return(this);
+                    IsInUse = false;
+                }
+            }
+
+            return base.OnInvalidate(invalidation, source);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -62,18 +62,13 @@ namespace osu.Framework.Graphics.Pooling
         }
 
         /// <summary>
-        /// Assign this drawable to a <see cref="IDrawablePool"/>.
+        /// Assign this drawable to a consumer.
         /// </summary>
-        /// <exception cref="InvalidOperationException">Thrown if this drawable is still in use, or is already in another pool.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if this drawable is still in use.</exception>
         internal void Assign()
         {
             if (IsInUse)
                 throw new InvalidOperationException($"This {nameof(PoolableDrawable)} is already in use");
-
-            if (pool != null)
-                throw new InvalidOperationException($"This {nameof(PoolableDrawable)} is already in a pool");
-
-            Debug.Assert(pool != null);
 
             IsInUse = true;
 

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Graphics.Pooling
 {
     public class PoolableDrawable : CompositeDrawable
     {
-        public override bool DisposeOnDeathRemoval => pool == null;
+        public override bool DisposeOnDeathRemoval => pool == null && base.DisposeOnDeathRemoval;
 
         /// <summary>
         /// Whether this pooled drawable is currently in use.

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -30,6 +30,15 @@ namespace osu.Framework.Graphics.Pooling
 
         public override bool IsPresent => waitingForPrepare || base.IsPresent;
 
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            // this allows a PooledDrawable to still function outside of a pool.
+            if (!IsInPool)
+                Assign();
+        }
+
         /// <summary>
         /// Return this drawable to its pool manually. Note that this is not required if the drawable is using lifetime cleanup.
         /// </summary>

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -104,7 +104,8 @@ namespace osu.Framework.Graphics.Pooling
             waitingForPrepare = true;
 
             // prepare call is scheduled as it may contain user code dependent on the clock being updated.
-            Schedule(prepare);
+            // must use Scheduler.Add, not Schedule as we may have the wrong clock at this point in load.
+            Scheduler.Add(prepare);
         }
 
         private void prepare()

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -105,13 +105,11 @@ namespace osu.Framework.Graphics.Pooling
 
             // prepare call is scheduled as it may contain user code dependent on the clock being updated.
             // must use Scheduler.Add, not Schedule as we may have the wrong clock at this point in load.
-            Scheduler.Add(prepare);
-        }
-
-        private void prepare()
-        {
-            PrepareForUse();
-            waitingForPrepare = false;
+            Scheduler.Add(() =>
+            {
+                PrepareForUse();
+                waitingForPrepare = false;
+            });
         }
 
         protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)


### PR DESCRIPTION
Proof of concept for early comment. Not ready for merge pending confirmation that it covers intended use cases osu!-side.

- `PoolableDrawable` or `PooledDrawable`? I went for the first since I've allowed them to be used outside of a pool context for flexibility.
- There may come a time we need to move the `PoolableDrawable` implementation to an interface (potential multiple inheritance woes?) but I didn't do this for the time being because it's a relatively lightweight base class and can be slotted in beneath `DrawableJudgement` and `SkinReloadableDrawable` (for the `DrawableHitObject` case).
- `DrawablePool` may eventually need to take a `LoadTarget` to specify the container used for BDL loading. For now it just loads using its parent.