### PR TITLE
Map mouse input to new / moved touches instead of only first

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
@@ -231,7 +231,7 @@ namespace osu.Framework.Tests.Visual.Input
                     if (mouseMove.ScreenSpaceMousePosition != getTouchDownPos(r.AssociatedSource))
                         return false;
 
-                    // Dequeue the false drag from first receptor to ensure there isn't any unexpected hidden event in this receptor.
+                    // Dequeue the "false drag" from first receptor to ensure there isn't any unexpected hidden event in this receptor.
                     if (!(firstReceptor.MouseEvents.TryDequeue(out MouseEvent me2) && me2 is DragEvent tmpMouseDrag))
                         return false;
 
@@ -239,9 +239,6 @@ namespace osu.Framework.Tests.Visual.Input
                         tmpMouseDrag.ScreenSpaceMousePosition != getTouchDownPos(r.AssociatedSource) ||
                         tmpMouseDrag.ScreenSpaceLastMousePosition != getTouchDownPos(r.AssociatedSource - 1) ||
                         tmpMouseDrag.ScreenSpaceMouseDownPosition != getTouchDownPos(firstReceptor.AssociatedSource))
-                        return false;
-
-                    if (firstReceptor.MouseEvents.Count > 0)
                         return false;
 
                     return r.MouseEvents.Count == 0;
@@ -254,9 +251,8 @@ namespace osu.Framework.Tests.Visual.Input
                     InputManager.MoveTouchTo(new Touch(s, getTouchMovePos(s)));
             });
 
-            AddAssert("received correct movement event on latest", () =>
+            AddAssert("received regular mouse-move event", () =>
             {
-                // mouse-move event fires regardless of whether it is dragging, dequeue it first.
                 if (!(lastReceptor.MouseEvents.TryDequeue(out MouseEvent me1) && me1 is MouseMoveEvent mouseMove))
                     return false;
 
@@ -264,17 +260,7 @@ namespace osu.Framework.Tests.Visual.Input
                     mouseMove.ScreenSpaceLastMousePosition != getTouchDownPos(lastReceptor.AssociatedSource))
                     return false;
 
-                // Can be uncommented back when the wrong-down-queue issue is fixed, no drag to latest because mouse is still dragging from first.
-                //if (!(lastReceptor.MouseEvents.TryDequeue(out MouseEvent me2) && me2 is DragEvent mouseDrag))
-                //    return false;
-
-                //if (mouseDrag.Button != MouseButton.Left ||
-                //    mouseDrag.ScreenSpaceMousePosition != getTouchMovePos(lastReceptor.AssociatedSource) ||
-                //    mouseDrag.ScreenSpaceLastMousePosition != getTouchDownPos(lastReceptor.AssociatedSource) ||
-                //    mouseDrag.ScreenSpaceMouseDownPosition != getTouchDownPos(lastReceptor.AssociatedSource))
-                //    return false;
-
-                // Still dequeue the "false drag" from first receptor to ensure there isn't any unexpected hidden event in this receptor.
+                // Dequeue the "false drag" from first receptor to ensure there isn't any unexpected hidden event in this receptor.
                 if (!(firstReceptor.MouseEvents.TryDequeue(out MouseEvent me2) && me2 is DragEvent tmpMouseDrag))
                     return false;
 
@@ -293,21 +279,10 @@ namespace osu.Framework.Tests.Visual.Input
                     InputManager.MoveTouchTo(new Touch(s, getTouchUpPos(s)));
             });
 
-            AddAssert("received correct movement event on latest", () =>
+            // No mouse-move event here since the touch has moved outside of its receptor area.
+            AddAssert("no mouse-move event received", () =>
             {
-                // No mouse move event here since the touch has moved outside of its receptor area. (only drag will received)
-
-                // Can be uncommented back when the wrong-down-queue issue is fixed, no drag to latest because mouse is still dragging from first.
-                //if (!(lastReceptor.MouseEvents.TryDequeue(out MouseEvent me) && me is DragEvent mouseDrag))
-                //    return false;
-
-                //if (mouseDrag.Button != MouseButton.Left ||
-                //    mouseDrag.ScreenSpaceMousePosition != getTouchUpPos(lastReceptor.AssociatedSource) ||
-                //    mouseDrag.ScreenSpaceLastMousePosition != getTouchMovePos(lastReceptor.AssociatedSource) ||
-                //    mouseDrag.ScreenSpaceMouseDownPosition != getTouchDownPos(lastReceptor.AssociatedSource))
-                //    return false;
-
-                // Still dequeue the "wrong drag" from first receptor to ensure there isn't any unexpected hidden event in this receptor.
+                // Dequeue the "false drag" from first receptor to ensure there isn't any unexpected hidden event in this receptor.
                 if (!(firstReceptor.MouseEvents.TryDequeue(out MouseEvent me) && me is DragEvent tmpMouseDrag))
                     return false;
 
@@ -326,24 +301,14 @@ namespace osu.Framework.Tests.Visual.Input
                     InputManager.EndTouch(new Touch(s, getTouchUpPos(s)));
             });
 
-            AddAssert("received correct up event on latest", () =>
+            AddAssert("received regular mouse-up event on first", () =>
             {
-                // Can be uncommented back when the wrong-down-queue issue is fixed, latest doesn't receive up because mouse thinks we're just dragging from first receptor to last.
-                //if (!(lastReceptor.MouseEvents.TryDequeue(out MouseEvent me) && me is MouseUpEvent mouseUp))
-                //    return false;
-
-                //if (mouseUp.Button != MouseButton.Left ||
-                //    mouseUp.ScreenSpaceMousePosition != getTouchUpPos(lastReceptor.AssociatedSource) ||
-                //    mouseUp.ScreenSpaceMouseDownPosition != getTouchDownPos(lastReceptor.AssociatedSource))
-                //    return false;
-
-                // Still dequeue the "wrong up" from first receptor to ensure there isn't any unexpected hidden event in this receptor.
-                if (!(firstReceptor.MouseEvents.TryDequeue(out MouseEvent me) && me is MouseUpEvent tmpMouseUp))
+                if (!(firstReceptor.MouseEvents.TryDequeue(out MouseEvent me) && me is MouseUpEvent mouseUp))
                     return false;
 
-                if (tmpMouseUp.Button != MouseButton.Left ||
-                    tmpMouseUp.ScreenSpaceMousePosition != getTouchUpPos(lastReceptor.AssociatedSource) ||
-                    tmpMouseUp.ScreenSpaceMouseDownPosition != getTouchDownPos(firstReceptor.AssociatedSource))
+                if (mouseUp.Button != MouseButton.Left ||
+                    mouseUp.ScreenSpaceMousePosition != getTouchUpPos(lastReceptor.AssociatedSource) ||
+                    mouseUp.ScreenSpaceMouseDownPosition != getTouchDownPos(firstReceptor.AssociatedSource))
                     return false;
 
                 return lastReceptor.MouseEvents.Count == 0;

--- a/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
@@ -195,7 +195,7 @@ namespace osu.Framework.Tests.Visual.Input
                 InputManager.BeginTouch(new Touch(firstReceptor.AssociatedSource, getTouchDownPos(firstReceptor.AssociatedSource)));
             });
 
-            AddAssert("received correct down event on first", () =>
+            AddAssert("received mouse-down event on first", () =>
             {
                 // event #1: move mouse to first touch position.
                 if (!(firstReceptor.MouseEvents.TryDequeue(out MouseEvent me1) && me1 is MouseMoveEvent mouseMove))

--- a/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneTouchInput.cs
@@ -295,7 +295,7 @@ namespace osu.Framework.Tests.Visual.Input
                         return false;
 
                     if (mouseMove.ScreenSpaceMousePosition != touch.Position ||
-                        lastPosition != null && mouseMove.ScreenSpaceLastMousePosition != lastPosition.Value)
+                        (lastPosition != null && mouseMove.ScreenSpaceLastMousePosition != lastPosition.Value))
                         return false;
                 }
 
@@ -305,7 +305,7 @@ namespace osu.Framework.Tests.Visual.Input
 
                 if (mouseDrag.Button != MouseButton.Left ||
                     mouseDrag.ScreenSpaceMousePosition != touch.Position ||
-                    lastPosition != null && mouseDrag.ScreenSpaceLastMousePosition != lastPosition.Value ||
+                    (lastPosition != null && mouseDrag.ScreenSpaceLastMousePosition != lastPosition.Value) ||
                     mouseDrag.ScreenSpaceMouseDownPosition != getTouchDownPos(firstReceptor.AssociatedSource))
                     return false;
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -570,9 +570,9 @@ namespace osu.Framework.Input
         }
 
         /// <summary>
-        /// Handles primary touch state change event to produce mouse input from.
+        /// Handles latest activated touch state change event to produce mouse input from.
         /// </summary>
-        /// <param name="e">The primary touch state change event.</param>
+        /// <param name="e">The latest activated touch state change event.</param>
         /// <returns>Whether mouse input has been performed accordingly.</returns>
         protected virtual bool HandleMouseTouchStateChange(TouchStateChangeEvent e)
         {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -579,7 +579,9 @@ namespace osu.Framework.Input
             if (!MapMouseToLatestTouch)
                 return false;
 
-            new MousePositionAbsoluteInput { Position = e.Touch.Position }.Apply(CurrentState, this);
+            if (e.IsActive == true || e.LastPosition != null)
+                new MousePositionAbsoluteInput { Position = e.Touch.Position }.Apply(CurrentState, this);
+
             new MouseButtonInput(MouseButton.Left, e.State.Touch.ActiveSources.HasAnyButtonPressed).Apply(CurrentState, this);
             return true;
         }
@@ -612,10 +614,7 @@ namespace osu.Framework.Input
 
                 case TouchStateChangeEvent touchChange:
                     HandleTouchStateChange(touchChange);
-
-                    if (touchChange.IsLatestTouch)
-                        HandleMouseTouchStateChange(touchChange);
-
+                    HandleMouseTouchStateChange(touchChange);
                     return;
 
                 case ButtonStateChangeEvent<JoystickButton> joystickButtonStateChange:

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -129,9 +129,9 @@ namespace osu.Framework.Input
         private readonly Dictionary<JoystickAxisSource, JoystickAxisEventManager> joystickAxisEventManagers = new Dictionary<JoystickAxisSource, JoystickAxisEventManager>();
 
         /// <summary>
-        /// Whether to produce mouse input on any primary touch input.
+        /// Whether to produce mouse input on any touch input from latest source.
         /// </summary>
-        protected virtual bool MapMouseToPrimaryTouch => true;
+        protected virtual bool MapMouseToLatestTouch => true;
 
         protected InputManager()
         {
@@ -576,11 +576,11 @@ namespace osu.Framework.Input
         /// <returns>Whether mouse input has been performed accordingly.</returns>
         protected virtual bool HandleMouseTouchStateChange(TouchStateChangeEvent e)
         {
-            if (!MapMouseToPrimaryTouch)
+            if (!MapMouseToLatestTouch)
                 return false;
 
             new MousePositionAbsoluteInput { Position = e.Touch.Position }.Apply(CurrentState, this);
-            new MouseButtonInput(MouseButton.Left, e.State.Touch.IsActive(e.Touch.Source)).Apply(CurrentState, this);
+            new MouseButtonInput(MouseButton.Left, e.State.Touch.ActiveSources.HasAnyButtonPressed).Apply(CurrentState, this);
             return true;
         }
 
@@ -613,7 +613,7 @@ namespace osu.Framework.Input
                 case TouchStateChangeEvent touchChange:
                     HandleTouchStateChange(touchChange);
 
-                    if (touchChange.Touch.Source == TouchSource.Touch1)
+                    if (touchChange.IsLatestTouch)
                         HandleMouseTouchStateChange(touchChange);
 
                     return;

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Input
 
         protected override bool HandleMouseTouchStateChange(TouchStateChangeEvent e)
         {
-            // The parent manager will propagate mouse events from primary touch input if we are using it.
+            // The parent manager will propagate mouse events from latest activated touch input if we are using it.
             if (UseParentInput)
                 return false;
 

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -80,7 +80,7 @@ namespace osu.Framework.Input
 
         protected override bool HandleMouseTouchStateChange(TouchStateChangeEvent e)
         {
-            // The parent manager will propagate mouse events from latest activated touch input if we are using it.
+            // The parent manager will propagate mouse events from latest moved touch input if we are using it.
             if (UseParentInput)
                 return false;
 

--- a/osu.Framework/Input/StateChanges/Events/TouchStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/TouchStateChangeEvent.cs
@@ -14,11 +14,6 @@ namespace osu.Framework.Input.StateChanges.Events
         public readonly Touch Touch;
 
         /// <summary>
-        /// Whether the source of this touch is the latest activated touch.
-        /// </summary>
-        public readonly bool IsLatestTouch;
-
-        /// <summary>
         /// Whether the <see cref="Touch"/> became active, or null if no activity change occurred.
         /// </summary>
         public readonly bool? IsActive;
@@ -28,11 +23,10 @@ namespace osu.Framework.Input.StateChanges.Events
         /// </summary>
         public readonly Vector2? LastPosition;
 
-        public TouchStateChangeEvent(InputState state, IInput input, Touch touch, bool isLatestTouch, bool? active, Vector2? lastPosition)
+        public TouchStateChangeEvent(InputState state, IInput input, Touch touch, bool? active, Vector2? lastPosition)
             : base(state, input)
         {
             Touch = touch;
-            IsLatestTouch = isLatestTouch;
 
             IsActive = active;
             LastPosition = lastPosition;

--- a/osu.Framework/Input/StateChanges/Events/TouchStateChangeEvent.cs
+++ b/osu.Framework/Input/StateChanges/Events/TouchStateChangeEvent.cs
@@ -14,6 +14,11 @@ namespace osu.Framework.Input.StateChanges.Events
         public readonly Touch Touch;
 
         /// <summary>
+        /// Whether the source of this touch is the latest activated touch.
+        /// </summary>
+        public readonly bool IsLatestTouch;
+
+        /// <summary>
         /// Whether the <see cref="Touch"/> became active, or null if no activity change occurred.
         /// </summary>
         public readonly bool? IsActive;
@@ -23,10 +28,12 @@ namespace osu.Framework.Input.StateChanges.Events
         /// </summary>
         public readonly Vector2? LastPosition;
 
-        public TouchStateChangeEvent(InputState state, IInput input, Touch touch, bool? active, Vector2? lastPosition)
+        public TouchStateChangeEvent(InputState state, IInput input, Touch touch, bool isLatestTouch, bool? active, Vector2? lastPosition)
             : base(state, input)
         {
             Touch = touch;
+            IsLatestTouch = isLatestTouch;
+
             IsActive = active;
             LastPosition = lastPosition;
         }

--- a/osu.Framework/Input/StateChanges/TouchInput.cs
+++ b/osu.Framework/Input/StateChanges/TouchInput.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
@@ -48,12 +47,9 @@ namespace osu.Framework.Input.StateChanges
         public void Apply(InputState state, IInputStateChangeHandler handler)
         {
             var touches = state.Touch;
-            var activityState = touches.ActiveSources;
 
             foreach (var touch in Touches)
             {
-                bool isLatestTouch = !activityState.IsPressed(touch.Source) || (activityState.Any() && touch.Source == activityState.Last());
-
                 var lastPosition = touches.GetTouchPosition(touch.Source);
                 touches.TouchPositions[(int)touch.Source] = touch.Position;
 
@@ -62,7 +58,7 @@ namespace osu.Framework.Input.StateChanges
 
                 if (activityChanged || positionChanged)
                 {
-                    handler.HandleInputStateChange(new TouchStateChangeEvent(state, this, touch, isLatestTouch,
+                    handler.HandleInputStateChange(new TouchStateChangeEvent(state, this, touch,
                         !activityChanged ? (bool?)null : Activate,
                         !positionChanged ? null : lastPosition
                     ));

--- a/osu.Framework/Input/StateChanges/TouchInput.cs
+++ b/osu.Framework/Input/StateChanges/TouchInput.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
@@ -47,9 +48,12 @@ namespace osu.Framework.Input.StateChanges
         public void Apply(InputState state, IInputStateChangeHandler handler)
         {
             var touches = state.Touch;
+            var activityState = touches.ActiveSources;
 
             foreach (var touch in Touches)
             {
+                bool isLatestTouch = !activityState.IsPressed(touch.Source) || activityState.Any() && touch.Source == activityState.Last();
+
                 var lastPosition = touches.GetTouchPosition(touch.Source);
                 touches.TouchPositions[(int)touch.Source] = touch.Position;
 
@@ -58,7 +62,7 @@ namespace osu.Framework.Input.StateChanges
 
                 if (activityChanged || positionChanged)
                 {
-                    handler.HandleInputStateChange(new TouchStateChangeEvent(state, this, touch,
+                    handler.HandleInputStateChange(new TouchStateChangeEvent(state, this, touch, isLatestTouch,
                         !activityChanged ? (bool?)null : Activate,
                         !positionChanged ? null : lastPosition
                     ));

--- a/osu.Framework/Input/StateChanges/TouchInput.cs
+++ b/osu.Framework/Input/StateChanges/TouchInput.cs
@@ -52,7 +52,7 @@ namespace osu.Framework.Input.StateChanges
 
             foreach (var touch in Touches)
             {
-                bool isLatestTouch = !activityState.IsPressed(touch.Source) || activityState.Any() && touch.Source == activityState.Last();
+                bool isLatestTouch = !activityState.IsPressed(touch.Source) || (activityState.Any() && touch.Source == activityState.Last());
 
                 var lastPosition = touches.GetTouchPosition(touch.Source);
                 touches.TouchPositions[(int)touch.Source] = touch.Position;

--- a/osu.Framework/Input/TouchSource.cs
+++ b/osu.Framework/Input/TouchSource.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Input
     public enum TouchSource
     {
         /// <summary>
-        /// The first and primary touch source.
+        /// The first touch source.
         /// </summary>
         Touch1,
 


### PR DESCRIPTION
As discussed and considered, mapping mouse input to any new / moved touches instead of first touch is more better as a good starting point.

Huge note though is that now with this new logic, there will be "false drags" raised when still holding a touch and pressing a new one (mouse moves from one to other while left still pressed, thus a false drag raised), discussed about that with the result of opening an issue post-merge as it doesn't seem easy to resolve. 