### PR TITLE
Add MIDI input handling to passthrough input manager

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestScenePassThroughInputManager.cs
@@ -153,6 +153,28 @@ namespace osu.Framework.Tests.Visual.Input
                 testInputManager.CurrentState.Touch.TouchPositions[(int)TouchSource.Touch2] == new Vector2(2));
         }
 
+        [Test]
+        public void TestMidiInput()
+        {
+            addTestInputManagerStep();
+
+            AddStep("press C3", () => InputManager.PressMidiKey(MidiKey.C3, 70));
+            AddAssert("synced properly", () =>
+                testInputManager.CurrentState.Midi.Keys.IsPressed(MidiKey.C3)
+                && testInputManager.CurrentState.Midi.Velocities[MidiKey.C3] == 70);
+
+            AddStep("UseParentInput = false", () => testInputManager.UseParentInput = false);
+            AddStep("release C3", () => InputManager.ReleaseMidiKey(MidiKey.C3, 40));
+            AddStep("press F#3", () => InputManager.PressMidiKey(MidiKey.FSharp3, 65));
+
+            AddStep("UseParentInput = true", () => testInputManager.UseParentInput = true);
+            AddAssert("synced properly", () =>
+                !testInputManager.CurrentState.Midi.Keys.IsPressed(MidiKey.C3) &&
+                testInputManager.CurrentState.Midi.Velocities[MidiKey.C3] == 40 &&
+                testInputManager.CurrentState.Midi.Keys.IsPressed(MidiKey.FSharp3) &&
+                testInputManager.CurrentState.Midi.Velocities[MidiKey.FSharp3] == 65);
+        }
+
         public class TestInputManager : ManualInputManager
         {
             public readonly TestSceneInputManager.ContainingInputManagerStatusText Status;

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -117,6 +117,10 @@ namespace osu.Framework.Input
                     new TouchInput(touch.ScreenSpaceTouch, touch.IsActive(touch.ScreenSpaceTouch)).Apply(CurrentState, this);
                     break;
 
+                case MidiEvent midi:
+                    new MidiKeyInput(midi.Key, midi.Velocity, midi.IsPressed(midi.Key)).Apply(CurrentState, this);
+                    break;
+
                 case KeyboardEvent _:
                 case JoystickButtonEvent _:
                 case JoystickAxisMoveEvent _:
@@ -178,6 +182,8 @@ namespace osu.Framework.Input
 
             new JoystickButtonInput(state?.Joystick?.Buttons, CurrentState.Joystick.Buttons).Apply(CurrentState, this);
             new JoystickAxisInput(state?.Joystick?.GetAxes()).Apply(CurrentState, this);
+
+            new MidiKeyInput(state?.Midi, CurrentState.Midi).Apply(CurrentState, this);
         }
     }
 }

--- a/osu.Framework/Input/StateChanges/MidiKeyInput.cs
+++ b/osu.Framework/Input/StateChanges/MidiKeyInput.cs
@@ -6,16 +6,38 @@ using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.StateChanges
 {
+    /// <summary>
+    /// Represents an input from a MIDI device.
+    /// </summary>
     public class MidiKeyInput : ButtonInput<MidiKey>
     {
+        /// <summary>
+        /// A mapping of <see cref="MidiKey"/>s to the velocities they were pressed or released with.
+        /// </summary>
         public readonly IReadOnlyDictionary<MidiKey, byte> Velocities;
 
+        /// <summary>
+        /// Creates a <see cref="MidiKeyInput"/> for a single key state.
+        /// </summary>
+        /// <param name="button">The <see cref="MidiKey"/> whose state changed.</param>
+        /// <param name="velocity">The velocity with which with the input was performed.</param>
+        /// <param name="isPressed">Whether <paramref name="button"/> was pressed or released.</param>
         public MidiKeyInput(MidiKey button, byte velocity, bool isPressed)
             : base(button, isPressed)
         {
             Velocities = new Dictionary<MidiKey, byte> { [button] = velocity };
         }
 
+        /// <summary>
+        /// Creates a <see cref="MidiKeyInput"/> from the difference of two <see cref="MidiState"/>s.
+        /// </summary>
+        /// <remarks>
+        /// Buttons that are pressed in <paramref name="previousState"/> and not pressed in <paramref name="currentState"/> will be listed as <see cref="ButtonStateChangeKind.Released"/>.
+        /// Buttons that are not pressed in <paramref name="previousState"/> and pressed in <paramref name="currentState"/> will be listed as <see cref="ButtonStateChangeKind.Pressed"/>.
+        /// Key velocities from <paramref name="currentState"/> always take precedence over velocities from <paramref name="previousState"/>.
+        /// </remarks>
+        /// <param name="currentState">The newer <see cref="MidiState"/>.</param>
+        /// <param name="previousState">The older <see cref="MidiState"/>.</param>
         public MidiKeyInput(MidiState currentState, MidiState previousState)
             : base(currentState.Keys, previousState.Keys)
         {
@@ -24,6 +46,9 @@ namespace osu.Framework.Input.StateChanges
             Velocities = new Dictionary<MidiKey, byte>(currentState.Velocities);
         }
 
+        /// <summary>
+        /// Retrieves the <see cref="ButtonStates{TButton}"/> from a <see cref="MidiKeyInput"/>.
+        /// </summary>
         protected override ButtonStates<MidiKey> GetButtonStates(InputState state) => state.Midi.Keys;
 
         public override void Apply(InputState state, IInputStateChangeHandler handler)

--- a/osu.Framework/Input/StateChanges/MidiKeyInput.cs
+++ b/osu.Framework/Input/StateChanges/MidiKeyInput.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.StateChanges
@@ -14,7 +15,7 @@ namespace osu.Framework.Input.StateChanges
         /// <summary>
         /// A mapping of <see cref="MidiKey"/>s to the velocities they were pressed or released with.
         /// </summary>
-        public readonly IReadOnlyDictionary<MidiKey, byte> Velocities;
+        public readonly IReadOnlyList<(MidiKey, byte)> Velocities;
 
         /// <summary>
         /// Creates a <see cref="MidiKeyInput"/> for a single key state.
@@ -25,7 +26,7 @@ namespace osu.Framework.Input.StateChanges
         public MidiKeyInput(MidiKey button, byte velocity, bool isPressed)
             : base(button, isPressed)
         {
-            Velocities = new Dictionary<MidiKey, byte> { [button] = velocity };
+            Velocities = new List<(MidiKey, byte)> { (button, velocity) };
         }
 
         /// <summary>
@@ -43,7 +44,7 @@ namespace osu.Framework.Input.StateChanges
         {
             // newer velocities always take precedence
             // if the newer midi state doesn't specify a velocity for a key, it will be preserved after Apply()
-            Velocities = new Dictionary<MidiKey, byte>(currentState.Velocities);
+            Velocities = currentState.Velocities.Select(entry => (entry.Key, entry.Value)).ToList();
         }
 
         /// <summary>

--- a/osu.Framework/Input/StateChanges/MidiKeyInput.cs
+++ b/osu.Framework/Input/StateChanges/MidiKeyInput.cs
@@ -1,29 +1,35 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using osu.Framework.Input.States;
 
 namespace osu.Framework.Input.StateChanges
 {
     public class MidiKeyInput : ButtonInput<MidiKey>
     {
-        public readonly MidiKey Button;
-        public readonly byte Velocity;
-        public readonly bool IsPressed;
+        public readonly IReadOnlyDictionary<MidiKey, byte> Velocities;
 
         public MidiKeyInput(MidiKey button, byte velocity, bool isPressed)
             : base(button, isPressed)
         {
-            Button = button;
-            Velocity = velocity;
-            IsPressed = isPressed;
+            Velocities = new Dictionary<MidiKey, byte> { [button] = velocity };
+        }
+
+        public MidiKeyInput(MidiState currentState, MidiState previousState)
+            : base(currentState.Keys, previousState.Keys)
+        {
+            // newer velocities always take precedence
+            // if the newer midi state doesn't specify a velocity for a key, it will be preserved after Apply()
+            Velocities = new Dictionary<MidiKey, byte>(currentState.Velocities);
         }
 
         protected override ButtonStates<MidiKey> GetButtonStates(InputState state) => state.Midi.Keys;
 
         public override void Apply(InputState state, IInputStateChangeHandler handler)
         {
-            state.Midi.Velocities[Button] = Velocity;
+            foreach (var (key, velocity) in Velocities)
+                state.Midi.Velocities[key] = velocity;
 
             base.Apply(state, handler);
         }

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -71,6 +71,9 @@ namespace osu.Framework.Testing.Input
 
         public void EndTouch(Touch touch) => Input(new TouchInput(touch, false));
 
+        public void PressMidiKey(MidiKey key, byte velocity) => Input(new MidiKeyInput(key, velocity, true));
+        public void ReleaseMidiKey(MidiKey key, byte velocity) => Input(new MidiKeyInput(key, velocity, false));
+
         private class ManualInputHandler : InputHandler
         {
             public override bool Initialize(GameHost host) => true;


### PR DESCRIPTION
Resolves #3686.

# Breaking changes

## `MidiKeyInput.{Button,Velocity,IsPressed}` have been removed

`MidiKeyInput` has been reworked to support pressing multiple keys with multiple velocities in one input, to bring MIDI inputs more in line with other input types in the framework.

* Instead of reading `MidiKeyInput.Button`, use `MidiKeyInput.Entries` to ascertain whether the input concerns a particular MIDI key.
* Instead of reading `MidiKeyInput.Velocity`, inspect the `MidiKeyInput.Velocities` dictionary to retrieve the velocity of the input for a given key.
* Instead of reading `MidiKeyInput.IsPressed`, use `MidiKeyInput.Entries` to match the key whose state you wish to retrieve and read the `ButtonInputEntry`'s `IsPressed` property.

# Summary

As stated in the issue thread, `PassThroughInputManager` did not take MIDI events into account. This PR adds support for passing through and synchronisation of MIDI event state.

I've tested this game-side with a framework checkout - here's a [mania gameplay video](https://drive.google.com/file/d/1jNIsk5_gqq3nUpB-dLSD99ZeFMNf3NQj/view?usp=sharing) with `tail -f` showing MIDI input being used. (Apologies for the poor quality of the gameplay; I don't ever touch mania.)

# Remarks

Unfortunately upon closer inspection the necessary change turned out to be more than just a one-liner, as there is also the necessity to support state synchronisation to make `UseParentInput` work with MIDI, too. This is the reason why I opted to outright replace the old properties and to follow the more idiomatic style of other inputs.

`Velocities` being in the input is awkward, but I'm not sure what to do about it. My immediate thought was that it would be good to have it in `ButtonInputEntry`, but given it's a struct it's not open to extensibility.

The change is hard-breaking in a sense that if anyone used the input class before then their project would stop compiling after the next bump, but I'd consider it (a) a bit of an oversight/mistake to add it in the form it was added originally anyway and (b) it should not break anyone's project from my rudimentary github search so I think it's fine.

I've also taken the opportunity to add xmldoc to the class, following @smoogipoo's lead.