### PR TITLE
Improve robustness of MIDI event parsing

### DIFF
--- a/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
@@ -174,8 +174,7 @@ namespace osu.Framework.Input.Handlers.Midi
                     velocity = MidiEvent.FixedDataSize(statusType) == 2 ? data[i++] : (byte)0;
                 }
 
-                if (runningStatus.ContainsKey(senderId))
-                    runningStatus.Remove(senderId);
+                runningStatus.Remove(senderId);
                 return;
             }
 

--- a/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
@@ -120,46 +120,72 @@ namespace osu.Framework.Input.Handlers.Midi
             }
         }
 
+        /// <remarks>
+        /// This function is not intended to provide complete correctness of MIDI parsing.
+        /// For now the goal is to correctly parse "note start" and "note end" events and correctly delimit all events.
+        /// </remarks>
         private void readEvent(byte[] data, string senderId, ref int i, out byte eventType, out byte key, out byte velocity)
         {
             byte statusType = data[i++];
 
+            // continuation messages:
+            // need running status to be interpreted correctly
             if (statusType <= 0x7F)
             {
-                // This is a running status, re-use the event type from the previous message
                 if (!runningStatus.ContainsKey(senderId))
                     throw new InvalidDataException($"Received running status of sender {senderId}, but no event type was stored");
 
                 eventType = runningStatus[senderId];
                 key = statusType;
                 velocity = data[i++];
+                return;
             }
-            else if (statusType >= 0xF8)
+
+            // real-time messages:
+            // 0 additional data bytes always, do not reset running status
+            if (statusType >= 0xF8)
             {
-                // Events F8 through FF do not reset the last known status byte
                 eventType = statusType;
-                key = data[i++];
-                velocity = data[i++];
+                key = velocity = 0;
+                return;
             }
-            else if (statusType >= 0xF0)
+
+            // system common messages:
+            // variable number of additional data bytes, reset running status
+            if (statusType >= 0xF0)
             {
-                // Events F0 through F7 reset the running status
                 eventType = statusType;
-                key = data[i++];
-                velocity = data[i++];
+
+                // system exclusive message
+                // vendor-specific, terminated by 0xF7
+                // ignoring their whole contents for now since we can't do anything with them anyway
+                if (statusType == 0xF0)
+                {
+                    while (data[i - 1] != 0xF7)
+                        i++;
+
+                    key = velocity = 0;
+                }
+                // other common system messages
+                // fixed size given by MidiEvent.FixedDataSize
+                else
+                {
+                    key = MidiEvent.FixedDataSize(statusType) >= 1 ? data[i++] : (byte)0;
+                    velocity = MidiEvent.FixedDataSize(statusType) == 2 ? data[i++] : (byte)0;
+                }
 
                 if (runningStatus.ContainsKey(senderId))
                     runningStatus.Remove(senderId);
+                return;
             }
-            else
-            {
-                // normal event, update running status
-                eventType = statusType;
-                key = data[i++];
-                velocity = data[i++];
 
-                runningStatus[senderId] = eventType;
-            }
+            // channel messages
+            // fixed size (varying per event type), set running status
+            eventType = statusType;
+            key = MidiEvent.FixedDataSize(statusType) >= 1 ? data[i++] : (byte)0;
+            velocity = MidiEvent.FixedDataSize(statusType) == 2 ? data[i++] : (byte)0;
+
+            runningStatus[senderId] = eventType;
         }
 
         private void dispatchEvent(byte eventType, byte key, byte velocity)


### PR DESCRIPTION
Resolves #3683 (hopefully).

- [x] Depends on #3689 (for game-side testability, mostly).

# Summary

The MIDI event parsing code was a little lax when it comes to treating incoming messages other than note on/off. This PR introduces checks and handling of special corner cases that can arise in MIDI messages.

The references I used are: [this part of the MIDI spec](https://www.midi.org/specifications-old/item/table-1-summary-of-midi-message) and sources of managed-midi.

I have tested some of this; the device I own (a Kawai ES110 digital piano) does not unfortunately produce a lot of the weird MIDI messages (especially not the real-time ones). I have however tested the weird ones that I can produce and I got no crashes or logged exceptions (and I did get some on `master`, so it's *some* improvement).

# Remarks

This is not intended to be completely correct and per-spec, as per the comment. The only goal is to parse note events correctly and to not mis-parse events by not reading to their end/stopping too early, etc.

Unfortunately [the managed-midi function I mentioned in the issue thread](https://github.com/atsushieno/managed-midi/blob/311b9e354ff70d551f9cc140a19e0a400e3c4dce/Commons.Music.Midi.Shared/SMF.cs#L312-L333) is not easily reusable here due to not handling the running status thing. I tried using it and had it sometimes mis-parse events because of not being aware of it.

[This one](https://github.com/atsushieno/managed-midi/blob/311b9e354ff70d551f9cc140a19e0a400e3c4dce/Commons.Music.Midi.Shared/SMF.cs#L731-L753) seemed closer to what I wanted, but it seems to ignore real-time messages, and also isn't public.

Not sure if this is something we want to have test cases for; can provide some on request.

@GenesisEB Would appreciate your testing on this to make sure the errors have in fact gone away.