### PR TITLE
Fix font load exceptions potentially crashing the game

### DIFF
--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Graphics.Textures;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -89,8 +88,10 @@ namespace osu.Framework.IO.Stores
                     await store.LoadFontAsync();
                     Logger.Log($"Loaded Font {store.FontName}!", level: LogLevel.Debug);
                 }
-                catch (OperationCanceledException)
+                catch
                 {
+                    // Errors are logged by LoadFontAsync() but also propagated outwards.
+                    // We can gracefully continue when loading a font fails, so the exception shouldn't trigger the unobserved exception handler of GameHost and potentially crash the game.
                 }
             });
         }


### PR DESCRIPTION
Should fix https://ci.appveyor.com/project/peppy/osu-framework/builds/33945568 + https://ci.appveyor.com/project/peppy/osu-framework/builds/33945025

I couldn't replicate this in practice but I have a pretty good idea of what's causing it. It seems like the unobserved handler [is only invoked on GC](https://github.com/dotnet/runtime/issues/21269), so what we're reaching here is a very time-critical scenario that requires:
1. Running two `GameHost`s one after another. The first will trigger the exception, dispose (removing its own handler), then the second will bind its handlers and attempt to run as normal. The exception likely actually happens in the second `GameHost`, where the font loads from the first are running in a background thread and trigger exceptions in the second.
2. A GC to trigger right after the second GameHost binds its own handlers. This is what eventually causes the unobserved handler to get invoked.

Regardless of whether the above is correct behaviour (tasks from the first `GameHost` should not trigger exceptions in the second), we don't want fonts to trigger unobserved exceptions anyway.