### PR TITLE
Disallow non-readonly fields in CachedModelDependencyContainer

### DIFF
--- a/osu.Framework/Allocation/CachedModelDependencyContainer.cs
+++ b/osu.Framework/Allocation/CachedModelDependencyContainer.cs
@@ -127,8 +127,14 @@ namespace osu.Framework.Allocation
                 {
                     if (!typeof(IBindable).IsAssignableFrom(field.FieldType))
                     {
-                        throw new InvalidOperationException($"The field \"{field.Name}\" does not subclass {nameof(IBindable)}. "
-                                                            + $"All fields or auto-properties of a cached model container's model must subclass {nameof(IBindable)}");
+                        throw new InvalidOperationException($"\"{field.DeclaringType}.{field.Name}\" does not subclass {nameof(IBindable)}. "
+                                                            + $"All fields of {typeof(TModel)} must subclass {nameof(IBindable)} to be used in a {nameof(CachedModelDependencyContainer<TModel>)}.");
+                    }
+
+                    if (!field.IsInitOnly)
+                    {
+                        throw new InvalidOperationException($"\"{field.DeclaringType}.{field.Name}\" is not readonly. "
+                                                            + $"All fields of {typeof(TModel)} must be readonly to be used in a {nameof(CachedModelDependencyContainer<TModel>)}.");
                     }
                 }
             }


### PR DESCRIPTION
See: https://github.com/ppy/osu/pull/9478

Since `CachedModelDependencyContainer` relies on being able to `UnbindFrom(previousBindable)`, we can't have these fields changing their values beyond the ctor.

# vNext

## `CachedModelDependencyContainer` models must now only contain read-only fields

Mutating bindables of models attached to a `CachedModelDependencyContainer` can lead to crashes or otherwise unexpected behaviour, and is now disallowed.