### PR TITLE
Fix seeking animation not consuming clock

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -209,6 +209,25 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddAssert("Animation is at beginning", () => animation.PlaybackPosition < 1000);
         }
 
+        [Test]
+        public void TestGotoZeroOnFirstFrameVisible()
+        {
+            loadNewAnimation();
+
+            AddStep("set time to 1000", () => clock.CurrentTime = 1000);
+            AddStep("hide animation", () => animation.Hide());
+
+            AddStep("set time = 2000", () => clock.CurrentTime = 2000);
+            AddStep("goto(0) and show", () =>
+            {
+                animation.GotoFrame(0);
+                animation.Show();
+            });
+
+            // Note: We won't get PlaybackPosition=0 here because the test runner increments the clock by at least 200ms per step, so 1000 is a safe value.
+            AddAssert("animation restarted from 0", () => animation.PlaybackPosition < 1000);
+        }
+
         private void loadNewAnimation(bool startFromCurrent = true, Action<TestAnimation> postLoadAction = null)
         {
             AddStep("load animation", () =>

--- a/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
+++ b/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
@@ -92,6 +92,8 @@ namespace osu.Framework.Graphics.Animations
             {
                 hasSeeked = true;
                 manualClock.CurrentTime = value;
+
+                consumeClockTime();
             }
         }
 


### PR DESCRIPTION
The sequence:
```
Hide()
{wait some time}
GotoFrame(0)
Show()
```
Would cause the clock to consume the `{wait some time}` period the first frame it becomes visible.

Unsure whether it's better for the consumption to be ignored during `Update()`. Thoughts? May be tricky to implement...