### PR TITLE
Fix exception when adding loaded drawable to unloaded parent

### DIFF
--- a/osu.Framework.Tests/Containers/TestSceneContainerState.cs
+++ b/osu.Framework.Tests/Containers/TestSceneContainerState.cs
@@ -12,6 +12,7 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Testing;
 using osu.Framework.Tests.Visual;
+using osuTK;
 
 namespace osu.Framework.Tests.Containers
 {
@@ -89,6 +90,26 @@ namespace osu.Framework.Tests.Containers
                     return true;
                 }
             });
+        }
+
+        /// <summary>
+        /// Tests whether a drawable that is loaded can be added to an unloaded container.
+        /// </summary>
+        [Test]
+        public void TestAddLoadedDrawableToUnloadedContainer()
+        {
+            Drawable target = null;
+
+            AddStep("load target", () =>
+            {
+                Add(target = new Box { Size = new Vector2(100) });
+
+                // Empty scheduler to force creation of the scheduler.
+                target.Schedule(() => { });
+            });
+
+            AddStep("remove target", () => Remove(target));
+            AddStep("add target to unloaded container", () => Add(new Container { Child = target }));
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -535,12 +535,14 @@ namespace osu.Framework.Graphics.Containers
             drawable.ChildID = ++currentChildID;
             drawable.RemoveCompletedTransforms = RemoveCompletedTransforms;
 
-            if (drawable.LoadState >= LoadState.Ready)
-                drawable.Parent = this;
-            else if (LoadState >= LoadState.Loading)
+            if (LoadState >= LoadState.Loading)
             {
                 // If we're already loaded, we can eagerly allow children to be loaded
-                loadChild(drawable);
+
+                if (drawable.LoadState >= LoadState.Ready)
+                    drawable.Parent = this;
+                else
+                    loadChild(drawable);
             }
 
             internalChildren.Add(drawable);


### PR DESCRIPTION
Setting `Parent` transfers the parent's clock to the target drawable, but it isn't set on the parent until it's started loading.