### PR TITLE
Fix memory leak when retrieving stack traces

### DIFF
--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -171,14 +171,21 @@ namespace osu.Framework.Statistics
 
         private static IList<ClrStackFrame> getStackTrace(Thread targetThread)
         {
-            var target = DataTarget.AttachToProcess(Process.GetCurrentProcess().Id, 200, AttachFlag.Passive);
-
-            if (target == null) return null;
-
-            using (target)
+            try
             {
-                var runtime = target.ClrVersions[0].CreateRuntime();
-                return runtime.Threads.FirstOrDefault(t => t.ManagedThreadId == targetThread.ManagedThreadId)?.StackTrace;
+                var target = DataTarget.AttachToProcess(Process.GetCurrentProcess().Id, 200, AttachFlag.Passive);
+
+                if (target == null) return null;
+
+                using (target)
+                {
+                    var runtime = target.ClrVersions[0].CreateRuntime();
+                    return runtime.Threads.FirstOrDefault(t => t.ManagedThreadId == targetThread.ManagedThreadId)?.StackTrace;
+                }
+            }
+            catch
+            {
+                return null;
             }
         }
 


### PR DESCRIPTION
We weren't correctly disposing the `DataTarget`, which results in it building  up a huge unmanaged memory footprint. Reference: https://lowleveldesign.org/2019/02/22/a-story-of-fixing-a-memory-leak-in-minidumper/ 