### PR TITLE
Always make the graphics context current on the draw thread

### DIFF
--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -42,6 +42,9 @@ namespace osu.Framework.Threading
             base.MakeCurrent();
 
             ThreadSafety.IsDrawThread = true;
+
+            // Seems to be required on some drivers as the context is lost from the draw thread.
+            host.Window?.MakeCurrent();
         }
 
         protected sealed override void Cleanup()


### PR DESCRIPTION
(Should) fixes https://github.com/ppy/osu/issues/6387
(Should) fixes https://github.com/ppy/osu/issues/4068

Haven't been able to replicate in the last 50 attempts. Seems like this is also the true reason for https://github.com/ppy/osu-framework/pull/3720.