### PR TITLE
Add marker interface and store source of last change to MouseState

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -581,17 +581,13 @@ namespace osu.Framework.Input
 
             if (e.IsActive == true || e.LastPosition != null)
             {
-                new MousePositionAbsoluteInputFromTouch
+                new MousePositionAbsoluteInputFromTouch(e)
                 {
-                    TouchEvent = e,
                     Position = e.Touch.Position
                 }.Apply(CurrentState, this);
             }
 
-            new MouseButtonInputFromTouch(MouseButton.Left, e.State.Touch.ActiveSources.HasAnyButtonPressed)
-            {
-                TouchEvent = e,
-            }.Apply(CurrentState, this);
+            new MouseButtonInputFromTouch(MouseButton.Left, e.State.Touch.ActiveSources.HasAnyButtonPressed, e).Apply(CurrentState, this);
             return true;
         }
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -580,9 +580,18 @@ namespace osu.Framework.Input
                 return false;
 
             if (e.IsActive == true || e.LastPosition != null)
-                new MousePositionAbsoluteInput { Position = e.Touch.Position }.Apply(CurrentState, this);
+            {
+                new MousePositionAbsoluteInputFromTouch
+                {
+                    TouchEvent = e,
+                    Position = e.Touch.Position
+                }.Apply(CurrentState, this);
+            }
 
-            new MouseButtonInput(MouseButton.Left, e.State.Touch.ActiveSources.HasAnyButtonPressed).Apply(CurrentState, this);
+            new MouseButtonInputFromTouch(MouseButton.Left, e.State.Touch.ActiveSources.HasAnyButtonPressed)
+            {
+                TouchEvent = e,
+            }.Apply(CurrentState, this);
             return true;
         }
 

--- a/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.StateChanges.Events;
+
+namespace osu.Framework.Input.StateChanges
+{
+    public interface ISourcedFromTouch
+    {
+        TouchStateChangeEvent TouchEvent { get; set; }
+    }
+}

--- a/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
@@ -5,8 +5,15 @@ using osu.Framework.Input.StateChanges.Events;
 
 namespace osu.Framework.Input.StateChanges
 {
+    /// <summary>
+    /// Denotes an input which was sourced from a touch event.
+    /// Generally used to mark when an alternate input was triggered from a touch source (ie. touch being emulated as a mouse).
+    /// </summary>
     public interface ISourcedFromTouch
     {
+        /// <summary>
+        /// The source touch event.
+        /// </summary>
         TouchStateChangeEvent TouchEvent { get; set; }
     }
 }

--- a/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
@@ -14,6 +14,6 @@ namespace osu.Framework.Input.StateChanges
         /// <summary>
         /// The source touch event.
         /// </summary>
-        TouchStateChangeEvent TouchEvent { get; set; }
+        TouchStateChangeEvent TouchEvent { get; }
     }
 }

--- a/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/ISourcedFromTouch.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Input.StateChanges
     /// Denotes an input which was sourced from a touch event.
     /// Generally used to mark when an alternate input was triggered from a touch source (ie. touch being emulated as a mouse).
     /// </summary>
-    public interface ISourcedFromTouch
+    public interface ISourcedFromTouch : IInput
     {
         /// <summary>
         /// The source touch event.

--- a/osu.Framework/Input/StateChanges/MouseButtonInputFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/MouseButtonInputFromTouch.cs
@@ -1,0 +1,18 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.StateChanges.Events;
+using osuTK.Input;
+
+namespace osu.Framework.Input.StateChanges
+{
+    public class MouseButtonInputFromTouch : MouseButtonInput, ISourcedFromTouch
+    {
+        public MouseButtonInputFromTouch(MouseButton button, bool isPressed)
+            : base(button, isPressed)
+        {
+        }
+
+        public TouchStateChangeEvent TouchEvent { get; set; }
+    }
+}

--- a/osu.Framework/Input/StateChanges/MouseButtonInputFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/MouseButtonInputFromTouch.cs
@@ -8,11 +8,12 @@ namespace osu.Framework.Input.StateChanges
 {
     public class MouseButtonInputFromTouch : MouseButtonInput, ISourcedFromTouch
     {
-        public MouseButtonInputFromTouch(MouseButton button, bool isPressed)
+        public MouseButtonInputFromTouch(MouseButton button, bool isPressed, TouchStateChangeEvent touchEvent)
             : base(button, isPressed)
         {
+            TouchEvent = touchEvent;
         }
 
-        public TouchStateChangeEvent TouchEvent { get; set; }
+        public TouchStateChangeEvent TouchEvent { get; }
     }
 }

--- a/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionAbsoluteInput.cs
@@ -29,6 +29,7 @@ namespace osu.Framework.Input.StateChanges
             {
                 var lastPosition = mouse.IsPositionValid ? mouse.Position : Position;
                 mouse.IsPositionValid = true;
+                mouse.LastSource = this;
                 mouse.Position = Position;
                 handler.HandleInputStateChange(new MousePositionChangeEvent(state, this, lastPosition));
             }

--- a/osu.Framework/Input/StateChanges/MousePositionAbsoluteInputFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionAbsoluteInputFromTouch.cs
@@ -7,6 +7,11 @@ namespace osu.Framework.Input.StateChanges
 {
     public class MousePositionAbsoluteInputFromTouch : MousePositionAbsoluteInput, ISourcedFromTouch
     {
-        public TouchStateChangeEvent TouchEvent { get; set; }
+        public MousePositionAbsoluteInputFromTouch(TouchStateChangeEvent touchEvent)
+        {
+            TouchEvent = touchEvent;
+        }
+
+        public TouchStateChangeEvent TouchEvent { get; }
     }
 }

--- a/osu.Framework/Input/StateChanges/MousePositionAbsoluteInputFromTouch.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionAbsoluteInputFromTouch.cs
@@ -1,0 +1,12 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.StateChanges.Events;
+
+namespace osu.Framework.Input.StateChanges
+{
+    public class MousePositionAbsoluteInputFromTouch : MousePositionAbsoluteInput, ISourcedFromTouch
+    {
+        public TouchStateChangeEvent TouchEvent { get; set; }
+    }
+}

--- a/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MousePositionRelativeInput.cs
@@ -27,6 +27,7 @@ namespace osu.Framework.Input.StateChanges
             {
                 var lastPosition = mouse.Position;
                 mouse.Position += Delta;
+                mouse.LastSource = this;
                 handler.HandleInputStateChange(new MousePositionChangeEvent(state, this, lastPosition));
             }
         }

--- a/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
+++ b/osu.Framework/Input/StateChanges/MouseScrollRelativeInput.cs
@@ -34,6 +34,7 @@ namespace osu.Framework.Input.StateChanges
             {
                 var lastScroll = mouse.Scroll;
                 mouse.Scroll += Delta;
+                mouse.LastSource = this;
                 handler.HandleInputStateChange(new MouseScrollChangeEvent(state, this, lastScroll, IsPrecise));
             }
         }

--- a/osu.Framework/Input/States/MouseState.cs
+++ b/osu.Framework/Input/States/MouseState.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Input.StateChanges;
 using osuTK;
 using osuTK.Input;
 
@@ -16,6 +17,11 @@ namespace osu.Framework.Input.States
         public Vector2 Position { get; set; }
 
         public bool IsPositionValid { get; set; } = true;
+
+        /// <summary>
+        /// The last input source to make a change to state.
+        /// </summary>
+        public IInput LastSource { get; set; }
 
         public bool IsPressed(MouseButton button) => Buttons.IsPressed(button);
         public void SetPressed(MouseButton button, bool pressed) => Buttons.SetPressed(button, pressed);

--- a/osu.Framework/Input/States/MouseState.cs
+++ b/osu.Framework/Input/States/MouseState.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Input.States
         public bool IsPositionValid { get; set; } = true;
 
         /// <summary>
-        /// The last input source to make a change to state.
+        /// The last input source to make a change to the state.
         /// </summary>
         public IInput LastSource { get; set; }
 


### PR DESCRIPTION
Alternative to https://github.com/ppy/osu-framework/pull/3675/files using interface rather than polluting non-touch classes with touch-specific booleans. Took same test from other PR to make it easy to compare implementation / usage.