### PR TITLE
Fix excessive list allocation in GetPendingInputs paths

### DIFF
--- a/osu.Framework/Input/Handlers/InputHandler.cs
+++ b/osu.Framework/Input/Handlers/InputHandler.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Input.Handlers
         /// Retrieve a list of all pending states since the last call to this method.
         /// </summary>
         /// <param name="inputs">The list for pending inputs to be added to.</param>
-        public virtual void GetPendingInputs(List<IInput> inputs)
+        public virtual void CollectPendingInputs(List<IInput> inputs)
         {
             lock (pendingInputsRetrievalLock)
             {
@@ -46,7 +46,7 @@ namespace osu.Framework.Input.Handlers
         public abstract int Priority { get; }
 
         /// <summary>
-        /// Whether this InputHandler should be collecting <see cref="IInput"/>s to return on the next <see cref="GetPendingInputs"/> call
+        /// Whether this InputHandler should be collecting <see cref="IInput"/>s to return on the next <see cref="CollectPendingInputs"/> call
         /// </summary>
         public readonly BindableBool Enabled = new BindableBool(true);
 

--- a/osu.Framework/Input/Handlers/InputHandler.cs
+++ b/osu.Framework/Input/Handlers/InputHandler.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Input.Handlers
         private readonly object pendingInputsRetrievalLock = new object();
 
         /// <summary>
-        /// Retrieve a list of all pending states since the last call to this method.
+        /// Add all pending states since the last call to this method to a provided list.
         /// </summary>
         /// <param name="inputs">The list for pending inputs to be added to.</param>
         public virtual void CollectPendingInputs(List<IInput> inputs)

--- a/osu.Framework/Input/Handlers/InputHandler.cs
+++ b/osu.Framework/Input/Handlers/InputHandler.cs
@@ -25,16 +25,13 @@ namespace osu.Framework.Input.Handlers
         /// <summary>
         /// Retrieve a list of all pending states since the last call to this method.
         /// </summary>
-        public virtual List<IInput> GetPendingInputs()
+        /// <param name="inputs">The list for pending inputs to be added to.</param>
+        public void GetPendingInputs(List<IInput> inputs)
         {
             lock (pendingInputsRetrievalLock)
             {
-                List<IInput> pending = new List<IInput>();
-
                 while (PendingInputs.TryDequeue(out IInput s))
-                    pending.Add(s);
-
-                return pending;
+                    inputs.Add(s);
             }
         }
 

--- a/osu.Framework/Input/Handlers/InputHandler.cs
+++ b/osu.Framework/Input/Handlers/InputHandler.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Input.Handlers
         /// Retrieve a list of all pending states since the last call to this method.
         /// </summary>
         /// <param name="inputs">The list for pending inputs to be added to.</param>
-        public void GetPendingInputs(List<IInput> inputs)
+        public virtual void GetPendingInputs(List<IInput> inputs)
         {
             lock (pendingInputsRetrievalLock)
             {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -414,14 +414,14 @@ namespace osu.Framework.Input
             }
         }
 
+        private readonly List<IInput> inputs = new List<IInput>();
+
         protected virtual List<IInput> GetPendingInputs()
         {
-            var inputs = new List<IInput>();
+            inputs.Clear();
 
             foreach (var h in InputHandlers)
-            {
-                inputs.AddRange(h.GetPendingInputs());
-            }
+                h.GetPendingInputs(inputs);
 
             return inputs;
         }

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -421,7 +421,7 @@ namespace osu.Framework.Input
             inputs.Clear();
 
             foreach (var h in InputHandlers)
-                h.GetPendingInputs(inputs);
+                h.CollectPendingInputs(inputs);
 
             return inputs;
         }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/191335/87902924-ca3aa400-ca95-11ea-9827-dd988f9e8238.png)


After:

![dotMemory-201 0 20200703 51832_2020-07-18_22-09-59](https://user-images.githubusercontent.com/191335/87853239-8cc60180-c943-11ea-8774-bdfd70ea03f9.png)