### PR TITLE
Fix CursorEffectContainer allocating excessively

### DIFF
--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Graphics.Cursor
             // keep track of all hovered drawables below this and nested effect containers
             // so we can decide which ones are valid candidates for receiving our effect and so
             // we know when we can abort our search.
-            for (int i = targetCandidates.IndexOf(this) - 1; i >= 0; i--)
+            for (int i = selfIndex - 1; i >= 0; i--)
             {
                 var candidate = targetCandidates[i] as TTarget;
 

--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Graphics.Containers;
-using osu.Framework.Input;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Input;
 
 namespace osu.Framework.Graphics.Cursor
 {
@@ -36,15 +36,27 @@ namespace osu.Framework.Graphics.Cursor
             Debug.Assert(targetChildren.Count == 0, $"{nameof(targetChildren)} should be empty but has {targetChildren.Count} elements.");
 
             // Skip all drawables in the hierarchy prior to (and including) ourself.
-            var targetCandidates = inputManager.PositionalInputQueue.Reverse().SkipWhile(d => d != this).Skip(1);
+            var targetCandidates = inputManager.PositionalInputQueue;
+
+            int selfIndex = targetCandidates.IndexOf(this);
+
+            if (selfIndex < 0) return;
 
             childDrawables.Add(this);
 
             // keep track of all hovered drawables below this and nested effect containers
             // so we can decide which ones are valid candidates for receiving our effect and so
             // we know when we can abort our search.
-            foreach (var candidate in targetCandidates)
+            for (int i = targetCandidates.IndexOf(this) - 1; i >= 0; i--)
             {
+                var candidate = targetCandidates[i] as TTarget;
+
+                if (candidate == null)
+                    continue;
+
+                if (!candidate.IsHovered)
+                    continue;
+
                 // Children of drawables we are responsible for transitively also fall into our subtree,
                 // and therefore we need to handle them. If they are not children of any drawables we handle,
                 // it means that we iterated beyond our subtree and may terminate.
@@ -83,23 +95,26 @@ namespace osu.Framework.Graphics.Cursor
                 if (nestedTtcChildDrawables.Contains(candidate))
                     continue;
 
-                if (candidate is TTarget target && target.IsHovered)
-                    // We found a valid candidate; keep track of it
-                    targetChildren.Add(target);
+                // We found a valid candidate; keep track of it
+                targetChildren.Add(candidate);
             }
         }
 
-        protected List<TTarget> FindTargets()
+        protected IEnumerable<TTarget> FindTargets()
         {
             findTargetChildren();
-
-            List<TTarget> result = new List<TTarget>(targetChildren);
-            result.Reverse();
 
             // Clean up
             childDrawables.Clear();
             nestedTtcChildDrawables.Clear();
             newChildDrawables.Clear();
+
+            if (targetChildren.Count == 0)
+                return Enumerable.Empty<TTarget>();
+
+            List<TTarget> result = new List<TTarget>(targetChildren);
+            result.Reverse();
+
             targetChildren.Clear();
 
             return result;

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -201,7 +201,7 @@ namespace osu.Framework.Graphics.Cursor
             if (inputManager.DraggedDrawable is IHasCustomTooltip customDraggedTarget)
                 return hasValidTooltip(customDraggedTarget) ? customDraggedTarget : null;
 
-            ITooltipContentProvider targetCandidate = FindTargets().Find(hasValidTooltip);
+            ITooltipContentProvider targetCandidate = FindTargets().FirstOrDefault(hasValidTooltip);
 
             // check this first - if we find no target candidate we still want to clear the recorded positions and update the lastCandidate.
             if (targetCandidate != lastCandidate)

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions.ListExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -144,9 +145,6 @@ namespace osu.Framework.Input
         {
             CurrentState = CreateInitialState();
             RelativeSizeAxes = Axes.Both;
-
-            readOnlyPositionalInputQueue = new SlimReadOnlyListWrapper<Drawable>(positionalInputQueue);
-            readOnlyInputQueue = new SlimReadOnlyListWrapper<Drawable>(inputQueue);
 
             foreach (var button in Enum.GetValues(typeof(MouseButton)).Cast<MouseButton>())
             {
@@ -438,8 +436,6 @@ namespace osu.Framework.Input
 
         private readonly List<Drawable> inputQueue = new List<Drawable>();
 
-        private readonly SlimReadOnlyListWrapper<Drawable> readOnlyInputQueue;
-
         private SlimReadOnlyListWrapper<Drawable> buildNonPositionalInputQueue()
         {
             inputQueue.Clear();
@@ -462,12 +458,10 @@ namespace osu.Framework.Input
             // need to be reversed.
             inputQueue.Reverse();
 
-            return readOnlyInputQueue;
+            return inputQueue.AsSlimReadOnly();
         }
 
         private readonly List<Drawable> positionalInputQueue = new List<Drawable>();
-
-        private readonly SlimReadOnlyListWrapper<Drawable> readOnlyPositionalInputQueue;
 
         private SlimReadOnlyListWrapper<Drawable> buildPositionalInputQueue(Vector2 screenSpacePos)
         {
@@ -481,7 +475,7 @@ namespace osu.Framework.Input
                 children[i].BuildPositionalInputQueue(screenSpacePos, positionalInputQueue);
 
             positionalInputQueue.Reverse();
-            return readOnlyPositionalInputQueue;
+            return positionalInputQueue.AsSlimReadOnly();
         }
 
         protected virtual bool HandleHoverEvents => true;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -112,13 +112,13 @@ namespace osu.Framework.Input
         /// that the return value of <see cref="Drawable.OnHover"/> is not taken
         /// into account.
         /// </summary>
-        public IEnumerable<Drawable> PositionalInputQueue => buildPositionalInputQueue(CurrentState.Mouse.Position);
+        public List<Drawable> PositionalInputQueue => buildPositionalInputQueue(CurrentState.Mouse.Position);
 
         /// <summary>
         /// Contains all <see cref="Drawable"/>s in top-down order which are considered
         /// for non-positional input.
         /// </summary>
-        public IEnumerable<Drawable> NonPositionalInputQueue => buildNonPositionalInputQueue();
+        public List<Drawable> NonPositionalInputQueue => buildNonPositionalInputQueue();
 
         private readonly Dictionary<MouseButton, MouseButtonEventManager> mouseButtonEventManagers = new Dictionary<MouseButton, MouseButtonEventManager>();
         private readonly Dictionary<Key, KeyEventManager> keyButtonEventManagers = new Dictionary<Key, KeyEventManager>();
@@ -428,7 +428,7 @@ namespace osu.Framework.Input
 
         private readonly List<Drawable> inputQueue = new List<Drawable>();
 
-        private IEnumerable<Drawable> buildNonPositionalInputQueue()
+        private List<Drawable> buildNonPositionalInputQueue()
         {
             inputQueue.Clear();
 
@@ -455,7 +455,7 @@ namespace osu.Framework.Input
 
         private readonly List<Drawable> positionalInputQueue = new List<Drawable>();
 
-        private IEnumerable<Drawable> buildPositionalInputQueue(Vector2 screenSpacePos)
+        private List<Drawable> buildPositionalInputQueue(Vector2 screenSpacePos)
         {
             positionalInputQueue.Clear();
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -112,13 +113,13 @@ namespace osu.Framework.Input
         /// that the return value of <see cref="Drawable.OnHover"/> is not taken
         /// into account.
         /// </summary>
-        public List<Drawable> PositionalInputQueue => buildPositionalInputQueue(CurrentState.Mouse.Position);
+        public ReadOnlyCollection<Drawable> PositionalInputQueue => buildPositionalInputQueue(CurrentState.Mouse.Position);
 
         /// <summary>
         /// Contains all <see cref="Drawable"/>s in top-down order which are considered
         /// for non-positional input.
         /// </summary>
-        public List<Drawable> NonPositionalInputQueue => buildNonPositionalInputQueue();
+        public ReadOnlyCollection<Drawable> NonPositionalInputQueue => buildNonPositionalInputQueue();
 
         private readonly Dictionary<MouseButton, MouseButtonEventManager> mouseButtonEventManagers = new Dictionary<MouseButton, MouseButtonEventManager>();
         private readonly Dictionary<Key, KeyEventManager> keyButtonEventManagers = new Dictionary<Key, KeyEventManager>();
@@ -137,6 +138,9 @@ namespace osu.Framework.Input
         {
             CurrentState = CreateInitialState();
             RelativeSizeAxes = Axes.Both;
+
+            readOnlyPositionalInputQueue = new ReadOnlyCollection<Drawable>(positionalInputQueue);
+            readOnlyInputQueue = new ReadOnlyCollection<Drawable>(inputQueue);
 
             foreach (var button in Enum.GetValues(typeof(MouseButton)).Cast<MouseButton>())
             {
@@ -428,7 +432,9 @@ namespace osu.Framework.Input
 
         private readonly List<Drawable> inputQueue = new List<Drawable>();
 
-        private List<Drawable> buildNonPositionalInputQueue()
+        private readonly ReadOnlyCollection<Drawable> readOnlyInputQueue;
+
+        private ReadOnlyCollection<Drawable> buildNonPositionalInputQueue()
         {
             inputQueue.Clear();
 
@@ -450,12 +456,14 @@ namespace osu.Framework.Input
             // need to be reversed.
             inputQueue.Reverse();
 
-            return inputQueue;
+            return readOnlyInputQueue;
         }
 
         private readonly List<Drawable> positionalInputQueue = new List<Drawable>();
 
-        private List<Drawable> buildPositionalInputQueue(Vector2 screenSpacePos)
+        private readonly ReadOnlyCollection<Drawable> readOnlyPositionalInputQueue;
+
+        private ReadOnlyCollection<Drawable> buildPositionalInputQueue(Vector2 screenSpacePos)
         {
             positionalInputQueue.Clear();
 
@@ -467,7 +475,7 @@ namespace osu.Framework.Input
                 children[i].BuildPositionalInputQueue(screenSpacePos, positionalInputQueue);
 
             positionalInputQueue.Reverse();
-            return positionalInputQueue;
+            return readOnlyPositionalInputQueue;
         }
 
         protected virtual bool HandleHoverEvents => true;

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
@@ -15,6 +14,7 @@ using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
+using osu.Framework.Lists;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
@@ -116,7 +116,7 @@ namespace osu.Framework.Input
         /// <remarks>
         /// This collection should not be retained as a reference. The contents is not stable outside of local usage.
         /// </remarks>
-        public ReadOnlyCollection<Drawable> PositionalInputQueue => buildPositionalInputQueue(CurrentState.Mouse.Position);
+        public SlimReadOnlyListWrapper<Drawable> PositionalInputQueue => buildPositionalInputQueue(CurrentState.Mouse.Position);
 
         /// <summary>
         /// Contains all <see cref="Drawable"/>s in top-down order which are considered
@@ -125,7 +125,7 @@ namespace osu.Framework.Input
         /// <remarks>
         /// This collection should not be retained as a reference. The contents is not stable outside of local usage.
         /// </remarks>
-        public ReadOnlyCollection<Drawable> NonPositionalInputQueue => buildNonPositionalInputQueue();
+        public SlimReadOnlyListWrapper<Drawable> NonPositionalInputQueue => buildNonPositionalInputQueue();
 
         private readonly Dictionary<MouseButton, MouseButtonEventManager> mouseButtonEventManagers = new Dictionary<MouseButton, MouseButtonEventManager>();
         private readonly Dictionary<Key, KeyEventManager> keyButtonEventManagers = new Dictionary<Key, KeyEventManager>();
@@ -145,8 +145,8 @@ namespace osu.Framework.Input
             CurrentState = CreateInitialState();
             RelativeSizeAxes = Axes.Both;
 
-            readOnlyPositionalInputQueue = new ReadOnlyCollection<Drawable>(positionalInputQueue);
-            readOnlyInputQueue = new ReadOnlyCollection<Drawable>(inputQueue);
+            readOnlyPositionalInputQueue = new SlimReadOnlyListWrapper<Drawable>(positionalInputQueue);
+            readOnlyInputQueue = new SlimReadOnlyListWrapper<Drawable>(inputQueue);
 
             foreach (var button in Enum.GetValues(typeof(MouseButton)).Cast<MouseButton>())
             {
@@ -438,9 +438,9 @@ namespace osu.Framework.Input
 
         private readonly List<Drawable> inputQueue = new List<Drawable>();
 
-        private readonly ReadOnlyCollection<Drawable> readOnlyInputQueue;
+        private readonly SlimReadOnlyListWrapper<Drawable> readOnlyInputQueue;
 
-        private ReadOnlyCollection<Drawable> buildNonPositionalInputQueue()
+        private SlimReadOnlyListWrapper<Drawable> buildNonPositionalInputQueue()
         {
             inputQueue.Clear();
 
@@ -467,9 +467,9 @@ namespace osu.Framework.Input
 
         private readonly List<Drawable> positionalInputQueue = new List<Drawable>();
 
-        private readonly ReadOnlyCollection<Drawable> readOnlyPositionalInputQueue;
+        private readonly SlimReadOnlyListWrapper<Drawable> readOnlyPositionalInputQueue;
 
-        private ReadOnlyCollection<Drawable> buildPositionalInputQueue(Vector2 screenSpacePos)
+        private SlimReadOnlyListWrapper<Drawable> buildPositionalInputQueue(Vector2 screenSpacePos)
         {
             positionalInputQueue.Clear();
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -113,12 +113,18 @@ namespace osu.Framework.Input
         /// that the return value of <see cref="Drawable.OnHover"/> is not taken
         /// into account.
         /// </summary>
+        /// <remarks>
+        /// This collection should not be retained as a reference. The contents is not stable outside of local usage.
+        /// </remarks>
         public ReadOnlyCollection<Drawable> PositionalInputQueue => buildPositionalInputQueue(CurrentState.Mouse.Position);
 
         /// <summary>
         /// Contains all <see cref="Drawable"/>s in top-down order which are considered
         /// for non-positional input.
         /// </summary>
+        /// <remarks>
+        /// This collection should not be retained as a reference. The contents is not stable outside of local usage.
+        /// </remarks>
         public ReadOnlyCollection<Drawable> NonPositionalInputQueue => buildNonPositionalInputQueue();
 
         private readonly Dictionary<MouseButton, MouseButtonEventManager> mouseButtonEventManagers = new Dictionary<MouseButton, MouseButtonEventManager>();


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/191335/87865322-c4b65e80-c9ae-11ea-8dfa-99b0478b90dc.png)

After:

![image](https://user-images.githubusercontent.com/191335/87865296-67221200-c9ae-11ea-8d5d-0e803fd2c461.png)

- [x] Test allocations are still correct with `ReadOnlyCollection` change.