### PR TITLE
Remove linq allocation on GlobalStatistics.Clear

### DIFF
--- a/osu.Framework/Statistics/GlobalStatistics.cs
+++ b/osu.Framework/Statistics/GlobalStatistics.cs
@@ -47,8 +47,11 @@ namespace osu.Framework.Statistics
         {
             lock (statistics)
             {
-                foreach (var stat in statistics.Where(s => group?.Equals(s.Group, StringComparison.Ordinal) != false).ToArray())
-                    statistics.Remove(stat);
+                for (int i = 0; i < statistics.Count; i++)
+                {
+                    if (group?.Equals(statistics[i].Group, StringComparison.Ordinal) != false)
+                        statistics.RemoveAt(i--);
+                }
             }
         }
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/191335/87870940-94d77d00-c9e7-11ea-8cd9-374c1255be84.png)

After:

![image](https://user-images.githubusercontent.com/191335/87870945-9b65f480-c9e7-11ea-8c61-cad66f477de0.png)
