### PR TITLE
Fix LINQ allocations in focusTopMostRequestingDrawable

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -776,7 +776,16 @@ namespace osu.Framework.Input
         private void focusTopMostRequestingDrawable()
         {
             // todo: don't rebuild input queue every frame
-            ChangeFocus(NonPositionalInputQueue.FirstOrDefault(target => target.RequestsFocus));
+            foreach (var d in NonPositionalInputQueue)
+            {
+                if (d.RequestsFocus)
+                {
+                    ChangeFocus(d);
+                    return;
+                }
+            }
+
+            ChangeFocus(null);
         }
 
         private class MouseLeftButtonEventManager : MouseButtonEventManager


### PR DESCRIPTION
Before:
![dotMemory-201 0 20200703 51832_2020-07-19_19-22-15](https://user-images.githubusercontent.com/191335/87872724-21893780-c9f6-11ea-84ae-0109ad3ca7a5.png)

After:
![image](https://user-images.githubusercontent.com/191335/87872734-2c43cc80-c9f6-11ea-8441-b06b7fd7a1b3.png)
