### PR TITLE
Fix LINQ / List alllocations in PropagateBlockableEvent

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -387,7 +387,7 @@ namespace osu.Framework.Input
 
             if (CurrentState.Mouse.IsPositionValid)
             {
-                highFrequencyDrawables.Clear();
+                Debug.Assert(highFrequencyDrawables.Count == 0);
 
                 foreach (var d in PositionalInputQueue)
                 {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -1,4 +1,4 @@
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -403,7 +403,7 @@ namespace osu.Framework.Input
                         highFrequencyDrawables.Add(d);
                 }
 
-                PropagateBlockableEvent(highFrequencyDrawables, new MouseMoveEvent(CurrentState));
+                PropagateBlockableEvent(highFrequencyDrawables.AsSlimReadOnly(), new MouseMoveEvent(CurrentState));
 
                 highFrequencyDrawables.Clear();
             }
@@ -699,7 +699,7 @@ namespace osu.Framework.Input
         /// <param name="drawables">The drawables in the queue.</param>
         /// <param name="e">The event.</param>
         /// <returns>Whether the event was handled.</returns>
-        protected virtual bool PropagateBlockableEvent(List<Drawable> drawables, UIEvent e)
+        protected virtual bool PropagateBlockableEvent(SlimReadOnlyListWrapper<Drawable> drawables, UIEvent e)
         {
             foreach (var d in drawables)
             {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -368,6 +368,8 @@ namespace osu.Framework.Input
 
         private bool hoverEventsUpdated;
 
+        private readonly List<Drawable> highFrequencyDrawables = new List<Drawable>();
+
         protected override void Update()
         {
             unfocusIfNoLongerValid();
@@ -385,7 +387,17 @@ namespace osu.Framework.Input
 
             if (CurrentState.Mouse.IsPositionValid)
             {
-                PropagateBlockableEvent(PositionalInputQueue.Where(d => d is IRequireHighFrequencyMousePosition), new MouseMoveEvent(CurrentState));
+                highFrequencyDrawables.Clear();
+
+                foreach (var d in PositionalInputQueue)
+                {
+                    if (d is IRequireHighFrequencyMousePosition)
+                        highFrequencyDrawables.Add(d);
+                }
+
+                PropagateBlockableEvent(highFrequencyDrawables, new MouseMoveEvent(CurrentState));
+
+                highFrequencyDrawables.Clear();
             }
 
             updateKeyRepeat(CurrentState);
@@ -674,7 +686,7 @@ namespace osu.Framework.Input
         /// <param name="drawables">The drawables in the queue.</param>
         /// <param name="e">The event.</param>
         /// <returns>Whether the event was handled.</returns>
-        protected virtual bool PropagateBlockableEvent(IEnumerable<Drawable> drawables, UIEvent e)
+        protected virtual bool PropagateBlockableEvent(List<Drawable> drawables, UIEvent e)
         {
             var handledBy = drawables.FirstOrDefault(target => target.TriggerEvent(e));
 


### PR DESCRIPTION
Two small changes:
- Don't alloc lists for `IRequireHighFrequency`
- Don't alloc enumerator in `PropagateBlockingEvent` (due to `IEnumerable` param type)
- [x] Depends on https://github.com/ppy/osu-framework/pull/3739.

As one requires the other I did this in a single PR.

Before:
![image](https://user-images.githubusercontent.com/191335/87872860-31ede200-c9f7-11ea-993e-6e35fcb725e9.png)

After:
![image](https://user-images.githubusercontent.com/191335/87872866-3adeb380-c9f7-11ea-94de-2fe1f6212225.png)
