### PR TITLE
Avoid allocating MouseMoveEvents for high frequency when not required

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -370,6 +370,8 @@ namespace osu.Framework.Input
 
         private readonly List<Drawable> highFrequencyDrawables = new List<Drawable>();
 
+        private MouseMoveEvent highFrequencyMoveEvent;
+
         protected override void Update()
         {
             unfocusIfNoLongerValid();
@@ -380,7 +382,9 @@ namespace osu.Framework.Input
 
             hoverEventsUpdated = false;
 
-            foreach (var result in GetPendingInputs())
+            var pendingInputs = GetPendingInputs();
+
+            foreach (var result in pendingInputs)
             {
                 result.Apply(CurrentState, this);
             }
@@ -395,7 +399,15 @@ namespace osu.Framework.Input
                         highFrequencyDrawables.Add(d);
                 }
 
-                PropagateBlockableEvent(highFrequencyDrawables, new MouseMoveEvent(CurrentState));
+                if (highFrequencyDrawables.Count > 0)
+                {
+                    // conditional avoid allocs of MouseMoveEvent when state is guaranteed to not have been mutated.
+                    // can be removed if we pool/change UIEvent allocation to be more efficient.
+                    if (highFrequencyMoveEvent == null || pendingInputs.Count > 0)
+                        highFrequencyMoveEvent = new MouseMoveEvent(CurrentState);
+
+                    PropagateBlockableEvent(highFrequencyDrawables, highFrequencyMoveEvent);
+                }
 
                 highFrequencyDrawables.Clear();
             }


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/3743

I'm not 100% on the logic here (whether checking for pending inputs is enough to guarantee `CurrentState` is not mutated. I can't find a case otherwise, but need feedback from @smoogipoo.

Before:
![image](https://user-images.githubusercontent.com/191335/87873703-98c2c980-c9fe-11ea-8477-b96141efe6c8.png)

After:
![image](https://user-images.githubusercontent.com/191335/87873706-9eb8aa80-c9fe-11ea-92cb-f3bae9dc684d.png)
