### PR TITLE
Avoid comparing buttons when there is guaranteed to be no difference

### DIFF
--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Linq;
+using System.Collections.Immutable;
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Input.States;
 
@@ -15,11 +15,11 @@ namespace osu.Framework.Input.StateChanges
     public abstract class ButtonInput<TButton> : IInput
         where TButton : struct
     {
-        public IEnumerable<ButtonInputEntry<TButton>> Entries;
+        public ImmutableArray<ButtonInputEntry<TButton>> Entries;
 
         protected ButtonInput(IEnumerable<ButtonInputEntry<TButton>> entries)
         {
-            Entries = entries;
+            Entries = entries.ToImmutableArray();
         }
 
         /// <summary>
@@ -29,7 +29,7 @@ namespace osu.Framework.Input.StateChanges
         /// <param name="isPressed">The state of <paramref name="button"/>.</param>
         protected ButtonInput(TButton button, bool isPressed)
         {
-            Entries = new[] { new ButtonInputEntry<TButton>(button, isPressed) };
+            Entries = new[] { new ButtonInputEntry<TButton>(button, isPressed) }.ToImmutableArray();
         }
 
         /// <summary>
@@ -45,8 +45,14 @@ namespace osu.Framework.Input.StateChanges
         {
             var difference = (current ?? new ButtonStates<TButton>()).EnumerateDifference(previous ?? new ButtonStates<TButton>());
 
-            Entries = difference.Released.Select(button => new ButtonInputEntry<TButton>(button, false))
-                                .Concat(difference.Pressed.Select(button => new ButtonInputEntry<TButton>(button, true)));
+            var entries = new List<ButtonInputEntry<TButton>>();
+
+            foreach (var button in difference.Released)
+                entries.Add(new ButtonInputEntry<TButton>(button, false));
+            foreach (var button in difference.Pressed)
+                entries.Add(new ButtonInputEntry<TButton>(button, true));
+
+            Entries = entries.ToImmutableArray();
         }
 
         /// <summary>
@@ -64,6 +70,9 @@ namespace osu.Framework.Input.StateChanges
 
         public virtual void Apply(InputState state, IInputStateChangeHandler handler)
         {
+            if (Entries.Length == 0)
+                return;
+
             var buttonStates = GetButtonStates(state);
 
             foreach (var entry in Entries)

--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Input.StateChanges
         /// <param name="isPressed">The state of <paramref name="button"/>.</param>
         protected ButtonInput(TButton button, bool isPressed)
         {
-            Entries = new[] { new ButtonInputEntry<TButton>(button, isPressed) }.ToImmutableArray();
+            Entries = ImmutableArray.Create(new ButtonInputEntry<TButton>(button, isPressed));
         }
 
         /// <summary>

--- a/osu.Framework/Input/States/ButtonStates.cs
+++ b/osu.Framework/Input/States/ButtonStates.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,13 +49,22 @@ namespace osu.Framework.Input.States
             return true;
         }
 
-        public bool HasAnyButtonPressed => pressedButtons.Any();
+        public bool HasAnyButtonPressed => pressedButtons.Count > 0;
 
         /// <summary>
         /// Enumerates the differences between ourselves and a previous <see cref="ButtonStates{TButton}"/>.
         /// </summary>
         /// <param name="lastButtons">The previous <see cref="ButtonStates{TButton}"/>.</param>
-        public ButtonStateDifference EnumerateDifference(ButtonStates<TButton> lastButtons) => new ButtonStateDifference(lastButtons.Except(this).ToArray(), this.Except(lastButtons).ToArray());
+        public ButtonStateDifference EnumerateDifference(ButtonStates<TButton> lastButtons)
+        {
+            if (!lastButtons.HasAnyButtonPressed)
+                return new ButtonStateDifference(Array.Empty<TButton>(), this);
+
+            if (!HasAnyButtonPressed)
+                return new ButtonStateDifference(lastButtons, Array.Empty<TButton>());
+
+            return new ButtonStateDifference(lastButtons.Except(this).ToArray(), this.Except(lastButtons).ToArray());
+        }
 
         /// <summary>
         /// Copies the state of another <see cref="ButtonStates{TButton}"/> to ourselves.

--- a/osu.Framework/Input/States/ButtonStates.cs
+++ b/osu.Framework/Input/States/ButtonStates.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.Input.States
         public ButtonStateDifference EnumerateDifference(ButtonStates<TButton> lastButtons)
         {
             if (!lastButtons.HasAnyButtonPressed)
-                return new ButtonStateDifference(Array.Empty<TButton>(), this.pressedButtons);
+                return new ButtonStateDifference(Array.Empty<TButton>(), pressedButtons);
 
             if (!HasAnyButtonPressed)
                 return new ButtonStateDifference(lastButtons.pressedButtons, Array.Empty<TButton>());

--- a/osu.Framework/Input/States/ButtonStates.cs
+++ b/osu.Framework/Input/States/ButtonStates.cs
@@ -58,10 +58,10 @@ namespace osu.Framework.Input.States
         public ButtonStateDifference EnumerateDifference(ButtonStates<TButton> lastButtons)
         {
             if (!lastButtons.HasAnyButtonPressed)
-                return new ButtonStateDifference(Array.Empty<TButton>(), this);
+                return new ButtonStateDifference(Array.Empty<TButton>(), this.pressedButtons);
 
             if (!HasAnyButtonPressed)
-                return new ButtonStateDifference(lastButtons, Array.Empty<TButton>());
+                return new ButtonStateDifference(lastButtons.pressedButtons, Array.Empty<TButton>());
 
             return new ButtonStateDifference(lastButtons.Except(this).ToArray(), this.Except(lastButtons).ToArray());
         }


### PR DESCRIPTION
Reduces allocations when moving the mouse with no buttons pressed.

Before:
![image](https://user-images.githubusercontent.com/191335/87876565-daaa3a80-ca13-11ea-9e1a-3fbf2f1d94e9.png)

After:
![image](https://user-images.githubusercontent.com/191335/87876521-88691980-ca13-11ea-9ab7-2f6a09128277.png)

