### PR TITLE
Add wrapper to create a slim read-only list

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkSlimReadOnlyCollection.cs
+++ b/osu.Framework.Benchmarks/BenchmarkSlimReadOnlyCollection.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Extensions.ListExtensions;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkSlimReadOnlyCollection
+    {
+        private readonly List<int> list = new List<int> { 0, 1, 2, 3, 4, 5, 3, 2, 3, 1, 4, 5, -1 };
+
+        [Benchmark(Baseline = true)]
+        public int List()
+        {
+            int sum = 0;
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (var v in list)
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ListAsReadOnly()
+        {
+            int sum = 0;
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (var v in list.AsReadOnly())
+                    sum += v;
+            }
+
+            return sum;
+        }
+
+        [Benchmark]
+        public int ListAsSlimReadOnly()
+        {
+            int sum = 0;
+
+            for (int i = 0; i < 1000; i++)
+            {
+                foreach (var v in list.AsSlimReadOnly())
+                    sum += v;
+            }
+
+            return sum;
+        }
+    }
+}

--- a/osu.Framework/Extensions/ListExtensions/ListExtensions.cs
+++ b/osu.Framework/Extensions/ListExtensions/ListExtensions.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Lists;
+
+namespace osu.Framework.Extensions.ListExtensions
+{
+    public static class ListExtensions
+    {
+        /// <summary>
+        /// Creates a new read-only view into a <see cref="List{T}"/>.
+        /// </summary>
+        /// <remarks>Enumeration does not allocate the enumerator.</remarks>
+        /// <param name="list">The list to create the view of.</param>
+        /// <typeparam name="T">The type of elements contained by the list.</typeparam>
+        /// <returns>The read-only view.</returns>
+        public static SlimReadOnlyListWrapper<T> AsSlimReadOnly<T>(this List<T> list)
+            => new SlimReadOnlyListWrapper<T>(list);
+    }
+}

--- a/osu.Framework/Lists/SlimReadOnlyListWrapper.cs
+++ b/osu.Framework/Lists/SlimReadOnlyListWrapper.cs
@@ -1,0 +1,93 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using osu.Framework.Extensions.ListExtensions;
+
+namespace osu.Framework.Lists
+{
+    /// <summary>
+    /// A wrapper that provides a read-only view into a <see cref="List{T}"/>.
+    /// This can be instantiated via the <see cref="ListExtensions.AsSlimReadOnly{T}"/> extension method.
+    /// </summary>
+    /// <typeparam name="T">The type of elements contained by the list.</typeparam>
+    public readonly struct SlimReadOnlyListWrapper<T> : IList<T>, IList, IReadOnlyList<T>
+    {
+        private readonly List<T> list;
+
+        public SlimReadOnlyListWrapper(List<T> list)
+        {
+            this.list = list;
+        }
+
+        public List<T>.Enumerator GetEnumerator() => list.GetEnumerator();
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Add(T item) => throw new NotImplementedException();
+
+        public int Add(object? value) => throw new NotImplementedException();
+
+        void IList.Clear() => throw new NotImplementedException();
+
+        public bool Contains(object? value) => ((IList)list).Contains(value);
+
+        public int IndexOf(object? value) => ((IList)list).IndexOf(value);
+
+        public void Insert(int index, object? value) => ((IList)list).Insert(index, value);
+
+        public void Remove(object? value) => throw new NotImplementedException();
+
+        void IList.RemoveAt(int index) => throw new NotImplementedException();
+
+        public bool IsFixedSize => ((IList)list).IsFixedSize;
+
+        bool IList.IsReadOnly => true;
+
+        object? IList.this[int index]
+        {
+            get => ((IList)list)[index];
+            set => throw new NotImplementedException();
+        }
+
+        void ICollection<T>.Clear() => throw new NotImplementedException();
+
+        public bool Contains(T item) => list.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => list.CopyTo(array, arrayIndex);
+
+        public bool Remove(T item) => throw new NotImplementedException();
+
+        public void CopyTo(Array array, int index) => ((ICollection)list).CopyTo(array, index);
+
+        int ICollection.Count => list.Count;
+
+        public bool IsSynchronized => ((ICollection)list).IsSynchronized;
+
+        public object SyncRoot => ((ICollection)list).SyncRoot;
+
+        int ICollection<T>.Count => list.Count;
+
+        bool ICollection<T>.IsReadOnly => true;
+
+        public int IndexOf(T item) => list.IndexOf(item);
+
+        public void Insert(int index, T item) => throw new NotImplementedException();
+
+        void IList<T>.RemoveAt(int index) => throw new NotImplementedException();
+
+        public T this[int index]
+        {
+            get => list[index];
+            set => throw new NotImplementedException();
+        }
+
+        int IReadOnlyCollection<T>.Count => list.Count;
+    }
+}


### PR DESCRIPTION
This should help with https://github.com/ppy/osu-framework/pull/3739 (it's a drop-in replacement). Supports `List<T>` for now, though in the future it could be upgraded to support more lists with minimal performance cost (~5us in the benchmarks).

|             Method |      Mean |    Error |   StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------- |----------:|---------:|---------:|------:|--------:|-------:|------:|------:|----------:|
|               List |  29.03 us | 0.051 us | 0.045 us |  1.00 |    0.00 |      - |     - |     - |         - |
|     ListAsReadOnly | 124.87 us | 0.520 us | 0.461 us |  4.30 |    0.02 | 1.7090 |     - |     - |   64000 B |
| ListAsSlimReadOnly |  28.89 us | 0.051 us | 0.045 us |  0.99 |    0.00 |      - |     - |     - |         - |
