### PR TITLE
Rescale joystick axis values according to deadzones

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneJoystick.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneJoystick.cs
@@ -211,7 +211,7 @@ namespace osu.Framework.Tests.Visual.Input
                 positiveAxisButton = JoystickButton.FirstAxisPositive + trackedAxis;
                 negativeAxisButton = JoystickButton.FirstAxisNegative + trackedAxis;
 
-                Size = new Vector2(50);
+                Size = new Vector2(100, 50);
 
                 InternalChildren = new[]
                 {
@@ -259,7 +259,7 @@ namespace osu.Framework.Tests.Visual.Input
             protected override bool OnJoystickAxisMove(JoystickAxisMoveEvent e)
             {
                 if (e.Axis.Source == trackedAxis)
-                    rawValue.Text = e.Axis.Value.ToString("0.00");
+                    rawValue.Text = e.Axis.Value.ToString("0.0000000");
 
                 return false;
             }

--- a/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
@@ -224,8 +224,8 @@ namespace osu.Framework.Input.Handlers.Joystick
                         if (Precision.AlmostEquals(0, axisValue))
                             continue;
 
-                        // Cap deadzones at 0.999f to avoid division by zero when rescaling
-                        defaultDeadZones.Value[i] = Math.Min(0.999f, axisValue + deadzone_threshold);
+                        // Cap deadzone at 0.5f to avoid division by zero and catastrophic cancellation when rescaling
+                        defaultDeadZones.Value[i] = Math.Min(0.5f, axisValue + deadzone_threshold);
                     }
                 }
             }

--- a/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/OsuTKJoystickHandler.cs
@@ -114,12 +114,15 @@ namespace osu.Framework.Input.Handlers.Joystick
                     if (Precision.AlmostEquals(value, 0, deadzone))
                         // Round values in the deadzone to zero.
                         value = 0;
+                    else
+                        // Rescale values then clamp back into [-1;1] range.
+                        value = Math.Clamp((value - deadzone * Math.Sign(value)) / (1 - deadzone), -1, 1);
 
                     AxesValues[i] = value;
 
-                    if (value > deadzone)
+                    if (value > 0)
                         Buttons.SetPressed(JoystickButton.FirstAxisPositive + i, true);
-                    else if (value < -deadzone)
+                    else if (value < 0)
                         Buttons.SetPressed(JoystickButton.FirstAxisNegative + i, true);
                 }
 
@@ -221,7 +224,8 @@ namespace osu.Framework.Input.Handlers.Joystick
                         if (Precision.AlmostEquals(0, axisValue))
                             continue;
 
-                        defaultDeadZones.Value[i] = axisValue + deadzone_threshold;
+                        // Cap deadzones at 0.999f to avoid division by zero when rescaling
+                        defaultDeadZones.Value[i] = Math.Min(0.999f, axisValue + deadzone_threshold);
                     }
                 }
             }


### PR DESCRIPTION
Closes #3712.

Only issue left seems to be rounding errors that are particularly visible on large deadzones, which is fairly easy to replicate using triggers.

On my Dualshock 4, extreme values on triggers (deadzone `0.999f`) without clamping are `-1.0152590` and `0.9847410`.