### PR TITLE
Improve performance/reduce allocations in ButtonInput

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkButtonInput.cs
+++ b/osu.Framework.Benchmarks/BenchmarkButtonInput.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Input.StateChanges;
+using osu.Framework.Input.StateChanges.Events;
+using osu.Framework.Input.States;
+using osuTK.Input;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkButtonInput
+    {
+        [Arguments(1)]
+        [Arguments(5)]
+        [Arguments(10)]
+        [Arguments(50)]
+        [Benchmark]
+        public KeyboardKeyInput FromTwoStates(int count)
+        {
+            var state1 = new ButtonStates<Key>();
+            var state2 = new ButtonStates<Key>();
+
+            for (int i = 0; i < count; i++)
+                state1.SetPressed((Key)i, true);
+
+            for (int i = count; i < 2 * count; i++)
+                state2.SetPressed((Key)i, true);
+
+            return new KeyboardKeyInput(state1, state2);
+        }
+
+        [Benchmark]
+        public InputState Apply()
+        {
+            var entries = new List<ButtonInputEntry<Key>>();
+
+            for (int i = 0; i < 10; i++)
+                entries.Add(new ButtonInputEntry<Key>((Key)i, true));
+
+            var input = new KeyboardKeyInput(entries);
+            var state = new InputState();
+            input.Apply(state, new NullStateChangeHandler());
+
+            return state;
+        }
+
+        private struct NullStateChangeHandler : IInputStateChangeHandler
+        {
+            public void HandleInputStateChange(InputStateChangeEvent inputStateChange)
+            {
+            }
+        }
+    }
+}

--- a/osu.Framework.Benchmarks/BenchmarkButtonStates.cs
+++ b/osu.Framework.Benchmarks/BenchmarkButtonStates.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Input.States;
+using osuTK.Input;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkButtonStates
+    {
+        [Benchmark(Baseline = true)]
+        public ButtonStates<MouseButton> CreateNew() => new ButtonStates<MouseButton>();
+
+        [Arguments(1)]
+        [Arguments(5)]
+        [Arguments(10)]
+        [Arguments(50)]
+        [Benchmark]
+        public bool SetPressed()
+        {
+            var states = new ButtonStates<MouseButton>();
+            states.SetPressed(MouseButton.Button1, true);
+            return states.HasAnyButtonPressed;
+        }
+
+        [Benchmark]
+        public int EnumerateEmptyDifferences() => new ButtonStates<MouseButton>().EnumerateDifference(new ButtonStates<MouseButton>()).Pressed.Length;
+
+        [Arguments(1)]
+        [Arguments(5)]
+        [Arguments(10)]
+        [Arguments(50)]
+        [Benchmark]
+        public int EnumerateBothDifferences(int count)
+        {
+            var state1 = new ButtonStates<Key>();
+            var state2 = new ButtonStates<Key>();
+
+            for (int i = 0; i < count; i++)
+                state1.SetPressed((Key)i, true);
+
+            for (int i = count; i < 2 * count; i++)
+                state2.SetPressed((Key)i, true);
+
+            return state1.EnumerateDifference(state2).Pressed.Length;
+        }
+    }
+}

--- a/osu.Framework/Input/StateChanges/ButtonInput.cs
+++ b/osu.Framework/Input/StateChanges/ButtonInput.cs
@@ -45,14 +45,14 @@ namespace osu.Framework.Input.StateChanges
         {
             var difference = (current ?? new ButtonStates<TButton>()).EnumerateDifference(previous ?? new ButtonStates<TButton>());
 
-            var entries = new List<ButtonInputEntry<TButton>>();
+            var builder = ImmutableArray.CreateBuilder<ButtonInputEntry<TButton>>(difference.Released.Length + difference.Pressed.Length);
 
             foreach (var button in difference.Released)
-                entries.Add(new ButtonInputEntry<TButton>(button, false));
+                builder.Add(new ButtonInputEntry<TButton>(button, false));
             foreach (var button in difference.Pressed)
-                entries.Add(new ButtonInputEntry<TButton>(button, true));
+                builder.Add(new ButtonInputEntry<TButton>(button, true));
 
-            Entries = entries.ToImmutableArray();
+            Entries = builder.MoveToImmutable();
         }
 
         /// <summary>


### PR DESCRIPTION
Follows on from the previous performance improvements, which now allows `ButtonInput` to use the builder and forego an extra `.ToArray()` + allocations therein.

Master:

|        Method | count |       Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |------ |-----------:|---------:|---------:|-------:|------:|------:|----------:|
|         Apply |     ? | 1,060.5 ns |  4.93 ns |  4.61 ns | 0.0706 |     - |     - |    2416 B |
| FromTwoStates |     1 |   370.1 ns |  2.30 ns |  2.04 ns | 0.0219 |     - |     - |     744 B |
| FromTwoStates |     5 |   849.8 ns |  4.34 ns |  3.85 ns | 0.0448 |     - |     - |    1528 B |
| FromTwoStates |    10 | 1,439.6 ns |  5.94 ns |  5.27 ns | 0.0820 |     - |     - |    2752 B |
| FromTwoStates |    50 | 5,172.2 ns | 19.83 ns | 18.55 ns | 0.3052 |     - |     - |   10416 B |

This PR:

|        Method | count |       Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------- |------ |-----------:|---------:|---------:|-------:|------:|------:|----------:|
|         Apply |     ? | 1,050.6 ns | 11.43 ns | 10.13 ns | 0.0706 |     - |     - |    2416 B |
| FromTwoStates |     1 |   298.9 ns |  2.10 ns |  1.97 ns | 0.0205 |     - |     - |     688 B |
| FromTwoStates |     5 |   724.4 ns |  3.61 ns |  3.38 ns | 0.0362 |     - |     - |    1232 B |
| FromTwoStates |    10 | 1,261.8 ns |  6.70 ns |  6.27 ns | 0.0648 |     - |     - |    2176 B |
| FromTwoStates |    50 | 4,906.3 ns | 18.98 ns | 16.83 ns | 0.2441 |     - |     - |    8256 B |
