### PR TITLE
Fix android screen suspension logic

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Android
                 {
                     RunOnUiThread(() =>
                     {
-                        if (allow.NewValue)
+                        if (!allow.NewValue)
                             Window.AddFlags(WindowManagerFlags.KeepScreenOn);
                         else
                             Window.ClearFlags(WindowManagerFlags.KeepScreenOn);


### PR DESCRIPTION
It turns out the logic wasn't even right for android screen suspension as it was missing a negation. Until now, the `KeepScreenOn` flag was set when `AllowScreenSuspension.Value = true`, which should actually be the other way around.