### PR TITLE
Fix sample potentially being left in a playing state due to threading

### DIFF
--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -1,0 +1,111 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using ManagedBass;
+using NUnit.Framework;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Development;
+using osu.Framework.IO.Stores;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Audio
+{
+    [TestFixture]
+    public class SampleBassTest
+    {
+        private DllResourceStore resources;
+
+        private SampleBass sample;
+
+        private SampleChannelBass channel;
+
+        [SetUp]
+        public void Setup()
+        {
+            // Initialize bass with no audio to make sure the test remains consistent even if there is no audio device.
+            Bass.Init(0);
+
+            resources = new DllResourceStore(typeof(TrackBassTest).Assembly);
+
+            sample = new SampleBass(resources.Get("Resources.Tracks.sample-track.mp3"));
+
+            channel = new SampleChannelBass(sample, channel => { });
+            updateSample();
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            Bass.Free();
+        }
+
+        [Test]
+        public void TestStart()
+        {
+            channel.Play();
+            updateSample();
+
+            Thread.Sleep(50);
+
+            updateSample();
+
+            Assert.IsTrue(channel.Playing);
+        }
+
+        [Test]
+        public void TestStop()
+        {
+            channel.Play();
+            updateSample();
+
+            channel.Stop();
+            updateSample();
+
+            Assert.IsFalse(channel.Playing);
+        }
+
+        [Test]
+        public void TestStopBeforeLoadFinished()
+        {
+            channel.Play();
+            channel.Stop();
+
+            updateSample();
+
+            Assert.IsFalse(channel.Playing);
+        }
+
+        private void updateSample() => runOnAudioThread(() =>
+        {
+            sample.Update();
+            channel.Update();
+        });
+
+        /// <summary>
+        /// Certain actions are invoked on the audio thread.
+        /// Here we simulate this process on a correctly named thread to avoid endless blocking.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        private void runOnAudioThread(Action action)
+        {
+            var resetEvent = new ManualResetEvent(false);
+
+            new Thread(() =>
+            {
+                ThreadSafety.IsAudioThread = true;
+
+                action();
+
+                resetEvent.Set();
+            })
+            {
+                Name = GameThread.PrefixedThreadNameFor("Audio")
+            }.Start();
+
+            if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException();
+        }
+    }
+}

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -103,13 +103,14 @@ namespace osu.Framework.Audio.Sample
 
         public override void Stop()
         {
-            if (channel == 0) return;
-
             base.Stop();
 
             EnqueueAction(() =>
             {
+                if (channel == 0) return;
+
                 Bass.ChannelStop(channel);
+
                 // ChannelStop frees the channel.
                 channel = 0;
             });


### PR DESCRIPTION
Fixes https://ci.appveyor.com/project/peppy/osu/builds/34357847/tests (I reproduced the failure in < 5 minutes of repeated tests, and could not for 1 hour of repeated testing with the fix applied). Should be obvious why this was breaking (the sample channel could still not be loaded at the time `Stop` is called).

Third new test fails on master 100%:

![image](https://user-images.githubusercontent.com/191335/88760682-7a03c600-d1a8-11ea-884e-de70d8e99141.png)


Also resolves https://github.com/ppy/osu/issues/9698.