### PR TITLE
Temporarily disable background stack trace fetching to avoid memory leak

### DIFF
--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -171,7 +171,11 @@ namespace osu.Framework.Statistics
 
         private static IList<ClrStackFrame> getStackTrace(Thread targetThread)
         {
-            try
+            // temporarily disabled due to memory leak per CreateRuntime() call.
+            // as a side note, we are using a legacy version of this package and the newer one removes the functionality we are using (but fixes the leak).
+            return null;
+
+            /*try
             {
                 var target = DataTarget.AttachToProcess(Process.GetCurrentProcess().Id, 200, AttachFlag.Passive);
 
@@ -186,7 +190,7 @@ namespace osu.Framework.Statistics
             catch
             {
                 return null;
-            }
+            }*/
         }
 
         #region IDisposable Support


### PR DESCRIPTION
- Closes #3768

Reproducible leak with simple code:
```csharp
using (var target = DataTarget.AttachToProcess(Process.GetCurrentProcess().Id, 200, AttachFlag.Passive))
{
    while (true)
    {
        var runtime = target.ClrVersions.First().CreateRuntime();
        runtime.Flush(); // leaks regardless of presence
    }
}
```

Storing runtime for reuse is not an option as the stack trace will not update. Using newer version of `Microsoft.Diagnostics.Runtime` is not an option as it no longer allows attaching to a running process.