### PR TITLE
Update to latest Microsoft.Diagnostics.Runtime

### DIFF
--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -77,6 +77,12 @@ namespace osu.Framework.Statistics
 
         private void startThread()
         {
+            // Since v2.0 of Microsoft.Diagnostics.Runtime, support is provided to retrieve stack traces on unix platforms but
+            // it causes a full core dump, which is very slow and causes a visible freeze.
+            // For the time being let's remain windows-only (as this functionality used to be).
+            if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
+                return;
+
             Trace.Assert(cancellation == null);
 
             var thread = new Thread(() => run((cancellation = new CancellationTokenSource()).Token))

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -30,7 +30,7 @@
     <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.0-beta0007" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.6.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="1.1.127808" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.137201" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="ManagedBass" Version="2.0.4" />
     <PackageReference Include="ManagedBass.Fx" Version="2.0.1" />


### PR DESCRIPTION
- Closes #3768 via new disposal of runtime

Stack traces must be stored as strings at the point of retrieval, else their underlying data is not available to be read at the point of logging. Sample output:

```

2020-07-29 16:06:30 [verbose]: | Stack trace:
2020-07-29 16:06:30 [verbose]: |- [GCFrame]
2020-07-29 16:06:30 [verbose]: |- [HelperMethodFrame]
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Sprites.SpriteText.CreateTextBuilder(osu.Framework.Text.ITexturedGlyphLookupStore)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Sprites.SpriteText.computeCharacters()
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Sprites.SpriteText.computeScreenSpaceCharacters()
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Sprites.SpriteText+SpriteTextDrawNode.ApplyState()
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Drawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.addFromComposite(UInt64, Int32, Boolean, Int32 ByRef, osu.Framework.Graphics.Containers.CompositeDrawable, System.Collections.Generic.List`1<osu.Framework.Graphics.DrawNode>)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Graphics.Containers.CompositeDrawable.GenerateDrawNodeSubtree(UInt64, Int32, Boolean)
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Platform.GameHost.UpdateFrame()
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Threading.GameThread.ProcessFrame()
2020-07-29 16:06:30 [verbose]: |- osu.Framework.Threading.GameThread.runWork()
2020-07-29 16:06:30 [verbose]: |- System.Threading.ThreadHelper.ThreadStart_Context(System.Object)
2020-07-29 16:06:30 [verbose]: |- System.Threading.ExecutionContext.RunInternal(System.Threading.ExecutionContext, System.Threading.ContextCallback, System.Object)
2020-07-29 16:06:30 [verbose]: |- System.Threading.ThreadHelper.ThreadStart()
2020-07-29 16:06:30 [verbose]: |- [GCFrame]
2020-07-29 16:06:30 [verbose]: |- [DebuggerU2MCatchHandlerFrame]
```
