### PR TITLE
Use different assembly names for dynamic assemblies

### DIFF
--- a/osu.Framework/Properties/AssemblyInfo.cs
+++ b/osu.Framework/Properties/AssemblyInfo.cs
@@ -8,6 +8,5 @@ using System.Runtime.CompilerServices;
 // behavior "in the wild".
 
 [assembly: InternalsVisibleTo("osu.Framework.Tests")]
-[assembly: InternalsVisibleTo("osu.Framework.Tests.Dynamic")]
 [assembly: InternalsVisibleTo("osu.Framework.Tests.iOS")]
 [assembly: InternalsVisibleTo("osu.Framework.Tests.Android")]


### PR DESCRIPTION
Resolves part (2) of https://github.com/ppy/osu-framework/issues/3775#issuecomment-666168195

I didn't realise that this would ever become a problem again, but in the PR above you could only change `LegacyFruitPiece` once - subsequent changes would use the old code. Rather than tinkering with the assembly version (which seems highly volatile), it's better to use a completely different assembly name altogether. Other examples using Roslyn typically use `Guid.NewGuid()` in similar cases.

The problem with this is getting `internal`s to work. Currently all non-test projects need to have a `InternalsVisibleTo(X.Tests.Dynamic)` attribute but this isn't possible if a completely new assembly name is used.

It turns out that there is an [internal compiler attribute](https://www.strathweb.com/2018/10/no-internalvisibleto-no-problem-bypassing-c-visibility-rules-with-roslyn/) (`IgnoresAccessChecksTo()`), which works in the opposite direction to `InternalsVisibleTo()`. This is only possible through dynamic compilation (i.e. this attribute cannot be used to achieve the effect with standard compiles.
The usage of this attribute is quite hacky, it requires:
1. `CSharpCompilationOptions` to include all metadata references.
2. Reflection to set an `internal` member of said `CSharpCompilationOptions`.
3. The building of a syntax tree using this new attribute/generating all values.

Can be tested to work with the following:
```diff
diff --git a/osu.Framework.Tests/Visual/TestSceneTesting.cs b/osu.Framework.Tests/Visual/TestSceneTesting.cs
new file mode 100644
index 000000000..3b186212d
--- /dev/null
+++ b/osu.Framework.Tests/Visual/TestSceneTesting.cs
@@ -0,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Tests.Visual
+{
+    public class TestSceneTesting : FrameworkTestScene
+    {
+        public TestSceneTesting()
+        {
+            ClassWithInternals.Value++;
+        }
+    }
+}
diff --git a/osu.Framework/ClassWithInternals.cs b/osu.Framework/ClassWithInternals.cs
new file mode 100644
index 000000000..b008b2792
--- /dev/null
+++ b/osu.Framework/ClassWithInternals.cs
@@ -0,0 +1,10 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework
+{
+    public class ClassWithInternals
+    {
+        internal static int Value;
+    }
+}
```