### PR TITLE
Improve performance of transform logic when many transforms are present

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkTransformUpdate.cs
+++ b/osu.Framework.Benchmarks/BenchmarkTransformUpdate.cs
@@ -1,0 +1,51 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Timing;
+using osuTK;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkTransformUpdate : BenchmarkTest
+    {
+        private TestBox target;
+
+        public override void SetUp()
+        {
+            base.SetUp();
+
+            const int transforms_count = 10000;
+
+            ManualClock clock;
+
+            target = new TestBox { Clock = new FramedClock(clock = new ManualClock()) };
+
+            // transform one target member over a long period
+            target.RotateTo(360, transforms_count * 2);
+
+            // transform another over the same period many times
+            for (int i = 0; i < transforms_count; i++)
+                target.Delay(i).MoveTo(new Vector2(0.01f), 1f);
+
+            clock.CurrentTime = target.LatestTransformEndTime;
+            target.Clock.ProcessFrame();
+        }
+
+        [Benchmark]
+        public void UpdateTransformsWithManyPresent()
+        {
+            for (int i = 0; i < 10000; i++)
+                target.UpdateTransforms();
+        }
+
+        private class TestBox : Box
+        {
+            public override bool RemoveCompletedTransforms => false;
+
+            public new void UpdateTransforms() => base.UpdateTransforms();
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneVisibilityContainer.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -125,7 +126,7 @@ namespace osu.Framework.Tests.Visual.Containers
 
         private class TestNestedVisibilityContainer : TestVisibilityContainer
         {
-            public bool BoxHasTransforms => box.Transforms.Count > 0;
+            public bool BoxHasTransforms => box.Transforms.Any();
 
             private readonly TestVisibilityContainer nested;
             private readonly Box box;

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkAtTime(500, box => Precision.AlmostEquals(box.Scale.X, 0.5f));
             checkAtTime(250, box => Precision.AlmostEquals(box.Scale.X, 0.75f));
 
-            AddAssert("check transform count", () => box.Transforms.Count == 1);
+            AddAssert("check transform count", () => box.Transforms.Count() == 1);
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkAtTime(interval * (i -= 2), box => Precision.AlmostEquals(box.Scale.X, 0.5f));
             checkAtTime(interval * --i, box => Precision.AlmostEquals(box.Scale.X, 0.75f));
 
-            AddAssert("check transform count", () => box.Transforms.Count == 4);
+            AddAssert("check transform count", () => box.Transforms.Count() == 4);
         }
 
         [Test]
@@ -105,7 +105,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkAtTime(interval * (i -= 2), box => Precision.AlmostEquals(box.Y, 0.75f));
             checkAtTime(interval * --i, box => Precision.AlmostEquals(box.X, 0.75f));
 
-            AddAssert("check transform count", () => box.Transforms.Count == 4);
+            AddAssert("check transform count", () => box.Transforms.Count() == 4);
         }
 
         [Test]
@@ -131,7 +131,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             checkAtTime(interval * (i - 2), box => Precision.AlmostEquals(box.Alpha, 1f));
 
-            AddAssert("check transform count", () => box.Transforms.Count == 7);
+            AddAssert("check transform count", () => box.Transforms.Count() == 7);
         }
 
         [Test]
@@ -154,7 +154,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             checkAtTime(interval * ++i, box => Precision.AlmostEquals(box.Scale.X, 0.1f));
 
-            AddAssert("check transform count", () => box.Transforms.Count == 2);
+            AddAssert("check transform count", () => box.Transforms.Count() == 2);
         }
 
         [Test]
@@ -176,7 +176,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkAtTime(interval * --i, box => Precision.AlmostEquals(box.Scale.X, 0.3125f));
             checkAtTime(interval * --i, box => Precision.AlmostEquals(box.Scale.X, 0.25f));
 
-            AddAssert("check transform count", () => box.Transforms.Count == 2);
+            AddAssert("check transform count", () => box.Transforms.Count() == 2);
         }
 
         [Test]
@@ -199,7 +199,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkAtTime(interval * --i, box => Precision.AlmostEquals(box.Scale.X, 0.6875f));
             checkAtTime(interval * --i, box => Precision.AlmostEquals(box.Scale.X, 0.375f));
 
-            AddAssert("check transform count", () => box.Transforms.Count == 2);
+            AddAssert("check transform count", () => box.Transforms.Count() == 2);
         }
 
         [Test]
@@ -216,7 +216,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkAtTime(interval * 4, box => Precision.AlmostEquals(box.Alpha, 1) && Precision.AlmostEquals(box.Scale.X, 0.9f));
             checkAtTime(interval * 2, box => Precision.AlmostEquals(box.Alpha, 0) && Precision.AlmostEquals(box.Scale.X, 0.575f));
 
-            AddAssert("check transform count", () => box.Transforms.Count == 3);
+            AddAssert("check transform count", () => box.Transforms.Count() == 3);
         }
 
         [Test]
@@ -238,8 +238,8 @@ namespace osu.Framework.Tests.Visual.Drawables
                     box.Delay(interval * 3).FadeOutFromOne(interval);
 
                     // FadeOutFromOne adds extra transforms which disallow testing this scenario, so we remove them.
-                    box.RemoveTransform(box.Transforms[2]);
-                    box.RemoveTransform(box.Transforms[0]);
+                    box.RemoveTransform(box.Transforms.ElementAt(2));
+                    box.RemoveTransform(box.Transforms.ElementAt(0));
                 }
             });
 
@@ -272,8 +272,8 @@ namespace osu.Framework.Tests.Visual.Drawables
                     box.Delay(interval * 3).FadeInFromZero(interval);
 
                     // FadeOutFromOne adds extra transforms which disallow testing this scenario, so we remove them.
-                    box.RemoveTransform(box.Transforms[2]);
-                    box.RemoveTransform(box.Transforms[0]);
+                    box.RemoveTransform(box.Transforms.ElementAt(2));
+                    box.RemoveTransform(box.Transforms.ElementAt(0));
                 }
             });
 
@@ -300,7 +300,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                 checkAtTime(interval * i, box => Precision.AlmostEquals(box.Rotation, 0));
             }
 
-            AddAssert("check transform count", () => box.Transforms.Count == 10);
+            AddAssert("check transform count", () => box.Transforms.Count() == 10);
 
             for (int i = count; i >= 0; i--)
             {
@@ -316,7 +316,7 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             checkAtTime(750, box => Precision.AlmostEquals(box.Rotation, 0f));
 
-            AddAssert("check transform count", () => box.Transforms.Count == 8);
+            AddAssert("check transform count", () => box.Transforms.Count() == 8);
 
             const int count = 4;
 
@@ -326,7 +326,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                 checkAtTime(interval * i, box => Precision.AlmostEquals(box.Rotation, 0));
             }
 
-            AddAssert("check transform count", () => box.Transforms.Count == 10);
+            AddAssert("check transform count", () => box.Transforms.Count() == 10);
 
             for (int i = count; i >= 0; i--)
             {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1822,7 +1822,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void autoSizeResizeTo(Vector2 newSize, double duration = 0, Easing easing = Easing.None)
         {
-            var currentTransform = Transforms.Count == 0 ? null : Transforms.OfType<AutoSizeTransform>().FirstOrDefault();
+            var currentTransform = !Transforms.Any() ? null : Transforms.OfType<AutoSizeTransform>().FirstOrDefault();
 
             if ((currentTransform?.EndValue ?? Size) != newSize)
             {

--- a/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Graphics.Transforms
         {
             if (rewinding && !transformable.RemoveCompletedTransforms)
             {
-                resetLastAppliedCache();
+                resetLastAppliedIndex();
 
                 bool appliedToEndRevert = false;
 
@@ -186,7 +186,7 @@ namespace osu.Framework.Graphics.Transforms
                 }
 
                 if (flushAppliedCache)
-                    resetLastAppliedCache();
+                    resetLastAppliedIndex();
                 // if this transform is applied to end, we can be sure that all previous transforms have been completed.
                 else if (t.AppliedToEnd)
                     lastAppliedIndex = i + 1;
@@ -214,7 +214,7 @@ namespace osu.Framework.Graphics.Transforms
 
             transform.TransformID = customTransformID ?? ++currentTransformID;
             int insertionIndex = transforms.Add(transform);
-            resetLastAppliedCache();
+            resetLastAppliedIndex();
 
             // Remove all existing following transforms touching the same property as this one.
             for (int i = insertionIndex + 1; i < transforms.Count; ++i)
@@ -250,7 +250,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="time">The time to clear <see cref="Transform"/>s after.</param>
         public virtual void ClearTransformsAfter(double time)
         {
-            resetLastAppliedCache();
+            resetLastAppliedIndex();
 
             var toAbort = transforms.Where(t => t.StartTime >= time).ToArray();
             transforms.RemoveAll(t => t.StartTime >= time);
@@ -270,7 +270,7 @@ namespace osu.Framework.Graphics.Transforms
             var toFlush = transforms.Where(toFlushPredicate).ToArray();
 
             transforms.RemoveAll(toFlushPredicate);
-            resetLastAppliedCache();
+            resetLastAppliedIndex();
 
             foreach (Transform t in toFlush)
             {
@@ -294,6 +294,6 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// Reset the last applied index cache completely.
         /// </summary>
-        private void resetLastAppliedCache() => lastAppliedIndex = null;
+        private void resetLastAppliedIndex() => lastAppliedIndex = null;
     }
 }

--- a/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Graphics.Transforms
 
         private readonly Transformable transformable;
 
-        private readonly Lazy<List<Action>> removalActions = new Lazy<List<Action>>(() => new List<Action>());
+        private readonly List<Action> removalActions = new List<Action>();
 
         /// <summary>
         /// Used to assign a monotonically increasing ID to <see cref="Transform"/>s as they are added. This member is
@@ -132,7 +132,7 @@ namespace osu.Framework.Graphics.Transforms
                             i--;
 
                             if (u.OnAbort != null)
-                                removalActions.Value.Add(u.OnAbort);
+                                removalActions.Add(u.OnAbort);
                         }
                         else
                             u.AppliedToEnd = true;
@@ -182,7 +182,7 @@ namespace osu.Framework.Graphics.Transforms
                             flushAppliedCache = true;
                         }
                         else if (t.OnComplete != null)
-                            removalActions.Value.Add(t.OnComplete);
+                            removalActions.Add(t.OnComplete);
                     }
                 }
 
@@ -223,7 +223,7 @@ namespace osu.Framework.Graphics.Transforms
                 var t = transforms[i];
                 transforms.RemoveAt(i--);
                 if (t.OnAbort != null)
-                    removalActions.Value.Add(t.OnAbort);
+                    removalActions.Add(t.OnAbort);
             }
 
             invokePendingRemovalActions();
@@ -282,10 +282,10 @@ namespace osu.Framework.Graphics.Transforms
 
         private void invokePendingRemovalActions()
         {
-            if (removalActions.IsValueCreated && removalActions.Value.Count > 0)
+            if (removalActions.Count > 0)
             {
-                var toRemove = removalActions.Value.ToArray();
-                removalActions.Value.Clear();
+                var toRemove = removalActions.ToArray();
+                removalActions.Clear();
 
                 foreach (var action in toRemove)
                     action();

--- a/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
@@ -1,0 +1,332 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using osu.Framework.Lists;
+using osu.Framework.Timing;
+
+namespace osu.Framework.Graphics.Transforms
+{
+    /// <summary>
+    /// Tracks the lifetime of transforms for one specified target member.
+    /// </summary>
+    internal class TargetMemberTransformTracker
+    {
+        /// <summary>
+        /// A lazily-initialized list of <see cref="Transform"/>s applied to this object.
+        /// </summary>
+        public IReadOnlyList<Transform> Transforms => transforms;
+
+        /// <summary>
+        /// The member this instance is tracking.
+        /// </summary>
+        public readonly string TargetMember;
+
+        private readonly SortedList<Transform> transforms = new SortedList<Transform>(Transform.COMPARER);
+
+        private readonly Transformable transformable;
+
+        private int? lastAppliedTransformIndex;
+
+        private readonly Lazy<List<Action>> removalActions = new Lazy<List<Action>>(() => new List<Action>());
+
+        public TargetMemberTransformTracker(Transformable transformable, string targetMember)
+        {
+            TargetMember = targetMember;
+            this.transformable = transformable;
+        }
+
+        public void UpdateTransforms(in double time, bool rewinding)
+        {
+            if (rewinding && !transformable.RemoveCompletedTransforms)
+            {
+                resetLastAppliedCache();
+
+                var appliedToEndReverts = new List<string>();
+
+                // Under the case that completed transforms are not removed, reversing the clock is permitted.
+                // We need to first look back through all the transforms and apply the start values of the ones that were previously
+                // applied, but now exist in the future relative to the current time.
+                for (int i = transforms.Count - 1; i >= 0; i--)
+                {
+                    var t = transforms[i];
+
+                    // rewind logic needs to only run on transforms which have been applied at least once.
+                    if (!t.Applied)
+                        continue;
+
+                    // some specific transforms can be marked as non-rewindable.
+                    if (!t.Rewindable)
+                        continue;
+
+                    if (time >= t.StartTime)
+                    {
+                        // we are in the middle of this transform, so we want to mark as not-completely-applied.
+                        // note that we should only do this for the last transform of each TargetMember to avoid incorrect application order.
+                        // the actual application will be in the main loop below now that AppliedToEnd is false.
+                        if (!appliedToEndReverts.Contains(t.TargetMember))
+                        {
+                            if (time < t.EndTime)
+                                t.AppliedToEnd = false;
+                            else
+                                t.Apply(t.EndTime);
+
+                            appliedToEndReverts.Add(t.TargetMember);
+                        }
+                    }
+                    else
+                    {
+                        // we are before the start time of this transform, so we want to eagerly apply the value at current time and mark as not-yet-applied.
+                        // this transform will not be applied again unless we play forward in the future.
+                        t.Apply(time);
+                        t.Applied = false;
+                        t.AppliedToEnd = false;
+                    }
+                }
+            }
+
+            for (int i = getLastAppliedIndex() ?? 0; i < transforms.Count; ++i)
+            {
+                var t = transforms[i];
+
+                var tCanRewind = !transformable.RemoveCompletedTransforms && t.Rewindable;
+
+                bool shouldFlushLastApplicationCache = false;
+
+                if (time < t.StartTime)
+                    break;
+
+                if (!t.Applied)
+                {
+                    // This is the first time we are updating this transform.
+                    // We will find other still active transforms which act on the same target member and remove them.
+                    // Since following transforms acting on the same target member are immediately removed when a
+                    // new one is added, we can be sure that previous transforms were added before this one and can
+                    // be safely removed.
+                    for (int j = getLastAppliedIndex() ?? 0; j < i; ++j)
+                    {
+                        var u = transforms[j];
+                        if (u.TargetMember != t.TargetMember) continue;
+
+                        if (!u.AppliedToEnd)
+                            // we may have applied the existing transforms too far into the future.
+                            // we want to prepare to potentially read into the newly activated transform's StartTime,
+                            // so we should re-apply using its StartTime as a basis.
+                            u.Apply(t.StartTime);
+
+                        if (!tCanRewind)
+                        {
+                            transforms.RemoveAt(j--);
+                            shouldFlushLastApplicationCache = true;
+                            i--;
+
+                            if (u.OnAbort != null)
+                                removalActions.Value.Add(u.OnAbort);
+                        }
+                        else
+                            u.AppliedToEnd = true;
+                    }
+                }
+
+                if (!t.HasStartValue)
+                {
+                    t.ReadIntoStartValue();
+                    t.HasStartValue = true;
+                }
+
+                if (!t.AppliedToEnd)
+                {
+                    t.Apply(time);
+
+                    t.AppliedToEnd = time >= t.EndTime;
+
+                    if (t.AppliedToEnd)
+                    {
+                        if (!tCanRewind)
+                        {
+                            transforms.RemoveAt(i--);
+                            shouldFlushLastApplicationCache = true;
+                        }
+
+                        if (t.IsLooping)
+                        {
+                            if (tCanRewind)
+                            {
+                                t.IsLooping = false;
+                                t = t.Clone();
+                            }
+
+                            t.AppliedToEnd = false;
+                            t.Applied = false;
+                            t.HasStartValue = false;
+
+                            t.IsLooping = true;
+
+                            t.StartTime += t.LoopDelay;
+                            t.EndTime += t.LoopDelay;
+
+                            // this could be added back at a lower index than where we are currently iterating, but
+                            // running the same transform twice isn't a huge deal.
+                            transforms.Add(t);
+                            shouldFlushLastApplicationCache = true;
+                        }
+                        else if (t.OnComplete != null)
+                            removalActions.Value.Add(t.OnComplete);
+                    }
+                }
+
+                if (shouldFlushLastApplicationCache)
+                    resetLastAppliedCache();
+                // if this transform is applied to end, we can be sure that all previous transforms for the TargetMember have been completed.
+                else if (t.AppliedToEnd)
+                    setLastAppliedIndex(i + 1);
+                // if not applied to end, tracking the first actively applying transform for each TargetMember is required
+                // to help find the common minimum index to start processing from each next update call.
+                else if (t.Applied && getLastAppliedIndex() == null)
+                    setLastAppliedIndex(i);
+            }
+
+            invokePendingRemovalActions();
+        }
+
+        private void invokePendingRemovalActions()
+        {
+            if (removalActions.IsValueCreated && removalActions.Value.Count > 0)
+            {
+                var toRemove = removalActions.Value.ToArray();
+                removalActions.Value.Clear();
+
+                foreach (var action in toRemove)
+                    action();
+            }
+        }
+
+        /// <summary>
+        /// Retrieve the last transform index that was <see cref="Transform.AppliedToEnd"/> (in <see cref="transforms"/>).
+        /// </summary>
+        private int? getLastAppliedIndex()
+        {
+            return lastAppliedTransformIndex;
+        }
+
+        /// <summary>
+        /// Set the last transform index that was <see cref="Transform.AppliedToEnd"/> for a specific target member.
+        /// </summary>
+        /// <param name="index">The index of the transform in <see cref="transforms"/>.</param>
+        private void setLastAppliedIndex(int? index = null)
+        {
+            lastAppliedTransformIndex = index;
+        }
+
+        /// <summary>
+        /// Reset the last applied index cache completely.
+        /// </summary>
+        private void resetLastAppliedCache() => lastAppliedTransformIndex = null;
+
+        /// <summary>
+        /// Removes a <see cref="Transform"/>.
+        /// </summary>
+        /// <param name="toRemove">The <see cref="Transform"/> to remove.</param>
+        public void RemoveTransform(Transform toRemove)
+        {
+            transforms.Remove(toRemove);
+        }
+
+        /// <summary>
+        /// Used to assign a monotonically increasing ID to <see cref="Transform"/>s as they are added. This member is
+        /// incremented whenever a <see cref="Transform"/> is added.
+        /// </summary>
+        private ulong currentTransformID;
+
+        /// <summary>
+        /// Adds to this object a <see cref="Transform"/> which was previously populated using this object via
+        /// <see cref="TransformableExtensions.PopulateTransform{TValue, TEasing, TThis}"/>.
+        /// Added <see cref="Transform"/>s are immediately applied, and therefore have an immediate effect on this object if the current time of this
+        /// object falls within <see cref="Transform.StartTime"/> and <see cref="Transform.EndTime"/>.
+        /// If <see cref="Transformable.Clock"/> is null, e.g. because this object has just been constructed, then the given transform will be finished instantaneously.
+        /// </summary>
+        /// <param name="transform">The <see cref="Transform"/> to be added.</param>
+        /// <param name="customTransformID">When not null, the <see cref="Transform.TransformID"/> to assign for ordering.</param>
+        public void AddTransform(Transform transform, ulong? customTransformID = null)
+        {
+            Debug.Assert(!(transform.TransformID == 0 && transforms.Contains(transform)), $"Zero-id {nameof(Transform)}s should never be contained already.");
+
+            // This contains check may be optimized away in the future, should it become a bottleneck
+            if (transform.TransformID != 0 && transforms.Contains(transform))
+                throw new InvalidOperationException($"{nameof(Transformable)} may not contain the same {nameof(Transform)} more than once.");
+
+            transform.TransformID = customTransformID ?? ++currentTransformID;
+            int insertionIndex = transforms.Add(transform);
+            resetLastAppliedCache();
+
+            // Remove all existing following transforms touching the same property as this one.
+            for (int i = insertionIndex + 1; i < transforms.Count; ++i)
+            {
+                var t = transforms[i];
+
+                if (t.TargetMember == transform.TargetMember)
+                {
+                    transforms.RemoveAt(i--);
+                    resetLastAppliedCache();
+                    if (t.OnAbort != null)
+                        removalActions.Value.Add(t.OnAbort);
+                }
+            }
+
+            invokePendingRemovalActions();
+
+            // If our newly added transform could have an immediate effect, then let's
+            // make this effect happen immediately.
+            if (transform.StartTime < Time.Current || transform.EndTime <= Time.Current)
+                UpdateTransforms(Time.Current, !transformable.RemoveCompletedTransforms && transform.StartTime <= Time.Current);
+        }
+
+        public FrameTimeInfo Time => transformable.Time;
+
+        /// <summary>
+        /// Removes <see cref="Transform"/>s that start after <paramref name="time"/>.
+        /// </summary>
+        /// <param name="time">The time to clear <see cref="Transform"/>s after.</param>
+        /// <param name="targetMember">
+        /// An optional <see cref="Transform.TargetMember"/> name of <see cref="Transform"/>s to clear.
+        /// Null for clearing all <see cref="Transform"/>s.
+        /// </param>
+        public virtual void ClearTransformsAfter(double time, string targetMember = null)
+        {
+            resetLastAppliedCache();
+
+            var toAbort = transforms.Where(t => t.StartTime >= time).ToArray();
+            transforms.RemoveAll(t => t.StartTime >= time);
+
+            foreach (var t in toAbort)
+                t.OnAbort?.Invoke();
+        }
+
+        /// <summary>
+        /// Finishes specified <see cref="Transform"/>s, using their <see cref="Transform{TValue}.EndValue"/>.
+        /// </summary>
+        public virtual void FinishTransforms()
+        {
+            Func<Transform, bool> toFlushPredicate;
+            if (TargetMember == null)
+                toFlushPredicate = t => !t.IsLooping;
+            else
+                toFlushPredicate = t => !t.IsLooping && t.TargetMember == TargetMember;
+
+            // Flush is undefined for endlessly looping transforms
+            var toFlush = transforms.Where(toFlushPredicate).ToArray();
+
+            transforms.RemoveAll(t => toFlushPredicate(t));
+            resetLastAppliedCache();
+
+            foreach (Transform t in toFlush)
+            {
+                t.Apply(t.EndTime);
+                t.OnComplete?.Invoke();
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using osu.Framework.Caching;
 using osu.Framework.Lists;
 
 namespace osu.Framework.Graphics.Transforms
@@ -40,7 +39,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// The index of the last transform in <see cref="transforms"/> to be applied to completion.
         /// </summary>
-        private readonly Cached<int> lastAppliedIndex = new Cached<int>();
+        private int? lastAppliedIndex;
 
         public TargetMemberTransformTracker(Transformable transformable, string targetMember)
         {
@@ -97,7 +96,7 @@ namespace osu.Framework.Graphics.Transforms
                 }
             }
 
-            for (int i = lastAppliedIndex.IsValid ? lastAppliedIndex.Value : 0; i < transforms.Count; ++i)
+            for (int i = lastAppliedIndex ?? 0; i < transforms.Count; ++i)
             {
                 var t = transforms[i];
 
@@ -115,7 +114,7 @@ namespace osu.Framework.Graphics.Transforms
                     // Since following transforms acting on the same target member are immediately removed when a
                     // new one is added, we can be sure that previous transforms were added before this one and can
                     // be safely removed.
-                    for (int j = lastAppliedIndex.IsValid ? lastAppliedIndex.Value : 0; j < i; ++j)
+                    for (int j = lastAppliedIndex ?? 0; j < i; ++j)
                     {
                         var u = transforms[j];
 
@@ -190,7 +189,7 @@ namespace osu.Framework.Graphics.Transforms
                     resetLastAppliedCache();
                 // if this transform is applied to end, we can be sure that all previous transforms have been completed.
                 else if (t.AppliedToEnd)
-                    lastAppliedIndex.Value = i + 1;
+                    lastAppliedIndex = i + 1;
             }
 
             invokePendingRemovalActions();
@@ -295,6 +294,6 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// Reset the last applied index cache completely.
         /// </summary>
-        private void resetLastAppliedCache() => lastAppliedIndex.Invalidate();
+        private void resetLastAppliedCache() => lastAppliedIndex = null;
     }
 }

--- a/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
@@ -180,13 +180,9 @@ namespace osu.Framework.Graphics.Transforms
 
                 if (shouldFlushLastApplicationCache)
                     resetLastAppliedCache();
-                // if this transform is applied to end, we can be sure that all previous transforms for the TargetMember have been completed.
+                // if this transform is applied to end, we can be sure that all previous transforms have been completed.
                 else if (t.AppliedToEnd)
                     setLastAppliedIndex(i + 1);
-                // if not applied to end, tracking the first actively applying transform for each TargetMember is required
-                // to help find the common minimum index to start processing from each next update call.
-                else if (t.Applied && getLastAppliedIndex() == null)
-                    setLastAppliedIndex(i);
             }
 
             invokePendingRemovalActions();

--- a/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
@@ -260,13 +260,13 @@ namespace osu.Framework.Graphics.Transforms
 
             invokePendingRemovalActions();
 
+            var time = transformable.Time.Current;
+
             // If our newly added transform could have an immediate effect, then let's
             // make this effect happen immediately.
-            if (transform.StartTime < Time.Current || transform.EndTime <= Time.Current)
-                UpdateTransforms(Time.Current, !transformable.RemoveCompletedTransforms && transform.StartTime <= Time.Current);
+            if (transform.StartTime < time || transform.EndTime <= time)
+                UpdateTransforms(time, !transformable.RemoveCompletedTransforms && transform.StartTime <= time);
         }
-
-        public FrameTimeInfo Time => transformable.Time;
 
         /// <summary>
         /// Removes <see cref="Transform"/>s that start after <paramref name="time"/>.

--- a/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
@@ -270,7 +270,7 @@ namespace osu.Framework.Graphics.Transforms
             // Flush is undefined for endlessly looping transforms
             var toFlush = transforms.Where(toFlushPredicate).ToArray();
 
-            transforms.RemoveAll(t => toFlushPredicate(t));
+            transforms.RemoveAll(toFlushPredicate);
             resetLastAppliedCache();
 
             foreach (Transform t in toFlush)

--- a/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetMemberTransformTracker.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Graphics.Transforms
     internal class TargetMemberTransformTracker
     {
         /// <summary>
-        /// A lazily-initialized list of <see cref="Transform"/>s applied to this object.
+        /// A list of <see cref="Transform"/>s associated with the <see cref="TargetMember"/>.
         /// </summary>
         public IEnumerable<Transform> Transforms => transforms;
 

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -2,12 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Lists;
-using osu.Framework.Timing;
+using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Allocation;
-using System.Collections.Generic;
-using System.Diagnostics;
+using osu.Framework.Timing;
 using osu.Framework.Utils;
 
 namespace osu.Framework.Graphics.Transforms
@@ -39,12 +37,10 @@ namespace osu.Framework.Graphics.Transforms
         /// </summary>
         protected double TransformDelay { get; private set; }
 
-        private readonly Lazy<SortedList<Transform>> transformsLazy = new Lazy<SortedList<Transform>>(() => new SortedList<Transform>(Transform.COMPARER));
-
         /// <summary>
         /// A lazily-initialized list of <see cref="Transform"/>s applied to this object.
         /// </summary>
-        public IReadOnlyList<Transform> Transforms => transformsLazy.IsValueCreated ? (IReadOnlyList<Transform>)transformsLazy.Value : Array.Empty<Transform>();
+        public IEnumerable<Transform> Transforms => targetMemberTrackers.SelectMany(t => t.Transforms);
 
         /// <summary>
         /// The end time in milliseconds of the latest transform enqueued for this <see cref="Transformable"/>.
@@ -81,41 +77,24 @@ namespace osu.Framework.Graphics.Transforms
             updateTransforms(Time.Current);
         }
 
-        private readonly Lazy<List<Action>> removalActions = new Lazy<List<Action>>(() => new List<Action>());
-
         private double lastUpdateTransformsTime;
 
-        private readonly Dictionary<string, int?> lastAppliedTransformIndices = new Dictionary<string, int?>();
+        private readonly List<TargetMemberTransformTracker> targetMemberTrackers = new List<TargetMemberTransformTracker>();
 
-        /// <summary>
-        /// Retrieve the last transform index that was <see cref="Transform.AppliedToEnd"/> (in <see cref="transformsLazy"/>).
-        /// </summary>
-        /// <param name="targetMember">An optional target member. If null, the highest common last application is returned.</param>
-        private int? getLastAppliedIndex(string targetMember = null)
+        private TargetMemberTransformTracker getTrackerFor(string targetMember, bool createIfNotExisting = false)
         {
-            if (targetMember == null)
-                return lastAppliedTransformIndices.Values.Min();
+            foreach (var t in targetMemberTrackers)
+            {
+                if (t.TargetMember == targetMember)
+                    return t;
+            }
 
-            if (lastAppliedTransformIndices.TryGetValue(targetMember, out int? val))
-                return val;
+            if (!createIfNotExisting) return null;
 
-            return null;
+            var tracker = new TargetMemberTransformTracker(this, targetMember);
+            targetMemberTrackers.Add(tracker);
+            return tracker;
         }
-
-        /// <summary>
-        /// Set the last transform index that was <see cref="Transform.AppliedToEnd"/> for a specific target member.
-        /// </summary>
-        /// <param name="targetMember">The target member to set the index of.</param>
-        /// <param name="index">The index of the transform in <see cref="transformsLazy"/>.</param>
-        private void setLastAppliedIndex(string targetMember, int? index = null)
-        {
-            lastAppliedTransformIndices[targetMember] = index;
-        }
-
-        /// <summary>
-        /// Reset the last applied index cache completely.
-        /// </summary>
-        private void resetLastAppliedCache() => lastAppliedTransformIndices.Clear();
 
         /// <summary>
         /// Process updates to this class based on loaded <see cref="Transform"/>s. This does not reset <see cref="TransformDelay"/>.
@@ -128,172 +107,9 @@ namespace osu.Framework.Graphics.Transforms
             bool rewinding = lastUpdateTransformsTime > time || forceRewindReprocess;
             lastUpdateTransformsTime = time;
 
-            if (!transformsLazy.IsValueCreated)
-                return;
-
-            var transforms = transformsLazy.Value;
-
-            if (rewinding && !RemoveCompletedTransforms)
-            {
-                resetLastAppliedCache();
-
-                var appliedToEndReverts = new List<string>();
-
-                // Under the case that completed transforms are not removed, reversing the clock is permitted.
-                // We need to first look back through all the transforms and apply the start values of the ones that were previously
-                // applied, but now exist in the future relative to the current time.
-                for (int i = transforms.Count - 1; i >= 0; i--)
-                {
-                    var t = transforms[i];
-
-                    // rewind logic needs to only run on transforms which have been applied at least once.
-                    if (!t.Applied)
-                        continue;
-
-                    // some specific transforms can be marked as non-rewindable.
-                    if (!t.Rewindable)
-                        continue;
-
-                    if (time >= t.StartTime)
-                    {
-                        // we are in the middle of this transform, so we want to mark as not-completely-applied.
-                        // note that we should only do this for the last transform of each TargetMember to avoid incorrect application order.
-                        // the actual application will be in the main loop below now that AppliedToEnd is false.
-                        if (!appliedToEndReverts.Contains(t.TargetMember))
-                        {
-                            if (time < t.EndTime)
-                                t.AppliedToEnd = false;
-                            else
-                                t.Apply(t.EndTime);
-
-                            appliedToEndReverts.Add(t.TargetMember);
-                        }
-                    }
-                    else
-                    {
-                        // we are before the start time of this transform, so we want to eagerly apply the value at current time and mark as not-yet-applied.
-                        // this transform will not be applied again unless we play forward in the future.
-                        t.Apply(time);
-                        t.Applied = false;
-                        t.AppliedToEnd = false;
-                    }
-                }
-            }
-
-            for (int i = getLastAppliedIndex() ?? 0; i < transforms.Count; ++i)
-            {
-                var t = transforms[i];
-
-                var tCanRewind = !RemoveCompletedTransforms && t.Rewindable;
-
-                bool shouldFlushLastApplicationCache = false;
-
-                if (time < t.StartTime)
-                    break;
-
-                if (!t.Applied)
-                {
-                    // This is the first time we are updating this transform.
-                    // We will find other still active transforms which act on the same target member and remove them.
-                    // Since following transforms acting on the same target member are immediately removed when a
-                    // new one is added, we can be sure that previous transforms were added before this one and can
-                    // be safely removed.
-                    for (int j = getLastAppliedIndex(t.TargetMember) ?? 0; j < i; ++j)
-                    {
-                        var u = transforms[j];
-                        if (u.TargetMember != t.TargetMember) continue;
-
-                        if (!u.AppliedToEnd)
-                            // we may have applied the existing transforms too far into the future.
-                            // we want to prepare to potentially read into the newly activated transform's StartTime,
-                            // so we should re-apply using its StartTime as a basis.
-                            u.Apply(t.StartTime);
-
-                        if (!tCanRewind)
-                        {
-                            transforms.RemoveAt(j--);
-                            shouldFlushLastApplicationCache = true;
-                            i--;
-
-                            if (u.OnAbort != null)
-                                removalActions.Value.Add(u.OnAbort);
-                        }
-                        else
-                            u.AppliedToEnd = true;
-                    }
-                }
-
-                if (!t.HasStartValue)
-                {
-                    t.ReadIntoStartValue();
-                    t.HasStartValue = true;
-                }
-
-                if (!t.AppliedToEnd)
-                {
-                    t.Apply(time);
-
-                    t.AppliedToEnd = time >= t.EndTime;
-
-                    if (t.AppliedToEnd)
-                    {
-                        if (!tCanRewind)
-                        {
-                            transforms.RemoveAt(i--);
-                            shouldFlushLastApplicationCache = true;
-                        }
-
-                        if (t.IsLooping)
-                        {
-                            if (tCanRewind)
-                            {
-                                t.IsLooping = false;
-                                t = t.Clone();
-                            }
-
-                            t.AppliedToEnd = false;
-                            t.Applied = false;
-                            t.HasStartValue = false;
-
-                            t.IsLooping = true;
-
-                            t.StartTime += t.LoopDelay;
-                            t.EndTime += t.LoopDelay;
-
-                            // this could be added back at a lower index than where we are currently iterating, but
-                            // running the same transform twice isn't a huge deal.
-                            transforms.Add(t);
-                            shouldFlushLastApplicationCache = true;
-                        }
-                        else if (t.OnComplete != null)
-                            removalActions.Value.Add(t.OnComplete);
-                    }
-                }
-
-                if (shouldFlushLastApplicationCache)
-                    resetLastAppliedCache();
-                // if this transform is applied to end, we can be sure that all previous transforms for the TargetMember have been completed.
-                else if (t.AppliedToEnd)
-                    setLastAppliedIndex(t.TargetMember, i + 1);
-                // if not applied to end, tracking the first actively applying transform for each TargetMember is required
-                // to help find the common minimum index to start processing from each next update call.
-                else if (t.Applied && getLastAppliedIndex(t.TargetMember) == null)
-                    setLastAppliedIndex(t.TargetMember, i);
-            }
-
-            invokePendingRemovalActions();
-        }
-
-        private void invokePendingRemovalActions()
-        {
-            if (removalActions.IsValueCreated && removalActions.Value.Count > 0)
-            {
-                var toRemove = removalActions.Value.ToArray();
-                removalActions.Value.Clear();
-
-                foreach (var action in toRemove)
-                    action();
-            }
+            // collection may grow due to abort / completion events.
+            for (var i = 0; i < targetMemberTrackers.Count; i++)
+                targetMemberTrackers[i].UpdateTransforms(time, rewinding);
         }
 
         /// <summary>
@@ -302,10 +118,8 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="toRemove">The <see cref="Transform"/> to remove.</param>
         public void RemoveTransform(Transform toRemove)
         {
-            if (!transformsLazy.IsValueCreated || !transformsLazy.Value.Remove(toRemove))
-                return;
+            getTrackerFor(toRemove.TargetMember)?.RemoveTransform(toRemove);
 
-            resetLastAppliedCache();
             toRemove.OnAbort?.Invoke();
         }
 
@@ -317,7 +131,8 @@ namespace osu.Framework.Graphics.Transforms
         /// An optional <see cref="Transform.TargetMember"/> name of <see cref="Transform"/>s to clear.
         /// Null for clearing all <see cref="Transform"/>s.
         /// </param>
-        public virtual void ClearTransforms(bool propagateChildren = false, string targetMember = null) => ClearTransformsAfter(double.NegativeInfinity, propagateChildren, targetMember);
+        public virtual void ClearTransforms(bool propagateChildren = false, string targetMember = null) =>
+            ClearTransformsAfter(double.NegativeInfinity, propagateChildren, targetMember);
 
         /// <summary>
         /// Removes <see cref="Transform"/>s that start after <paramref name="time"/>.
@@ -330,25 +145,16 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void ClearTransformsAfter(double time, bool propagateChildren = false, string targetMember = null)
         {
-            if (!transformsLazy.IsValueCreated)
-                return;
-
-            resetLastAppliedCache();
-            Transform[] toAbort;
-
-            if (targetMember == null)
+            if (targetMember != null)
             {
-                toAbort = transformsLazy.Value.Where(t => t.StartTime >= time).ToArray();
-                transformsLazy.Value.RemoveAll(t => t.StartTime >= time);
+                getTrackerFor(targetMember)?.ClearTransformsAfter(time);
             }
             else
             {
-                toAbort = transformsLazy.Value.Where(t => t.StartTime >= time && t.TargetMember == targetMember).ToArray();
-                transformsLazy.Value.RemoveAll(t => t.StartTime >= time && t.TargetMember == targetMember);
+                // collection may grow due to abort / completion events.
+                for (var i = 0; i < targetMemberTrackers.Count; i++)
+                    targetMemberTrackers[i].ClearTransformsAfter(time);
             }
-
-            foreach (var t in toAbort)
-                t.OnAbort?.Invoke();
         }
 
         /// <summary>
@@ -376,25 +182,15 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void FinishTransforms(bool propagateChildren = false, string targetMember = null)
         {
-            if (!transformsLazy.IsValueCreated)
-                return;
-
-            Func<Transform, bool> toFlushPredicate;
-            if (targetMember == null)
-                toFlushPredicate = t => !t.IsLooping;
-            else
-                toFlushPredicate = t => !t.IsLooping && t.TargetMember == targetMember;
-
-            // Flush is undefined for endlessly looping transforms
-            var toFlush = transformsLazy.Value.Where(toFlushPredicate).ToArray();
-
-            transformsLazy.Value.RemoveAll(t => toFlushPredicate(t));
-            resetLastAppliedCache();
-
-            foreach (Transform t in toFlush)
+            if (targetMember != null)
             {
-                t.Apply(t.EndTime);
-                t.OnComplete?.Invoke();
+                getTrackerFor(targetMember)?.FinishTransforms();
+            }
+            else
+            {
+                // collection may grow due to abort / completion events.
+                for (var i = 0; i < targetMemberTrackers.Count; i++)
+                    targetMemberTrackers[i].FinishTransforms();
             }
         }
 
@@ -459,12 +255,6 @@ namespace osu.Framework.Graphics.Transforms
         }
 
         /// <summary>
-        /// Used to assign a monotonically increasing ID to <see cref="Transform"/>s as they are added. This member is
-        /// incremented whenever a <see cref="Transform"/> is added.
-        /// </summary>
-        private ulong currentTransformID;
-
-        /// <summary>
         /// Adds to this object a <see cref="Transform"/> which was previously populated using this object via
         /// <see cref="TransformableExtensions.PopulateTransform{TValue, TEasing, TThis}"/>.
         /// Added <see cref="Transform"/>s are immediately applied, and therefore have an immediate effect on this object if the current time of this
@@ -492,38 +282,7 @@ namespace osu.Framework.Graphics.Transforms
                 return;
             }
 
-            var transforms = transformsLazy.Value;
-
-            Debug.Assert(!(transform.TransformID == 0 && transforms.Contains(transform)), $"Zero-id {nameof(Transform)}s should never be contained already.");
-
-            // This contains check may be optimized away in the future, should it become a bottleneck
-            if (transform.TransformID != 0 && transforms.Contains(transform))
-                throw new InvalidOperationException($"{nameof(Transformable)} may not contain the same {nameof(Transform)} more than once.");
-
-            transform.TransformID = customTransformID ?? ++currentTransformID;
-            int insertionIndex = transforms.Add(transform);
-            resetLastAppliedCache();
-
-            // Remove all existing following transforms touching the same property as this one.
-            for (int i = insertionIndex + 1; i < transforms.Count; ++i)
-            {
-                var t = transforms[i];
-
-                if (t.TargetMember == transform.TargetMember)
-                {
-                    transforms.RemoveAt(i--);
-                    resetLastAppliedCache();
-                    if (t.OnAbort != null)
-                        removalActions.Value.Add(t.OnAbort);
-                }
-            }
-
-            invokePendingRemovalActions();
-
-            // If our newly added transform could have an immediate effect, then let's
-            // make this effect happen immediately.
-            if (transform.StartTime < Time.Current || transform.EndTime <= Time.Current)
-                updateTransforms(Time.Current, !RemoveCompletedTransforms && transform.StartTime <= Time.Current);
+            getTrackerFor(transform.TargetMember, true).AddTransform(transform, customTransformID);
         }
     }
 }

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -40,9 +40,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// A lazily-initialized list of <see cref="Transform"/>s applied to this object.
         /// </summary>
-        public IEnumerable<Transform> Transforms => !targetMemberTrackers.IsValueCreated
-            ? Enumerable.Empty<Transform>()
-            : targetMemberTrackers.Value.SelectMany(t => t.Transforms);
+        public IEnumerable<Transform> Transforms => targetMemberTrackers.SelectMany(t => t.Transforms);
 
         /// <summary>
         /// The end time in milliseconds of the latest transform enqueued for this <see cref="Transformable"/>.
@@ -81,15 +79,11 @@ namespace osu.Framework.Graphics.Transforms
 
         private double lastUpdateTransformsTime;
 
-        private readonly Lazy<List<TargetMemberTransformTracker>> targetMemberTrackers =
-            new Lazy<List<TargetMemberTransformTracker>>(() => new List<TargetMemberTransformTracker>());
+        private readonly List<TargetMemberTransformTracker> targetMemberTrackers = new List<TargetMemberTransformTracker>();
 
         private TargetMemberTransformTracker getTrackerFor(string targetMember, bool createIfNotExisting = false)
         {
-            if (!targetMemberTrackers.IsValueCreated && !createIfNotExisting)
-                return null;
-
-            foreach (var t in targetMemberTrackers.Value)
+            foreach (var t in targetMemberTrackers)
             {
                 if (t.TargetMember == targetMember)
                     return t;
@@ -98,7 +92,7 @@ namespace osu.Framework.Graphics.Transforms
             if (!createIfNotExisting) return null;
 
             var tracker = new TargetMemberTransformTracker(this, targetMember);
-            targetMemberTrackers.Value.Add(tracker);
+            targetMemberTrackers.Add(tracker);
             return tracker;
         }
 
@@ -110,17 +104,12 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="forceRewindReprocess">Whether prior transforms should be reprocessed even if a rewind was not detected.</param>
         private void updateTransforms(double time, bool forceRewindReprocess = false)
         {
-            if (!targetMemberTrackers.IsValueCreated)
-                return;
-
             bool rewinding = lastUpdateTransformsTime > time || forceRewindReprocess;
             lastUpdateTransformsTime = time;
 
-            var trackers = targetMemberTrackers.Value;
-
             // collection may grow due to abort / completion events.
-            for (var i = 0; i < trackers.Count; i++)
-                trackers[i].UpdateTransforms(time, rewinding);
+            for (var i = 0; i < targetMemberTrackers.Count; i++)
+                targetMemberTrackers[i].UpdateTransforms(time, rewinding);
         }
 
         /// <summary>
@@ -156,20 +145,15 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void ClearTransformsAfter(double time, bool propagateChildren = false, string targetMember = null)
         {
-            if (!targetMemberTrackers.IsValueCreated)
-                return;
-
             if (targetMember != null)
             {
                 getTrackerFor(targetMember)?.ClearTransformsAfter(time);
             }
             else
             {
-                var trackers = targetMemberTrackers.Value;
-
                 // collection may grow due to abort / completion events.
-                for (var i = 0; i < trackers.Count; i++)
-                    trackers[i].ClearTransformsAfter(time);
+                for (var i = 0; i < targetMemberTrackers.Count; i++)
+                    targetMemberTrackers[i].ClearTransformsAfter(time);
             }
         }
 
@@ -198,20 +182,15 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void FinishTransforms(bool propagateChildren = false, string targetMember = null)
         {
-            if (!targetMemberTrackers.IsValueCreated)
-                return;
-
             if (targetMember != null)
             {
                 getTrackerFor(targetMember)?.FinishTransforms();
             }
             else
             {
-                var trackers = targetMemberTrackers.Value;
-
                 // collection may grow due to abort / completion events.
-                for (var i = 0; i < trackers.Count; i++)
-                    trackers[i].FinishTransforms();
+                for (var i = 0; i < targetMemberTrackers.Count; i++)
+                    targetMemberTrackers[i].FinishTransforms();
             }
         }
 

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -158,7 +158,7 @@ namespace osu.Framework.Graphics.Transforms
                     if (time >= t.StartTime)
                     {
                         // we are in the middle of this transform, so we want to mark as not-completely-applied.
-                        // note that we should only do this for the last transform of each TargetMemeber to avoid incorrect application order.
+                        // note that we should only do this for the last transform of each TargetMember to avoid incorrect application order.
                         // the actual application will be in the main loop below now that AppliedToEnd is false.
                         if (!appliedToEndReverts.Contains(t.TargetMember))
                         {

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -187,6 +187,8 @@ namespace osu.Framework.Graphics.Transforms
 
                 var tCanRewind = !RemoveCompletedTransforms && t.Rewindable;
 
+                bool shouldFlushLastApplicationCache = false;
+
                 if (time < t.StartTime)
                     break;
 
@@ -211,7 +213,7 @@ namespace osu.Framework.Graphics.Transforms
                         if (!tCanRewind)
                         {
                             transforms.RemoveAt(j--);
-                            resetLastAppliedCache();
+                            shouldFlushLastApplicationCache = true;
                             i--;
 
                             if (u.OnAbort != null)
@@ -239,7 +241,7 @@ namespace osu.Framework.Graphics.Transforms
                         if (!tCanRewind)
                         {
                             transforms.RemoveAt(i--);
-                            resetLastAppliedCache();
+                            shouldFlushLastApplicationCache = true;
                         }
 
                         if (t.IsLooping)
@@ -262,14 +264,16 @@ namespace osu.Framework.Graphics.Transforms
                             // this could be added back at a lower index than where we are currently iterating, but
                             // running the same transform twice isn't a huge deal.
                             transforms.Add(t);
-                            resetLastAppliedCache();
+                            shouldFlushLastApplicationCache = true;
                         }
                         else if (t.OnComplete != null)
                             removalActions.Value.Add(t.OnComplete);
                     }
                 }
 
-                if (t.AppliedToEnd)
+                if (shouldFlushLastApplicationCache)
+                    resetLastAppliedCache();
+                else if (t.AppliedToEnd)
                     setLastAppliedIndex(t.TargetMember, i);
             }
 


### PR DESCRIPTION
Focuses on decreasing the iteration overhead of per-frame transform processing when many transforms are present in the transforms list (and cannot be removed due to rewind support or otherwise).

# Basic idea

Store the last fully applied transform index and only continue processing from that point onwards. To keep things simple, invalidate this cache on any add/remove/rewind operation. These scenarios can be optimised in the future if/when required.

# Difficulties

To make this work, transforms had to be split into per-`TargetMember` lists. If this was not the case, it becomes hard to choose a starting index (originally I was using the "minimum" of any `TargetMember` but this can lead to situations with no optimisation is possible).

As such, there is now one new `TargetMemberTransformTracker` class per `TargetMember` being tracked for a `Transformable`. These are only constructed when used and the memory / allocation overhead does not seem any worse than it was previously.

# Benchmarks

## UpdateTransformsWithManyPresent 

|                          Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------- |---------:|---------:|---------:|------:|------:|------:|----------:|
| (master)  | 821.0 ms | 22.08 ms | 65.09 ms |     - |     - |     - |      48 B |
| (this PR) | 0.2574 ms | 3.84 us  | 3.40 us  |     - |     - |     - |       2 B |

- Closes https://github.com/ppy/osu/issues/9605

- [x] Add benchmarks (not sure if required; osu!-side storyboard shows an improvement from 40ms frame times to <0.1ms)
- [x] Add lazy initialisation of dictionary (similar to `transformsLazy`)
- [x] Assess whether dictionary should only be initialised/used over a certain list length (to save on memory @smoogipoo thoughts?)
- [x] Move transform add / remove / removeAt into dedicated methods to avoid needing to do the cache clear at each usage?

I've implemented this in the simplest way possible. Further optimisations (adjusting indices rather than completing flushing the cache) are obviously possible but come with added complexity. Mainly PRing early for feedback (cases which may need to be tested and aren't already covered; general direction etc.) and considerations.