### PR TITLE
Fix allocations by hidden drawable visualisers

### DIFF
--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -287,8 +287,8 @@ namespace osu.Framework.Graphics.Visualisation
 
         protected override void Dispose(bool isDisposing)
         {
-            base.Dispose(isDisposing);
             detachEvents();
+            base.Dispose(isDisposing);
         }
 
         protected override bool OnHover(HoverEvent e)

--- a/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
+++ b/osu.Framework/Graphics/Visualisation/VisualisedDrawable.cs
@@ -375,20 +375,11 @@ namespace osu.Framework.Graphics.Visualisation
             isExpanded = false;
         }
 
-        private void onAutoSize()
-        {
-            Scheduler.Add(() => activityAutosize.FadeOutFromOne(1));
-        }
+        private void onAutoSize() => activityAutosize.FadeOutFromOne(1);
 
-        private void onLayout()
-        {
-            Scheduler.Add(() => activityLayout.FadeOutFromOne(1));
-        }
+        private void onLayout() => activityLayout.FadeOutFromOne(1);
 
-        private void onInvalidated(Drawable d)
-        {
-            Scheduler.Add(() => activityInvalidate.FadeOutFromOne(1));
-        }
+        private void onInvalidated(Drawable d) => activityInvalidate.FadeOutFromOne(1);
 
         private void onDispose()
         {


### PR DESCRIPTION
This was allocating a ton with many hidden visualisers. E.g. the many-invalidation scenario in https://github.com/ppy/osu-framework/issues/3785 would allocate over 1GB/min.

These schedules don't seem to be required - they were likely here to prevent disposal-related failures but this code has also changed quite a lot over the years and I haven't been able to make it fail.