### PR TITLE
Complete the ITrack interface and DrawableTrack implementation

### DIFF
--- a/osu.Framework/Audio/Track/ITrack.cs
+++ b/osu.Framework/Audio/Track/ITrack.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Framework.Audio.Track
 {
     /// <summary>
@@ -9,9 +11,24 @@ namespace osu.Framework.Audio.Track
     public interface ITrack : IHasAmplitudes
     {
         /// <summary>
+        /// Invoked when this track has completed.
+        /// </summary>
+        event Action Completed;
+
+        /// <summary>
+        /// Invoked when this track has failed.
+        /// </summary>
+        event Action Failed;
+
+        /// <summary>
         /// States if this track should repeat.
         /// </summary>
         bool Looping { get; set; }
+
+        /// <summary>
+        /// Is this track capable of producing audio?
+        /// </summary>
+        bool IsDummyDevice { get; }
 
         /// <summary>
         /// Point in time in milliseconds to restart the track to on loop or <see cref="Restart"/>.
@@ -28,7 +45,25 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         double Length { get; set; }
 
+        /// <summary>
+        /// The bitrate of this track.
+        /// </summary>
+        int? Bitrate { get; }
+
+        /// <summary>
+        /// Whether this track is currently running.
+        /// </summary>
         bool IsRunning { get; }
+
+        /// <summary>
+        /// Whether this track is reversed.
+        /// </summary>
+        bool IsReversed { get; }
+
+        /// <summary>
+        /// Whether this track has finished playing back.
+        /// </summary>
+        public bool HasCompleted { get; }
 
         /// <summary>
         /// Reset this track to a logical default state.
@@ -40,6 +75,9 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         void Restart();
 
+        /// <summary>
+        /// Removes all speed adjustments added to this track.
+        /// </summary>
         void ResetSpeedAdjustments();
 
         /// <summary>

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -15,9 +15,6 @@ namespace osu.Framework.Audio.Track
         protected virtual void RaiseCompleted() => Completed?.Invoke();
         protected virtual void RaiseFailed() => Failed?.Invoke();
 
-        /// <summary>
-        /// Is this track capable of producing audio?
-        /// </summary>
         public virtual bool IsDummyDevice => true;
 
         /// <summary>

--- a/osu.Framework/Graphics/Audio/DrawableTrack.cs
+++ b/osu.Framework/Graphics/Audio/DrawableTrack.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Audio.Track;
 
 namespace osu.Framework.Graphics.Audio
@@ -23,11 +24,25 @@ namespace osu.Framework.Graphics.Audio
             this.track = track;
         }
 
+        public event Action Completed
+        {
+            add => track.Completed += value;
+            remove => track.Completed -= value;
+        }
+
+        public event Action Failed
+        {
+            add => track.Failed += value;
+            remove => track.Failed -= value;
+        }
+
         public bool Looping
         {
             get => track.Looping;
             set => track.Looping = value;
         }
+
+        public bool IsDummyDevice => track.IsDummyDevice;
 
         public double RestartPoint
         {
@@ -43,7 +58,13 @@ namespace osu.Framework.Graphics.Audio
             set => track.Length = value;
         }
 
+        public int? Bitrate => track.Bitrate;
+
         public bool IsRunning => track.IsRunning;
+
+        public bool IsReversed => track.IsReversed;
+
+        public bool HasCompleted => track.HasCompleted;
 
         public void Reset() => track.Reset();
 


### PR DESCRIPTION
Since `DrawableTrack` is seen as a complete alternative to `Track` that can be used in the draw hierarchy, it seems reasonable that the interface should be complete.