### PR TITLE
Fix previous sample channels not immediately freed on new playbacks

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -66,11 +66,11 @@ namespace osu.Framework.Audio.Sample
                     return;
                 }
 
-                // Remove looping flag from previous channel to prevent endless playback
-                setLoopFlag(false);
+                // Free previous channels as we're creating a new channel for every playback, since old channels
+                // may be overriden when too many other channels are created from the same sample.
+                if (Bass.ChannelIsActive(channel) != PlaybackState.Stopped)
+                    Bass.ChannelStop(channel);
 
-                // We are creating a new channel for every playback, since old channels may
-                // be overridden when too many other channels are created from the same sample.
                 channel = ((SampleBass)Sample).CreateChannel();
 
                 Bass.ChannelSetAttribute(channel, ChannelAttribute.NoRamp, 1);


### PR DESCRIPTION
Not sure why it isn't done already, it is a major problem for long samples, as the previous one would not get freed and stay playing without the game being aware of, which is a resource leak to my knowledge.

Untestable as it is an audio code, but I believe it should be very clear.