### PR TITLE
Fix DrawableTrack not resetting adjustments correctly

### DIFF
--- a/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
+++ b/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Audio;
+using osu.Framework.Testing;
+using osu.Framework.Tests.Visual;
+using osu.Framework.Utils;
+
+namespace osu.Framework.Tests.Audio
+{
+    [HeadlessTest]
+    public class TestSceneDrawableTrack : FrameworkTestScene
+    {
+        [Resolved]
+        private ITrackStore trackStore { get; set; }
+
+        private DrawableTrack track;
+
+        [SetUp]
+        public void Setup() => Schedule(() =>
+        {
+            Child = track = new DrawableTrack(trackStore.Get("sample-track"));
+        });
+
+        [Test]
+        public void TestVolumeResetWhenReset()
+        {
+            AddStep("set volume to 0", () => track.Volume.Value = 0);
+            AddAssert("track volume is 0", () => Precision.AlmostEquals(0, track.AggregateVolume.Value));
+
+            AddStep("reset", () => track.Reset());
+            AddAssert("track volume is 1", () => Precision.AlmostEquals(1, track.AggregateVolume.Value));
+        }
+
+        [Test]
+        public void TestAdjustmentsRemovedWhenReset()
+        {
+            // ReSharper disable once NotAccessedVariable
+            // Bindable - need to store the reference.
+            BindableDouble volumeAdjustment = null;
+
+            AddStep("add adjustment", () => track.AddAdjustment(AdjustableProperty.Volume, volumeAdjustment = new BindableDouble { Value = 0.5 }));
+            AddAssert("track volume is 0.5", () => Precision.AlmostEquals(0.5, track.AggregateVolume.Value));
+
+            AddStep("reset", () => track.Reset());
+            AddAssert("track volume is 1", () => Precision.AlmostEquals(1, track.Volume.Value));
+        }
+    }
+}

--- a/osu.Framework/Graphics/Audio/DrawableTrack.cs
+++ b/osu.Framework/Graphics/Audio/DrawableTrack.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Timing;
 
@@ -73,11 +74,23 @@ namespace osu.Framework.Graphics.Audio
 
         public bool HasCompleted => track.HasCompleted;
 
-        public void Reset() => track.Reset();
+        public void Reset()
+        {
+            Volume.Value = 1;
+
+            ResetSpeedAdjustments();
+
+            Stop();
+            Seek(0);
+        }
 
         public void Restart() => track.Restart();
 
-        public void ResetSpeedAdjustments() => track.ResetSpeedAdjustments();
+        public void ResetSpeedAdjustments()
+        {
+            RemoveAllAdjustments(AdjustableProperty.Frequency);
+            RemoveAllAdjustments(AdjustableProperty.Tempo);
+        }
 
         public bool Seek(double seek) => track.Seek(seek);
 

--- a/osu.Framework/Graphics/Audio/DrawableTrack.cs
+++ b/osu.Framework/Graphics/Audio/DrawableTrack.cs
@@ -3,13 +3,14 @@
 
 using System;
 using osu.Framework.Audio.Track;
+using osu.Framework.Timing;
 
 namespace osu.Framework.Graphics.Audio
 {
     /// <summary>
     /// A <see cref="Track"/> wrapper to allow insertion in the draw hierarchy to allow transforms, lifetime management etc.
     /// </summary>
-    public class DrawableTrack : DrawableAudioWrapper, ITrack
+    public class DrawableTrack : DrawableAudioWrapper, ITrack, IAdjustableClock
     {
         private readonly Track track;
 
@@ -51,6 +52,12 @@ namespace osu.Framework.Graphics.Audio
         }
 
         public double CurrentTime => track.CurrentTime;
+
+        public double Rate
+        {
+            get => track.Rate;
+            set => track.Rate = value;
+        }
 
         public double Length
         {


### PR DESCRIPTION
Fixes `DrawableTrack` resetting the underlying track, when it should be resetting its local adjustments instead. https://github.com/ppy/osu-framework/pull/3790 added the ability to add adjustments to `DrawableTrack`.

Also makes `DrawableTrack` an `IAdjustableClock` so it is interface-compatible with `Track`.