### PR TITLE
Add better separator for KeyCombination display

### DIFF
--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -143,7 +143,7 @@ namespace osu.Framework.Input.Bindings
         /// <returns>The string representation.</returns>
         public override string ToString() => string.Join(',', Keys.Select(k => (int)k));
 
-        public string ReadableString() => string.Join(' ', Keys.Select(getReadableKey));
+        public string ReadableString() => string.Join('-', Keys.Select(getReadableKey));
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsModifierKey(InputKey key) => key == InputKey.Control || key == InputKey.Shift || key == InputKey.Alt || key == InputKey.Super;
@@ -250,10 +250,10 @@ namespace osu.Framework.Input.Bindings
                     return "~";
 
                 case InputKey.Minus:
-                    return "-";
+                    return "Minus";
 
                 case InputKey.Plus:
-                    return "+";
+                    return "Plus";
 
                 case InputKey.BracketLeft:
                     return "(";


### PR DESCRIPTION
Renames +/- to Plus/Minus to avoid conflict.
Before:

![image](https://user-images.githubusercontent.com/191335/89513571-b1f5b380-d80f-11ea-8f22-58fb15fcb212.png)


After:

![image](https://user-images.githubusercontent.com/191335/89513597-b8842b00-d80f-11ea-8059-980b04a4a891.png)
