### PR TITLE
Remember window position between sessions (SDL)

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -20,6 +20,7 @@ namespace osu.Framework.Tests.Visual.Platform
     public class TestSceneFullscreen : FrameworkTestScene
     {
         private readonly SpriteText currentActualSize = new SpriteText();
+        private readonly SpriteText currentDisplayMode = new SpriteText();
         private readonly SpriteText currentWindowMode = new SpriteText();
         private readonly SpriteText supportedWindowModes = new SpriteText();
         private readonly Dropdown<Display> displaysDropdown;
@@ -40,6 +41,7 @@ namespace osu.Framework.Tests.Visual.Platform
                 {
                     currentBindableSize,
                     currentActualSize,
+                    currentDisplayMode,
                     currentWindowMode,
                     supportedWindowModes,
                     displaysDropdown = new BasicDropdown<Display> { Width = 600 }
@@ -121,6 +123,7 @@ namespace osu.Framework.Tests.Visual.Platform
             base.Update();
 
             currentActualSize.Text = $"Window size: {window?.Bounds.Size}";
+            currentDisplayMode.Text = $"Display mode: {window?.CurrentDisplayMode}";
         }
     }
 }

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -36,8 +36,8 @@ namespace osu.Framework.Input
                     // confine cursor
                     if (Host.Window != null && Host.Window.CursorState.HasFlag(CursorState.Confined))
                     {
-                        float scale = (Host.Window as DesktopWindow)?.Scale ?? 1f;
-                        mouse.Position = Vector2.Clamp(mouse.Position, Vector2.Zero, new Vector2(Host.Window.Width * scale, Host.Window.Height * scale));
+                        var clientSize = Host.Window.ClientSize;
+                        mouse.Position = Vector2.Clamp(mouse.Position, Vector2.Zero, new Vector2(clientSize.Width, clientSize.Height));
                     }
 
                     break;

--- a/osu.Framework/Platform/DesktopWindow.cs
+++ b/osu.Framework/Platform/DesktopWindow.cs
@@ -141,12 +141,9 @@ namespace osu.Framework.Platform
 
         private void updateWindowPositionConfig()
         {
-            if (WindowState.Value == Platform.WindowState.Normal)
-            {
-                var relativePosition = RelativePosition;
-                windowPositionX.Value = relativePosition.X;
-                windowPositionY.Value = relativePosition.Y;
-            }
+            var relativePosition = RelativePosition;
+            windowPositionX.Value = relativePosition.X;
+            windowPositionY.Value = relativePosition.Y;
         }
 
         private void confineMouseModeChanged(ValueChangedEvent<ConfineMouseMode> args)

--- a/osu.Framework/Platform/DesktopWindow.cs
+++ b/osu.Framework/Platform/DesktopWindow.cs
@@ -22,6 +22,13 @@ namespace osu.Framework.Platform
 
         public readonly Bindable<ConfineMouseMode> ConfineMouseMode = new Bindable<ConfineMouseMode>();
 
+        /// <summary>
+        /// Gets or sets the window's position on the current screen given a relative value between 0 and 1.
+        /// The position is calculated with respect to the window's size such that:
+        ///   (0, 0) indicates that the window is aligned to the top left of the screen,
+        ///   (1, 1) indicates that the window is aligned to the bottom right of the screen, and
+        ///   (0.5, 0.5) indicates that the window is centred on the screen.
+        /// </summary>
         protected Vector2 RelativePosition
         {
             get

--- a/osu.Framework/Platform/DesktopWindow.cs
+++ b/osu.Framework/Platform/DesktopWindow.cs
@@ -11,8 +11,37 @@ namespace osu.Framework.Platform
     public class DesktopWindow : Window
     {
         private readonly BindableSize sizeWindowed = new BindableSize();
+        private readonly BindableDouble windowPositionX = new BindableDouble();
+        private readonly BindableDouble windowPositionY = new BindableDouble();
 
         public readonly Bindable<ConfineMouseMode> ConfineMouseMode = new Bindable<ConfineMouseMode>();
+
+        protected Vector2 RelativePosition
+        {
+            get
+            {
+                var displayBounds = CurrentDisplay.Value.Bounds;
+                var windowX = Position.Value.X - displayBounds.X;
+                var windowY = Position.Value.Y - displayBounds.Y;
+                var windowSize = sizeWindowed.Value;
+
+                return new Vector2(
+                    displayBounds.Width > windowSize.Width ? (float)windowX / (displayBounds.Width - windowSize.Width) : 0,
+                    displayBounds.Height > windowSize.Height ? (float)windowY / (displayBounds.Height - windowSize.Height) : 0);
+            }
+            set
+            {
+                if (WindowMode.Value != Configuration.WindowMode.Windowed)
+                    return;
+
+                var displayBounds = CurrentDisplay.Value.Bounds;
+                var windowSize = sizeWindowed.Value;
+                var windowX = (int)Math.Round((displayBounds.Width - windowSize.Width) * value.X);
+                var windowY = (int)Math.Round((displayBounds.Height - windowSize.Height) * value.Y);
+
+                Position.Value = new Point(windowX + displayBounds.X, windowY + displayBounds.Y);
+            }
+        }
 
         /// <summary>
         /// Initialises a window for desktop platforms.
@@ -35,16 +64,41 @@ namespace osu.Framework.Platform
 
             config.BindWith(FrameworkSetting.WindowedSize, sizeWindowed);
 
+            config.BindWith(FrameworkSetting.WindowedPositionX, windowPositionX);
+            config.BindWith(FrameworkSetting.WindowedPositionY, windowPositionY);
+
+            RelativePosition = new Vector2((float)windowPositionX.Value, (float)windowPositionY.Value);
             config.BindWith(FrameworkSetting.ConfineMouseMode, ConfineMouseMode);
             ConfineMouseMode.BindValueChanged(confineMouseModeChanged, true);
 
             Resized += onResized;
+            Moved += onMoved;
         }
 
         private void onResized()
         {
-            if (!Size.Value.IsEmpty && WindowMode.Value == Configuration.WindowMode.Windowed)
-                sizeWindowed.Value = Size.Value;
+            if (WindowState.Value == Platform.WindowState.Normal)
+            {
+                sizeWindowed.Value = WindowBackend.Size;
+                Size.Value = sizeWindowed.Value;
+                updateWindowPositionConfig();
+            }
+        }
+
+        private void onMoved(Point point)
+        {
+            if (WindowState.Value == Platform.WindowState.Normal)
+                updateWindowPositionConfig();
+        }
+
+        private void updateWindowPositionConfig()
+        {
+            if (WindowState.Value == Platform.WindowState.Normal)
+            {
+                var relativePosition = RelativePosition;
+                windowPositionX.Value = relativePosition.X;
+                windowPositionY.Value = relativePosition.Y;
+            }
         }
 
         private void confineMouseModeChanged(ValueChangedEvent<ConfineMouseMode> args)

--- a/osu.Framework/Platform/DesktopWindow.cs
+++ b/osu.Framework/Platform/DesktopWindow.cs
@@ -13,6 +13,7 @@ namespace osu.Framework.Platform
         private readonly BindableSize sizeWindowed = new BindableSize();
         private readonly BindableDouble windowPositionX = new BindableDouble();
         private readonly BindableDouble windowPositionY = new BindableDouble();
+        private readonly Bindable<DisplayIndex> windowDisplayIndex = new Bindable<DisplayIndex>();
 
         public readonly Bindable<ConfineMouseMode> ConfineMouseMode = new Bindable<ConfineMouseMode>();
 
@@ -56,10 +57,22 @@ namespace osu.Framework.Platform
         {
             base.SetupWindow(config);
 
+            CurrentDisplay.ValueChanged += evt =>
+            {
+                windowDisplayIndex.Value = (DisplayIndex)evt.NewValue.Index;
+                windowPositionX.Value = 0.5;
+                windowPositionY.Value = 0.5;
+            };
+
+            config.BindWith(FrameworkSetting.LastDisplayDevice, windowDisplayIndex);
+            windowDisplayIndex.BindValueChanged(evt => CurrentDisplay.Value = Displays.ElementAtOrDefault((int)evt.NewValue) ?? PrimaryDisplay, true);
             sizeWindowed.ValueChanged += evt =>
             {
-                if (!evt.NewValue.IsEmpty && WindowState.Value == Platform.WindowState.Normal)
-                    Size.Value = evt.NewValue;
+                if (evt.NewValue.IsEmpty)
+                    return;
+
+                WindowBackend.Size = evt.NewValue;
+                Size.Value = evt.NewValue;
             };
 
             config.BindWith(FrameworkSetting.WindowedSize, sizeWindowed);

--- a/osu.Framework/Platform/Display.cs
+++ b/osu.Framework/Platform/Display.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Drawing;
+using System.Linq;
 
 namespace osu.Framework.Platform
 {
@@ -50,5 +51,23 @@ namespace osu.Framework.Platform
 
             return Index == other.Index;
         }
+
+        /// <summary>
+        /// Attempts to find a <see cref="DisplayMode"/> for the given <see cref="Display"/> that
+        /// closely matches the requested parameters.
+        /// </summary>
+        /// <param name="size">The <see cref="Size"/> to match.</param>
+        /// <param name="bitsPerPixel">The bits per pixel to match. If null, the highest available bits per pixel will be used.</param>
+        /// <param name="refreshRate">The refresh rate in hertz. If null, the highest available refresh rate will be used.</param>
+        /// <returns></returns>
+        public DisplayMode FindDisplayMode(Size size, int? bitsPerPixel = null, int? refreshRate = null) =>
+            DisplayModes.Where(mode => mode.Size.Width <= size.Width && mode.Size.Height <= size.Height &&
+                                       (bitsPerPixel == null || mode.BitsPerPixel == bitsPerPixel) &&
+                                       (refreshRate == null || mode.RefreshRate == refreshRate))
+                        .OrderByDescending(mode => mode.Size.Width)
+                        .ThenByDescending(mode => mode.Size.Height)
+                        .ThenByDescending(mode => mode.RefreshRate)
+                        .ThenByDescending(mode => mode.BitsPerPixel)
+                        .FirstOrDefault();
     }
 }

--- a/osu.Framework/Platform/DisplayMode.cs
+++ b/osu.Framework/Platform/DisplayMode.cs
@@ -38,6 +38,6 @@ namespace osu.Framework.Platform
             RefreshRate = refreshRate;
         }
 
-        public override string ToString() => $"Format: {Format}, Size: {Size}, BitsPerPixel: {BitsPerPixel}, RefreshRate: {RefreshRate}";
+        public override string ToString() => $"Size: {Size}, BitsPerPixel: {BitsPerPixel}, RefreshRate: {RefreshRate}, Format: {Format}";
     }
 }

--- a/osu.Framework/Platform/IWindowBackend.cs
+++ b/osu.Framework/Platform/IWindowBackend.cs
@@ -36,6 +36,11 @@ namespace osu.Framework.Platform
         Size Size { get; set; }
 
         /// <summary>
+        /// Returns the drawable area, after scaling.
+        /// </summary>
+        Size ClientSize { get; }
+
+        /// <summary>
         /// Returns the scale of window's drawable area.
         /// In high-dpi environments this will be greater than one.
         /// </summary>

--- a/osu.Framework/Platform/IWindowBackend.cs
+++ b/osu.Framework/Platform/IWindowBackend.cs
@@ -79,14 +79,14 @@ namespace osu.Framework.Platform
         Display PrimaryDisplay { get; }
 
         /// <summary>
-        /// Gets the <see cref="Display"/> that this window is currently on.
+        /// Gets or sets the <see cref="Display"/> that this window is currently on.
         /// </summary>
         Display CurrentDisplay { get; set; }
 
         /// <summary>
-        /// Gets the <see cref="DisplayMode"/> for the display that this window is currently on.
+        /// Gets or sets the <see cref="DisplayMode"/> for the display that this window is currently on.
         /// </summary>
-        DisplayMode CurrentDisplayMode { get; }
+        DisplayMode CurrentDisplayMode { get; set; }
 
         #endregion
 
@@ -100,12 +100,12 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Invoked after the window has resized.
         /// </summary>
-        event Action Resized;
+        event Action<Size> Resized;
 
         /// <summary>
         /// Invoked after the window's state has changed.
         /// </summary>
-        event Action WindowStateChanged;
+        event Action<WindowState> WindowStateChanged;
 
         /// <summary>
         /// Invoked when the user attempts to close the window.

--- a/osu.Framework/Platform/IWindowBackend.cs
+++ b/osu.Framework/Platform/IWindowBackend.cs
@@ -41,12 +41,6 @@ namespace osu.Framework.Platform
         Size ClientSize { get; }
 
         /// <summary>
-        /// Returns the scale of window's drawable area.
-        /// In high-dpi environments this will be greater than one.
-        /// </summary>
-        float Scale { get; }
-
-        /// <summary>
         /// Returns or sets the cursor's visibility within the window.
         /// </summary>
         bool CursorVisible { get; set; }

--- a/osu.Framework/Platform/Sdl/Sdl2Extensions.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2Extensions.cs
@@ -437,8 +437,10 @@ namespace osu.Framework.Platform.Sdl
 
         public static WindowState ToWindowState(this SDL.SDL_WindowFlags windowFlags)
         {
+            // NOTE: on macOS, SDL2 does not differentiate between "maximised" and "fullscreen desktop"
             if (windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP) ||
-                windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_BORDERLESS) && windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN))
+                windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_BORDERLESS) && windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN) ||
+                windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED) && RuntimeInfo.OS == RuntimeInfo.Platform.MacOsx)
                 return WindowState.FullscreenBorderless;
 
             if (windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_MINIMIZED))
@@ -464,7 +466,9 @@ namespace osu.Framework.Platform.Sdl
                     return SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN;
 
                 case WindowState.Maximised:
-                    return SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED;
+                    return RuntimeInfo.OS == RuntimeInfo.Platform.MacOsx
+                        ? SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP
+                        : SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED;
 
                 case WindowState.Minimised:
                     return SDL.SDL_WindowFlags.SDL_WINDOW_MINIMIZED;

--- a/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
@@ -228,7 +228,10 @@ namespace osu.Framework.Platform.Sdl
                 SDL.SDL_GetCurrentDisplayMode(currentDisplayIndex, out var mode);
                 return displayModeFromSDL(mode);
             }
-            set { }
+            set
+            {
+                // TODO: change display modes
+            }
         }
 
         private static Display displayFromSDL(int displayIndex)

--- a/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
@@ -109,7 +109,7 @@ namespace osu.Framework.Platform.Sdl
             }
         }
 
-        private readonly Cached<float> scale = new Cached<float>();
+        private readonly Cached<float> cachedScale = new Cached<float>();
 
         public Size ClientSize
         {
@@ -120,20 +120,20 @@ namespace osu.Framework.Platform.Sdl
             }
         }
 
-        public float Scale => validateScale();
+        private float scale => validateScale();
 
         private float validateScale(bool force = false)
         {
-            if (!force && scale.IsValid)
-                return scale.Value;
+            if (!force && cachedScale.IsValid)
+                return cachedScale.Value;
 
             if (SdlWindowHandle == IntPtr.Zero)
                 return 1f;
 
             SDL.SDL_GL_GetDrawableSize(SdlWindowHandle, out int w, out _);
 
-            scale.Value = w / (float)Size.Width;
-            return scale.Value;
+            cachedScale.Value = w / (float)Size.Width;
+            return cachedScale.Value;
         }
 
         private bool cursorVisible = true;
@@ -376,7 +376,7 @@ namespace osu.Framework.Platform.Sdl
 
             var rx = x - Position.X;
             var ry = y - Position.Y;
-            OnMouseMove(new MousePositionAbsoluteInput { Position = new Vector2(rx * Scale, ry * Scale) });
+            OnMouseMove(new MousePositionAbsoluteInput { Position = new Vector2(rx * scale, ry * scale) });
         }
 
         #endregion
@@ -553,7 +553,7 @@ namespace osu.Framework.Platform.Sdl
         }
 
         private void handleMouseMotionEvent(SDL.SDL_MouseMotionEvent evtMotion) =>
-            OnMouseMove(new MousePositionAbsoluteInput { Position = new Vector2(evtMotion.x * Scale, evtMotion.y * Scale) });
+            OnMouseMove(new MousePositionAbsoluteInput { Position = new Vector2(evtMotion.x * scale, evtMotion.y * scale) });
 
         private unsafe void handleTextInputEvent(SDL.SDL_TextInputEvent evtText)
         {

--- a/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
@@ -111,6 +111,15 @@ namespace osu.Framework.Platform.Sdl
 
         private readonly Cached<float> scale = new Cached<float>();
 
+        public Size ClientSize
+        {
+            get
+            {
+                SDL.SDL_GL_GetDrawableSize(SdlWindowHandle, out var w, out var h);
+                return new Size(w, h);
+            }
+        }
+
         public float Scale => validateScale();
 
         private float validateScale(bool force = false)

--- a/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
@@ -228,6 +228,7 @@ namespace osu.Framework.Platform.Sdl
                 SDL.SDL_GetCurrentDisplayMode(currentDisplayIndex, out var mode);
                 return displayModeFromSDL(mode);
             }
+            set { }
         }
 
         private static Display displayFromSDL(int displayIndex)
@@ -268,8 +269,8 @@ namespace osu.Framework.Platform.Sdl
         #region IWindowBackend.Events
 
         public event Action Update;
-        public event Action Resized;
-        public event Action WindowStateChanged;
+        public event Action<Size> Resized;
+        public event Action<WindowState> WindowStateChanged;
         public event Func<bool> CloseRequested;
         public event Action Closed;
         public event Action FocusLost;
@@ -299,8 +300,8 @@ namespace osu.Framework.Platform.Sdl
         #region Event Invocation
 
         protected virtual void OnUpdate() => Update?.Invoke();
-        protected virtual void OnResized() => Resized?.Invoke();
-        protected virtual void OnWindowStateChanged() => WindowStateChanged?.Invoke();
+        protected virtual void OnResized(Size size) => Resized?.Invoke(size);
+        protected virtual void OnWindowStateChanged(WindowState state) => WindowStateChanged?.Invoke(state);
         protected virtual bool OnCloseRequested() => CloseRequested?.Invoke() ?? false;
         protected virtual void OnClosed() => Closed?.Invoke();
         protected virtual void OnFocusLost() => FocusLost?.Invoke();
@@ -604,17 +605,16 @@ namespace osu.Framework.Platform.Sdl
                     OnMoved(new Point(evtWindow.data1, evtWindow.data2));
                     break;
 
-                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SIZE_CHANGED:
                     checkCurrentDisplay();
                     validateScale(true);
-                    OnResized();
+                    OnResized(new Size(evtWindow.data1, evtWindow.data2));
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MAXIMIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESTORED:
-                    OnWindowStateChanged();
+                    OnWindowStateChanged(windowFlags.ToWindowState());
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_ENTER:

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -51,12 +51,6 @@ namespace osu.Framework.Platform
         /// </summary>
         public bool Exists => WindowBackend.Exists;
 
-        /// <summary>
-        /// Returns the scale of window's drawable area.
-        /// In high-dpi environments this will be greater than one.
-        /// </summary>
-        public float Scale => WindowBackend.Scale;
-
         public Display PrimaryDisplay => WindowBackend.PrimaryDisplay;
 
         public DisplayMode CurrentDisplayMode => WindowBackend.CurrentDisplayMode;

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -22,8 +22,8 @@ namespace osu.Framework.Platform
     /// </summary>
     public class Window : IWindow
     {
-        private readonly IWindowBackend windowBackend;
-        private readonly IGraphicsBackend graphicsBackend;
+        protected readonly IWindowBackend WindowBackend;
+        protected readonly IGraphicsBackend GraphicsBackend;
 
         #region Properties
 
@@ -32,8 +32,8 @@ namespace osu.Framework.Platform
         /// </summary>
         public string Title
         {
-            get => windowBackend.Title;
-            set => windowBackend.Title = value;
+            get => WindowBackend.Title;
+            set => WindowBackend.Title = value;
         }
 
         /// <summary>
@@ -41,27 +41,27 @@ namespace osu.Framework.Platform
         /// </summary>
         public bool VerticalSync
         {
-            get => graphicsBackend.VerticalSync;
-            set => graphicsBackend.VerticalSync = value;
+            get => GraphicsBackend.VerticalSync;
+            set => GraphicsBackend.VerticalSync = value;
         }
 
         /// <summary>
         /// Returns true if window has been created.
         /// Returns false if the window has not yet been created, or has been closed.
         /// </summary>
-        public bool Exists => windowBackend.Exists;
+        public bool Exists => WindowBackend.Exists;
 
         /// <summary>
         /// Returns the scale of window's drawable area.
         /// In high-dpi environments this will be greater than one.
         /// </summary>
-        public float Scale => windowBackend.Scale;
+        public float Scale => WindowBackend.Scale;
 
-        public Display PrimaryDisplay => windowBackend.PrimaryDisplay;
+        public Display PrimaryDisplay => WindowBackend.PrimaryDisplay;
 
-        public DisplayMode CurrentDisplayMode => windowBackend.CurrentDisplayMode;
+        public DisplayMode CurrentDisplayMode => WindowBackend.CurrentDisplayMode;
 
-        public IEnumerable<Display> Displays => windowBackend.Displays;
+        public IEnumerable<Display> Displays => WindowBackend.Displays;
 
         public WindowMode DefaultWindowMode => Configuration.WindowMode.Windowed;
 
@@ -258,19 +258,19 @@ namespace osu.Framework.Platform
         /// <param name="graphicsBackend">The <see cref="IGraphicsBackend"/> to use.</param>
         public Window(IWindowBackend windowBackend, IGraphicsBackend graphicsBackend)
         {
-            this.windowBackend = windowBackend;
-            this.graphicsBackend = graphicsBackend;
+            WindowBackend = windowBackend;
+            GraphicsBackend = graphicsBackend;
 
             Position.ValueChanged += position_ValueChanged;
             Size.ValueChanged += size_ValueChanged;
 
             CursorState.ValueChanged += evt =>
             {
-                this.windowBackend.CursorVisible = !evt.NewValue.HasFlag(Platform.CursorState.Hidden);
-                this.windowBackend.CursorConfined = evt.NewValue.HasFlag(Platform.CursorState.Confined);
+                WindowBackend.CursorVisible = !evt.NewValue.HasFlag(Platform.CursorState.Hidden);
+                WindowBackend.CursorConfined = evt.NewValue.HasFlag(Platform.CursorState.Confined);
             };
 
-            WindowState.ValueChanged += evt => this.windowBackend.WindowState = evt.NewValue;
+            WindowState.ValueChanged += evt => WindowBackend.WindowState = evt.NewValue;
 
             Visible.ValueChanged += visible_ValueChanged;
 
@@ -298,61 +298,61 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Starts the window's run loop.
         /// </summary>
-        public void Run() => windowBackend.Run();
+        public void Run() => WindowBackend.Run();
 
         /// <summary>
         /// Attempts to close the window.
         /// </summary>
-        public void Close() => windowBackend.Close();
+        public void Close() => WindowBackend.Close();
 
         /// <summary>
         /// Creates the concrete window implementation and initialises the graphics backend.
         /// </summary>
         public void Create()
         {
-            windowBackend.Create();
+            WindowBackend.Create();
 
-            windowBackend.Resized += windowBackend_Resized;
-            windowBackend.WindowStateChanged += () => WindowState.Value = windowBackend.WindowState;
-            windowBackend.Moved += windowBackend_Moved;
-            windowBackend.Hidden += () => Visible.Value = false;
-            windowBackend.Shown += () => Visible.Value = true;
+            WindowBackend.Resized += windowBackend_Resized;
+            WindowBackend.WindowStateChanged += windowBackend_WindowStateChanged;
+            WindowBackend.Moved += windowBackend_Moved;
+            WindowBackend.Hidden += () => Visible.Value = false;
+            WindowBackend.Shown += () => Visible.Value = true;
 
-            windowBackend.FocusGained += () => focused.Value = true;
-            windowBackend.FocusLost += () => focused.Value = false;
-            windowBackend.MouseEntered += () => cursorInWindow.Value = true;
-            windowBackend.MouseLeft += () => cursorInWindow.Value = false;
+            WindowBackend.FocusGained += () => focused.Value = true;
+            WindowBackend.FocusLost += () => focused.Value = false;
+            WindowBackend.MouseEntered += () => cursorInWindow.Value = true;
+            WindowBackend.MouseLeft += () => cursorInWindow.Value = false;
 
-            windowBackend.Closed += OnExited;
-            windowBackend.CloseRequested += OnExitRequested;
-            windowBackend.Update += OnUpdate;
-            windowBackend.KeyDown += OnKeyDown;
-            windowBackend.KeyUp += OnKeyUp;
-            windowBackend.KeyTyped += OnKeyTyped;
-            windowBackend.MouseDown += OnMouseDown;
-            windowBackend.MouseUp += OnMouseUp;
-            windowBackend.MouseMove += OnMouseMove;
-            windowBackend.MouseWheel += OnMouseWheel;
-            windowBackend.DragDrop += OnDragDrop;
+            WindowBackend.Closed += OnExited;
+            WindowBackend.CloseRequested += OnExitRequested;
+            WindowBackend.Update += OnUpdate;
+            WindowBackend.KeyDown += OnKeyDown;
+            WindowBackend.KeyUp += OnKeyUp;
+            WindowBackend.KeyTyped += OnKeyTyped;
+            WindowBackend.MouseDown += OnMouseDown;
+            WindowBackend.MouseUp += OnMouseUp;
+            WindowBackend.MouseMove += OnMouseMove;
+            WindowBackend.MouseWheel += OnMouseWheel;
+            WindowBackend.DragDrop += OnDragDrop;
 
-            windowBackend.DisplayChanged += d => CurrentDisplay.Value = d;
+            WindowBackend.DisplayChanged += d => CurrentDisplay.Value = d;
 
-            graphicsBackend.Initialise(windowBackend);
+            GraphicsBackend.Initialise(WindowBackend);
 
-            CurrentDisplay.Value = windowBackend.CurrentDisplay;
-            CurrentDisplay.ValueChanged += evt => windowBackend.CurrentDisplay = evt.NewValue;
+            CurrentDisplay.Value = WindowBackend.CurrentDisplay;
+            CurrentDisplay.ValueChanged += evt => WindowBackend.CurrentDisplay = evt.NewValue;
         }
 
         /// <summary>
         /// Requests that the graphics backend perform a buffer swap.
         /// </summary>
-        public void SwapBuffers() => graphicsBackend.SwapBuffers();
+        public void SwapBuffers() => GraphicsBackend.SwapBuffers();
 
         /// <summary>
         /// Requests that the graphics backend become the current context.
         /// May not be required for some backends.
         /// </summary>
-        public void MakeCurrent() => graphicsBackend.MakeCurrent();
+        public void MakeCurrent() => GraphicsBackend.MakeCurrent();
 
         public virtual void CycleMode()
         {
@@ -366,9 +366,27 @@ namespace osu.Framework.Platform
 
         #region Bindable Handling
 
+        protected virtual void UpdateWindowMode(WindowMode mode)
+        {
+            switch (mode)
+            {
+                case Configuration.WindowMode.Fullscreen:
+                    WindowBackend.WindowState = Platform.WindowState.Fullscreen;
+                    break;
+
+                case Configuration.WindowMode.Borderless:
+                    WindowBackend.WindowState = Platform.WindowState.FullscreenBorderless;
+                    break;
+
+                case Configuration.WindowMode.Windowed:
+                    WindowBackend.WindowState = Platform.WindowState.Normal;
+                    break;
+            }
+        }
+
         private void visible_ValueChanged(ValueChangedEvent<bool> evt)
         {
-            windowBackend.Visible = evt.NewValue;
+            WindowBackend.Visible = evt.NewValue;
 
             if (evt.NewValue)
                 OnShown();
@@ -378,13 +396,13 @@ namespace osu.Framework.Platform
 
         private bool boundsChanging;
 
-        private void windowBackend_Resized()
+        private void windowBackend_Resized(Size size)
         {
             if (!boundsChanging)
             {
                 boundsChanging = true;
-                Position.Value = windowBackend.Position;
-                Size.Value = windowBackend.Size;
+                Position.Value = WindowBackend.Position;
+                Size.Value = size;
                 boundsChanging = false;
             }
 
@@ -409,7 +427,7 @@ namespace osu.Framework.Platform
                 return;
 
             boundsChanging = true;
-            windowBackend.Position = evt.NewValue;
+            WindowBackend.Position = evt.NewValue;
             boundsChanging = false;
         }
 
@@ -419,8 +437,28 @@ namespace osu.Framework.Platform
                 return;
 
             boundsChanging = true;
-            windowBackend.Size = evt.NewValue;
+            WindowBackend.Size = evt.NewValue;
             boundsChanging = false;
+        }
+
+        private void windowBackend_WindowStateChanged(WindowState windowState)
+        {
+            WindowState.Value = windowState;
+
+            switch (windowState)
+            {
+                case Platform.WindowState.Fullscreen:
+                    WindowMode.Value = Configuration.WindowMode.Fullscreen;
+                    break;
+
+                case Platform.WindowState.FullscreenBorderless:
+                    WindowMode.Value = Configuration.WindowMode.Borderless;
+                    break;
+
+                case Platform.WindowState.Normal:
+                    WindowMode.Value = Configuration.WindowMode.Windowed;
+                    break;
+            }
         }
 
         #endregion
@@ -485,32 +523,32 @@ namespace osu.Framework.Platform
 
         public Rectangle ClientRectangle
         {
-            get => new Rectangle(Position.Value.X, Position.Value.Y, (int)(Size.Value.Width * Scale), (int)(Size.Value.Height * Scale));
+            get => new Rectangle(Point.Empty, WindowBackend.ClientSize);
             set
             {
-                Position.Value = value.Location;
-                Size.Value = new Size((int)(value.Width / Scale), (int)(value.Height / Scale));
             }
         }
 
         Size INativeWindow.ClientSize
         {
-            get => new Size((int)(Size.Value.Width * Scale), (int)(Size.Value.Height * Scale));
-            set => Size.Value = new Size((int)(value.Width / Scale), (int)(value.Height / Scale));
+            get => WindowBackend.ClientSize;
+            set
+            {
+            }
         }
 
         public MouseCursor Cursor { get; set; }
 
         public bool CursorVisible
         {
-            get => windowBackend.CursorVisible;
-            set => windowBackend.CursorVisible = value;
+            get => WindowBackend.CursorVisible;
+            set => WindowBackend.CursorVisible = value;
         }
 
         public bool CursorGrabbed
         {
-            get => windowBackend.CursorConfined;
-            set => windowBackend.CursorConfined = value;
+            get => WindowBackend.CursorConfined;
+            set => WindowBackend.CursorConfined = value;
         }
 
 #pragma warning disable 0067


### PR DESCRIPTION
Adds some minor missing features to the `DesktopWindow` class without making significant changes to the SDL window backend.  The work in this PR will be required regardless of the windowing toolkit we end up using.

* Last window display and relative position are now remembered between sessions
* Window mode is now remembered between sessions

Alternative to part of #3781.  If we end up sticking with SDL, much of the code in that PR can be rebased/reused.

Needs testing on Linux.