### PR TITLE
Atlas viewer view all textures

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -60,7 +60,7 @@ namespace osu.Framework
 
         private DrawVisualiser drawVisualiser;
 
-        private TextureAtlasVisualiser atlasVisualiser;
+        private TextureVisualiser textureVisualiser;
 
         private LogOverlay logOverlay;
 
@@ -293,16 +293,16 @@ namespace osu.Framework
 
                 case FrameworkAction.ToggleAtlasVisualiser:
 
-                    if (atlasVisualiser == null)
+                    if (textureVisualiser == null)
                     {
-                        LoadComponentAsync(atlasVisualiser = new TextureAtlasVisualiser
+                        LoadComponentAsync(textureVisualiser = new TextureVisualiser
                         {
                             Position = new Vector2(100 + 2 * ToolWindow.WIDTH, 100),
                             Depth = float.MinValue / 2,
                         }, AddInternal);
                     }
 
-                    atlasVisualiser.ToggleVisibility();
+                    textureVisualiser.ToggleVisibility();
                     return true;
 
                 case FrameworkAction.ToggleLogOverlay:

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Linq;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Textures;
-using osu.Framework.Lists;
 using osuTK.Graphics.ES30;
 using SixLabors.ImageSharp.PixelFormats;
 
@@ -17,22 +14,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
     internal class TextureGLAtlas : TextureGLSingle
     {
         /// <summary>
-        /// Contains all currently-active <see cref="TextureGLAtlas"/>es.
-        /// </summary>
-        private static readonly LockedWeakList<TextureGLAtlas> all_atlases = new LockedWeakList<TextureGLAtlas>();
-
-        /// <summary>
         /// The amount of padding around each texture in the atlas.
         /// </summary>
         private readonly int padding;
-
-        /// <summary>
-        /// Invoked when a new <see cref="TextureGLAtlas"/> is created.
-        /// </summary>
-        /// <remarks>
-        /// Invocation from the draw or update thread cannot be assumed.
-        /// </remarks>
-        public static event Action<TextureGLAtlas> TextureCreated;
 
         private readonly RectangleI atlasBounds;
 
@@ -44,22 +28,6 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             this.padding = padding;
 
             atlasBounds = new RectangleI(0, 0, Width, Height);
-
-            all_atlases.Add(this);
-
-            TextureCreated?.Invoke(this);
-        }
-
-        /// <summary>
-        /// Retrieves all currently-active <see cref="TextureGLAtlas"/>es.
-        /// </summary>
-        public static TextureGLAtlas[] GetAllAtlases() => all_atlases.ToArray();
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            all_atlases.Remove(this);
         }
 
         internal override void SetData(ITextureUpload upload, WrapMode wrapModeS, WrapMode wrapModeT, Opacity? uploadOpacity)

--- a/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
@@ -15,19 +15,47 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Visualisation
 {
-    internal class TextureAtlasVisualiser : ToolWindow
+    internal class TextureVisualiser : ToolWindow
     {
-        private readonly FillFlowContainer<TexturePanel> panelFlow;
+        private readonly FillFlowContainer<TexturePanel> atlasFlow;
+        private readonly FillFlowContainer<TexturePanel> textureFlow;
 
-        public TextureAtlasVisualiser()
-            : base("Texture Atlases", "(Ctrl+F3 to toggle)")
+        public TextureVisualiser()
+            : base("Textures", "(Ctrl+F3 to toggle)")
         {
-            ScrollContent.Child = panelFlow = new FillFlowContainer<TexturePanel>
+            ScrollContent.Child = new FillFlowContainer
             {
                 RelativeSizeAxes = Axes.X,
                 AutoSizeAxes = Axes.Y,
-                Spacing = new Vector2(22),
-                Padding = new MarginPadding(10),
+                Children = new Drawable[]
+                {
+                    new SpriteText
+                    {
+                        Text = "Atlases",
+                        Padding = new MarginPadding(5),
+                        Font = FrameworkFont.Condensed.With(weight: "Bold")
+                    },
+                    atlasFlow = new FillFlowContainer<TexturePanel>
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Spacing = new Vector2(22),
+                        Padding = new MarginPadding(10),
+                    },
+                    new SpriteText
+                    {
+                        Text = "Textures",
+                        Padding = new MarginPadding(5),
+                        Font = FrameworkFont.Condensed.With(weight: "Bold")
+                    },
+                    textureFlow = new FillFlowContainer<TexturePanel>
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Spacing = new Vector2(22),
+                        Padding = new MarginPadding(10),
+                    }
+                }
             };
         }
 
@@ -35,43 +63,46 @@ namespace osu.Framework.Graphics.Visualisation
         {
             base.PopIn();
 
-            foreach (var tex in TextureGLAtlas.GetAllAtlases())
+            foreach (var tex in TextureGLSingle.GetAllTextures())
                 addTexture(tex);
 
-            TextureGLAtlas.TextureCreated += addTexture;
+            TextureGLSingle.TextureCreated += addTexture;
         }
 
         protected override void PopOut()
         {
             base.PopOut();
 
-            panelFlow.Clear();
+            atlasFlow.Clear();
+            textureFlow.Clear();
 
-            TextureGLAtlas.TextureCreated -= addTexture;
+            TextureGLSingle.TextureCreated -= addTexture;
         }
 
-        private void addTexture(TextureGLAtlas texture) => Schedule(() =>
+        private void addTexture(TextureGLSingle texture) => Schedule(() =>
         {
-            if (panelFlow.Any(p => p.AtlasTexture == texture))
+            var target = texture is TextureGLAtlas ? atlasFlow : textureFlow;
+
+            if (target.Any(p => p.Texture == texture))
                 return;
 
-            panelFlow.Add(new TexturePanel(texture));
+            target.Add(new TexturePanel(texture));
         });
 
         private class TexturePanel : CompositeDrawable
         {
-            private readonly WeakReference<TextureGLAtlas> atlasReference;
+            private readonly WeakReference<TextureGLSingle> textureReference;
 
-            public TextureGLAtlas AtlasTexture => atlasReference.TryGetTarget(out var tex) ? tex : null;
+            public TextureGLSingle Texture => textureReference.TryGetTarget(out var tex) ? tex : null;
 
             private readonly SpriteText titleText;
             private readonly SpriteText footerText;
 
             private readonly UsageBackground usage;
 
-            public TexturePanel(TextureGLAtlas atlasTexture)
+            public TexturePanel(TextureGLSingle texture)
             {
-                atlasReference = new WeakReference<TextureGLAtlas>(atlasTexture);
+                textureReference = new WeakReference<TextureGLSingle>(texture);
 
                 Size = new Vector2(100, 132);
 
@@ -96,7 +127,7 @@ namespace osu.Framework.Graphics.Visualisation
                             AutoSizeAxes = Axes.Y,
                             Children = new Drawable[]
                             {
-                                usage = new UsageBackground(atlasReference)
+                                usage = new UsageBackground(textureReference)
                                 {
                                     Size = new Vector2(100)
                                 },
@@ -118,15 +149,15 @@ namespace osu.Framework.Graphics.Visualisation
 
                 try
                 {
-                    var atlas = AtlasTexture;
+                    var texture = Texture;
 
-                    if (atlas?.Available != true)
+                    if (texture?.Available != true)
                     {
                         Expire();
                         return;
                     }
 
-                    titleText.Text = $"{atlas.TextureId}. {atlas.Width}x{atlas.Height} ";
+                    titleText.Text = $"{texture.TextureId}. {texture.Width}x{texture.Height} ";
                     footerText.Text = Precision.AlmostBigger(usage.AverageUsagesPerFrame, 1) ? $"{usage.AverageUsagesPerFrame:N0} binds" : string.Empty;
                 }
                 catch { }
@@ -135,15 +166,15 @@ namespace osu.Framework.Graphics.Visualisation
 
         private class UsageBackground : Box
         {
-            private readonly WeakReference<TextureGLAtlas> atlasReference;
+            private readonly WeakReference<TextureGLSingle> textureReference;
 
             private ulong lastBindCount;
 
             public float AverageUsagesPerFrame { get; private set; }
 
-            public UsageBackground(WeakReference<TextureGLAtlas> atlasReference)
+            public UsageBackground(WeakReference<TextureGLSingle> textureReference)
             {
-                this.atlasReference = atlasReference;
+                this.textureReference = textureReference;
             }
 
             protected override DrawNode CreateDrawNode() => new UsageBackgroundDrawNode(this);
@@ -154,7 +185,7 @@ namespace osu.Framework.Graphics.Visualisation
 
                 private ColourInfo drawColour;
 
-                private WeakReference<TextureGLAtlas> atlasReference;
+                private WeakReference<TextureGLSingle> textureReference;
 
                 public UsageBackgroundDrawNode(Box source)
                     : base(source)
@@ -165,12 +196,12 @@ namespace osu.Framework.Graphics.Visualisation
                 {
                     base.ApplyState();
 
-                    atlasReference = Source.atlasReference;
+                    textureReference = Source.textureReference;
                 }
 
                 public override void Draw(Action<TexturedVertex2D> vertexAction)
                 {
-                    if (!atlasReference.TryGetTarget(out var texture))
+                    if (!textureReference.TryGetTarget(out var texture))
                         return;
 
                     if (!texture.Available)
@@ -194,7 +225,7 @@ namespace osu.Framework.Graphics.Visualisation
 
                 protected override void Blit(Action<TexturedVertex2D> vertexAction)
                 {
-                    if (!atlasReference.TryGetTarget(out var texture))
+                    if (!textureReference.TryGetTarget(out var texture))
                         return;
 
                     const float border_width = 4;
@@ -207,7 +238,7 @@ namespace osu.Framework.Graphics.Visualisation
                     // background
                     DrawQuad(Texture, shrunkenQuad, Color4.Black, null, vertexAction);
 
-                    // atlas texture
+                    // texture
                     texture.Bind();
                     DrawQuad(texture, shrunkenQuad, Color4.White, null, vertexAction);
                 }

--- a/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
@@ -238,6 +238,23 @@ namespace osu.Framework.Graphics.Visualisation
                     // background
                     DrawQuad(Texture, shrunkenQuad, Color4.Black, null, vertexAction);
 
+                    float aspect = (float)texture.Width / texture.Height;
+
+                    if (aspect > 1)
+                    {
+                        float newHeight = shrunkenQuad.Height / aspect;
+
+                        shrunkenQuad.Y += (shrunkenQuad.Height - newHeight) / 2;
+                        shrunkenQuad.Height = newHeight;
+                    }
+                    else if (aspect < 1)
+                    {
+                        float newWidth = shrunkenQuad.Width / (1 / aspect);
+
+                        shrunkenQuad.X += (shrunkenQuad.Width - newWidth) / 2;
+                        shrunkenQuad.Width = newWidth;
+                    }
+
                     // texture
                     texture.Bind();
                     DrawQuad(texture, shrunkenQuad, Color4.White, null, vertexAction);

--- a/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
@@ -5,6 +5,7 @@ using System;
 using System.Linq;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Shapes;
@@ -164,7 +165,7 @@ namespace osu.Framework.Graphics.Visualisation
             }
         }
 
-        private class UsageBackground : Box
+        private class UsageBackground : Box, IHasTooltip
         {
             private readonly WeakReference<TextureGLSingle> textureReference;
 
@@ -261,6 +262,17 @@ namespace osu.Framework.Graphics.Visualisation
                 }
 
                 protected internal override bool CanDrawOpaqueInterior => false;
+            }
+
+            public string TooltipText
+            {
+                get
+                {
+                    if (!textureReference.TryGetTarget(out var texture))
+                        return string.Empty;
+
+                    return $"type: {texture.GetType().Name}, size: {(float)(texture.Width * texture.Height * 4) / 1024 / 1024:N2}mb";
+                }
             }
         }
     }

--- a/osu.Framework/Graphics/Visualisation/ToolWindow.cs
+++ b/osu.Framework/Graphics/Visualisation/ToolWindow.cs
@@ -69,17 +69,22 @@ namespace osu.Framework.Graphics.Visualisation
                         }
                     }
                 },
-                MainHorizontalContent = new FillFlowContainer
+                new TooltipContainer
                 {
                     RelativeSizeAxes = Axes.Y,
                     AutoSizeAxes = Axes.X,
-                    Direction = FillDirection.Horizontal,
-                    Children = new Drawable[]
+                    Child = MainHorizontalContent = new FillFlowContainer
                     {
-                        ScrollContent = new BasicScrollContainer<Drawable>
+                        RelativeSizeAxes = Axes.Y,
+                        AutoSizeAxes = Axes.X,
+                        Direction = FillDirection.Horizontal,
+                        Children = new Drawable[]
                         {
-                            RelativeSizeAxes = Axes.Y,
-                            Width = WIDTH
+                            ScrollContent = new BasicScrollContainer<Drawable>
+                            {
+                                RelativeSizeAxes = Axes.Y,
+                                Width = WIDTH
+                            }
                         }
                     }
                 },


### PR DESCRIPTION
While looking into texture memory consumption, it became obvious that we are missing most of the picture and need to resort to 3rd party profilers to find where texture memory is being consumed outside of atlas textures.

This adds the ability to see all textures, no matter what usage.

Future work could split this view by `Type` name for better definition (ie. being able to see all `BufferedContainer` backing textures separately).

split into two categories:

![image](https://user-images.githubusercontent.com/191335/90106773-d9ee9500-dd82-11ea-8777-15d21bd4f06e.png)

aspect ratio support:

![image](https://user-images.githubusercontent.com/191335/90106714-c7745b80-dd82-11ea-9057-bf9340197864.png)

added tooltip information:

![image](https://user-images.githubusercontent.com/191335/90107889-7bc2b180-dd84-11ea-8187-3b64c46751ef.png)

