### PR TITLE
Fix VideoTexture not working with the texture viewer

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -49,9 +49,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         private readonly All filteringMode;
 
         /// <summary>
-        /// The total amount of times this <see cref="TextureGLAtlas"/> was bound.
+        /// The total amount of times this <see cref="TextureGLSingle"/> was bound.
         /// </summary>
-        public ulong BindCount { get; private set; }
+        public ulong BindCount { get; protected set; }
 
         // ReSharper disable once InconsistentlySynchronizedField (no need to lock here. we don't really care if the value is stale).
         public override bool Loaded => textureId > 0 || uploadQueue.Count > 0;

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -183,6 +183,11 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
+        /// <summary>
+        /// Retrieves the size of this texture in bytes.
+        /// </summary>
+        public virtual int GetByteSize() => Width * Height * 4;
+
         private static void rotateVector(ref Vector2 toRotate, float sin, float cos)
         {
             float oldX = toRotate.X;

--- a/osu.Framework/Graphics/Video/VideoTexture.cs
+++ b/osu.Framework/Graphics/Video/VideoTexture.cs
@@ -42,6 +42,10 @@ namespace osu.Framework.Graphics.Video
 
         public override int TextureId => textureIds?[0] ?? 0;
 
+        private int textureSize;
+
+        public override int GetByteSize() => textureSize;
+
         internal override bool Bind(TextureUnit unit, WrapMode wrapModeS, WrapMode wrapModeT)
         {
             if (!Available)
@@ -83,13 +87,21 @@ namespace osu.Framework.Graphics.Video
 
                     if (i == 0)
                     {
-                        GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8,
-                            videoUpload.Frame->width, videoUpload.Frame->height, 0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
+                        int width = videoUpload.Frame->width;
+                        int height = videoUpload.Frame->height;
+
+                        GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8, width, height, 0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
+
+                        textureSize += width * height;
                     }
                     else
                     {
-                        GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8,
-                            (videoUpload.Frame->width + 1) / 2, (videoUpload.Frame->height + 1) / 2, 0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
+                        int width = (videoUpload.Frame->width + 1) / 2;
+                        int height = (videoUpload.Frame->height + 1) / 2;
+
+                        GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8, width, height, 0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
+
+                        textureSize += width * height;
                     }
 
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)All.Linear);

--- a/osu.Framework/Graphics/Video/VideoTexture.cs
+++ b/osu.Framework/Graphics/Video/VideoTexture.cs
@@ -40,13 +40,25 @@ namespace osu.Framework.Graphics.Video
             base.SetData(upload, wrapModeS, wrapModeT, Opacity = Opacity.Opaque);
         }
 
+        public override int TextureId => textureIds?[0] ?? 0;
+
         internal override bool Bind(TextureUnit unit, WrapMode wrapModeS, WrapMode wrapModeT)
         {
             if (!Available)
                 throw new ObjectDisposedException(ToString(), "Can not bind a disposed texture.");
 
+            Upload();
+
+            if (textureIds == null)
+                return false;
+
+            bool anyBound = false;
+
             for (int i = 0; i < textureIds.Length; i++)
-                GLWrapper.BindTexture(textureIds[i], unit + i, wrapModeS, wrapModeT);
+                anyBound |= GLWrapper.BindTexture(textureIds[i], unit + i, wrapModeS, wrapModeT);
+
+            if (anyBound)
+                BindCount++;
 
             return true;
         }

--- a/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
@@ -271,7 +271,7 @@ namespace osu.Framework.Graphics.Visualisation
                     if (!textureReference.TryGetTarget(out var texture))
                         return string.Empty;
 
-                    return $"type: {texture.GetType().Name}, size: {(float)(texture.Width * texture.Height * 4) / 1024 / 1024:N2}mb";
+                    return $"type: {texture.GetType().Name}, size: {(float)texture.GetByteSize() / 1024 / 1024:N2}mb";
                 }
             }
         }


### PR DESCRIPTION
Two fixes here:
1. Making `VideoTexture.Bind()` forcefully upload the texture. This is already done in the base `TextureGLSingle.Bind()` so I thought of just copying the same usage. Probably fixes cases where GLWrapper's upload is running behind and doesn't upload the texture in time.
2. Fixing crash due to potentially null array + adding the bind count.

The texture visualiser will only show the ID of the first internal texture for each `VideoTexture`, and only the representation for the texture bound to slot 0 on the GPU, but will display an accurate frame size. It's a bit of a best-case effort sort of scenario for now, and we can maybe change that in the future but it requires `VideoTexture` to use `TextureGLSingle`s for the internal textures.

Also interesting to note that we somehow initialise 7 `VideoTexture`s per video (9.2MB total for the sample video). I thought we only initialised 3...