### PR TITLE
Fix transforms operating on same properties being applied out of order

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -350,6 +350,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkAtTime(750, box => box.Y == 0.375f);
             checkAtTime(1000, box => box.Y == 0.25f);
             checkAtTime(1500, box => box.Y == 0.25f);
+            checkAtTime(1250, box => box.Y == 0.25f);
             checkAtTime(750, box => box.Y == 0.375f);
         }
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -335,6 +335,24 @@ namespace osu.Framework.Tests.Visual.Drawables
             }
         }
 
+        [Test]
+        public void TestMultipleTransformTargets()
+        {
+            boxTest(box =>
+            {
+                box.Delay(500).MoveTo(new Vector2(0, 0.25f), 500);
+                box.MoveToY(0.5f, 250);
+            });
+
+            checkAtTime(double.MinValue, box => box.Y == 0);
+            checkAtTime(0, box => box.Y == 0);
+            checkAtTime(250, box => box.Y == 0.5f);
+            checkAtTime(750, box => box.Y == 0.375f);
+            checkAtTime(1000, box => box.Y == 0.25f);
+            checkAtTime(1500, box => box.Y == 0.25f);
+            checkAtTime(750, box => box.Y == 0.375f);
+        }
+
         private Box box;
 
         private void checkAtTime(double time, Func<Box, bool> assert)

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -44,11 +44,12 @@ namespace osu.Framework.Graphics
         /// <param name="newValue">The value to transform to.</param>
         /// <param name="duration">The transform duration.</param>
         /// <param name="easing">The transform easing to be used for tweening.</param>
+        /// <param name="grouping">An optional grouping specification to be used when the same property may be touched by multiple transform types.</param>
         /// <returns>A <see cref="TransformSequence{T}"/> to which further transforms can be added.</returns>
-        public static TransformSequence<TThis> TransformTo<TThis, TValue, TEasing>(this TThis t, string propertyOrFieldName, TValue newValue, double duration, in TEasing easing)
+        public static TransformSequence<TThis> TransformTo<TThis, TValue, TEasing>(this TThis t, string propertyOrFieldName, TValue newValue, double duration, in TEasing easing, string grouping = null)
             where TThis : class, ITransformable
             where TEasing : IEasingFunction
-            => t.TransformTo(t.MakeTransform(propertyOrFieldName, newValue, duration, easing));
+            => t.TransformTo(t.MakeTransform(propertyOrFieldName, newValue, duration, easing, grouping));
 
         /// <summary>
         /// Applies a <see cref="Transform"/> to a given <see cref="ITransformable"/>.
@@ -77,11 +78,12 @@ namespace osu.Framework.Graphics
         /// <param name="newValue">The value to transform to.</param>
         /// <param name="duration">The transform duration.</param>
         /// <param name="easing">The transform easing to be used for tweening.</param>
+        /// <param name="grouping">An optional grouping specification to be used when the same property may be touched by multiple transform types.</param>
         /// <returns>The resulting <see cref="Transform{TValue, T}"/>.</returns>
         public static Transform<TValue, DefaultEasingFunction, TThis> MakeTransform<TThis, TValue>(this TThis t, string propertyOrFieldName, TValue newValue, double duration = 0,
-                                                                                                   Easing easing = Easing.None)
+                                                                                                   Easing easing = Easing.None, string grouping = null)
             where TThis : class, ITransformable
-            => t.MakeTransform(propertyOrFieldName, newValue, duration, new DefaultEasingFunction(easing));
+            => t.MakeTransform(propertyOrFieldName, newValue, duration, new DefaultEasingFunction(easing), grouping);
 
         /// <summary>
         /// Creates a <see cref="Transform{TValue, T}"/> for smoothly changing <paramref name="propertyOrFieldName"/>
@@ -96,11 +98,12 @@ namespace osu.Framework.Graphics
         /// <param name="newValue">The value to transform to.</param>
         /// <param name="duration">The transform duration.</param>
         /// <param name="easing">The transform easing to be used for tweening.</param>
+        /// <param name="grouping">An optional grouping specification to be used when the same property may be touched by multiple transform types.</param>
         /// <returns>The resulting <see cref="Transform{TValue, T}"/>.</returns>
-        public static Transform<TValue, TEasing, TThis> MakeTransform<TThis, TEasing, TValue>(this TThis t, string propertyOrFieldName, TValue newValue, double duration, in TEasing easing)
+        public static Transform<TValue, TEasing, TThis> MakeTransform<TThis, TEasing, TValue>(this TThis t, string propertyOrFieldName, TValue newValue, double duration, in TEasing easing, string grouping = null)
             where TThis : class, ITransformable
             where TEasing : IEasingFunction
-            => t.PopulateTransform(new TransformCustom<TValue, TEasing, TThis>(propertyOrFieldName), newValue, duration, easing);
+            => t.PopulateTransform(new TransformCustom<TValue, TEasing, TThis>(propertyOrFieldName, grouping), newValue, duration, easing);
 
         /// <summary>
         /// Populates a newly created <see cref="Transform{TValue, T}"/> with necessary values.
@@ -598,7 +601,7 @@ namespace osu.Framework.Graphics
         public static TransformSequence<T> ResizeWidthTo<T, TEasing>(this T drawable, float newWidth, double duration, in TEasing easing)
             where T : Drawable
             where TEasing : IEasingFunction
-            => drawable.TransformTo(nameof(drawable.Width), newWidth, duration, easing);
+            => drawable.TransformTo(nameof(drawable.Width), newWidth, duration, easing, nameof(drawable.Size));
 
         /// <summary>
         /// Smoothly adjusts <see cref="Drawable.Height"/> over time.
@@ -607,7 +610,7 @@ namespace osu.Framework.Graphics
         public static TransformSequence<T> ResizeHeightTo<T, TEasing>(this T drawable, float newHeight, double duration, in TEasing easing)
             where T : Drawable
             where TEasing : IEasingFunction
-            => drawable.TransformTo(nameof(drawable.Height), newHeight, duration, easing);
+            => drawable.TransformTo(nameof(drawable.Height), newHeight, duration, easing, nameof(drawable.Position));
 
         /// <summary>
         /// Smoothly adjusts <see cref="Drawable.Position"/> over time.
@@ -645,7 +648,7 @@ namespace osu.Framework.Graphics
         public static TransformSequence<T> MoveToX<T, TEasing>(this T drawable, float destination, double duration, in TEasing easing)
             where T : Drawable
             where TEasing : IEasingFunction
-            => drawable.TransformTo(nameof(drawable.X), destination, duration, easing);
+            => drawable.TransformTo(nameof(drawable.X), destination, duration, easing, nameof(drawable.Position));
 
         /// <summary>
         /// Smoothly adjusts <see cref="Drawable.Y"/> over time.
@@ -654,7 +657,7 @@ namespace osu.Framework.Graphics
         public static TransformSequence<T> MoveToY<T, TEasing>(this T drawable, float destination, double duration, in TEasing easing)
             where T : Drawable
             where TEasing : IEasingFunction
-            => drawable.TransformTo(nameof(drawable.Y), destination, duration, easing);
+            => drawable.TransformTo(nameof(drawable.Y), destination, duration, easing, nameof(drawable.Position));
 
         /// <summary>
         /// Smoothly adjusts <see cref="Drawable.Position"/> by an offset to its final value over time.

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -610,7 +610,7 @@ namespace osu.Framework.Graphics
         public static TransformSequence<T> ResizeHeightTo<T, TEasing>(this T drawable, float newHeight, double duration, in TEasing easing)
             where T : Drawable
             where TEasing : IEasingFunction
-            => drawable.TransformTo(nameof(drawable.Height), newHeight, duration, easing, nameof(drawable.Position));
+            => drawable.TransformTo(nameof(drawable.Height), newHeight, duration, easing, nameof(drawable.Size));
 
         /// <summary>
         /// Smoothly adjusts <see cref="Drawable.Position"/> over time.

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Graphics.Transforms
             {
                 resetLastAppliedIndex();
 
-                var appliedToEndReverts = new List<string>();
+                bool appliedToEndRevert = false;
 
                 // Under the case that completed transforms are not removed, reversing the clock is permitted.
                 // We need to first look back through all the transforms and apply the start values of the ones that were previously
@@ -82,14 +82,14 @@ namespace osu.Framework.Graphics.Transforms
                         // we are in the middle of this transform, so we want to mark as not-completely-applied.
                         // note that we should only do this for the last transform to avoid incorrect application order.
                         // the actual application will be in the main loop below now that AppliedToEnd is false.
-                        if (!appliedToEndReverts.Contains(t.TargetMember))
+                        if (!appliedToEndRevert)
                         {
                             if (time < t.EndTime)
                                 t.AppliedToEnd = false;
                             else
                                 t.Apply(t.EndTime);
 
-                            appliedToEndReverts.Add(t.TargetMember);
+                            appliedToEndRevert = true;
                         }
                     }
                     else

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -12,17 +12,17 @@ namespace osu.Framework.Graphics.Transforms
     /// <summary>
     /// Tracks the lifetime of transforms for one specified target member.
     /// </summary>
-    internal class TargetMemberTransformTracker
+    internal class TargetGroupingTransformTracker
     {
         /// <summary>
-        /// A list of <see cref="Transform"/>s associated with the <see cref="TargetMember"/>.
+        /// A list of <see cref="Transform"/>s associated with the <see cref="TargetGrouping"/>.
         /// </summary>
         public IEnumerable<Transform> Transforms => transforms;
 
         /// <summary>
         /// The member this instance is tracking.
         /// </summary>
-        public readonly string TargetMember;
+        public readonly string TargetGrouping;
 
         private readonly SortedList<Transform> transforms = new SortedList<Transform>(Transform.COMPARER);
 
@@ -41,9 +41,16 @@ namespace osu.Framework.Graphics.Transforms
         /// </summary>
         private int? lastAppliedIndex;
 
-        public TargetMemberTransformTracker(Transformable transformable, string targetMember)
+        /// <summary>
+        /// All <see cref="Transform.TargetMember"/>s which are handled by this tracker.
+        /// </summary>
+        public IEnumerable<string> TargetMembers => targetMembers;
+
+        private readonly HashSet<string> targetMembers = new HashSet<string>();
+
+        public TargetGroupingTransformTracker(Transformable transformable, string targetGrouping)
         {
-            TargetMember = targetMember;
+            TargetGrouping = targetGrouping;
             this.transformable = transformable;
         }
 
@@ -53,7 +60,7 @@ namespace osu.Framework.Graphics.Transforms
             {
                 resetLastAppliedIndex();
 
-                bool appliedToEndRevert = false;
+                var appliedToEndReverts = new List<string>();
 
                 // Under the case that completed transforms are not removed, reversing the clock is permitted.
                 // We need to first look back through all the transforms and apply the start values of the ones that were previously
@@ -75,14 +82,14 @@ namespace osu.Framework.Graphics.Transforms
                         // we are in the middle of this transform, so we want to mark as not-completely-applied.
                         // note that we should only do this for the last transform to avoid incorrect application order.
                         // the actual application will be in the main loop below now that AppliedToEnd is false.
-                        if (!appliedToEndRevert)
+                        if (!appliedToEndReverts.Contains(t.TargetMember))
                         {
                             if (time < t.EndTime)
                                 t.AppliedToEnd = false;
                             else
                                 t.Apply(t.EndTime);
 
-                            appliedToEndRevert = true;
+                            appliedToEndReverts.Add(t.TargetMember);
                         }
                     }
                     else
@@ -117,6 +124,7 @@ namespace osu.Framework.Graphics.Transforms
                     for (int j = lastAppliedIndex ?? 0; j < i; ++j)
                     {
                         var u = transforms[j];
+                        if (u.TargetMember != t.TargetMember) continue;
 
                         if (!u.AppliedToEnd)
                             // we may have applied the existing transforms too far into the future.
@@ -208,6 +216,11 @@ namespace osu.Framework.Graphics.Transforms
         {
             Debug.Assert(!(transform.TransformID == 0 && transforms.Contains(transform)), $"Zero-id {nameof(Transform)}s should never be contained already.");
 
+            if (transform.TargetGrouping != TargetGrouping)
+                throw new ArgumentException($"Target grouping \"{transform.TargetGrouping}\" does not match this tracker's grouping \"{TargetGrouping}\".", nameof(transform));
+
+            targetMembers.Add(transform.TargetMember);
+
             // This contains check may be optimized away in the future, should it become a bottleneck
             if (transform.TransformID != 0 && transforms.Contains(transform))
                 throw new InvalidOperationException($"{nameof(Transformable)} may not contain the same {nameof(Transform)} more than once.");
@@ -220,9 +233,13 @@ namespace osu.Framework.Graphics.Transforms
             for (int i = insertionIndex + 1; i < transforms.Count; ++i)
             {
                 var t = transforms[i];
-                transforms.RemoveAt(i--);
-                if (t.OnAbort != null)
-                    removalActions.Add(t.OnAbort);
+
+                if (t.TargetMember == transform.TargetMember)
+                {
+                    transforms.RemoveAt(i--);
+                    if (t.OnAbort != null)
+                        removalActions.Add(t.OnAbort);
+                }
             }
 
             invokePendingRemovalActions();
@@ -248,12 +265,26 @@ namespace osu.Framework.Graphics.Transforms
         /// Removes <see cref="Transform"/>s that start after <paramref name="time"/>.
         /// </summary>
         /// <param name="time">The time to clear <see cref="Transform"/>s after.</param>
-        public virtual void ClearTransformsAfter(double time)
+        /// <param name="targetMember">
+        /// An optional <see cref="Transform.TargetMember"/> name of <see cref="Transform"/>s to clear.
+        /// Null for clearing all <see cref="Transform"/>s.
+        /// </param>
+        public virtual void ClearTransformsAfter(double time, string targetMember = null)
         {
             resetLastAppliedIndex();
 
-            var toAbort = transforms.Where(t => t.StartTime >= time).ToArray();
-            transforms.RemoveAll(t => t.StartTime >= time);
+            Transform[] toAbort;
+
+            if (targetMember == null)
+            {
+                toAbort = transforms.Where(t => t.StartTime >= time).ToArray();
+                transforms.RemoveAll(t => t.StartTime >= time);
+            }
+            else
+            {
+                toAbort = transforms.Where(t => t.TargetMember == targetMember && t.StartTime >= time).ToArray();
+                transforms.RemoveAll(t => t.TargetMember == targetMember && t.StartTime >= time);
+            }
 
             foreach (var t in toAbort)
                 t.OnAbort?.Invoke();
@@ -262,14 +293,22 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// Finishes specified <see cref="Transform"/>s, using their <see cref="Transform{TValue}.EndValue"/>.
         /// </summary>
-        public virtual void FinishTransforms()
+        /// <param name="targetMember">
+        /// An optional <see cref="Transform.TargetMember"/> name of <see cref="Transform"/>s to finish.
+        /// Null for finishing all <see cref="Transform"/>s.
+        /// </param>
+        public virtual void FinishTransforms(string targetMember = null)
         {
-            bool toFlushPredicate(Transform t) => !t.IsLooping;
+            Func<Transform, bool> toFlushPredicate;
+            if (targetMember == null)
+                toFlushPredicate = t => !t.IsLooping;
+            else
+                toFlushPredicate = t => !t.IsLooping && t.TargetMember == targetMember;
 
             // Flush is undefined for endlessly looping transforms
             var toFlush = transforms.Where(toFlushPredicate).ToArray();
 
-            transforms.RemoveAll(toFlushPredicate);
+            transforms.RemoveAll(t => toFlushPredicate(t));
             resetLastAppliedIndex();
 
             foreach (Transform t in toFlush)

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -36,6 +36,11 @@ namespace osu.Framework.Graphics.Transforms
 
         public abstract string TargetMember { get; }
 
+        /// <summary>
+        /// A grouping specification that should match any other <see cref="Transform"/>s which affect the same properties.
+        /// </summary>
+        public virtual string TargetGrouping => TargetMember;
+
         public abstract void Apply(double time);
 
         public abstract void ReadIntoStartValue();

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -37,8 +37,15 @@ namespace osu.Framework.Graphics.Transforms
         public abstract string TargetMember { get; }
 
         /// <summary>
-        /// A grouping specification that should match any other <see cref="Transform"/>s which affect the same properties.
+        /// The name of the grouping this <see cref="Transform"/> belongs to.
+        /// Defaults to <see cref="TargetMember"/>.
         /// </summary>
+        /// <remarks>
+        /// Transforms in a single group affect the same property (or properties) of a <see cref="Transformable"/>.
+        /// It is assumed that transforms in different groups are independent from each other
+        /// in that they affect different properties, and therefore they can be applied independently
+        /// in any order without affecting the end result.
+        /// </remarks>
         public virtual string TargetGrouping => TargetMember;
 
         public abstract void Apply(double time);

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -21,9 +21,9 @@ namespace osu.Framework.Graphics.Transforms
         where T : class, ITransformable
         where TEasing : IEasingFunction
     {
-        private readonly string targetGrouping;
-
         public override string TargetGrouping => targetGrouping ?? TargetMember;
+
+        private readonly string targetGrouping;
 
         private delegate TValue ReadFunc(T transformable);
 

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -21,6 +21,10 @@ namespace osu.Framework.Graphics.Transforms
         where T : class, ITransformable
         where TEasing : IEasingFunction
     {
+        private readonly string targetGrouping;
+
+        public override string TargetGrouping => targetGrouping ?? TargetMember;
+
         private delegate TValue ReadFunc(T transformable);
 
         private delegate void WriteFunc(T transformable, TValue value);
@@ -155,9 +159,11 @@ namespace osu.Framework.Graphics.Transforms
         /// <see cref="Transform.EndTime"/>, and a current time.
         /// </summary>
         /// <param name="propertyOrFieldName">The property or field name to be operated upon.</param>
-        public TransformCustom(string propertyOrFieldName)
+        /// <param name="grouping">An optional grouping, for a case where the target property can potentially conflict with others.</param>
+        public TransformCustom(string propertyOrFieldName, string grouping = null)
         {
             TargetMember = propertyOrFieldName;
+            targetGrouping = grouping;
 
             accessor = getAccessor(propertyOrFieldName);
             Trace.Assert(accessor.Read != null && accessor.Write != null, $"Failed to populate {nameof(accessor)}.");

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -92,13 +92,16 @@ namespace osu.Framework.Graphics.Transforms
             return null;
         }
 
-        private TargetGroupingTransformTracker getTrackerForGrouping(string targetGrouping)
+        private TargetGroupingTransformTracker getTrackerForGrouping(string targetGrouping, bool createIfNotExisting)
         {
             foreach (var t in targetGroupingTrackers)
             {
                 if (t.TargetGrouping == targetGrouping)
                     return t;
             }
+
+            if (!createIfNotExisting)
+                return null;
 
             var tracker = new TargetGroupingTransformTracker(this, targetGrouping);
             targetGroupingTrackers.Add(tracker);
@@ -127,7 +130,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="toRemove">The <see cref="Transform"/> to remove.</param>
         public void RemoveTransform(Transform toRemove)
         {
-            getTrackerForGrouping(toRemove.TargetGrouping)?.RemoveTransform(toRemove);
+            getTrackerForGrouping(toRemove.TargetGrouping, false)?.RemoveTransform(toRemove);
 
             toRemove.OnAbort?.Invoke();
         }
@@ -291,7 +294,7 @@ namespace osu.Framework.Graphics.Transforms
                 return;
             }
 
-            getTrackerForGrouping(transform.TargetGrouping).AddTransform(transform, customTransformID);
+            getTrackerForGrouping(transform.TargetGrouping, true).AddTransform(transform, customTransformID);
         }
     }
 }

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -127,7 +127,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="toRemove">The <see cref="Transform"/> to remove.</param>
         public void RemoveTransform(Transform toRemove)
         {
-            getTrackerFor(toRemove.TargetGrouping)?.RemoveTransform(toRemove);
+            getTrackerForGrouping(toRemove.TargetGrouping)?.RemoveTransform(toRemove);
 
             toRemove.OnAbort?.Invoke();
         }


### PR DESCRIPTION
This basically brings back logic that was removed in the previous PR (#3779) as it is still required. The tracker class will now potentially be tracking more than one target member in the case they touch the same underlying property. Less optimal, but this is the best we can do (and should still be fine for most use cases).

For reference, I brought the `xAt(targetMember)` logic back from https://raw.githubusercontent.com/ppy/osu-framework/d0fc93793e7d4aac79d34dbdec7190a0951bdc16/osu.Framework/Graphics/Transforms/Transformable.cs, which can be cross-checked during review.

- Closes https://github.com/ppy/osu-framework/issues/3817