### PR TITLE
Reconfigure bass for lower latency on linux

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -280,9 +280,6 @@ namespace osu.Framework.Audio
             //we have successfully initialised a new device.
             UpdateDevice(deviceIndex);
 
-            Bass.PlaybackBufferLength = 100;
-            Bass.UpdatePeriod = 5;
-
             return true;
         }
 
@@ -296,7 +293,9 @@ namespace osu.Framework.Audio
                 return true;
 
             // reduce latency to a known sane minimum.
+            Bass.Configure(ManagedBass.Configuration.DevicePeriod, 1);
             Bass.Configure(ManagedBass.Configuration.DeviceBufferLength, 10);
+            Bass.Configure(ManagedBass.Configuration.PlaybackBufferLength, 100);
 
             // this likely doesn't help us but also doesn't seem to cause any issues or any cpu increase.
             Bass.Configure(ManagedBass.Configuration.UpdatePeriod, 5);


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/3800

This should hopefully not cause any issues, because the buffer length remains unchanged from the previous value. This value is also ignored on Windows.
With that being said this needs confirmation on macOS and iOS, and possibly Android. On macOS/iOS specifically, buffer length is [documented](http://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html) as being twice the device period, ignoring our custom value and potentially behaving badly after this change.

The other effect is CPU% increase from ~0.5% to ~1.5%.

Also I'm not sure what the removed lines were doing outside of the main `InitBass()` function, so I've moved them in there. I'm also further confused as to what `PlaybackBufferLength` does since I can't seem to find docs for it, but I've left it in for the time being (doesn't seem to have any effect with or without on my linux box).