### PR TITLE
Fix LargeTextureStore never purging textures

### DIFF
--- a/osu.Framework/Graphics/Textures/LargeTextureStore.cs
+++ b/osu.Framework/Graphics/Textures/LargeTextureStore.cs
@@ -41,19 +41,19 @@ namespace osu.Framework.Graphics.Textures
                 if (tex?.TextureGL == null)
                     return null;
 
-                if (!referenceCounts.TryGetValue(name, out TextureWithRefCount.ReferenceCount count))
-                    referenceCounts[name] = count = new TextureWithRefCount.ReferenceCount(referenceCountLock, () => onAllReferencesLost(name));
+                if (!referenceCounts.TryGetValue(tex.LookupKey, out TextureWithRefCount.ReferenceCount count))
+                    referenceCounts[tex.LookupKey] = count = new TextureWithRefCount.ReferenceCount(referenceCountLock, () => onAllReferencesLost(tex));
 
                 return new TextureWithRefCount(tex.TextureGL, count);
             }
         }
 
-        private void onAllReferencesLost(string name)
+        private void onAllReferencesLost(Texture texture)
         {
             Debug.Assert(Monitor.IsEntered(referenceCountLock));
 
-            referenceCounts.Remove(name);
-            Purge(name);
+            referenceCounts.Remove(texture.LookupKey);
+            Purge(texture);
         }
     }
 }

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -28,6 +28,11 @@ namespace osu.Framework.Graphics.Textures
         public string AssetName;
 
         /// <summary>
+        /// A lookup key used by <see cref="TextureStore"/>s.
+        /// </summary>
+        internal string LookupKey;
+
+        /// <summary>
         /// At what multiple of our expected resolution is our underlying texture?
         /// </summary>
         public float ScaleAdjust = 1;

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -116,7 +116,10 @@ namespace osu.Framework.Graphics.Textures
                 {
                     try
                     {
-                        textureCache[key] = tex = getTexture(name, wrapModeS, wrapModeT);
+                        tex = getTexture(name, wrapModeS, wrapModeT);
+                        if (tex != null)
+                            tex.LookupKey = key;
+                        textureCache[key] = tex;
                     }
                     catch (TextureTooLargeForGLException)
                     {
@@ -129,16 +132,20 @@ namespace osu.Framework.Graphics.Textures
         }
 
         /// <summary>
-        /// Disposes and removes a texture with the specified name from the texture cache.
+        /// Disposes and removes a texture from the cache.
         /// </summary>
-        /// <param name="name">The name of the texture to purge from the cache.</param>
-        protected void Purge(string name)
+        /// <param name="texture">The texture to purge from the cache.</param>
+        protected void Purge(Texture texture)
         {
             lock (textureCache)
             {
-                if (textureCache.TryGetValue(name, out var tex))
-                    tex.Dispose();
-                textureCache.Remove(name);
+                if (textureCache.TryGetValue(texture.LookupKey, out var tex))
+                {
+                    tex?.TextureGL?.Dispose();
+                    tex?.Dispose();
+                }
+
+                textureCache.Remove(texture.LookupKey);
             }
         }
     }

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -141,6 +141,8 @@ namespace osu.Framework.Graphics.Textures
             {
                 if (textureCache.TryGetValue(texture.LookupKey, out var tex))
                 {
+                    // we are doing this locally as right now, Textures don't dispose the underlying texture (leaving it to GC finalizers).
+                    // in the case of a purge operation we are pretty sure this is the intended behaviour.
                     tex?.TextureGL?.Dispose();
                     tex?.Dispose();
                 }


### PR DESCRIPTION
Regressed with the introduction of wrap modes (changing the key but not using it in all locations).

Also takes the load off the finalizer for actually disposing the gl-side texture.