### PR TITLE
Fix DLUW not unloading when masked away

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -372,6 +373,51 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddUntilStep("wait for unload", () => wrapper.Content?.IsLoaded != true);
         }
 
+        [Test]
+        public void TestUnloadedWhenAsyncLoadCompletedAndMaskedAway()
+        {
+            BasicScrollContainer scrollContainer = null;
+            DelayedLoadTestDrawable child = null;
+
+            AddStep("add panel", () =>
+            {
+                Child = scrollContainer = new BasicScrollContainer
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(128),
+                    Child = new Container
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 1000,
+                        Child = new Container
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            Height = 128,
+                            Child = new DelayedLoadUnloadWrapper(() => child = new DelayedLoadTestDrawable { RelativeSizeAxes = Axes.Both }, 0, 1000)
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = 128
+                            }
+                        }
+                    }
+                };
+            });
+
+            // Check that the child is disposed when its async-load completes while the DLUW is masked away.
+            AddAssert("wait for load to begin", () => child?.LoadState == LoadState.Loading);
+            AddStep("scroll to end", () => scrollContainer.ScrollToEnd(false));
+            AddStep("allow load", () => child.AllowLoad.Set());
+            AddUntilStep("drawable disposed", () => child.IsDisposed);
+
+            // Check that reuse of the child is not attempted.
+            Drawable lastChild = null;
+            AddStep("store child", () => lastChild = child);
+            AddStep("scroll to start", () => scrollContainer.ScrollToStart(false));
+            AddWaitStep("wait some frames", 2);
+            AddAssert("child not loaded", () => lastChild.LoadState != LoadState.Loaded);
+        }
+
         public class TestScrollContainer : BasicScrollContainer
         {
             public new Scheduler Scheduler => base.Scheduler;
@@ -399,6 +445,18 @@ namespace osu.Framework.Tests.Visual.Drawables
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre,
                 };
+            }
+        }
+
+        public class DelayedLoadTestDrawable : CompositeDrawable
+        {
+            public readonly ManualResetEventSlim AllowLoad = new ManualResetEventSlim(false);
+
+            [BackgroundDependencyLoader]
+            private void load()
+            {
+                if (!AllowLoad.Wait(TimeSpan.FromSeconds(10)))
+                    throw new TimeoutException();
             }
         }
     }

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Graphics.Containers
             content.LifetimeEnd = lifetimeEnd;
 
             // Scheduled for another frame since Update() may not have run yet and thus OptimisingContainer may not be up-to-date
-            Schedule(() =>
+            Game.Schedule(() =>
             {
                 Debug.Assert(!contentLoaded);
                 Debug.Assert(unloadSchedule == null);
@@ -131,7 +131,9 @@ namespace osu.Framework.Graphics.Containers
                 if (isDisposed)
                     return;
 
-                ClearInternal();
+                // The content may not be part of our hierarchy, so it needs to be disposed manually. To prevent double-queuing of disposals, clear does not dispose.
+                ClearInternal(false);
+                DisposeChildAsync(Content);
                 Content = null;
 
                 timeHidden = 0;


### PR DESCRIPTION
Fixes the issue found in https://github.com/ppy/osu/pull/9849

The case here is: begin an async load of the beatmap panel, and immediately scroll down to mask it away. Since the `EndDelayedLoad` callback was scheduled locally, DLUW won't have a chance to schedule the unload.