### PR TITLE
Disable stack trace collection on windows

### DIFF
--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -84,9 +84,8 @@ namespace osu.Framework.Statistics
                 return;
 
             // As it turns out, it's also too slow to be useful on windows, so let's fully disable for the time being.
-            return;
 
-            Trace.Assert(cancellation == null);
+            /*Trace.Assert(cancellation == null);
 
             var thread = new Thread(() => run((cancellation = new CancellationTokenSource()).Token))
             {
@@ -94,7 +93,7 @@ namespace osu.Framework.Statistics
                 IsBackground = true
             };
 
-            thread.Start();
+            thread.Start();*/
         }
 
         private bool isCollecting;

--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -83,6 +83,9 @@ namespace osu.Framework.Statistics
             if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
                 return;
 
+            // As it turns out, it's also too slow to be useful on windows, so let's fully disable for the time being.
+            return;
+
             Trace.Assert(cancellation == null);
 
             var thread = new Thread(() => run((cancellation = new CancellationTokenSource()).Token))

--- a/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
+++ b/osu.Framework/Statistics/BackgroundStackTraceCollector.cs
@@ -80,10 +80,11 @@ namespace osu.Framework.Statistics
             // Since v2.0 of Microsoft.Diagnostics.Runtime, support is provided to retrieve stack traces on unix platforms but
             // it causes a full core dump, which is very slow and causes a visible freeze.
             // For the time being let's remain windows-only (as this functionality used to be).
-            if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
-                return;
 
             // As it turns out, it's also too slow to be useful on windows, so let's fully disable for the time being.
+
+            //if (RuntimeInfo.OS != RuntimeInfo.Platform.Windows)
+            //    return;
 
             /*Trace.Assert(cancellation == null);
 


### PR DESCRIPTION
Turns out this is also too slow now to be useful. We can revisit this when we need it again. We are still far from requiring this for performance diagnostics.