### PR TITLE
Fix build warnings

### DIFF
--- a/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
+++ b/osu.Framework.Tests/Clocks/DecoupleableClockTest.cs
@@ -378,7 +378,7 @@ namespace osu.Framework.Tests.Clocks
 
         private class TestClockWithRange : TestClock
         {
-            public double MinTime { get; set; } = 0;
+            public double MinTime => 0;
             public double MaxTime { get; set; } = double.PositiveInfinity;
 
             public override bool Seek(double position)

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
@@ -1153,9 +1153,6 @@ namespace osu.Framework.Tests.Visual.Containers
 
     internal class InfofulBox : Container
     {
-#pragma warning disable CA1805
-        public bool Chameleon = false;
-#pragma warning restore CA1805
         public bool AllowDrag = true;
 
         protected override void OnDrag(DragEvent e)
@@ -1174,46 +1171,6 @@ namespace osu.Framework.Tests.Visual.Containers
                 RelativeSizeAxes = Axes.Both,
                 Depth = float.MaxValue,
             });
-        }
-
-        private int lastSwitch;
-
-        protected override void Update()
-        {
-            if (Chameleon && (int)Time.Current / 1000 != lastSwitch)
-            {
-                lastSwitch = (int)Time.Current / 1000;
-
-                switch (lastSwitch % 6)
-                {
-                    case 0:
-                        Anchor = (Anchor)((int)Anchor + 1);
-                        Origin = (Anchor)((int)Origin + 1);
-                        break;
-
-                    case 1:
-                        this.MoveTo(new Vector2(0, 0), 800, Easing.Out);
-                        break;
-
-                    case 2:
-                        this.MoveTo(new Vector2(200, 0), 800, Easing.Out);
-                        break;
-
-                    case 3:
-                        this.MoveTo(new Vector2(200, 200), 800, Easing.Out);
-                        break;
-
-                    case 4:
-                        this.MoveTo(new Vector2(0, 200), 800, Easing.Out);
-                        break;
-
-                    case 5:
-                        this.MoveTo(new Vector2(0, 0), 800, Easing.Out);
-                        break;
-                }
-            }
-
-            base.Update();
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSizing.cs
@@ -1153,7 +1153,9 @@ namespace osu.Framework.Tests.Visual.Containers
 
     internal class InfofulBox : Container
     {
+#pragma warning disable CA1805
         public bool Chameleon = false;
+#pragma warning restore CA1805
         public bool AllowDrag = true;
 
         protected override void OnDrag(DragEvent e)

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Graphics.Containers
             //Words matched by parent is not needed to match children
             var childTerms = terms.Where(term =>
                 !filterable.FilterTerms.Any(filterTerm =>
-                    filterTerm.IndexOf(term, StringComparison.InvariantCultureIgnoreCase) >= 0)).ToArray();
+                    filterTerm.Contains(term, StringComparison.InvariantCultureIgnoreCase))).ToArray();
 
             bool matching = childTerms.Length == 0;
 

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -547,12 +547,10 @@ namespace osu.Framework.Graphics.Sprites
 
         #endregion
 
-#pragma warning disable CA1805
         /// <summary>
         /// The characters that should be excluded from fixed-width application. Defaults to (".", ",", ":", " ") if null.
         /// </summary>
-        protected virtual char[] FixedWidthExcludeCharacters { get; } = null;
-#pragma warning restore CA1805
+        protected virtual char[] FixedWidthExcludeCharacters => null;
 
         /// <summary>
         /// The character to fallback to use if a character glyph lookup failed.

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -547,10 +547,12 @@ namespace osu.Framework.Graphics.Sprites
 
         #endregion
 
+#pragma warning disable CA1805
         /// <summary>
         /// The characters that should be excluded from fixed-width application. Defaults to (".", ",", ":", " ") if null.
         /// </summary>
         protected virtual char[] FixedWidthExcludeCharacters { get; } = null;
+#pragma warning restore CA1805
 
         /// <summary>
         /// The character to fallback to use if a character glyph lookup failed.

--- a/osu.Framework/IO/Stores/IResourceStore.cs
+++ b/osu.Framework/IO/Stores/IResourceStore.cs
@@ -78,6 +78,6 @@ namespace osu.Framework.IO.Stores
         /// <param name="source">A list of filenames.</param>
         /// <returns>A list of filenames excluding common system files.</returns>
         public static IEnumerable<string> ExcludeSystemFileNames(this IEnumerable<string> source) =>
-            source.Where(entry => !system_filename_ignore_list.Any(ignoredName => entry.IndexOf(ignoredName, StringComparison.OrdinalIgnoreCase) >= 0));
+            source.Where(entry => !system_filename_ignore_list.Any(ignoredName => entry.Contains(ignoredName, StringComparison.OrdinalIgnoreCase)));
     }
 }

--- a/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameWindow.cs
@@ -267,6 +267,7 @@ namespace osu.Framework.Platform.MacOS
         }
     }
 
+    [Flags]
     internal enum CocoaKeyModifiers
     {
         LeftControl = 1,

--- a/osu.Framework/Statistics/PerformanceMonitor.cs
+++ b/osu.Framework/Statistics/PerformanceMonitor.cs
@@ -128,7 +128,7 @@ namespace osu.Framework.Statistics
 
         private readonly int[] lastAmountGarbageCollects = new int[3];
 
-        public bool HandleGC = false;
+        public bool HandleGC;
 
         private readonly Dictionary<StatisticsCounterType, GlobalStatistic<long>> globalStatistics = new Dictionary<StatisticsCounterType, GlobalStatistic<long>>();
 

--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -21,8 +21,6 @@ namespace osu.Framework.Timing
 
         public FrameTimeInfo TimeInfo => new FrameTimeInfo { Elapsed = ElapsedFrameTime, Current = CurrentTime };
 
-        public double AverageFrameTime { get; } = 0;
-
         public double FramesPerSecond => 0;
 
         public virtual void ChangeSource(IClock source)

--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Timing
 
         public double AverageFrameTime { get; } = 0;
 
-        public double FramesPerSecond { get; } = 0;
+        public double FramesPerSecond => 0;
 
         public virtual void ChangeSource(IClock source)
         {


### PR DESCRIPTION
# Summary

Somehow, somewhere, several build warnings have popped up yet again; this PR is supposed to resolve them in the framework. Taking it from the top:

## [CA1805: Do not initialise unnecessarily](https://docs.microsoft.com/sl-si/visualstudio/code-quality/ca1805?view=vs-2017)

This one is actually split into three commits; e3563b9 is supposed to deal with the most obvious cases where you can either eliminate the default or even straight up convert to a get-only constant property with no additional cost.

d2f4ada removes `AverageFrameTime` from `InterpolatingFramedClock`, which was a remnant from an old `IFramedClock` member [removed in this commit](https://github.com/ppy/osu-framework/commit/9ad78a1335d7e764b59bb25654f363b225a14f5c).

6dfd270 contains the most interesting cases. One is a declaration of a virtual property that is supposed to default to `null` (so I left the initialiser in and suppressed the warning to make it 1000% clear along with the xmldoc that it does default to `null`), and the other is... a mystery to me - it's a `Chameleon` property in `TestSceneSizing`, which is referenced in commented lines throughout the scene. It's been stuck in there since 2016, so just in case I left it in with a suppression (as if I didn't disable that warning, another warning shows that the field is unused).

## [CA2248: Provide correct enum argument to `Enum.HasFlag`](https://docs.microsoft.com/gl-es/visualstudio/code-quality/ca2248?view=vs-2019)

Straight and simple, one case fixed in af924b5. Not much to talk about there.

## CA2249: Consider using `string.Contains` instead of `string.IndexOf` for readability

(no docs link, must be fresh!) Also a no-brainer. Runtime sources [show that the two versions are equivalent](https://github.com/dotnet/runtime/blob/6072e4d3a7a2a1493f514cdf4be75a3d56580e84/src/libraries/System.Private.CoreLib/src/System/String.Searching.cs#L24-L29). (Also includes a hilarious comment suppressing this same warning.)

# Remarks

This PR is dedicated to [this discord message](https://discord.com/channels/188630481301012481/589331078574112768/744091307152244768).