### PR TITLE
Fix TextBox not invalidating properly

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -198,11 +198,11 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestInputOverride()
         {
-            ExposedTextFlowBox overrideInputBox = null;
+            InsertableTextBox overrideInputBox = null;
 
             AddStep("add override textbox", () =>
             {
-                textBoxes.Add(overrideInputBox = new ExposedTextFlowBox
+                textBoxes.Add(overrideInputBox = new InsertableTextBox
                 {
                     Text = @"Override input textbox",
                     Size = new Vector2(500, 30),
@@ -211,12 +211,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 overrideInputBox.Current.BindValueChanged(vce =>
                 {
                     if (vce.NewValue != @"Input overridden!")
-                        overrideInputBox.Text = @"Input overridden!";
+                        overrideInputBox.Current.Value = @"Input overridden!";
                 });
             });
 
             AddStep(@"set some text", () => overrideInputBox.Text = "smth");
-            AddAssert(@"verify display state", () => overrideInputBox.TextFlow.Children.Count == "Input overridden!".Length);
+            AddAssert(@"verify display state", () => overrideInputBox.FlowingText.Length == "Input overridden!".Length);
         }
 
         [TestCase(true, true)]
@@ -447,11 +447,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("select all", () => textBox.OnPressed(new PlatformAction(PlatformActionType.SelectAll)));
             AddStep("insert string", () => textBox.InsertString("another"));
             AddAssert("text replaced", () => textBox.FlowingText == "another" && textBox.FlowingText == textBox.Text);
-        }
-
-        private class ExposedTextFlowBox : BasicTextBox
-        {
-            public new FillFlowContainer TextFlow => base.TextFlow;
         }
 
         private class InsertableTextBox : BasicTextBox

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -90,6 +90,19 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     TabbableContentContainer = textBoxes
                 });
 
+                BasicTextBox overrideInputBox;
+                textBoxes.Add(overrideInputBox = new BasicTextBox
+                {
+                    Text = @"Override input textbox",
+                    Size = new Vector2(500, 30),
+                    TabbableContentContainer = textBoxes
+                });
+                overrideInputBox.Current.BindValueChanged(vce =>
+                {
+                    if (vce.NewValue != @"Input overridden!")
+                        overrideInputBox.Text = @"Input overridden!";
+                });
+
                 textBoxes.Add(new CustomTextBox
                 {
                     Text = @"Custom textbox",
@@ -180,6 +193,30 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep(@"set number text", () => numbers.Text = @"1h2e3l4l5o6");
             AddAssert(@"number text only numbers", () => numbers.Text == @"123456");
+        }
+
+        [Test]
+        public void TestInputOverride()
+        {
+            ExposedTextFlowBox overrideInputBox = null;
+
+            AddStep("add override textbox", () =>
+            {
+                textBoxes.Add(overrideInputBox = new ExposedTextFlowBox
+                {
+                    Text = @"Override input textbox",
+                    Size = new Vector2(500, 30),
+                    TabbableContentContainer = textBoxes
+                });
+                overrideInputBox.Current.BindValueChanged(vce =>
+                {
+                    if (vce.NewValue != @"Input overridden!")
+                        overrideInputBox.Text = @"Input overridden!";
+                });
+            });
+
+            AddStep(@"set some text", () => overrideInputBox.Text = "smth");
+            AddAssert(@"verify display state", () => overrideInputBox.TextFlow.Children.Count == "Input overridden!".Length);
         }
 
         [TestCase(true, true)]
@@ -410,6 +447,11 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("select all", () => textBox.OnPressed(new PlatformAction(PlatformActionType.SelectAll)));
             AddStep("insert string", () => textBox.InsertString("another"));
             AddAssert("text replaced", () => textBox.FlowingText == "another" && textBox.FlowingText == textBox.Text);
+        }
+
+        private class ExposedTextFlowBox : BasicTextBox
+        {
+            public new FillFlowContainer TextFlow => base.TextFlow;
         }
 
         private class InsertableTextBox : BasicTextBox

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -340,8 +340,8 @@ namespace osu.Framework.Graphics.UserInterface
             //have to run this after children flow
             if (!cursorAndLayout.IsValid)
             {
-                updateCursorAndLayout();
                 cursorAndLayout.Validate();
+                updateCursorAndLayout();
             }
         }
 


### PR DESCRIPTION
If a user binds the Current.ValueChanged-Event of a TextBox and changes
the text of the textbox inside the ValueChanged-Handler either by
directly assigning to TextBox.Current.Value or TextBox.Text the TextBox
will not show the newly assigned text until another change is made to
the contents or caret of the TextBox by either User Input or Code run
on a different Update.

The reason this happens is because regardless of if Current.Value or the text of the TextBox has changed, the layout will get validated after updateCursorAndLayout() has finished executing - however, updateCursorAndLayout() also happens to be the trigger for the ValueChanged-Event. Thus, if changes to the TextBox Text or Current.Value are made at this point, the (after calling the callback now outdated) Layout will still be assumed valid.

I fixed this by validating the layout first and then calling updateCursorAndLayout() after (just switching the order) - now if changes to TextBox.Text or Current.Value are made in a ValueChanged-Handler, the calls to invalidate the Layout made by these actions successfully invalidate the Layout instead of being overridden by the later call to cursorAndLayout.Validate() inside TextBox.UpdateAfterChildren().

This also adds a test to verify this behaviour.