### PR TITLE
Revert device period to fix linux audio crackling

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -293,7 +293,6 @@ namespace osu.Framework.Audio
                 return true;
 
             // reduce latency to a known sane minimum.
-            Bass.Configure(ManagedBass.Configuration.DevicePeriod, 1);
             Bass.Configure(ManagedBass.Configuration.DeviceBufferLength, 10);
             Bass.Configure(ManagedBass.Configuration.PlaybackBufferLength, 100);
 


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/9865

Needs more testing, especially with existing user configs (I tested with default PA config).