### PR TITLE
Move IAggregateAudioAdjustment.GetAggregate() to extensions method

### DIFF
--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -74,8 +74,6 @@ namespace osu.Framework.Audio
 
         public IBindable<double> AggregateTempo => adjustments.AggregateTempo;
 
-        public IBindable<double> GetAggregate(AdjustableProperty type) => adjustments.GetAggregate(type);
-
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/osu.Framework/Audio/AggregateAdjustmentExtensions.cs
+++ b/osu.Framework/Audio/AggregateAdjustmentExtensions.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Audio
+{
+    public static class AggregateAdjustmentExtensions
+    {
+        /// <summary>
+        /// Get the aggregate result for a specific adjustment type.
+        /// </summary>
+        /// <param name="adjustment">The audio adjustments to return from.</param>
+        /// <param name="type">The adjustment type.</param>
+        /// <returns>The aggregate result.</returns>
+        public static IBindable<double> GetAggregate(this IAggregateAudioAdjustment adjustment, AdjustableProperty type)
+        {
+            switch (type)
+            {
+                case AdjustableProperty.Volume:
+                    return adjustment.AggregateVolume;
+
+                case AdjustableProperty.Balance:
+                    return adjustment.AggregateBalance;
+
+                case AdjustableProperty.Frequency:
+                    return adjustment.AggregateFrequency;
+
+                case AdjustableProperty.Tempo:
+                    return adjustment.AggregateTempo;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), "Invalid adjustable property type.");
+            }
+        }
+    }
+}

--- a/osu.Framework/Audio/AudioAdjustments.cs
+++ b/osu.Framework/Audio/AudioAdjustments.cs
@@ -72,9 +72,6 @@ namespace osu.Framework.Audio
         public void RemoveAdjustment(AdjustableProperty type, BindableNumber<double> adjustBindable)
             => getAggregate(type).RemoveSource(adjustBindable);
 
-        public IBindable<double> GetAggregate(AdjustableProperty type)
-            => getAggregate(type).Result;
-
         /// <summary>
         /// Bind all adjustments from an <see cref="IAggregateAudioAdjustment"/>.
         /// </summary>

--- a/osu.Framework/Audio/IAggregateAudioAdjustment.cs
+++ b/osu.Framework/Audio/IAggregateAudioAdjustment.cs
@@ -29,12 +29,5 @@ namespace osu.Framework.Audio
         /// The aggregate rate at which the component is played back (does not affect pitch). 1 is 100% playback speed.
         /// </summary>
         IBindable<double> AggregateTempo { get; }
-
-        /// <summary>
-        /// Get the aggregate result for a specific adjustment type.
-        /// </summary>
-        /// <param name="type">The adjustment type.</param>
-        /// <returns>The aggregate result.</returns>
-        IBindable<double> GetAggregate(AdjustableProperty type);
     }
 }

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -96,7 +96,5 @@ namespace osu.Framework.Graphics.Audio
         public IBindable<double> AggregateFrequency => adjustments.AggregateFrequency;
 
         public IBindable<double> AggregateTempo => adjustments.AggregateTempo;
-
-        public IBindable<double> GetAggregate(AdjustableProperty type) => adjustments.GetAggregate(type);
     }
 }


### PR DESCRIPTION
# Breaking changes

## `IAggregateAudioAdjustment.GetAggregate()` has been made an extension method

To avoid aggregate adjustment implementations from having to implement both `Aggregate{Volume,Balance,Frequency,Tempo}` and `GetAggregate()`, the latter has been made an extension method returning one of the aforementioned four values for the appropriate property of the adjustment.

Possible compilation failures related to `GetAggregate()` should be resolved by adding a using statement for the `osu.Framework.Audio` namespace to the files affected. 

---

Probably incorrect to have both `Aggregate{Volume/Balance/etc..}` and `GetAggregate()` require implementation from the class when one should redirect to the other.

Could use default interface implementation for this, but would cause changing every usage to do an explicit cast to the interface (`((IAggregateAudioAdjustment)adjustment).GetAggregate()`), which doesn't sound like something that would be allowed anywhere.