### PR TITLE
Make drawable-wrapped audio components respect clock running state

### DIFF
--- a/osu.Framework.Tests/TestSceneDrawableAudioWrapper.cs
+++ b/osu.Framework.Tests/TestSceneDrawableAudioWrapper.cs
@@ -1,0 +1,148 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Audio.Track;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Audio;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Framework.Tests.Visual;
+using osu.Framework.Timing;
+
+namespace osu.Framework.Tests
+{
+    [HeadlessTest]
+    public class TestSceneDrawableAudioWrapper : FrameworkTestScene
+    {
+        private IAdjustableClock audioClock;
+        private AudioContainer<DrawableAudioWrapper> audioContainer;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Child = audioContainer = new AudioContainer<DrawableAudioWrapper>
+            {
+                Clock = new FramedClock(audioClock = new StopwatchClock(true)),
+                Frequency = { Value = 2f },
+                Children = new DrawableAudioWrapper[]
+                {
+                    createTestTrack(0.75f),
+                    createTestSample(1.50f),
+                    new AudioContainer { Frequency = { Value = 0f } },
+                }
+            };
+
+            Assert.IsTrue(checkAllComponentsFrequencies(audioContainer, 1f));
+        });
+
+        [Test]
+        public void TestParentAdjustsAutomaticallyBoundToChildren()
+        {
+            AddStep("change parent volume", () => audioContainer.Volume.Value = 0.5f);
+            AddAssert("children volume adjusted", () => audioContainer.All(c => c.AggregateVolume.Value == 0.5f));
+            AddStep("change volume back", () => audioContainer.Volume.Value = 1f);
+            AddAssert("children volume adjusted back", () => audioContainer.All(c => c.AggregateVolume.Value == 1f));
+        }
+
+        [Test]
+        public void TestZeroFrequencyOnClockStop()
+        {
+            AddStep("stop audio clock", () => audioClock.Stop());
+            AddAssert("all component frequency set zero", () => checkAllComponentsFrequencies(audioContainer, 0f));
+
+            // pick first audio component and ensure its public aggregate frequency is still non-zero,
+            // clock state frequency adjustment is applied internally to their underlying components.
+            AddAssert("clock adjustment not publicly exposed", () => audioContainer.First().AggregateFrequency.Value != 0);
+        }
+
+        [Test]
+        public void TestClockSpeedNotAffectingFrequency()
+        {
+            AddStep("change audio clock rate", () => audioClock.Rate = 1.25f);
+            AddAssert("frequency remains unchanged", () => checkAllComponentsFrequencies(audioContainer, 1f));
+        }
+
+        [Test]
+        public void TestParentClockAdjustsNotAffectingIndependents()
+        {
+            IAdjustableClock independentClock = null;
+            AudioContainer<DrawableAudioWrapper> independentContainer = null;
+
+            AddStep("add independent container", () =>
+            {
+                audioContainer.Add(independentContainer = new AudioContainer<DrawableAudioWrapper>
+                {
+                    Frequency = { Value = 0.25f },
+                    Clock = new FramedClock(independentClock = new StopwatchClock(true)),
+                    Children = new DrawableAudioWrapper[]
+                    {
+                        createTestTrack(-2.0f),
+                        createTestSample(1f),
+                    }
+                });
+            });
+
+            AddStep("stop parent clock", () => audioClock.Stop());
+            AddAssert("ensure parent frequency set zero", () => checkAllComponentsFrequencies(audioContainer, 0f));
+            AddAssert("independent container remain unchanged", () => checkAllComponentsFrequencies(independentContainer, 1f));
+
+            AddStep("start parent clock", () => audioClock.Start());
+            AddStep("stop independent clock", () => independentClock.Stop());
+            AddAssert("ensure parent frequency back one", () => checkAllComponentsFrequencies(audioContainer, 1f));
+            AddAssert("independent container frequency set zero", () => checkAllComponentsFrequencies(independentContainer, 0f));
+        }
+
+        /// <summary>
+        /// Checks if the audio hierarchy of a container match up with the <paramref name="expectedInternalFrequencyAdjustment"/>.
+        /// </summary>
+        /// <param name="container">The container to check for.</param>
+        /// <param name="expectedInternalFrequencyAdjustment">The expected internal frequency adjustment, this is multiplied by the wrapper's <see cref="DrawableAudioWrapper.AggregateFrequency"/> for each to check.</param>
+        /// <returns>Whether all frequencies match up with the expected value.</returns>
+        private bool checkAllComponentsFrequencies(AudioContainer<DrawableAudioWrapper> container, double expectedInternalFrequencyAdjustment)
+        {
+            var children = container.ChildrenOfType<DrawableAudioWrapper>()
+                                    .Where(c => c.Clock == container.Clock)
+                                    .OfType<IComponentAggregateAdjustment>();
+
+            return children.All(daw => daw.ComponentFrequency.Value == daw.AggregateFrequency.Value * expectedInternalFrequencyAdjustment);
+        }
+
+        private TestDrawableTrack createTestTrack(double frequency) => new TestDrawableTrack(new TrackVirtual(0)) { Frequency = { Value = frequency } };
+        private TestDrawableSample createTestSample(double frequency) => new TestDrawableSample(new SampleChannelVirtual()) { Frequency = { Value = frequency } };
+
+        private interface IComponentAggregateAdjustment : IAggregateAudioAdjustment
+        {
+            IBindable<double> ComponentFrequency { get; }
+        }
+
+        private class TestDrawableTrack : DrawableTrack, IComponentAggregateAdjustment
+        {
+            private readonly Track track;
+
+            public IBindable<double> ComponentFrequency => track.AggregateFrequency;
+
+            public TestDrawableTrack(Track track, bool disposeTrackOnDisposal = true)
+                : base(track, disposeTrackOnDisposal)
+            {
+                this.track = track;
+            }
+        }
+
+        private class TestDrawableSample : DrawableSample, IComponentAggregateAdjustment
+        {
+            private readonly SampleChannel channel;
+
+            public IBindable<double> ComponentFrequency => channel.AggregateFrequency;
+
+            public TestDrawableSample(SampleChannel channel, bool disposeChannelOnDisposal = true)
+                : base(channel, disposeChannelOnDisposal)
+            {
+                this.channel = channel;
+            }
+        }
+    }
+}

--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -74,8 +74,6 @@ namespace osu.Framework.Audio
 
         public IBindable<double> AggregateTempo => adjustments.AggregateTempo;
 
-        public IBindable<double> GetAggregate(AdjustableProperty type) => adjustments.GetAggregate(type);
-
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/osu.Framework/Audio/AggregateAdjustmentExtensions.cs
+++ b/osu.Framework/Audio/AggregateAdjustmentExtensions.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Audio
+{
+    public static class AggregateAdjustmentExtensions
+    {
+        public static IBindable<double> GetAggregate(this IAggregateAudioAdjustment adjustment, AdjustableProperty type)
+        {
+            switch (type)
+            {
+                case AdjustableProperty.Volume:
+                    return adjustment.AggregateVolume;
+
+                case AdjustableProperty.Balance:
+                    return adjustment.AggregateBalance;
+
+                case AdjustableProperty.Frequency:
+                    return adjustment.AggregateFrequency;
+
+                case AdjustableProperty.Tempo:
+                    return adjustment.AggregateTempo;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(type), "Invalid adjustable property type.");
+            }
+        }
+    }
+}

--- a/osu.Framework/Audio/AudioAdjustments.cs
+++ b/osu.Framework/Audio/AudioAdjustments.cs
@@ -72,9 +72,6 @@ namespace osu.Framework.Audio
         public void RemoveAdjustment(AdjustableProperty type, BindableNumber<double> adjustBindable)
             => getAggregate(type).RemoveSource(adjustBindable);
 
-        public IBindable<double> GetAggregate(AdjustableProperty type)
-            => getAggregate(type).Result;
-
         /// <summary>
         /// Bind all adjustments from an <see cref="IAggregateAudioAdjustment"/>.
         /// </summary>

--- a/osu.Framework/Audio/AudioAdjustments.cs
+++ b/osu.Framework/Audio/AudioAdjustments.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Audio
         {
             foreach (AdjustableProperty type in Enum.GetValues(typeof(AdjustableProperty)))
             {
-                var aggregate = getAggregate(type) = new AggregateBindable<double>(getAggregateFunction(type), getProperty(type).GetUnboundCopy());
+                var aggregate = getAggregate(type) = new AggregateBindable<double>(GetAggregateFunction(type), getProperty(type).GetUnboundCopy());
                 aggregate.AddSource(getProperty(type));
             }
         }
@@ -140,7 +140,7 @@ namespace osu.Framework.Audio
             throw new ArgumentException($"{nameof(AdjustableProperty)} \"{type}\" is missing mapping", nameof(type));
         }
 
-        private Func<double, double, double> getAggregateFunction(AdjustableProperty type)
+        internal static Func<double, double, double> GetAggregateFunction(AdjustableProperty type)
         {
             switch (type)
             {

--- a/osu.Framework/Audio/IAggregateAudioAdjustment.cs
+++ b/osu.Framework/Audio/IAggregateAudioAdjustment.cs
@@ -29,12 +29,5 @@ namespace osu.Framework.Audio
         /// The aggregate rate at which the component is played back (does not affect pitch). 1 is 100% playback speed.
         /// </summary>
         IBindable<double> AggregateTempo { get; }
-
-        /// <summary>
-        /// Get the aggregate result for a specific adjustment type.
-        /// </summary>
-        /// <param name="type">The adjustment type.</param>
-        /// <returns>The aggregate result.</returns>
-        IBindable<double> GetAggregate(AdjustableProperty type);
     }
 }

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -96,7 +96,5 @@ namespace osu.Framework.Graphics.Audio
         public IBindable<double> AggregateFrequency => adjustments.AggregateFrequency;
 
         public IBindable<double> AggregateTempo => adjustments.AggregateTempo;
-
-        public IBindable<double> GetAggregate(AdjustableProperty type) => adjustments.GetAggregate(type);
     }
 }

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -16,26 +16,6 @@ namespace osu.Framework.Graphics.Audio
     [Cached(typeof(IAggregateAudioAdjustment))]
     public abstract class DrawableAudioWrapper : CompositeDrawable, IAggregateAudioAdjustment, IAdjustableAudioComponent
     {
-        /// <summary>
-        /// The volume of this component.
-        /// </summary>
-        public BindableNumber<double> Volume => adjustments.Volume;
-
-        /// <summary>
-        /// The playback balance of this sample (-1 .. 1 where 0 is centered)
-        /// </summary>
-        public BindableNumber<double> Balance => adjustments.Balance;
-
-        /// <summary>
-        /// Rate at which the component is played back (affects pitch). 1 is 100% playback speed, or default frequency.
-        /// </summary>
-        public BindableNumber<double> Frequency => adjustments.Frequency;
-
-        /// <summary>
-        /// Rate at which the component is played back (does not affect pitch). 1 is 100% playback speed.
-        /// </summary>
-        public BindableNumber<double> Tempo => adjustments.Tempo;
-
         private readonly AdjustableAudioComponent component;
         private readonly bool disposeUnderlyingComponentOnDispose;
 
@@ -91,21 +71,24 @@ namespace osu.Framework.Graphics.Audio
                 component?.Dispose();
         }
 
-        public void AddAdjustment(AdjustableProperty type, BindableNumber<double> adjustBindable)
-            => adjustments.AddAdjustment(type, adjustBindable);
+        #region Public audio adjustments exposure
 
-        public void RemoveAdjustment(AdjustableProperty type, BindableNumber<double> adjustBindable)
-            => adjustments.RemoveAdjustment(type, adjustBindable);
+        public IBindable<double> AggregateVolume => publicAdjustments.AggregateVolume;
+        public IBindable<double> AggregateBalance => publicAdjustments.AggregateBalance;
+        public IBindable<double> AggregateFrequency => publicAdjustments.AggregateFrequency;
+        public IBindable<double> AggregateTempo => publicAdjustments.AggregateTempo;
 
-        public void RemoveAllAdjustments(AdjustableProperty type) => adjustments.RemoveAllAdjustments(type);
+        public BindableNumber<double> Volume => publicAdjustments.Volume;
+        public BindableNumber<double> Balance => publicAdjustments.Balance;
+        public BindableNumber<double> Frequency => publicAdjustments.Frequency;
+        public BindableNumber<double> Tempo => publicAdjustments.Tempo;
 
-        public IBindable<double> AggregateVolume => adjustments.AggregateVolume;
+        public void AddAdjustment(AdjustableProperty type, BindableNumber<double> adjustBindable) => publicAdjustments.AddAdjustment(type, adjustBindable);
+        public void RemoveAdjustment(AdjustableProperty type, BindableNumber<double> adjustBindable) => publicAdjustments.RemoveAdjustment(type, adjustBindable);
+        public void RemoveAllAdjustments(AdjustableProperty type) => publicAdjustments.RemoveAllAdjustments(type);
 
-        public IBindable<double> AggregateBalance => adjustments.AggregateBalance;
+        #endregion
 
-        public IBindable<double> AggregateFrequency => adjustments.AggregateFrequency;
-
-        public IBindable<double> AggregateTempo => adjustments.AggregateTempo;
         /// <summary>
         /// Represents a <see cref="AudioAdjustments"/> class with internal adjustments that isn't exposed in <see cref="PublicAdjustments"/>.
         /// </summary>


### PR DESCRIPTION
- [x] Depends on #3829 
- [x] Depends on #3835

Makes components-backed `DrawableAudioWrapper`s respect the `IClock.IsRunning` state that's assigned to them, if stopped then a frequency adjustment to `0` would be applied internally to the underlying component itself, not visible by `DrawableAudioWrapper.AggregateFrequency`.

## Introducing `AudioWrapperAdjustments`

This introduces a private `AudioWrapperAdjustments` class, which has extra adjustments ("clock state frequency adjustment" currently) mixed internally with the public adjustments (`PublicAdjustments`) all to the `IAggregateAudioAdjustment` interface explicit implementation. 

This is done as a way to make "internal adjustments to the underlying component" possible without interfering with what the consumer adjusts or what children would bind to. 

Also chose against creating another `AudioAdjustments` for the internal adjustments as it has a useless amount of bindables in it, if it's possible to wrap some aggregates to their public ones and create aggregate bindables for others then why wasting.

---

Also adds a headless test scene for `DrawableAudioWrapper` ensuring the adjustments for the wrapper and the underlying component are as expected and are isolated from each other, and thus they should behave correctly in, mostly all cases.

---

### Note:

This alone doesn't entirely replace the existing "pause sample on gameplay pause logic" osu!-side, after testing with this logic turns out `FrameStabilityContainer` doesn't stop its `StabilityGameplayClock` when pausing, which is probably a bug as the parent gameplay clock stops, will look at fixing it as soon as possible.