### PR TITLE
Fix transforms added during load being potentially not processed

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -254,6 +254,37 @@ namespace osu.Framework.Tests.Visual.Drawables
         }
 
         [Test]
+        public void AddPastTransformFromFutureWhenNotInHierarchy()
+        {
+            AddStep("seek clock to 1000", () => manualClock.CurrentTime = interval * 4);
+
+            AddStep("create box", () =>
+            {
+                box = createBox();
+                box.Clock = manualFramedClock;
+                box.RemoveCompletedTransforms = false;
+
+                manualFramedClock.ProcessFrame();
+                using (box.BeginAbsoluteSequence(0))
+                    box.Delay(interval * 2).FadeOut(interval);
+            });
+
+            AddStep("seek clock to 0", () => manualClock.CurrentTime = 0);
+
+            AddStep("add box", () =>
+            {
+                Add(new AnimationContainer
+                {
+                    Child = box,
+                    ExaminableDrawable = box,
+                });
+            });
+
+            checkAtTime(interval * 2, box => Precision.AlmostEquals(box.Alpha, 1));
+            checkAtTime(interval * 3, box => Precision.AlmostEquals(box.Alpha, 0));
+        }
+
+        [Test]
         public void AddPastTransformFromFuture()
         {
             boxTest(box =>
@@ -375,19 +406,24 @@ namespace osu.Framework.Tests.Visual.Drawables
             {
                 Add(new AnimationContainer(startTime)
                 {
-                    Child = box = new Box
-                    {
-                        Anchor = Anchor.Centre,
-                        Origin = Anchor.Centre,
-                        RelativeSizeAxes = Axes.Both,
-                        RelativePositionAxes = Axes.Both,
-                        Scale = new Vector2(0.25f),
-                    },
+                    Child = box = createBox(),
                     ExaminableDrawable = box,
                 });
 
                 action(box);
             });
+        }
+
+        private static Box createBox()
+        {
+            return new Box
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativeSizeAxes = Axes.Both,
+                RelativePositionAxes = Axes.Both,
+                Scale = new Vector2(0.25f),
+            };
         }
 
         private class AnimationContainer : Container

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -243,13 +243,6 @@ namespace osu.Framework.Graphics.Transforms
             }
 
             invokePendingRemovalActions();
-
-            var time = transformable.Time.Current;
-
-            // If our newly added transform could have an immediate effect, then let's
-            // make this effect happen immediately.
-            if (transform.StartTime < time || transform.EndTime <= time)
-                UpdateTransforms(time, !transformable.RemoveCompletedTransforms && transform.StartTime <= time);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -295,6 +295,13 @@ namespace osu.Framework.Graphics.Transforms
             }
 
             getTrackerForGrouping(transform.TargetGrouping, true).AddTransform(transform, customTransformID);
+
+            // If our newly added transform could have an immediate effect, then let's
+            // make this effect happen immediately.
+            // This is done globally instead of locally in the single member tracker
+            // to keep the transformable's state consistent (e.g. with lastUpdateTransformsTime)
+            if (transform.StartTime < Time.Current || transform.EndTime <= Time.Current)
+                updateTransforms(Time.Current, !RemoveCompletedTransforms && transform.StartTime <= Time.Current);
         }
     }
 }


### PR DESCRIPTION
Aims to resolve ppy/osu#9832, although I'm not sure if wasted effort in light of #3837.

# Summary

Most of the paper trail as to why this arose is [in the issue](https://github.com/ppy/osu/issues/9832#issuecomment-674459266). In short: adding a transform during load or outside hierarchy would wrongly update a single tracker's last applied transform index, while the transformable itself kept a last transform time which was not updated in line, leading to a desync.

Resolve as proposed [here](https://github.com/ppy/osu/issues/9832#issuecomment-674482116) by updating the entire transformable.

# Remarks

This resolution actually let me uncover #3837, as I went to check a storyboard and saw that it wasn't processing `X` transforms properly (but `Y` transforms worked). That was due to them having an equal `StartTime`.

I also tried [moving the last transform time to the tracker](https://github.com/ppy/osu-framework/compare/master...bdach:add-transform-in-the-past-v3) but I'm not sure I like that better over this. It's a CPU-memory tradeoff; that version reads a little nicer maybe but duplicating the same state/having trackers have their own separate last transform update time sounds like trouble down the line.