### PR TITLE
Invoke text mutation method events only when done by user input

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -413,104 +412,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("text replaced", () => textBox.FlowingText == "another" && textBox.FlowingText == textBox.Text);
         }
 
-        [Test]
-        public void TestTextboxEventsInvokedProperly()
-        {
-            EventQueuesTextBox textBox = null;
-
-            AddStep("add limited textbox", () =>
-            {
-                textBoxes.Add(textBox = new EventQueuesTextBox
-                {
-                    CommitOnFocusLost = true,
-                    ReleaseFocusOnCommit = false,
-                    Size = new Vector2(200, 40),
-                    Text = "some default text",
-                });
-            });
-
-            AddStep("focus textbox", () =>
-            {
-                InputManager.MoveMouseTo(textBox);
-                InputManager.Click(MouseButton.Left);
-            });
-
-            #region Text mutation
-
-            AddStep("set text property once more", () => textBox.Text = "set property once more");
-            AddStep("insert string via protected method", () => textBox.InsertString(" inserted string."));
-            AddAssert("no user text consumed event", () => textBox.UserConsumedTextQueue.Count == 0);
-
-            // todo: this is not straightforward to support at the moment (requires manipulating ITextInputSource, which is stored at host level), steps commented for now.
-            //AddStep("press letter key to insert text", () => addToPendingTextInput());
-            //AddAssert("user text consumed event", () => textBox.UserConsumedTextQueue.Dequeue() == "W" && textBox.UserConsumedTextQueue.Count == 0);
-
-            AddStep("invoke delete action to remove text", () => textBox.DeletePreviousCharacter());
-            AddAssert("user text removed event", () => textBox.UserRemovedTextQueue.Dequeue() == "." && textBox.UserRemovedTextQueue.Count == 0);
-
-            #endregion
-
-            #region Commit with focus lost & enter key
-
-            AddStep("press enter key for committing text", () => InputManager.Key(Key.Enter));
-
-            AddAssert("text committed event", () =>
-                // Ensure dequeued text commit event has textChanged = true.
-                textBox.CommittedTextQueue.Dequeue() && textBox.CommittedTextQueue.Count == 0);
-
-            AddStep("click away", () =>
-            {
-                InputManager.MoveMouseTo(Content.ToScreenSpace(Vector2.Zero));
-                InputManager.Click(MouseButton.Left);
-            });
-
-            AddAssert("text committed event", () =>
-                // Ensure dequeued text commit event has textChanged = false.
-                textBox.CommittedTextQueue.Dequeue() == false && textBox.CommittedTextQueue.Count == 0);
-
-            // Refocus back for the remaining checks below.
-            AddStep("focus textbox", () =>
-            {
-                InputManager.MoveMouseTo(textBox);
-                InputManager.Click(MouseButton.Left);
-            });
-
-            #endregion
-
-            #region Caret moving / expanding selection
-
-            AddStep("invoke move action to move caret", () => textBox.MoveToStart());
-            AddAssert("caret moved event", () =>
-                // Ensure dequeued caret move event has selecting = false.
-                textBox.CaretMovedQueue.Dequeue() == false && textBox.CommittedTextQueue.Count == 0);
-
-            AddStep("invoke select action to expand selection", () => textBox.OnPressed(new PlatformAction(PlatformActionType.CharNext, PlatformActionMethod.Select)));
-            AddAssert("caret moved event", () =>
-                // Ensure dequeued caret move event has selecting = true.
-                textBox.CaretMovedQueue.Dequeue() && textBox.CommittedTextQueue.Count == 0);
-
-            #endregion
-
-            AddAssert("all event queues emptied", () => textBox.UserConsumedTextQueue.Count == 0 &&
-                                                        textBox.UserRemovedTextQueue.Count == 0 &&
-                                                        textBox.CommittedTextQueue.Count == 0 &&
-                                                        textBox.CaretMovedQueue.Count == 0);
-        }
-
-        private class EventQueuesTextBox : InsertableTextBox
-        {
-            public readonly Queue<string> UserConsumedTextQueue = new Queue<string>();
-            public readonly Queue<string> UserRemovedTextQueue = new Queue<string>();
-            public readonly Queue<bool> CommittedTextQueue = new Queue<bool>();
-            public readonly Queue<bool> CaretMovedQueue = new Queue<bool>();
-
-            protected override void OnUserTextConsumed(string consumed) => UserConsumedTextQueue.Enqueue(consumed);
-            protected override void OnUserTextRemoved(string removed) => UserRemovedTextQueue.Enqueue(removed);
-            protected override void OnTextCommitted(bool textChanged) => CommittedTextQueue.Enqueue(textChanged);
-            protected override void OnCaretMoved(bool selecting) => CaretMovedQueue.Enqueue(selecting);
-        }
-
-        private class InsertableTextBox : BasicTextBox
+        public class InsertableTextBox : BasicTextBox
         {
             /// <summary>
             /// Returns the shown-in-screen text.

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
@@ -410,6 +411,103 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("select all", () => textBox.OnPressed(new PlatformAction(PlatformActionType.SelectAll)));
             AddStep("insert string", () => textBox.InsertString("another"));
             AddAssert("text replaced", () => textBox.FlowingText == "another" && textBox.FlowingText == textBox.Text);
+        }
+
+        [Test]
+        public void TestTextboxEventsInvokedProperly()
+        {
+            EventQueuesTextBox textBox = null;
+
+            AddStep("add limited textbox", () =>
+            {
+                textBoxes.Add(textBox = new EventQueuesTextBox
+                {
+                    CommitOnFocusLost = true,
+                    ReleaseFocusOnCommit = false,
+                    Size = new Vector2(200, 40),
+                    Text = "some default text",
+                });
+            });
+
+            AddStep("focus textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            #region Text mutation
+
+            AddStep("set text property once more", () => textBox.Text = "set property once more");
+            AddStep("insert string via protected method", () => textBox.InsertString(" inserted string."));
+            AddAssert("no user text consumed event", () => textBox.UserConsumedTextQueue.Count == 0);
+
+            // todo: this is not straightforward to support at the moment (requires manipulating ITextInputSource, which is stored at host level), steps commented for now.
+            //AddStep("press letter key to insert text", () => addToPendingTextInput());
+            //AddAssert("user text consumed event", () => textBox.UserConsumedTextQueue.Dequeue() == "W" && textBox.UserConsumedTextQueue.Count == 0);
+
+            AddStep("invoke delete action to remove text", () => textBox.DeletePreviousCharacter());
+            AddAssert("user text removed event", () => textBox.UserRemovedTextQueue.Dequeue() == "." && textBox.UserRemovedTextQueue.Count == 0);
+
+            #endregion
+
+            #region Commit with focus lost & enter key
+
+            AddStep("press enter key for committing text", () => InputManager.Key(Key.Enter));
+
+            AddAssert("text committed event", () =>
+                // Ensure dequeued text commit event has textChanged = true.
+                textBox.CommittedTextQueue.Dequeue() && textBox.CommittedTextQueue.Count == 0);
+
+            AddStep("click away", () =>
+            {
+                InputManager.MoveMouseTo(Content.ToScreenSpace(Vector2.Zero));
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("text committed event", () =>
+                // Ensure dequeued text commit event has textChanged = false.
+                textBox.CommittedTextQueue.Dequeue() == false && textBox.CommittedTextQueue.Count == 0);
+
+            // Refocus back for the remaining checks below.
+            AddStep("focus textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            #endregion
+
+            #region Caret moving / expanding selection
+
+            AddStep("invoke move action to move caret", () => textBox.MoveToStart());
+            AddAssert("caret moved event", () =>
+                // Ensure dequeued caret move event has selecting = false.
+                textBox.CaretMovedQueue.Dequeue() == false && textBox.CommittedTextQueue.Count == 0);
+
+            AddStep("invoke select action to expand selection", () => textBox.OnPressed(new PlatformAction(PlatformActionType.CharNext, PlatformActionMethod.Select)));
+            AddAssert("caret moved event", () =>
+                // Ensure dequeued caret move event has selecting = true.
+                textBox.CaretMovedQueue.Dequeue() && textBox.CommittedTextQueue.Count == 0);
+
+            #endregion
+
+            AddAssert("all event queues emptied", () => textBox.UserConsumedTextQueue.Count == 0 &&
+                                                        textBox.UserRemovedTextQueue.Count == 0 &&
+                                                        textBox.CommittedTextQueue.Count == 0 &&
+                                                        textBox.CaretMovedQueue.Count == 0);
+        }
+
+        private class EventQueuesTextBox : InsertableTextBox
+        {
+            public readonly Queue<string> UserConsumedTextQueue = new Queue<string>();
+            public readonly Queue<string> UserRemovedTextQueue = new Queue<string>();
+            public readonly Queue<bool> CommittedTextQueue = new Queue<bool>();
+            public readonly Queue<bool> CaretMovedQueue = new Queue<bool>();
+
+            protected override void OnUserTextConsumed(string consumed) => UserConsumedTextQueue.Enqueue(consumed);
+            protected override void OnUserTextRemoved(string removed) => UserRemovedTextQueue.Enqueue(removed);
+            protected override void OnTextCommitted(bool textChanged) => CommittedTextQueue.Enqueue(textChanged);
+            protected override void OnCaretMoved(bool selecting) => CaretMovedQueue.Enqueue(selecting);
         }
 
         private class InsertableTextBox : BasicTextBox

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBoxEvents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBoxEvents.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             public readonly Queue<bool> CommittedTextQueue = new Queue<bool>();
             public readonly Queue<bool> CaretMovedQueue = new Queue<bool>();
 
-            protected override void OnUserTextConsumed(string consumed) => UserConsumedTextQueue.Enqueue(consumed);
+            protected override void OnUserTextAdded(string consumed) => UserConsumedTextQueue.Enqueue(consumed);
             protected override void OnUserTextRemoved(string removed) => UserRemovedTextQueue.Enqueue(removed);
             protected override void OnTextCommitted(bool textChanged) => CommittedTextQueue.Enqueue(textChanged);
             protected override void OnCaretMoved(bool selecting) => CaretMovedQueue.Enqueue(selecting);

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBoxEvents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBoxEvents.cs
@@ -1,0 +1,129 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Input;
+using osu.Framework.Testing;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Tests.Visual.UserInterface
+{
+    public class TestSceneTextBoxEvents : ManualInputManagerTestScene
+    {
+        private EventQueuesTextBox textBox;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("add textbox", () => Child = textBox = new EventQueuesTextBox
+            {
+                CommitOnFocusLost = true,
+                ReleaseFocusOnCommit = false,
+                Size = new Vector2(200, 40),
+                Text = "some default text",
+            });
+
+            AddStep("focus textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("move caret to end", () =>
+            {
+                textBox.MoveToEnd();
+                textBox.CaretMovedQueue.Dequeue();
+            });
+        }
+
+        [Test]
+        public void TestMutatingTextPropertyDoesntInvokeEvent()
+        {
+            AddStep("set text property once more", () => textBox.Text = "set property once more");
+            AddStep("insert string via protected method", () => textBox.InsertString(" inserted string."));
+            AddAssert("no user text consumed event", () => textBox.UserConsumedTextQueue.Count == 0);
+        }
+
+        [Test]
+        [Ignore("not possible to test yet for attached reason.")]
+        public void TestInsertingUserTextInvokesEvent()
+        {
+            // todo: this is not straightforward to test at the moment (requires manipulating ITextInputSource, which is stored at host level), steps commented for now.
+            //AddStep("press letter key to insert text", () => addToPendingTextInput());
+            //AddAssert("user text consumed event", () => textBox.UserConsumedTextQueue.Dequeue() == "W" && textBox.UserConsumedTextQueue.Count == 0);
+        }
+
+        [Test]
+        public void TestDeletingPrevCharActionInvokesEvent()
+        {
+            string lastText = null;
+
+            AddStep("invoke delete action to remove text", () =>
+            {
+                lastText = textBox.Text;
+                textBox.DeletePreviousCharacter();
+            });
+            AddAssert("user text removed event raised", () => textBox.UserRemovedTextQueue.Dequeue() == lastText.Last().ToString() && textBox.UserRemovedTextQueue.Count == 0);
+        }
+
+        [Test]
+        public void TestCommittingTextInvokesEvents()
+        {
+            AddStep("insert text", () => textBox.InsertString(" with another"));
+            AddStep("press enter key for committing text", () => InputManager.Key(Key.Enter));
+
+            AddAssert("text committed event raised", () =>
+                // Ensure dequeued text commit event has textChanged = true.
+                textBox.CommittedTextQueue.Dequeue() && textBox.CommittedTextQueue.Count == 0);
+
+            AddStep("click away", () =>
+            {
+                InputManager.MoveMouseTo(textBox.ScreenSpaceDrawQuad.BottomRight + Vector2.One * 20);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("text committed event raised", () =>
+                // Ensure dequeued text commit event has textChanged = false.
+                textBox.CommittedTextQueue.Dequeue() == false && textBox.CommittedTextQueue.Count == 0);
+        }
+
+        [Test]
+        public void TestMovingOrExpandingSelectionInvokesEvent()
+        {
+            AddStep("invoke move action to move caret", () => textBox.MoveToStart());
+            AddAssert("caret moved event", () =>
+                // Ensure dequeued caret move event has selecting = false.
+                textBox.CaretMovedQueue.Dequeue() == false && textBox.CommittedTextQueue.Count == 0);
+
+            AddStep("invoke select action to expand selection", () => textBox.OnPressed(new PlatformAction(PlatformActionType.CharNext, PlatformActionMethod.Select)));
+            AddAssert("caret moved event", () =>
+                // Ensure dequeued caret move event has selecting = true.
+                textBox.CaretMovedQueue.Dequeue() && textBox.CommittedTextQueue.Count == 0);
+        }
+
+        [TearDownSteps]
+        public void TearDownSteps()
+        {
+            AddAssert("all event queues emptied", () => textBox.UserConsumedTextQueue.Count == 0 &&
+                                                        textBox.UserRemovedTextQueue.Count == 0 &&
+                                                        textBox.CommittedTextQueue.Count == 0 &&
+                                                        textBox.CaretMovedQueue.Count == 0);
+        }
+
+        private class EventQueuesTextBox : TestSceneTextBox.InsertableTextBox
+        {
+            public readonly Queue<string> UserConsumedTextQueue = new Queue<string>();
+            public readonly Queue<string> UserRemovedTextQueue = new Queue<string>();
+            public readonly Queue<bool> CommittedTextQueue = new Queue<bool>();
+            public readonly Queue<bool> CaretMovedQueue = new Queue<bool>();
+
+            protected override void OnUserTextConsumed(string consumed) => UserConsumedTextQueue.Enqueue(consumed);
+            protected override void OnUserTextRemoved(string removed) => UserRemovedTextQueue.Enqueue(removed);
+            protected override void OnTextCommitted(bool textChanged) => CommittedTextQueue.Enqueue(textChanged);
+            protected override void OnCaretMoved(bool selecting) => CaretMovedQueue.Enqueue(selecting);
+        }
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -567,9 +567,9 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         /// <summary>
-        /// Invoked whenever a text string has been removed by user input.
+        /// Invoked when text is removed via user input.
         /// </summary>
-        /// <param name="removed">The removed text string.</param>
+        /// <param name="removed">The text which was removed.</param>
         protected virtual void OnUserTextRemoved(string removed)
         {
         }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -559,10 +559,10 @@ namespace osu.Framework.Graphics.UserInterface
         protected abstract void NotifyInputError();
 
         /// <summary>
-        /// Invoked whenever pending text input from user has been consumed, this is not necessarily what has been inserted to <see cref="Text"/> (i.e. some may have been disallowed by <see cref="CanAddCharacter"/>)
+        /// Invoked when new text is added via user input.
         /// </summary>
-        /// <param name="consumed">The consumed text string.</param>
-        protected virtual void OnUserTextConsumed(string consumed)
+        /// <param name="added">The text which was added.</param>
+        protected virtual void OnUserTextAdded(string added)
         {
         }
 
@@ -686,7 +686,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (!string.IsNullOrEmpty(pendingText) && !ReadOnly)
             {
                 InsertString(pendingText);
-                OnUserTextConsumed(pendingText);
+                OnUserTextAdded(pendingText);
             }
 
             if (consumingText)
@@ -967,7 +967,7 @@ namespace osu.Framework.Graphics.UserInterface
                 imeDrawables.Add(d);
             });
 
-            OnUserTextConsumed(insertedValue);
+            OnUserTextAdded(insertedValue);
         }
 
         #endregion

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using osu.Framework.Caching;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -163,8 +162,12 @@ namespace osu.Framework.Graphics.UserInterface
                     if (string.IsNullOrEmpty(SelectedText) || !AllowClipboardExport) return true;
 
                     clipboard?.SetText(SelectedText);
+
                     if (action.ActionType == PlatformActionType.Cut)
-                        removeSelection();
+                    {
+                        string removedText = removeSelection();
+                        OnUserTextRemoved(removedText);
+                    }
 
                     return true;
 
@@ -248,7 +251,10 @@ namespace osu.Framework.Graphics.UserInterface
                             selectionEnd = Math.Clamp(selectionStart + amount.Value, 0, text.Length);
 
                         if (selectionLength > 0)
-                            removeSelection();
+                        {
+                            string removedText = removeSelection();
+                            OnUserTextRemoved(removedText);
+                        }
 
                         break;
                 }
@@ -419,7 +425,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Removes the selected text if a selection persists.
         /// </summary>
-        private void removeSelection() => removeCharacters(selectionLength);
+        private string removeSelection() => removeCharacters(selectionLength);
 
         /// <summary>
         /// Removes a specified <paramref name="number"/> of characters left side of the current position.
@@ -427,16 +433,17 @@ namespace osu.Framework.Graphics.UserInterface
         /// <remarks>
         /// If a selection persists, <see cref="removeSelection"/> must be called instead.
         /// </remarks>
-        private void removeCharacters(int number = 1)
+        /// <returns>A string of the removed characters.</returns>
+        private string removeCharacters(int number = 1)
         {
             if (Current.Disabled || text.Length == 0)
-                return;
+                return string.Empty;
 
             int removeStart = Math.Clamp(selectionRight - number, 0, selectionRight);
             int removeCount = selectionRight - removeStart;
 
             if (removeCount == 0)
-                return;
+                return string.Empty;
 
             Debug.Assert(selectionLength == 0 || removeCount == selectionLength);
 
@@ -455,7 +462,6 @@ namespace osu.Framework.Graphics.UserInterface
 
             var removedText = text.Substring(removeStart, removeCount);
             text = text.Remove(removeStart, removeCount);
-            OnTextRemoved(removedText);
 
             // Reorder characters depth after removal to avoid ordering issues with newly added characters.
             for (int i = removeStart; i < TextFlow.Count; i++)
@@ -464,6 +470,8 @@ namespace osu.Framework.Graphics.UserInterface
             selectionStart = selectionEnd = removeStart;
 
             cursorAndLayout.Invalidate();
+
+            return removedText;
         }
 
         /// <summary>
@@ -507,8 +515,6 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void insertString(string value, Action<Drawable> drawableCreationParameters = null)
         {
-            StringBuilder inserted = new StringBuilder();
-
             if (string.IsNullOrEmpty(value)) return;
 
             if (Current.Disabled)
@@ -540,15 +546,11 @@ namespace osu.Framework.Graphics.UserInterface
                 drawableCreationParameters?.Invoke(drawable);
 
                 text = text.Insert(selectionLeft, c.ToString());
-                inserted.Append(c);
 
                 selectionStart = selectionEnd = selectionLeft + 1;
 
                 cursorAndLayout.Invalidate();
             }
-
-            if (inserted.Length > 0)
-                OnTextAdded(inserted.ToString());
         }
 
         /// <summary>
@@ -557,18 +559,18 @@ namespace osu.Framework.Graphics.UserInterface
         protected abstract void NotifyInputError();
 
         /// <summary>
-        /// Invoked whenever a text string has been inserted to <see cref="Text"/>.
+        /// Invoked whenever pending text input from user has been consumed, this is not necessarily what has been inserted to <see cref="Text"/> (i.e. some may have been disallowed by <see cref="CanAddCharacter"/>)
         /// </summary>
-        /// <param name="added">The inserted text string.</param>
-        protected virtual void OnTextAdded(string added)
+        /// <param name="consumed">The consumed text string.</param>
+        protected virtual void OnUserTextConsumed(string consumed)
         {
         }
 
         /// <summary>
-        /// Invoked whenever a text string has been removed from <see cref="Text"/>.
+        /// Invoked whenever a text string has been removed by user input.
         /// </summary>
         /// <param name="removed">The removed text string.</param>
-        protected virtual void OnTextRemoved(string removed)
+        protected virtual void OnUserTextRemoved(string removed)
         {
         }
 
@@ -682,7 +684,10 @@ namespace osu.Framework.Graphics.UserInterface
             string pendingText = textInput?.GetPendingText();
 
             if (!string.IsNullOrEmpty(pendingText) && !ReadOnly)
+            {
                 InsertString(pendingText);
+                OnUserTextConsumed(pendingText);
+            }
 
             if (consumingText)
                 Schedule(consumePendingText);
@@ -953,12 +958,16 @@ namespace osu.Framework.Graphics.UserInterface
                 //in the case of backspacing (or a NOP), we can exit early here.
                 return;
 
-            insertString(s.Substring(matchCount), d =>
+            var insertedValue = s.Substring(matchCount);
+
+            insertString(insertedValue, d =>
             {
                 d.Colour = Color4.Aqua;
                 d.Alpha = 0.6f;
                 imeDrawables.Add(d);
             });
+
+            OnUserTextConsumed(insertedValue);
         }
 
         #endregion

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -958,16 +958,16 @@ namespace osu.Framework.Graphics.UserInterface
                 //in the case of backspacing (or a NOP), we can exit early here.
                 return;
 
-            var insertedValue = s.Substring(matchCount);
+            string insertedText = s.Substring(matchCount);
 
-            insertString(insertedValue, d =>
+            insertString(insertedText, d =>
             {
                 d.Colour = Color4.Aqua;
                 d.Alpha = 0.6f;
                 imeDrawables.Add(d);
             });
 
-            OnUserTextAdded(insertedValue);
+            OnUserTextAdded(insertedText);
         }
 
         #endregion


### PR DESCRIPTION
Closes ppy/osu#9882
Regression from #3289

Replaces text mutation events to only being called when the mutation is done by user input.

## Remarks
- There is a commented piece of the pushed test case, which is about pressing a key and checking if the event handler has been invoked, but currently, the text input consumption logic is limited at a host level from manipulating or creating a test class for it, making this not straightforward to test, didn't want to bother with it so I added a TODO comment on top of it for now.
- First time using regions inside methods, but felt better than splitting each in an own test case method as it requires setting up the same textbox for each, lengthening the test scene even more.
- There is also a side-issue with the textbox text property that became visible on the written test (setting `Text` a second time), will report it asap.