### PR TITLE
Fix transforms potentially being skipped due to incorrect order of application

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -367,6 +367,29 @@ namespace osu.Framework.Tests.Visual.Drawables
         }
 
         [Test]
+        public void TestSimultaneousTransformsOutOfOrder()
+        {
+            boxTest(box =>
+            {
+                using (box.BeginAbsoluteSequence(0))
+                {
+                    box.MoveToX(0.5f, 4 * interval);
+                    box.Delay(interval).MoveToY(0.5f, 2 * interval);
+                }
+            });
+
+            checkAtTime(0, box => Precision.AlmostEquals(box.Position, new Vector2(0)));
+            checkAtTime(interval, box => Precision.AlmostEquals(box.Position, new Vector2(0.125f, 0)));
+            checkAtTime(2 * interval, box => Precision.AlmostEquals(box.Position, new Vector2(0.25f, 0.25f)));
+            checkAtTime(3 * interval, box => Precision.AlmostEquals(box.Position, new Vector2(0.375f, 0.5f)));
+            checkAtTime(4 * interval, box => Precision.AlmostEquals(box.Position, new Vector2(0.5f)));
+            checkAtTime(3 * interval, box => Precision.AlmostEquals(box.Position, new Vector2(0.375f, 0.5f)));
+            checkAtTime(2 * interval, box => Precision.AlmostEquals(box.Position, new Vector2(0.25f, 0.25f)));
+            checkAtTime(interval, box => Precision.AlmostEquals(box.Position, new Vector2(0.125f, 0)));
+            checkAtTime(0, box => Precision.AlmostEquals(box.Position, new Vector2(0)));
+        }
+
+        [Test]
         public void TestMultipleTransformTargets()
         {
             boxTest(box =>

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// The index of the last transform in <see cref="transforms"/> to be applied to completion.
         /// </summary>
-        private readonly Dictionary<string, int> lastAppliedIndex = new Dictionary<string, int>();
+        private readonly Dictionary<string, int> lastAppliedTransformIndices = new Dictionary<string, int>();
 
         /// <summary>
         /// All <see cref="Transform.TargetMember"/>s which are handled by this tracker.
@@ -99,7 +99,7 @@ namespace osu.Framework.Graphics.Transforms
                 }
             }
 
-            for (int i = getLastAppliedIndex() ?? 0; i < transforms.Count; ++i)
+            for (int i = getLastAppliedIndex(); i < transforms.Count; ++i)
             {
                 var t = transforms[i];
 
@@ -117,7 +117,7 @@ namespace osu.Framework.Graphics.Transforms
                     // Since following transforms acting on the same target member are immediately removed when a
                     // new one is added, we can be sure that previous transforms were added before this one and can
                     // be safely removed.
-                    for (int j = getLastAppliedIndex(t.TargetMember) ?? 0; j < i; ++j)
+                    for (int j = getLastAppliedIndex(t.TargetMember); j < i; ++j)
                     {
                         var u = transforms[j];
                         if (u.TargetMember != t.TargetMember) continue;
@@ -320,21 +320,19 @@ namespace osu.Framework.Graphics.Transforms
             }
         }
 
-        private readonly Dictionary<string, int?> lastAppliedTransformIndices = new Dictionary<string, int?>();
-
         /// <summary>
         /// Retrieve the last transform index that was <see cref="Transform.AppliedToEnd"/>.
         /// </summary>
         /// <param name="targetMember">An optional target member. If null, the lowest common last application is returned.</param>
-        private int? getLastAppliedIndex(string targetMember = null)
+        private int getLastAppliedIndex(string targetMember = null)
         {
             if (targetMember == null)
                 return lastAppliedTransformIndices.Values.Min();
 
-            if (lastAppliedTransformIndices.TryGetValue(targetMember, out int? val))
+            if (lastAppliedTransformIndices.TryGetValue(targetMember, out int val))
                 return val;
 
-            return null;
+            return 0;
         }
 
         /// <summary>
@@ -342,7 +340,7 @@ namespace osu.Framework.Graphics.Transforms
         /// </summary>
         /// <param name="targetMember">The target member to set the index of.</param>
         /// <param name="index">The index of the transform in <see cref="transforms"/>.</param>
-        private void setLastAppliedIndex(string targetMember, int? index = null)
+        private void setLastAppliedIndex(string targetMember, int index)
         {
             lastAppliedTransformIndices[targetMember] = index;
         }

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -225,12 +225,21 @@ namespace osu.Framework.Graphics.Transforms
             int insertionIndex = transforms.Add(transform);
             resetLastAppliedCache();
 
+            bool insertionWasAtEndOfList = insertionIndex == transforms.Count - 1;
+
             // Remove all existing following transforms touching the same property as this one.
-            for (int i = insertionIndex + 1; i < transforms.Count; ++i)
+            for (int i = 0; i < transforms.Count; ++i)
             {
                 var t = transforms[i];
 
-                if (t.TargetMember == transform.TargetMember)
+                if (!insertionWasAtEndOfList && i < insertionIndex)
+                {
+                    // as we are removing all transforms after the newly added one, the TargetMember may not be in a good state.
+                    // this could mean that we get an incorrect value read into our StartValue on next update.
+                    // To avoid this, we ensure all transforms before the insertion point on next update.
+                    t.AppliedToEnd = false;
+                }
+                else if (i > insertionIndex && t.TargetMember == transform.TargetMember)
                 {
                     transforms.RemoveAt(i--);
                     if (t.OnAbort != null)

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -225,21 +225,12 @@ namespace osu.Framework.Graphics.Transforms
             int insertionIndex = transforms.Add(transform);
             resetLastAppliedCache();
 
-            bool insertionWasAtEndOfList = insertionIndex == transforms.Count - 1;
-
             // Remove all existing following transforms touching the same property as this one.
-            for (int i = 0; i < transforms.Count; ++i)
+            for (int i = insertionIndex + 1; i < transforms.Count; ++i)
             {
                 var t = transforms[i];
 
-                if (!insertionWasAtEndOfList && i < insertionIndex)
-                {
-                    // as we are removing all transforms after the newly added one, the TargetMember may not be in a good state.
-                    // this could mean that we get an incorrect value read into our StartValue on next update.
-                    // To avoid this, we ensure all transforms before the insertion point on next update.
-                    t.AppliedToEnd = false;
-                }
-                else if (i > insertionIndex && t.TargetMember == transform.TargetMember)
+                if (t.TargetMember == transform.TargetMember)
                 {
                     transforms.RemoveAt(i--);
                     if (t.OnAbort != null)

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -248,6 +248,7 @@ namespace osu.Framework.Graphics.Transforms
         public void RemoveTransform(Transform toRemove)
         {
             transforms.Remove(toRemove);
+            resetLastAppliedCache();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// The index of the last transform in <see cref="transforms"/> to be applied to completion.
         /// </summary>
-        private int? lastAppliedIndex;
+        private readonly Dictionary<string, int> lastAppliedIndex = new Dictionary<string, int>();
 
         /// <summary>
         /// All <see cref="Transform.TargetMember"/>s which are handled by this tracker.
@@ -58,9 +58,9 @@ namespace osu.Framework.Graphics.Transforms
         {
             if (rewinding && !transformable.RemoveCompletedTransforms)
             {
-                resetLastAppliedIndex();
+                resetLastAppliedCache();
 
-                bool appliedToEndRevert = false;
+                var appliedToEndReverts = new List<string>();
 
                 // Under the case that completed transforms are not removed, reversing the clock is permitted.
                 // We need to first look back through all the transforms and apply the start values of the ones that were previously
@@ -80,16 +80,16 @@ namespace osu.Framework.Graphics.Transforms
                     if (time >= t.StartTime)
                     {
                         // we are in the middle of this transform, so we want to mark as not-completely-applied.
-                        // note that we should only do this for the last transform to avoid incorrect application order.
+                        // note that we should only do this for the last transform of each TargetMember to avoid incorrect application order.
                         // the actual application will be in the main loop below now that AppliedToEnd is false.
-                        if (!appliedToEndRevert)
+                        if (!appliedToEndReverts.Contains(t.TargetMember))
                         {
                             if (time < t.EndTime)
                                 t.AppliedToEnd = false;
                             else
                                 t.Apply(t.EndTime);
 
-                            appliedToEndRevert = true;
+                            appliedToEndReverts.Add(t.TargetMember);
                         }
                     }
                     else
@@ -103,7 +103,7 @@ namespace osu.Framework.Graphics.Transforms
                 }
             }
 
-            for (int i = lastAppliedIndex ?? 0; i < transforms.Count; ++i)
+            for (int i = getLastAppliedIndex() ?? 0; i < transforms.Count; ++i)
             {
                 var t = transforms[i];
 
@@ -121,7 +121,7 @@ namespace osu.Framework.Graphics.Transforms
                     // Since following transforms acting on the same target member are immediately removed when a
                     // new one is added, we can be sure that previous transforms were added before this one and can
                     // be safely removed.
-                    for (int j = lastAppliedIndex ?? 0; j < i; ++j)
+                    for (int j = getLastAppliedIndex(t.TargetMember) ?? 0; j < i; ++j)
                     {
                         var u = transforms[j];
                         if (u.TargetMember != t.TargetMember) continue;
@@ -194,10 +194,10 @@ namespace osu.Framework.Graphics.Transforms
                 }
 
                 if (flushAppliedCache)
-                    resetLastAppliedIndex();
+                    resetLastAppliedCache();
                 // if this transform is applied to end, we can be sure that all previous transforms have been completed.
                 else if (t.AppliedToEnd)
-                    lastAppliedIndex = i + 1;
+                    setLastAppliedIndex(t.TargetMember, i + 1);
             }
 
             invokePendingRemovalActions();
@@ -227,7 +227,7 @@ namespace osu.Framework.Graphics.Transforms
 
             transform.TransformID = customTransformID ?? ++currentTransformID;
             int insertionIndex = transforms.Add(transform);
-            resetLastAppliedIndex();
+            resetLastAppliedCache();
 
             // Remove all existing following transforms touching the same property as this one.
             for (int i = insertionIndex + 1; i < transforms.Count; ++i)
@@ -264,7 +264,7 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void ClearTransformsAfter(double time, string targetMember = null)
         {
-            resetLastAppliedIndex();
+            resetLastAppliedCache();
 
             Transform[] toAbort;
 
@@ -302,7 +302,7 @@ namespace osu.Framework.Graphics.Transforms
             var toFlush = transforms.Where(toFlushPredicate).ToArray();
 
             transforms.RemoveAll(t => toFlushPredicate(t));
-            resetLastAppliedIndex();
+            resetLastAppliedCache();
 
             foreach (Transform t in toFlush)
             {
@@ -323,9 +323,40 @@ namespace osu.Framework.Graphics.Transforms
             }
         }
 
+        private readonly Dictionary<string, int?> lastAppliedTransformIndices = new Dictionary<string, int?>();
+
+        /// <summary>
+        /// Retrieve the last transform index that was <see cref="Transform.AppliedToEnd"/>.
+        /// </summary>
+        /// <param name="targetMember">An optional target member. If null, the highest common last application is returned.</param>
+        private int? getLastAppliedIndex(string targetMember = null)
+        {
+            if (targetMember == null)
+                return lastAppliedTransformIndices.Values.Min();
+
+            if (lastAppliedTransformIndices.TryGetValue(targetMember, out int? val))
+                return val;
+
+            return null;
+        }
+
+        /// <summary>
+        /// Set the last transform index that was <see cref="Transform.AppliedToEnd"/> for a specific target member.
+        /// </summary>
+        /// <param name="targetMember">The target member to set the index of.</param>
+        /// <param name="index">The index of the transform in <see cref="transforms"/>.</param>
+        private void setLastAppliedIndex(string targetMember, int? index = null)
+        {
+            lastAppliedTransformIndices[targetMember] = index;
+        }
+
         /// <summary>
         /// Reset the last applied index cache completely.
         /// </summary>
-        private void resetLastAppliedIndex() => lastAppliedIndex = null;
+        private void resetLastAppliedCache()
+        {
+            foreach (var tracked in targetMembers)
+                lastAppliedTransformIndices[tracked] = 0;
+        }
     }
 }

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -325,7 +325,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// Retrieve the last transform index that was <see cref="Transform.AppliedToEnd"/>.
         /// </summary>
-        /// <param name="targetMember">An optional target member. If null, the highest common last application is returned.</param>
+        /// <param name="targetMember">An optional target member. If null, the lowest common last application is returned.</param>
         private int? getLastAppliedIndex(string targetMember = null)
         {
             if (targetMember == null)

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -84,11 +84,7 @@ namespace osu.Framework.Graphics.Transforms
                         // the actual application will be in the main loop below now that AppliedToEnd is false.
                         if (!appliedToEndReverts.Contains(t.TargetMember))
                         {
-                            if (time < t.EndTime)
-                                t.AppliedToEnd = false;
-                            else
-                                t.Apply(t.EndTime);
-
+                            t.AppliedToEnd = false;
                             appliedToEndReverts.Add(t.TargetMember);
                         }
                     }


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/3837.

Best understood by going through commits one by one and looking at test failures in `TestSceneTransformRewinding` in visual tests, but basically:

- We don't want to be applying transforms in the rewind code. This is iterating in the wrong direction through the transforms list and will not lead to correct application order between overlapping TargetMembers.
- With the removal of the application just mentioned, a regression shows up when adding a transform in the past which will immediately complete in the next frame – rewind logic will not be run to reset `AppliedToEnd` so the end value may not be updated correctly. This is resolved by marking as *not* `AppliedToEnd` in `AddTransform` when required.
- All dictionary / cache logic is taken from previous iteration I had written (https://raw.githubusercontent.com/ppy/osu-framework/aa8eaf127060cc4a0be82e5ab616c09bc44a5fff/osu.Framework/Graphics/Transforms/Transformable.cs)