### PR TITLE
Add support for seeking a non-loaded animation

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -24,6 +24,9 @@ namespace osu.Framework.Tests.Visual.Sprites
         private TestAnimation animation;
         private Container animationContainer;
 
+        [Resolved]
+        private FontStore fontStore { get; set; }
+
         [SetUpSteps]
         public void SetUpSteps()
         {
@@ -232,7 +235,7 @@ namespace osu.Framework.Tests.Visual.Sprites
         {
             AddStep("load animation", () =>
             {
-                animationContainer.Child = animation = new TestAnimation(startFromCurrent)
+                animationContainer.Child = animation = new TestAnimation(startFromCurrent, fontStore)
                 {
                     Loop = false,
                 };
@@ -260,27 +263,16 @@ namespace osu.Framework.Tests.Visual.Sprites
         {
             public const int LOADABLE_FRAMES = 72;
 
-            [Resolved]
-            private FontStore fontStore { get; set; }
-
             public int FramesProcessed;
 
-            public TestAnimation(bool startFromCurrent)
+            // fontStore passed in via ctor to be able to test scenarios where an animation
+            // already has frames before load
+            public TestAnimation(bool startFromCurrent, FontStore fontStore)
                 : base(startFromCurrent)
             {
                 Anchor = Anchor.Centre;
                 Origin = Anchor.Centre;
-            }
 
-            protected override void DisplayFrame(Texture content)
-            {
-                FramesProcessed++;
-                base.DisplayFrame(content);
-            }
-
-            [BackgroundDependencyLoader]
-            private void load()
-            {
                 for (int i = 0; i < LOADABLE_FRAMES; i++)
                 {
                     AddFrame(new Texture(fontStore.Get(null, (char)('0' + i))?.Texture.TextureGL)
@@ -288,6 +280,12 @@ namespace osu.Framework.Tests.Visual.Sprites
                         ScaleAdjust = 1 + i / 40f,
                     }, 250);
                 }
+            }
+
+            protected override void DisplayFrame(Texture content)
+            {
+                FramesProcessed++;
+                base.DisplayFrame(content);
             }
         }
     }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -231,6 +231,21 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddAssert("animation restarted from 0", () => animation.PlaybackPosition < 1000);
         }
 
+        [TestCase(0)]
+        [TestCase(48)]
+        public void TestGotoFrameBeforeLoaded(int frame)
+        {
+            AddStep("create new animation", () => animation = new TestAnimation(true, fontStore)
+            {
+                Loop = false
+            });
+            AddStep($"go to frame {frame}", () => animation.GotoFrame(frame));
+
+            AddStep("load animation", () => animationContainer.Child = animation);
+
+            AddAssert($"animation is at frame {frame}", () => animation.CurrentFrameIndex == frame);
+        }
+
         private void loadNewAnimation(bool startFromCurrent = true, Action<TestAnimation> postLoadAction = null)
         {
             AddStep("load animation", () =>

--- a/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
+++ b/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
@@ -93,7 +93,11 @@ namespace osu.Framework.Graphics.Animations
                 hasSeeked = true;
                 manualClock.CurrentTime = value;
 
-                consumeClockTime();
+                // consume current clock to avoid additional jumps on top of the seek due to time naturally elapsing.
+                // there's no need to do this before we're loaded - LoadComplete() will also consume clock initially,
+                // and Time might not even be initialised yet during load
+                if (IsLoaded)
+                    consumeClockTime();
             }
         }
 


### PR DESCRIPTION
Resolves #3847 / usable with ppy/osu#9985 (although not necessarily a hard dependency)

# Summary

Setting `PlaybackPosition` before the animation was loaded could result in a `NullReferenceException` due to not necessarily having received a clock in `Time` yet.

As proposed in the issue, resolve this by not consuming time in the setter of `PlaybackPosition` if the animation isn't yet loaded -`LoadComplete()` will do it anyway before the update loop starts to run.

# Remarks

I opted not to add the guard to `consumeClockTime` itself as other call sites should be safe and should actually throw if the operation doesn't succeed. The other call sites are:

* `Clock.set` - should have access to `Time` by the virtue of actually setting the animation's clock,
* `LoadComplete()` - should have correct clock in place already,
* `Update()` - has no right to run if the drawable isn't loaded.

Test cases added (both for seeking to start, as well as arbitrary frame).