### PR TITLE
Avoid firing CollectionChanged on no-op BindableList.RemoveAll

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -944,6 +944,20 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
+        public void TestRemoveAllNoopDoesntNotifySubscibers()
+        {
+            bindableStringList.Add("0");
+            bindableStringList.Add("0");
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringList.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringList.RemoveAll(m => m == "1");
+
+            Assert.That(triggeredArgs, Is.Null);
+        }
+
+        [Test]
         public void TestRemoveAllNotifiesBoundLists()
         {
             bindableStringList.Add("0");

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -299,6 +299,8 @@ namespace osu.Framework.Bindables
 
             var removed = collection.FindAll(match);
 
+            if (removed.Count == 0) return removed.Count;
+
             // RemoveAll is internally optimised
             collection.RemoveAll(match);
 


### PR DESCRIPTION
Noticed this while investigating #3852.