### PR TITLE
Fix Game.Dispose potentially ending before children have been (async) disposed

### DIFF
--- a/osu.Framework.Tests/Platform/ComponentAsyncDisposalTest.cs
+++ b/osu.Framework.Tests/Platform/ComponentAsyncDisposalTest.cs
@@ -1,0 +1,116 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Tests.Platform
+{
+    [TestFixture]
+    public class ComponentAsyncDisposalTest
+    {
+        private TestTestGame game;
+        private HeadlessGameHost host;
+
+        private const int timeout = 10000;
+
+        /// <summary>
+        /// Ensure that if a component is on the async disposal queue, the game will wait for the queue to empty before disposing itself.
+        /// While we generally don't dispose games in normal execution, this may be used in tests, and can cause unwanted exceptions in (cancelled) load
+        /// methods if not ordered correctly.
+        /// </summary>
+        [Test]
+        public void TestChildDisposedBeforeGame()
+        {
+            var gameCreated = new ManualResetEventSlim();
+
+            var task = Task.Run(() =>
+            {
+                using (host = new HeadlessGameHost(@"host", false))
+                {
+                    game = new TestTestGame();
+                    gameCreated.Set();
+                    host.Run(game);
+                }
+            });
+
+            Assert.IsTrue(gameCreated.Wait(timeout));
+            Assert.IsTrue(game.BecameAlive.Wait(timeout));
+
+            var container = new DisposableContainer();
+
+            game.Schedule(() => game.Add(container));
+
+            Assert.IsTrue(container.BecameAlive.Wait(timeout));
+
+            game.Schedule(() =>
+            {
+                game.ClearInternal(false);
+                game.DisposeChildAsync(container);
+            });
+
+            game.Exit();
+
+            Assert.IsTrue(task.Wait(timeout));
+
+            game.Dispose();
+
+            Assert.IsTrue(container.DisposedSuccessfully.Wait(timeout));
+        }
+
+        private class DisposableContainer : Container
+        {
+            [Resolved]
+            private TestTestGame game { get; set; }
+
+            public readonly ManualResetEventSlim BecameAlive = new ManualResetEventSlim();
+
+            public readonly ManualResetEventSlim DisposedSuccessfully = new ManualResetEventSlim();
+
+            protected override void LoadComplete()
+            {
+                BecameAlive.Set();
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                game.DisposalStarted.Wait(timeout);
+
+                // make sure we take some time to dispose (forcing Game to wait on the async queue).
+                Thread.Sleep(100);
+
+                // we want to ensure that game is still alive pending our disposal.
+                if (!game.IsDisposed)
+                    DisposedSuccessfully.Set();
+
+                base.Dispose(isDisposing);
+            }
+        }
+
+        [Cached]
+        private class TestTestGame : TestGame
+        {
+            public readonly ManualResetEventSlim BecameAlive = new ManualResetEventSlim();
+
+            public readonly ManualResetEventSlim DisposalStarted = new ManualResetEventSlim();
+
+            public readonly ManualResetEventSlim DisposalCompleted = new ManualResetEventSlim();
+
+            protected override void LoadComplete()
+            {
+                BecameAlive.Set();
+            }
+
+            protected override void Dispose(bool isDisposing)
+            {
+                DisposalStarted.Set();
+                base.Dispose(isDisposing);
+                DisposalCompleted.Set();
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Platform/GameHostSuspendTest.cs
+++ b/osu.Framework.Tests/Platform/GameHostSuspendTest.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Tests.Platform
     public class GameHostSuspendTest
     {
         private TestTestGame game;
-        private TestHeadlessGameHost host;
+        private HeadlessGameHost host;
 
         private const int timeout = 10000;
 
@@ -23,7 +23,7 @@ namespace osu.Framework.Tests.Platform
 
             var task = Task.Run(() =>
             {
-                using (host = new TestHeadlessGameHost(@"host", false))
+                using (host = new HeadlessGameHost(@"host", false))
                 {
                     game = new TestTestGame();
                     gameCreated.Set();
@@ -55,14 +55,6 @@ namespace osu.Framework.Tests.Platform
             game.Exit();
 
             Assert.IsTrue(task.Wait(timeout));
-        }
-
-        private class TestHeadlessGameHost : HeadlessGameHost
-        {
-            public TestHeadlessGameHost(string hostname, bool bindIPC)
-                : base(hostname, bindIPC)
-            {
-            }
         }
 
         private class TestTestGame : TestGame

--- a/osu.Framework.Tests/Threading/AsyncDisposalQueueTest.cs
+++ b/osu.Framework.Tests/Threading/AsyncDisposalQueueTest.cs
@@ -39,6 +39,20 @@ namespace osu.Framework.Tests.Threading
             Assert.That(objects.Select(d => d.TaskId).Distinct().Count(), Is.LessThan(objects.Count));
         }
 
+        [Test]
+        public void TestManyAsyncDisposalUsingWait()
+        {
+            var objects = new List<DisposableObject>();
+            for (int i = 0; i < 10000; i++)
+                objects.Add(new DisposableObject());
+
+            objects.ForEach(AsyncDisposalQueue.Enqueue);
+
+            AsyncDisposalQueue.WaitForEmpty();
+
+            Assert.That(objects.All(o => o.IsDisposed));
+        }
+
         private class DisposableObject : IDisposable
         {
             public int? TaskId { get; private set; }

--- a/osu.Framework/Allocation/AsyncDisposalQueue.cs
+++ b/osu.Framework/Allocation/AsyncDisposalQueue.cs
@@ -24,6 +24,10 @@ namespace osu.Framework.Allocation
 
         private static int runningTasks;
 
+        /// <summary>
+        /// Enqueue a disposable object for asynchronous disposal.
+        /// </summary>
+        /// <param name="disposable">The object to dispose.</param>
         public static void Enqueue(IDisposable disposable)
         {
             lock (disposal_queue)

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -351,6 +351,8 @@ namespace osu.Framework
 
         protected override void Dispose(bool isDisposing)
         {
+            AsyncDisposalQueue.WaitForEmpty();
+
             Audio?.Dispose();
             Audio = null;
 


### PR DESCRIPTION
Wait for global async disposal queue to empty before disposing the game itself, as the components within may be relying on game/host access in their ongoing background functions (ie. if they are still in an async load cancelling state).

Fixes test failures seen in https://github.com/ppy/osu/pull/10026, that started to show up from various usage of `DelayedLoadUnloadWrapper` (which is using the async disposal queue in a slightly different way since https://github.com/ppy/osu-framework/pull/3825/files).

I also fixed an edge case in `AsyncDisposalQueue` which can't be easily tested but should be easy enough to understand:

- Enqueue an item
- Processing begins on that item
- New item enqueued before processing ends. Task isn't started because one is already running, but that task will not process any newly added items.

I've fixed this by making the task loop until the queue empties, and also locking over these checks to ensure safety.