### PR TITLE
Change disposal order to better protect against async disposal queue failures

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -352,7 +352,7 @@ namespace osu.Framework
         protected override void Dispose(bool isDisposing)
         {
             // ensure any async disposals are completed before we begin to rip components out.
-            // if we were to not wait, async disposals may through unexpected exceptions.
+            // if we were to not wait, async disposals may throw unexpected exceptions.
             AsyncDisposalQueue.WaitForEmpty();
 
             base.Dispose(isDisposing);

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -353,6 +353,10 @@ namespace osu.Framework
         {
             AsyncDisposalQueue.WaitForEmpty();
 
+            base.Dispose(isDisposing);
+
+            AsyncDisposalQueue.WaitForEmpty();
+
             Audio?.Dispose();
             Audio = null;
 
@@ -361,8 +365,6 @@ namespace osu.Framework
 
             localFonts?.Dispose();
             localFonts = null;
-
-            base.Dispose(isDisposing);
         }
     }
 }

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -351,10 +351,13 @@ namespace osu.Framework
 
         protected override void Dispose(bool isDisposing)
         {
+            // ensure any async disposals are completed before we begin to rip components out.
+            // if we were to not wait, async disposals may through unexpected exceptions.
             AsyncDisposalQueue.WaitForEmpty();
 
             base.Dispose(isDisposing);
 
+            // call a second time to protect against anything being potentially async disposed in the base.Dispose call.
             AsyncDisposalQueue.WaitForEmpty();
 
             Audio?.Dispose();


### PR DESCRIPTION
Previous change (#3860) was not enough to always fix the issue (happened again [here](https://ci.appveyor.com/project/peppy/osu/builds/35023352/tests)).

I was able to reproduce the failure locally, and this more solid fix has not failed over 1000+ test runs.