### PR TITLE
Typo fixes & Math.Clamp

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Android
 
             UIVisibilityFlags = SystemUiFlags.LayoutFlags | SystemUiFlags.ImmersiveSticky | SystemUiFlags.HideNavigation;
 
-            // Firing up the on-screen keyboard (eg: interacting with textboxes) may cause the UI visibility flags to be altered thus showing the navigaton bar and potentially the status bar
+            // Firing up the on-screen keyboard (eg: interacting with textboxes) may cause the UI visibility flags to be altered thus showing the navigation bar and potentially the status bar
             // This sets back the UI flags to hidden once the interaction with the on-screen keyboard has finished.
             Window.DecorView.SystemUiVisibilityChange += (_, e) =>
             {

--- a/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
+++ b/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
@@ -156,7 +156,7 @@ namespace osu.Framework.Android.Input
             if (Enum.TryParse(keyCode.ToString(), out Key key))
                 return key;
 
-            // this is the worst case senario. Please note that the osu-framework keyboard handling cannot cope with Key.Unknown.
+            // this is the worst case scenario. Please note that the osu-framework keyboard handling cannot cope with Key.Unknown.
             return Key.Unknown;
         }
 

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/Bird.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/Bird.cs
@@ -36,7 +36,7 @@ namespace FlappyDon.Game.Elements
             {
                 // Because the quad is rotated 45 degrees during animation and the collision
                 // event occurs when even the corner touches, shrink the collision box
-                // so that it more acdurately matches the bounds of the character on-screen.
+                // so that it more accurately matches the bounds of the character on-screen.
                 RectangleF rect = ScreenSpaceDrawQuad.AABBFloat;
                 rect = rect.Shrink(new Vector2(rect.Width * 0.3f, rect.Height * 0.2f));
                 return Quad.FromRectangle(rect);

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Audio.Sample
             }
         }
 
-        private double bassFreq => MathHelper.Clamp(initialFrequency * AggregateFrequency.Value, 100, 100000);
+        private double bassFreq => Math.Clamp(initialFrequency * AggregateFrequency.Value, 100, 100000);
 
         public override bool Looping
         {

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -4,7 +4,6 @@
 using System;
 using ManagedBass;
 using osu.Framework.Audio.Track;
-using osuTK;
 
 namespace osu.Framework.Audio.Sample
 {

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -341,7 +341,7 @@ namespace osu.Framework.Audio.Track
             public double HighIntensity;
 
             /// <summary>
-            /// Cconstructs a <see cref="Point"/>.
+            /// Constructs a <see cref="Point"/>.
             /// </summary>
             /// <param name="channels">The number of channels that contain data.</param>
             public Point(int channels)

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -351,7 +351,7 @@ namespace osu.Framework.Bindables
             Debug.Assert(isSupportedType());
 
             // Comparison between typeof(T) and type literals are treated as **constant** on value types.
-            // Code pathes for other types will be eliminated.
+            // Code paths for other types will be eliminated.
             if (typeof(T) == typeof(byte))
                 ((BindableNumber<byte>)(object)this).Value = val.ToByte(NumberFormatInfo.InvariantInfo);
             else if (typeof(T) == typeof(sbyte))

--- a/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
+++ b/osu.Framework/Extensions/ObjectExtensions/ObjectExtensions.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Extensions.ObjectExtensions
         /// Coerces a nullable object as non-nullable. This is an alternative to the C# 8 null-forgiving operator "<c>!</c>".
         /// </summary>
         /// <remarks>
-        /// This should only be used when when an assertion or other handling is not a reasonable alternative.
+        /// This should only be used when an assertion or other handling is not a reasonable alternative.
         /// </remarks>
         /// <param name="obj">The nullable object.</param>
         /// <typeparam name="T">The type of the object.</typeparam>

--- a/osu.Framework/Graphics/Containers/AudioContainer.cs
+++ b/osu.Framework/Graphics/Containers/AudioContainer.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Graphics.Containers
     /// <remarks>
     /// This is a bare-minimal implementation of a container, so it may be required to be nested inside a <see cref="Container"/> for some use cases.
     /// </remarks>
-    /// <typeparam name="T">The tyoe of <see cref="Drawable"/>.</typeparam>
+    /// <typeparam name="T">The type of <see cref="Drawable"/>.</typeparam>
     public class AudioContainer<T> : DrawableAudioWrapper, IContainerEnumerable<T>, IContainerCollection<T>, ICollection<T>, IReadOnlyList<T>
         where T : Drawable
     {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -633,7 +633,7 @@ namespace osu.Framework.Graphics.Containers
         /// Updates the life status of <see cref="InternalChildren"/> according to their
         /// <see cref="Drawable.ShouldBeAlive"/> property.
         /// </summary>
-        /// <returns>True if the life status of at least one child changed.</returns>
+        /// <returns>True iff the life status of at least one child changed.</returns>
         protected virtual bool UpdateChildrenLife()
         {
             // Can not have alive children if we are not loaded.

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Graphics.Containers
     [ExcludeFromDynamicCompile]
     public abstract partial class CompositeDrawable : Drawable
     {
-        #region Contruction and disposal
+        #region Construction and disposal
 
         /// <summary>
         /// Constructs a <see cref="CompositeDrawable"/> that stores children.
@@ -633,7 +633,7 @@ namespace osu.Framework.Graphics.Containers
         /// Updates the life status of <see cref="InternalChildren"/> according to their
         /// <see cref="Drawable.ShouldBeAlive"/> property.
         /// </summary>
-        /// <returns>True iff the life status of at least one child changed.</returns>
+        /// <returns>True if the life status of at least one child changed.</returns>
         protected virtual bool UpdateChildrenLife()
         {
             // Can not have alive children if we are not loaded.

--- a/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
+++ b/osu.Framework/Graphics/Containers/LifetimeManagementContainer.cs
@@ -360,7 +360,7 @@ namespace osu.Framework.Graphics.Containers
     }
 
     /// <summary>
-    /// Represents one of boudaries of lifetime interval.
+    /// Represents one of boundaries of lifetime interval.
     /// </summary>
     public enum LifetimeBoundaryKind
     {

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -209,7 +209,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Add an arbitrary <see cref="SpriteText"/> to this <see cref="TextFlowContainer"/>.
         /// While default creation parameters are applied automatically, word wrapping is unavailable for contained words.
-        /// This should only be used when a specialised <see cref="SpriteText"/> type is requried.
+        /// This should only be used when a specialised <see cref="SpriteText"/> type is required.
         /// </summary>
         /// <param name="text">The text to add.</param>
         /// <param name="creationParameters">A callback providing any <see cref="SpriteText" /> instances created for this new text.</param>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -200,7 +200,7 @@ namespace osu.Framework.Graphics
 
         /// <summary>
         /// Whether this Drawable is fully loaded.
-        /// This is true iff <see cref="UpdateSubTree"/> has run once on this <see cref="Drawable"/>.
+        /// This is true if <see cref="UpdateSubTree"/> has run once on this <see cref="Drawable"/>.
         /// </summary>
         public bool IsLoaded => loadState >= LoadState.Loaded;
 
@@ -1531,12 +1531,12 @@ namespace osu.Framework.Graphics
         internal virtual Drawable Original => this;
 
         /// <summary>
-        /// True iff <see cref="CreateProxy"/> has been called before.
+        /// True if <see cref="CreateProxy"/> has been called before.
         /// </summary>
         public bool HasProxy => proxy != null;
 
         /// <summary>
-        /// True iff this <see cref="Drawable"/> is not a proxy of any <see cref="Drawable"/>.
+        /// True if this <see cref="Drawable"/> is not a proxy of any <see cref="Drawable"/>.
         /// </summary>
         public bool IsProxy => Original != this;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -200,7 +200,7 @@ namespace osu.Framework.Graphics
 
         /// <summary>
         /// Whether this Drawable is fully loaded.
-        /// This is true if <see cref="UpdateSubTree"/> has run once on this <see cref="Drawable"/>.
+        /// This is true iff <see cref="UpdateSubTree"/> has run once on this <see cref="Drawable"/>.
         /// </summary>
         public bool IsLoaded => loadState >= LoadState.Loaded;
 
@@ -1531,12 +1531,12 @@ namespace osu.Framework.Graphics
         internal virtual Drawable Original => this;
 
         /// <summary>
-        /// True if <see cref="CreateProxy"/> has been called before.
+        /// True iff <see cref="CreateProxy"/> has been called before.
         /// </summary>
         public bool HasProxy => proxy != null;
 
         /// <summary>
-        /// True if this <see cref="Drawable"/> is not a proxy of any <see cref="Drawable"/>.
+        /// True iff this <see cref="Drawable"/> is not a proxy of any <see cref="Drawable"/>.
         /// </summary>
         public bool IsProxy => Original != this;
 

--- a/osu.Framework/Graphics/Primitives/Line.cs
+++ b/osu.Framework/Graphics/Primitives/Line.cs
@@ -98,7 +98,7 @@ namespace osu.Framework.Graphics.Primitives
         /// <summary>
         /// Intersects this line with another.
         /// </summary>
-        /// <param name="otherStart">The start point of the other line to intsersect with.</param>
+        /// <param name="otherStart">The start point of the other line to intersect with.</param>
         /// <param name="otherEnd">The end point of the other line to intersect with.</param>
         /// <param name="distance">The distance along this line at which the intersection occurs. To compute the point of intersection, <see cref="At"/>.</param>
         /// <returns>Whether the two lines intersect. An intersection may occur even if the two lines don't touch, at which point the parameter will be outside the [0, 1] range.</returns>

--- a/osu.Framework/Graphics/Primitives/RectangleF.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleF.cs
@@ -194,7 +194,7 @@ namespace osu.Framework.Graphics.Primitives
 
         /// <summary>
         /// Gets this <see cref="RectangleF"/> with positive width and height.
-        /// This is usefull if you have a <see cref="RectangleF"/> with negative <see cref="Width"/> or <see cref="Height"/>.
+        /// This is useful if you have a <see cref="RectangleF"/> with negative <see cref="Width"/> or <see cref="Height"/>.
         /// </summary>
         /// <example>
         /// var rect = new <see cref="RectangleF"/> { <see cref="Width"/> = -200, <see cref="Height"/> = -300 }

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -146,7 +146,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// Invokes <paramref name="originFunc"/> inside a <see cref="Transformable.BeginAbsoluteSequence(double, bool)"/>
         /// such that <see cref="ITransformable.TransformStartTime"/> is the current time of this <see cref="TransformSequence{T}"/>.
-        /// It is the respondibility of <paramref name="originFunc"/> to make appropriate use of <see cref="ITransformable.TransformStartTime"/>.
+        /// It is the responsibility of <paramref name="originFunc"/> to make appropriate use of <see cref="ITransformable.TransformStartTime"/>.
         /// </summary>
         /// <typeparam name="TResult">The return type of <paramref name="originFunc"/>.</typeparam>
         /// <param name="originFunc">The function to be invoked.</param>
@@ -163,7 +163,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <summary>
         /// Invokes <paramref name="originAction"/> inside a <see cref="Transformable.BeginAbsoluteSequence(double, bool)"/>
         /// such that <see cref="ITransformable.TransformStartTime"/> is the current time of this <see cref="TransformSequence{T}"/>.
-        /// It is the respondibility of <paramref name="originAction"/> to make appropriate use of <see cref="ITransformable.TransformStartTime"/>.
+        /// It is the responsibility of <paramref name="originAction"/> to make appropriate use of <see cref="ITransformable.TransformStartTime"/>.
         /// </summary>
         /// <param name="originAction">The function to be invoked.</param>
         /// <returns>This <see cref="TransformSequence{T}"/>.</returns>

--- a/osu.Framework/Input/Bindings/InputKey.cs
+++ b/osu.Framework/Input/Bindings/InputKey.cs
@@ -736,7 +736,7 @@ namespace osu.Framework.Input.Bindings
         ExtraMouseButton7 = 141,
 
         /// <summary>
-        /// The eigth extra mouse button.
+        /// The eighth extra mouse button.
         /// </summary>
         ExtraMouseButton8 = 142,
 

--- a/osu.Framework/Input/ButtonEventManager.cs
+++ b/osu.Framework/Input/ButtonEventManager.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Input
 
         /// <summary>
         /// The input queue for propagating button up events.
-        /// This is created from <see cref="InputQueue"/> when the the button is pressed.
+        /// This is created from <see cref="InputQueue"/> when the button is pressed.
         /// </summary>
         [CanBeNull]
         protected List<Drawable> ButtonDownInputQueue { get; private set; }

--- a/osu.Framework/Input/Events/DoubleClickEvent.cs
+++ b/osu.Framework/Input/Events/DoubleClickEvent.cs
@@ -8,7 +8,7 @@ using osuTK.Input;
 namespace osu.Framework.Input.Events
 {
     /// <summary>
-    /// An event represeting a mouse double click.
+    /// An event representing a mouse double click.
     /// </summary>
     public class DoubleClickEvent : MouseButtonEvent
     {

--- a/osu.Framework/Input/Events/DragEndEvent.cs
+++ b/osu.Framework/Input/Events/DragEndEvent.cs
@@ -8,7 +8,7 @@ using osuTK.Input;
 namespace osu.Framework.Input.Events
 {
     /// <summary>
-    /// An event represeting the end of a mouse drag.
+    /// An event representing the end of a mouse drag.
     /// Triggered when the mouse button used for dragging is released.
     /// </summary>
     public class DragEndEvent : MouseButtonEvent

--- a/osu.Framework/Input/Events/DragEvent.cs
+++ b/osu.Framework/Input/Events/DragEvent.cs
@@ -8,7 +8,7 @@ using osuTK.Input;
 namespace osu.Framework.Input.Events
 {
     /// <summary>
-    /// An event represeting a mouse drag.
+    /// An event representing a mouse drag.
     /// Triggered when mouse is moved while dragging.
     /// </summary>
     public class DragEvent : MouseButtonEvent

--- a/osu.Framework/Input/Events/DragStartEvent.cs
+++ b/osu.Framework/Input/Events/DragStartEvent.cs
@@ -8,7 +8,7 @@ using osuTK.Input;
 namespace osu.Framework.Input.Events
 {
     /// <summary>
-    /// An event represeting the start of a mouse drag.
+    /// An event representing the start of a mouse drag.
     /// </summary>
     public class DragStartEvent : MouseButtonEvent
     {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -289,7 +289,7 @@ namespace osu.Framework.Input
         /// <summary>
         /// Get the <see cref="JoystickAxisEventManager"/> responsible for a specified joystick axis.
         /// </summary>
-        /// <param name="source">The axis to find the the manager for.</param>
+        /// <param name="source">The axis to find the manager for.</param>
         /// <returns>The <see cref="JoystickAxisEventManager"/>.</returns>
         public JoystickAxisEventManager GetJoystickAxisEventManagerFor(JoystickAxisSource source)
         {

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -16,7 +16,7 @@ using osu.Framework.Threading;
 namespace osu.Framework.Platform
 {
     /// <summary>
-    /// Runs a game host in a specifc threading mode.
+    /// Runs a game host in a specific threading mode.
     /// </summary>
     public class ThreadRunner
     {

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Threading
         public bool HasPendingTasks => runQueue.Count > 0 || timedTasks.Count > 0 || perUpdateTasks.Count > 0;
 
         /// <summary>
-        /// The base thread is assumed to be the the thread on which the constructor is run.
+        /// The base thread is assumed to be the thread on which the constructor is run.
         /// </summary>
         public Scheduler()
         {
@@ -43,7 +43,7 @@ namespace osu.Framework.Threading
         }
 
         /// <summary>
-        /// The base thread is assumed to be the the thread on which the constructor is run.
+        /// The base thread is assumed to be the thread on which the constructor is run.
         /// </summary>
         public Scheduler(Func<bool> isCurrentThread, IClock clock)
         {

--- a/osu.Framework/Utils/Blur.cs
+++ b/osu.Framework/Utils/Blur.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Utils
         }
 
         /// <summary>
-        /// Finds the guassian blur kernel size where the magnitude of the gaussian distribution within the kernel
+        /// Finds the gaussian blur kernel size where the magnitude of the gaussian distribution within the kernel
         /// is greater than or equal to cutoffThreshold times the maximum of the distribution.
         /// </summary>
         /// <param name="sigma">Standard deviation of the distribution.</param>


### PR DESCRIPTION
Judging by https://github.com/ppy/osu/commit/da41b70d438108d09b058bdc05b8f6f93c8d1f19, replacing MathHelper with Math seems fine.