### PR TITLE
Fix BasicTabControl not working

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -28,6 +28,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         private StyledMultilineTabControl multilineTabControl;
         private StyledTabControl simpleTabcontrol;
         private StyledTabControl simpleTabcontrolNoSwitchOnRemove;
+        private BasicTabControl<TestEnum?> basicTabControl;
 
         public TestSceneTabControl()
         {
@@ -82,6 +83,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     {
                         Size = new Vector2(200, 30)
                     },
+                    basicTabControl = new BasicTabControl<TestEnum?>
+                    {
+                        Size = new Vector2(200, 20)
+                    }
                 }
             });
 
@@ -92,6 +97,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 multilineTabControl.AddItem(item);
                 switchingTabControl.AddItem(item);
                 withoutDropdownTabControl.AddItem(item);
+                basicTabControl.AddItem(item);
             }
 
             items.Take(7).ForEach(item => pinnedAndAutoSort.AddItem(item));

--- a/osu.Framework/Graphics/UserInterface/BasicDropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDropdown.cs
@@ -29,6 +29,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Foreground.Padding = new MarginPadding(5);
                 BackgroundColour = FrameworkColour.Green;
                 BackgroundColourHover = FrameworkColour.YellowGreen;
+
                 Children = new[]
                 {
                     label = new SpriteText

--- a/osu.Framework/Graphics/UserInterface/BasicTabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicTabControl.cs
@@ -61,13 +61,7 @@ namespace osu.Framework.Graphics.UserInterface
                     Foreground.RelativeSizeAxes = Axes.None;
                     Foreground.AutoSizeAxes = Axes.Both;
 
-                    Foreground.Children = new[]
-                    {
-                        new SpriteText
-                        {
-                            Text = "…",
-                        }
-                    };
+                    Foreground.Child = new SpriteText { Text = "…" };
                 }
             }
         }

--- a/osu.Framework/Graphics/UserInterface/BasicTabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicTabControl.cs
@@ -44,8 +44,31 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 Menu.Anchor = Anchor.TopRight;
                 Menu.Origin = Anchor.TopRight;
+
                 Header.Anchor = Anchor.TopRight;
                 Header.Origin = Anchor.TopRight;
+            }
+
+            protected override DropdownHeader CreateHeader() => new BasicTabControlDropdownHeader();
+
+            public class BasicTabControlDropdownHeader : BasicDropdownHeader
+            {
+                public BasicTabControlDropdownHeader()
+                {
+                    RelativeSizeAxes = Axes.None;
+                    AutoSizeAxes = Axes.X;
+
+                    Foreground.RelativeSizeAxes = Axes.None;
+                    Foreground.AutoSizeAxes = Axes.Both;
+
+                    Foreground.Children = new[]
+                    {
+                        new SpriteText
+                        {
+                            Text = "…",
+                        }
+                    };
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/3881

Added some basic styling that isn't a plain box like the "styled tab controls" already in the test:
![image](https://user-images.githubusercontent.com/1329837/92765459-50a59f00-f3d0-11ea-9278-0d526f8ed07e.png)

Side note: what the heck is this pattern? This is so inverse to how anything in the framework should work... `TabControl` + `Dropdown` are long due for a makeover.