### PR TITLE
Ensure async disposal threads are quiet before disposing game

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -351,6 +351,8 @@ namespace osu.Framework
 
         protected override void Dispose(bool isDisposing)
         {
+            RecycleSchedulers();
+
             // ensure any async disposals are completed before we begin to rip components out.
             // if we were to not wait, async disposals may throw unexpected exceptions.
             AsyncDisposalQueue.WaitForEmpty();


### PR DESCRIPTION
PRing this in a haphazard state for comment, and because I've lost most of my sanity while fixing up test issues.

Had this manifest in weird ways:

- Collection modified exception inside `UpdateTransforms` internals
- osu! FilterControl having null fields in orders that should be impossible

I'm having issues reproducing now that I'm actually trying, unfortunately. A good path forward would probably be checking my changes here and stating beyond doubt that it is *not* required as we have enough safety to ensure disposal of drawables can't happen while a load is still in progress. I don't believe it is, and as such resolved components may be ripped out from beneath still-loading-drawables.

Note that this is a very rare occurrence and does not deserve priority attention in review/testing, just wanted to get this PR'd for next time it comes up.