### PR TITLE
Reduce TextureStore lock contention

### DIFF
--- a/osu.Framework/Graphics/Textures/LargeTextureStore.cs
+++ b/osu.Framework/Graphics/Textures/LargeTextureStore.cs
@@ -34,13 +34,13 @@ namespace osu.Framework.Graphics.Textures
         /// <returns>The texture.</returns>
         public override Texture Get(string name, WrapMode wrapModeS, WrapMode wrapModeT)
         {
+            var tex = base.Get(name, wrapModeS, wrapModeT);
+
+            if (tex?.TextureGL == null)
+                return null;
+
             lock (referenceCountLock)
             {
-                var tex = base.Get(name, wrapModeS, wrapModeT);
-
-                if (tex?.TextureGL == null)
-                    return null;
-
                 if (!referenceCounts.TryGetValue(tex.LookupKey, out TextureWithRefCount.ReferenceCount count))
                     referenceCounts[tex.LookupKey] = count = new TextureWithRefCount.ReferenceCount(referenceCountLock, () => onAllReferencesLost(tex));
 

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -6,6 +6,7 @@ using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.IO.Stores;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Logging;
 using osuTK.Graphics.ES30;
@@ -15,7 +16,9 @@ namespace osu.Framework.Graphics.Textures
     public class TextureStore : ResourceStore<TextureUpload>
     {
         private readonly Dictionary<string, Texture> textureCache = new Dictionary<string, Texture>();
+
         private readonly object retrievalLock = new object();
+        private readonly ReaderWriterLockSlim textureLock = new ReaderWriterLockSlim();
 
         private readonly All filteringMode;
         private readonly bool manualMipmaps;
@@ -61,7 +64,11 @@ namespace osu.Framework.Graphics.Textures
             if (Atlas != null)
             {
                 if ((glTexture = Atlas.Add(upload.Width, upload.Height, wrapModeS, wrapModeT)) == null)
-                    Logger.Log($"Texture requested ({upload.Width}x{upload.Height}) which exceeds {nameof(TextureStore)}'s atlas size ({max_atlas_size}x{max_atlas_size}) - bypassing atlasing. Consider using {nameof(LargeTextureStore)}.", LoggingTarget.Performance);
+                {
+                    Logger.Log(
+                        $"Texture requested ({upload.Width}x{upload.Height}) which exceeds {nameof(TextureStore)}'s atlas size ({max_atlas_size}x{max_atlas_size}) - bypassing atlasing. Consider using {nameof(LargeTextureStore)}.",
+                        LoggingTarget.Performance);
+                }
             }
 
             glTexture ??= new TextureGLSingle(upload.Width, upload.Height, manualMipmaps, filteringMode, wrapModeS, wrapModeT);
@@ -86,7 +93,8 @@ namespace osu.Framework.Graphics.Textures
         /// <param name="wrapModeS">The texture wrap mode in horizontal direction.</param>
         /// <param name="wrapModeT">The texture wrap mode in vertical direction.</param>
         /// <returns>The texture.</returns>
-        public Task<Texture> GetAsync(string name, WrapMode wrapModeT, WrapMode wrapModeS) => Task.Run(() => Get(name, wrapModeS, wrapModeT)); // TODO: best effort. need to re-think textureCache data structure to fix this.
+        public Task<Texture> GetAsync(string name, WrapMode wrapModeT, WrapMode wrapModeS) =>
+            Task.Run(() => Get(name, wrapModeS, wrapModeT)); // TODO: best effort. need to re-think textureCache data structure to fix this.
 
         /// <summary>
         /// Retrieves a texture from the store and adds it to the atlas.
@@ -111,20 +119,32 @@ namespace osu.Framework.Graphics.Textures
             this.LogIfNonBackgroundThread(key);
 
             // Check if the texture exists in the cache.
-            lock (textureCache)
+            textureLock.EnterReadLock();
+
+            try
             {
                 if (textureCache.TryGetValue(key, out var tex))
                     return tex;
+            }
+            finally
+            {
+                textureLock.ExitReadLock();
             }
 
             // Take an exclusive lock on retrieval of the texture.
             lock (retrievalLock)
             {
-                // If another retrieval of the texture happened before us, we should check if the texture exists in the cache again.
-                lock (textureCache)
+                // If another retrieval of the texture happened before us, we should check if the texture exists in the cache again
+                textureLock.EnterReadLock();
+
+                try
                 {
                     if (textureCache.TryGetValue(key, out var tex))
                         return tex;
+                }
+                finally
+                {
+                    textureLock.ExitReadLock();
                 }
 
                 try
@@ -133,8 +153,16 @@ namespace osu.Framework.Graphics.Textures
                     if (tex != null)
                         tex.LookupKey = key;
 
-                    lock (textureCache)
+                    textureLock.EnterWriteLock();
+
+                    try
+                    {
                         textureCache[key] = tex;
+                    }
+                    finally
+                    {
+                        textureLock.ExitWriteLock();
+                    }
 
                     return tex;
                 }
@@ -153,17 +181,45 @@ namespace osu.Framework.Graphics.Textures
         /// <param name="texture">The texture to purge from the cache.</param>
         protected void Purge(Texture texture)
         {
-            lock (textureCache)
-            {
-                if (textureCache.TryGetValue(texture.LookupKey, out var tex))
-                {
-                    // we are doing this locally as right now, Textures don't dispose the underlying texture (leaving it to GC finalizers).
-                    // in the case of a purge operation we are pretty sure this is the intended behaviour.
-                    tex?.TextureGL?.Dispose();
-                    tex?.Dispose();
-                }
+            textureLock.EnterUpgradeableReadLock();
 
-                textureCache.Remove(texture.LookupKey);
+            try
+            {
+                if (!textureCache.TryGetValue(texture.LookupKey, out var tex))
+                    return;
+
+                // we are doing this locally as right now, Textures don't dispose the underlying texture (leaving it to GC finalizers).
+                // in the case of a purge operation we are pretty sure this is the intended behaviour.
+                tex?.TextureGL?.Dispose();
+                tex?.Dispose();
+
+                textureLock.EnterWriteLock();
+
+                try
+                {
+                    textureCache.Remove(texture.LookupKey);
+                }
+                finally
+                {
+                    textureLock.ExitWriteLock();
+                }
+            }
+            finally
+            {
+                textureLock.ExitUpgradeableReadLock();
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+
+            try
+            {
+                textureLock?.Dispose();
+            }
+            catch
+            {
             }
         }
     }


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu/pull/10229 (otherwise osu! will crash after exiting from gameplay)

This is pretty visible by scrolling through beatmap listing with https://github.com/ppy/osu-framework/pull/3894.

The contention occurs between `Get()` and `Purge()`, especially when online resources are involved.

Another level of locking has been added to ensure that only one retrieval is happening concurrently (preserves current behaviour) and that the lock on `textureCache` is taken for as short of a period as possible.