### PR TITLE
Improve performance of drawable disposal

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -105,10 +105,11 @@ namespace osu.Framework.Graphics
                 total_count.Value--;
 
                 Dispose(isDisposing);
-
                 UnbindAllBindables();
 
-                Parent = null;
+                // Bypass expensive operations as a result of setting the Parent property, by setting the field directly.
+                parent = null;
+                ChildID = 0;
 
                 OnUpdate = null;
                 Invalidated = null;


### PR DESCRIPTION
Hoisted out of https://github.com/ppy/osu-framework/pull/3894 because that PR needs more consideration.

Sets the parent field instead of the property, bypassing the invalidation which is unnecessary for all propagation sources (self, parent, child).

Explanation for why the propagate-invalidation-to-parent case is unnecessary: disposal can not occur unless either 1) the drawable is removed from the parent (i.e. the parent will have invalidated from elsewhere) or 2) the parent is also being disposed.

Before:
![Screenshot_2020-09-24_16-12-59](https://user-images.githubusercontent.com/1329837/94113196-7aa39a80-fe81-11ea-9563-b0b4c4db3ea9.png)

After:
![Screenshot_2020-09-24_16-15-05](https://user-images.githubusercontent.com/1329837/94113206-7d9e8b00-fe81-11ea-869a-fb6a662d1396.png)