### PR TITLE
Extract numeric type check to utils class from BindableNumber

### DIFF
--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.CompilerServices;
+using osu.Framework.Utils;
 
 namespace osu.Framework.Bindables
 {
@@ -23,7 +23,7 @@ namespace osu.Framework.Bindables
             // Directly comparing typeof(T) to type literal is recognized pattern of JIT and very fast.
             // Just a pointer comparison for reference types, or constant for value types.
             // The check will become NOP after optimization.
-            if (!isSupportedType())
+            if (!Validation.IsNumericType<T>())
             {
                 throw new NotSupportedException(
                     $"{nameof(BindableNumber<T>)} only accepts the primitive numeric types (except for {typeof(decimal).FullName}) as type arguments. You provided {typeof(T).FullName}.");
@@ -162,7 +162,7 @@ namespace osu.Framework.Bindables
         {
             get
             {
-                Debug.Assert(isSupportedType());
+                Debug.Assert(Validation.IsNumericType<T>());
 
                 if (typeof(T) == typeof(sbyte))
                     return (T)(object)sbyte.MinValue;
@@ -194,7 +194,7 @@ namespace osu.Framework.Bindables
         {
             get
             {
-                Debug.Assert(isSupportedType());
+                Debug.Assert(Validation.IsNumericType<T>());
 
                 if (typeof(T) == typeof(sbyte))
                     return (T)(object)sbyte.MaxValue;
@@ -226,6 +226,8 @@ namespace osu.Framework.Bindables
         {
             get
             {
+                Debug.Assert(Validation.IsNumericType<T>());
+
                 if (typeof(T) == typeof(sbyte))
                     return (T)(object)(sbyte)1;
                 if (typeof(T) == typeof(byte))
@@ -348,7 +350,7 @@ namespace osu.Framework.Bindables
         public void Set<TNewValue>(TNewValue val) where TNewValue : struct,
             IFormattable, IConvertible, IComparable<TNewValue>, IEquatable<TNewValue>
         {
-            Debug.Assert(isSupportedType());
+            Debug.Assert(Validation.IsNumericType<T>());
 
             // Comparison between typeof(T) and type literals are treated as **constant** on value types.
             // Code paths for other types will be eliminated.
@@ -377,7 +379,7 @@ namespace osu.Framework.Bindables
         public void Add<TNewValue>(TNewValue val) where TNewValue : struct,
             IFormattable, IConvertible, IComparable<TNewValue>, IEquatable<TNewValue>
         {
-            Debug.Assert(isSupportedType());
+            Debug.Assert(Validation.IsNumericType<T>());
 
             // Comparison between typeof(T) and type literals are treated as **constant** on value types.
             // Code pathes for other types will be eliminated.
@@ -460,18 +462,5 @@ namespace osu.Framework.Bindables
 
         private static T clamp(T value, T minValue, T maxValue)
             => max(minValue, min(maxValue, value));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool isSupportedType() =>
-            typeof(T) == typeof(sbyte)
-            || typeof(T) == typeof(byte)
-            || typeof(T) == typeof(short)
-            || typeof(T) == typeof(ushort)
-            || typeof(T) == typeof(int)
-            || typeof(T) == typeof(uint)
-            || typeof(T) == typeof(long)
-            || typeof(T) == typeof(ulong)
-            || typeof(T) == typeof(float)
-            || typeof(T) == typeof(double);
     }
 }

--- a/osu.Framework/Utils/Validation.cs
+++ b/osu.Framework/Utils/Validation.cs
@@ -26,19 +26,7 @@ namespace osu.Framework.Utils
         public static bool IsFinite(MarginPadding toCheck) => float.IsFinite(toCheck.Top) && float.IsFinite(toCheck.Bottom) && float.IsFinite(toCheck.Left) && float.IsFinite(toCheck.Right);
 
         /// <summary>
-        /// Returns whether the provided generic type <typeparamref name="T"/> is a numeric type, i.e. one of the following types:
-        /// <list type="bullet">
-        /// <item><description><see cref="sbyte"/></description></item>
-        /// <item><description><see cref="byte"/></description></item>
-        /// <item><description><see cref="short"/></description></item>
-        /// <item><description><see cref="ushort"/></description></item>
-        /// <item><description><see cref="int"/></description></item>
-        /// <item><description><see cref="uint"/></description></item>
-        /// <item><description><see cref="long"/></description></item>
-        /// <item><description><see cref="ulong"/></description></item>
-        /// <item><description><see cref="float"/></description></item>
-        /// <item><description><see cref="double"/></description></item>
-        /// </list>
+        /// Returns whether the provided generic type <typeparamref name="T"/> is a numeric type (except for <see cref="decimal"/>, <c>false</c> is returned for it).
         /// </summary>
         /// <typeparam name="T">The generic type to check with</typeparam>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/osu.Framework/Utils/Validation.cs
+++ b/osu.Framework/Utils/Validation.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Utils
         /// </summary>
         /// <typeparam name="T">The generic type to check with</typeparam>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsNumericType<T>() =>
+        internal static bool IsNumericType<T>() =>
             typeof(T) == typeof(sbyte)
             || typeof(T) == typeof(byte)
             || typeof(T) == typeof(short)

--- a/osu.Framework/Utils/Validation.cs
+++ b/osu.Framework/Utils/Validation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Runtime.CompilerServices;
 using osuTK;
 using osu.Framework.Graphics;
 
@@ -23,5 +24,34 @@ namespace osu.Framework.Utils
         /// <param name="toCheck">The <see cref="MarginPadding"/> to check.</param>
         /// <returns>False if either component of <paramref name="toCheck"/> are Infinity or NaN, true otherwise. </returns>
         public static bool IsFinite(MarginPadding toCheck) => float.IsFinite(toCheck.Top) && float.IsFinite(toCheck.Bottom) && float.IsFinite(toCheck.Left) && float.IsFinite(toCheck.Right);
+
+        /// <summary>
+        /// Returns whether the provided generic type <typeparamref name="T"/> is a numeric type, i.e. one of the following types:
+        /// <list type="bullet">
+        /// <item><description><see cref="sbyte"/></description></item>
+        /// <item><description><see cref="byte"/></description></item>
+        /// <item><description><see cref="short"/></description></item>
+        /// <item><description><see cref="ushort"/></description></item>
+        /// <item><description><see cref="int"/></description></item>
+        /// <item><description><see cref="uint"/></description></item>
+        /// <item><description><see cref="long"/></description></item>
+        /// <item><description><see cref="ulong"/></description></item>
+        /// <item><description><see cref="float"/></description></item>
+        /// <item><description><see cref="double"/></description></item>
+        /// </list>
+        /// </summary>
+        /// <typeparam name="T">The generic type to check with</typeparam>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNumericType<T>() =>
+            typeof(T) == typeof(sbyte)
+            || typeof(T) == typeof(byte)
+            || typeof(T) == typeof(short)
+            || typeof(T) == typeof(ushort)
+            || typeof(T) == typeof(int)
+            || typeof(T) == typeof(uint)
+            || typeof(T) == typeof(long)
+            || typeof(T) == typeof(ulong)
+            || typeof(T) == typeof(float)
+            || typeof(T) == typeof(double);
     }
 }


### PR DESCRIPTION
Required in another PR involving arithmetic operation between generic types, therefore I need to use this method there to shorten stuff and not copy-paste.