### PR TITLE
Fix offset-based position transform not respecting previous transforms

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkTransform.cs
+++ b/osu.Framework.Benchmarks/BenchmarkTransform.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.Benchmarks
                 throw new NotImplementedException();
             }
 
-            protected override void ReadIntoStartValue(Box d)
+            protected override void ReadValues(Box d)
             {
                 throw new NotImplementedException();
             }

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -408,6 +408,36 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkAtTime(750, box => box.Y == 0.375f);
         }
 
+        [Test]
+        public void TestMoveToOffsetRespectsRelevantTransforms()
+        {
+            boxTest(box =>
+            {
+                box.MoveToY(0.25f, 250);
+                box.Delay(500).MoveToOffset(new Vector2(0, 0.25f), 250);
+            });
+
+            checkAtTime(0, box => box.Y == 0);
+            checkAtTime(250, box => box.Y == 0.25f);
+            checkAtTime(500, box => box.Y == 0.25f);
+            checkAtTime(750, box => box.Y == 0.5f);
+        }
+
+        [Test]
+        public void TestMoveToOffsetRespectsTransformsOrder()
+        {
+            boxTest(box =>
+            {
+                box.Delay(500).MoveToOffset(new Vector2(0, 0.25f), 250);
+                box.MoveToY(0.25f, 250);
+            });
+
+            checkAtTime(0, box => box.Y == 0);
+            checkAtTime(250, box => box.Y == 0.25f);
+            checkAtTime(500, box => box.Y == 0.25f);
+            checkAtTime(750, box => box.Y == 0.5f);
+        }
+
         private Box box;
 
         private void checkAtTime(double time, Func<Box, bool> assert)

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.CompilerServices;
+using osu.Framework.Utils;
 
 namespace osu.Framework.Bindables
 {
@@ -23,7 +23,7 @@ namespace osu.Framework.Bindables
             // Directly comparing typeof(T) to type literal is recognized pattern of JIT and very fast.
             // Just a pointer comparison for reference types, or constant for value types.
             // The check will become NOP after optimization.
-            if (!isSupportedType())
+            if (!Validation.IsNumericType<T>())
             {
                 throw new NotSupportedException(
                     $"{nameof(BindableNumber<T>)} only accepts the primitive numeric types (except for {typeof(decimal).FullName}) as type arguments. You provided {typeof(T).FullName}.");
@@ -162,7 +162,7 @@ namespace osu.Framework.Bindables
         {
             get
             {
-                Debug.Assert(isSupportedType());
+                Debug.Assert(Validation.IsNumericType<T>());
 
                 if (typeof(T) == typeof(sbyte))
                     return (T)(object)sbyte.MinValue;
@@ -194,7 +194,7 @@ namespace osu.Framework.Bindables
         {
             get
             {
-                Debug.Assert(isSupportedType());
+                Debug.Assert(Validation.IsNumericType<T>());
 
                 if (typeof(T) == typeof(sbyte))
                     return (T)(object)sbyte.MaxValue;
@@ -226,6 +226,8 @@ namespace osu.Framework.Bindables
         {
             get
             {
+                Debug.Assert(Validation.IsNumericType<T>());
+
                 if (typeof(T) == typeof(sbyte))
                     return (T)(object)(sbyte)1;
                 if (typeof(T) == typeof(byte))
@@ -348,7 +350,7 @@ namespace osu.Framework.Bindables
         public void Set<TNewValue>(TNewValue val) where TNewValue : struct,
             IFormattable, IConvertible, IComparable<TNewValue>, IEquatable<TNewValue>
         {
-            Debug.Assert(isSupportedType());
+            Debug.Assert(Validation.IsNumericType<T>());
 
             // Comparison between typeof(T) and type literals are treated as **constant** on value types.
             // Code paths for other types will be eliminated.
@@ -377,7 +379,7 @@ namespace osu.Framework.Bindables
         public void Add<TNewValue>(TNewValue val) where TNewValue : struct,
             IFormattable, IConvertible, IComparable<TNewValue>, IEquatable<TNewValue>
         {
-            Debug.Assert(isSupportedType());
+            Debug.Assert(Validation.IsNumericType<T>());
 
             // Comparison between typeof(T) and type literals are treated as **constant** on value types.
             // Code pathes for other types will be eliminated.
@@ -460,18 +462,5 @@ namespace osu.Framework.Bindables
 
         private static T clamp(T value, T minValue, T maxValue)
             => max(minValue, min(maxValue, value));
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool isSupportedType() =>
-            typeof(T) == typeof(sbyte)
-            || typeof(T) == typeof(byte)
-            || typeof(T) == typeof(short)
-            || typeof(T) == typeof(ushort)
-            || typeof(T) == typeof(int)
-            || typeof(T) == typeof(uint)
-            || typeof(T) == typeof(long)
-            || typeof(T) == typeof(ulong)
-            || typeof(T) == typeof(float)
-            || typeof(T) == typeof(double);
     }
 }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1833,7 +1833,7 @@ namespace osu.Framework.Graphics.Containers
                     baseSize = newSize;
                 }
                 else
-                    this.TransformTo(this.PopulateTransform(new AutoSizeTransform { Rewindable = false }, newSize, duration, easing));
+                    this.TransformTo(this.PopulateTransform(new AutoSizeTransform(newSize) { Rewindable = false }, duration, easing));
             }
         }
 
@@ -1852,8 +1852,8 @@ namespace osu.Framework.Graphics.Containers
 
         private class AutoSizeTransform : TransformCustom<Vector2, CompositeDrawable>
         {
-            public AutoSizeTransform()
-                : base(nameof(baseSize))
+            public AutoSizeTransform(Vector2 newSize)
+                : base(nameof(baseSize), newSize)
             {
             }
         }

--- a/osu.Framework/Graphics/Containers/FlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FlowContainer.cs
@@ -183,7 +183,7 @@ namespace osu.Framework.Graphics.Containers
                 if (currentTargetPos != finalPos)
                 {
                     if (LayoutDuration > 0)
-                        d.TransformTo(d.PopulateTransform(new FlowTransform { Rewindable = false }, finalPos, LayoutDuration, LayoutEasing));
+                        d.TransformTo(d.PopulateTransform(new FlowTransform(finalPos) { Rewindable = false }, LayoutDuration, LayoutEasing));
                     else
                     {
                         if (existingTransform != null) d.ClearTransforms(false, nameof(FlowTransform));
@@ -220,8 +220,8 @@ namespace osu.Framework.Graphics.Containers
 
         private class FlowTransform : TransformCustom<Vector2, Drawable>
         {
-            public FlowTransform()
-                : base(nameof(Position))
+            public FlowTransform(Vector2 newPosition)
+                : base(nameof(Position), newPosition)
             {
             }
         }

--- a/osu.Framework/Graphics/TransformableExtensions.cs
+++ b/osu.Framework/Graphics/TransformableExtensions.cs
@@ -133,12 +133,11 @@ namespace osu.Framework.Graphics
         /// <typeparam name="TValue">The value type which is being transformed.</typeparam>
         /// <param name="t">The <see cref="ITransformable"/> the <see cref="Transform{TValue, T}"/> will be applied to.</param>
         /// <param name="transform">The transform to populate.</param>
-        /// <param name="newValue">The value to transform to.</param>
         /// <param name="duration">The transform duration.</param>
         /// <param name="easing">The transform easing to be used for tweening.</param>
         /// <returns>The populated <paramref name="transform"/>.</returns>
-        public static Transform<TValue, DefaultEasingFunction, TThis> PopulateTransform<TValue, TThis>(this TThis t, Transform<TValue, DefaultEasingFunction, TThis> transform, TValue newValue,
-                                                                                                       double duration = 0, Easing easing = Easing.None)
+        public static Transform<TValue, DefaultEasingFunction, TThis> PopulateTransform<TValue, TThis>(this TThis t, Transform<TValue, DefaultEasingFunction, TThis> transform, double duration = 0,
+                                                                                                       Easing easing = Easing.None)
             where TThis : class, ITransformable
             => t.PopulateTransform(transform, duration, new DefaultEasingFunction(easing));
 

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -142,10 +142,10 @@ namespace osu.Framework.Graphics.Transforms
                     }
                 }
 
-                if (!t.HasStartValue)
+                if (!t.HasReadValues)
                 {
-                    t.ReadIntoStartValue();
-                    t.HasStartValue = true;
+                    t.ReadValues();
+                    t.HasReadValues = true;
                 }
 
                 if (!t.AppliedToEnd)
@@ -172,7 +172,7 @@ namespace osu.Framework.Graphics.Transforms
 
                             t.AppliedToEnd = false;
                             t.Applied = false;
-                            t.HasStartValue = false;
+                            t.HasReadValues = false;
 
                             t.IsLooping = true;
 

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -303,6 +303,7 @@ namespace osu.Framework.Graphics.Transforms
 
             foreach (Transform t in toFlush)
             {
+                t.ReadValues();
                 t.Apply(t.EndTime);
                 t.OnComplete?.Invoke();
             }

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -82,7 +82,7 @@ namespace osu.Framework.Graphics.Transforms
     public abstract class Transform<TValue> : Transform
     {
         public TValue StartValue { get; protected set; }
-        public TValue EndValue { get; protected internal set; }
+        public TValue EndValue { get; protected set; }
     }
 
     public abstract class Transform<TValue, TEasing, T> : Transform<TValue>

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -50,9 +50,9 @@ namespace osu.Framework.Graphics.Transforms
 
         public abstract void Apply(double time);
 
-        public abstract void ReadIntoStartValue();
+        public abstract void ReadValues();
 
-        internal bool HasStartValue;
+        internal bool HasReadValues;
 
         public Action OnComplete;
 
@@ -101,11 +101,11 @@ namespace osu.Framework.Graphics.Transforms
             Applied = true;
         }
 
-        public sealed override void ReadIntoStartValue() => ReadIntoStartValue(Target);
+        public sealed override void ReadValues() => ReadValues(Target);
 
         protected abstract void Apply(T d, double time);
 
-        protected abstract void ReadIntoStartValue(T d);
+        protected abstract void ReadValues(T d);
 
         public override string ToString() => $"{Target.GetType().Name}.{TargetMember} {StartTime}-{EndTime}ms {StartValue} -> {EndValue}";
     }

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -13,11 +13,14 @@ namespace osu.Framework.Graphics.Transforms
         public override string TargetMember { get; }
 
         private readonly Bindable<TValue> targetBindable;
+        private readonly TValue newValue;
+
         private readonly InterpolationFunc<TValue, TEasing> interpolationFunc;
 
-        public TransformBindable(Bindable<TValue> targetBindable)
+        public TransformBindable(Bindable<TValue> targetBindable, TValue newValue)
         {
             this.targetBindable = targetBindable;
+            this.newValue = newValue;
 
             // Lambda expression is used so that the delegate is cached (see: https://github.com/dotnet/roslyn/issues/5835)
             interpolationFunc = (double d, TValue value, TValue tValue, double time, double endTime, in TEasing type)
@@ -35,6 +38,11 @@ namespace osu.Framework.Graphics.Transforms
         }
 
         protected override void Apply(T d, double time) => targetBindable.Value = valueAt(time);
-        protected override void ReadValues(T d) => StartValue = targetBindable.Value;
+
+        protected override void ReadValues(T d)
+        {
+            StartValue = targetBindable.Value;
+            EndValue = newValue;
+        }
     }
 }

--- a/osu.Framework/Graphics/Transforms/TransformBindable.cs
+++ b/osu.Framework/Graphics/Transforms/TransformBindable.cs
@@ -35,6 +35,6 @@ namespace osu.Framework.Graphics.Transforms
         }
 
         protected override void Apply(T d, double time) => targetBindable.Value = valueAt(time);
-        protected override void ReadIntoStartValue(T d) => StartValue = targetBindable.Value;
+        protected override void ReadValues(T d) => StartValue = targetBindable.Value;
     }
 }

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -185,7 +185,10 @@ namespace osu.Framework.Graphics.Transforms
 
         protected override void Apply(T d, double time) => accessor.Write(d, valueAt(time));
 
-        protected override void ReadIntoStartValue(T d) => StartValue = accessor.Read(d);
+        protected override void ReadValues(T d)
+        {
+            StartValue = accessor.Read(d);
+        }
     }
 
     internal class TransformCustom<TValue, T> : TransformCustom<TValue, DefaultEasingFunction, T>

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -162,7 +162,14 @@ namespace osu.Framework.Graphics.Transforms
         /// </summary>
         /// <param name="propertyOrFieldName">The property or field name to be operated upon.</param>
         /// <param name="grouping">An optional grouping, for a case where the target property can potentially conflict with others.</param>
-        public TransformCustom(string propertyOrFieldName, string grouping = null)
+        /// <param name="newValue">The value to transform to.</param>
+        public TransformCustom(string propertyOrFieldName, string grouping, TValue newValue)
+            : this(propertyOrFieldName, grouping)
+        {
+            this.newValue = newValue;
+        }
+
+        protected TransformCustom(string propertyOrFieldName, string grouping)
         {
             TargetMember = propertyOrFieldName;
             targetGrouping = grouping;

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -204,8 +204,8 @@ namespace osu.Framework.Graphics.Transforms
     internal class TransformCustom<TValue, T> : TransformCustom<TValue, DefaultEasingFunction, T>
         where T : class, ITransformable
     {
-        public TransformCustom(string propertyOrFieldName, string grouping = null)
-            : base(propertyOrFieldName, grouping)
+        public TransformCustom(string propertyOrFieldName, TValue newValue, string grouping = null)
+            : base(propertyOrFieldName, grouping, newValue)
         {
         }
     }

--- a/osu.Framework/Graphics/Transforms/TransformCustom.cs
+++ b/osu.Framework/Graphics/Transforms/TransformCustom.cs
@@ -25,6 +25,8 @@ namespace osu.Framework.Graphics.Transforms
 
         private readonly string targetGrouping;
 
+        private readonly TValue newValue;
+
         private delegate TValue ReadFunc(T transformable);
 
         private delegate void WriteFunc(T transformable, TValue value);
@@ -188,14 +190,15 @@ namespace osu.Framework.Graphics.Transforms
         protected override void ReadValues(T d)
         {
             StartValue = accessor.Read(d);
+            EndValue = newValue;
         }
     }
 
     internal class TransformCustom<TValue, T> : TransformCustom<TValue, DefaultEasingFunction, T>
         where T : class, ITransformable
     {
-        public TransformCustom(string propertyOrFieldName)
-            : base(propertyOrFieldName)
+        public TransformCustom(string propertyOrFieldName, string grouping = null)
+            : base(propertyOrFieldName, grouping)
         {
         }
     }

--- a/osu.Framework/Graphics/Transforms/TransformOffset.cs
+++ b/osu.Framework/Graphics/Transforms/TransformOffset.cs
@@ -1,0 +1,58 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using osu.Framework.Utils;
+using osuTK;
+
+namespace osu.Framework.Graphics.Transforms
+{
+    internal class TransformOffset<TValue, TEasing, T> : TransformCustom<TValue, TEasing, T>
+        where T : class, ITransformable
+        where TEasing : IEasingFunction
+    {
+        private readonly TValue offset;
+
+        public TransformOffset(string propertyOrFieldName, string grouping, TValue offset)
+            : base(propertyOrFieldName, grouping)
+        {
+            Debug.Assert(Validation.IsNumericType<TValue>() || typeof(TValue) == typeof(Vector2));
+
+            this.offset = offset;
+        }
+
+        protected override void ReadValues(T d)
+        {
+            base.ReadValues(d);
+
+            EndValue = sum(StartValue, offset);
+        }
+
+        private static TValue sum(TValue a, TValue b)
+        {
+            if (typeof(TValue) == typeof(Vector2))
+                return (TValue)(object)((Vector2)(object)a + (Vector2)(object)b);
+
+            if (typeof(TValue) == typeof(sbyte))
+                return (TValue)(object)((sbyte)(object)a + (sbyte)(object)b);
+            if (typeof(TValue) == typeof(byte))
+                return (TValue)(object)((byte)(object)a + (byte)(object)b);
+            if (typeof(TValue) == typeof(short))
+                return (TValue)(object)((short)(object)a + (short)(object)b);
+            if (typeof(TValue) == typeof(ushort))
+                return (TValue)(object)((ushort)(object)a + (ushort)(object)b);
+            if (typeof(TValue) == typeof(int))
+                return (TValue)(object)((int)(object)a + (int)(object)b);
+            if (typeof(TValue) == typeof(uint))
+                return (TValue)(object)((uint)(object)a + (uint)(object)b);
+            if (typeof(TValue) == typeof(long))
+                return (TValue)(object)((long)(object)a + (long)(object)b);
+            if (typeof(TValue) == typeof(ulong))
+                return (TValue)(object)((ulong)(object)a + (ulong)(object)b);
+            if (typeof(TValue) == typeof(float))
+                return (TValue)(object)((float)(object)a + (float)(object)b);
+
+            return (TValue)(object)((double)(object)a + (double)(object)b);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -187,7 +187,7 @@ namespace osu.Framework.Graphics.Transforms
                 t.OnAbort = null;
                 t.OnComplete = null;
 
-                if (!t.HasStartValue)
+                if (!t.HasReadValues)
                     t.TargetTransformable.RemoveTransform(t);
             }
 

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -289,6 +289,7 @@ namespace osu.Framework.Graphics.Transforms
 
             if (Clock == null)
             {
+                transform.ReadValues();
                 transform.Apply(transform.EndTime);
                 transform.OnComplete?.Invoke();
                 return;

--- a/osu.Framework/Utils/Validation.cs
+++ b/osu.Framework/Utils/Validation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Runtime.CompilerServices;
 using osuTK;
 using osu.Framework.Graphics;
 
@@ -23,5 +24,34 @@ namespace osu.Framework.Utils
         /// <param name="toCheck">The <see cref="MarginPadding"/> to check.</param>
         /// <returns>False if either component of <paramref name="toCheck"/> are Infinity or NaN, true otherwise. </returns>
         public static bool IsFinite(MarginPadding toCheck) => float.IsFinite(toCheck.Top) && float.IsFinite(toCheck.Bottom) && float.IsFinite(toCheck.Left) && float.IsFinite(toCheck.Right);
+
+        /// <summary>
+        /// Returns whether the provided generic type <typeparamref name="T"/> is a numeric type, i.e. one of the following types:
+        /// <list type="bullet">
+        /// <item><description><see cref="sbyte"/></description></item>
+        /// <item><description><see cref="byte"/></description></item>
+        /// <item><description><see cref="short"/></description></item>
+        /// <item><description><see cref="ushort"/></description></item>
+        /// <item><description><see cref="int"/></description></item>
+        /// <item><description><see cref="uint"/></description></item>
+        /// <item><description><see cref="long"/></description></item>
+        /// <item><description><see cref="ulong"/></description></item>
+        /// <item><description><see cref="float"/></description></item>
+        /// <item><description><see cref="double"/></description></item>
+        /// </list>
+        /// </summary>
+        /// <typeparam name="T">The generic type to check with</typeparam>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNumericType<T>() =>
+            typeof(T) == typeof(sbyte)
+            || typeof(T) == typeof(byte)
+            || typeof(T) == typeof(short)
+            || typeof(T) == typeof(ushort)
+            || typeof(T) == typeof(int)
+            || typeof(T) == typeof(uint)
+            || typeof(T) == typeof(long)
+            || typeof(T) == typeof(ulong)
+            || typeof(T) == typeof(float)
+            || typeof(T) == typeof(double);
     }
 }


### PR DESCRIPTION
Closes #3821 

- [ ] Depends on #3901

Basically `MoveToOffset` previously calculates the end value based off the current `Position` value **when the transform is first added** (i.e. when `MoveToOffset(...)` call is first executed), which is quite incorrect for cases mentioned in the linked issue (which is added to the test).

Therefore I fixed it by introducing a `TransformOffset` class that calculates the end value by the start value **when the start time of the transform has reached**.

---

# vNext

## `Transform.ReadIntoStartValue()` has been renamed to `ReadValues()`

Renamed as the latest changes were depending on not just reading into `StartValue`, but into `EndValue` as well. See https://github.com/ppy/osu-framework/pull/3902