### PR TITLE
Fix offset-based position transform not respecting previous transforms

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -408,6 +408,36 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkAtTime(750, box => box.Y == 0.375f);
         }
 
+        [Test]
+        public void TestMoveToOffsetRespectsRelevantTransforms()
+        {
+            boxTest(box =>
+            {
+                box.MoveToY(0.25f, 250);
+                box.Delay(500).MoveToOffset(new Vector2(0, 0.25f), 250);
+            });
+
+            checkAtTime(0, box => box.Y == 0);
+            checkAtTime(250, box => box.Y == 0.25f);
+            checkAtTime(500, box => box.Y == 0.25f);
+            checkAtTime(750, box => box.Y == 0.5f);
+        }
+
+        [Test]
+        public void TestMoveToOffsetRespectsTransformsOrder()
+        {
+            boxTest(box =>
+            {
+                box.Delay(500).MoveToOffset(new Vector2(0, 0.25f), 250);
+                box.MoveToY(0.25f, 250);
+            });
+
+            checkAtTime(0, box => box.Y == 0);
+            checkAtTime(250, box => box.Y == 0.25f);
+            checkAtTime(500, box => box.Y == 0.25f);
+            checkAtTime(750, box => box.Y == 0.5f);
+        }
+
         private Box box;
 
         private void checkAtTime(double time, Func<Box, bool> assert)

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -303,6 +303,7 @@ namespace osu.Framework.Graphics.Transforms
 
             foreach (Transform t in toFlush)
             {
+                t.ReadIntoStartValue();
                 t.Apply(t.EndTime);
                 t.OnComplete?.Invoke();
             }

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -303,7 +303,12 @@ namespace osu.Framework.Graphics.Transforms
 
             foreach (Transform t in toFlush)
             {
-                t.ReadIntoStartValue();
+                if (!t.HasStartValue)
+                {
+                    t.ReadIntoStartValue();
+                    t.HasStartValue = true;
+                }
+
                 t.Apply(t.EndTime);
                 t.OnComplete?.Invoke();
             }

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -289,6 +289,7 @@ namespace osu.Framework.Graphics.Transforms
 
             if (Clock == null)
             {
+                transform.ReadIntoStartValue();
                 transform.Apply(transform.EndTime);
                 transform.OnComplete?.Invoke();
                 return;

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -289,7 +289,12 @@ namespace osu.Framework.Graphics.Transforms
 
             if (Clock == null)
             {
-                transform.ReadIntoStartValue();
+                if (!transform.HasStartValue)
+                {
+                    transform.ReadIntoStartValue();
+                    transform.HasStartValue = true;
+                }
+
                 transform.Apply(transform.EndTime);
                 transform.OnComplete?.Invoke();
                 return;


### PR DESCRIPTION
Closes #3821
Supersedes #3902 

See https://github.com/ppy/osu-framework/pull/3902#issuecomment-699742964 for reason why superseded.

---

`ReadIntoStartValue()` is added before `Apply()` to fix cases where the position offset transform would be applied without its value being read, therefore leading to incorrect results. (as the commit says https://github.com/ppy/osu-framework/commit/1589926137f8e295bad6923bd939ea8af96d9c43)