### PR TITLE
Fix TextBox.OnCommit firing with incorrect "isNew" value after manual text change

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -202,12 +202,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     Text = "Default Text",
                     CommitOnFocusLost = commitOnFocusLost,
                     Size = new Vector2(500, 30),
-                    OnCommit = (_, newText) =>
-                    {
-                        commitCount++;
-                        wasNewText = newText;
-                    }
                 });
+
+                textBox.OnCommit += (_, newText) =>
+                {
+                    commitCount++;
+                    wasNewText = newText;
+                };
             });
 
             AddAssert("ensure no commits", () => commitCount == 0);

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBoxEvents.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBoxEvents.cs
@@ -15,6 +15,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
     {
         private EventQueuesTextBox textBox;
 
+        private const string default_text = "some default text";
+
         [SetUpSteps]
         public void SetUpSteps()
         {
@@ -23,7 +25,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 CommitOnFocusLost = true,
                 ReleaseFocusOnCommit = false,
                 Size = new Vector2(200, 40),
-                Text = "some default text",
+                Text = default_text,
             });
 
             AddStep("focus textbox", () =>
@@ -37,6 +39,28 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 textBox.MoveToEnd();
                 textBox.CaretMovedQueue.Dequeue();
             });
+        }
+
+        [Test]
+        public void TestCommitIsNewTextSecondTime()
+        {
+            AddStep("add handler to reset on commit", () => textBox.OnCommit += (sender, isNew) =>
+            {
+                if (!isNew)
+                    return;
+
+                textBox.Text = default_text;
+            });
+
+            AddStep("insert text", () => textBox.InsertString("temporary text"));
+            AddStep("press enter key for committing text", () => InputManager.Key(Key.Enter));
+            AddAssert("text committed event raised with new", () => textBox.CommittedTextQueue.Dequeue());
+            AddAssert("text is restored to default by event", () => textBox.Text == default_text);
+
+            AddStep("insert text", () => textBox.InsertString("temporary text"));
+            AddStep("press enter key for committing text", () => InputManager.Key(Key.Enter));
+            AddAssert("text committed event raised with new", () => textBox.CommittedTextQueue.Dequeue());
+            AddAssert("text is restored to default by event", () => textBox.Text == default_text);
         }
 
         [Test]

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -734,8 +734,6 @@ namespace osu.Framework.Graphics.UserInterface
 
         private string lastCommitText;
 
-        private bool hasNewComittableText => text != lastCommitText;
-
         private void killFocus()
         {
             var manager = GetContainingInputManager();
@@ -756,10 +754,11 @@ namespace osu.Framework.Graphics.UserInterface
                     return;
             }
 
-            OnTextCommitted(hasNewComittableText);
-            OnCommit?.Invoke(this, hasNewComittableText);
-
+            bool isNew = text != lastCommitText;
             lastCommitText = text;
+
+            OnTextCommitted(isNew);
+            OnCommit?.Invoke(this, isNew);
         }
 
         protected override void OnKeyUp(KeyUpEvent e)

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -84,7 +84,11 @@ namespace osu.Framework.Graphics.UserInterface
 
         public delegate void OnCommitHandler(TextBox sender, bool newText);
 
-        public OnCommitHandler OnCommit;
+        /// <summary>
+        /// Fired whenever text is committed via a user action.
+        /// This usually happens on pressing enter, but can also be triggered on focus loss automatically, via <see cref="CommitOnFocusLost"/>.
+        /// </summary>
+        public event OnCommitHandler OnCommit;
 
         private readonly Scheduler textUpdateScheduler = new Scheduler(() => ThreadSafety.IsUpdateThread, null);
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -223,13 +223,6 @@ namespace osu.Framework.Testing
                             {
                                 searchTextBox = new TestBrowserTextBox
                                 {
-                                    OnCommit = delegate
-                                    {
-                                        var firstTest = leftFlowContainer.Where(b => b.IsPresent).SelectMany(b => b.FilterableChildren).OfType<TestSubButton>()
-                                                                         .FirstOrDefault(b => b.MatchingFilter)?.TestType;
-                                        if (firstTest != null)
-                                            LoadTest(firstTest);
-                                    },
                                     Height = 25,
                                     RelativeSizeAxes = Axes.X,
                                     PlaceholderText = "type to search",
@@ -251,6 +244,14 @@ namespace osu.Framework.Testing
                         }
                     }
                 },
+            };
+
+            searchTextBox.OnCommit += delegate
+            {
+                var firstTest = leftFlowContainer.Where(b => b.IsPresent).SelectMany(b => b.FilterableChildren).OfType<TestSubButton>()
+                                                 .FirstOrDefault(b => b.MatchingFilter)?.TestType;
+                if (firstTest != null)
+                    LoadTest(firstTest);
             };
 
             searchTextBox.Current.ValueChanged += e => leftFlowContainer.SearchTerm = e.NewValue;


### PR DESCRIPTION
The text should make the issue self-explanatory. Also converts the `OnCommit` delegate to a proper `event` type.