### PR TITLE
Fix LargeTextureStore reference count race conditions

### DIFF
--- a/osu.Framework/Graphics/Textures/LargeTextureStore.cs
+++ b/osu.Framework/Graphics/Textures/LargeTextureStore.cs
@@ -4,9 +4,9 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
+using JetBrains.Annotations;
 using osu.Framework.IO.Stores;
 using osuTK.Graphics.ES30;
-using osu.Framework.Graphics.OpenGL.Textures;
 
 namespace osu.Framework.Graphics.Textures
 {
@@ -23,28 +23,38 @@ namespace osu.Framework.Graphics.Textures
         {
         }
 
-        /// <summary>
-        /// Retrieves a texture.
-        /// This texture should only be assigned once, as reference counting is being used internally.
-        /// If you wish to use the same texture multiple times, call this method an equal number of times.
-        /// </summary>
-        /// <param name="name">The name of the texture.</param>
-        /// <param name="wrapModeS">The horizontal wrap mode of the texture.</param>
-        /// <param name="wrapModeT">The vertical wrap mode of the texture.</param>
-        /// <returns>The texture.</returns>
-        public override Texture Get(string name, WrapMode wrapModeS, WrapMode wrapModeT)
+        protected override bool TryGetCached(string lookupKey, out Texture texture)
         {
-            var tex = base.Get(name, wrapModeS, wrapModeT);
+            lock (referenceCountLock)
+            {
+                if (base.TryGetCached(lookupKey, out var tex))
+                {
+                    texture = createTextureWithRefCount(lookupKey, tex);
+                    return true;
+                }
 
-            if (tex?.TextureGL == null)
+                texture = null;
+                return false;
+            }
+        }
+
+        protected override Texture CacheAndReturnTexture(string lookupKey, Texture texture)
+        {
+            lock (referenceCountLock)
+                return createTextureWithRefCount(lookupKey, base.CacheAndReturnTexture(lookupKey, texture));
+        }
+
+        private TextureWithRefCount createTextureWithRefCount([NotNull] string lookupKey, [CanBeNull] Texture baseTexture)
+        {
+            if (baseTexture == null)
                 return null;
 
             lock (referenceCountLock)
             {
-                if (!referenceCounts.TryGetValue(tex.LookupKey, out TextureWithRefCount.ReferenceCount count))
-                    referenceCounts[tex.LookupKey] = count = new TextureWithRefCount.ReferenceCount(referenceCountLock, () => onAllReferencesLost(tex));
+                if (!referenceCounts.TryGetValue(lookupKey, out TextureWithRefCount.ReferenceCount count))
+                    referenceCounts[lookupKey] = count = new TextureWithRefCount.ReferenceCount(referenceCountLock, () => onAllReferencesLost(baseTexture));
 
-                return new TextureWithRefCount(tex.TextureGL, count);
+                return new TextureWithRefCount(baseTexture.TextureGL, count);
             }
         }
 


### PR DESCRIPTION
The reduction in lock contention from https://github.com/ppy/osu-framework/pull/3895 brought in some race conditions centred around caching. This has failed a few of our CI runs: https://ci.appveyor.com/project/peppy/osu/builds/35530150/tests

I had 3 goals in mind:
1. Fix the race condition.
2. Maintain the performance improvements from that original PR.
3. Avoid deadlocks.

## Repro

The failures can be explored with the following repro:
```csharp
public class TestSceneTesting : FrameworkTestScene
{
    private LargeTextureStore largeStore;

    [BackgroundDependencyLoader]
    private void load(GameHost host, Game game)
    {
        largeStore = new LargeTextureStore(host.CreateTextureLoaderStore(new NamespacedResourceStore<byte[]>(game.Resources, @"Textures")));
    }

    [Test]
    public void RunTest()
    {
        AddStep("start threads", () =>
        {
            for (int i = 0; i < 2; i++)
            {
                new Thread(() =>
                {
                    while (true)
                    {
                        using (var tex = largeStore.Get("sample-texture"))
                            Assert.That(tex.Available);
                    }
                }).Start();
            }
        });

        AddWaitStep("keep alive", 100000000);
    }
}
```

There are two cases, which occur with both of the cached lookups. They both follow the same pattern, however their timings differ:

1. Thread 1 retrieves the non-cached texture
https://github.com/ppy/osu-framework/blob/3906554d22ebda815e48cbd72ec364a846fc9a81/osu.Framework/Graphics/Textures/TextureStore.cs#L132-L139
2. Thread 2 retrieves the cached texture (the timings differ slightly here depending on which cache path is taken)
https://github.com/ppy/osu-framework/blob/3906554d22ebda815e48cbd72ec364a846fc9a81/osu.Framework/Graphics/Textures/TextureStore.cs#L114-L118
3. Thread 1 continues to write the reference count, and return the texture to the user
https://github.com/ppy/osu-framework/blob/3906554d22ebda815e48cbd72ec364a846fc9a81/osu.Framework/Graphics/Textures/LargeTextureStore.cs#L42-L48
4. Thread 1 then disposes the texture. Thread 2 has not incremented the reference count yet so the texture gets purged immediately.
5. Thread 2 previously retrieved the texture but doesn't know it's been purged, so it continues on with making a reference count and returning the texture to the user, but it's now an invalid texture.

## Solution

The core of why this problem is happening is because cached texture retrieval does not take an exclusive lock over the reference count, so the texture could be returned while the reference count is being decremented.

My biggest concern was avoiding deadlock-y situations - it's easy to get into e.g. disposal tries taking the locks `referenceCountLock -> textureCache` (via `Purge()`) while a retrieval tries taking the locks `textureCache -> referenceCountLock`.  
By extracting the code that reads from/writes to the cache into virtual methods, I'm able to take direction-equivalent locks in `LargeTextureStore` (always `referenceCountLock -> textureCache`).

If the issue is related to cache retrieval, why is the cache write path also locked? If this wasn't the case, the issue would occur in reverse from the above - the thread with the cached texture disposes first:
1. Thread 1 takes a lock on `texutreCache`, writes the texture, releases the lock.
2. Thread 2 takes a lock on `referenceCountLock`, takes a lock on `textureCache`, retrieves texture from cache.
3. Thread 2 releases `textureCache` lock, writes reference count.
4. Thread 2 releases `referenceCountLock`, returns to the user, disposes texture. Thread 1 has not incremented the reference count yet so the texture gets purged immediately.
5. Thread 1 takes a lock on `referenceCountLock`, writes reference count (by this point the texture is purged).
6. Thread 1 releases `referenceCountLock` and returns the texture to the user (but it's now an invalid texture).

So writing to the cache must also be locked. This will replicate via the above repro, but it takes a few minutes to do so.

## Testing

I've run the test above for several hours and haven't seen a failure.