### PR TITLE
Expose sample length

### DIFF
--- a/osu.Framework/Audio/Sample/ISampleChannel.cs
+++ b/osu.Framework/Audio/Sample/ISampleChannel.cs
@@ -33,5 +33,10 @@ namespace osu.Framework.Audio.Sample
         /// States if this sample should repeat.
         /// </summary>
         bool Looping { get; set; }
+
+        /// <summary>
+        /// The length of the underlying sample, in milliseconds.
+        /// </summary>
+        double Length { get; }
     }
 }

--- a/osu.Framework/Audio/Sample/Sample.cs
+++ b/osu.Framework/Audio/Sample/Sample.cs
@@ -7,6 +7,11 @@ namespace osu.Framework.Audio.Sample
     {
         public const int DEFAULT_CONCURRENCY = 2;
 
+        /// <summary>
+        /// The length in milliseconds of this <see cref="Sample"/>.
+        /// </summary>
+        public double Length { get; protected set; }
+
         protected readonly int PlaybackConcurrency;
 
         /// <summary>

--- a/osu.Framework/Audio/Sample/SampleBass.cs
+++ b/osu.Framework/Audio/Sample/SampleBass.cs
@@ -59,6 +59,13 @@ namespace osu.Framework.Audio.Sample
 
         private int loadSample(byte[] data)
         {
+            int handle = getSampleHandle(data);
+            Length = Bass.ChannelBytes2Seconds(handle, data.Length) * 1000;
+            return handle;
+        }
+
+        private int getSampleHandle(byte[] data)
+        {
             const BassFlags flags = BassFlags.Default | BassFlags.SampleOverrideLongestPlaying;
 
             if (RuntimeInfo.SupportsJIT)

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -56,6 +56,11 @@ namespace osu.Framework.Audio.Sample
 
         public override bool IsAlive => base.IsAlive && !Played;
 
+        /// <summary>
+        /// The length of the underlying <see cref="Sample"/>, in milliseconds.
+        /// </summary>
+        public double Length => Sample.Length;
+
         public virtual ChannelAmplitudes CurrentAmplitudes { get; } = ChannelAmplitudes.Empty;
     }
 }

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -54,12 +54,9 @@ namespace osu.Framework.Audio.Sample
 
         public virtual bool Played => WasStarted && !Playing;
 
-        public override bool IsAlive => base.IsAlive && !Played;
-
-        /// <summary>
-        /// The length of the underlying <see cref="Sample"/>, in milliseconds.
-        /// </summary>
         public double Length => Sample.Length;
+
+        public override bool IsAlive => base.IsAlive && !Played;
 
         public virtual ChannelAmplitudes CurrentAmplitudes { get; } = ChannelAmplitudes.Empty;
     }

--- a/osu.Framework/Graphics/Audio/DrawableSample.cs
+++ b/osu.Framework/Graphics/Audio/DrawableSample.cs
@@ -38,9 +38,6 @@ namespace osu.Framework.Graphics.Audio
             set => channel.Looping = value;
         }
 
-        /// <summary>
-        /// The length of the sample in milliseconds.
-        /// </summary>
         public double Length => channel.Length;
 
         public ChannelAmplitudes CurrentAmplitudes => channel.CurrentAmplitudes;

--- a/osu.Framework/Graphics/Audio/DrawableSample.cs
+++ b/osu.Framework/Graphics/Audio/DrawableSample.cs
@@ -38,6 +38,11 @@ namespace osu.Framework.Graphics.Audio
             set => channel.Looping = value;
         }
 
+        /// <summary>
+        /// The length of the sample in milliseconds.
+        /// </summary>
+        public double Length => channel.Length;
+
         public ChannelAmplitudes CurrentAmplitudes => channel.CurrentAmplitudes;
     }
 }


### PR DESCRIPTION
PRing for potential use with ppy/osu#10358, albeit I'm not 100% convinced it will prove useful just yet.

# Summary

Expose the length of `Sample`s, `SampleChannel`s and `DrawableSample`s to framework consumers. The unit chosen to expose at is milliseconds, for consistency with other members (`Time.Current`, `Track.Length`).

# Remarks

`VirtualSample`s and `SampleChannelVirtual` instances will report a zero length by default.