### PR TITLE
Clear reference to dependencies aggressively on CompositeDrawable disposal

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -296,6 +296,7 @@ namespace osu.Framework.Graphics.Containers
             }
 
             OnAutoSize = null;
+            Dependencies = null;
             schedulerAfterChildren = null;
 
             base.Dispose(isDisposing);


### PR DESCRIPTION
While we'd like to say that reference leaks will never occur, when they do, having a reference to dependencies still live can cause a runaway scenario where the single reference leak can be holding references to a whole subtree for good.

Adding this as a failsafe avoids such scenarios.