### PR TITLE
Fix WaveformGraph bypassing parent colour

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneWaveform.cs
@@ -115,6 +115,20 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddUntilStep("wait for load", () => graph.Regenerated);
         }
 
+        [Test]
+        public void TestWaveformAlpha()
+        {
+            TestWaveform graph = null;
+
+            AddStep("create waveform", () => waveformContainer.Child = graph = new TestWaveform(track, 1)
+            {
+                Waveform = waveform,
+                Alpha = 0.5f,
+            });
+
+            AddUntilStep("wait for load", () => graph.Regenerated);
+        }
+
         private void startStop()
         {
             if (track.IsRunning)
@@ -154,7 +168,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                     {
                         RelativeSizeAxes = Axes.Both,
                         Resolution = resolution,
-                        Colour = new Color4(232, 78, 6, 255),
+                        BaseColour = new Color4(232, 78, 6, 255),
                         LowColour = new Color4(255, 232, 100, 255),
                         MidColour = new Color4(255, 153, 19, 255),
                         HighColour = new Color4(255, 46, 7, 255),

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -8,6 +8,7 @@ using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics.Batches;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shaders;
@@ -77,6 +78,26 @@ namespace osu.Framework.Graphics.Audio
 
                 waveform = value;
                 generate();
+            }
+        }
+
+        private Color4 baseColour = Color4.White;
+
+        /// <summary>
+        /// The base colour of the graph for frequencies that don't fall into the predefined low/mid/high buckets.
+        /// Also serves as the default value of <see cref="LowColour"/>, <see cref="MidColour"/>, and <see cref="HighColour"/>.
+        /// </summary>
+        public Color4 BaseColour
+        {
+            get => baseColour;
+            set
+            {
+                if (baseColour == value)
+                    return;
+
+                baseColour = value;
+
+                Invalidate(Invalidation.DrawNode);
             }
         }
 
@@ -232,6 +253,7 @@ namespace osu.Framework.Graphics.Audio
             private Vector2 drawSize;
             private int channels;
 
+            private Color4 baseColour;
             private Color4 lowColour;
             private Color4 midColour;
             private Color4 highColour;
@@ -265,9 +287,10 @@ namespace osu.Framework.Graphics.Audio
                 midMax = Source.resampledMaxMidIntensity;
                 lowMax = Source.resampledMaxLowIntensity;
 
-                lowColour = Source.lowColour ?? DrawColourInfo.Colour;
-                midColour = Source.midColour ?? DrawColourInfo.Colour;
-                highColour = Source.highColour ?? DrawColourInfo.Colour;
+                baseColour = Source.baseColour;
+                lowColour = Source.lowColour ?? baseColour;
+                midColour = Source.midColour ?? baseColour;
+                highColour = Source.highColour ?? baseColour;
             }
 
             private readonly QuadBatch<TexturedVertex2D> vertexBatch = new QuadBatch<TexturedVertex2D>(1000, 10);
@@ -302,14 +325,17 @@ namespace osu.Framework.Graphics.Audio
                     if (leftX > localMaskingRectangle.Right)
                         break; // X is always increasing
 
-                    Color4 colour = DrawColourInfo.Colour;
+                    Color4 frequencyColour = baseColour;
 
                     // colouring is applied in the order of interest to a viewer.
-                    colour = Interpolation.ValueAt(points[i].MidIntensity / midMax, colour, midColour, 0, 1);
+                    frequencyColour = Interpolation.ValueAt(points[i].MidIntensity / midMax, frequencyColour, midColour, 0, 1);
                     // high end (cymbal) can help find beat, so give it priority over mids.
-                    colour = Interpolation.ValueAt(points[i].HighIntensity / highMax, colour, highColour, 0, 1);
+                    frequencyColour = Interpolation.ValueAt(points[i].HighIntensity / highMax, frequencyColour, highColour, 0, 1);
                     // low end (bass drum) is generally the best visual aid for beat matching, so give it priority over high/mid.
-                    colour = Interpolation.ValueAt(points[i].LowIntensity / lowMax, colour, lowColour, 0, 1);
+                    frequencyColour = Interpolation.ValueAt(points[i].LowIntensity / lowMax, frequencyColour, lowColour, 0, 1);
+
+                    ColourInfo finalColour = DrawColourInfo.Colour;
+                    finalColour.ApplyChild(frequencyColour);
 
                     Quad quadToDraw;
 
@@ -341,7 +367,7 @@ namespace osu.Framework.Graphics.Audio
                     }
 
                     quadToDraw *= DrawInfo.Matrix;
-                    DrawQuad(texture, quadToDraw, colour, null, vertexBatch.AddAction, Vector2.Divide(localInflationAmount, quadToDraw.Size));
+                    DrawQuad(texture, quadToDraw, finalColour, null, vertexBatch.AddAction, Vector2.Divide(localInflationAmount, quadToDraw.Size));
                 }
 
                 shader.Unbind();


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/10460

Now respects alpha + parent colour.

# vNext

## `WaveformGraph.BaseColour` should be used instead of `Colour` for the default frequency colour

`Colour` now uniformly affects the entire graph as expected.