### PR TITLE
Fix LoadComponentAsync enumerating input enumerable multiple times

### DIFF
--- a/osu.Framework.Tests/Containers/TestSceneLoadComponentAsync.cs
+++ b/osu.Framework.Tests/Containers/TestSceneLoadComponentAsync.cs
@@ -18,6 +18,29 @@ namespace osu.Framework.Tests.Containers
     public class TestSceneLoadComponentAsync : FrameworkTestScene
     {
         [Test]
+        public void TestEnumerableOnlyInvokedOnce()
+        {
+            int invocationCount = 0;
+
+            IEnumerable<AsyncChildLoadingComposite> composite = getEnumerableComponent(() =>
+            {
+                invocationCount++;
+                return new AsyncChildLoadingComposite();
+            });
+
+            AddStep("load async", () => LoadComponentsAsync(composite, AddRange));
+
+            AddUntilStep("component loaded", () => Children.Count == 1);
+
+            AddAssert("invocation count is 1", () => invocationCount == 1);
+        }
+
+        private IEnumerable<AsyncChildLoadingComposite> getEnumerableComponent(Func<AsyncChildLoadingComposite> createComponent)
+        {
+            yield return createComponent();
+        }
+
+        [Test]
         public void TestUnpublishedChildDisposal()
         {
             AsyncChildLoadingComposite composite = null;

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -154,6 +154,8 @@ namespace osu.Framework.Graphics.Containers
             loadingComponents ??= new WeakList<Drawable>();
 
             var loadables = components.ToArray();
+            if (loadables.Length == 0)
+                return Task.CompletedTask;
 
             foreach (var d in loadables)
             {
@@ -166,9 +168,6 @@ namespace osu.Framework.Graphics.Containers
             return Task.Factory.StartNew(() => loadComponents(loadables, deps, true, linkedSource.Token), linkedSource.Token, TaskCreationOptions.HideScheduler, taskScheduler).ContinueWith(loaded =>
             {
                 var exception = loaded.Exception?.AsSingular();
-
-                if (!loaded.Result.Any())
-                    return;
 
                 if (linkedSource.Token.IsCancellationRequested)
                 {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -211,7 +211,6 @@ namespace osu.Framework.Graphics.Containers
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString());
 
-            // ReSharper disable once IteratorMethodResultIsIgnored (we don't care about the results here).
             loadComponents(components.ToList(), Dependencies, false);
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -216,18 +216,18 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Load the provided components.
+        /// Load the provided components. Any components which could not be loaded will be removed from the provided list.
         /// </summary>
         private void loadComponents<TLoadable>(List<TLoadable> components, IReadOnlyDependencyContainer dependencies, bool isDirectAsyncContext, CancellationToken cancellation = default)
             where TLoadable : Drawable
         {
-            foreach (var c in components)
+            for (var i = 0; i < components.Count; i++)
             {
                 if (cancellation.IsCancellationRequested)
                     break;
 
-                if (!c.LoadFromAsync(Clock, dependencies, isDirectAsyncContext))
-                    components.Remove(c);
+                if (!components[i].LoadFromAsync(Clock, dependencies, isDirectAsyncContext))
+                    components.Remove(components[i--]);
             }
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -154,8 +154,6 @@ namespace osu.Framework.Graphics.Containers
             loadingComponents ??= new WeakList<Drawable>();
 
             var loadables = components.ToArray();
-            if (loadables.Length == 0)
-                return Task.CompletedTask;
 
             foreach (var d in loadables)
             {
@@ -168,6 +166,9 @@ namespace osu.Framework.Graphics.Containers
             return Task.Factory.StartNew(() => loadComponents(loadables, deps, true, linkedSource.Token), linkedSource.Token, TaskCreationOptions.HideScheduler, taskScheduler).ContinueWith(loaded =>
             {
                 var exception = loaded.Exception?.AsSingular();
+
+                if (!loaded.Result.Any())
+                    return;
 
                 if (linkedSource.Token.IsCancellationRequested)
                 {


### PR DESCRIPTION
This is a huge oversight: calling `LoadComponentAsync` with a live `IEnumerable` will result in the provided drawable(s) being constructed multiple times. The final returned values are also not the loaded once, but fresh instances.

I've confirmed the test I added behaves per expectations on master / this branch, but I've somehow broken exceptions and reference retention with this change. PRing for feedback.