### PR TITLE
Remove custom SortedList<T> enumerator

### DIFF
--- a/osu.Framework.Tests/Lists/TestSortedList.cs
+++ b/osu.Framework.Tests/Lists/TestSortedList.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using osu.Framework.Lists;
 using NUnit.Framework;
@@ -82,6 +83,23 @@ namespace osu.Framework.Tests.Lists
             };
 
             Assert.IsTrue(list.IndexOf(10) >= 0);
+        }
+
+        [Test]
+        public void TestCollectionModifiedException()
+        {
+            var list = new SortedList<int>(Comparer<int>.Default)
+            {
+                10,
+                10,
+                10,
+            };
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                foreach (var _ in list)
+                    list.RemoveAt(list.Count - 1);
+            });
         }
     }
 }

--- a/osu.Framework/Lists/SortedList.cs
+++ b/osu.Framework/Lists/SortedList.cs
@@ -128,7 +128,7 @@ namespace osu.Framework.Lists
 
         void ICollection<T>.Add(T item) => Add(item);
 
-        public Enumerator GetEnumerator() => new Enumerator(this);
+        public List<T>.Enumerator GetEnumerator() => list.GetEnumerator();
 
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
 
@@ -146,30 +146,5 @@ namespace osu.Framework.Lists
         }
 
         #endregion
-
-        public struct Enumerator : IEnumerator<T>
-        {
-            private SortedList<T> list;
-            private int currentIndex;
-
-            internal Enumerator(SortedList<T> list)
-            {
-                this.list = list;
-                currentIndex = -1; // The first MoveNext() should bring the iterator to 0
-            }
-
-            public bool MoveNext() => ++currentIndex < list.Count;
-
-            public void Reset() => currentIndex = -1;
-
-            public readonly T Current => list[currentIndex];
-
-            readonly object IEnumerator.Current => Current;
-
-            public void Dispose()
-            {
-                list = null;
-            }
-        }
     }
 }


### PR DESCRIPTION
The `List<T>` enumerator has additional safety guards preventing against modifying the collection during enumeration. There was no reason for `SortedList<T>` to have a custom enumerator other than to prevent boxing, but `List<T>.Enumerator` is already exposed for that purpose.