### PR TITLE
Remove BindableList<T> enumerator allocations

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkBindableList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkBindableList.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Benchmarks
     [MemoryDiagnoser]
     public class BenchmarkBindableList
     {
-        private BindableList<int> list = new BindableList<int>();
+        private readonly BindableList<int> list = new BindableList<int>();
 
         [GlobalSetup]
         public void GlobalSetup()

--- a/osu.Framework.Benchmarks/BenchmarkBindableList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkBindableList.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkBindableList
+    {
+        private BindableList<int> list = new BindableList<int>();
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            for (int i = 0; i < 10; i++)
+                list.Add(i);
+        }
+
+        [Benchmark]
+        public int Enumerate()
+        {
+            int result = 0;
+
+            for (int i = 0; i < 100; i++)
+            {
+                foreach (var val in list)
+                    result += val;
+            }
+
+            return result;
+        }
+    }
+}

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -639,11 +639,11 @@ namespace osu.Framework.Bindables
 
         #region IEnumerable
 
-        public IEnumerator<T> GetEnumerator()
-            => collection.GetEnumerator();
+        public List<T>.Enumerator GetEnumerator() => collection.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator()
-            => GetEnumerator();
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         #endregion IEnumerable
 


### PR DESCRIPTION
For the rare case when someone may enumerate a `BindableList<T>`.

```diff
  |    Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
  |---------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
- | Enumerate | 8.641 us | 0.1626 us | 0.1597 us | 0.1068 |     - |     - |   3.91 KB |
+ | Enumerate | 2.360 us | 0.0106 us | 0.0083 us |      - |     - |     - |         - |
```