### PR TITLE
Implement precise scrolling for SDL

### DIFF
--- a/osu.Framework/Platform/DesktopWindow.cs
+++ b/osu.Framework/Platform/DesktopWindow.cs
@@ -19,6 +19,7 @@ namespace osu.Framework.Platform
 {
     /// <summary>
     /// Implementation of <see cref="Window"/> used for desktop platforms.
+    /// Uses <see cref="Sdl2WindowBackend"/> and <see cref="Sdl2GraphicsBackend"/> by default.
     /// </summary>
     public class DesktopWindow : Window
     {
@@ -66,14 +67,8 @@ namespace osu.Framework.Platform
             }
         }
 
-        /// <summary>
-        /// Initialises a window for desktop platforms.
-        /// Uses <see cref="Sdl2WindowBackend"/> and <see cref="Sdl2GraphicsBackend"/>.
-        /// </summary>
-        public DesktopWindow()
-            : base(new Sdl2WindowBackend(), new Sdl2GraphicsBackend())
-        {
-        }
+        protected override IWindowBackend CreateWindowBackend() => new Sdl2WindowBackend();
+        protected override IGraphicsBackend CreateGraphicsBackend() => new Sdl2GraphicsBackend();
 
         public override void SetupWindow(FrameworkConfigManager config)
         {

--- a/osu.Framework/Platform/MacOS/MacOSDesktopWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSDesktopWindow.cs
@@ -1,0 +1,10 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Platform.MacOS
+{
+    public class MacOSDesktopWindow : DesktopWindow
+    {
+        protected override IWindowBackend CreateWindowBackend() => new MacOSWindowBackend();
+    }
+}

--- a/osu.Framework/Platform/MacOS/MacOSDesktopWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSDesktopWindow.cs
@@ -3,6 +3,10 @@
 
 namespace osu.Framework.Platform.MacOS
 {
+    /// <summary>
+    /// macOS-specific subclass of <see cref="DesktopWindow"/> that specifies a custom
+    /// <see cref="IWindowBackend"/>.
+    /// </summary>
     public class MacOSDesktopWindow : DesktopWindow
     {
         protected override IWindowBackend CreateWindowBackend() => new MacOSWindowBackend();

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Platform.MacOS
         }
 
         protected override IWindow CreateWindow() =>
-            !UseSdl ? (IWindow)new MacOSGameWindow() : new DesktopWindow();
+            !UseSdl ? (IWindow)new MacOSGameWindow() : new MacOSDesktopWindow();
 
         public override string UserStoragePath
         {

--- a/osu.Framework/Platform/MacOS/MacOSWindowBackend.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindowBackend.cs
@@ -51,8 +51,10 @@ namespace osu.Framework.Platform.MacOS
 
             // according to osuTK, 0.1f is the scaling factor expected to be returned by CGEventSourceGetPixelsPerLine
             const float scale_factor = 0.1f;
-            var scrollingDeltaX = Cocoa.SendFloat(theEvent, sel_scrollingdeltax);
-            var scrollingDeltaY = Cocoa.SendFloat(theEvent, sel_scrollingdeltay);
+
+            float scrollingDeltaX = Cocoa.SendFloat(theEvent, sel_scrollingdeltax);
+            float scrollingDeltaY = Cocoa.SendFloat(theEvent, sel_scrollingdeltay);
+
             ScheduleEvent(() => OnMouseWheel(new Vector2(scrollingDeltaX * scale_factor, scrollingDeltaY * scale_factor), true));
         }
     }

--- a/osu.Framework/Platform/MacOS/MacOSWindowBackend.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindowBackend.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Platform.MacOS.Native;
+using osu.Framework.Platform.Sdl;
+using osuTK;
+
+namespace osu.Framework.Platform.MacOS
+{
+    public class MacOSWindowBackend : Sdl2WindowBackend
+    {
+        private static readonly IntPtr sel_hasprecisescrollingdeltas = Selector.Get("hasPreciseScrollingDeltas");
+        private static readonly IntPtr sel_scrollingdeltax = Selector.Get("scrollingDeltaX");
+        private static readonly IntPtr sel_scrollingdeltay = Selector.Get("scrollingDeltaY");
+        private static readonly IntPtr sel_respondstoselector_ = Selector.Get("respondsToSelector:");
+
+        private delegate void ScrollWheelDelegate(IntPtr handle, IntPtr selector, IntPtr theEvent); // v@:@
+
+        private IntPtr swizzledScrollWheel;
+        private ScrollWheelDelegate scrollWheelHandler;
+
+        public override void Create()
+        {
+            base.Create();
+
+            var viewClass = Class.Get("SDLView");
+            scrollWheelHandler = scrollWheel;
+            swizzledScrollWheel = Class.SwizzleMethod(viewClass, "scrollWheel:", "v@:@", scrollWheelHandler);
+        }
+
+        private void scrollWheel(IntPtr handle, IntPtr selector, IntPtr theEvent)
+        {
+            var hasPrecise = Cocoa.SendBool(theEvent, sel_respondstoselector_, sel_hasprecisescrollingdeltas) && Cocoa.SendBool(theEvent, sel_hasprecisescrollingdeltas);
+
+            if (hasPrecise)
+            {
+                const float scale_factor = 0.1f;
+                var scrollingDeltaX = Cocoa.SendFloat(theEvent, sel_scrollingdeltax);
+                var scrollingDeltaY = Cocoa.SendFloat(theEvent, sel_scrollingdeltay);
+                OnMouseWheel(new Vector2(scrollingDeltaX * scale_factor, scrollingDeltaY * scale_factor), true);
+            }
+            else
+                Cocoa.SendVoid(handle, swizzledScrollWheel, theEvent);
+        }
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/Class.cs
+++ b/osu.Framework/Platform/MacOS/Native/Class.cs
@@ -29,26 +29,28 @@ namespace osu.Framework.Platform.MacOS.Native
             return id;
         }
 
-        public static void RegisterMethod(IntPtr handle, Delegate d, string selector, string typeString) =>
-            class_replaceMethod(handle, Selector.Get(selector), Marshal.GetFunctionPointerForDelegate(d), typeString);
+        public static void RegisterMethod(IntPtr handle, Delegate action, string selector, string typeString) =>
+            class_replaceMethod(handle, Selector.Get(selector), Marshal.GetFunctionPointerForDelegate(action), typeString);
 
         /// <summary>
         /// Performs method swizzling for a given selector, using a given delegate implementation.
+        /// </summary>
+        /// <remarks>
         /// This essentially adds a new Objective-C method, then swaps the implementation with an existing one.
         /// Returns a selector to the newly registered method, which has the original implementation of
         /// <paramref name="selector"/> before swizzling.
         /// https://nshipster.com/method-swizzling/
-        /// </summary>
+        /// </remarks>
         /// <param name="classHandle">The Objective-C class which should have a method swizzled.</param>
         /// <param name="selector">The selector to swizzle.</param>
         /// <param name="typeString">The type encoding of the selector.</param>
-        /// <param name="d">The delegate to use as the new implementation.</param>
+        /// <param name="action">The delegate to use as the new implementation.</param>
         /// <returns>A selector for the newly registered method, containing the old implementation.</returns>
-        public static IntPtr SwizzleMethod(IntPtr classHandle, string selector, string typeString, Delegate d)
+        public static IntPtr SwizzleMethod(IntPtr classHandle, string selector, string typeString, Delegate action)
         {
             var targetSelector = Selector.Get(selector);
             var targetMethod = class_getInstanceMethod(classHandle, targetSelector);
-            var newMethodImplementation = Marshal.GetFunctionPointerForDelegate(d);
+            var newMethodImplementation = Marshal.GetFunctionPointerForDelegate(action);
             var newSelector = Selector.Get($"orig_{selector}");
             class_replaceMethod(classHandle, newSelector, newMethodImplementation, typeString);
             var newMethod = class_getInstanceMethod(classHandle, newSelector);

--- a/osu.Framework/Platform/MacOS/Native/Class.cs
+++ b/osu.Framework/Platform/MacOS/Native/Class.cs
@@ -9,16 +9,10 @@ namespace osu.Framework.Platform.MacOS.Native
     internal static class Class
     {
         [DllImport(Cocoa.LIB_OBJ_C)]
-        private static extern IntPtr class_getName(IntPtr handle);
-
-        [DllImport(Cocoa.LIB_OBJ_C)]
         private static extern IntPtr class_replaceMethod(IntPtr classHandle, IntPtr selector, IntPtr method, string types);
 
         [DllImport(Cocoa.LIB_OBJ_C)]
         private static extern IntPtr class_getInstanceMethod(IntPtr classHandle, IntPtr selector);
-
-        [DllImport(Cocoa.LIB_OBJ_C)]
-        private static extern IntPtr method_getImplementation(IntPtr method);
 
         [DllImport(Cocoa.LIB_OBJ_C)]
         private static extern void method_exchangeImplementations(IntPtr method1, IntPtr method2);

--- a/osu.Framework/Platform/MacOS/Native/Class.cs
+++ b/osu.Framework/Platform/MacOS/Native/Class.cs
@@ -38,6 +38,18 @@ namespace osu.Framework.Platform.MacOS.Native
         public static void RegisterMethod(IntPtr handle, Delegate d, string selector, string typeString) =>
             class_replaceMethod(handle, Selector.Get(selector), Marshal.GetFunctionPointerForDelegate(d), typeString);
 
+        /// <summary>
+        /// Performs method swizzling for a given selector, using a given delegate implementation.
+        /// This essentially adds a new Objective-C method, then swaps the implementation with an existing one.
+        /// Returns a selector to the newly registered method, which has the original implementation of
+        /// <paramref name="selector"/> before swizzling.
+        /// https://nshipster.com/method-swizzling/
+        /// </summary>
+        /// <param name="classHandle">The Objective-C class which should have a method swizzled.</param>
+        /// <param name="selector">The selector to swizzle.</param>
+        /// <param name="typeString">The type encoding of the selector.</param>
+        /// <param name="d">The delegate to use as the new implementation.</param>
+        /// <returns>A selector for the newly registered method, containing the old implementation.</returns>
         public static IntPtr SwizzleMethod(IntPtr classHandle, string selector, string typeString, Delegate d)
         {
             var targetSelector = Selector.Get(selector);

--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -69,6 +69,13 @@ namespace osu.Framework.Platform.MacOS.Native
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern void SendVoid(IntPtr receiver, IntPtr selector, IntPtr intPtr1, IntPtr intPtr2, IntPtr intPtr3, IntPtr intPtr4);
 
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend_fpret")]
+        public static extern float SendFloat_i386(IntPtr receiver, IntPtr selector);
+
+        // On x64 using selector that return CGFloat give you 64 bit == double
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern double SendFloat_x64(IntPtr receiver, IntPtr selector);
+
         public static IntPtr AppKitLibrary;
 
         [DllImport(LIB_CORE_GRAPHICS, EntryPoint = "CGCursorIsVisible")]
@@ -109,5 +116,7 @@ namespace osu.Framework.Platform.MacOS.Native
             IntPtr ptr = dlsym(handle, symbol);
             return ptr == IntPtr.Zero ? IntPtr.Zero : Marshal.ReadIntPtr(ptr);
         }
+
+        public static float SendFloat(IntPtr receiver, IntPtr selector) => IntPtr.Size == 4 ? SendFloat_i386(receiver, selector) : (float)SendFloat_x64(receiver, selector);
     }
 }

--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -40,12 +40,6 @@ namespace osu.Framework.Platform.MacOS.Native
         public static extern uint SendUint(IntPtr receiver, IntPtr selector);
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
-        public static extern int SendInt(IntPtr receiver, IntPtr selector, IntPtr ptr1);
-
-        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
-        public static extern int SendInt(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
-
-        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern bool SendBool(IntPtr receiver, IntPtr selector);
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
@@ -55,16 +49,10 @@ namespace osu.Framework.Platform.MacOS.Native
         public static extern bool SendBool(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
-        public static extern void SendVoid(IntPtr receiver, IntPtr selector);
-
-        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern void SendVoid(IntPtr receiver, IntPtr selector, uint arg);
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern void SendVoid(IntPtr receiver, IntPtr selector, IntPtr ptr1);
-
-        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
-        public static extern void SendVoid(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern void SendVoid(IntPtr receiver, IntPtr selector, IntPtr intPtr1, IntPtr intPtr2, IntPtr intPtr3, IntPtr intPtr4);

--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -72,9 +72,10 @@ namespace osu.Framework.Platform.MacOS.Native
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend_fpret")]
         public static extern float SendFloat_i386(IntPtr receiver, IntPtr selector);
 
-        // On x64 using selector that return CGFloat give you 64 bit == double
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern double SendFloat_x64(IntPtr receiver, IntPtr selector);
+
+        public static float SendFloat(IntPtr receiver, IntPtr selector) => IntPtr.Size == 4 ? SendFloat_i386(receiver, selector) : (float)SendFloat_x64(receiver, selector);
 
         public static IntPtr AppKitLibrary;
 
@@ -116,7 +117,5 @@ namespace osu.Framework.Platform.MacOS.Native
             IntPtr ptr = dlsym(handle, symbol);
             return ptr == IntPtr.Zero ? IntPtr.Zero : Marshal.ReadIntPtr(ptr);
         }
-
-        public static float SendFloat(IntPtr receiver, IntPtr selector) => IntPtr.Size == 4 ? SendFloat_i386(receiver, selector) : (float)SendFloat_x64(receiver, selector);
     }
 }

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -247,7 +247,14 @@ namespace osu.Framework.Platform
 
         #endregion
 
+        /// <summary>
+        /// Creates an instance of <see cref="IWindowBackend"/> for the platform.
+        /// </summary>
         protected abstract IWindowBackend CreateWindowBackend();
+
+        /// <summary>
+        /// Creates an instance of <see cref="IGraphicsBackend"/> for the platform.
+        /// </summary>
         protected abstract IGraphicsBackend CreateGraphicsBackend();
 
         protected Window()

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Platform
     /// Implementation of <see cref="IWindow"/> that provides bindables and
     /// delegates responsibility to window and graphics backends.
     /// </summary>
-    public class Window : IWindow
+    public abstract class Window : IWindow
     {
         protected readonly IWindowBackend WindowBackend;
         protected readonly IGraphicsBackend GraphicsBackend;
@@ -247,17 +247,13 @@ namespace osu.Framework.Platform
 
         #endregion
 
-        #region Constructors
+        protected abstract IWindowBackend CreateWindowBackend();
+        protected abstract IGraphicsBackend CreateGraphicsBackend();
 
-        /// <summary>
-        /// Creates a new <see cref="Window"/> using the specified window and graphics backends.
-        /// </summary>
-        /// <param name="windowBackend">The <see cref="IWindowBackend"/> to use.</param>
-        /// <param name="graphicsBackend">The <see cref="IGraphicsBackend"/> to use.</param>
-        public Window(IWindowBackend windowBackend, IGraphicsBackend graphicsBackend)
+        protected Window()
         {
-            WindowBackend = windowBackend;
-            GraphicsBackend = graphicsBackend;
+            WindowBackend = CreateWindowBackend();
+            GraphicsBackend = CreateGraphicsBackend();
 
             SupportedWindowModes = new BindableList<WindowMode>(DefaultSupportedWindowModes);
 
@@ -292,10 +288,6 @@ namespace osu.Framework.Platform
                     OnMouseLeft();
             };
         }
-
-        #endregion
-
-        #region Methods
 
         /// <summary>
         /// Starts the window's run loop.
@@ -374,8 +366,6 @@ namespace osu.Framework.Platform
             if (!OnExitRequested())
                 WindowBackend.Close();
         }
-
-        #endregion
 
         #region Bindable Handling
 


### PR DESCRIPTION
Adds support for "precise" scrolling on macOS for the SDL backend.

Due to the way SDL handles scroll wheel events on macOS, the precise deltas in the `NSEvent` are ignored.  Unfortunately, the originating `NSEvent` is not available to us anywhere in the SDL event loop itself.

To solve this, we swizzle out `[SDLView scrollWheel:(NSEvent *)]` to use our own custom function that handles precision deltas.  If precision deltas are unavailable (due to using a physical notched scroll wheel rather than a trackpad), it calls the original implementation of the method.

The logic for converting and scaling precise deltas is the same as that in osuTK's `CocoaNativeWindow`.

Instantiation of `IWindowBackend` and `IGraphicsBackend` have been moved to abstract methods rather than being passed down through constructors.