### PR TITLE
Allow DelayedLoadWrapper to late-construct its content

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
@@ -9,6 +9,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
 using osuTK;
 using osuTK.Graphics;
 
@@ -16,17 +17,16 @@ namespace osu.Framework.Tests.Visual.Drawables
 {
     public class TestSceneDelayedLoadWrapper : FrameworkTestScene
     {
+        private FillFlowContainer<Container> flow;
+        private TestSceneDelayedLoadUnloadWrapper.TestScrollContainer scroll;
+        private int loaded;
+
         private const int panel_count = 2048;
 
-        [TestCase(false)]
-        [TestCase(true)]
-        public void TestManyChildren(bool instant)
+        [SetUpSteps]
+        public void SetUpSteps()
         {
-            FillFlowContainer<Container> flow = null;
-            TestSceneDelayedLoadUnloadWrapper.TestScrollContainer scroll = null;
-            int loaded = 0;
-
-            AddStep("create children", () =>
+            AddStep("create scroll container", () =>
             {
                 loaded = 0;
 
@@ -45,7 +45,15 @@ namespace osu.Framework.Tests.Visual.Drawables
                         }
                     }
                 };
+            });
+        }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestManyChildren(bool instant)
+        {
+            AddStep("create children", () =>
+            {
                 for (int i = 1; i < panel_count; i++)
                 {
                     flow.Add(new Container

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
@@ -97,6 +97,77 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddUntilStep("repeating schedulers removed", () => !scroll.Scheduler.HasPendingTasks);
         }
 
+        [Test]
+        public void TestLifetimeOutwardsPropagation()
+        {
+            Container wrapped = null;
+            DelayedLoadWrapper wrapper = null;
+
+            AddStep("create child", () =>
+            {
+                flow.Add(new Container
+                {
+                    Size = new Vector2(128),
+                    Children = new Drawable[]
+                    {
+                        wrapper = new DelayedLoadWrapper(wrapped = new Container
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                            {
+                                new TestBox(() => loaded++) { RelativeSizeAxes = Axes.Both }
+                            }
+                        }),
+                    }
+                });
+
+                wrapper.DelayedLoadComplete += content => content.FadeOut(500).Expire();
+            });
+
+            AddAssert("wrapper lifetime equals content lifetime", () => wrapper.LifetimeEnd == wrapped.LifetimeEnd);
+
+            AddUntilStep("wrapper expired", () => !wrapper.IsAlive);
+        }
+
+        [Test]
+        public void TestLifetimeInwardsPropagation()
+        {
+            Container wrapped = null;
+            DelayedLoadWrapper wrapper = null;
+            double lifetimeEnd = 0;
+
+            AddStep("create child", () =>
+            {
+                flow.Add(new Container
+                {
+                    Size = new Vector2(128),
+                    Children = new Drawable[]
+                    {
+                        wrapper = new DelayedLoadWrapper(wrapped = new Container
+                        {
+                            // this lifetime will be overwritten by the one on the wrapper.
+                            LifetimeEnd = Time.Current + 4000,
+                            RelativeSizeAxes = Axes.Both,
+                            Children = new Drawable[]
+                            {
+                                new TestBox(() => loaded++) { RelativeSizeAxes = Axes.Both }
+                            }
+                        })
+                        {
+                            LifetimeEnd = lifetimeEnd = Time.Current + 2000,
+                        }
+                    }
+                });
+            });
+
+            AddUntilStep("wait for load", () => wrapper.DelayedLoadCompleted);
+
+            AddAssert("wrapper lifetime is correct", () => wrapper.LifetimeEnd == lifetimeEnd);
+            AddAssert("content lifetime is correct", () => wrapped.LifetimeEnd == lifetimeEnd);
+
+            AddUntilStep("wrapper expired", () => !wrapper.IsAlive);
+        }
+
         [TestCase(false)]
         [TestCase(true)]
         public void TestManyChildrenFunction(bool instant)

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -30,44 +30,11 @@ namespace osu.Framework.Graphics.Containers
 
         protected bool ShouldUnloadContent => timeBeforeUnload == 0 || timeHidden > timeBeforeUnload;
 
-        private double lifetimeStart = double.MinValue;
-
-        public override double LifetimeStart
-        {
-            get => Content?.LifetimeStart ?? lifetimeStart;
-            set
-            {
-                if (Content != null)
-                    Content.LifetimeStart = value;
-                lifetimeStart = value;
-            }
-        }
-
-        private double lifetimeEnd = double.MaxValue;
-
-        public override double LifetimeEnd
-        {
-            get => Content?.LifetimeEnd ?? lifetimeEnd;
-            set
-            {
-                if (Content != null)
-                    Content.LifetimeEnd = value;
-                lifetimeEnd = value;
-            }
-        }
-
-        private ScheduledDelegate scheduledLifetimeUpdate;
         private ScheduledDelegate scheduledUnloadCheckRegistration;
 
         protected override void EndDelayedLoad(Drawable content)
         {
             base.EndDelayedLoad(content);
-
-            scheduledLifetimeUpdate = Schedule(() =>
-            {
-                content.LifetimeStart = lifetimeStart;
-                content.LifetimeEnd = lifetimeEnd;
-            });
 
             // Scheduled for another frame since Update() may not have run yet and thus OptimisingContainer may not be up-to-date
             scheduledUnloadCheckRegistration = Game.Schedule(() =>
@@ -113,9 +80,6 @@ namespace osu.Framework.Graphics.Containers
 
                 total_loaded.Value--;
             }
-
-            scheduledLifetimeUpdate?.Cancel();
-            scheduledLifetimeUpdate = null;
 
             scheduledUnloadCheckRegistration?.Cancel();
             scheduledUnloadCheckRegistration = null;

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -34,11 +34,11 @@ namespace osu.Framework.Graphics.Containers
 
         public override double LifetimeStart
         {
-            get => base.Content?.LifetimeStart ?? lifetimeStart;
+            get => Content?.LifetimeStart ?? lifetimeStart;
             set
             {
-                if (base.Content != null)
-                    base.Content.LifetimeStart = value;
+                if (Content != null)
+                    Content.LifetimeStart = value;
                 lifetimeStart = value;
             }
         }
@@ -47,11 +47,11 @@ namespace osu.Framework.Graphics.Containers
 
         public override double LifetimeEnd
         {
-            get => base.Content?.LifetimeEnd ?? lifetimeEnd;
+            get => Content?.LifetimeEnd ?? lifetimeEnd;
             set
             {
-                if (base.Content != null)
-                    base.Content.LifetimeEnd = value;
+                if (Content != null)
+                    Content.LifetimeEnd = value;
                 lifetimeEnd = value;
             }
         }

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -12,13 +12,11 @@ namespace osu.Framework.Graphics.Containers
 {
     public class DelayedLoadUnloadWrapper : DelayedLoadWrapper
     {
-        private readonly Func<Drawable> createContentFunction;
         private readonly double timeBeforeUnload;
 
         public DelayedLoadUnloadWrapper(Func<Drawable> createContentFunction, double timeBeforeLoad = 500, double timeBeforeUnload = 1000)
-            : base(createContentFunction(), timeBeforeLoad)
+            : base(createContentFunction, timeBeforeLoad)
         {
-            this.createContentFunction = createContentFunction;
             this.timeBeforeUnload = timeBeforeUnload;
 
             AddLayout(unloadClockBacking);
@@ -57,8 +55,6 @@ namespace osu.Framework.Graphics.Containers
                 lifetimeEnd = value;
             }
         }
-
-        public override Drawable Content => base.Content ?? (Content = createContentFunction());
 
         private bool contentLoaded;
         private ScheduledDelegate scheduledLifetimeUpdate;

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -16,6 +16,10 @@ namespace osu.Framework.Graphics.Containers
     /// Has the ability to delay the loading until it has been visible on-screen for a specified duration.
     /// In order to benefit from delayed load, we must be inside a <see cref="ScrollContainer{T}"/>.
     /// </summary>
+    /// <remarks>
+    /// <see cref="LifetimeStart"/> and <see cref="LifetimeEnd"/> are propagated from the wrapper to the content on content load.
+    /// After load, the content's lifetime is preferred, meaning any changes to content's lifetime post-load will be respected.
+    /// </remarks>
     public class DelayedLoadWrapper : CompositeDrawable
     {
         [Resolved]
@@ -56,16 +60,30 @@ namespace osu.Framework.Graphics.Containers
             AddLayout(isIntersectingCache);
         }
 
+        private double lifetimeStart = double.MinValue;
+
         public override double LifetimeStart
         {
-            get => Content?.LifetimeStart ?? base.LifetimeStart;
-            set => Content.LifetimeStart = value;
+            get => Content?.LifetimeStart ?? lifetimeStart;
+            set
+            {
+                if (Content != null)
+                    Content.LifetimeStart = value;
+                lifetimeStart = value;
+            }
         }
+
+        private double lifetimeEnd = double.MaxValue;
 
         public override double LifetimeEnd
         {
-            get => Content?.LifetimeEnd ?? base.LifetimeEnd;
-            set => Content.LifetimeEnd = value;
+            get => Content?.LifetimeEnd ?? lifetimeEnd;
+            set
+            {
+                if (Content != null)
+                    Content.LifetimeEnd = value;
+                lifetimeEnd = value;
+            }
         }
 
         private Drawable content;
@@ -142,6 +160,9 @@ namespace osu.Framework.Graphics.Containers
             // This code is running on the game's scheduler, while this DLW may have been async disposed, so the addition is scheduled locally to prevent adding to disposed DLWs.
             scheduledAddition = Schedule(() =>
             {
+                content.LifetimeStart = lifetimeStart;
+                content.LifetimeEnd = lifetimeEnd;
+
                 AddInternal(content);
 
                 DelayedLoadCompleted = true;


### PR DESCRIPTION
Not only does this tidy up the `DelayedLoadUnloadWrapper` flow, but it allows us to (in both cases) avoid the overhead of construction of the content drawable until a load actually occurs.

Tested against my beatmap carousel changes, this reduces finalizer disposal to zero (and greatly reduces allocs in fast scrolling) as expected.

- Make sure you are okay with the Relative/AutoSize propgation. I haven't changed anything for the old-style ctor for compatibility reasons, but now the transfer is done at load time, overwriting anything set locally. Maybe this needs to be mentioned somewhere in the xmldoc?
- Should we obsolete the old ctor?