### PR TITLE
Improve robustness of DLW/DLUW logic

### DIFF
--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -60,7 +60,6 @@ namespace osu.Framework.Graphics.Containers
 
         public override Drawable Content => base.Content ?? (Content = createContentFunction());
 
-        private bool contentLoaded;
         private ScheduledDelegate scheduledLifetimeUpdate;
 
         protected override void EndDelayedLoad(Drawable content)
@@ -76,11 +75,9 @@ namespace osu.Framework.Graphics.Containers
             // Scheduled for another frame since Update() may not have run yet and thus OptimisingContainer may not be up-to-date
             Game.Schedule(() =>
             {
-                Debug.Assert(!contentLoaded);
+                DelayedLoadCompleted = true;
+
                 Debug.Assert(unloadSchedule == null);
-
-                contentLoaded = true;
-
                 unloadSchedule = Game.Scheduler.AddDelayed(checkForUnload, 0, true);
                 Debug.Assert(unloadSchedule != null);
 
@@ -121,7 +118,7 @@ namespace osu.Framework.Graphics.Containers
             if (!ShouldUnloadContent)
                 return;
 
-            Debug.Assert(contentLoaded);
+            Debug.Assert(DelayedLoadCompleted);
 
             // The content may not be part of our hierarchy, so it needs to be disposed manually. To prevent double-queuing of disposals, clear does not dispose.
             ClearInternal(false);
@@ -132,7 +129,7 @@ namespace osu.Framework.Graphics.Containers
 
             CancelTasks();
 
-            contentLoaded = false;
+            DelayedLoadTriggered = DelayedLoadCompleted = false;
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -76,10 +76,14 @@ namespace osu.Framework.Graphics.Containers
             // Scheduled for another frame since Update() may not have run yet and thus OptimisingContainer may not be up-to-date
             scheduledUnloadCheckRegistration = Game.Schedule(() =>
             {
+                // Since this code is running on the game scheduler, it needs to be safe against a potential simultaneous async disposal.
                 lock (disposalLock)
                 {
                     if (isDisposed)
                         return;
+
+                    // Content must have finished loading, but not necessarily added to the hierarchy.
+                    Debug.Assert(DelayedLoadTriggered);
 
                     Debug.Assert(unloadSchedule == null);
                     unloadSchedule = Game.Scheduler.AddDelayed(checkForUnload, 0, true);
@@ -126,6 +130,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void checkForUnload()
         {
+            // Since this code is running on the game scheduler, it needs to be safe against a potential simultaneous async disposal.
             lock (disposalLock)
             {
                 if (isDisposed)

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -84,6 +84,7 @@ namespace osu.Framework.Graphics.Containers
 
                     // Content must have finished loading, but not necessarily added to the hierarchy.
                     Debug.Assert(DelayedLoadTriggered);
+                    Debug.Assert(Content.LoadState >= LoadState.Ready);
 
                     Debug.Assert(unloadSchedule == null);
                     unloadSchedule = Game.Scheduler.AddDelayed(checkForUnload, 0, true);
@@ -138,6 +139,7 @@ namespace osu.Framework.Graphics.Containers
 
                 // Guard against multiple executions of checkForUnload() without an intermediate load having started.
                 Debug.Assert(DelayedLoadTriggered);
+                Debug.Assert(Content.LoadState >= LoadState.Ready);
 
                 // This code can be expensive, so only run if we haven't yet loaded.
                 if (IsIntersecting)
@@ -154,9 +156,15 @@ namespace osu.Framework.Graphics.Containers
                 // 2: The content has finished loading.
                 // 3: The content may not have been added to the hierarchy (e.g. if this DLUW is hidden). This is dependent upon the value of DelayedLoadCompleted.
                 if (DelayedLoadCompleted)
+                {
+                    Debug.Assert(Content.LoadState == LoadState.Loaded);
                     ClearInternal(); // Content added, remove AND dispose.
+                }
                 else
+                {
+                    Debug.Assert(Content.LoadState == LoadState.Ready);
                     DisposeChildAsync(Content); // Content not added, only need to dispose.
+                }
 
                 Content = null;
                 timeHidden = 0;

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -125,8 +125,12 @@ namespace osu.Framework.Graphics.Containers
             Debug.Assert(DelayedLoadCompleted);
 
             // The content may not be part of our hierarchy, so it needs to be disposed manually. To prevent double-queuing of disposals, clear does not dispose.
-            ClearInternal(false);
-            DisposeChildAsync(Content);
+            if (!Content.IsDisposed)
+            {
+                ClearInternal(false);
+                DisposeChildAsync(Content);
+            }
+
             Content = null;
 
             timeHidden = 0;

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -81,7 +81,9 @@ namespace osu.Framework.Graphics.Containers
                     if (isDisposed)
                         return;
 
-                    DelayedLoadCompleted = true;
+                    // See DLW: The load callback is scheduled onto the game scheduler, so the local scheduler runs first (on the same game frame).
+                    // This scheduled delegate will only execute on the NEXT game frame.
+                    Debug.Assert(DelayedLoadCompleted);
 
                     Debug.Assert(unloadSchedule == null);
                     unloadSchedule = Game.Scheduler.AddDelayed(checkForUnload, 0, true);

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -130,23 +130,21 @@ namespace osu.Framework.Graphics.Containers
 
         private void checkForUnload()
         {
-            Debug.Assert(!IsDisposed);
-
-            // This code can be expensive, so only run if we haven't yet loaded.
-            if (IsIntersecting)
-                timeHidden = 0;
-            else
-                timeHidden += unloadClock.ElapsedFrameTime;
-
-            if (!ShouldUnloadContent)
-                return;
-
-            Debug.Assert(DelayedLoadCompleted);
-
             lock (disposalLock)
             {
                 if (isDisposed)
                     return;
+
+                // This code can be expensive, so only run if we haven't yet loaded.
+                if (IsIntersecting)
+                    timeHidden = 0;
+                else
+                    timeHidden += unloadClock.ElapsedFrameTime;
+
+                if (!ShouldUnloadContent)
+                    return;
+
+                Debug.Assert(DelayedLoadCompleted);
 
                 // The content may not be part of our hierarchy, so it needs to be disposed manually. To prevent double-queuing of disposals, clear does not dispose.
                 ClearInternal(false);

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -61,6 +61,7 @@ namespace osu.Framework.Graphics.Containers
         public override Drawable Content => base.Content ?? (Content = createContentFunction());
 
         private ScheduledDelegate scheduledLifetimeUpdate;
+        private ScheduledDelegate scheduledUnloadCheckRegistration;
 
         protected override void EndDelayedLoad(Drawable content)
         {
@@ -73,7 +74,7 @@ namespace osu.Framework.Graphics.Containers
             });
 
             // Scheduled for another frame since Update() may not have run yet and thus OptimisingContainer may not be up-to-date
-            Game.Schedule(() =>
+            scheduledUnloadCheckRegistration = Game.Schedule(() =>
             {
                 DelayedLoadCompleted = true;
 
@@ -99,6 +100,9 @@ namespace osu.Framework.Graphics.Containers
 
             scheduledLifetimeUpdate?.Cancel();
             scheduledLifetimeUpdate = null;
+
+            scheduledUnloadCheckRegistration?.Cancel();
+            scheduledUnloadCheckRegistration = null;
         }
 
         private readonly LayoutValue<IFrameBasedClock> unloadClockBacking = new LayoutValue<IFrameBasedClock>(Invalidation.Parent);

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -81,10 +81,6 @@ namespace osu.Framework.Graphics.Containers
                     if (isDisposed)
                         return;
 
-                    // See DLW: The load callback is scheduled onto the game scheduler, so the local scheduler runs first (on the same game frame).
-                    // This scheduled delegate will only execute on the NEXT game frame.
-                    Debug.Assert(DelayedLoadCompleted);
-
                     Debug.Assert(unloadSchedule == null);
                     unloadSchedule = Game.Scheduler.AddDelayed(checkForUnload, 0, true);
                     Debug.Assert(unloadSchedule != null);

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -135,6 +135,9 @@ namespace osu.Framework.Graphics.Containers
                 if (isDisposed)
                     return;
 
+                // checkForUnload() is the only method that can set this to false. If it happens it means this delegate has somehow run twice without having been cancelled.
+                Debug.Assert(DelayedLoadCompleted);
+
                 // This code can be expensive, so only run if we haven't yet loaded.
                 if (IsIntersecting)
                     timeHidden = 0;
@@ -143,8 +146,6 @@ namespace osu.Framework.Graphics.Containers
 
                 if (!ShouldUnloadContent)
                     return;
-
-                Debug.Assert(DelayedLoadCompleted);
 
                 // The content may not be part of our hierarchy, so it needs to be disposed manually. To prevent double-queuing of disposals, clear does not dispose.
                 ClearInternal(false);

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -103,8 +103,9 @@ namespace osu.Framework.Graphics.Containers
             scheduledAddition = Schedule(() =>
             {
                 AddInternal(content);
-                DelayedLoadComplete?.Invoke(content);
+
                 DelayedLoadCompleted = true;
+                DelayedLoadComplete?.Invoke(content);
             });
         }
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -114,6 +114,12 @@ namespace osu.Framework.Graphics.Containers
             CancelTasks();
         }
 
+        protected override void Dispose(bool isDisposing)
+        {
+            base.Dispose(isDisposing);
+            CancelTasks();
+        }
+
         protected virtual void CancelTasks()
         {
             isIntersectingCache.Invalidate();


### PR DESCRIPTION
This aims to let ppy/osu#10493 be merged. I am PRing this just to have this out/visible/editable by someone other than me, so that me looking at this is not a blocker.

There are three distinct issues this PR aims to fix. As they touch the same places I don't really want to split this into three PRs as it'd probably significantly harm readability.

# Possibility of multiple loads starting

As I outlined in the PR thread already, DLW has two flags that determine whether the content needs to be loaded: `DelayedLoadTriggered` and `DelayedLoadCompleted`. On current `master`, the first is a shorthand for `loadTask != null`, and the second is a shorthand for `InternalChildren.Count > 0`.

Because the addition of `Content` is scheduled in DLW, there is a one-frame window of opportunity in which `DelayedLoadTriggered` becomes `false` (as the load has concluded) while `DelayedLoadCompleted` does not yet become `true`.

See the following log excerpt for an example (this is taken from game-side `TestScenePlaySongSelect.TestExternalBeatmapChangeWhileFiltered`):

```
[frame 0]
Update()        | [runtime] 2020-10-14 16:20:11 [verbose]: DLW #20420726: load started in Update at thread GameThread.Update (id 16, is pool thread = False). Time = 177366,6666666725
                | [runtime] 2020-10-14 16:20:11 [verbose]: DLW #20420726: BeginDelayedLoad started at thread GameThread.Update (id 16, is pool thread = False). Time = 177366,6666666725

[frame 1]
game scheduler  | [runtime] 2020-10-14 16:20:11 [verbose]: DLW #20420726: loadTask cleared via load end at thread GameThread.Update (id 16, is pool thread = False). Time = 177400,00000000585
                | [runtime] 2020-10-14 16:20:11 [verbose]: DLW #20420726: loadTask cleared by task cancellation at thread GameThread.Update (id 16, is pool thread = False). Time = 177400,00000000585
Update()        | [runtime] 2020-10-14 16:20:11 [verbose]: DLW #20420726: load started in Update at thread GameThread.Update (id 16, is pool thread = False). Time = 177400,00000000585
                | [runtime] 2020-10-14 16:20:11 [verbose]: DLW #20420726: BeginDelayedLoad started at thread GameThread.Update (id 16, is pool thread = False). Time = 177400,00000000585

[frame 2]
game scheduler  | [runtime] 2020-10-14 16:20:11 [verbose]: DLW #20420726: loadTask cleared via load end at thread GameThread.Update (id 16, is pool thread = False). Time = 177433,3333333392
                | [runtime] 2020-10-14 16:20:11 [verbose]: DLUW #20420726: adding scheduled unload check at thread GameThread.Update (id 16, is pool thread = False). Time = 177433,3333333392
local scheduler | [runtime] 2020-10-14 16:20:11 [verbose]: DLW #20420726: content added at thread GameThread.Update (id 16, is pool thread = False). Time = 177433,3333333392

[frame 3]
game scheduler  | [runtime] 2020-10-14 16:20:11 [verbose]: DLUW #20420726: adding scheduled unload check at thread GameThread.Update (id 16, is pool thread = False). Time = 177466,66666667254
                | [runtime] 2020-10-14 16:20:11 [error]: An unhandled error has occurred.
                | [runtime] 2020-10-14 16:20:11 [error]: NUnit.Framework.AssertionException: :
```

The failing assert is [this one](https://github.com/ppy/osu-framework/blob/master/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs#L79). This PR includes a test that will trip this same assertion on `master`.

The resolution proposal for this is to track load trigger/completion state by setting the flags manually instead of delegating.

# Cancelling DLW/DLUW's load does not really cancel load

While DLW has a local reference to a `loadTask` which performs the drawable load, it doesn't actually cancel the task if need be. [There is no cancellation token passed in](https://github.com/ppy/osu-framework/blob/7b594edd61d2747dc47a9756dcb4fdd0f0ec7b33/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs#L91) and [the task is just set to `null` if task cancellation is requested](https://github.com/ppy/osu-framework/blob/7b594edd61d2747dc47a9756dcb4fdd0f0ec7b33/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs#L116).

Similarly, DLUW [schedules a schedule](https://github.com/ppy/osu-framework/blob/7b594edd61d2747dc47a9756dcb4fdd0f0ec7b33/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs#L76-L88) (sic) that tracks whether the inner drawable needs to be unloaded. The outer schedule itself is not tracked, so if the loading is cancelled in the middle, `checkForUnload` will get scheduled on the game scheduler every frame anyway, potentially [tripping over other assertions](https://github.com/ppy/osu-framework/blob/7b594edd61d2747dc47a9756dcb4fdd0f0ec7b33/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs#L113).

Both resolved by adding more cancellations.

This is mostly supplementary to the flag changes, as I want to ensure there is no plausible way to have `checkForUnload` be scheduled multiple times due to not interrupting the flow properly.

# DLUW can attempt to clean up its already-disposed `Content`

- [x] Figure out a proper fix for this (see https://github.com/ppy/osu-framework/pull/3936#issuecomment-709613884)

`checkForUnload()` can fail on one of these operations:

https://github.com/ppy/osu-framework/blob/7b594edd61d2747dc47a9756dcb4fdd0f0ec7b33/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs#L126-L129

as there is a possibility that `Content` has been disposed from under it. The failure is in `ClearInternal` (`Parent` set is not allowed on disposed drawables, regardless of whether the value is `null` or not). Resolve by adding another guard.

I don't know how this can happen yet. It's inconsistent and best visible game-side on `TestScenePlaySongSelect.     TestGroupedDifficultyIconSelecting`. My best explanation for this right now is *(handwaving about async disposal queue)*.

Perhaps the operation ordering is slightly wrong, too, as the children are disposed before the parent, and `UnbindAllBindables()` (which triggers `CancelTasks()` for DLW/DLUW) is called after drawable disposal, but I don't really get why that would be the issue given that `checkForUnload()` is scheduled onto the game scheduler and as such it shouldn't be possible for operation order to influence that.

---

DLW/DLUW logic overall is very difficult for me to navigate. I'm not sure if I'm just tired out of my mind these past few days but the amount of scheduling involved makes it very hard to track what goes where. That's why I'm very unconfident of these changes, but I'm less confident I have the time or the skills to try and rewrite.

I've tested this by stressing game-side `TestScenePlaySongSelect` for a bit (each test 50 times). Looks green, for whatever that's worth.