### PR TITLE
Enable string StartsWith/EndsWith culture inspections and fix usages

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -200,7 +200,9 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceWithSingleOrDefault_002E3/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ReplaceWithSingleOrDefault_002E4/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SeparateControlTransferStatement/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringEndsWithIsCultureSpecific/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringLiteralTypo/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringStartsWithIsCultureSpecific/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StructCanBeMadeReadOnly/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FBuiltInTypes/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=SuggestVarOrType_005FSimpleTypes/@EntryIndexedValue">DO_NOT_SHOW</s:String>
@@ -782,6 +784,7 @@ See the LICENCE file in the repository root for full licence text.&#xD;
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CustomTools/CustomToolsData/@EntryValue"></s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EFeature_002EServices_002EDaemon_002ESettings_002EMigration_002ESwaWarningsModeSettingsMigrate/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>

--- a/osu.Framework.Tests/IO/TestDesktopStorage.cs
+++ b/osu.Framework.Tests/IO/TestDesktopStorage.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Tests.IO
             {
                 var basePath = storage.GetFullPath(string.Empty);
 
-                Assert.IsTrue(basePath.EndsWith(guid));
+                Assert.IsTrue(basePath.EndsWith(guid, StringComparison.Ordinal));
 
                 Assert.Throws<ArgumentException>(() => storage.GetFullPath("../"));
                 Assert.Throws<ArgumentException>(() => storage.GetFullPath(".."));

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -445,7 +445,7 @@ namespace osu.Framework.Tests.IO
             Assert.IsTrue(responseObject.Form.ContainsKey("testkey2"));
             Assert.IsTrue(responseObject.Form["testkey2"] == "testval2");
 
-            Assert.IsTrue(responseObject.Headers.ContentType.StartsWith("multipart/form-data; boundary="));
+            Assert.IsTrue(responseObject.Headers.ContentType.StartsWith("multipart/form-data; boundary=", StringComparison.Ordinal));
         }
 
         [Test, Retry(5)]

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
 
                                     var emphases = new List<string>();
 
-                                    while (parent != null && parent is EmphasisInline e)
+                                    while (parent is EmphasisInline e)
                                     {
                                         emphases.Add(e.DelimiterCount == 2 ? new string(e.DelimiterChar, 2) : e.DelimiterChar.ToString());
                                         parent = parent.Parent;

--- a/osu.Framework/Graphics/Shaders/ShaderPart.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderPart.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Graphics.Shaders
                     if (string.IsNullOrEmpty(line))
                         continue;
 
-                    if (line.StartsWith("#version")) // the version directive has to appear before anything else in the shader
+                    if (line.StartsWith("#version", StringComparison.Ordinal)) // the version directive has to appear before anything else in the shader
                     {
                         shaderCodes.Add(line);
                         continue;

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -231,7 +231,7 @@ namespace osu.Framework.IO.Network
         {
             var url = Url;
 
-            if (!AllowInsecureRequests && !url.StartsWith(@"https://"))
+            if (!AllowInsecureRequests && !url.StartsWith(@"https://", StringComparison.Ordinal))
             {
                 logger.Add($"Insecure request was automatically converted to https ({Url})");
                 url = @"https://" + url.Replace(@"http://", @"");

--- a/osu.Framework/IO/Stores/DllResourceStore.cs
+++ b/osu.Framework/IO/Stores/DllResourceStore.cs
@@ -72,7 +72,7 @@ namespace osu.Framework.IO.Stores
         public IEnumerable<string> GetAvailableResources() =>
             assembly.GetManifestResourceNames().Select(n =>
             {
-                n = n.Substring(n.StartsWith(prefix) ? prefix.Length + 1 : 0);
+                n = n.Substring(n.StartsWith(prefix, StringComparison.Ordinal) ? prefix.Length + 1 : 0);
 
                 int lastDot = n.LastIndexOf('.');
 

--- a/osu.Framework/IO/Stores/NamespacedResourceStore.cs
+++ b/osu.Framework/IO/Stores/NamespacedResourceStore.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -25,7 +26,7 @@ namespace osu.Framework.IO.Stores
         protected override IEnumerable<string> GetFilenames(string name) => base.GetFilenames($@"{Namespace}/{name}");
 
         public override IEnumerable<string> GetAvailableResources() => base.GetAvailableResources()
-                                                                           .Where(x => x.StartsWith($"{Namespace}/"))
+                                                                           .Where(x => x.StartsWith($"{Namespace}/", StringComparison.Ordinal))
                                                                            .Select(x => x[(Namespace.Length + 1)..]);
     }
 }

--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Platform
             string basePath = Path.GetFullPath(GetFullPath(string.Empty));
             return paths.Select(Path.GetFullPath).Select(path =>
             {
-                if (!path.StartsWith(basePath)) throw new ArgumentException($"\"{path}\" does not start with \"{basePath}\" and is probably malformed");
+                if (!path.StartsWith(basePath, StringComparison.Ordinal)) throw new ArgumentException($"\"{path}\" does not start with \"{basePath}\" and is probably malformed");
 
                 return path.AsSpan(basePath.Length).TrimStart(Path.DirectorySeparatorChar).ToString();
             });
@@ -62,7 +62,7 @@ namespace osu.Framework.Platform
             var basePath = Path.GetFullPath(BasePath).TrimEnd(Path.DirectorySeparatorChar);
             var resolvedPath = Path.GetFullPath(Path.Combine(basePath, path));
 
-            if (!resolvedPath.StartsWith(basePath)) throw new ArgumentException($"\"{resolvedPath}\" traverses outside of \"{basePath}\" and is probably malformed");
+            if (!resolvedPath.StartsWith(basePath, StringComparison.Ordinal)) throw new ArgumentException($"\"{resolvedPath}\" traverses outside of \"{basePath}\" and is probably malformed");
 
             if (createIfNotExisting) Directory.CreateDirectory(Path.GetDirectoryName(resolvedPath));
             return resolvedPath;

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Testing
             assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(n =>
             {
                 Debug.Assert(n.FullName != null);
-                return n.FullName.StartsWith("osu") || assemblyNamespace != null && n.FullName.StartsWith(assemblyNamespace);
+                return n.FullName.StartsWith("osu", StringComparison.Ordinal) || assemblyNamespace != null && n.FullName.StartsWith(assemblyNamespace, StringComparison.Ordinal);
             }).ToList();
 
             //we want to build the lists here because we're interested in the assembly we were *created* on.
@@ -488,7 +488,7 @@ namespace osu.Framework.Testing
                 if (name == nameof(TestScene.TestConstructor) || m.GetCustomAttribute(typeof(IgnoreAttribute), false) != null)
                     continue;
 
-                if (name.StartsWith("Test"))
+                if (name.StartsWith("Test", StringComparison.Ordinal))
                     name = name.Substring(4);
 
                 int runCount = 1;


### PR DESCRIPTION
Turns out we had these disabled for whatever reason. As they recently caused issues in stable, I wanted to get these out of the way to ensure they can't be an issue here. I'm guessing it may resolve some issues specific regions may already be seeing (ruleset loading?).

Also applies a couple of new inspections that come from Rider EAP.