### PR TITLE
Fix AudioManagers not disposed on audiothread disposal

### DIFF
--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -84,11 +84,15 @@ namespace osu.Framework.Threading
 
             lock (managers)
             {
+                // AudioManagers are iterated over backwards since disposal will unregister and remove them from the list.
                 for (int i = managers.Count - 1; i >= 0; i--)
                 {
                     var m = managers[i];
 
                     m.Dispose();
+
+                    // Audio component disposal (including the AudioManager itself) is scheduled and only runs when the AudioThread updates.
+                    // But the AudioThread won't run another update since it's exiting, so an update must be performed manually in order to finish the disposal.
                     m.Update();
                 }
 

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -84,8 +84,14 @@ namespace osu.Framework.Threading
 
             lock (managers)
             {
-                foreach (var manager in managers)
-                    manager.Dispose();
+                for (int i = managers.Count - 1; i >= 0; i--)
+                {
+                    var m = managers[i];
+
+                    m.Dispose();
+                    m.Update();
+                }
+
                 managers.Clear();
             }
 

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -154,14 +154,14 @@ namespace osu.Framework.Threading
                 if (exitCompleted)
                     return;
 
+                MakeCurrent();
+
                 if (exitRequested)
                 {
                     PerformExit();
                     exitCompleted = true;
                     return;
                 }
-
-                MakeCurrent();
 
                 Monitor?.NewFrame();
 


### PR DESCRIPTION
This is really only ever going to be an issue in tests.

I noticed while running tests via `dotnet test` on Windows, that memory would spike up above 2GB on the test runner. Dumped the process and found...
![](https://user-images.githubusercontent.com/1329837/96238790-d32a0b80-0fd9-11eb-9720-09b840293d34.png)
So previous `AudioManager` instances were being left alive, but how?

Well the only way that this delegate stops is if the cancellation token is cancelled, which happens in `AudioManager.Dispose(bool)`: https://github.com/ppy/osu-framework/blob/93bd7a6e9bb75cc2232c3582e76ba960db680bcb/osu.Framework/Audio/AudioManager.cs#L160-L162
Note that this is the **virtual** Dispose, which is enqueued onto the audio thread.

When exiting, the audio thread correctly disposes the manager:
https://github.com/ppy/osu-framework/blob/93bd7a6e9bb75cc2232c3582e76ba960db680bcb/osu.Framework/Threading/AudioThread.cs#L81-L90
Since this is the **non-virtual** Dispose, it doesn't run immediately and waits for another audio thread update. However since the list is cleared right after, this doesn't actually happen. Furthermore, even if the list wasn't cleared, `GameThread` exits after `PerformExit()`:
https://github.com/ppy/osu-framework/blob/93bd7a6e9bb75cc2232c3582e76ba960db680bcb/osu.Framework/Threading/GameThread.cs#L150-L162
https://github.com/ppy/osu-framework/blob/93bd7a6e9bb75cc2232c3582e76ba960db680bcb/osu.Framework/Threading/GameThread.cs#L125-L134

The simplest way of going about this is to update once more manually after Disposing.

I've also moved `MakeCurrent` above `PerformExit()` to safely facilitate this, since we're now running audio logic inside `PerformExit()`. None of our other threads to anything in `PerformExit()` but I think this makes more sense in general.

Note that it doesn't fix all of my issues - Bass still internally deadlocks on linux and there still seems to be leaks somewhere else:
![image](https://user-images.githubusercontent.com/1329837/96240107-77f91880-0fdb-11eb-8a12-82b3a63d755f.png)
But it's a start...