### PR TITLE
Fix DLUW sometimes crashing on disposal

### DIFF
--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -76,15 +76,22 @@ namespace osu.Framework.Graphics.Containers
             // Scheduled for another frame since Update() may not have run yet and thus OptimisingContainer may not be up-to-date
             Game.Schedule(() =>
             {
-                Debug.Assert(!contentLoaded);
-                Debug.Assert(unloadSchedule == null);
+                // This code is running on the game's scheduler meanwhile an async disposal may have already been triggered from elsewhere in the hierarchy.
+                lock (disposalLock)
+                {
+                    if (isDisposed)
+                        return;
 
-                contentLoaded = true;
+                    Debug.Assert(!contentLoaded);
+                    Debug.Assert(unloadSchedule == null);
 
-                unloadSchedule = Game.Scheduler.AddDelayed(checkForUnload, 0, true);
-                Debug.Assert(unloadSchedule != null);
+                    contentLoaded = true;
 
-                total_loaded.Value++;
+                    unloadSchedule = Game.Scheduler.AddDelayed(checkForUnload, 0, true);
+                    Debug.Assert(unloadSchedule != null);
+
+                    total_loaded.Value++;
+                }
             });
         }
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -104,9 +104,9 @@ namespace osu.Framework.Graphics.Containers
             });
         }
 
-        internal override void UnbindAllBindables()
+        protected override void Dispose(bool isDisposing)
         {
-            base.UnbindAllBindables();
+            base.Dispose(isDisposing);
             CancelTasks();
         }
 

--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -104,6 +104,12 @@ namespace osu.Framework.Graphics.Containers
             });
         }
 
+        internal override void UnbindAllBindables()
+        {
+            base.UnbindAllBindables();
+            CancelTasks();
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);


### PR DESCRIPTION
Alternative to & closes #3936
Fixes the CI issues in https://github.com/ppy/osu/pull/10493 (at least, I can't make `TestScenePlaySongSelect.TestGroupedDifficultyIconSelecting` fail).

Reverts https://github.com/ppy/osu-framework/pull/3926, and fixes the memory leak - by locking and checking the disposal state prior to scheduling the unload delegate.

It wasn't always scheduled twice on the game like this - the disposal check already existed previously in `checkForUnload`, but it wasn't hoisted out of there when the game started being scheduled to a second time in https://github.com/ppy/osu-framework/pull/3825.

Credit to @bdach for the test case (taken from #3936).