### PR TITLE
Improve transform allocation overhead (with focus on AutoSize)

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkManySpinningBoxes.cs
+++ b/osu.Framework.Benchmarks/BenchmarkManySpinningBoxes.cs
@@ -4,34 +4,66 @@
 using BenchmarkDotNet.Attributes;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Benchmarks
 {
     public class BenchmarkManySpinningBoxes : GameBenchmark
     {
+        private TestGame game;
+
         [Test]
         [Benchmark]
-        public void RunFrame() => RunSingleFrame();
+        public void RunFrame()
+        {
+            game.MainContent.AutoSizeAxes = Axes.None;
+            game.MainContent.RelativeSizeAxes = Axes.Both;
+            RunSingleFrame();
+        }
 
-        protected override Game CreateGame() => new TestGame();
+        [Test]
+        [Benchmark]
+        public void RunFrameWithAutoSize()
+        {
+            game.MainContent.RelativeSizeAxes = Axes.None;
+            game.MainContent.AutoSizeAxes = Axes.Both;
+            RunSingleFrame();
+        }
+
+        [Test]
+        [Benchmark]
+        public void RunFrameWithAutoSizeDuration()
+        {
+            game.MainContent.RelativeSizeAxes = Axes.None;
+            game.MainContent.AutoSizeAxes = Axes.Both;
+            game.MainContent.AutoSizeDuration = 100;
+            RunSingleFrame();
+        }
+
+        protected override Game CreateGame() => game = new TestGame();
 
         private class TestGame : Game
         {
+            public Container MainContent;
+
             protected override void LoadComplete()
             {
                 base.LoadComplete();
+
+                Add(MainContent = new Container());
 
                 for (int i = 0; i < 1000; i++)
                 {
                     var box = new Box
                     {
-                        RelativeSizeAxes = Axes.Both,
+                        Size = new Vector2(100),
                         Colour = Color4.Black
                     };
 
-                    Add(box);
+                    MainContent.Add(box);
 
                     box.Spin(200, RotationDirection.Clockwise);
                 }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1842,7 +1842,7 @@ namespace osu.Framework.Graphics.Containers
 
         private void autoSizeResizeTo(Vector2 newSize, double duration = 0, Easing easing = Easing.None)
         {
-            var currentTransform = !Transforms.Any() ? null : Transforms.OfType<AutoSizeTransform>().FirstOrDefault();
+            var currentTransform = TransformsForTargetMember(nameof(baseSize)).FirstOrDefault() as AutoSizeTransform;
 
             if ((currentTransform?.EndValue ?? Size) != newSize)
             {

--- a/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
+++ b/osu.Framework/Graphics/Transforms/TargetGroupingTransformTracker.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Graphics.Transforms
 
         private readonly Transformable transformable;
 
-        private readonly List<Action> removalActions = new List<Action>();
+        private readonly Queue<Action> removalActions = new Queue<Action>();
 
         /// <summary>
         /// Used to assign a monotonically increasing ID to <see cref="Transform"/>s as they are added. This member is
@@ -135,7 +135,7 @@ namespace osu.Framework.Graphics.Transforms
                             i--;
 
                             if (u.OnAbort != null)
-                                removalActions.Add(u.OnAbort);
+                                removalActions.Enqueue(u.OnAbort);
                         }
                         else
                             u.AppliedToEnd = true;
@@ -185,7 +185,7 @@ namespace osu.Framework.Graphics.Transforms
                             flushAppliedCache = true;
                         }
                         else if (t.OnComplete != null)
-                            removalActions.Add(t.OnComplete);
+                            removalActions.Enqueue(t.OnComplete);
                     }
                 }
 
@@ -234,7 +234,7 @@ namespace osu.Framework.Graphics.Transforms
                 {
                     transforms.RemoveAt(i--);
                     if (t.OnAbort != null)
-                        removalActions.Add(t.OnAbort);
+                        removalActions.Enqueue(t.OnAbort);
                 }
             }
 
@@ -316,14 +316,8 @@ namespace osu.Framework.Graphics.Transforms
 
         private void invokePendingRemovalActions()
         {
-            if (removalActions.Count > 0)
-            {
-                var toRemove = removalActions.ToArray();
-                removalActions.Clear();
-
-                foreach (var action in toRemove)
-                    action();
-            }
+            while (removalActions.TryDequeue(out var action))
+                action();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Transforms/TransformSequence.cs
+++ b/osu.Framework/Graphics/Transforms/TransformSequence.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.Transforms
 
         private readonly T origin;
 
-        private readonly List<Transform> transforms = new List<Transform>();
+        private readonly List<Transform> transforms = new List<Transform>(1); // the most common usage of transforms sees one transform being added.
 
         private bool hasCompleted = true;
 

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -42,6 +42,9 @@ namespace osu.Framework.Graphics.Transforms
         /// </summary>
         public IEnumerable<Transform> Transforms => targetGroupingTrackers.SelectMany(t => t.Transforms);
 
+        internal IEnumerable<Transform> TransformsForTargetMember(string targetMember) =>
+            getTrackerFor(targetMember)?.Transforms ?? Enumerable.Empty<Transform>();
+
         /// <summary>
         /// The end time in milliseconds of the latest transform enqueued for this <see cref="Transformable"/>.
         /// Will return the current time value if no transforms are present.

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -42,7 +42,12 @@ namespace osu.Framework.Graphics.Transforms
         /// </summary>
         public IEnumerable<Transform> Transforms => targetGroupingTrackers.SelectMany(t => t.Transforms);
 
-        internal IEnumerable<Transform> TransformsForTargetMember(string targetMember) =>
+        /// <summary>
+        /// Retrieves the <see cref="Transform"/>s for a given target member.
+        /// </summary>
+        /// <param name="targetMember">The target member to find the <see cref="Transform"/>s for.</param>
+        /// <returns>An enumeration over the transforms for the target member.</returns>
+        public IEnumerable<Transform> TransformsForTargetMember(string targetMember) =>
             getTrackerFor(targetMember)?.Transforms ?? Enumerable.Empty<Transform>();
 
         /// <summary>


### PR DESCRIPTION
A collection of a few low-effort allocation optimisations. Most applicable to the edge case where `AutoSizeDuration > 0` and size is updated every frame. This happens at the osu! menu.

I think a more permanent solution would be using a Lerp call in place of this, but we will need to obsolete / remove `AutoSizeEasing` (not sure we want this - it can give correct results in the case autosize is only changed once in a while... but maybe it's just not worth supporting?).

before

|                       Method |       Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |-----------:|--------:|--------:|------:|------:|------:|----------:|
|                     RunFrame |   739.0 us | 5.82 us | 4.86 us |     - |     - |     - |       1 B |
|         RunFrameWithAutoSize | 1,321.7 us | 6.70 us | 6.27 us |     - |     - |     - |     124 B |
| RunFrameWithAutoSizeDuration | 1,102.9 us | 5.52 us | 4.61 us |     - |     - |     - |     828 B |


after (enumeration reduction https://github.com/ppy/osu-framework/commit/246502b3becbac03fb810b3dab533f4a8b842819)

|                       Method |       Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |-----------:|--------:|--------:|------:|------:|------:|----------:|
|                     RunFrame |   721.0 us | 4.81 us | 4.26 us |     - |     - |     - |      10 B |
|         RunFrameWithAutoSize | 1,319.9 us | 5.05 us | 4.22 us |     - |     - |     - |       1 B |
| RunFrameWithAutoSizeDuration | 1,107.1 us | 7.04 us | 6.59 us |     - |     - |     - |     524 B |

after (list -> queue https://github.com/ppy/osu-framework/commit/dcaabb1a42ac60f5deee89b81ef9ddcd37f2b179)

|                       Method |       Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |-----------:|---------:|---------:|------:|------:|------:|----------:|
|                     RunFrame |   713.9 us |  3.07 us |  2.87 us |     - |     - |     - |      10 B |
|         RunFrameWithAutoSize | 1,319.8 us |  6.13 us |  5.73 us |     - |     - |     - |       1 B |
| RunFrameWithAutoSizeDuration | 1,113.2 us | 19.86 us | 17.61 us |     - |     - |     - |     492 B |

after (start list at size 1 https://github.com/ppy/osu-framework/commit/9de51768387e37a48d895728c91dbd6954311ed5)

|                       Method |       Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |-----------:|--------:|--------:|------:|------:|------:|----------:|
|                     RunFrame |   712.6 us | 2.01 us | 1.78 us |     - |     - |     - |       1 B |
|         RunFrameWithAutoSize | 1,309.5 us | 4.96 us | 4.64 us |     - |     - |     - |       1 B |
| RunFrameWithAutoSizeDuration | 1,103.3 us | 8.26 us | 6.89 us |     - |     - |     - |     449 B |
