### PR TITLE
Fix headless being limited to 1000hz

### DIFF
--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -45,6 +45,10 @@ namespace osu.Framework.Platform
         {
             base.SetupForRun();
 
+            MaximumDrawHz = double.MaxValue;
+            MaximumUpdateHz = double.MaxValue;
+            MaximumInactiveHz = double.MaxValue;
+
             if (!realtime) customClock = new FramedClock(new FastClock(CLOCK_RATE));
         }
 


### PR DESCRIPTION
Noticeable in benchmarks. Doesn't seem to affect tests at all (likely due to the clock override) but seems safe to put in headless as a catch-all anyways.

before:
|              Method |     Mean |   Error |  StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------- |---------:|--------:|--------:|------:|------:|------:|----------:|
|   TestEmptyGameLoop | 994.6 us | 1.49 us | 1.25 us |     - |     - |     - |      20 B |
|  TestAllocContainer | 993.8 us | 1.92 us | 1.80 us |     - |     - |     - |    1665 B |
| TestLoadedContainer | 993.6 us | 2.14 us | 2.00 us |     - |     - |     - |    2124 B |
|     TestAllocSprite | 994.0 us | 1.93 us | 1.80 us |     - |     - |     - |    1424 B |
|    TestLoadedSprite | 993.9 us | 2.62 us | 2.45 us |     - |     - |     - |    1706 B |


after:
|              Method |      Mean |     Error |    StdDev |  Gen 0 |  Gen 1 | Gen 2 | Allocated |
|-------------------- |----------:|----------:|----------:|-------:|-------:|------:|----------:|
|   TestEmptyGameLoop |  5.359 us | 0.1010 us | 0.0896 us |      - |      - |     - |         - |
|  TestAllocContainer |  7.407 us | 0.0813 us | 0.0760 us | 0.4120 | 0.1984 |     - |    1751 B |
| TestLoadedContainer | 13.150 us | 0.2548 us | 0.2502 us | 0.5188 | 0.2441 |     - |    2207 B |
|     TestAllocSprite |  6.963 us | 0.1063 us | 0.1138 us | 0.3510 | 0.1678 |     - |    1472 B |
|    TestLoadedSprite | 10.418 us | 0.0726 us | 0.0679 us | 0.3967 | 0.1831 |     - |    1750 B |