### PR TITLE
Add DrawablePool statistics to GlobalStatistics

### DIFF
--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -160,8 +160,10 @@ namespace osu.Framework.Graphics.Pooling
             get => countInUse;
             private set
             {
-                if (statistic != null)
-                    statistic.Value.CountInUse += value - countInUse;
+                if (statistic == null)
+                    return;
+
+                statistic.Value.CountInUse += value - countInUse;
                 countInUse = value;
             }
         }
@@ -176,8 +178,10 @@ namespace osu.Framework.Graphics.Pooling
             get => countConstructed;
             private set
             {
-                if (statistic != null)
-                    statistic.Value.CountConstructed += value - countConstructed;
+                if (statistic == null)
+                    return;
+
+                statistic.Value.CountConstructed += value - countConstructed;
                 countConstructed = value;
             }
         }
@@ -192,8 +196,10 @@ namespace osu.Framework.Graphics.Pooling
             get => countAvailable;
             private set
             {
-                if (statistic != null)
-                    statistic.Value.CountAvailable += value - countAvailable;
+                if (statistic == null)
+                    return;
+
+                statistic.Value.CountAvailable += value - countAvailable;
                 countAvailable = value;
             }
         }

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Containers;
@@ -160,8 +161,7 @@ namespace osu.Framework.Graphics.Pooling
             get => countInUse;
             private set
             {
-                if (statistic == null)
-                    return;
+                Debug.Assert(statistic != null);
 
                 statistic.Value.CountInUse += value - countInUse;
                 countInUse = value;
@@ -178,8 +178,7 @@ namespace osu.Framework.Graphics.Pooling
             get => countConstructed;
             private set
             {
-                if (statistic == null)
-                    return;
+                Debug.Assert(statistic != null);
 
                 statistic.Value.CountConstructed += value - countConstructed;
                 countConstructed = value;
@@ -196,8 +195,7 @@ namespace osu.Framework.Graphics.Pooling
             get => countAvailable;
             private set
             {
-                if (statistic == null)
-                    return;
+                Debug.Assert(statistic != null);
 
                 statistic.Value.CountAvailable += value - countAvailable;
                 countAvailable = value;


### PR DESCRIPTION
This can be/has been useful in visualising pool usage.

Preview: https://drive.google.com/file/d/16bMpWYfDMOecs67TBJMY2M7-7bEs7eEG/view?usp=sharing

The current format is `count_available / count_newed (count_in_use)`, but please provide an alternative if this doesn't sit right with you.