### PR TITLE
Add a way to retrieve unknown types from DrawablePool

### DIFF
--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -72,6 +72,8 @@ namespace osu.Framework.Graphics.Pooling
             push((T)pooledDrawable);
         }
 
+        PoolableDrawable IDrawablePool.Get(Action<PoolableDrawable> setupAction) => Get(setupAction);
+
         /// <summary>
         /// Get a drawable from this pool.
         /// </summary>

--- a/osu.Framework/Graphics/Pooling/IDrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/IDrawablePool.cs
@@ -1,10 +1,19 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Framework.Graphics.Pooling
 {
     public interface IDrawablePool
     {
+        /// <summary>
+        /// Get a drawable from this pool.
+        /// </summary>
+        /// <param name="setupAction">An optional action to be performed on this drawable immediately after retrieval. Should generally be used to prepare the drawable into a usable state.</param>
+        /// <returns>The drawable.</returns>
+        PoolableDrawable Get(Action<PoolableDrawable> setupAction = null);
+
         /// <summary>
         /// Return a drawable after use.
         /// </summary>


### PR DESCRIPTION
Hitobject pooling has brought up a case where it's necessary to retrieve drawables from a set of untyped pools where constraints on the types retrieved are locally guaranteed.

This makes the following (example) scenario possible:

```csharp
private List<IDrawablePool> pools = new List<IDrawablePool>();

void Register<T>(DrawablePool<T> pool)
    where T : DrawableHitObject, new()
{
    pools.Add(pool);
}

DrawableHitObject Retrieve()
{
    // DrawableHitObject type guaranteed by the constraint on Register().
    return (DrawableHitObject)pools[2].Get(d => ((DrawableHitObject)d).SomeMethod());
}
```