### PR TITLE
Add a way to re-sort CompositeDrawable children

### DIFF
--- a/osu.Framework.Tests/Lists/TestSortedList.cs
+++ b/osu.Framework.Tests/Lists/TestSortedList.cs
@@ -101,5 +101,36 @@ namespace osu.Framework.Tests.Lists
                     list.RemoveAt(list.Count - 1);
             });
         }
+
+        [Test]
+        public void TestSortAfterChangedComparer()
+        {
+            var list = new SortedList<TestObjectWithAdjustableComparer>
+            {
+                new TestObjectWithAdjustableComparer { Id = 0 },
+                new TestObjectWithAdjustableComparer { Id = 1 },
+                new TestObjectWithAdjustableComparer { Id = 2 },
+                new TestObjectWithAdjustableComparer { Id = 3 },
+            };
+
+            var first = list[0];
+            var last = list[^1];
+
+            // Reverse the list and re-sort.
+            for (int i = 0; i < list.Count; i++)
+                list[i].Id = list.Count - 1 - i;
+            list.Sort();
+
+            // Test that the list has been reversed.
+            Assert.That(list[0], Is.EqualTo(last));
+            Assert.That(list[^1], Is.EqualTo(first));
+        }
+
+        private class TestObjectWithAdjustableComparer : IComparable<TestObjectWithAdjustableComparer>
+        {
+            public int Id;
+
+            public int CompareTo(TestObjectWithAdjustableComparer other) => Id.CompareTo(other.Id);
+        }
     }
 }

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCompositeDrawable.cs
@@ -1,0 +1,68 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    public class TestSceneCompositeDrawable : FrameworkTestScene
+    {
+        [Test]
+        public void TestSortWithComparerChange()
+        {
+            SortableComposite composite = null;
+            Drawable firstItem = null;
+            Drawable lastItem = null;
+
+            AddStep("add composite", () => Child = composite = new SortableComposite());
+
+            AddStep("reverse comparer", () =>
+            {
+                firstItem = composite.InternalChildren[0];
+                lastItem = composite.InternalChildren[^1];
+
+                for (int i = 0; i < composite.InternalChildren.Count; i++)
+                    ((SortableBox)composite.InternalChildren[i]).Id = composite.InternalChildren.Count - 1 - i;
+                composite.Sort();
+            });
+
+            AddAssert("children reversed", () => composite.InternalChildren[0] == lastItem && composite.InternalChildren[^1] == firstItem);
+        }
+
+        private class SortableComposite : CompositeDrawable
+        {
+            public SortableComposite()
+            {
+                Anchor = Anchor.Centre;
+                Origin = Anchor.Centre;
+                AutoSizeAxes = Axes.Both;
+
+                for (int i = 0; i < 128; i++)
+                {
+                    AddInternal(new SortableBox
+                    {
+                        Id = i,
+                        Colour = new Color4(i / 255f, i / 255f, i / 255f, 1.0f),
+                        Position = new Vector2(3 * i),
+                        Size = new Vector2(50)
+                    });
+                }
+            }
+
+            public void Sort() => SortInternal();
+
+            protected override int Compare(Drawable x, Drawable y)
+                => ((SortableBox)x).Id.CompareTo(((SortableBox)y).Id);
+        }
+
+        private class SortableBox : Box
+        {
+            public int Id;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -599,6 +599,20 @@ namespace osu.Framework.Graphics.Containers
             ChildDepthChanged?.Invoke(child);
         }
 
+        /// <summary>
+        /// Sorts all children of this <see cref="CompositeDrawable"/>.
+        /// </summary>
+        /// <remarks>
+        /// This can be used to re-sort the children if the result of <see cref="Compare"/> has changed.
+        /// </remarks>
+        protected internal void SortInternal()
+        {
+            ensureChildMutationAllowed();
+
+            internalChildren.Sort();
+            aliveInternalChildren.Sort();
+        }
+
         private void ensureChildMutationAllowed()
         {
             switch (LoadState)

--- a/osu.Framework/Lists/SortedList.cs
+++ b/osu.Framework/Lists/SortedList.cs
@@ -122,6 +122,14 @@ namespace osu.Framework.Lists
 
         public int FindIndex(Predicate<T> match) => list.FindIndex(match);
 
+        /// <summary>
+        /// Re-sorts this <see cref="SortedList{T}"/> by the comparer.
+        /// </summary>
+        /// <remarks>
+        /// This can be used to re-sort the <see cref="SortedList{T}"/> if the comparer result has changed.
+        /// </remarks>
+        public void Sort() => list.Sort(Comparer);
+
         public override string ToString() => $@"{GetType().ReadableName()} ({Count} items)";
 
         #region ICollection<T> Implementation


### PR DESCRIPTION
Re-sorting children on comparer change is really ugly and error prone. It's done in at least `HitObjectContainer` osu!-side, where the comparer is sorted by `HitObject.StartTime` (a mutable variable), and the solution is to remove-then-readd:
https://github.com/ppy/osu/blob/89797d7a57e6c86bb9c15c03fd67e4b60cedbfaa/osu.Game/Rulesets/UI/HitObjectContainer.cs#L67-L75

The upcoming hitobject pooling changes demonstrate the error-proneness of this - remove-then-add is not possible with `PoolableDrawable` because they're returned to the `DrawablePool` when the parent is changed:
https://github.com/ppy/osu-framework/blob/d42278299b1b3ce1b06781563f063b71f89238e3/osu.Framework/Graphics/Pooling/PoolableDrawable.cs#L115-L124

Based on the several workarounds I've tried to get around this, I've come to the conclusion that the only reasonable solution is to expose a method that can re-sort children in-place based on the `CompositeDrawable`'s existing comparer.

I've only exposed this as a protected method from `CompositeDrawable`, because CompositeDrawable defines the comparer itself so only it can know whether this method should be used.