### PR TITLE
Fix unmanaged string being incorrectly parsed as ANSI in SDL

### DIFF
--- a/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
@@ -754,7 +754,7 @@ namespace osu.Framework.Platform.Sdl
             if (ptr == IntPtr.Zero)
                 return;
 
-            string text = Marshal.PtrToStringAnsi(ptr) ?? "";
+            string text = Marshal.PtrToStringUTF8(ptr) ?? "";
 
             foreach (char c in text)
                 ScheduleEvent(() => OnKeyTyped(c));


### PR DESCRIPTION
[SDL_TEXTINPUTEVENT.text](https://wiki.libsdl.org/SDL_TextInputEvent) is incorrectly parsed as ANSI instead of UTF-8, leading to incorrect non-ascii text inputs.

Before:
![before](https://user-images.githubusercontent.com/22643729/97088040-8b852e80-162e-11eb-8c1e-27f62f2233de.gif)

After:
![after](https://user-images.githubusercontent.com/22643729/97088041-8de78880-162e-11eb-83a0-195e5b1a17e4.gif)

