### PR TITLE
Fix ChildrenOfType being thread-unsafe

### DIFF
--- a/osu.Framework/Testing/TestingExtensions.cs
+++ b/osu.Framework/Testing/TestingExtensions.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Linq;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 
@@ -19,7 +20,7 @@ namespace osu.Framework.Testing
 
             if (drawable is CompositeDrawable composite)
             {
-                foreach (var child in composite.InternalChildren)
+                foreach (var child in composite.InternalChildren.ToArray())
                 {
                     foreach (var found in child.ChildrenOfType<T>())
                         yield return found;


### PR DESCRIPTION
Could potentially fail when components are being asynchronously loaded.

```
osu.Game.Tests.Visual.Editing.TestSceneEditorClipboard.TestCutPaste(2000)

TearDown : System.InvalidOperationException : Collection was modified; enumeration operation may not execute.
--TearDown
   at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
   at osu.Framework.Testing.TestingExtensions.ChildrenOfType[T](Drawable drawable)+MoveNext()
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Boolean& found)
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source)
   at osu.Game.Tests.Visual.EditorTestScene.get_EditorComponentsReady()
```

Not that this really solves the issue but it should be fine for this test-only method.