### PR TITLE
Fix OnResume being called twice when calling Exit from a blocked OnExiting implementation

### DIFF
--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -214,7 +214,6 @@ namespace osu.Framework.Screens
                 throw new ScreenNotInStackException(nameof(MakeCurrent));
 
             // while a parent still exists and exiting is not blocked, continue to iterate upwards.
-            IScreen firstScreen = CurrentScreen;
             IScreen exitSource = null;
 
             while (CurrentScreen != null)

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -219,11 +219,20 @@ namespace osu.Framework.Screens
 
             while (CurrentScreen != null)
             {
-                if (exitFrom(exitSource, shouldFireResumeEvent: false) || CurrentScreen == target)
+                if (exitFrom(exitSource, shouldFireResumeEvent: false))
                 {
-                    // don't fire the resume event if the first screen blocked the exit.
-                    if (CurrentScreen != firstScreen)
+                    // exit was blocked, but a nested exit operation may have succeeded (ie. a screen calling this.Exit() after blocking).
+                    // in such a case, the MakeCurrent / resumeFrom flow would have already been performed.
+                    // to avoid a duplicate resumeFrom event, only fire from here if it can be assured that the current screen is still the one which blocked the exit above.
+                    if (CurrentScreen == exitSource)
                         resumeFrom(exitSource);
+
+                    return;
+                }
+
+                if (CurrentScreen == target)
+                {
+                    resumeFrom(exitSource);
                     return;
                 }
 


### PR DESCRIPTION
An issue that arose while looking into https://github.com/ppy/osu/issues/10418. Not required to fix that issue, but probably good to fix this while we're here.