### PR TITLE
SDL raw input

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -189,6 +189,8 @@ namespace osu.Framework.Tests.Visual.Input
             setRawInputConfig(false);
             AddToggleStep("Toggle ConfineMouseMode", setConfineMouseModeConfig);
             setConfineMouseModeConfig(false);
+            AddToggleStep("Toggle MapAbsoluteInputToWindow", setMapAbsoluteConfig);
+            setMapAbsoluteConfig(false);
         }
 
         private void setCursorSensivityConfig(double x)
@@ -204,6 +206,11 @@ namespace osu.Framework.Tests.Visual.Input
         private void setConfineMouseModeConfig(bool x)
         {
             config.Set(FrameworkSetting.ConfineMouseMode, x ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen);
+        }
+
+        private void setMapAbsoluteConfig(bool x)
+        {
+            config.Set(FrameworkSetting.MapAbsoluteInputToWindow, x);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
 
@@ -17,6 +18,9 @@ namespace osu.Framework.Tests.Visual.Input
 {
     public class TestSceneInputManager : FrameworkTestScene
     {
+        private string normalMouseHandlerName;
+        private string rawMouseHandlerName;
+
         public TestSceneInputManager()
         {
             Add(new Container
@@ -173,8 +177,12 @@ namespace osu.Framework.Tests.Visual.Input
         private FrameworkConfigManager config { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(GameHost host)
         {
+            bool usingSdl = host.Window is DesktopWindow;
+            normalMouseHandlerName = usingSdl ? nameof(MouseHandler) : nameof(OsuTKMouseHandler);
+            rawMouseHandlerName = usingSdl ? nameof(RawMouseHandler) : nameof(OsuTKRawMouseHandler);
+
             AddSliderStep("Cursor sensivity", 0.5, 5, 1, setCursorSensivityConfig);
             setCursorSensivityConfig(1);
             AddToggleStep("Toggle raw input", setRawInputConfig);
@@ -190,7 +198,7 @@ namespace osu.Framework.Tests.Visual.Input
 
         private void setRawInputConfig(bool x)
         {
-            config.Set(FrameworkSetting.IgnoredInputHandlers, x ? nameof(OsuTKMouseHandler) : nameof(OsuTKRawMouseHandler));
+            config.Set(FrameworkSetting.IgnoredInputHandlers, x ? normalMouseHandlerName : rawMouseHandlerName);
         }
 
         private void setConfineMouseModeConfig(bool x)

--- a/osu.Framework/Input/Handlers/Mouse/RawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/RawMouseHandler.cs
@@ -1,0 +1,113 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Bindables;
+using osu.Framework.Input.StateChanges;
+using osu.Framework.Platform;
+using osu.Framework.Statistics;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Input.Handlers.Mouse
+{
+    public class RawMouseHandler : InputHandler, IHasCursorSensitivity, INeedsMousePositionFeedback
+    {
+        public BindableDouble Sensitivity { get; } = new BindableDouble(1) { MinValue = 0.1, MaxValue = 10 };
+
+        public override bool IsActive => true;
+        public override int Priority => 0;
+
+        private DesktopWindow window;
+
+        private readonly BindableBool mapAbsoluteInputToWindow = new BindableBool();
+        private readonly IBindable<bool> windowActive = new BindableBool();
+
+        public override bool Initialize(GameHost host)
+        {
+            if (!(host.Window is DesktopWindow desktopWindow))
+                return false;
+
+            window = desktopWindow;
+            mapAbsoluteInputToWindow.BindTo(window.MapAbsoluteInputToWindow);
+            windowActive.BindTo(window.IsActive);
+            windowActive.ValueChanged += _ => updateRelativeMouseMode();
+
+            Enabled.BindValueChanged(evt =>
+            {
+                if (evt.NewValue)
+                {
+                    window.MouseMove += handleMouseMove;
+                    window.MouseMoveRelative += handleMouseMoveRelative;
+                    window.MouseDown += handleMouseDown;
+                    window.MouseUp += handleMouseUp;
+                    window.MouseWheel += handleMouseWheel;
+                }
+                else
+                {
+                    window.MouseMove -= handleMouseMove;
+                    window.MouseMoveRelative -= handleMouseMoveRelative;
+                    window.MouseDown -= handleMouseDown;
+                    window.MouseUp -= handleMouseUp;
+                    window.MouseWheel -= handleMouseWheel;
+                }
+
+                updateRelativeMouseMode();
+            });
+
+            return true;
+        }
+
+        private void enqueueInput(IInput input)
+        {
+            PendingInputs.Enqueue(input);
+            FrameStatistics.Increment(StatisticsCounterType.MouseEvents);
+        }
+
+        private void handleMouseMove(Vector2 position)
+        {
+            if (windowActive.Value && !window.RelativeMouseMode && window.ClientRectangle.Contains((int)position.X, (int)position.Y))
+            {
+                enqueueInput(new MousePositionAbsoluteInput { Position = position });
+                window.RelativeMouseMode = true;
+                return;
+            }
+
+            Console.WriteLine($"RawMouseHandler.handleMouseMove({position})");
+
+            enqueueInput(new MousePositionAbsoluteInput { Position = position });
+        }
+
+        private void handleMouseMoveRelative(Vector2 delta)
+        {
+            if (!window.RelativeMouseMode)
+                return;
+
+            Console.WriteLine($"RawMouseHandler.handleMouseMoveRelative({delta})");
+
+            enqueueInput(new MousePositionRelativeInput { Delta = delta * (float)Sensitivity.Value });
+        }
+
+        private void handleMouseDown(MouseButton button) => enqueueInput(new MouseButtonInput(button, true));
+
+        private void handleMouseUp(MouseButton button) => enqueueInput(new MouseButtonInput(button, false));
+
+        private void handleMouseWheel(Vector2 delta, bool precise) => enqueueInput(new MouseScrollRelativeInput { Delta = delta, IsPrecise = precise });
+
+        private void updateRelativeMouseMode() => window.RelativeMouseMode = windowActive.Value && Enabled.Value;
+
+        public void FeedbackMousePositionChange(Vector2 position)
+        {
+            if (!Enabled.Value || !window.RelativeMouseMode)
+                return;
+
+            var clientSize = window.ClientRectangle.Size;
+            float scale = clientSize.Width == 0 ? 1f : window.Size.Value.Width / (float)clientSize.Width;
+
+            if (position.X < 0 || position.Y < 0 || position.X > clientSize.Width || position.Y > clientSize.Height)
+            {
+                window.MousePosition = position * scale;
+            }
+        }
+    }
+}

--- a/osu.Framework/Input/Handlers/Mouse/RawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/RawMouseHandler.cs
@@ -89,9 +89,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             if (!Enabled.Value)
                 return;
 
-            var clientSize = window.ClientRectangle.Size;
-            float scale = clientSize.Width == 0 ? 1f : window.Size.Value.Width / (float)clientSize.Width;
-            window.UpdateRelativeMode(position * scale);
+            window.UpdateRelativeMode(position);
         }
     }
 }

--- a/osu.Framework/Input/Handlers/Mouse/RawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/RawMouseHandler.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using osu.Framework.Bindables;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
@@ -64,19 +63,9 @@ namespace osu.Framework.Input.Handlers.Mouse
             FrameStatistics.Increment(StatisticsCounterType.MouseEvents);
         }
 
-        private void handleMouseMove(Vector2 position)
-        {
-            Console.WriteLine($"RawMouseHandler.handleMouseMove({position})");
+        private void handleMouseMove(Vector2 position) => enqueueInput(new MousePositionAbsoluteInput { Position = position });
 
-            enqueueInput(new MousePositionAbsoluteInput { Position = position });
-        }
-
-        private void handleMouseMoveRelative(Vector2 delta)
-        {
-            Console.WriteLine($"RawMouseHandler.handleMouseMoveRelative({delta})");
-
-            enqueueInput(new MousePositionRelativeInput { Delta = delta * (float)Sensitivity.Value });
-        }
+        private void handleMouseMoveRelative(Vector2 delta) => enqueueInput(new MousePositionRelativeInput { Delta = delta * (float)Sensitivity.Value });
 
         private void handleMouseDown(MouseButton button) => enqueueInput(new MouseButtonInput(button, true));
 

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -117,12 +117,22 @@ namespace osu.Framework.Platform
                     return defaultEnabled.Concat(defaultDisabled);
 
                 default:
-                    return new InputHandler[]
+                    var enabled = new InputHandler[]
                     {
                         new KeyboardHandler(),
                         new MouseHandler(),
                         new JoystickHandler(),
                     };
+
+                    var disabled = new InputHandler[]
+                    {
+                        new RawMouseHandler(),
+                    };
+
+                    foreach (var h in disabled)
+                        h.Enabled.Value = false;
+
+                    return enabled.Concat(disabled);
             }
         }
 

--- a/osu.Framework/Platform/DesktopWindow.cs
+++ b/osu.Framework/Platform/DesktopWindow.cs
@@ -71,14 +71,13 @@ namespace osu.Framework.Platform
         protected override IGraphicsBackend CreateGraphicsBackend() => new Sdl2GraphicsBackend();
 
         /// <summary>
-        /// Sets or gets the mouse position in unscaled screen coordinates, relative to the top left corner of the window.
-        /// Setting the mouse position will also disable <see cref="Window.RelativeMouseMode"/> if enabled.
+        /// Enables or disables <see cref="Window.RelativeMouseMode"/> based on the given <paramref name="position"/>.
+        /// If the position is within the window and relative mode is disabled, relative mode will be enabled.
+        /// If the position is outside the window and relative mode is enabled, relative mode will be disabled
+        /// and the mouse cursor will be warped to <paramref name="position"/>.
+        /// <param name="position">The given screen location to check, relative to the top left corner of the window, in logical coordinates. If null, defaults to current position.</param>
         /// </summary>
-        public Vector2 MousePosition
-        {
-            get => WindowBackend.MousePosition;
-            set => WindowBackend.MousePosition = value;
-        }
+        public void UpdateRelativeMode(Vector2? position = null) => WindowBackend.UpdateRelativeMode(position);
 
         public override void SetupWindow(FrameworkConfigManager config)
         {
@@ -112,6 +111,8 @@ namespace osu.Framework.Platform
                 WindowBackend.Size = evt.NewValue;
                 Size.Value = evt.NewValue;
             };
+
+            IsActive.ValueChanged += _ => UpdateRelativeMode();
 
             config.BindWith(FrameworkSetting.SizeFullscreen, sizeFullscreen);
             config.BindWith(FrameworkSetting.WindowedSize, sizeWindowed);

--- a/osu.Framework/Platform/DesktopWindow.cs
+++ b/osu.Framework/Platform/DesktopWindow.cs
@@ -70,6 +70,16 @@ namespace osu.Framework.Platform
         protected override IWindowBackend CreateWindowBackend() => new Sdl2WindowBackend();
         protected override IGraphicsBackend CreateGraphicsBackend() => new Sdl2GraphicsBackend();
 
+        /// <summary>
+        /// Sets or gets the mouse position in unscaled screen coordinates, relative to the top left corner of the window.
+        /// Setting the mouse position will also disable <see cref="Window.RelativeMouseMode"/> if enabled.
+        /// </summary>
+        public Vector2 MousePosition
+        {
+            get => WindowBackend.MousePosition;
+            set => WindowBackend.MousePosition = value;
+        }
+
         public override void SetupWindow(FrameworkConfigManager config)
         {
             base.SetupWindow(config);

--- a/osu.Framework/Platform/DesktopWindow.cs
+++ b/osu.Framework/Platform/DesktopWindow.cs
@@ -75,7 +75,7 @@ namespace osu.Framework.Platform
         /// If the position is within the window and relative mode is disabled, relative mode will be enabled.
         /// If the position is outside the window and relative mode is enabled, relative mode will be disabled
         /// and the mouse cursor will be warped to <paramref name="position"/>.
-        /// <param name="position">The given screen location to check, relative to the top left corner of the window, in logical coordinates. If null, defaults to current position.</param>
+        /// <param name="position">The given screen location to check, relative to the top left corner of the window, in scaled coordinates. If null, defaults to current position.</param>
         /// </summary>
         public void UpdateRelativeMode(Vector2? position = null) => WindowBackend.UpdateRelativeMode(position);
 

--- a/osu.Framework/Platform/DesktopWindow.cs
+++ b/osu.Framework/Platform/DesktopWindow.cs
@@ -32,6 +32,7 @@ namespace osu.Framework.Platform
         private readonly Bindable<DisplayIndex> windowDisplayIndex = new Bindable<DisplayIndex>();
 
         public readonly Bindable<ConfineMouseMode> ConfineMouseMode = new Bindable<ConfineMouseMode>();
+        public readonly BindableBool MapAbsoluteInputToWindow = new BindableBool();
 
         /// <summary>
         /// Gets or sets the window's position on the current screen given a relative value between 0 and 1.
@@ -127,6 +128,8 @@ namespace osu.Framework.Platform
 
             config.BindWith(FrameworkSetting.ConfineMouseMode, ConfineMouseMode);
             ConfineMouseMode.BindValueChanged(confineMouseModeChanged, true);
+
+            config.BindWith(FrameworkSetting.MapAbsoluteInputToWindow, MapAbsoluteInputToWindow);
 
             Resized += onResized;
             Moved += onMoved;

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -268,6 +268,8 @@ namespace osu.Framework.Platform
         /// </summary>
         public virtual BindableSafeArea SafeAreaPadding { get; } = new BindableSafeArea();
 
+        public bool RelativeMouseMode { get; set; }
+
         private readonly BindableList<WindowMode> supportedWindowModes = new BindableList<WindowMode>();
 
         public IBindableList<WindowMode> SupportedWindowModes => supportedWindowModes;

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -50,6 +50,11 @@ namespace osu.Framework.Platform
         bool CursorInWindow { get; }
 
         /// <summary>
+        /// Enables or disables relative mouse mode.
+        /// </summary>
+        bool RelativeMouseMode { get; set; }
+
+        /// <summary>
         /// Controls the state of the OS cursor.
         /// </summary>
         CursorState CursorState { get; set; }

--- a/osu.Framework/Platform/IWindowBackend.cs
+++ b/osu.Framework/Platform/IWindowBackend.cs
@@ -56,6 +56,20 @@ namespace osu.Framework.Platform
         bool CursorConfined { get; set; }
 
         /// <summary>
+        /// Enables or disables relative mouse mode.
+        /// While relative mouse mode is disabled, <see cref="MouseMove"/> events will be fired.
+        /// While relative mouse mode is enabled, <see cref="MouseMoveRelative"/> events will be fired.
+        /// </summary>
+        bool RelativeMouseMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the mouse position in unscaled display coordinates,
+        /// relative to the top left corner of the window.
+        /// Setting the mouse position will also disable <see cref="RelativeMouseMode"/>.
+        /// </summary>
+        Vector2 MousePosition { get; set; }
+
+        /// <summary>
         /// Returns or sets the window's current <see cref="WindowState"/>.
         /// </summary>
         WindowState WindowState { get; set; }
@@ -161,9 +175,18 @@ namespace osu.Framework.Platform
         event Action<Vector2, bool> MouseWheel;
 
         /// <summary>
-        /// Invoked when the user moves the mouse cursor within the window.
+        /// Invoked when the user moves the mouse cursor, if relative mouse mode is disabled.
+        /// The <see cref="Vector2"/> provided is the position relative to the top left corner of the window,
+        /// with DPI scaling applied.
         /// </summary>
         event Action<Vector2> MouseMove;
+
+        /// <summary>
+        /// Invoked when the user moves the mouse cursor, if relative mouse mode is enabled.
+        /// The <see cref="Vector2"/> provided is the number of pixels the cursor has moved since the previous
+        /// <see cref="MouseMoveRelative"/> invocation.
+        /// </summary>
+        event Action<Vector2> MouseMoveRelative;
 
         /// <summary>
         /// Invoked when the user presses a mouse button.

--- a/osu.Framework/Platform/IWindowBackend.cs
+++ b/osu.Framework/Platform/IWindowBackend.cs
@@ -63,13 +63,6 @@ namespace osu.Framework.Platform
         bool RelativeMouseMode { get; set; }
 
         /// <summary>
-        /// Gets or sets the mouse position in unscaled display coordinates,
-        /// relative to the top left corner of the window.
-        /// Setting the mouse position will also disable <see cref="RelativeMouseMode"/>.
-        /// </summary>
-        Vector2 MousePosition { get; set; }
-
-        /// <summary>
         /// Returns or sets the window's current <see cref="WindowState"/>.
         /// </summary>
         WindowState WindowState { get; set; }
@@ -267,6 +260,15 @@ namespace osu.Framework.Platform
         /// </summary>
         /// <param name="image">An <see cref="Image{Rgba32}"/> to set as the window icon.</param>
         void SetIcon(Image<Rgba32> image);
+
+        /// <summary>
+        /// Enables or disables <see cref="Window.RelativeMouseMode"/> based on the given <paramref name="position"/>.
+        /// If the position is within the window and relative mode is disabled, relative mode will be enabled.
+        /// If the position is outside the window and relative mode is enabled, relative mode will be disabled
+        /// and the mouse cursor will be warped to <paramref name="position"/>.
+        /// <param name="position">The given screen location to check, relative to the top left corner of the window, in logical coordinates. If null, defaults to current position.</param>
+        /// </summary>
+        void UpdateRelativeMode(Vector2? position = null);
 
         #endregion
     }

--- a/osu.Framework/Platform/IWindowBackend.cs
+++ b/osu.Framework/Platform/IWindowBackend.cs
@@ -266,7 +266,7 @@ namespace osu.Framework.Platform
         /// If the position is within the window and relative mode is disabled, relative mode will be enabled.
         /// If the position is outside the window and relative mode is enabled, relative mode will be disabled
         /// and the mouse cursor will be warped to <paramref name="position"/>.
-        /// <param name="position">The given screen location to check, relative to the top left corner of the window, in logical coordinates. If null, defaults to current position.</param>
+        /// <param name="position">The given screen location to check, relative to the top left corner of the window, in scaled coordinates. If null, defaults to current position.</param>
         /// </summary>
         void UpdateRelativeMode(Vector2? position = null);
 

--- a/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
@@ -475,7 +475,8 @@ namespace osu.Framework.Platform.Sdl
                 if (!Exists)
                     break;
 
-                processEvents();
+                if (SDL.SDL_PollEvent(out var evt) > 0)
+                    processEvent(evt);
 
                 if (!mouseInWindow && !RelativeMouseMode)
                     pollMouse();
@@ -538,97 +539,94 @@ namespace osu.Framework.Platform.Sdl
         /// <param name="action">The <see cref="Action"/> to execute.</param>
         protected void ScheduleEvent(Action action) => eventScheduler.Add(action);
 
-        private void processEvents()
+        private void processEvent(SDL.SDL_Event evt)
         {
-            while (SDL.SDL_PollEvent(out var evt) > 0)
+            switch (evt.type)
             {
-                switch (evt.type)
-                {
-                    case SDL.SDL_EventType.SDL_QUIT:
-                    case SDL.SDL_EventType.SDL_APP_TERMINATING:
-                        handleQuitEvent(evt.quit);
-                        break;
+                case SDL.SDL_EventType.SDL_QUIT:
+                case SDL.SDL_EventType.SDL_APP_TERMINATING:
+                    handleQuitEvent(evt.quit);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_WINDOWEVENT:
-                        handleWindowEvent(evt.window);
-                        break;
+                case SDL.SDL_EventType.SDL_WINDOWEVENT:
+                    handleWindowEvent(evt.window);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_KEYDOWN:
-                    case SDL.SDL_EventType.SDL_KEYUP:
-                        handleKeyboardEvent(evt.key);
-                        break;
+                case SDL.SDL_EventType.SDL_KEYDOWN:
+                case SDL.SDL_EventType.SDL_KEYUP:
+                    handleKeyboardEvent(evt.key);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_TEXTEDITING:
-                        handleTextEditingEvent(evt.edit);
-                        break;
+                case SDL.SDL_EventType.SDL_TEXTEDITING:
+                    handleTextEditingEvent(evt.edit);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_TEXTINPUT:
-                        handleTextInputEvent(evt.text);
-                        break;
+                case SDL.SDL_EventType.SDL_TEXTINPUT:
+                    handleTextInputEvent(evt.text);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_MOUSEMOTION:
-                        handleMouseMotionEvent(evt.motion);
-                        break;
+                case SDL.SDL_EventType.SDL_MOUSEMOTION:
+                    handleMouseMotionEvent(evt.motion);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
-                    case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
-                        handleMouseButtonEvent(evt.button);
-                        break;
+                case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
+                case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
+                    handleMouseButtonEvent(evt.button);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_MOUSEWHEEL:
-                        handleMouseWheelEvent(evt.wheel);
-                        break;
+                case SDL.SDL_EventType.SDL_MOUSEWHEEL:
+                    handleMouseWheelEvent(evt.wheel);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_JOYAXISMOTION:
-                        handleJoyAxisEvent(evt.jaxis);
-                        break;
+                case SDL.SDL_EventType.SDL_JOYAXISMOTION:
+                    handleJoyAxisEvent(evt.jaxis);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_JOYBALLMOTION:
-                        handleJoyBallEvent(evt.jball);
-                        break;
+                case SDL.SDL_EventType.SDL_JOYBALLMOTION:
+                    handleJoyBallEvent(evt.jball);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_JOYHATMOTION:
-                        handleJoyHatEvent(evt.jhat);
-                        break;
+                case SDL.SDL_EventType.SDL_JOYHATMOTION:
+                    handleJoyHatEvent(evt.jhat);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_JOYBUTTONDOWN:
-                    case SDL.SDL_EventType.SDL_JOYBUTTONUP:
-                        handleJoyButtonEvent(evt.jbutton);
-                        break;
+                case SDL.SDL_EventType.SDL_JOYBUTTONDOWN:
+                case SDL.SDL_EventType.SDL_JOYBUTTONUP:
+                    handleJoyButtonEvent(evt.jbutton);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_JOYDEVICEADDED:
-                    case SDL.SDL_EventType.SDL_JOYDEVICEREMOVED:
-                        handleJoyDeviceEvent(evt.jdevice);
-                        break;
+                case SDL.SDL_EventType.SDL_JOYDEVICEADDED:
+                case SDL.SDL_EventType.SDL_JOYDEVICEREMOVED:
+                    handleJoyDeviceEvent(evt.jdevice);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_CONTROLLERAXISMOTION:
-                        handleControllerAxisEvent(evt.caxis);
-                        break;
+                case SDL.SDL_EventType.SDL_CONTROLLERAXISMOTION:
+                    handleControllerAxisEvent(evt.caxis);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_CONTROLLERBUTTONDOWN:
-                    case SDL.SDL_EventType.SDL_CONTROLLERBUTTONUP:
-                        handleControllerButtonEvent(evt.cbutton);
-                        break;
+                case SDL.SDL_EventType.SDL_CONTROLLERBUTTONDOWN:
+                case SDL.SDL_EventType.SDL_CONTROLLERBUTTONUP:
+                    handleControllerButtonEvent(evt.cbutton);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_CONTROLLERDEVICEADDED:
-                    case SDL.SDL_EventType.SDL_CONTROLLERDEVICEREMOVED:
-                    case SDL.SDL_EventType.SDL_CONTROLLERDEVICEREMAPPED:
-                        handleControllerDeviceEvent(evt.cdevice);
-                        break;
+                case SDL.SDL_EventType.SDL_CONTROLLERDEVICEADDED:
+                case SDL.SDL_EventType.SDL_CONTROLLERDEVICEREMOVED:
+                case SDL.SDL_EventType.SDL_CONTROLLERDEVICEREMAPPED:
+                    handleControllerDeviceEvent(evt.cdevice);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_FINGERDOWN:
-                    case SDL.SDL_EventType.SDL_FINGERUP:
-                    case SDL.SDL_EventType.SDL_FINGERMOTION:
-                        handleTouchFingerEvent(evt.tfinger);
-                        break;
+                case SDL.SDL_EventType.SDL_FINGERDOWN:
+                case SDL.SDL_EventType.SDL_FINGERUP:
+                case SDL.SDL_EventType.SDL_FINGERMOTION:
+                    handleTouchFingerEvent(evt.tfinger);
+                    break;
 
-                    case SDL.SDL_EventType.SDL_DROPFILE:
-                    case SDL.SDL_EventType.SDL_DROPTEXT:
-                    case SDL.SDL_EventType.SDL_DROPBEGIN:
-                    case SDL.SDL_EventType.SDL_DROPCOMPLETE:
-                        handleDropEvent(evt.drop);
-                        break;
-                }
+                case SDL.SDL_EventType.SDL_DROPFILE:
+                case SDL.SDL_EventType.SDL_DROPTEXT:
+                case SDL.SDL_EventType.SDL_DROPBEGIN:
+                case SDL.SDL_EventType.SDL_DROPCOMPLETE:
+                    handleDropEvent(evt.drop);
+                    break;
             }
         }
 

--- a/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
@@ -31,7 +31,6 @@ namespace osu.Framework.Platform.Sdl
         private readonly Scheduler commandScheduler = new Scheduler();
         private readonly Scheduler eventScheduler = new Scheduler();
 
-        private bool mouseInWindow;
         private Point previousPolledPoint = Point.Empty;
 
         private readonly Dictionary<int, Sdl2ControllerBindings> controllers = new Dictionary<int, Sdl2ControllerBindings>();
@@ -338,6 +337,8 @@ namespace osu.Framework.Platform.Sdl
         #endregion
 
         #region Convenience Functions
+
+        private bool mouseInWindow => windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_MOUSE_FOCUS);
 
         private SDL.SDL_SysWMinfo windowWmInfo
         {
@@ -905,12 +906,10 @@ namespace osu.Framework.Platform.Sdl
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_ENTER:
-                    mouseInWindow = true;
                     ScheduleEvent(OnMouseEntered);
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_LEAVE:
-                    mouseInWindow = false;
                     ScheduleEvent(OnMouseLeft);
                     break;
 

--- a/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
@@ -803,11 +803,9 @@ namespace osu.Framework.Platform.Sdl
 
         private void handleMouseMotionEvent(SDL.SDL_MouseMotionEvent evtMotion)
         {
-            const int relative_threshold = 20;
-
             if (SDL.SDL_GetRelativeMouseMode() == SDL.SDL_bool.SDL_FALSE)
                 ScheduleEvent(() => OnMouseMove(new Vector2(evtMotion.x * scale, evtMotion.y * scale)));
-            else if (Math.Abs(evtMotion.xrel) < relative_threshold && Math.Abs(evtMotion.yrel) < relative_threshold)
+            else
                 ScheduleEvent(() => OnMouseMoveRelative(new Vector2(evtMotion.xrel, evtMotion.yrel)));
         }
 

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -51,6 +51,17 @@ namespace osu.Framework.Platform
         /// </summary>
         public bool Exists => WindowBackend.Exists;
 
+        /// <summary>
+        /// Enables or disables relative mouse mode.
+        /// While relative mouse mode is disabled, <see cref="MouseMove"/> events will be fired.
+        /// While relative mouse mode is enabled, <see cref="MouseMoveRelative"/> events will be fired.
+        /// </summary>
+        public bool RelativeMouseMode
+        {
+            get => WindowBackend.RelativeMouseMode;
+            set => WindowBackend.RelativeMouseMode = value;
+        }
+
         public Display PrimaryDisplay => WindowBackend.PrimaryDisplay;
 
         public DisplayMode CurrentDisplayMode => WindowBackend.CurrentDisplayMode;
@@ -188,9 +199,18 @@ namespace osu.Framework.Platform
         public event Action<Vector2, bool> MouseWheel;
 
         /// <summary>
-        /// Invoked when the user moves the mouse cursor within the window.
+        /// Invoked when the user moves the mouse cursor, if relative mouse mode is disabled.
+        /// The <see cref="Vector2"/> provided is the position relative to the top left corner of the window,
+        /// with DPI scaling applied.
         /// </summary>
         public event Action<Vector2> MouseMove;
+
+        /// <summary>
+        /// Invoked when the user moves the mouse cursor, if relative mouse mode is enabled.
+        /// The <see cref="Vector2"/> provided is the number of pixels the cursor has moved since the previous
+        /// <see cref="MouseMoveRelative"/> invocation.
+        /// </summary>
+        public event Action<Vector2> MouseMoveRelative;
 
         /// <summary>
         /// Invoked when the user presses a mouse button.
@@ -254,6 +274,7 @@ namespace osu.Framework.Platform
         protected virtual void OnMoved(Point point) => Moved?.Invoke(point);
         protected virtual void OnMouseWheel(Vector2 delta, bool precise) => MouseWheel?.Invoke(delta, precise);
         protected virtual void OnMouseMove(Vector2 position) => MouseMove?.Invoke(position);
+        protected virtual void OnMouseMoveRelative(Vector2 delta) => MouseMoveRelative?.Invoke(delta);
         protected virtual void OnMouseDown(MouseButton button) => MouseDown?.Invoke(button);
         protected virtual void OnMouseUp(MouseButton button) => MouseUp?.Invoke(button);
         protected virtual void OnKeyDown(Key key) => KeyDown?.Invoke(key);
@@ -355,6 +376,7 @@ namespace osu.Framework.Platform
             WindowBackend.MouseDown += OnMouseDown;
             WindowBackend.MouseUp += OnMouseUp;
             WindowBackend.MouseMove += OnMouseMove;
+            WindowBackend.MouseMoveRelative += OnMouseMoveRelative;
             WindowBackend.MouseWheel += OnMouseWheel;
             WindowBackend.DragDrop += OnDragDrop;
 

--- a/osu.Framework/Platform/WindowBackend.cs
+++ b/osu.Framework/Platform/WindowBackend.cs
@@ -26,6 +26,8 @@ namespace osu.Framework.Platform
         public abstract Size ClientSize { get; }
         public abstract bool CursorVisible { get; set; }
         public abstract bool CursorConfined { get; set; }
+        public abstract bool RelativeMouseMode { get; set; }
+        public abstract Vector2 MousePosition { get; set; }
         public abstract WindowState WindowState { get; set; }
         public abstract bool Exists { get; protected set; }
         public abstract Display CurrentDisplay { get; set; }
@@ -49,6 +51,7 @@ namespace osu.Framework.Platform
         public event Action<Point> Moved;
         public event Action<Vector2, bool> MouseWheel;
         public event Action<Vector2> MouseMove;
+        public event Action<Vector2> MouseMoveRelative;
         public event Action<MouseButton> MouseDown;
         public event Action<MouseButton> MouseUp;
         public event Action<Key> KeyDown;
@@ -86,6 +89,7 @@ namespace osu.Framework.Platform
         protected virtual void OnMoved(Point point) => Moved?.Invoke(point);
         protected virtual void OnMouseWheel(Vector2 delta, bool precise) => MouseWheel?.Invoke(delta, precise);
         protected virtual void OnMouseMove(Vector2 position) => MouseMove?.Invoke(position);
+        protected virtual void OnMouseMoveRelative(Vector2 delta) => MouseMoveRelative?.Invoke(delta);
         protected virtual void OnMouseDown(MouseButton button) => MouseDown?.Invoke(button);
         protected virtual void OnMouseUp(MouseButton button) => MouseUp?.Invoke(button);
         protected virtual void OnKeyDown(Key key) => KeyDown?.Invoke(key);

--- a/osu.Framework/Platform/WindowBackend.cs
+++ b/osu.Framework/Platform/WindowBackend.cs
@@ -27,7 +27,6 @@ namespace osu.Framework.Platform
         public abstract bool CursorVisible { get; set; }
         public abstract bool CursorConfined { get; set; }
         public abstract bool RelativeMouseMode { get; set; }
-        public abstract Vector2 MousePosition { get; set; }
         public abstract WindowState WindowState { get; set; }
         public abstract bool Exists { get; protected set; }
         public abstract Display CurrentDisplay { get; set; }
@@ -72,6 +71,8 @@ namespace osu.Framework.Platform
         public abstract void RequestClose();
 
         public abstract void SetIcon(Image<Rgba32> image);
+
+        public abstract void UpdateRelativeMode(Vector2? position = null);
 
         #region Event Invocation
 


### PR DESCRIPTION
Implements raw input with the SDL backend.  Should work fine on Windows (tested) and Linux (untested), but macOS is non-trivial and thus a future task.

There were some gotchas that made this take longer than it should have, specifically that events were being invoked in batches rather than sequentially.  The call to `SDL_SetRelativeMouseMode` purges all pending SDL mouse motion events, but it's possible that they have already been polled and added to `eventScheduler`.  I have thus changed the event loop to only handle a single SDL event at a time.  This means that any event invocations can be sure to immediately execute SDL commands before the next invocation.  Note that it is still using the scheduler, so that subclasses can inject events if required (such as with `MacOSWindowBackend`).

While the "raw" part of macOS is not implemented by SDL, the "relative" part is.  This means that the sensitivity slider and map absolute options can be used, but for now the mouse still includes OS acceleration.

"Map Absolute" scales the relative movement based on a window with a long edge of 1024 pixels.  This is somewhat of a guess, since it was hard to match against osuTK's implementation.

Needs testing on Linux, and verification on the implementation's "correctness" based on the user's expectation of the functionality.

Should hopefully resolve all or most of #2860, #2814, #2247, #2077, #1378

Requires a change to osu! to correctly select the raw input mouse handler when running SDL.