### PR TITLE
Replace SDL_GL_SwapWindow with flushBuffer call on macOS

### DIFF
--- a/osu.Framework/Platform/MacOS/MacOSDesktopWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSDesktopWindow.cs
@@ -10,5 +10,6 @@ namespace osu.Framework.Platform.MacOS
     public class MacOSDesktopWindow : DesktopWindow
     {
         protected override IWindowBackend CreateWindowBackend() => new MacOSWindowBackend();
+        protected override IGraphicsBackend CreateGraphicsBackend() => new MacOSGraphicsBackend();
     }
 }

--- a/osu.Framework/Platform/MacOS/MacOSGraphicsBackend.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGraphicsBackend.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Platform.MacOS.Native;
+using osu.Framework.Platform.Sdl;
+using SDL2;
+
+namespace osu.Framework.Platform.MacOS
+{
+    /// <summary>
+    /// A macOS-specific subclass of <see cref="Sdl2GraphicsBackend"/> that implements a minor fix to <see cref="SwapBuffers"/>.
+    /// </summary>
+    public class MacOSGraphicsBackend : Sdl2GraphicsBackend
+    {
+        private static readonly IntPtr sel_flushbuffer = Selector.Get("flushBuffer");
+
+        /// <summary>
+        /// There is a rare case where <see cref="SDL.SDL_GL_SwapWindow"/> can cause a crash due to
+        /// SDL attempting to call [NSOpenGLContext update] on a thread other than the main thread.
+        /// Instead we forcefully call [NSOpenGLContext flushBuffer].
+        /// </summary>
+        public override void SwapBuffers() => Cocoa.SendVoid(Context, sel_flushbuffer);
+    }
+}

--- a/osu.Framework/Platform/MacOS/Native/Cocoa.cs
+++ b/osu.Framework/Platform/MacOS/Native/Cocoa.cs
@@ -49,6 +49,9 @@ namespace osu.Framework.Platform.MacOS.Native
         public static extern bool SendBool(IntPtr receiver, IntPtr selector, IntPtr ptr1, IntPtr ptr2);
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
+        public static extern void SendVoid(IntPtr receiver, IntPtr selector);
+
+        [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]
         public static extern void SendVoid(IntPtr receiver, IntPtr selector, uint arg);
 
         [DllImport(LIB_OBJ_C, EntryPoint = "objc_msgSend")]


### PR DESCRIPTION
Fixes a potential crash where SDL can incorrectly attempt to call `[NSOpenGLContext update]` on a non-main thread from within `SDL_GL_SwapWindow`.