### PR TITLE
Add documentation about project templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The BASS audio library (a dependency of this framework) is a commercial product.
 
 ## Developing a game using osu!framework
 
-If you want to get started making your own game project using osu!framework, check out our [project templates](https://github.com/ppy/osu-framework/tree/master/osu.Framework.Templates). You can either start off from an empty project, or take a peek at a working sample game. Either way, full project structure, cross-platform support and testing setup are included!
+If you want to get started making your own game project using osu!framework, check out our [project templates](https://github.com/ppy/osu-framework/tree/master/osu.Framework.Templates). You can either start off from an empty project, or take a peek at a working sample game. Either way, full project structure, cross-platform support, and testing setup are included!
 
 ## Projects that use osu!framework
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ This framework is licensed under the [MIT licence](https://opensource.org/licens
 
 The BASS audio library (a dependency of this framework) is a commercial product. While it is free for non-commercial use, please ensure to [obtain a valid licence](http://www.un4seen.com/bass.html#license) if you plan on distributing any application using it commercially.
 
+## Developing a game using osu!framework
+
+If you want to get started making your own game project using osu!framework, check out our [project templates](https://github.com/ppy/osu-framework/tree/master/osu.Framework.Templates). You can either start off from an empty project, or take a peek at a working sample game. Either way, full project structure, cross-platform support and testing setup are included!
+
 ## Projects that use osu!framework
 
 [osu!](https://github.com/ppy/osu) – rhythm is just a *click* away!

--- a/osu.Framework.Templates/README.md
+++ b/osu.Framework.Templates/README.md
@@ -1,0 +1,17 @@
+# osu.Framework.Templates
+
+Templates to use when starting off with osu!framework. Create a fully-testable, cross-platform, and ready-for-git project using osu!framework using just two lines.
+
+## Usage
+
+```bash
+# install (or update) template package.
+# this only needs to be done once
+dotnet new -i ppy.osu.Framework.Templates
+
+# create a new empty freeform osu!framework game
+dotnet new osu-framework-game -n MyNewGame
+
+# ...or start with a working Flappy Bird clone
+dotnet new osu-framework-flappy-game -n MyNewFlappyGame
+```

--- a/osu.Framework.Templates/README.md
+++ b/osu.Framework.Templates/README.md
@@ -1,6 +1,6 @@
 # osu.Framework.Templates
 
-Templates to use when starting off with osu!framework. Create a fully-testable, cross-platform, and ready-for-git project using osu!framework using just two lines.
+Templates to use when starting off with osu!framework. Create a fully-testable, cross-platform, and ready-for-git project using osu!framework in just two lines.
 
 ## Usage
 


### PR DESCRIPTION
Long overdue, really. Hopefully will make starting off easier for people who might not be aware that these exist.

The README link will look bad if clicked from the rich diff, but [this](https://github.com/bdach/osu-framework/tree/templates-readme/osu.Framework.Templates) is how it's supposed to look (link points to same subdirectory on my fork/branch - git shows `README.md` file contents in subdirectories too).

Wording ~~stolen~~ borrowed and slightly tweaked from the [ruleset templates](https://github.com/ppy/osu-templates).