### PR TITLE
Expose and define cache storage

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using osuTK;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
@@ -20,6 +18,7 @@ using osu.Framework.Input.Bindings;
 using osu.Framework.IO.Stores;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
+using osuTK;
 
 namespace osu.Framework
 {
@@ -149,7 +148,7 @@ namespace osu.Framework
             Shaders = new ShaderManager(new NamespacedResourceStore<byte[]>(Resources, @"Shaders"));
             dependencies.Cache(Shaders);
 
-            var cacheStorage = Host.Storage.GetStorageForDirectory(Path.Combine("cache", "fonts"));
+            var cacheStorage = Host.CacheStorage.GetStorageForDirectory("fonts");
 
             // base store is for user fonts
             Fonts = new FontStore(useAtlas: true, cacheStorage: cacheStorage);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -134,7 +134,15 @@ namespace osu.Framework.Platform
 
         public abstract string UserStoragePath { get; }
 
+        /// <summary>
+        /// The main storage as proposed by the host game.
+        /// </summary>
         public Storage Storage { get; protected set; }
+
+        /// <summary>
+        /// An auxiliary cache storage which is fixed in the default game directory.
+        /// </summary>
+        public Storage CacheStorage { get; protected set; }
 
         /// <summary>
         /// If caps-lock is enabled on the system, false if not overwritten by a subclass
@@ -522,6 +530,8 @@ namespace osu.Framework.Platform
                 Dependencies.CacheAs(this);
 
                 Dependencies.CacheAs(Storage = game.CreateStorage(this, GetDefaultGameStorage()));
+
+                CacheStorage = GetDefaultGameStorage().GetStorageForDirectory("cache");
 
                 SetupForRun();
 


### PR DESCRIPTION
As proposed in https://github.com/ppy/osu/pull/10496, this splits out cache storage to its own immutable location. We can add game customisation of it if/when that need arises, but for now the idea is to have it on the OS drive / default install location for highest performance.