### PR TITLE
Allow SDL to use existing raw input implementation

### DIFF
--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -34,8 +34,6 @@ namespace osu.Framework.Android
 
         public override void SetupWindow(FrameworkConfigManager config)
         {
-            // Let's just say the cursor is always in the window.
-            CursorInWindow = true;
         }
 
         protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new[]

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -190,7 +190,7 @@ namespace osu.Framework.Tests.Visual.Input
 
         private void setRawInputConfig(bool x)
         {
-            config.Set(FrameworkSetting.IgnoredInputHandlers, x ? nameof(OsuTKMouseHandler) : nameof(OsuTKRawMouseHandler));
+            config.Set(FrameworkSetting.IgnoredInputHandlers, x ? $"{nameof(OsuTKMouseHandler)} {nameof(MouseHandler)}" : nameof(OsuTKRawMouseHandler));
         }
 
         private void setConfineMouseModeConfig(bool x)

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.iOS
         {
             Resize += onResize;
             // for now, let's just say the cursor is always in the window.
-            CursorInWindow = true;
+            CursorInWindow.Value = true;
         }
 
         public override IGraphicsContext Context => GameView.GraphicsContext;

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -24,8 +24,6 @@ namespace osu.Framework.iOS
         public override void SetupWindow(FrameworkConfigManager config)
         {
             Resize += onResize;
-            // for now, let's just say the cursor is always in the window.
-            CursorInWindow.Value = true;
         }
 
         public override IGraphicsContext Context => GameView.GraphicsContext;

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKMouseHandler.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                     host.InputThread.Scheduler.Add(scheduled = new ScheduledDelegate(delegate
                     {
                         // we should be getting events if the mouse is inside the window.
-                        if (MouseInWindow || !host.Window.Visible || host.Window.WindowState == osuTK.WindowState.Minimized) return;
+                        if (MouseInWindow.Value || !host.Window.Visible || host.Window.WindowState == osuTK.WindowState.Minimized) return;
 
                         var cursorState = osuTK.Input.Mouse.GetCursorState();
 
@@ -67,7 +67,7 @@ namespace osu.Framework.Input.Handlers.Mouse
 
         private void handleMouseEvent(object sender, osuTK.Input.MouseEventArgs e)
         {
-            if (!MouseInWindow)
+            if (!MouseInWindow.Value)
                 return;
 
             if (e.Mouse.X < 0 || e.Mouse.Y < 0)

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKMouseHandlerBase.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKMouseHandlerBase.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Bindables;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
@@ -11,17 +12,13 @@ namespace osu.Framework.Input.Handlers.Mouse
     internal abstract class OsuTKMouseHandlerBase : InputHandler
     {
         protected GameHost Host;
-        protected bool MouseInWindow;
+        protected IBindable<bool> MouseInWindow;
 
         public override bool Initialize(GameHost host)
         {
             Host = host;
 
-            MouseInWindow = host.Window.CursorInWindow;
-
-            host.Window.MouseLeave += (s, e) => MouseInWindow = false;
-            host.Window.MouseEnter += (s, e) => MouseInWindow = true;
-
+            MouseInWindow = host.Window.CursorInWindow.GetBoundCopy();
             return true;
         }
 

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
@@ -47,7 +47,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                         if (!host.Window.Visible || host.Window.WindowState == osuTK.WindowState.Minimized)
                             return;
 
-                        if ((MouseInWindow || lastEachDeviceStates.Any(s => s != null && s.Buttons.HasAnyButtonPressed)) && host.Window.Focused)
+                        if ((MouseInWindow.Value || lastEachDeviceStates.Any(s => s != null && s.Buttons.HasAnyButtonPressed)) && host.Window.Focused)
                         {
                             osuTK.Input.Mouse.GetStates(newRawStates);
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Input
     {
         protected override ImmutableArray<InputHandler> InputHandlers => Host.AvailableInputHandlers;
 
-        protected override bool HandleHoverEvents => Host.Window?.CursorInWindow ?? true;
+        protected override bool HandleHoverEvents => Host.Window?.CursorInWindow.Value ?? true;
 
         protected internal override bool ShouldBeAlive => true;
 
@@ -43,13 +43,13 @@ namespace osu.Framework.Input
                     break;
 
                 case ButtonStateChangeEvent<MouseButton> buttonChange:
-                    if (buttonChange.Kind == ButtonStateChangeKind.Pressed && Host.Window?.CursorInWindow == false)
+                    if (buttonChange.Kind == ButtonStateChangeKind.Pressed && Host.Window?.CursorInWindow.Value == false)
                         return;
 
                     break;
 
                 case MouseScrollChangeEvent _:
-                    if (Host.Window?.CursorInWindow == false)
+                    if (Host.Window?.CursorInWindow.Value == false)
                         return;
 
                     break;

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -98,6 +98,7 @@ namespace osu.Framework.Platform
             switch (Window)
             {
                 case GameWindow _:
+                {
                     var defaultEnabled = new InputHandler[]
                     {
                         new OsuTKMouseHandler(),
@@ -115,14 +116,27 @@ namespace osu.Framework.Platform
                         h.Enabled.Value = false;
 
                     return defaultEnabled.Concat(defaultDisabled);
+                }
 
                 default:
-                    return new InputHandler[]
+                {
+                    var defaultEnabled = new InputHandler[]
                     {
                         new KeyboardHandler(),
                         new MouseHandler(),
                         new JoystickHandler(),
                     };
+
+                    var defaultDisabled = new InputHandler[]
+                    {
+                        new OsuTKRawMouseHandler(),
+                    };
+
+                    foreach (var h in defaultDisabled)
+                        h.Enabled.Value = false;
+
+                    return defaultEnabled.Concat(defaultDisabled);
+                }
             }
         }
 

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -57,9 +57,6 @@ namespace osu.Framework.Platform
 
         private readonly BindableBool cursorInWindow = new BindableBool();
 
-        /// <summary>
-        /// Provides a read-only bindable that monitors the whether the cursor is in the window.
-        /// </summary>
         public IBindable<bool> CursorInWindow => cursorInWindow;
 
         /// <summary>

--- a/osu.Framework/Platform/GameWindow.cs
+++ b/osu.Framework/Platform/GameWindow.cs
@@ -55,10 +55,12 @@ namespace osu.Framework.Platform
 
         protected readonly Scheduler UpdateFrameScheduler = new Scheduler();
 
+        private readonly BindableBool cursorInWindow = new BindableBool();
+
         /// <summary>
-        /// Whether the OS cursor is currently contained within the game window.
+        /// Provides a read-only bindable that monitors the whether the cursor is in the window.
         /// </summary>
-        public bool CursorInWindow { get; protected set; }
+        public IBindable<bool> CursorInWindow => cursorInWindow;
 
         /// <summary>
         /// Available resolutions for full-screen display.
@@ -113,8 +115,8 @@ namespace osu.Framework.Platform
             Closing += (sender, e) => e.Cancel = ExitRequested?.Invoke() ?? false;
             Closed += (sender, e) => Exited?.Invoke();
 
-            MouseEnter += (sender, args) => CursorInWindow = true;
-            MouseLeave += (sender, args) => CursorInWindow = false;
+            MouseEnter += (sender, args) => cursorInWindow.Value = true;
+            MouseLeave += (sender, args) => cursorInWindow.Value = false;
 
             FocusedChanged += (o, e) => isActive.Value = Focused;
 

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Whether the OS cursor is currently contained within the game window.
         /// </summary>
-        bool CursorInWindow { get; }
+        IBindable<bool> CursorInWindow { get; }
 
         /// <summary>
         /// Controls the state of the OS cursor.

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -114,9 +114,6 @@ namespace osu.Framework.Platform
 
         private readonly BindableBool cursorInWindow = new BindableBool();
 
-        /// <summary>
-        /// Provides a read-only bindable that monitors the whether the cursor is in the window.
-        /// </summary>
         public IBindable<bool> CursorInWindow => cursorInWindow;
 
         public IBindableList<WindowMode> SupportedWindowModes { get; }

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -662,8 +662,6 @@ namespace osu.Framework.Platform
 
 #pragma warning restore 0067
 
-        bool IWindow.CursorInWindow => CursorInWindow.Value;
-
         CursorState IWindow.CursorState
         {
             get => CursorState.Value;

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -112,7 +112,7 @@ namespace osu.Framework.Platform
         /// </summary>
         public IBindable<bool> Focused => focused;
 
-        private readonly BindableBool cursorInWindow = new BindableBool();
+        private readonly BindableBool cursorInWindow = new BindableBool(true);
 
         public IBindable<bool> CursorInWindow => cursorInWindow;
 

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -684,9 +684,9 @@ namespace osu.Framework.Platform
         {
         }
 
-        public Point PointToClient(Point point) => point;
+        public virtual Point PointToClient(Point point) => point;
 
-        public Point PointToScreen(Point point) => point;
+        public virtual Point PointToScreen(Point point) => point;
 
         public Icon Icon { get; set; }
 

--- a/osu.Framework/Platform/Windows/WindowsDesktopWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsDesktopWindow.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Drawing;
 using System.Runtime.InteropServices;
 using osu.Framework.Platform.Windows.Native;
 
@@ -40,6 +41,24 @@ namespace osu.Framework.Platform.Windows
                 SendMessage(windowHandle, seticon_message, (IntPtr)icon_big, largeIcon.Handle);
             }
         }
+
+        public override Point PointToClient(Point point)
+        {
+            ScreenToClient(WindowBackend.WindowHandle, ref point);
+            return point;
+        }
+
+        public override Point PointToScreen(Point point)
+        {
+            ClientToScreen(WindowBackend.WindowHandle, ref point);
+            return point;
+        }
+
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern bool ScreenToClient(IntPtr hWnd, ref Point point);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern bool ClientToScreen(IntPtr hWnd, ref Point point);
 
         [DllImport("user32.dll", CharSet = CharSet.Auto)]
         private static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);


### PR DESCRIPTION
Simplest possible implementation. Note that this ends up using osuTK's fallback when mouse is outside the window / non-focused. I don't think this is a huge deal.

- [x] Depends on https://github.com/ppy/osu-framework/pull/3981 (for simplicity of merge, due to renames)