### PR TITLE
Add OsuTK prefix and drop "Desktop" naming where redundant

### DIFF
--- a/.idea/.idea.osu-framework/.idea/indexLayout.xml
+++ b/.idea/.idea.osu-framework/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ContentModelUserStore">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -4,14 +4,14 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Configuration;
+using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
-using GameWindow = osu.Framework.Platform.GameWindow;
 using WindowState = osuTK.WindowState;
 
 namespace osu.Framework.Android
 {
-    public class AndroidGameWindow : GameWindow
+    public class AndroidGameWindow : OsuTKWindow
     {
         public override IGraphicsContext Context
             => View.GraphicsContext;

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Tests.Visual.Platform
         private static readonly Color4 window_fill = new Color4(95, 113, 197, 255);
         private static readonly Color4 window_stroke = new Color4(36, 59, 166, 255);
 
-        private DesktopGameWindow window;
+        private OsuTKDesktopWindow window;
         private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
 
         public TestSceneBorderless()
@@ -136,7 +136,7 @@ namespace osu.Framework.Tests.Visual.Platform
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager config, GameHost host)
         {
-            window = host.Window as DesktopGameWindow;
+            window = host.Window as OsuTKDesktopWindow;
             config.BindWith(FrameworkSetting.WindowMode, windowMode);
 
             if (window == null)

--- a/osu.Framework.iOS/IOSGameWindow.cs
+++ b/osu.Framework.iOS/IOSGameWindow.cs
@@ -5,14 +5,14 @@ using System;
 using System.Collections.Generic;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
+using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
-using GameWindow = osu.Framework.Platform.GameWindow;
 using WindowState = osuTK.WindowState;
 
 namespace osu.Framework.iOS
 {
-    public class IOSGameWindow : GameWindow
+    public class IOSGameWindow : OsuTKWindow
     {
         internal static IOSGameView GameView;
 

--- a/osu.Framework/Graphics/Containers/SafeAreaDefiningContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaDefiningContainer.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Containers
     /// A <see cref="Container"/> that is automatically cached and provides a <see cref="BindableSafeArea"/> representing
     /// the desired safe area margins. Should be used in conjunction with child <see cref="SafeAreaContainer"/>s.
     /// The root of the scenegraph contains an instance of this container, with <see cref="BindableSafeArea"/> automatically bound
-    /// to the host <see cref="GameWindow"/>'s <see cref="GameWindow.SafeAreaPadding"/>.
+    /// to the host <see cref="OsuTKWindow"/>'s <see cref="OsuTKWindow.SafeAreaPadding"/>.
     /// </summary>
     [Cached(typeof(ISafeArea))]
     public class SafeAreaDefiningContainer : Container<Drawable>, ISafeArea
@@ -23,7 +23,7 @@ namespace osu.Framework.Graphics.Containers
 
         /// <summary>
         /// Initialises a <see cref="SafeAreaDefiningContainer"/> by optionally providing a custom <see cref="BindableSafeArea"/>.
-        /// If no such binding is provided, the container will default to <see cref="GameWindow.SafeAreaPadding"/>.
+        /// If no such binding is provided, the container will default to <see cref="OsuTKWindow.SafeAreaPadding"/>.
         /// </summary>
         /// <param name="safeArea">The custom <see cref="BindableSafeArea"/> to bind to, if required.</param>
         public SafeAreaDefiningContainer(BindableSafeArea safeArea = null)

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -19,7 +19,6 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Platform;
 using osu.Framework.Timing;
-using GameWindow = osu.Framework.Platform.GameWindow;
 
 namespace osu.Framework.Graphics.OpenGL
 {
@@ -101,7 +100,7 @@ namespace osu.Framework.Graphics.OpenGL
         {
             if (IsInitialized) return;
 
-            if (host.Window is GameWindow win)
+            if (host.Window is OsuTKWindow win)
                 IsEmbedded = win.IsEmbedded;
 
             GLWrapper.host = new WeakReference<GameHost>(host);

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             base.Initialize(host);
 
             // Get the bindables we need to determine whether to confine the mouse to window or not
-            if (host.Window is DesktopGameWindow desktopWindow)
+            if (host.Window is OsuTKDesktopWindow desktopWindow)
             {
                 windowMode.BindTo(desktopWindow.WindowMode);
                 mapAbsoluteInputToWindow.BindTo(desktopWindow.MapAbsoluteInputToWindow);

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -97,7 +97,7 @@ namespace osu.Framework.Platform
         {
             switch (Window)
             {
-                case GameWindow _:
+                case OsuTKWindow _:
                     var defaultEnabled = new InputHandler[]
                     {
                         new OsuTKMouseHandler(),

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Platform
 {
     /// <summary>
     /// Interface representation of the game window, intended to hide any implementation-specific code.
-    /// Currently inherits from osuTK; this will be removed as part of the <see cref="GameWindow"/> refactor.
+    /// Currently inherits from osuTK; this will be removed as part of the <see cref="OsuTKWindow"/> refactor.
     /// </summary>
     public interface IWindow : IGameWindow
     {

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Platform.Linux
         }
 
         protected override IWindow CreateWindow() =>
-            !UseSdl ? (IWindow)new LinuxGameWindow() : new DesktopWindow();
+            !UseSdl ? (IWindow)new OsuTKLinuxWindow() : new DesktopWindow();
 
         public override string UserStoragePath
         {
@@ -41,6 +41,6 @@ namespace osu.Framework.Platform.Linux
         }
 
         public override Clipboard GetClipboard() =>
-            Window is DesktopWindow || (Window as LinuxGameWindow)?.IsSdl == true ? (Clipboard)new SdlClipboard() : new LinuxClipboard();
+            Window is DesktopWindow || (Window as OsuTKLinuxWindow)?.IsSdl == true ? (Clipboard)new SdlClipboard() : new LinuxClipboard();
     }
 }

--- a/osu.Framework/Platform/Linux/OsuTKLinuxWindow.cs
+++ b/osu.Framework/Platform/Linux/OsuTKLinuxWindow.cs
@@ -8,11 +8,11 @@ using osuTK;
 
 namespace osu.Framework.Platform.Linux
 {
-    public class LinuxGameWindow : DesktopGameWindow
+    public class OsuTKLinuxWindow : OsuTKDesktopWindow
     {
         public bool IsSdl { get; private set; }
 
-        public LinuxGameWindow()
+        public OsuTKLinuxWindow()
         {
             Load += OnLoad;
         }

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Platform.MacOS
         }
 
         protected override IWindow CreateWindow() =>
-            !UseSdl ? (IWindow)new MacOSGameWindow() : new MacOSDesktopWindow();
+            !UseSdl ? (IWindow)new OsuTKMacOSWindow() : new MacOSWindow();
 
         public override string UserStoragePath
         {

--- a/osu.Framework/Platform/MacOS/MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindow.cs
@@ -7,7 +7,7 @@ namespace osu.Framework.Platform.MacOS
     /// macOS-specific subclass of <see cref="DesktopWindow"/> that specifies a custom
     /// <see cref="IWindowBackend"/>.
     /// </summary>
-    public class MacOSDesktopWindow : DesktopWindow
+    public class MacOSWindow : DesktopWindow
     {
         protected override IWindowBackend CreateWindowBackend() => new MacOSWindowBackend();
     }

--- a/osu.Framework/Platform/MacOS/OsuTKMacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/OsuTKMacOSWindow.cs
@@ -15,7 +15,7 @@ using System.Diagnostics;
 
 namespace osu.Framework.Platform.MacOS
 {
-    internal class MacOSGameWindow : DesktopGameWindow
+    internal class OsuTKMacOSWindow : OsuTKDesktopWindow
     {
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate void FlagsChangedDelegate(IntPtr self, IntPtr cmd, IntPtr notification);
@@ -51,7 +51,7 @@ namespace osu.Framework.Platform.MacOS
 
         private WindowMode? pendingWindowMode;
 
-        public MacOSGameWindow()
+        public OsuTKMacOSWindow()
         {
             Load += OnLoad;
             UpdateFrame += OnUpdateFrame;

--- a/osu.Framework/Platform/OsuTKDesktopWindow.cs
+++ b/osu.Framework/Platform/OsuTKDesktopWindow.cs
@@ -15,7 +15,7 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Platform
 {
-    public abstract class DesktopGameWindow : GameWindow
+    public abstract class OsuTKDesktopWindow : OsuTKWindow
     {
         private const int default_width = 1366;
         private const int default_height = 768;
@@ -34,7 +34,7 @@ namespace osu.Framework.Platform
 
         public override IGraphicsContext Context => Implementation.Context;
 
-        protected new osuTK.GameWindow Implementation => (osuTK.GameWindow)base.Implementation;
+        protected new GameWindow Implementation => (GameWindow)base.Implementation;
 
         public readonly BindableBool MapAbsoluteInputToWindow = new BindableBool();
 
@@ -75,7 +75,7 @@ namespace osu.Framework.Platform
                       .Where(x => x != null)
                       .Select(ExtensionMethods.ToDisplay);
 
-        protected DesktopGameWindow()
+        protected OsuTKDesktopWindow()
             : base(default_width, default_height)
         {
             Resize += OnResize;

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -21,10 +21,10 @@ using Icon = osuTK.Icon;
 
 namespace osu.Framework.Platform
 {
-    public abstract class GameWindow : IWindow
+    public abstract class OsuTKWindow : IWindow
     {
         /// <summary>
-        /// The <see cref="IGraphicsContext"/> associated with this <see cref="GameWindow"/>.
+        /// The <see cref="IGraphicsContext"/> associated with this <see cref="OsuTKWindow"/>.
         /// </summary>
         [NotNull]
         public abstract IGraphicsContext Context { get; }
@@ -36,7 +36,7 @@ namespace osu.Framework.Platform
         public event Func<bool> ExitRequested;
 
         /// <summary>
-        /// Invoked when the <see cref="GameWindow"/> has closed.
+        /// Invoked when the <see cref="OsuTKWindow"/> has closed.
         /// </summary>
         [CanBeNull]
         public event Action Exited;
@@ -70,7 +70,7 @@ namespace osu.Framework.Platform
         private readonly Bindable<bool> isActive = new Bindable<bool>();
 
         /// <summary>
-        /// Whether this <see cref="GameWindow"/> is active (in the foreground).
+        /// Whether this <see cref="OsuTKWindow"/> is active (in the foreground).
         /// </summary>
         public IBindable<bool> IsActive => isActive;
 
@@ -96,9 +96,9 @@ namespace osu.Framework.Platform
         }
 
         /// <summary>
-        /// Creates a <see cref="GameWindow"/> with a given <see cref="IGameWindow"/> implementation.
+        /// Creates a <see cref="OsuTKWindow"/> with a given <see cref="IGameWindow"/> implementation.
         /// </summary>
-        protected GameWindow([NotNull] IGameWindow implementation)
+        protected OsuTKWindow([NotNull] IGameWindow implementation)
         {
             Implementation = implementation;
             Implementation.KeyDown += OnKeyDown;
@@ -163,11 +163,11 @@ namespace osu.Framework.Platform
         }
 
         /// <summary>
-        /// Creates a <see cref="GameWindow"/> with given dimensions.
+        /// Creates a <see cref="OsuTKWindow"/> with given dimensions.
         /// <para>Note that this will use the default <see cref="osuTK.GameWindow"/> implementation, which is not compatible with every platform.</para>
         /// </summary>
-        protected GameWindow(int width, int height)
-            : this(new osuTK.GameWindow(width, height, new GraphicsMode(GraphicsMode.Default.ColorFormat, GraphicsMode.Default.Depth, GraphicsMode.Default.Stencil, GraphicsMode.Default.Samples, GraphicsMode.Default.AccumulatorFormat, 3)))
+        protected OsuTKWindow(int width, int height)
+            : this(new GameWindow(width, height, new GraphicsMode(GraphicsMode.Default.ColorFormat, GraphicsMode.Default.Depth, GraphicsMode.Default.Stencil, GraphicsMode.Default.Samples, GraphicsMode.Default.AccumulatorFormat, 3)))
         {
         }
 
@@ -574,18 +574,18 @@ namespace osu.Framework.Platform
         Default = 0,
 
         /// <summary>
-        /// The OS cursor is hidden while hovering the <see cref="GameWindow"/>, but can still move anywhere.
+        /// The OS cursor is hidden while hovering the <see cref="OsuTKWindow"/>, but can still move anywhere.
         /// </summary>
         Hidden = 1,
 
         /// <summary>
-        /// The OS cursor is confined to the <see cref="GameWindow"/> while the window is in focus.
+        /// The OS cursor is confined to the <see cref="OsuTKWindow"/> while the window is in focus.
         /// </summary>
         Confined = 2,
 
         /// <summary>
-        /// The OS cursor is hidden while hovering the <see cref="GameWindow"/>.
-        /// It is confined to the <see cref="GameWindow"/> while the window is in focus and can move freely otherwise.
+        /// The OS cursor is hidden while hovering the <see cref="OsuTKWindow"/>.
+        /// It is confined to the <see cref="OsuTKWindow"/> while the window is in focus and can move freely otherwise.
         /// </summary>
         HiddenAndConfined = Hidden | Confined,
     }

--- a/osu.Framework/Platform/Windows/OsuTKWindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/OsuTKWindowsWindow.cs
@@ -8,7 +8,7 @@ using osu.Framework.Platform.Windows.Native;
 
 namespace osu.Framework.Platform.Windows
 {
-    internal class WindowsGameWindow : DesktopGameWindow
+    internal class OsuTKWindowsWindow : OsuTKDesktopWindow
     {
         private const int seticon_message = 0x0080;
 

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -50,7 +50,7 @@ namespace osu.Framework.Platform.Windows
         }
 
         protected override IWindow CreateWindow() =>
-            !UseSdl ? (IWindow)new WindowsGameWindow() : new WindowsDesktopWindow();
+            !UseSdl ? (IWindow)new OsuTKWindowsWindow() : new WindowsWindow();
 
         public override IEnumerable<KeyBinding> PlatformKeyBindings => base.PlatformKeyBindings.Concat(new[]
         {

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -7,7 +7,7 @@ using osu.Framework.Platform.Windows.Native;
 
 namespace osu.Framework.Platform.Windows
 {
-    public class WindowsDesktopWindow : DesktopWindow
+    public class WindowsWindow : DesktopWindow
     {
         private const int seticon_message = 0x0080;
         private const int icon_big = 1;


### PR DESCRIPTION
Part of an effort to make the window hierarchy understandable to the point I can work with it.