### PR TITLE
Fix SDL drawing window white on first display on windows

### DIFF
--- a/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
+++ b/osu.Framework/Platform/Sdl/Sdl2WindowBackend.cs
@@ -426,11 +426,13 @@ namespace osu.Framework.Platform.Sdl
             SDL.SDL_WindowFlags flags = SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL |
                                         SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE |
                                         SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI |
+                                        SDL.SDL_WindowFlags.SDL_WINDOW_HIDDEN | // shown after first swap to avoid white flash on startup (windows)
                                         WindowState.ToFlags();
 
             SDL.SDL_SetHint(SDL.SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4, "1");
 
             SdlWindowHandle = SDL.SDL_CreateWindow($"{title} (SDL)", Position.X, Position.Y, Size.Width, Size.Height, flags);
+
             cachedScale.Invalidate();
             Exists = true;
         }

--- a/osu.Framework/Platform/Window.cs
+++ b/osu.Framework/Platform/Window.cs
@@ -91,7 +91,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Provides a bindable that controls the window's visibility.
         /// </summary>
-        public Bindable<bool> Visible { get; } = new BindableBool();
+        public Bindable<bool> Visible { get; } = new BindableBool(true);
 
         public Bindable<Display> CurrentDisplay { get; } = new Bindable<Display>();
 
@@ -366,10 +366,21 @@ namespace osu.Framework.Platform
             CurrentDisplay.ValueChanged += evt => WindowBackend.CurrentDisplay = evt.NewValue;
         }
 
+        private bool firstDraw = true;
+
         /// <summary>
         /// Requests that the graphics backend perform a buffer swap.
         /// </summary>
-        public void SwapBuffers() => GraphicsBackend.SwapBuffers();
+        public void SwapBuffers()
+        {
+            GraphicsBackend.SwapBuffers();
+
+            if (firstDraw)
+            {
+                WindowBackend.Visible = Visible.Value;
+                firstDraw = false;
+            }
+        }
 
         /// <summary>
         /// Requests that the graphics backend become the current context.


### PR DESCRIPTION
This is mostly for windows, where the window can be drawn bright white while initialising, but also seems to have an effect on macOS (draws transparent/gray otherwise).