### PR TITLE
Avoid resetting drawable lifetime on PooledDrawables that aren't assigned a pool

### DIFF
--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -100,9 +100,9 @@ namespace osu.Framework.Graphics.Pooling
             else
                 CountAvailable--;
 
+            drawable.Assign();
             drawable.LifetimeStart = double.MinValue;
             drawable.LifetimeEnd = double.MaxValue;
-            drawable.Assign();
 
             setupAction?.Invoke(drawable);
 

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -102,12 +102,11 @@ namespace osu.Framework.Graphics.Pooling
 
             drawable.LifetimeStart = double.MinValue;
             drawable.LifetimeEnd = double.MaxValue;
-
-            setupAction?.Invoke(drawable);
             drawable.Assign();
 
-            CountInUse++;
+            setupAction?.Invoke(drawable);
 
+            CountInUse++;
             return drawable;
         }
 

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -100,8 +100,12 @@ namespace osu.Framework.Graphics.Pooling
             else
                 CountAvailable--;
 
+            drawable.LifetimeStart = double.MinValue;
+            drawable.LifetimeEnd = double.MaxValue;
+
             setupAction?.Invoke(drawable);
             drawable.Assign();
+
             CountInUse++;
 
             return drawable;

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -28,6 +28,12 @@ namespace osu.Framework.Graphics.Pooling
         /// </summary>
         private bool waitingForPrepare;
 
+        /// <summary>
+        /// Whether <see cref="Drawable.LifetimeStart"/> and <see cref="Drawable.LifetimeEnd"/> should be reset to their default values
+        /// every time this <see cref="PoolableDrawable"/> is assigned to a new consumer.
+        /// </summary>
+        public virtual bool ResetLifetimeWhenAssigned => true;
+
         public override bool IsPresent => waitingForPrepare || base.IsPresent;
 
         protected override void LoadComplete()
@@ -98,8 +104,11 @@ namespace osu.Framework.Graphics.Pooling
 
             IsInUse = true;
 
-            LifetimeStart = double.MinValue;
-            LifetimeEnd = double.MaxValue;
+            if (ResetLifetimeWhenAssigned)
+            {
+                LifetimeStart = double.MinValue;
+                LifetimeEnd = double.MaxValue;
+            }
 
             waitingForPrepare = true;
 

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -28,12 +28,6 @@ namespace osu.Framework.Graphics.Pooling
         /// </summary>
         private bool waitingForPrepare;
 
-        /// <summary>
-        /// Whether <see cref="Drawable.LifetimeStart"/> and <see cref="Drawable.LifetimeEnd"/> should be reset to their default values
-        /// every time this <see cref="PoolableDrawable"/> is assigned to a new consumer.
-        /// </summary>
-        public virtual bool ResetLifetimeWhenAssigned => true;
-
         public override bool IsPresent => waitingForPrepare || base.IsPresent;
 
         protected override void LoadComplete()
@@ -103,12 +97,6 @@ namespace osu.Framework.Graphics.Pooling
                 throw new InvalidOperationException($"This {nameof(PoolableDrawable)} is already in use");
 
             IsInUse = true;
-
-            if (ResetLifetimeWhenAssigned)
-            {
-                LifetimeStart = double.MinValue;
-                LifetimeEnd = double.MaxValue;
-            }
 
             waitingForPrepare = true;
 


### PR DESCRIPTION
Tried a few things osu-side, but I think this is the simplest/least hacky solution.

Will fix the test failures in https://github.com/ppy/osu/pull/10717