### PR TITLE
Fix initial application of state not occurring if invalidation not pending

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -82,12 +82,7 @@ namespace osu.Framework.Audio.Sample
 
                 relativeFrequencyHandler.SetChannel(channel);
                 bassAmplitudeProcessor?.SetChannel(channel);
-            });
 
-            InvalidateState();
-
-            EnqueueAction(() =>
-            {
                 // ensure state is correct before starting.
                 InvalidateState();
 

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Audio.Sample
             EnqueueAction(() =>
             {
                 // ensure state is correct before starting.
-                UpdateState();
+                InvalidateState();
 
                 if (channel != 0 && !relativeFrequencyHandler.IsFrequencyZero)
                     Bass.ChannelPlay(channel, restart);

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -264,7 +264,7 @@ namespace osu.Framework.Audio.Track
         private bool startInternal()
         {
             // ensure state is correct before starting.
-            UpdateState();
+            InvalidateState();
 
             // Bass will restart the track if it has reached its end. This behavior isn't desirable so block locally.
             if (Bass.ChannelGetPosition(activeStream) == byteLength)


### PR DESCRIPTION
Turns out calling `UpdateState` is not enough since it still checks the `pendingInvalidation` flag.

Closes https://github.com/ppy/osu/issues/10778.