### PR TITLE
Don't log performance issues on non-async lookups if they are cached

### DIFF
--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -35,14 +35,14 @@ namespace osu.Framework.Audio.Sample
 
             if (string.IsNullOrEmpty(name)) return null;
 
-            this.LogIfNonBackgroundThread(name);
-
             lock (sampleCache)
             {
                 SampleChannel channel = null;
 
                 if (!sampleCache.TryGetValue(name, out Sample sample))
                 {
+                    this.LogIfNonBackgroundThread(name);
+
                     byte[] data = store.Get(name);
                     sample = sampleCache[name] = data == null ? null : new SampleBass(data, PendingActions, PlaybackConcurrency);
                 }

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -114,8 +114,6 @@ namespace osu.Framework.Graphics.Textures
 
             string key = $"{name}:wrap-{(int)wrapModeS}-{(int)wrapModeT}";
 
-            this.LogIfNonBackgroundThread(key);
-
             // Check if the texture exists in the cache.
             if (TryGetCached(key, out var cached))
                 return cached;
@@ -126,6 +124,8 @@ namespace osu.Framework.Graphics.Textures
                 // If another retrieval of the texture happened before us, we should check if the texture exists in the cache again.
                 if (TryGetCached(key, out cached))
                     return cached;
+
+                this.LogIfNonBackgroundThread(key);
 
                 try
                 {


### PR DESCRIPTION
While this is still generally a no-go (you can never be sure that the underlying texture/sample lookups are cached, which is why we always logged) the overhead from logging these issues can become overwhelming, with megabytes of output per second.

This should still be enough to generally cover cases a developer would care about.