### PR TITLE
Add transform preview to draw visualiser

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformRewinding.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Transforms;
+using osu.Framework.Graphics.Visualisation;
 using osu.Framework.Utils;
 using osu.Framework.Timing;
 using osuTK;
@@ -586,38 +587,8 @@ namespace osu.Framework.Tests.Visual.Drawables
                 {
                     transforms.Clear();
                     foreach (var t in ExaminableDrawable.Transforms)
-                        transforms.Add(new DrawableTransform(t));
+                        transforms.Add(new DrawableTransform(t, 15));
                     displayedTransforms = new List<Transform>(ExaminableDrawable.Transforms);
-                }
-            }
-
-            private class DrawableTransform : CompositeDrawable
-            {
-                private readonly Transform transform;
-                private readonly Box applied;
-                private readonly Box appliedToEnd;
-                private readonly SpriteText text;
-                private const float height = 15;
-
-                public DrawableTransform(Transform transform)
-                {
-                    this.transform = transform;
-                    RelativeSizeAxes = Axes.X;
-                    Height = height;
-                    InternalChildren = new Drawable[]
-                    {
-                        applied = new Box { Size = new Vector2(height) },
-                        appliedToEnd = new Box { X = height + 2, Size = new Vector2(height) },
-                        text = new SpriteText { X = (height + 2) * 2, Font = new FontUsage(size: height) },
-                    };
-                }
-
-                protected override void Update()
-                {
-                    base.Update();
-                    applied.Colour = transform.Applied ? Color4.Green : Color4.Red;
-                    appliedToEnd.Colour = transform.AppliedToEnd ? Color4.Green : Color4.Red;
-                    text.Text = transform.ToString();
                 }
             }
 

--- a/osu.Framework/Graphics/Transforms/Transform.cs
+++ b/osu.Framework/Graphics/Transforms/Transform.cs
@@ -107,7 +107,7 @@ namespace osu.Framework.Graphics.Transforms
 
         protected abstract void ReadIntoStartValue(T d);
 
-        public override string ToString() => $"{Target.GetType().Name}.{TargetMember} {StartTime}-{EndTime}ms {StartValue} -> {EndValue}";
+        public override string ToString() => $"{Target.GetType().Name}.{TargetMember} {StartTime:0.000}-{EndTime:0.000}ms {StartValue} -> {EndValue}";
     }
 
     public abstract class Transform<TValue, T> : Transform<TValue, DefaultEasingFunction, T>

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -299,7 +299,7 @@ namespace osu.Framework.Graphics.Visualisation
 
             if (newHighlight == null)
             {
-                drawableInspector.UpdateFrom(null);
+                drawableInspector.InspectedDrawable.Value = null;
                 return;
             }
 
@@ -309,7 +309,7 @@ namespace osu.Framework.Graphics.Visualisation
                 highlightedTarget = newHighlight;
                 newHighlight.IsHighlighted = true;
 
-                drawableInspector.UpdateFrom(newHighlight.Target);
+                drawableInspector.InspectedDrawable.Value = newHighlight.Target;
             }
         }
 

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Graphics.Visualisation
         private readonly TreeContainer treeContainer;
 
         private VisualisedDrawable highlightedTarget;
-        private readonly PropertyDisplay propertyDisplay;
+        private readonly DrawableInspector drawableInspector;
         private readonly InfoOverlay overlay;
         private InputManager inputManager;
 
@@ -72,28 +72,28 @@ namespace osu.Framework.Graphics.Visualisation
 
                             if (visualised != null)
                             {
-                                propertyDisplay.Show();
+                                drawableInspector.Show();
                                 setHighlight(visualised);
                             }
                         }
                     },
-                    ToggleProperties = delegate
+                    ToggleInspector = delegate
                     {
                         if (targetVisualiser == null)
                             return;
 
-                        propertyDisplay.ToggleVisibility();
+                        drawableInspector.ToggleVisibility();
 
-                        if (propertyDisplay.State.Value == Visibility.Visible)
+                        if (drawableInspector.State.Value == Visibility.Visible)
                             setHighlight(targetVisualiser);
                     },
                 },
                 new CursorContainer()
             };
 
-            propertyDisplay = treeContainer.PropertyDisplay;
+            drawableInspector = treeContainer.DrawableInspector;
 
-            propertyDisplay.State.ValueChanged += v =>
+            drawableInspector.State.ValueChanged += v =>
             {
                 switch (v.NewValue)
                 {
@@ -124,7 +124,7 @@ namespace osu.Framework.Graphics.Visualisation
             this.FadeOut(100);
 
             setHighlight(null);
-            propertyDisplay.Hide();
+            drawableInspector.Hide();
 
             recycleVisualisers();
         }
@@ -139,7 +139,7 @@ namespace osu.Framework.Graphics.Visualisation
 
             visualiser.HighlightTarget = d =>
             {
-                propertyDisplay.Show();
+                drawableInspector.Show();
 
                 // Either highlight or dehighlight the target, depending on whether
                 // it is currently highlighted
@@ -162,7 +162,7 @@ namespace osu.Framework.Graphics.Visualisation
             treeContainer.Target = null;
 
             if (Target == null)
-                propertyDisplay.Hide();
+                drawableInspector.Hide();
         }
 
         private VisualisedDrawable targetVisualiser;
@@ -299,17 +299,17 @@ namespace osu.Framework.Graphics.Visualisation
 
             if (newHighlight == null)
             {
-                propertyDisplay.UpdateFrom(null);
+                drawableInspector.UpdateFrom(null);
                 return;
             }
 
             // Only update when property display is visible
-            if (propertyDisplay.State.Value == Visibility.Visible)
+            if (drawableInspector.State.Value == Visibility.Visible)
             {
                 highlightedTarget = newHighlight;
                 newHighlight.IsHighlighted = true;
 
-                propertyDisplay.UpdateFrom(newHighlight.Target);
+                drawableInspector.UpdateFrom(newHighlight.Target);
             }
         }
 

--- a/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
@@ -1,22 +1,25 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 
 namespace osu.Framework.Graphics.Visualisation
 {
     public class DrawableInspector : VisibilityContainer
     {
-        private const float width = 600;
+        [Cached]
+        public Bindable<Drawable> InspectedDrawable { get; private set; } = new Bindable<Drawable>();
 
-        private readonly PropertyDisplay propertyDisplay;
+        private const float width = 600;
 
         public DrawableInspector()
         {
             Width = width;
             RelativeSizeAxes = Axes.Y;
 
-            Child = propertyDisplay = new PropertyDisplay();
+            Child = new PropertyDisplay();
         }
 
         protected override void PopIn()
@@ -27,11 +30,6 @@ namespace osu.Framework.Graphics.Visualisation
         protected override void PopOut()
         {
             this.ResizeWidthTo(0, 500, Easing.OutQuint);
-        }
-
-        public void UpdateFrom(Drawable source)
-        {
-            propertyDisplay.UpdateFrom(source);
         }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
@@ -11,7 +11,7 @@ using osu.Framework.Graphics.UserInterface;
 
 namespace osu.Framework.Graphics.Visualisation
 {
-    public class DrawableInspector : VisibilityContainer
+    internal class DrawableInspector : VisibilityContainer
     {
         [Cached]
         public Bindable<Drawable> InspectedDrawable { get; private set; } = new Bindable<Drawable>();

--- a/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
@@ -1,9 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.UserInterface;
 
 namespace osu.Framework.Graphics.Visualisation
 {
@@ -14,22 +18,88 @@ namespace osu.Framework.Graphics.Visualisation
 
         private const float width = 600;
 
+        private readonly FillFlowContainer content;
+        private readonly TabControl<Tab> inspectorTabControl;
+        private readonly Container tabContentContainer;
+        private readonly PropertyDisplay propertyDisplay;
+        private readonly TransformDisplay transformDisplay;
+
         public DrawableInspector()
         {
             Width = width;
             RelativeSizeAxes = Axes.Y;
 
-            Child = new PropertyDisplay();
+            Child = content = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Direction = FillDirection.Vertical,
+                Children = new Drawable[]
+                {
+                    inspectorTabControl = new BasicTabControl<Tab>
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        Height = 20,
+                        Margin = new MarginPadding
+                        {
+                            Horizontal = 10,
+                            Vertical = 5
+                        },
+                        Items = Enum.GetValues(typeof(Tab)).Cast<Tab>().ToList()
+                    },
+                    tabContentContainer = new Container
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Children = new Drawable[]
+                        {
+                            propertyDisplay = new PropertyDisplay(),
+                            transformDisplay = new TransformDisplay()
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+            inspectorTabControl.Current.BindValueChanged(showTab, true);
+        }
+
+        private void showTab(ValueChangedEvent<Tab> tabChanged)
+        {
+            tabContentContainer.Children.ForEach(tab => tab.Hide());
+
+            switch (tabChanged.NewValue)
+            {
+                case Tab.Properties:
+                    propertyDisplay.Show();
+                    break;
+
+                case Tab.Transforms:
+                    transformDisplay.Show();
+                    break;
+            }
         }
 
         protected override void PopIn()
         {
             this.ResizeWidthTo(width, 500, Easing.OutQuint);
+
+            inspectorTabControl.Current.Value = Tab.Properties;
+            content.Show();
         }
 
         protected override void PopOut()
         {
+            content.Hide();
+
             this.ResizeWidthTo(0, 500, Easing.OutQuint);
+        }
+
+        private enum Tab
+        {
+            Properties,
+            Transforms
         }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawableInspector.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Graphics.Visualisation
+{
+    public class DrawableInspector : VisibilityContainer
+    {
+        private const float width = 600;
+
+        private readonly PropertyDisplay propertyDisplay;
+
+        public DrawableInspector()
+        {
+            Width = width;
+            RelativeSizeAxes = Axes.Y;
+
+            Child = propertyDisplay = new PropertyDisplay();
+        }
+
+        protected override void PopIn()
+        {
+            this.ResizeWidthTo(width, 500, Easing.OutQuint);
+        }
+
+        protected override void PopOut()
+        {
+            this.ResizeWidthTo(0, 500, Easing.OutQuint);
+        }
+
+        public void UpdateFrom(Drawable source)
+        {
+            propertyDisplay.UpdateFrom(source);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Visualisation/DrawableTransform.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawableTransform.cs
@@ -1,0 +1,41 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Transforms;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Graphics.Visualisation
+{
+    internal class DrawableTransform : CompositeDrawable
+    {
+        private readonly Transform transform;
+        private readonly Box applied;
+        private readonly Box appliedToEnd;
+        private readonly SpriteText text;
+
+        public DrawableTransform(Transform transform, float height = 20)
+        {
+            this.transform = transform;
+            RelativeSizeAxes = Axes.X;
+            Height = height;
+            InternalChildren = new Drawable[]
+            {
+                applied = new Box { Size = new Vector2(height) },
+                appliedToEnd = new Box { X = height + 2, Size = new Vector2(height) },
+                text = new SpriteText { X = (height + 2) * 2, Font = new FontUsage(size: height) },
+            };
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            applied.Colour = transform.Applied ? Color4.Green : Color4.Red;
+            appliedToEnd.Colour = transform.AppliedToEnd ? Color4.Green : Color4.Red;
+            text.Text = transform.ToString();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
@@ -17,18 +17,15 @@ using osu.Framework.Extensions.TypeExtensions;
 
 namespace osu.Framework.Graphics.Visualisation
 {
-    internal class PropertyDisplay : VisibilityContainer
+    internal class PropertyDisplay : Container
     {
         private readonly FillFlowContainer flow;
-
-        private const float width = 600;
 
         protected override Container<Drawable> Content => flow;
 
         public PropertyDisplay()
         {
-            Width = width;
-            RelativeSizeAxes = Axes.Y;
+            RelativeSizeAxes = Axes.Both;
 
             AddRangeInternal(new Drawable[]
             {
@@ -73,16 +70,6 @@ namespace osu.Framework.Graphics.Visualisation
                                .Where(m => m.GetCustomAttribute<CompilerGeneratedAttribute>() == null)
                                .Where(m => m.GetCustomAttribute<DebuggerBrowsableAttribute>()?.State != DebuggerBrowsableState.Never)
                                .Select(m => new PropertyItem(m, source)));
-        }
-
-        protected override void PopIn()
-        {
-            this.ResizeWidthTo(width, 500, Easing.OutQuint);
-        }
-
-        protected override void PopOut()
-        {
-            this.ResizeWidthTo(0, 500, Easing.OutQuint);
         }
 
         private class PropertyItem : Container

--- a/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/PropertyDisplay.cs
@@ -7,6 +7,8 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
@@ -20,6 +22,8 @@ namespace osu.Framework.Graphics.Visualisation
     internal class PropertyDisplay : Container
     {
         private readonly FillFlowContainer flow;
+
+        private Bindable<Drawable> inspectedDrawable;
 
         protected override Container<Drawable> Content => flow;
 
@@ -49,7 +53,20 @@ namespace osu.Framework.Graphics.Visualisation
             });
         }
 
-        public void UpdateFrom(Drawable source)
+        [BackgroundDependencyLoader]
+        private void load(Bindable<Drawable> inspected)
+        {
+            inspectedDrawable = inspected.GetBoundCopy();
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            inspectedDrawable.BindValueChanged(inspected => updateProperties(inspected.NewValue), true);
+        }
+
+        private void updateProperties(IDrawable source)
         {
             Clear();
 

--- a/osu.Framework/Graphics/Visualisation/TransformDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/TransformDisplay.cs
@@ -1,20 +1,61 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
 
 namespace osu.Framework.Graphics.Visualisation
 {
-    public class TransformDisplay : Container
+    internal class TransformDisplay : Container
     {
+        private readonly FillFlowContainer<DrawableTransform> flow;
+        private Bindable<Drawable> inspectedDrawable;
+
         public TransformDisplay()
         {
             RelativeSizeAxes = Axes.Both;
-            Child = new SpriteText
+            Children = new Drawable[]
             {
-                Text = "This will be the transform display."
+                new Box
+                {
+                    Colour = FrameworkColour.GreenDarker,
+                    RelativeSizeAxes = Axes.Both
+                },
+                new BasicScrollContainer
+                {
+                    Padding = new MarginPadding(10),
+                    RelativeSizeAxes = Axes.Both,
+                    ScrollbarOverlapsContent = false,
+                    Child = flow = new FillFlowContainer<DrawableTransform>
+                    {
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Direction = FillDirection.Vertical,
+                        Spacing = new Vector2(0, 2)
+                    }
+                }
             };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(Bindable<Drawable> inspected)
+        {
+            inspectedDrawable = inspected.GetBoundCopy();
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            flow.Clear();
+
+            if (inspectedDrawable.Value == null)
+                return;
+
+            foreach (var t in inspectedDrawable.Value.Transforms)
+                flow.Add(new DrawableTransform(t));
         }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/TransformDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/TransformDisplay.cs
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Graphics.Visualisation
+{
+    public class TransformDisplay : Container
+    {
+        public TransformDisplay()
+        {
+            RelativeSizeAxes = Axes.Both;
+            Child = new SpriteText
+            {
+                Text = "This will be the transform display."
+            };
+        }
+    }
+}

--- a/osu.Framework/Graphics/Visualisation/TreeContainer.cs
+++ b/osu.Framework/Graphics/Visualisation/TreeContainer.cs
@@ -14,9 +14,9 @@ namespace osu.Framework.Graphics.Visualisation
 
         public Action ChooseTarget;
         public Action GoUpOneParent;
-        public Action ToggleProperties;
+        public Action ToggleInspector;
 
-        internal PropertyDisplay PropertyDisplay { get; private set; }
+        internal DrawableInspector DrawableInspector { get; private set; }
 
         [Resolved]
         private DrawVisualiser visualiser { get; set; }
@@ -44,9 +44,9 @@ namespace osu.Framework.Graphics.Visualisation
 
             AddButton(@"choose target", () => ChooseTarget?.Invoke());
             AddButton(@"up one parent", () => GoUpOneParent?.Invoke());
-            AddButton(@"view properties", () => ToggleProperties?.Invoke());
+            AddButton(@"toggle inspector", () => ToggleInspector?.Invoke());
 
-            MainHorizontalContent.Add(PropertyDisplay = new PropertyDisplay());
+            MainHorizontalContent.Add(DrawableInspector = new DrawableInspector());
         }
 
         protected override void Update()


### PR DESCRIPTION
This PR adds a way to preview transform application progress from the draw visualiser. See [video showing preview of behaviour](https://drive.google.com/file/d/1cDzC90larwbeEQEBmOLcJdVrZV_dmu7t/view?usp=sharing).

Display code partially shamelessly stolen from existing test scene and wedged into the draw visualiser. Allocating drawables every frame is admittedly wasteful, but seeing that it's for debugging purposes... Tracking transforms externally is not an easy task anyway (I fiddled some with `WeakReference`s but my attempts appeared crazily unsafe - could seemingly die on a nullref even if `TryGetTarget` returned `true`). For what it's worth I confirmed that the code doesn't run unless the tab is specifically opened.

Mostly usable for rewindable transforms. I made a proof-of-concept of also keeping non-rewindable transform preview for like half a second after removal, but it honestly wasn't very usable. It was also similarly unsafe because of either having to fiddle with `WeakReference`s and not being able to tell if they're still valid, or having to hold references to the transform from the drawable and make sure that they are eventually removed.