### PR TITLE
Update tools to allow InspectCode to run in non-Windows environment

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,18 @@
       "commands": [
         "dotnet-format"
       ]
+    },
+    "jetbrains.resharper.globaltools": {
+      "version": "2020.2.4",
+      "commands": [
+        "jb"
+      ]
+    },
+    "nvika": {
+      "version": "2.0.0",
+      "commands": [
+        "nvika"
+      ]
     }
   }
 }

--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -3,6 +3,7 @@
 	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002Emp3/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002Epng/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002Ewav/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/ExcludedFiles/FileMasksToSkip/=_002A_002Eh/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=2A66DD92_002DADB1_002D4994_002D89E2_002DC94E04ACDA0D_002Fd_003AMigrations/@EntryIndexedValue">ExplicitlyExcluded</s:String>
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/FilesAndFoldersToSkip2/=D9A367C9_002D4C1A_002D489F_002D9B05_002DA0CEA2B53B58/@EntryIndexedValue">ExplicitlyExcluded</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/AnalysisEnabled/@EntryValue">SOLUTION</s:String>

--- a/osu.Framework.Tests/Text/TextBuilderTest.cs
+++ b/osu.Framework.Tests/Text/TextBuilderTest.cs
@@ -47,12 +47,12 @@ namespace osu.Framework.Tests.Text
         public TextBuilderTest()
         {
             fontStore = new TestStore(
-                (normal_font, new TestGlyph('a', x_offset, y_offset, x_advance, width, height, kerning)),
-                (normal_font, new TestGlyph('b', b_x_offset, b_y_offset, b_x_advance, b_width, b_height, b_kerning)),
-                (normal_font, new TestGlyph('m', m_x_offset, m_y_offset, m_x_advance, m_width, m_height, m_kerning)),
-                (fixed_width_font, new TestGlyph('a', x_offset, y_offset, x_advance, width, height, kerning)),
-                (fixed_width_font, new TestGlyph('b', b_x_offset, b_y_offset, b_x_advance, b_width, b_height, b_kerning)),
-                (fixed_width_font, new TestGlyph('m', m_x_offset, m_y_offset, m_x_advance, m_width, m_height, m_kerning))
+                new GlyphEntry(normal_font, new TestGlyph('a', x_offset, y_offset, x_advance, width, height, kerning)),
+                new GlyphEntry(normal_font, new TestGlyph('b', b_x_offset, b_y_offset, b_x_advance, b_width, b_height, b_kerning)),
+                new GlyphEntry(normal_font, new TestGlyph('m', m_x_offset, m_y_offset, m_x_advance, m_width, m_height, m_kerning)),
+                new GlyphEntry(fixed_width_font, new TestGlyph('a', x_offset, y_offset, x_advance, width, height, kerning)),
+                new GlyphEntry(fixed_width_font, new TestGlyph('b', b_x_offset, b_y_offset, b_x_advance, b_width, b_height, b_kerning)),
+                new GlyphEntry(fixed_width_font, new TestGlyph('m', m_x_offset, m_y_offset, m_x_advance, m_width, m_height, m_kerning))
             );
         }
 
@@ -326,10 +326,10 @@ namespace osu.Framework.Tests.Text
             var font = new TestFontUsage("test");
             var nullFont = new TestFontUsage(null);
             var builder = new TextBuilder(new TestStore(
-                (font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                (nullFont, new TestGlyph('a', 0, 0, 0, 0, 0, 0)),
-                (font, new TestGlyph('?', 0, 0, 0, 0, 0, 0)),
-                (nullFont, new TestGlyph('?', 0, 0, 0, 0, 0, 0))
+                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('a', 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(font, new TestGlyph('?', 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('?', 0, 0, 0, 0, 0, 0))
             ), font);
 
             builder.AddText("a");
@@ -346,10 +346,10 @@ namespace osu.Framework.Tests.Text
             var font = new TestFontUsage("test");
             var nullFont = new TestFontUsage(null);
             var builder = new TextBuilder(new TestStore(
-                (font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                (nullFont, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                (font, new TestGlyph('?', 0, 0, 0, 0, 0, 0)),
-                (nullFont, new TestGlyph('?', 1, 0, 0, 0, 0, 0))
+                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(font, new TestGlyph('?', 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('?', 1, 0, 0, 0, 0, 0))
             ), font);
 
             builder.AddText("a");
@@ -367,10 +367,10 @@ namespace osu.Framework.Tests.Text
             var font = new TestFontUsage("test");
             var nullFont = new TestFontUsage(null);
             var builder = new TextBuilder(new TestStore(
-                (font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                (nullFont, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                (font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                (nullFont, new TestGlyph('?', 1, 0, 0, 0, 0, 0))
+                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('?', 1, 0, 0, 0, 0, 0))
             ), font);
 
             builder.AddText("a");
@@ -414,9 +414,9 @@ namespace osu.Framework.Tests.Text
 
         private class TestStore : ITexturedGlyphLookupStore
         {
-            private readonly (FontUsage font, ITexturedCharacterGlyph glyph)[] glyphs;
+            private readonly GlyphEntry[] glyphs;
 
-            public TestStore(params (FontUsage font, ITexturedCharacterGlyph glyph)[] glyphs)
+            public TestStore(params GlyphEntry[] glyphs)
             {
                 this.glyphs = glyphs;
             }
@@ -425,13 +425,25 @@ namespace osu.Framework.Tests.Text
             {
                 if (string.IsNullOrEmpty(fontName))
                 {
-                    return glyphs.FirstOrDefault(g => g.glyph!.Character == character).glyph;
+                    return glyphs.FirstOrDefault(g => g.Glyph.Character == character).Glyph;
                 }
 
-                return glyphs.FirstOrDefault(g => g.font!.FontName == fontName && g.glyph!.Character == character).glyph;
+                return glyphs.FirstOrDefault(g => g.Font.FontName == fontName && g.Glyph.Character == character).Glyph;
             }
 
             public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => throw new System.NotImplementedException();
+        }
+
+        private readonly struct GlyphEntry
+        {
+            public readonly FontUsage Font;
+            public readonly ITexturedCharacterGlyph Glyph;
+
+            public GlyphEntry(FontUsage font, ITexturedCharacterGlyph glyph)
+            {
+                Font = font;
+                Glyph = glyph;
+            }
         }
 
         private readonly struct TestGlyph : ITexturedCharacterGlyph

--- a/osu.Framework.Tests/Text/TextBuilderTest.cs
+++ b/osu.Framework.Tests/Text/TextBuilderTest.cs
@@ -424,9 +424,11 @@ namespace osu.Framework.Tests.Text
             public ITexturedCharacterGlyph Get(string fontName, char character)
             {
                 if (string.IsNullOrEmpty(fontName))
-                    return glyphs.FirstOrDefault(g => g.glyph.Character == character).glyph;
+                {
+                    return glyphs.FirstOrDefault(g => g.glyph!.Character == character).glyph;
+                }
 
-                return glyphs.FirstOrDefault(g => g.font.FontName == fontName && g.glyph.Character == character).glyph;
+                return glyphs.FirstOrDefault(g => g.font!.FontName == fontName && g.glyph!.Character == character).glyph;
             }
 
             public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => throw new System.NotImplementedException();

--- a/osu.Framework/Allocation/CachedModelDependencyContainer.cs
+++ b/osu.Framework/Allocation/CachedModelDependencyContainer.cs
@@ -91,7 +91,7 @@ namespace osu.Framework.Allocation
             {
                 foreach (var field in type.GetFields(activator_flags))
                 {
-                    perform(targetShadowModel, field, lastModel, t => t.shadowProp!.UnbindFrom(t.modelProp));
+                    perform(targetShadowModel, field, lastModel, (shadowProp, modelProp) => shadowProp.UnbindFrom(modelProp));
                 }
             }
 
@@ -99,7 +99,7 @@ namespace osu.Framework.Allocation
             {
                 foreach (var field in type.GetFields(activator_flags))
                 {
-                    perform(targetShadowModel, field, newModel, t => t.shadowProp!.BindTo(t.modelProp));
+                    perform(targetShadowModel, field, newModel, (shadowProp, modelProp) => shadowProp.BindTo(modelProp));
                 }
             }
         }
@@ -107,18 +107,18 @@ namespace osu.Framework.Allocation
         /// <summary>
         /// Perform an arbitrary action across a shadow model and model.
         /// </summary>
-        private void perform(TModel targetShadowModel, MemberInfo member, TModel target, Action<(IBindable shadowProp, IBindable modelProp)> action)
+        private void perform(TModel targetShadowModel, MemberInfo member, TModel target, Action<IBindable, IBindable> action)
         {
             if (target == null) return;
 
             switch (member)
             {
                 case PropertyInfo pi:
-                    action(((IBindable)pi.GetValue(targetShadowModel), (IBindable)pi.GetValue(target)));
+                    action((IBindable)pi.GetValue(targetShadowModel), (IBindable)pi.GetValue(target));
                     break;
 
                 case FieldInfo fi:
-                    action(((IBindable)fi.GetValue(targetShadowModel), (IBindable)fi.GetValue(target)));
+                    action((IBindable)fi.GetValue(targetShadowModel), (IBindable)fi.GetValue(target));
                     break;
             }
         }

--- a/osu.Framework/Allocation/CachedModelDependencyContainer.cs
+++ b/osu.Framework/Allocation/CachedModelDependencyContainer.cs
@@ -90,13 +90,17 @@ namespace osu.Framework.Allocation
             foreach (var type in typeof(TModel).EnumerateBaseTypes())
             {
                 foreach (var field in type.GetFields(activator_flags))
-                    perform(targetShadowModel, field, lastModel, t => t.shadowProp.UnbindFrom(t.modelProp));
+                {
+                    perform(targetShadowModel, field, lastModel, t => t.shadowProp!.UnbindFrom(t.modelProp));
+                }
             }
 
             foreach (var type in typeof(TModel).EnumerateBaseTypes())
             {
                 foreach (var field in type.GetFields(activator_flags))
-                    perform(targetShadowModel, field, newModel, t => t.shadowProp.BindTo(t.modelProp));
+                {
+                    perform(targetShadowModel, field, newModel, t => t.shadowProp!.BindTo(t.modelProp));
+                }
             }
         }
 

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -303,7 +303,7 @@ namespace osu.Framework.Graphics.Containers
             int[] distributedIndices = Enumerable.Range(0, cellSizes.Length).Where(i => i >= dimensions.Length || dimensions[i].Mode == GridSizeMode.Distributed).ToArray();
 
             // The dimensions corresponding to all distributed cells
-            IEnumerable<(int i, Dimension dim)> distributedDimensions = distributedIndices.Select(i => (i, i >= dimensions.Length ? new Dimension() : dimensions[i]));
+            IEnumerable<DimensionEntry> distributedDimensions = distributedIndices.Select(i => new DimensionEntry(i, i >= dimensions.Length ? new Dimension() : dimensions[i]));
 
             // Total number of distributed cells
             int distributionCount = distributedIndices.Length;
@@ -315,18 +315,30 @@ namespace osu.Framework.Graphics.Containers
             float distributionSize = Math.Max(0, spanLength - requiredSize) / distributionCount;
 
             // Write the sizes of distributed cells. Ordering is important to maximize excess at every step
-            foreach (var (i, dim) in distributedDimensions.OrderBy(d => d.dim!.Range))
+            foreach (var entry in distributedDimensions.OrderBy(d => d.Dimension.Range))
             {
                 // Cells start off at their minimum size, and the total size should not exceed their maximum size
-                cellSizes[i] = Math.Min(dim.MaxSize, dim.MinSize + distributionSize);
+                cellSizes[entry.Index] = Math.Min(entry.Dimension.MaxSize, entry.Dimension.MinSize + distributionSize);
 
                 // If there's no excess, any further distributions are guaranteed to also have no excess, so this becomes a null-op
                 // If there is an excess, the excess should be re-distributed among all other n-1 distributed cells
                 if (--distributionCount > 0)
-                    distributionSize += Math.Max(0, distributionSize - dim.Range) / distributionCount;
+                    distributionSize += Math.Max(0, distributionSize - entry.Dimension.Range) / distributionCount;
             }
 
             return cellSizes;
+        }
+
+        private readonly struct DimensionEntry
+        {
+            public readonly int Index;
+            public readonly Dimension Dimension;
+
+            public DimensionEntry(int index, Dimension dimension)
+            {
+                Index = index;
+                Dimension = dimension;
+            }
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -315,7 +315,7 @@ namespace osu.Framework.Graphics.Containers
             float distributionSize = Math.Max(0, spanLength - requiredSize) / distributionCount;
 
             // Write the sizes of distributed cells. Ordering is important to maximize excess at every step
-            foreach (var (i, dim) in distributedDimensions.OrderBy(d => d.dim.Range))
+            foreach (var (i, dim) in distributedDimensions.OrderBy(d => d.dim!.Range))
             {
                 // Cells start off at their minimum size, and the total size should not exceed their maximum size
                 cellSizes[i] = Math.Min(dim.MaxSize, dim.MinSize + distributionSize);

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -238,7 +238,7 @@ namespace osu.Framework.Graphics.Transforms
 
             return new ValueInvokeOnDisposal<(Transformable transformable, double delay, bool recursive, double newTransformDelay)>((this, delay, recursive, newTransformDelay), sender =>
             {
-                if (!Precision.AlmostEquals(sender.newTransformDelay, sender.transformable.TransformDelay))
+                if (!Precision.AlmostEquals(sender.newTransformDelay!, sender.transformable!.TransformDelay))
                 {
                     throw new InvalidOperationException(
                         $"{nameof(sender.transformable.TransformStartTime)} at the end of delayed sequence is not the same as at the beginning, but should be. " +
@@ -263,7 +263,7 @@ namespace osu.Framework.Graphics.Transforms
 
             return new ValueInvokeOnDisposal<(Transformable transformable, double oldTransformDelay, double newTransformDelay)>((this, oldTransformDelay, newTransformDelay), sender =>
             {
-                if (!Precision.AlmostEquals(sender.newTransformDelay, sender.transformable.TransformDelay))
+                if (!Precision.AlmostEquals(sender.newTransformDelay!, sender.transformable!.TransformDelay))
                 {
                     throw new InvalidOperationException(
                         $"{nameof(sender.transformable.TransformStartTime)} at the end of absolute sequence is not the same as at the beginning, but should be. " +

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -236,17 +236,34 @@ namespace osu.Framework.Graphics.Transforms
             AddDelay(delay, recursive);
             double newTransformDelay = TransformDelay;
 
-            return new ValueInvokeOnDisposal<(Transformable transformable, double delay, bool recursive, double newTransformDelay)>((this, delay, recursive, newTransformDelay), sender =>
+            return new ValueInvokeOnDisposal<DelayedSequenceSender>(new DelayedSequenceSender(this, delay, recursive, newTransformDelay), sender =>
             {
-                if (!Precision.AlmostEquals(sender.newTransformDelay!, sender.transformable!.TransformDelay))
+                if (!Precision.AlmostEquals(sender.NewTransformDelay, sender.Transformable.TransformDelay))
                 {
                     throw new InvalidOperationException(
-                        $"{nameof(sender.transformable.TransformStartTime)} at the end of delayed sequence is not the same as at the beginning, but should be. " +
-                        $"(begin={sender.newTransformDelay} end={sender.transformable.TransformDelay})");
+                        $"{nameof(sender.Transformable.TransformStartTime)} at the end of delayed sequence is not the same as at the beginning, but should be. " +
+                        $"(begin={sender.NewTransformDelay} end={sender.Transformable.TransformDelay})");
                 }
 
-                AddDelay(-sender.delay, sender.recursive);
+                AddDelay(-sender.Delay, sender.Recursive);
             });
+        }
+
+        /// An ad-hoc struct used as a closure environment in <see cref="BeginDelayedSequence" />.
+        private readonly struct DelayedSequenceSender
+        {
+            public readonly Transformable Transformable;
+            public readonly double Delay;
+            public readonly bool Recursive;
+            public readonly double NewTransformDelay;
+
+            public DelayedSequenceSender(Transformable transformable, double delay, bool recursive, double newTransformDelay)
+            {
+                Transformable = transformable;
+                Delay = delay;
+                Recursive = recursive;
+                NewTransformDelay = newTransformDelay;
+            }
         }
 
         /// <summary>
@@ -261,17 +278,32 @@ namespace osu.Framework.Graphics.Transforms
             double oldTransformDelay = TransformDelay;
             double newTransformDelay = TransformDelay = newTransformStartTime - (Clock?.CurrentTime ?? 0);
 
-            return new ValueInvokeOnDisposal<(Transformable transformable, double oldTransformDelay, double newTransformDelay)>((this, oldTransformDelay, newTransformDelay), sender =>
+            return new ValueInvokeOnDisposal<AbsoluteSequenceSender>(new AbsoluteSequenceSender(this, oldTransformDelay, newTransformDelay), sender =>
             {
-                if (!Precision.AlmostEquals(sender.newTransformDelay!, sender.transformable!.TransformDelay))
+                if (!Precision.AlmostEquals(sender.NewTransformDelay, sender.Transformable.TransformDelay))
                 {
                     throw new InvalidOperationException(
-                        $"{nameof(sender.transformable.TransformStartTime)} at the end of absolute sequence is not the same as at the beginning, but should be. " +
-                        $"(begin={sender.newTransformDelay} end={sender.transformable.TransformDelay})");
+                        $"{nameof(sender.Transformable.TransformStartTime)} at the end of absolute sequence is not the same as at the beginning, but should be. " +
+                        $"(begin={sender.NewTransformDelay} end={sender.Transformable.TransformDelay})");
                 }
 
-                sender.transformable.TransformDelay = sender.oldTransformDelay;
+                sender.Transformable.TransformDelay = sender.OldTransformDelay;
             });
+        }
+
+        /// An ad-hoc struct used as a closure environment in <see cref="BeginAbsoluteSequence" />.
+        private readonly struct AbsoluteSequenceSender
+        {
+            public readonly Transformable Transformable;
+            public readonly double OldTransformDelay;
+            public readonly double NewTransformDelay;
+
+            public AbsoluteSequenceSender(Transformable transformable, double oldTransformDelay, double newTransformDelay)
+            {
+                Transformable = transformable;
+                OldTransformDelay = oldTransformDelay;
+                NewTransformDelay = newTransformDelay;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
ReSharper command-line tool and `NVika` is updated to the latest version. The new versions publish itself as `dotnet tool` and it makes the build script simpler. The new versions also allow `InspectCode` target of the Cake build script to run in non-Windows machines.

There were new ReSharper errors due to the version difference. I used several ad-hoc struct types to workaround the issue (it seems like the tuple types are the issue). I also added a setting to prevented `*.h` shader header files to be analyzed as C++ header files and causing errors.