### PR TITLE
Rework DCC class expansion heuristic to reduce failures

### DIFF
--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -453,8 +453,8 @@ namespace osu.Framework.Testing
             if (range.Count % 2 == 1)
                 return range[centre];
 
-            // If count is even, return the average of the two nearest elements (centre will be truncated).
-            return (range[centre] + range[(int)Math.Ceiling(range.Count / 2f)]) / 2;
+            // If count is even, return the average of the two nearest elements (centre is essentially the upper index).
+            return (range[centre - 1] + range[centre]) / 2;
         }
 
         private bool typeInheritsFromGame(TypeReference reference)


### PR DESCRIPTION
Motivated by all the DCC failures we've been having recently, I've tried to change the heuristic to something that is more statistically sound rather than guesswork attempting to do the same.

The tl;dr is to exclude traversing into parents that are outliers depending on how many subsequent parents they would expand.

For example, if we're iterating through judgements which aren't really referenced that much and thus expand 1-2 parents, but then reach `OsuPlayfield` that is referenced by a lot of the hierarchy and thus expands 100 parents, `OsuPlayfield` is treated as an outlier.

Up to you whether these changes should be merged at this point or wait until another DCC issue comes up and it can be tested to work there. My current testing:
```
Pass:
TestSceneScorePanel -> AccuracyCircle
TestSceneBeatmapInfoWedge -> BeatmapInfoWedge
TestSceneMigrationScreens -> TestSceneMigrationScreens
TestSceneDrawableJudgement -> DefaultJudgement (child of DrawableJudgement)
TestSceneDrawableDrumRoll -> DrawableDrumRoll
TestSceneDrawableDrumRoll -> LegacyDrumRoll

Fail:
TestSceneHitObjectComposer -> OverlaySelectionBlueprint
```