### PR TITLE
Allow dynamic recompilation to access internal members

### DIFF
--- a/osu.Framework/Testing/AssemblyReference.cs
+++ b/osu.Framework/Testing/AssemblyReference.cs
@@ -6,7 +6,7 @@ using Microsoft.CodeAnalysis;
 
 namespace osu.Framework.Testing
 {
-    public readonly struct AssemblyReference
+    internal readonly struct AssemblyReference
     {
         public readonly Assembly Assembly;
         public readonly bool IgnoreAccessChecks;

--- a/osu.Framework/Testing/AssemblyReference.cs
+++ b/osu.Framework/Testing/AssemblyReference.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+
+namespace osu.Framework.Testing
+{
+    public readonly struct AssemblyReference
+    {
+        public readonly Assembly Assembly;
+        public readonly bool IgnoreAccessChecks;
+
+        public AssemblyReference(Assembly assembly, bool ignoreAccessChecks)
+        {
+            Assembly = assembly;
+            IgnoreAccessChecks = ignoreAccessChecks;
+        }
+
+        public MetadataReference GetReference() => MetadataReference.CreateFromFile(Assembly.Location);
+    }
+}

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -125,50 +125,13 @@ namespace osu.Framework.Testing
 
                 CompilationStarted?.Invoke();
 
-                var newRequiredFiles = await referenceBuilder.GetReferencedFiles(targetType, changedFile);
-                foreach (var f in newRequiredFiles)
-                    requiredFiles.Add(f);
-
-                var requiredAssemblies = await referenceBuilder.GetReferencedAssemblies(targetType, changedFile);
-
-                var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
-
-                // ReSharper disable once RedundantExplicitArrayCreation this doesn't compile when the array is empty
-                var parseOptions = new CSharpParseOptions(preprocessorSymbols: new string[]
-                {
-#if DEBUG
-                    "DEBUG",
-#endif
-#if TRACE
-                    "TRACE",
-#endif
-#if RELEASE
-                    "RELEASE",
-#endif
-                }, languageVersion: LanguageVersion.Latest);
-
-                var references = requiredAssemblies.Where(a => !string.IsNullOrEmpty(a))
-                                                   .Select(a => MetadataReference.CreateFromFile(a));
-
-                // ensure we don't duplicate the dynamic suffix.
-                string assemblyNamespace = targetType.Assembly.GetName().Name?.Replace(".Dynamic", "");
-
-                string assemblyVersion = $"{++currentVersion}.0.*";
-                string dynamicNamespace = $"{assemblyNamespace}.Dynamic";
-
-                var compilation = CSharpCompilation.Create(
-                    dynamicNamespace,
-                    requiredFiles.Select(file => CSharpSyntaxTree.ParseText(File.ReadAllText(file, Encoding.UTF8), parseOptions, file, encoding: Encoding.UTF8))
-                                 // Compile the assembly with a new version so that it replaces the existing one
-                                 .Append(CSharpSyntaxTree.ParseText($"using System.Reflection; [assembly: AssemblyVersion(\"{assemblyVersion}\")]", parseOptions)),
-                    references,
-                    options
-                );
+                var files = await addRequiredFiles(targetType, changedFile);
+                var assemblies = await getRequiredAssemblies(targetType, changedFile);
 
                 using (var pdbStream = new MemoryStream())
                 using (var peStream = new MemoryStream())
                 {
-                    var compilationResult = compilation.Emit(peStream, pdbStream);
+                    var compilationResult = createCompilation(targetType, files, assemblies).Emit(peStream, pdbStream);
 
                     if (compilationResult.Success)
                     {
@@ -203,6 +166,55 @@ namespace osu.Framework.Testing
             {
                 isCompiling = false;
             }
+        }
+
+        private async Task<IEnumerable<string>> addRequiredFiles(Type targetType, string changedFile)
+        {
+            foreach (var f in await referenceBuilder.GetReferencedFiles(targetType, changedFile))
+                requiredFiles.Add(f);
+            return requiredFiles;
+        }
+
+        private async Task<IEnumerable<MetadataReference>> getRequiredAssemblies(Type targetType, string changedFile)
+            => (await referenceBuilder.GetReferencedAssemblies(targetType, changedFile))
+               .Where(a => !string.IsNullOrEmpty(a))
+               .Select(a => MetadataReference.CreateFromFile(a));
+
+        private CSharpCompilation createCompilation(Type targetType, IEnumerable<string> files, IEnumerable<MetadataReference> assemblies)
+        {
+            // ReSharper disable once RedundantExplicitArrayCreation this doesn't compile when the array is empty
+            var parseOptions = new CSharpParseOptions(preprocessorSymbols: new string[]
+            {
+#if DEBUG
+                "DEBUG",
+#endif
+#if TRACE
+                "TRACE",
+#endif
+#if RELEASE
+                "RELEASE",
+#endif
+            }, languageVersion: LanguageVersion.Latest);
+
+            // Add the syntax trees for all referenced files.
+            var syntaxTrees = new List<SyntaxTree>();
+            foreach (var f in files)
+                syntaxTrees.Add(CSharpSyntaxTree.ParseText(File.ReadAllText(f, Encoding.UTF8), parseOptions, f, encoding: Encoding.UTF8));
+
+            // Add a syntax tree to define the new assembly version, such that it replaces any existing dynamic assembly.
+            string assemblyVersion = $"{++currentVersion}.0.*";
+            syntaxTrees.Add(CSharpSyntaxTree.ParseText($"using System.Reflection; [assembly: AssemblyVersion(\"{assemblyVersion}\")]", parseOptions));
+
+            // Determine the new assembly name, ensuring that the dynamic suffix is not duplicated.
+            string assemblyNamespace = targetType.Assembly.GetName().Name?.Replace(".Dynamic", "");
+            string dynamicNamespace = $"{assemblyNamespace}.Dynamic";
+
+            return CSharpCompilation.Create(
+                dynamicNamespace,
+                syntaxTrees,
+                assemblies,
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+            );
         }
 
         /// <summary>

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -175,7 +175,7 @@ namespace osu.Framework.Testing
             var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
                 .WithMetadataImportOptions(MetadataImportOptions.Internal);
 
-            // This is an internal property which allows the compiler to ignore accessibility.
+            // This is an internal property which allows the compiler to ignore accessibility checks.
             // https://www.strathweb.com/2018/10/no-internalvisibleto-no-problem-bypassing-c-visibility-rules-with-roslyn/
             var topLevelBinderFlagsProperty = typeof(CSharpCompilationOptions).GetProperty("TopLevelBinderFlags", BindingFlags.Instance | BindingFlags.NonPublic);
             Debug.Assert(topLevelBinderFlagsProperty != null);
@@ -205,13 +205,14 @@ namespace osu.Framework.Testing
             foreach (var f in files)
                 syntaxTrees.Add(CSharpSyntaxTree.ParseText(File.ReadAllText(f, Encoding.UTF8), parseOptions, f, encoding: Encoding.UTF8));
 
-            // Add a syntax tree to define the new assembly version, such that it replaces any existing dynamic assembly.
+            // Add the new assembly version, such that it replaces any existing dynamic assembly.
             string assemblyVersion = $"{++currentVersion}.0.*";
             syntaxTrees.Add(CSharpSyntaxTree.ParseText($"using System.Reflection; [assembly: AssemblyVersion(\"{assemblyVersion}\")]", parseOptions));
 
             // Add a custom compiler attribute to allow ignoring access checks.
             syntaxTrees.Add(CSharpSyntaxTree.ParseText(ignores_access_checks_to_attribute_syntax, parseOptions));
 
+            // Ignore access checks for assemblies that have had their internal types referenced.
             var ignoreAccessChecksText = new StringBuilder();
             ignoreAccessChecksText.AppendLine("using System.Runtime.CompilerServices;");
             foreach (var asm in assemblies.Where(asm => asm.IgnoreAccessChecks))

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -16,7 +16,7 @@ using System.Text;
 
 namespace osu.Framework.Testing
 {
-    public class DynamicClassCompiler<T> : IDisposable
+    internal class DynamicClassCompiler<T> : IDisposable
         where T : IDynamicallyCompile
     {
         public event Action CompilationStarted;

--- a/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace osu.Framework.Testing
 {
-    public class EmptyTypeReferenceBuilder : ITypeReferenceBuilder
+    internal class EmptyTypeReferenceBuilder : ITypeReferenceBuilder
     {
         public Task Initialise(string solutionFile) => Task.CompletedTask;
 

--- a/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
@@ -14,8 +14,8 @@ namespace osu.Framework.Testing
         public async Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile)
             => await Task.FromResult(Array.Empty<string>());
 
-        public async Task<IReadOnlyCollection<string>> GetReferencedAssemblies(Type testType, string changedFile)
-            => await Task.FromResult(Array.Empty<string>());
+        public async Task<IReadOnlyCollection<AssemblyReference>> GetReferencedAssemblies(Type testType, string changedFile)
+            => await Task.FromResult(Array.Empty<AssemblyReference>());
 
         public void Reset()
         {

--- a/osu.Framework/Testing/IDynamicallyCompile.cs
+++ b/osu.Framework/Testing/IDynamicallyCompile.cs
@@ -6,7 +6,7 @@ namespace osu.Framework.Testing
     /// <summary>
     /// A class which can be recompiled at runtime to allow for rapid testing.
     /// </summary>
-    public interface IDynamicallyCompile
+    internal interface IDynamicallyCompile
     {
         /// <summary>
         /// A reference to the original instance which dynamic compilation was based on.

--- a/osu.Framework/Testing/ITypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/ITypeReferenceBuilder.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Testing
         /// <param name="testType">The <see cref="Type"/>.</param>
         /// <param name="changedFile">The file.</param>
         /// <returns>The file names containing all assemblies referenced between <paramref name="testType"/> and <paramref name="changedFile"/>.</returns>
-        Task<IReadOnlyCollection<string>> GetReferencedAssemblies(Type testType, string changedFile);
+        Task<IReadOnlyCollection<AssemblyReference>> GetReferencedAssemblies(Type testType, string changedFile);
 
         /// <summary>
         /// Resets this <see cref="ITypeReferenceBuilder"/>.

--- a/osu.Framework/Testing/ITypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/ITypeReferenceBuilder.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace osu.Framework.Testing
 {
-    public interface ITypeReferenceBuilder
+    internal interface ITypeReferenceBuilder
     {
         /// <summary>
         /// Initialises this <see cref="ITypeReferenceBuilder"/> with a given solution file.

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -19,7 +19,7 @@ using osu.Framework.Logging;
 
 namespace osu.Framework.Testing
 {
-    public class RoslynTypeReferenceBuilder : ITypeReferenceBuilder
+    internal class RoslynTypeReferenceBuilder : ITypeReferenceBuilder
     {
         // The "Attribute" suffix disappears when used via a nuget package, so it is trimmed here.
         private static readonly string exclude_attribute_name = nameof(ExcludeFromDynamicCompileAttribute).Replace(nameof(Attribute), string.Empty);

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -320,7 +320,7 @@ namespace osu.Framework.Testing
                 }
 
                 if (typeSymbol.DeclaredAccessibility == Accessibility.Internal)
-                    assembliesContainingReferencedInternalMembers.Add(typeSymbol.ContainingAssembly.ToDisplayString());
+                    assembliesContainingReferencedInternalMembers.Add(typeSymbol.ContainingAssembly.Name);
 
                 result.Add(reference);
             }


### PR DESCRIPTION
This is a bit of a proof-of-concept and I'm not sure on the viability of it going forward, ready for merge if you think it's fine. It fixes the `TestSceneDrawableJudgement -> LegacyJudgementPieceNew` case pointed out in Discord (accessing `SkinInfo.DEFAULT_SKIN`, etc).

See https://www.strathweb.com/2018/10/no-internalvisibleto-no-problem-bypassing-c-visibility-rules-with-roslyn/ for more info.

There is an internal compiler attribute `IgnoresAccessChecksTo(assemblyName)` which acts inversely to `InternalsVisibleTo(assemblyName)`. However it:
1. Requires setting internal compiler option `TopLevelBinderFlags`, and thus the API surface may change.
2. Requires importing all `internal` symbols, which can be an issue because it means there is the possibility of type conflicts in matching namespaces. This already happens with `JetBrains.Annotations`, which libraries define themselves and conflict with the nuget `JetBrains.Annotations` package.
    * To get around this, I'm excluding all assemblies that contain a `JetBrains.Annotations` namespace themselves, and only including the nuget package.
    * This is not an exhaustive search - if two libraries included the same namespace+type combo that is not `JetBrains.Annotations`, DCC would fail.
    * `Microsoft.EntityFrameworkCore` assemblies all get excluded so types referencing EF symbols can't be dynamically recompiled. This isn't a huge issue for us because all of our EF stuff is done in manager classes that can't be recompiled anyway (they're too far-reaching).

I haven't yet found a way to get past (2), and if it becomes a problem then we may have to reconsider...