### PR TITLE
Do not include bindable properties in UnbindAllBindables

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -377,7 +377,7 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestUnbindOnDrawableDisposeProperty()
+        public void TestUnbindOnDrawableDoNotDisposeDelegatingProperty()
         {
             var bindable = new Bindable<int>();
 
@@ -397,6 +397,23 @@ namespace osu.Framework.Tests.Bindables
 
             drawable.SetValue(3);
             Assert.IsTrue(valueChanged, "bound correctly");
+        }
+
+        [Test]
+        public void TestUnbindOnDrawableDisposeAutoProperty()
+        {
+            bool valueChanged = false;
+            var drawable = new TestDrawable3();
+            drawable.Bindable.ValueChanged += _ => valueChanged = true;
+
+            drawable.Bindable.Value = 1;
+            Assert.IsTrue(valueChanged, "bound correctly");
+
+            drawable.Dispose();
+            valueChanged = false;
+
+            drawable.Bindable.Value = 2;
+            Assert.IsFalse(valueChanged, "unbound correctly");
         }
 
         [Test]
@@ -500,6 +517,17 @@ namespace osu.Framework.Tests.Bindables
             }
 
             public void SetValue(int value) => bindable.Value = value;
+        }
+
+        private class TestDrawable3 : Drawable
+        {
+            public Bindable<int> Bindable { get; } = new Bindable<int>();
+
+            public TestDrawable3()
+            {
+                // because we are run outside of a game instance but need the cached disposal methods.
+                Load(new FramedClock(), new DependencyContainer());
+            }
         }
     }
 }

--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -392,8 +392,11 @@ namespace osu.Framework.Tests.Bindables
             drawable.Dispose();
             valueChanged = false;
 
-            drawable.SetValue(2);
-            Assert.IsFalse(valueChanged, "unbound correctly");
+            bindable.Value = 2;
+            Assert.IsTrue(valueChanged, "bound correctly");
+
+            drawable.SetValue(3);
+            Assert.IsTrue(valueChanged, "bound correctly");
         }
 
         [Test]

--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -390,11 +390,12 @@ namespace osu.Framework.Tests.Bindables
             Assert.IsTrue(valueChanged, "bound correctly");
 
             drawable.Dispose();
-            valueChanged = false;
 
+            valueChanged = false;
             bindable.Value = 2;
             Assert.IsTrue(valueChanged, "bound correctly");
 
+            valueChanged = false;
             drawable.SetValue(3);
             Assert.IsTrue(valueChanged, "bound correctly");
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -151,11 +151,6 @@ namespace osu.Framework.Graphics
                                      .Where(f => typeof(IUnbindable).IsAssignableFrom(f.FieldType))
                                      .Select(f => new Action<object>(target => ((IUnbindable)f.GetValue(target))?.UnbindAll())));
 
-                // Generate delegates to unbind properties
-                actions.AddRange(type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                                     .Where(p => typeof(IUnbindable).IsAssignableFrom(p.PropertyType))
-                                     .Select(p => new Action<object>(target => ((IUnbindable)p.GetValue(target))?.UnbindAll())));
-
                 unbind_action_cache[type] = target =>
                 {
                     foreach (var a in actions)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -151,6 +151,10 @@ namespace osu.Framework.Graphics
                                      .Where(f => typeof(IUnbindable).IsAssignableFrom(f.FieldType))
                                      .Select(f => new Action<object>(target => ((IUnbindable)f.GetValue(target))?.UnbindAll())));
 
+                // Delegates to unbind properties are intentionally not generated.
+                // Properties with backing fields (including automatic properties) will be picked up by the field unbind delegate generation,
+                // while ones without backing fields (like get-only properties that delegate to another drawable's bindable) should not be unbound here.
+
                 unbind_action_cache[type] = target =>
                 {
                     foreach (var a in actions)


### PR DESCRIPTION
closes #4014

As mentioned in the issue, unbinding external bindables is pretty dodgy. I updated the unbinding code and changed the test to test for the opposite behaviour.