### PR TITLE
Fix PrepareForUse potentially getting called twice on the same pooled usage

### DIFF
--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -62,6 +62,7 @@ namespace osu.Framework.Graphics.Pooling
 
         /// <summary>
         /// Perform any initialisation on new usage of this drawable.
+        /// This is scheduled to the first update frame and may not be run if this is never reached.
         /// </summary>
         protected virtual void PrepareForUse()
         {
@@ -69,6 +70,7 @@ namespace osu.Framework.Graphics.Pooling
 
         /// <summary>
         /// Perform any clean-up required before returning this drawable to a pool.
+        /// This is called regardless of whether <see cref="PrepareForUse"/> was executed.
         /// </summary>
         protected virtual void FreeAfterUse()
         {

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
+using osu.Framework.Threading;
 
 namespace osu.Framework.Graphics.Pooling
 {
@@ -27,6 +28,8 @@ namespace osu.Framework.Graphics.Pooling
         /// A flag to keep the drawable present to guarantee the prepare call can be performed as a scheduled call.
         /// </summary>
         private bool waitingForPrepare;
+
+        private ScheduledDelegate scheduledPrepare;
 
         public override bool IsPresent => waitingForPrepare || base.IsPresent;
 
@@ -102,11 +105,12 @@ namespace osu.Framework.Graphics.Pooling
 
             // prepare call is scheduled as it may contain user code dependent on the clock being updated.
             // must use Scheduler.Add, not Schedule as we may have the wrong clock at this point in load.
-            Scheduler.Add(() =>
+            scheduledPrepare?.Cancel();
+            scheduledPrepare = Scheduler.AddDelayed(() =>
             {
                 PrepareForUse();
                 waitingForPrepare = false;
-            });
+            }, 0);
         }
 
         protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)


### PR DESCRIPTION
This turns out to be quite dangerous and the cause for https://github.com/ppy/osu/issues/10938. It also fixes hitobjects disappearing in the editor at random.

Closes https://github.com/ppy/osu/issues/10938.