### PR TITLE
Fix PoolableDrawable being returned from child invalidations propagating upwards

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDrawablePool.cs
@@ -233,6 +233,22 @@ namespace osu.Framework.Tests.Visual.Drawables
             Assert.DoesNotThrow(() => new TestPool(100, 1).Get());
         }
 
+        /// <summary>
+        /// Tests that when a child of a pooled drawable receives a parent invalidation, the parent pooled drawable is not returned.
+        /// A parent invalidation can happen on the child if it's added to the hierarchy of the parent.
+        /// </summary>
+        [Test]
+        public void TestParentInvalidationFromChildDoesNotReturnPooledParent()
+        {
+            resetWithNewPool(() => new TestPool(TimePerAction, 1));
+
+            TestDrawable drawable = null;
+
+            AddStep("consume item", () => drawable = consumeDrawable(false));
+            AddStep("add child", () => drawable.AddChild(Empty()));
+            AddAssert("not freed", () => drawable.FreedCount == 0);
+        }
+
         protected override void Update()
         {
             base.Update();
@@ -329,6 +345,8 @@ namespace osu.Framework.Tests.Visual.Drawables
                     },
                 };
             }
+
+            public void AddChild(Drawable drawable) => AddInternal(drawable);
 
             public new bool IsDisposed => base.IsDisposed;
 

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -115,7 +115,7 @@ namespace osu.Framework.Graphics.Pooling
 
         protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
         {
-            if (invalidation.HasFlag(Invalidation.Parent))
+            if (source != InvalidationSource.Child && invalidation.HasFlag(Invalidation.Parent))
             {
                 if (IsInUse && Parent == null)
                     Return();


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/4017 (for testing)

Discovered in https://github.com/LumpBloom7/sentakki/pull/144, which adds its own sound to the hierarchy: https://github.com/LumpBloom7/sentakki/blob/0f6747f305f1ce0cff18c2b4b50196046b1b5fa4/osu.Game.Rulesets.Sentakki/Objects/Drawables/DrawableSlideNode.cs#L50-L55

This wasn't discovered on our side since we're always adding to child containers, and child invalidations only propagate upwards one level. It's probably arguable whether a child's `Parent` invalidation should propagate to its parent, but that's a consideration for another day.