### PR TITLE
Fix RearrangeableList tests failing via headless run

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneRearrangeableListContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneRearrangeableListContainer.cs
@@ -262,7 +262,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("add item 1", () => delayedList.Items.Add(1));
             AddStep("allow load", () => delayedList.AllowLoad.Release(100));
 
-            AddAssert("only one item", () => delayedList.ChildrenOfType<BasicRearrangeableListItem<int>>().Count() == 1);
+            AddUntilStep("only one item", () => delayedList.ChildrenOfType<BasicRearrangeableListItem<int>>().Count() == 1);
         }
 
         private void addDragSteps(int from, int to, int[] expectedSequence)


### PR DESCRIPTION
Can reproduce this 100% when running tests from rider (headless). Not sure if this covers the test scenario completely (seems like the drawables are loaded asynchronously), can add some wait and re-assert steps if that's deemed required.

Closes https://github.com/ppy/osu-framework/issues/3930.