### PR TITLE
Make Scheduler.Add() return the scheduled delegate

### DIFF
--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -28,12 +28,18 @@ namespace osu.Framework.Tests.Threading
 
             int invocations = 0;
 
-            scheduler.Add(() => invocations++, forceScheduled);
+            var del = scheduler.Add(() => invocations++, forceScheduled);
 
             if (fromMainThread && !forceScheduled)
+            {
                 Assert.AreEqual(1, invocations);
+                Assert.That(del, Is.Null);
+            }
             else
+            {
                 Assert.AreEqual(0, invocations);
+                Assert.That(del, Is.Not.Null);
+            }
 
             scheduler.Update();
             Assert.AreEqual(1, invocations);

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -198,6 +198,7 @@ namespace osu.Framework.Threading
         /// <summary>
         /// Add a task to be scheduled.
         /// </summary>
+        /// <remarks>If scheduled, the task will be run on the next <see cref="Update"/> independent of the current clock time.</remarks>
         /// <param name="task">The work to be done.</param>
         /// <param name="forceScheduled">If set to false, the task will be executed immediately if we are on the main thread.</param>
         /// <returns>The scheduled task, or <c>null</c> if the task was executed immediately.</returns>
@@ -221,6 +222,7 @@ namespace osu.Framework.Threading
         /// <summary>
         /// Add a task to be scheduled.
         /// </summary>
+        /// <remarks>The task will be run on the next <see cref="Update"/> independent of the current clock time.</remarks>
         /// <param name="task">The scheduled delegate to add.</param>
         /// <exception cref="InvalidOperationException">Thrown when attempting to add a scheduled delegate that has been already completed.</exception>
         public void Add(ScheduledDelegate task)
@@ -238,7 +240,7 @@ namespace osu.Framework.Threading
         }
 
         /// <summary>
-        /// Add a task which will be run after a specified delay.
+        /// Add a task which will be run after a specified delay from the current clock time.
         /// </summary>
         /// <param name="task">The work to be done.</param>
         /// <param name="timeUntilRun">Milliseconds until run.</param>
@@ -258,6 +260,7 @@ namespace osu.Framework.Threading
         /// <summary>
         /// Adds a task which will only be run once per frame, no matter how many times it was scheduled in the previous frame.
         /// </summary>
+        /// <remarks>The task will be run on the next <see cref="Update"/> independent of the current clock time.</remarks>
         /// <param name="task">The work to be done.</param>
         /// <returns>Whether this is the first queue attempt of this work.</returns>
         public bool AddOnce(Action task)

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using JetBrains.Annotations;
 using osu.Framework.Extensions;
 using osu.Framework.Timing;
 
@@ -202,7 +203,8 @@ namespace osu.Framework.Threading
         /// <param name="task">The work to be done.</param>
         /// <param name="forceScheduled">If set to false, the task will be executed immediately if we are on the main thread.</param>
         /// <returns>The scheduled task, or <c>null</c> if the task was executed immediately.</returns>
-        public ScheduledDelegate Add(Action task, bool forceScheduled = true)
+        [CanBeNull]
+        public ScheduledDelegate Add([NotNull] Action task, bool forceScheduled = true)
         {
             if (!forceScheduled && IsMainThread)
             {
@@ -225,7 +227,7 @@ namespace osu.Framework.Threading
         /// <remarks>The task will be run on the next <see cref="Update"/> independent of the current clock time.</remarks>
         /// <param name="task">The scheduled delegate to add.</param>
         /// <exception cref="InvalidOperationException">Thrown when attempting to add a scheduled delegate that has been already completed.</exception>
-        public void Add(ScheduledDelegate task)
+        public void Add([NotNull] ScheduledDelegate task)
         {
             if (task.Completed)
                 throw new InvalidOperationException($"Can not add a {nameof(ScheduledDelegate)} that has been already {nameof(ScheduledDelegate.Completed)}");
@@ -246,7 +248,8 @@ namespace osu.Framework.Threading
         /// <param name="timeUntilRun">Milliseconds until run.</param>
         /// <param name="repeat">Whether this task should repeat.</param>
         /// <returns>The scheduled task.</returns>
-        public ScheduledDelegate AddDelayed(Action task, double timeUntilRun, bool repeat = false)
+        [NotNull]
+        public ScheduledDelegate AddDelayed([NotNull] Action task, double timeUntilRun, bool repeat = false)
         {
             // We are locking here already to make sure we have no concurrent access to currentTime
             lock (queueLock)
@@ -263,7 +266,7 @@ namespace osu.Framework.Threading
         /// <remarks>The task will be run on the next <see cref="Update"/> independent of the current clock time.</remarks>
         /// <param name="task">The work to be done.</param>
         /// <returns>Whether this is the first queue attempt of this work.</returns>
-        public bool AddOnce(Action task)
+        public bool AddOnce([NotNull] Action task)
         {
             lock (queueLock)
             {


### PR DESCRIPTION
As discussed in Discord, there's been very few times when a `bool` return has been useful here.

Additionally, in some places such as `PoolableDrawable`, it's unsafe to use `AddDelayed` unless you're fully conscious of potential rewindability because `AddDelayed` adds the clock's current time to the execution time. At this point, I'd say none of us are able to do this since such a regression went completely unnoticed in https://github.com/ppy/osu-framework/pull/4017.

Another point to consider is `Drawable.Schedule()` forwards to `Scheduler.AddDelayed` to apply the transform delay (even if 0), which is also "unsafe" as above if you're only expecting something to be executed in the next update. Such cases can be handled in two ways:
```
using (BeginAbsoluteSequence(double.MinValue))
    Schedule(() => { });

---

Scheduler.Add(() => { });
```
With the latter, as a result of this PR, now being cancellable by the delegate now being returned.