### PR TITLE
Fix some debuggers not correctly showing exception stacks

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -244,7 +244,7 @@ namespace osu.Framework.Platform
         {
             var exception = (Exception)args.ExceptionObject;
             exception.Data["unhandled"] = "unhandled";
-            handleException(exception);
+            handleException(sender, exception);
         }
 
         private void unobservedExceptionHandler(object sender, UnobservedTaskExceptionEventArgs args)
@@ -252,19 +252,41 @@ namespace osu.Framework.Platform
             Debug.Assert(args.Exception != null);
 
             args.Exception.Data["unhandled"] = "unobserved";
-            handleException(args.Exception);
+            handleException(sender, args.Exception);
         }
 
-        private void handleException(Exception exception)
+        private void handleException(object sender, Exception exception)
         {
             if (ExceptionThrown?.Invoke(exception) != true)
             {
                 AppDomain.CurrentDomain.UnhandledException -= unhandledExceptionHandler;
 
                 var captured = ExceptionDispatchInfo.Capture(exception);
+                var thrownEvent = new ManualResetEventSlim(false);
 
                 //we want to throw this exception on the input thread to interrupt window and also headless execution.
-                InputThread.Scheduler.Add(() => { captured.Throw(); });
+                InputThread.Scheduler.Add(() =>
+                {
+                    try
+                    {
+                        captured.Throw();
+                    }
+                    finally
+                    {
+                        thrownEvent.Set();
+                    }
+                });
+
+                // Stopping running threads before the exception is rethrown on the input thread causes some debuggers (e.g. Rider 2020.2) to not properly display the stack.
+                // To avoid this, the exceptioning thread will be paused until the rethrow takes place.
+                // Importantly, this is bypassed for GameThread sources in two situations where deadlocks can occur:
+                // 1. When the exceptioning thread is already the input thread.
+                // 2. When the game is running in single-threaded mode. Single threaded stacks will be displayed correctly at the point of rethrow.
+                if (!(sender is GameThread)
+                    || (sender != InputThread && executionMode.Value == ExecutionMode.MultiThreaded))
+                {
+                    thrownEvent.Wait();
+                }
 
                 // schedule an exit to the input thread.
                 // this is required for single threaded execution, else the draw thread may get stuck looping before the above schedule finishes.


### PR DESCRIPTION
From:
![Screenshot_2020-11-25_18-38-53](https://user-images.githubusercontent.com/1329837/100235378-b0dbc400-2f6f-11eb-93c0-25a886fa5ebb.png)

To:
![Screenshot_2020-11-25_18-39-37](https://user-images.githubusercontent.com/1329837/100235384-b33e1e00-2f6f-11eb-99e1-6d71c5f1da92.png)

Discovered this mostly by accident, but it seems like having the crashed thread exit before the debugger does its thing causes the stack trace to not display correctly.

Scenarios I've tested:
- Throw in `DrawableHitObject.load()` single/multi-threaded.
- Throw in `DrawableHitObject.Update()` single/multi-threaded.
- Throw in `DrawableHitObject.load()` with `TestSceneOsuPlayer.TestConstructor`.
    - This doesn't launch your debugger but that seems to just be a function of how nunit works since it runs all test code within exception-safe blocks.