### PR TITLE
Close midi devices on disconnect

### DIFF
--- a/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
@@ -67,6 +67,7 @@ namespace osu.Framework.Input.Handlers.Midi
 
                     if (inputs.All(i => i.Id != key))
                     {
+                        value.CloseAsync().Wait();
                         value.MessageReceived -= onMidiMessageReceived;
                         openedDevices.Remove(key);
 


### PR DESCRIPTION
Should fix https://github.com/ppy/osu/issues/10969

I'm not currently able to test this, so would appreciate a confirmation. Should be replicable by adding a `GC.Collect(); GC.WaitForPendingFinalizers()` after the `openedDevices.Remove(key);` line.