### PR TITLE
Fix binding bindables potentially transfers values while it's disabled

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -23,6 +23,32 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
+        public void TestBindWhileDisabled()
+        {
+            Bindable<string> bindable1 = new Bindable<string> { Disabled = true };
+            Bindable<string> bindable2 = new Bindable<string>("different");
+
+            bindable1.BindTo(bindable2);
+
+            Assert.AreEqual(false, bindable1.Disabled);
+            Assert.AreEqual("different", bindable1.Value);
+            Assert.AreEqual(bindable2.Value, bindable1.Value);
+        }
+
+        [Test]
+        public void TestBindToDisabled()
+        {
+            Bindable<string> bindable1 = new Bindable<string>();
+            Bindable<string> bindable2 = new Bindable<string>("different") { Disabled = true };
+
+            bindable1.BindTo(bindable2);
+
+            Assert.AreEqual(true, bindable1.Disabled);
+            Assert.AreEqual("different", bindable1.Value);
+            Assert.AreEqual(bindable2.Value, bindable1.Value);
+        }
+
+        [Test]
         public void TestPropagation()
         {
             Bindable<string> bindable1 = new Bindable<string>("default");

--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -23,6 +23,26 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
+        public void TestBindToEquivalent()
+        {
+            Bindable<string> bindable1 = new Bindable<string>("same");
+            Bindable<string> bindable2 = new Bindable<string>("same");
+
+            bool changed1 = false, changed2 = false;
+            bindable1.ValueChanged += _ => changed1 = true;
+            bindable1.DefaultChanged += _ => changed1 = true;
+            bindable1.DisabledChanged += _ => changed1 = true;
+            bindable2.ValueChanged += _ => changed2 = true;
+            bindable2.DefaultChanged += _ => changed2 = true;
+            bindable2.DisabledChanged += _ => changed2 = true;
+
+            bindable1.BindTo(bindable2);
+
+            Assert.AreEqual(false, changed1);
+            Assert.AreEqual(false, changed2);
+        }
+
+        [Test]
         public void TestBindWhileDisabled()
         {
             Bindable<string> bindable1 = new Bindable<string> { Disabled = true };

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -190,9 +190,9 @@ namespace osu.Framework.Bindables
             if (Bindings?.Contains(them) == true)
                 throw new InvalidOperationException($"This bindable is already bound to the requested bindable ({them}).");
 
-            Value = them.Value;
-            Default = them.Default;
-            Disabled = them.Disabled;
+            SetValue(Value, them.Value);
+            SetDefaultValue(Default, them.Default);
+            SetDisabled(them.Disabled);
 
             addWeakReference(them.weakReference);
             them.addWeakReference(weakReference);

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -53,8 +53,6 @@ namespace osu.Framework.Bindables
                 // if a lease is active, disabled can *only* be changed by that leased bindable.
                 throwIfLeased();
 
-                if (disabled == value) return;
-
                 SetDisabled(value);
             }
         }
@@ -63,6 +61,8 @@ namespace osu.Framework.Bindables
         {
             if (!bypassChecks)
                 throwIfLeased();
+
+            if (disabled == value) return;
 
             disabled = value;
             TriggerDisabledChange(source ?? this, true, bypassChecks);
@@ -92,14 +92,14 @@ namespace osu.Framework.Bindables
                 if (Disabled)
                     throw new InvalidOperationException($"Can not set value to \"{value.ToString()}\" as bindable is disabled.");
 
-                if (EqualityComparer<T>.Default.Equals(this.value, value)) return;
-
                 SetValue(this.value, value);
             }
         }
 
         internal void SetValue(T previousValue, T value, bool bypassChecks = false, Bindable<T> source = null)
         {
+            if (EqualityComparer<T>.Default.Equals(this.value, value)) return;
+
             this.value = value;
             TriggerValueChange(previousValue, source ?? this, true, bypassChecks);
         }
@@ -118,14 +118,14 @@ namespace osu.Framework.Bindables
                 if (Disabled)
                     throw new InvalidOperationException($"Can not set default value to \"{value.ToString()}\" as bindable is disabled.");
 
-                if (EqualityComparer<T>.Default.Equals(defaultValue, value)) return;
-
                 SetDefaultValue(defaultValue, value);
             }
         }
 
         internal void SetDefaultValue(T previousValue, T value, bool bypassChecks = false, Bindable<T> source = null)
         {
+            if (EqualityComparer<T>.Default.Equals(defaultValue, value)) return;
+
             defaultValue = value;
             TriggerDefaultChange(previousValue, source ?? this, true, bypassChecks);
         }

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Bindables
         /// <param name="precision">The new precision.</param>
         /// <param name="updateCurrentValue">Whether to update the current value after the precision is set.</param>
         /// <param name="source">The bindable that triggered this. A null value represents the current bindable instance.</param>
-        internal void SetPrecision(T precision, bool updateCurrentValue, BindableNumber<T> source)
+        internal void SetPrecision(T precision, bool updateCurrentValue = true, BindableNumber<T> source = null)
         {
             this.precision = precision;
             TriggerPrecisionChange(source);
@@ -111,7 +111,7 @@ namespace osu.Framework.Bindables
         /// <param name="minValue">The new minimum value.</param>
         /// <param name="updateCurrentValue">Whether to update the current value after the minimum value is set.</param>
         /// <param name="source">The bindable that triggered this. A null value represents the current bindable instance.</param>
-        internal void SetMinValue(T minValue, bool updateCurrentValue, BindableNumber<T> source)
+        internal void SetMinValue(T minValue, bool updateCurrentValue = true, BindableNumber<T> source = null)
         {
             this.minValue = minValue;
             TriggerMinValueChange(source);
@@ -143,7 +143,7 @@ namespace osu.Framework.Bindables
         /// <param name="maxValue">The new maximum value.</param>
         /// <param name="updateCurrentValue">Whether to update the current value after the maximum value is set.</param>
         /// <param name="source">The bindable that triggered this. A null value represents the current bindable instance.</param>
-        internal void SetMaxValue(T maxValue, bool updateCurrentValue, BindableNumber<T> source)
+        internal void SetMaxValue(T maxValue, bool updateCurrentValue = true, BindableNumber<T> source = null)
         {
             this.maxValue = maxValue;
             TriggerMaxValueChange(source);
@@ -322,9 +322,9 @@ namespace osu.Framework.Bindables
         {
             if (them is BindableNumber<T> other)
             {
-                Precision = other.Precision;
-                MinValue = other.MinValue;
-                MaxValue = other.MaxValue;
+                SetPrecision(other.Precision);
+                SetMinValue(other.MinValue);
+                SetMaxValue(other.MaxValue);
 
                 if (MinValue.CompareTo(MaxValue) > 0)
                 {

--- a/osu.Framework/Bindables/LeasedBindable.cs
+++ b/osu.Framework/Bindables/LeasedBindable.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using JetBrains.Annotations;
 
 namespace osu.Framework.Bindables
@@ -67,8 +66,6 @@ namespace osu.Framework.Bindables
                 if (source != null)
                     checkValid();
 
-                if (EqualityComparer<T>.Default.Equals(Value, value)) return;
-
                 SetValue(base.Value, value, true);
             }
         }
@@ -81,8 +78,6 @@ namespace osu.Framework.Bindables
                 if (source != null)
                     checkValid();
 
-                if (EqualityComparer<T>.Default.Equals(Default, value)) return;
-
                 SetDefaultValue(base.Default, value, true);
             }
         }
@@ -94,8 +89,6 @@ namespace osu.Framework.Bindables
             {
                 if (source != null)
                     checkValid();
-
-                if (Disabled == value) return;
 
                 SetDisabled(value, true);
             }


### PR DESCRIPTION
Resolves #3218

This fixes the issue by transferring the values directly via `Set...` methods, which bypass the disabled check.