### PR TITLE
Fix native delegate callback getting garbage collected

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -406,13 +406,16 @@ namespace osu.Framework.Platform
             WindowMode.TriggerChange();
         }
 
+        // reference must be kept to avoid GC, see https://stackoverflow.com/a/6193914
+        private SDL.SDL_EventFilter eventFilterDelegate;
+
         /// <summary>
         /// Starts the window's run loop.
         /// </summary>
         public void Run()
         {
             // polling via SDL_PollEvent blocks on resizes (https://stackoverflow.com/a/50858339)
-            SDL.SDL_SetEventFilter((_, eventPtr) =>
+            SDL.SDL_SetEventFilter(eventFilterDelegate = (_, eventPtr) =>
             {
                 // ReSharper disable once PossibleNullReferenceException
                 var e = (SDL.SDL_Event)Marshal.PtrToStructure(eventPtr, typeof(SDL.SDL_Event));

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -8,6 +8,7 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Input;
@@ -407,6 +408,7 @@ namespace osu.Framework.Platform
         }
 
         // reference must be kept to avoid GC, see https://stackoverflow.com/a/6193914
+        [UsedImplicitly]
         private SDL.SDL_EventFilter eventFilterDelegate;
 
         /// <summary>


### PR DESCRIPTION
Didn't notice this as it only happens when startup occurs fast enough to GC to have run (not in my VM or with a debugger attached, but can happen on my gaming PC).

Fixes the following startup crash:
```
Process terminated. A callback was made on a garbage collected delegate of type
'SDL2-CS!SDL2.SDL+SDL_EventFilter::Invoke'.
   at SDL2.SDL.SDL_ShowWindow(IntPtr)
   at SDL2.SDL.SDL_ShowWindow(IntPtr)
   at osu.Framework.Platform.SDL2DesktopWindow+<>c__DisplayClass67_0.<set_Visible>b__0()
```