### PR TITLE
Fix SDL2 window restore event not being forwarded to active state

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -890,11 +890,6 @@ namespace osu.Framework.Platform
                     updateWindowSize();
                     break;
 
-                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
-                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MAXIMIZED:
-                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESTORED:
-                    break;
-
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_ENTER:
                     cursorInWindow.Value = true;
                     ScheduleEvent(OnMouseEntered);
@@ -905,10 +900,12 @@ namespace osu.Framework.Platform
                     ScheduleEvent(OnMouseLeft);
                     break;
 
+                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESTORED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED:
                     ScheduleEvent(OnFocusGained);
                     break;
 
+                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_LOST:
                     ScheduleEvent(OnFocusLost);
                     break;


### PR DESCRIPTION
With previous logic we were not handling `WINDOWEVENT_RESTORED`. As it turns out, the `FOCUS_GAINED` event is not fired in cases where a window is restored from a minimised state, potentially leaving the game thinking it is not active (and blocking input).

on winkey-d:
```
SDL_WINDOWEVENT_MINIMIZED
SDL_WINDOWEVENT_LEAVE
SDL_WINDOWEVENT_FOCUS_LOST <-- focus lost fired, but focus gained doesn't
SDL_WINDOWEVENT_RESTORED
SDL_WINDOWEVENT_EXPOSED
SDL_WINDOWEVENT_ENTER
SDL_WINDOWEVENT_EXPOSED
```

on minimise:

```
SDL_WINDOWEVENT_LEAVE
SDL_WINDOWEVENT_MINIMIZED
SDL_WINDOWEVENT_FOCUS_LOST
SDL_WINDOWEVENT_RESTORED
SDL_WINDOWEVENT_FOCUS_GAINED
SDL_WINDOWEVENT_EXPOSED
```

on alt-tab:
```
SDL_WINDOWEVENT_LEAVE
SDL_WINDOWEVENT_FOCUS_LOST
SDL_WINDOWEVENT_ENTER
SDL_WINDOWEVENT_FOCUS_GAINED
```

Handling the minimise and restore events seems the safest way to resolve this (we are doing similar in osuTK implementations). The `Focused` property already handles the case it is set to the same value twice.

Potential fix for https://github.com/ppy/osu-framework/issues/4050 (needs confirmation; i can't reproduce this in the first place).