### PR TITLE
Fix switching fullscreen resolutions potentially resulting in incorrect render resolution

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -887,7 +887,8 @@ namespace osu.Framework.Platform
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SIZE_CHANGED:
-                    updateWindowSize();
+                    if (windowState == WindowState.Normal)
+                        updateWindowSize();
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:


### PR DESCRIPTION
This is really painful to need to do, but is required due to two other hacks/workarounds:

This addition for fullscreen, where we enter windowed mode briefly:
https://github.com/ppy/osu-framework/blob/6272037fdf3eb9d17afe40b3823e47f6340b9c1e/osu.Framework/Platform/SDL2DesktopWindow.cs#L963-L966

In conjunction with the SDL event filtering where we handle resize events (to stop blocking updates when resizing the window):
https://github.com/ppy/osu-framework/blob/6272037fdf3eb9d17afe40b3823e47f6340b9c1e/osu.Framework/Platform/SDL2DesktopWindow.cs#L420-L427

Closes https://github.com/ppy/osu-framework/issues/4060