### PR TITLE
Fix borderless size being based on a potentially outdated value

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -971,7 +971,7 @@ namespace osu.Framework.Platform
 
                 case WindowState.FullscreenBorderless:
                     SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP);
-                    Size = CurrentDisplayMode.Size;
+                    Size = currentDisplay.Bounds.Size;
                     break;
 
                 case WindowState.Maximised:


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/4061

Reading from `CurrentDisplayMode` is awkward as it is only valid when in fullscreen (and only initialised below the usage here).