### PR TITLE
Remove disposed pool statistics from global statistics

### DIFF
--- a/osu.Framework/Statistics/GlobalStatistics.cs
+++ b/osu.Framework/Statistics/GlobalStatistics.cs
@@ -57,6 +57,15 @@ namespace osu.Framework.Statistics
         }
 
         /// <summary>
+        /// Remove a specific statistic.
+        /// </summary>
+        /// <param name="statistic">The statistic to remove.</param>
+        public static void Remove(IGlobalStatistic statistic)
+        {
+            lock (statistics) statistics.Remove(statistic);
+        }
+
+        /// <summary>
         /// Register a new statistic type.
         /// </summary>
         /// <param name="stat">The statistic to register.</param>


### PR DESCRIPTION
Open to suggestion on how to improve this visually. We could potentially add an identifier string to better describe multiple instances of the same pool (allow them to override or provide a string based on their specifics).

![image](https://user-images.githubusercontent.com/191335/100984852-95377580-358e-11eb-8cb1-c2120266c0b6.png)
