### PR TITLE
Fix startup crash on older windows releases

### DIFF
--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -22,8 +22,15 @@ namespace osu.Framework.Platform.Windows
 
         public WindowsWindow()
         {
-            // SDL doesn't handle DPI correctly on windows, but this brings things mostly in-line with expectations. (https://bugzilla.libsdl.org/show_bug.cgi?id=3281)
-            SetProcessDpiAwareness(ProcessDpiAwareness.Process_System_DPI_Aware);
+            try
+            {
+                // SDL doesn't handle DPI correctly on windows, but this brings things mostly in-line with expectations. (https://bugzilla.libsdl.org/show_bug.cgi?id=3281)
+                SetProcessDpiAwareness(ProcessDpiAwareness.Process_System_DPI_Aware);
+            }
+            catch
+            {
+                // API doesn't exist on Windows 7 so it needs to be allowed to fail silently.
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #4071

Attempted to test this on windows 7 but the hoops required to jump through to get net core working are too time consuming. No reason it shouldn't work unless there are further issues related to SDL2 itself (but we can wait for user reports for that).