### PR TITLE
Fix mouse polling on maximised SDL window calculating incorrectly

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -880,7 +880,7 @@ namespace osu.Framework.Platform
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MOVED:
                     var newPosition = new Point(evtWindow.data1, evtWindow.data2);
 
-                    if (windowState == WindowState.Normal && !newPosition.Equals(Position))
+                    if (WindowMode.Value == Configuration.WindowMode.Windowed && !newPosition.Equals(Position))
                     {
                         position = newPosition;
                         updateWindowPositionConfigFromCurrent();
@@ -891,7 +891,7 @@ namespace osu.Framework.Platform
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SIZE_CHANGED:
-                    if (windowState == WindowState.Normal)
+                    if (WindowMode.Value == Configuration.WindowMode.Windowed)
                         updateWindowSize();
                     break;
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -564,7 +564,7 @@ namespace osu.Framework.Platform
 
             previousPolledPoint = new Point(x, y);
 
-            var pos = windowState == WindowState.Normal ? Position : windowDisplayBounds.Location;
+            var pos = WindowMode.Value == Configuration.WindowMode.Windowed ? Position : windowDisplayBounds.Location;
             var rx = x - pos.X;
             var ry = y - pos.Y;
 


### PR DESCRIPTION
Previously, only normal (un-maximised) window state would use the window position to determine the global cursor position in relation to the game's position when being outside of the window, which results in incorrect mouse positions when in maximised window state (due to it *incorrectly* using the location of the entire monitor instead) as can be seen below.

Before:
![2020-12-05 18 46 54](https://user-images.githubusercontent.com/22781491/101258077-0c0c7400-3731-11eb-9445-2ded091391e4.gif)

After:
![2020-12-05 19 08 05](https://user-images.githubusercontent.com/22781491/101258079-12025500-3731-11eb-8f69-b6c32017e099.gif)

---

One side effect from this is that now the position and size of a maximized window would be saved to config as well, which may not be a good thing to have, although it still saves in some cases on master, and I think saving whether the window was last in maximised state or not and create the window based on it would be a better choice IMO (in a separate PR).
