### PR TITLE
Support NumLock in SDL key mapping function

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -11,7 +11,9 @@ namespace osu.Framework.Platform.SDL2
     {
         public static Key ToKey(this SDL.SDL_Keysym sdlKeysym)
         {
-            bool numLockOn = sdlKeysym.mod.HasFlag(SDL.SDL_Keymod.KMOD_NUM);
+            // Apple devices don't have the notion of NumLock (they have a Clear key instead).
+            // treat them as if they always have NumLock on (the numpad always performs its primary actions).
+            bool numLockOn = sdlKeysym.mod.HasFlag(SDL.SDL_Keymod.KMOD_NUM) || RuntimeInfo.IsApple;
 
             switch (sdlKeysym.scancode)
             {

--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -11,6 +11,8 @@ namespace osu.Framework.Platform.SDL2
     {
         public static Key ToKey(this SDL.SDL_Keysym sdlKeysym)
         {
+            bool numLockOn = sdlKeysym.mod.HasFlag(SDL.SDL_Keymod.KMOD_NUM);
+
             switch (sdlKeysym.scancode)
             {
                 default:
@@ -303,37 +305,37 @@ namespace osu.Framework.Platform.SDL2
                     return Key.KeypadEnter;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_1:
-                    return Key.Keypad1;
+                    return numLockOn ? Key.Keypad1 : Key.End;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_2:
-                    return Key.Keypad2;
+                    return numLockOn ? Key.Keypad2 : Key.Down;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_3:
-                    return Key.Keypad3;
+                    return numLockOn ? Key.Keypad3 : Key.PageDown;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_4:
-                    return Key.Keypad4;
+                    return numLockOn ? Key.Keypad4 : Key.Left;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_5:
                     return Key.Keypad5;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_6:
-                    return Key.Keypad6;
+                    return numLockOn ? Key.Keypad6 : Key.Right;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_7:
-                    return Key.Keypad7;
+                    return numLockOn ? Key.Keypad7 : Key.Home;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_8:
-                    return Key.Keypad8;
+                    return numLockOn ? Key.Keypad8 : Key.Up;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_9:
-                    return Key.Keypad9;
+                    return numLockOn ? Key.Keypad9 : Key.PageUp;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_0:
-                    return Key.Keypad0;
+                    return numLockOn ? Key.Keypad0 : Key.Insert;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_PERIOD:
-                    return Key.KeypadPeriod;
+                    return numLockOn ? Key.KeypadPeriod : Key.Delete;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_NONUSBACKSLASH:
                     return Key.NonUSBackSlash;

--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -33,6 +33,7 @@ namespace osu.Framework
         public static bool SupportsJIT => OS != Platform.iOS;
         public static bool IsDesktop => OS == Platform.Linux || OS == Platform.MacOsx || OS == Platform.Windows;
         public static bool IsMobile => OS == Platform.iOS || OS == Platform.Android;
+        public static bool IsApple => OS == Platform.iOS || OS == Platform.MacOsx;
 
         static RuntimeInfo()
         {


### PR DESCRIPTION
Closes #2728 (in the SDL case).

- [x] Needs testing on Apple devices (macOS + iOS with external keyboard)

In order to properly support the behaviour of <kbd>NumLock</kbd> that is in line with user expectations, check the state of <kbd>NumLock</kbd> when unmapping SDL's scancodes and return the appropriate alternative keys for keypad numbers and the comma key when <kbd>NumLock</kbd> is off.

I can imagine this could be wrong on Apple platforms as they don't have the notion of a <kbd>NumLock</kbd> key, hence I'd be grateful if this could be checked. I don't really want to pepper in platform checks unless I absolutely have to.

Briefly considered not using `HasFlag` due to its memory concerns but I don't necessarily think it's the hottest path out there and there are way more worrying places that use `HasFlag` already performance-wise, so for now I opted for readability. Can be cleaned up at a later stage if deemed worthwhile, I think.

Tested on Ubuntu 18.04 & Windows 10.