### PR TITLE
Fix window getting moved out-of-place while in maximised state

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -219,6 +219,12 @@ namespace osu.Framework.Platform
         }
 
         /// <summary>
+        /// Stores whether the window used to be in maximised state or not.
+        /// Used to properly decide what window state to pick when switching to windowed mode (see <see cref="WindowMode"/> change event)
+        /// </summary>
+        private bool windowMaximised;
+
+        /// <summary>
         /// Returns the drawable area, after scaling.
         /// </summary>
         public Size ClientSize => new Size(Size.Width, Size.Height);
@@ -921,18 +927,6 @@ namespace osu.Framework.Platform
         }
 
         /// <summary>
-        /// Stores whether the window used to be in maximised state or not.
-        /// Used to properly decide what window state to pick when switching to windowed mode (see <see cref="WindowMode"/> change event)
-        /// </summary>
-        private bool windowMaximised;
-
-        private void updateMaximisedState()
-        {
-            if (windowState == WindowState.Normal || windowState == WindowState.Maximised)
-                windowMaximised = windowState == WindowState.Maximised;
-        }
-
-        /// <summary>
         /// Should be run on a regular basis to check for external window state changes.
         /// </summary>
         private void updateWindowSpecifics()
@@ -950,9 +944,9 @@ namespace osu.Framework.Platform
             {
                 windowState = currentState;
                 ScheduleEvent(() => OnWindowStateChanged(currentState));
-            }
 
-            updateMaximisedState();
+                updateMaximisedState();
+            }
 
             int newDisplayIndex = SDL.SDL_GetWindowDisplayIndex(SDLWindowHandle);
 
@@ -1018,6 +1012,12 @@ namespace osu.Framework.Platform
                 currentDisplayMode = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);
 
             isChangingWindowState = false;
+        }
+
+        private void updateMaximisedState()
+        {
+            if (windowState == WindowState.Normal || windowState == WindowState.Maximised)
+                windowMaximised = windowState == WindowState.Maximised;
         }
 
         protected void OnHidden() { }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -926,7 +926,7 @@ namespace osu.Framework.Platform
         /// </summary>
         private bool windowMaximised;
 
-        private void updateMaximisedState(WindowState windowState)
+        private void updateMaximisedState()
         {
             if (windowState == WindowState.Normal || windowState == WindowState.Maximised)
                 windowMaximised = windowState == WindowState.Maximised;
@@ -946,13 +946,13 @@ namespace osu.Framework.Platform
 
             var currentState = ((SDL.SDL_WindowFlags)SDL.SDL_GetWindowFlags(SDLWindowHandle)).ToWindowState();
 
-            updateMaximisedState(currentState);
-
             if (windowState != currentState)
             {
                 windowState = currentState;
                 ScheduleEvent(() => OnWindowStateChanged(currentState));
             }
+
+            updateMaximisedState();
 
             int newDisplayIndex = SDL.SDL_GetWindowDisplayIndex(SDLWindowHandle);
 
@@ -1012,7 +1012,7 @@ namespace osu.Framework.Platform
                     break;
             }
 
-            updateMaximisedState(windowState);
+            updateMaximisedState();
 
             if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
                 currentDisplayMode = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -926,6 +926,12 @@ namespace osu.Framework.Platform
         /// </summary>
         private bool windowMaximised;
 
+        private void updateMaximisedState(WindowState windowState)
+        {
+            if (windowState == WindowState.Normal || windowState == WindowState.Maximised)
+                windowMaximised = windowState == WindowState.Maximised;
+        }
+
         /// <summary>
         /// Should be run on a regular basis to check for external window state changes.
         /// </summary>
@@ -940,8 +946,7 @@ namespace osu.Framework.Platform
 
             var currentState = ((SDL.SDL_WindowFlags)SDL.SDL_GetWindowFlags(SDLWindowHandle)).ToWindowState();
 
-            if (currentState == WindowState.Normal || currentState == WindowState.Maximised)
-                windowMaximised = currentState == WindowState.Maximised;
+            updateMaximisedState(currentState);
 
             if (windowState != currentState)
             {
@@ -977,8 +982,6 @@ namespace osu.Framework.Platform
                     SDL.SDL_SetWindowSize(SDLWindowHandle, Size.Width, Size.Height);
 
                     updateWindowPositionFromConfig();
-
-                    windowMaximised = false;
                     break;
 
                 case WindowState.Fullscreen:
@@ -1002,13 +1005,14 @@ namespace osu.Framework.Platform
                 case WindowState.Maximised:
                     SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_bool.SDL_FALSE);
                     SDL.SDL_MaximizeWindow(SDLWindowHandle);
-                    windowMaximised = true;
                     break;
 
                 case WindowState.Minimised:
                     SDL.SDL_MinimizeWindow(SDLWindowHandle);
                     break;
             }
+
+            updateMaximisedState(windowState);
 
             if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
                 currentDisplayMode = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -963,6 +963,8 @@ namespace osu.Framework.Platform
                     Size = sizeWindowed.Value;
 
                     SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_bool.SDL_FALSE);
+                    SDL.SDL_RestoreWindow(SDLWindowHandle);
+
                     SDL.SDL_SetWindowSize(SDLWindowHandle, Size.Width, Size.Height);
 
                     updateWindowPositionFromConfig();

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -987,6 +987,7 @@ namespace osu.Framework.Platform
                     break;
 
                 case WindowState.Maximised:
+                    SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_bool.SDL_FALSE);
                     SDL.SDL_MaximizeWindow(SDLWindowHandle);
                     break;
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1096,7 +1096,16 @@ namespace osu.Framework.Platform
                         break;
 
                     case Configuration.WindowMode.Windowed:
-                        WindowState = WindowState.Normal;
+                        // todo: this will cause WindowState value to stay at Fullscreen/Borderless for a whole frame
+                        // but is required for taking correct actions based on whether the window is maximised or not.
+                        ScheduleCommand(() =>
+                        {
+                            SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_bool.SDL_FALSE);
+
+                            var sdlWindowState = ((SDL.SDL_WindowFlags)SDL.SDL_GetWindowFlags(SDLWindowHandle)).ToWindowState();
+                            Debug.Assert(sdlWindowState == WindowState.Maximised || sdlWindowState == WindowState.Normal);
+                            WindowState = sdlWindowState;
+                        });
                         break;
                 }
 


### PR DESCRIPTION
Closes #4070

The issue is coming from the window implementation setting `WindowState` to `Normal` regardless of whether it is maximised or not, which causes the window to potentially have its position changed according to the config while being in maximised state.

This also adds `SDL_RestoreWindow(handle)` to normal state for correct window state updating, as, previously, switching from maximised/minimised state to normal state via `WindowState` property would do absolutely nothing.