### PR TITLE
Fix borderless fullscreen unexpectedly running in exclusive mode on windows

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -962,6 +962,7 @@ namespace osu.Framework.Platform
                 case WindowState.Normal:
                     Size = sizeWindowed.Value;
 
+                    SDL.SDL_SetWindowBordered(SDLWindowHandle, SDL.SDL_bool.SDL_TRUE);
                     SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_bool.SDL_FALSE);
                     SDL.SDL_SetWindowSize(SDLWindowHandle, Size.Width, Size.Height);
 
@@ -982,8 +983,7 @@ namespace osu.Framework.Platform
                     break;
 
                 case WindowState.FullscreenBorderless:
-                    SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP);
-                    Size = currentDisplay.Bounds.Size;
+                    Size = SetBorderless();
                     break;
 
                 case WindowState.Maximised:
@@ -999,6 +999,20 @@ namespace osu.Framework.Platform
                 currentDisplayMode = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);
 
             isChangingWindowState = false;
+        }
+
+        /// <summary>
+        /// Prepare display of a borderless window.
+        /// </summary>
+        /// <returns>
+        /// The size of the borderless window's draw area.
+        /// </returns>
+        protected virtual Size SetBorderless()
+        {
+            // this is a generally sane method of handling borderless, and works well on macOS and linux.
+            SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP);
+
+            return currentDisplay.Bounds.Size;
         }
 
         protected void OnHidden() { }

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -5,6 +5,7 @@ using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using osu.Framework.Platform.Windows.Native;
+using SDL2;
 
 namespace osu.Framework.Platform.Windows
 {
@@ -31,6 +32,21 @@ namespace osu.Framework.Platform.Windows
             {
                 // API doesn't exist on Windows 7 so it needs to be allowed to fail silently.
             }
+        }
+
+        protected override Size SetBorderless()
+        {
+            SDL.SDL_SetWindowBordered(SDLWindowHandle, SDL.SDL_bool.SDL_FALSE);
+
+            Size positionOffsetHack = new Size(1, 1);
+
+            var newSize = CurrentDisplay.Bounds.Size + positionOffsetHack;
+
+            // for now let's use the same 1px hack that we've always used to force borderless.
+            SDL.SDL_SetWindowSize(SDLWindowHandle, newSize.Width, newSize.Height);
+            SDL.SDL_SetWindowPosition(SDLWindowHandle, -positionOffsetHack.Width, -positionOffsetHack.Height);
+
+            return newSize;
         }
 
         /// <summary>


### PR DESCRIPTION
This employs the age-old hack that we've been relying on in stable/osuTK of misaligning the window with the screen. On a quick check, many other games use this same method, so it seems like the best we're going to do for the time being.

I've left the existing borderless operation mode for non-windows platforms, since it works better.

Closes https://github.com/ppy/osu-framework/issues/4068
Addresses part of https://github.com/ppy/osu-framework/issues/4074#issuecomment-739690107
Brings back issue mentioned in https://github.com/ppy/osu-framework/issues/3456 (i believe we may be able to solve this, but this is a separate task which requires further investigation into how other games/windowing systems get it working).