### PR TITLE
Fix ScreenStack getting into an invalid state if a push fails due to load state

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
@@ -235,6 +235,17 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestPushAlreadyLoadedScreenFails()
+        {
+            TestScreen screen1 = null;
+
+            AddStep("push once", () => stack.Push(screen1 = new TestScreen()));
+            AddStep("exit", () => screen1.Exit());
+            AddStep("push again fails", () => Assert.Throws<InvalidOperationException>(() => stack.Push(screen1)));
+            AddAssert("stack in valid state", () => stack.CurrentScreen == baseScreen);
+        }
+
+        [Test]
         public void TestEventOrder()
         {
             List<int> order = new List<int>();

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -98,16 +98,16 @@ namespace osu.Framework.Screens
             // Suspend the current screen, if there is one
             if (source != null && source != stack.Peek()) throw new ScreenNotCurrentException(nameof(Push));
 
+            var newScreenDrawable = newScreen.AsDrawable();
+
+            if (newScreenDrawable.IsLoaded)
+                throw new InvalidOperationException("A screen should not be loaded before being pushed.");
+
             if (suspendImmediately)
                 suspend(source, newScreen);
 
             stack.Push(newScreen);
             ScreenPushed?.Invoke(source, newScreen);
-
-            var newScreenDrawable = newScreen.AsDrawable();
-
-            if (newScreenDrawable.IsLoaded)
-                throw new InvalidOperationException("A screen should not be loaded before being pushed.");
 
             // this needs to be queued here before the load is begun so it preceed any potential OnSuspending event (also attached to OnLoadComplete).
             newScreenDrawable.OnLoadComplete += _ => newScreen.OnEntering(source);


### PR DESCRIPTION
Previously, it was feasible for a push operation to fail, but the new screen to be already part of the stack, leaving *no* screen displayed to the user (rather than the screen before the push).

Found when investigating https://github.com/ppy/osu/issues/11135. Doesn't solve the issue, but should at least leave the game in a better state if such a scenario comes up again.