### PR TITLE
Fix maximised window position and size being saved to config

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -998,6 +998,9 @@ namespace osu.Framework.Platform
                 case WindowState.Maximised:
                     SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_bool.SDL_FALSE);
                     SDL.SDL_MaximizeWindow(SDLWindowHandle);
+
+                    SDL.SDL_GL_GetDrawableSize(SDLWindowHandle, out int w, out int h);
+                    Size = new Size(w, h);
                     break;
 
                 case WindowState.Minimised:

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -895,7 +895,6 @@ namespace osu.Framework.Platform
 
                     break;
 
-                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SIZE_CHANGED:
                     if (WindowMode.Value == Configuration.WindowMode.Windowed)
                         updateWindowSize();

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -347,6 +347,9 @@ namespace osu.Framework.Platform
 
         private void updateWindowPositionConfigFromCurrent()
         {
+            if (WindowState != WindowState.Normal)
+                return;
+
             var displayBounds = CurrentDisplay.Bounds;
 
             var windowX = Position.X - displayBounds.X;


### PR DESCRIPTION
Fixes maximised window's size silently getting saved internally to framework config.

This is occurring due to us updating window sizes on an `SDL_WINDOWEVENT_RESIZED`, as that event seems to be sent before SDL finishes processing the external change (putting the window in maximised mode, in this case), unlike `SDL_WINDOWEVENT_SIZE_CHANGED`. Here are the window events I got, and what the value of `WindowState` was for each:
![image](https://user-images.githubusercontent.com/22781491/101773057-4b560e80-3afd-11eb-92b7-fdab47b0aac3.png)

as you can see `SDL_WINDOWEVENT_RESIZED` is sent while the window state is still at `Normal`, while `SDL_WINDOWEVENT_SIZE_CHANGED` is sent while the window state has changed to `Maximised`.

Also, `SDL_WINDOWEVENT_RESIZED` would always have an `SDL_WINDOWEVENT_SIZE_CHANGED` event sent afterwards, [as stated in the docs](https://wiki.libsdl.org/SDL_WindowEventID), so technically nothing should ever be regressing here.

---

Also fixes maximised window's position getting saved as well, due to no checks preventing from that.