### PR TITLE
Save maximised window state for use in next startup

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -27,6 +27,7 @@ namespace osu.Framework.Configuration
             Set(FrameworkSetting.ExecutionMode, ExecutionMode.MultiThreaded);
             Set(FrameworkSetting.WindowedPositionX, 0.5, -0.5, 1.5);
             Set(FrameworkSetting.WindowedPositionY, 0.5, -0.5, 1.5);
+            Set(FrameworkSetting.WindowMaximised, false);
             Set(FrameworkSetting.LastDisplayDevice, DisplayIndex.Default);
             Set(FrameworkSetting.AudioDevice, string.Empty);
             Set(FrameworkSetting.VolumeUniversal, 1.0, 0.0, 1.0, 0.01);
@@ -74,6 +75,7 @@ namespace osu.Framework.Configuration
         WindowedSize,
         WindowedPositionX,
         WindowedPositionY,
+        WindowMaximised,
         LastDisplayDevice,
 
         SizeFullscreen,

--- a/osu.Framework/Platform/IGraphicsBackend.cs
+++ b/osu.Framework/Platform/IGraphicsBackend.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Drawing;
+
 namespace osu.Framework.Platform
 {
     /// <summary>
@@ -25,6 +27,11 @@ namespace osu.Framework.Platform
         /// or on the next screen refresh if true.
         /// </summary>
         void SwapBuffers();
+
+        /// <summary>
+        /// Resets buffer to the desired size, making the window cleared to black colour.
+        /// </summary>
+        void ResetBuffer(Size size);
 
         /// <summary>
         /// Makes the graphics backend the current context, if appropriate for the driver.

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -15,6 +15,8 @@ namespace osu.Framework.Platform
     /// </summary>
     public interface IWindow : IDisposable
     {
+        internal static Size MaxSize = new Size(9999, 9999);
+
         /// <summary>
         /// Cycles through the available <see cref="WindowMode"/>s as determined by <see cref="SupportedWindowModes"/>.
         /// </summary>

--- a/osu.Framework/Platform/PassthroughGraphicsBackend.cs
+++ b/osu.Framework/Platform/PassthroughGraphicsBackend.cs
@@ -3,11 +3,13 @@
 
 using System;
 using System.Diagnostics;
+using System.Drawing;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Logging;
+using osuTK;
 using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
@@ -79,6 +81,11 @@ namespace osu.Framework.Platform
             // We need to release the context in this thread, since Windows locks it and prevents
             // the draw thread from taking it. macOS seems to gracefully ignore this.
             MakeCurrent(IntPtr.Zero);
+        }
+
+        public void ResetBuffer(Size size)
+        {
+            GLWrapper.Reset(new Vector2(size.Width, size.Height));
         }
 
         public void MakeCurrent() => MakeCurrent(Context);

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -408,7 +408,6 @@ namespace osu.Framework.Platform
             graphicsBackend.Initialise(this);
 
             updateWindowSpecifics();
-            WindowMode.TriggerChange();
         }
 
         // reference must be kept to avoid GC, see https://stackoverflow.com/a/6193914
@@ -499,13 +498,18 @@ namespace osu.Framework.Platform
 
         public void SwapBuffers()
         {
-            graphicsBackend.SwapBuffers();
-
             if (firstDraw)
             {
+                // SDL actions like SDL_MaximizeWindow() **may** display the window regardless of whether it was hidden.
+                // This is the best place to perform such actions, as the window would have something drawn to it right on next frame.
+                WindowMode.TriggerChange();
+
                 Visible = true;
                 firstDraw = false;
+                return;
             }
+
+            graphicsBackend.SwapBuffers();
         }
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -501,7 +501,9 @@ namespace osu.Framework.Platform
             if (firstDraw)
             {
                 // SDL actions like SDL_MaximizeWindow() **may** display the window regardless of whether it was hidden.
-                // This is the best place to perform such actions, as the window would have something drawn to it right on next frame.
+                // This is the best place to perform such actions, as the window would have something drawn to it.
+                graphicsBackend.ResetBuffer(IWindow.MaxSize);
+                graphicsBackend.SwapBuffers();
                 WindowMode.TriggerChange();
 
                 Visible = true;

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -330,11 +330,8 @@ namespace osu.Framework.Platform
             }
         }
 
-        private void updateWindowPositionFromConfig()
+        private Point getWindowPositionFromConfig()
         {
-            if (WindowState != WindowState.Normal)
-                return;
-
             var configPosition = new Vector2((float)windowPositionX.Value, (float)windowPositionY.Value);
 
             var displayBounds = CurrentDisplay.Bounds;
@@ -342,7 +339,7 @@ namespace osu.Framework.Platform
             var windowX = (int)Math.Round((displayBounds.Width - windowSize.Width) * configPosition.X);
             var windowY = (int)Math.Round((displayBounds.Height - windowSize.Height) * configPosition.Y);
 
-            Position = new Point(windowX + displayBounds.X, windowY + displayBounds.Y);
+            return new Point(windowX + displayBounds.X, windowY + displayBounds.Y);
         }
 
         private void updateWindowPositionConfigFromCurrent()
@@ -397,16 +394,17 @@ namespace osu.Framework.Platform
         /// </summary>
         public virtual void Create()
         {
-            SDL.SDL_WindowFlags flags = SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL |
-                                        SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE |
-                                        SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI |
-                                        SDL.SDL_WindowFlags.SDL_WINDOW_HIDDEN | // shown after first swap to avoid white flash on startup (windows)
-                                        WindowState.ToFlags();
+            const SDL.SDL_WindowFlags flags = SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL |
+                                              SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE |
+                                              SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI |
+                                              SDL.SDL_WindowFlags.SDL_WINDOW_HIDDEN; // shown after first swap to avoid white flash on startup (windows)
 
             SDL.SDL_SetHint(SDL.SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4, "1");
 
-            SDLWindowHandle = SDL.SDL_CreateWindow(title, Position.X, Position.Y, Size.Width, Size.Height, flags);
+            position = getWindowPositionFromConfig();
+            Size = sizeWindowed.Value;
 
+            SDLWindowHandle = SDL.SDL_CreateWindow(title, Position.X, Position.Y, Size.Width, Size.Height, flags);
             Exists = true;
 
             MouseEntered += () => cursorInWindow.Value = true;
@@ -978,7 +976,7 @@ namespace osu.Framework.Platform
 
                     SDL.SDL_SetWindowSize(SDLWindowHandle, Size.Width, Size.Height);
 
-                    updateWindowPositionFromConfig();
+                    Position = getWindowPositionFromConfig();
                     break;
 
                 case WindowState.Fullscreen:

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -213,12 +213,6 @@ namespace osu.Framework.Platform
         }
 
         /// <summary>
-        /// Stores whether the window used to be in maximised state or not.
-        /// Used to properly decide what window state to pick when switching to windowed mode (see <see cref="WindowMode"/> change event)
-        /// </summary>
-        private bool windowMaximised;
-
-        /// <summary>
         /// Returns the drawable area, after scaling.
         /// </summary>
         public Size ClientSize => new Size(Size.Width, Size.Height);
@@ -358,6 +352,7 @@ namespace osu.Framework.Platform
         private readonly BindableSize sizeWindowed = new BindableSize();
         private readonly BindableDouble windowPositionX = new BindableDouble();
         private readonly BindableDouble windowPositionY = new BindableDouble();
+        private readonly BindableBool windowMaximised = new BindableBool();
         private readonly Bindable<DisplayIndex> windowDisplayIndexBindable = new Bindable<DisplayIndex>();
 
         public SDL2DesktopWindow()
@@ -1018,7 +1013,7 @@ namespace osu.Framework.Platform
         private void updateMaximisedState()
         {
             if (windowState == WindowState.Normal || windowState == WindowState.Maximised)
-                windowMaximised = windowState == WindowState.Maximised;
+                windowMaximised.Value = windowState == WindowState.Maximised;
         }
 
         private void updateWindowVisibility(bool visible)
@@ -1122,6 +1117,8 @@ namespace osu.Framework.Platform
             config.BindWith(FrameworkSetting.WindowedPositionX, windowPositionX);
             config.BindWith(FrameworkSetting.WindowedPositionY, windowPositionY);
 
+            config.BindWith(FrameworkSetting.WindowMaximised, windowMaximised);
+
             config.BindWith(FrameworkSetting.WindowMode, WindowMode);
 
             WindowMode.BindValueChanged(evt =>
@@ -1137,7 +1134,7 @@ namespace osu.Framework.Platform
                         break;
 
                     case Configuration.WindowMode.Windowed:
-                        WindowState = windowMaximised ? WindowState.Maximised : WindowState.Normal;
+                        WindowState = windowMaximised.Value ? WindowState.Maximised : WindowState.Normal;
                         break;
                 }
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -162,7 +162,13 @@ namespace osu.Framework.Platform
             set
             {
                 visible = value;
-                ScheduleCommand(() => updateWindowVisibility(value));
+                ScheduleCommand(() =>
+                {
+                    if (value)
+                        SDL.SDL_ShowWindow(SDLWindowHandle);
+                    else
+                        SDL.SDL_HideWindow(SDLWindowHandle);
+                });
             }
         }
 
@@ -1000,10 +1006,6 @@ namespace osu.Framework.Platform
 
             updateMaximisedState();
 
-            // Functions like SDL_MaximizeWindow or SDL_RestoreWindow show the window
-            // even if they were hidden previously, which is not what we want.
-            updateWindowVisibility(Visible);
-
             if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
                 currentDisplayMode = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);
 
@@ -1014,14 +1016,6 @@ namespace osu.Framework.Platform
         {
             if (windowState == WindowState.Normal || windowState == WindowState.Maximised)
                 windowMaximised.Value = windowState == WindowState.Maximised;
-        }
-
-        private void updateWindowVisibility(bool visible)
-        {
-            if (visible)
-                SDL.SDL_ShowWindow(SDLWindowHandle);
-            else
-                SDL.SDL_HideWindow(SDLWindowHandle);
         }
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -162,13 +162,7 @@ namespace osu.Framework.Platform
             set
             {
                 visible = value;
-                ScheduleCommand(() =>
-                {
-                    if (value)
-                        SDL.SDL_ShowWindow(SDLWindowHandle);
-                    else
-                        SDL.SDL_HideWindow(SDLWindowHandle);
-                });
+                ScheduleCommand(() => updateWindowVisibility(value));
             }
         }
 
@@ -1011,6 +1005,10 @@ namespace osu.Framework.Platform
 
             updateMaximisedState();
 
+            // Functions like SDL_MaximizeWindow or SDL_RestoreWindow show the window
+            // even if they were hidden previously, which is not what we want.
+            updateWindowVisibility(Visible);
+
             if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
                 currentDisplayMode = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);
 
@@ -1021,6 +1019,14 @@ namespace osu.Framework.Platform
         {
             if (windowState == WindowState.Normal || windowState == WindowState.Maximised)
                 windowMaximised = windowState == WindowState.Maximised;
+        }
+
+        private void updateWindowVisibility(bool visible)
+        {
+            if (visible)
+                SDL.SDL_ShowWindow(SDLWindowHandle);
+            else
+                SDL.SDL_HideWindow(SDLWindowHandle);
         }
 
         /// <summary>


### PR DESCRIPTION
- [x] Depends on #4085 (fixing bugs encounterable here)

Saves maximised window state internally to framework config for use in next startups, this PR also has several changes required for "start-up in maximised state" to work correctly:
#### https://github.com/ppy/osu-framework/commit/5c16fa6464f8081358e373a931294e9ec64de64f
To make restoring the window from initial maximised state work properly, as now the window would switch to maximised state while its already positioned and sized to config values, unlike previously where it would switch to maximised state while its position is 0 and size is `default_width,default_height` (1366x768).