### PR TITLE
Add back MIDI input handler for SDL2 window

### DIFF
--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -125,6 +125,7 @@ namespace osu.Framework.Platform
                         new KeyboardHandler(),
                         new MouseHandler(),
                         new JoystickHandler(),
+                        new MidiInputHandler(),
                     };
 
                     var defaultDisabled = new InputHandler[]


### PR DESCRIPTION
Wanted to test out this MIDI controller I got recently, and found the input not working due to a missing input handler registration. Not sure how that happened.