### PR TITLE
Fix window size doubling up every startup on macOS retina displays

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -412,6 +412,7 @@ namespace osu.Framework.Platform
             graphicsBackend.Initialise(this);
 
             updateWindowSpecifics();
+            updateWindowSize();
             WindowMode.TriggerChange();
         }
 
@@ -479,7 +480,7 @@ namespace osu.Framework.Platform
                 if (windowState == WindowState.Normal)
                 {
                     windowStateChanging = true;
-                    sizeWindowed.Value = newSize;
+                    sizeWindowed.Value = scaleSize(newSize, 1 / Scale);
                     windowStateChanging = false;
                 }
 
@@ -968,13 +969,13 @@ namespace osu.Framework.Platform
             switch (windowState)
             {
                 case WindowState.Normal:
-                    Size = sizeWindowed.Value;
+                    Size = scaleSize(sizeWindowed.Value, Scale);
 
                     SDL.SDL_SetWindowBordered(SDLWindowHandle, SDL.SDL_bool.SDL_TRUE);
                     SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_bool.SDL_FALSE);
                     SDL.SDL_RestoreWindow(SDLWindowHandle);
 
-                    SDL.SDL_SetWindowSize(SDLWindowHandle, Size.Width, Size.Height);
+                    SDL.SDL_SetWindowSize(SDLWindowHandle, sizeWindowed.Value.Width, sizeWindowed.Value.Height);
 
                     updateWindowPositionFromConfig();
                     break;

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1213,7 +1213,7 @@ namespace osu.Framework.Platform
                 CursorStateBindable.Value &= ~CursorState.Confined;
         }
 
-        #region SDL Helper functions
+        #region Helper functions
 
         private SDL.SDL_DisplayMode getClosestDisplayMode(Size size, int refreshRate, int displayIndex)
         {
@@ -1257,6 +1257,8 @@ namespace osu.Framework.Platform
             SDL.SDL_PixelFormatEnumToMasks(mode.format, out var bpp, out _, out _, out _, out _);
             return new DisplayMode(SDL.SDL_GetPixelFormatName(mode.format), new Size(mode.w, mode.h), bpp, mode.refresh_rate, modeIndex, displayIndex);
         }
+
+        private static Size scaleSize(Size size, float scale) => new Size((int)(size.Width * scale), (int)(size.Height * scale));
 
         #endregion
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -364,7 +364,7 @@ namespace osu.Framework.Platform
         private void storeWindowSizeToConfig()
         {
             windowStateChanging = true;
-            sizeWindowed.Value = scaleSize(Size, 1 / Scale);
+            sizeWindowed.Value = (Size / Scale).ToSize();
             windowStateChanging = false;
         }
 
@@ -978,7 +978,7 @@ namespace osu.Framework.Platform
             switch (windowState)
             {
                 case WindowState.Normal:
-                    Size = scaleSize(sizeWindowed.Value, Scale);
+                    Size = (sizeWindowed.Value * Scale).ToSize();
 
                     SDL.SDL_SetWindowBordered(SDLWindowHandle, SDL.SDL_bool.SDL_TRUE);
                     SDL.SDL_SetWindowFullscreen(SDLWindowHandle, (uint)SDL.SDL_bool.SDL_FALSE);
@@ -1270,8 +1270,6 @@ namespace osu.Framework.Platform
             SDL.SDL_PixelFormatEnumToMasks(mode.format, out var bpp, out _, out _, out _, out _);
             return new DisplayMode(SDL.SDL_GetPixelFormatName(mode.format), new Size(mode.w, mode.h), bpp, mode.refresh_rate, modeIndex, displayIndex);
         }
-
-        private static Size scaleSize(Size size, float scale) => new Size((int)(size.Width * scale), (int)(size.Height * scale));
 
         #endregion
 


### PR DESCRIPTION
Closes #4088 

- [x] Depends on #4093 (for merge ease)

The reason is as mentioned here https://github.com/ppy/osu-framework/issues/4088#issuecomment-742722081.

Fixed by removing the scale on `sizeWindowed` bindable as it should not have it on. Also adds `updateWindowSize()` before `WindowMode.TriggerChange()` to get the correct display scale for setting up normal state properly.