### PR TITLE
Fix continuous resize events no longer handled

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -330,43 +330,10 @@ namespace osu.Framework.Platform
             }
         }
 
-        private void readWindowPositionFromConfig()
-        {
-            if (WindowState != WindowState.Normal)
-                return;
-
-            var configPosition = new Vector2((float)windowPositionX.Value, (float)windowPositionY.Value);
-
-            var displayBounds = CurrentDisplay.Bounds;
-            var windowSize = sizeWindowed.Value;
-            var windowX = (int)Math.Round((displayBounds.Width - windowSize.Width) * configPosition.X);
-            var windowY = (int)Math.Round((displayBounds.Height - windowSize.Height) * configPosition.Y);
-
-            Position = new Point(windowX + displayBounds.X, windowY + displayBounds.Y);
-        }
-
-        private void storeWindowPositionToConfig()
-        {
-            if (WindowState != WindowState.Normal)
-                return;
-
-            var displayBounds = CurrentDisplay.Bounds;
-
-            var windowX = Position.X - displayBounds.X;
-            var windowY = Position.Y - displayBounds.Y;
-
-            var windowSize = sizeWindowed.Value;
-
-            windowPositionX.Value = displayBounds.Width > windowSize.Width ? (float)windowX / (displayBounds.Width - windowSize.Width) : 0;
-            windowPositionY.Value = displayBounds.Height > windowSize.Height ? (float)windowY / (displayBounds.Height - windowSize.Height) : 0;
-        }
-
-        private void storeWindowSizeToConfig()
-        {
-            storingSizeToConfig = true;
-            sizeWindowed.Value = Size;
-            storingSizeToConfig = false;
-        }
+        /// <summary>
+        /// Set to <c>true</c> while the window size is being stored to config to avoid bindable feedback.
+        /// </summary>
+        private bool storingSizeToConfig;
 
         private bool firstDraw = true;
 
@@ -1033,6 +1000,44 @@ namespace osu.Framework.Platform
                 windowMaximised = windowState == WindowState.Maximised;
         }
 
+        private void readWindowPositionFromConfig()
+        {
+            if (WindowState != WindowState.Normal)
+                return;
+
+            var configPosition = new Vector2((float)windowPositionX.Value, (float)windowPositionY.Value);
+
+            var displayBounds = CurrentDisplay.Bounds;
+            var windowSize = sizeWindowed.Value;
+            var windowX = (int)Math.Round((displayBounds.Width - windowSize.Width) * configPosition.X);
+            var windowY = (int)Math.Round((displayBounds.Height - windowSize.Height) * configPosition.Y);
+
+            Position = new Point(windowX + displayBounds.X, windowY + displayBounds.Y);
+        }
+
+        private void storeWindowPositionToConfig()
+        {
+            if (WindowState != WindowState.Normal)
+                return;
+
+            var displayBounds = CurrentDisplay.Bounds;
+
+            var windowX = Position.X - displayBounds.X;
+            var windowY = Position.Y - displayBounds.Y;
+
+            var windowSize = sizeWindowed.Value;
+
+            windowPositionX.Value = displayBounds.Width > windowSize.Width ? (float)windowX / (displayBounds.Width - windowSize.Width) : 0;
+            windowPositionY.Value = displayBounds.Height > windowSize.Height ? (float)windowY / (displayBounds.Height - windowSize.Height) : 0;
+        }
+
+        private void storeWindowSizeToConfig()
+        {
+            storingSizeToConfig = true;
+            sizeWindowed.Value = Size;
+            storingSizeToConfig = false;
+        }
+
         /// <summary>
         /// Prepare display of a borderless window.
         /// </summary>
@@ -1084,11 +1089,6 @@ namespace osu.Framework.Platform
         #endregion
 
         protected virtual IGraphicsBackend CreateGraphicsBackend() => new SDL2GraphicsBackend();
-
-        /// <summary>
-        /// Set to <c>true</c> while the window size is being stored to config to avoid bindable feedback.
-        /// </summary>
-        private bool storingSizeToConfig;
 
         /// <summary>
         /// Set to <c>true</c> when a call to <see cref="updateWindowStateAndSize"/> is in progress.

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -363,9 +363,9 @@ namespace osu.Framework.Platform
 
         private void storeWindowSizeToConfig()
         {
-            windowStateChanging = true;
+            storingSizeToConfig = true;
             sizeWindowed.Value = Size;
-            windowStateChanging = false;
+            storingSizeToConfig = false;
         }
 
         private bool firstDraw = true;

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -435,7 +435,9 @@ namespace osu.Framework.Platform
 
                 if (e.type == SDL.SDL_EventType.SDL_WINDOWEVENT && e.window.windowEvent == SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED)
                 {
-                    handleSDLEvent(e);
+                    // This function will be invoked before the SDL internal states are all changed. (as documented here: https://wiki.libsdl.org/SDL_SetEventFilter)
+                    // Therefore we should only update the client size without saving to config, as we don't know what state the window would end up in.
+                    updateWindowSize(false);
                     return 0;
                 }
 
@@ -467,7 +469,11 @@ namespace osu.Framework.Platform
             SDL.SDL_Quit();
         }
 
-        private void updateWindowSize()
+        /// <summary>
+        /// Updates the client size and the scale according to the window.
+        /// </summary>
+        /// <param name="saveToConfig">Whether the new window size should be saved to the config.</param>
+        private void updateWindowSize(bool saveToConfig = true)
         {
             SDL.SDL_GL_GetDrawableSize(SDLWindowHandle, out var w, out var h);
             var newSize = new Size(w, h);
@@ -479,7 +485,7 @@ namespace osu.Framework.Platform
             {
                 Size = newSize;
 
-                if (windowState == WindowState.Normal)
+                if (windowState == WindowState.Normal && saveToConfig)
                 {
                     windowStateChanging = true;
                     sizeWindowed.Value = newSize;


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu-framework/pull/4085

The aforementioned PR (by me..) removed the case handling the `RESIZED` event thinking that it gets fired before the SDL has processed it, while it actually gets sent after the `SIZE_CHANGED` event, [as noted there](https://github.com/ppy/osu-framework/pull/4085#issuecomment-742707285).

Turns out that there was an event filter set to listen for it to handle continuous resize events (as `SDL_PollEvent` blocks those), and since the `SDL_WINDOWEVENT_RESIZED` case was removed, these events are no longer handled, causing the window to not update the client size while resizing:
<img src="https://user-images.githubusercontent.com/22781491/101988963-2bb21800-3cae-11eb-89e1-8bf9b3a383a8.gif" width=500/>

This fixes it by updating the client size on those continuous resize events, **but** without saving the new size to config, as we don't know what state the window would end up in once finishing from the external change (i.e. switching to maximised mode):
<img src="https://user-images.githubusercontent.com/22781491/101989204-dbd45080-3caf-11eb-9d56-803ec201ec73.gif" width=500/>
