### PR TITLE
Rename a few members in SDL2DesktopWindow for readability

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -935,7 +935,7 @@ namespace osu.Framework.Platform
         {
             // this method is potentially called from another thread (see event filter usage).
             // this flag ensures such calls don't interfere with a user-requested screen mode change.
-            if (isChangingWindowState)
+            if (windowStateAndSizeUpdateRunning)
                 return;
 
             Debug.Assert(SDLWindowHandle != IntPtr.Zero);
@@ -965,7 +965,7 @@ namespace osu.Framework.Platform
         /// </summary>
         private void updateWindowStateAndSize()
         {
-            isChangingWindowState = true;
+            windowStateAndSizeUpdateRunning = true;
 
             switch (windowState)
             {
@@ -1016,7 +1016,7 @@ namespace osu.Framework.Platform
             if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
                 currentDisplayMode = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);
 
-            isChangingWindowState = false;
+            windowStateAndSizeUpdateRunning = false;
         }
 
         private void updateMaximisedState()
@@ -1082,7 +1082,10 @@ namespace osu.Framework.Platform
         /// </summary>
         private bool storingSizeToConfig;
 
-        private bool isChangingWindowState;
+        /// <summary>
+        /// Set to <c>true</c> when a call to <see cref="updateWindowStateAndSize"/> is in progress.
+        /// </summary>
+        private bool windowStateAndSizeUpdateRunning;
 
         public void SetupWindow(FrameworkConfigManager config)
         {

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -481,9 +481,9 @@ namespace osu.Framework.Platform
 
                 if (windowState == WindowState.Normal)
                 {
-                    windowStateChanging = true;
+                    storingSizeToConfig = true;
                     sizeWindowed.Value = newSize;
-                    windowStateChanging = false;
+                    storingSizeToConfig = false;
                 }
 
                 ScheduleEvent(() => OnResized());
@@ -1078,9 +1078,9 @@ namespace osu.Framework.Platform
         protected virtual IGraphicsBackend CreateGraphicsBackend() => new SDL2GraphicsBackend();
 
         /// <summary>
-        /// Set to true during a state change operation to avoid bindable feedback.
+        /// Set to <c>true</c> while the window size is being stored to config to avoid bindable feedback.
         /// </summary>
-        private bool windowStateChanging;
+        private bool storingSizeToConfig;
 
         private bool isChangingWindowState;
 
@@ -1098,7 +1098,7 @@ namespace osu.Framework.Platform
 
             sizeFullscreen.ValueChanged += evt =>
             {
-                if (windowStateChanging) return;
+                if (storingSizeToConfig) return;
 
                 if (windowState == WindowState.Fullscreen)
                     ScheduleCommand(updateWindowStateAndSize);
@@ -1106,7 +1106,7 @@ namespace osu.Framework.Platform
 
             sizeWindowed.ValueChanged += evt =>
             {
-                if (windowStateChanging) return;
+                if (storingSizeToConfig) return;
 
                 if (windowState == WindowState.Normal)
                     ScheduleCommand(updateWindowStateAndSize);

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -330,7 +330,7 @@ namespace osu.Framework.Platform
             }
         }
 
-        private void updateWindowPositionFromConfig()
+        private void readWindowPositionFromConfig()
         {
             if (WindowState != WindowState.Normal)
                 return;
@@ -345,7 +345,7 @@ namespace osu.Framework.Platform
             Position = new Point(windowX + displayBounds.X, windowY + displayBounds.Y);
         }
 
-        private void updateWindowPositionConfigFromCurrent()
+        private void storeWindowPositionToConfig()
         {
             if (WindowState != WindowState.Normal)
                 return;
@@ -892,7 +892,7 @@ namespace osu.Framework.Platform
                     if (WindowMode.Value == Configuration.WindowMode.Windowed && !newPosition.Equals(Position))
                     {
                         position = newPosition;
-                        updateWindowPositionConfigFromCurrent();
+                        storeWindowPositionToConfig();
                         ScheduleEvent(() => OnMoved(newPosition));
                     }
 
@@ -978,7 +978,7 @@ namespace osu.Framework.Platform
 
                     SDL.SDL_SetWindowSize(SDLWindowHandle, Size.Width, Size.Height);
 
-                    updateWindowPositionFromConfig();
+                    readWindowPositionFromConfig();
                     break;
 
                 case WindowState.Fullscreen:


### PR DESCRIPTION
Noticed while looking through #4093.

The whole window state management really needs refactoring anyway, but this is not intended to be that - this PR has just a few simple renames to keep the WTF factor down for now.