### PR TITLE
Fix zero-length repeat delegates ignoring initial delay

### DIFF
--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -211,6 +211,30 @@ namespace osu.Framework.Tests.Threading
             }
         }
 
+        [Test]
+        public void TestZeroDelayRepeatingDelegate()
+        {
+            var clock = new StopwatchClock();
+            scheduler.UpdateClock(clock);
+
+            int invocations = 0;
+
+            scheduler.Add(new ScheduledDelegate(() => invocations++, 500, 0));
+
+            int expectedInvocations = 0;
+
+            for (double d = 0; d <= 2500; d += 100)
+            {
+                clock.Seek(d);
+                scheduler.Update();
+
+                if (d >= 500)
+                    expectedInvocations++;
+
+                Assert.AreEqual(expectedInvocations, invocations);
+            }
+        }
+
         [TestCase(false)]
         [TestCase(true)]
         public void TestRepeatingDelayedDelegateCatchUp(bool performCatchUp)

--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -219,7 +219,11 @@ namespace osu.Framework.Tests.Threading
 
             int invocations = 0;
 
+            Assert.Zero(scheduler.TotalPendingTasks);
+
             scheduler.Add(new ScheduledDelegate(() => invocations++, 500, 0));
+
+            Assert.AreEqual(1, scheduler.TotalPendingTasks);
 
             int expectedInvocations = 0;
 
@@ -232,6 +236,7 @@ namespace osu.Framework.Tests.Threading
                     expectedInvocations++;
 
                 Assert.AreEqual(expectedInvocations, invocations);
+                Assert.AreEqual(1, scheduler.TotalPendingTasks);
             }
         }
 

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -30,7 +30,12 @@ namespace osu.Framework.Threading
         /// <summary>
         /// Whether there are any tasks queued to run (including delayed tasks in the future).
         /// </summary>
-        public bool HasPendingTasks => runQueue.Count > 0 || timedTasks.Count > 0 || perUpdateTasks.Count > 0;
+        public bool HasPendingTasks => TotalPendingTasks > 0;
+
+        /// <summary>
+        /// The total number of <see cref="ScheduledDelegate"/>s tracked by this instance for future execution.
+        /// </summary>
+        internal int TotalPendingTasks => runQueue.Count + timedTasks.Count + perUpdateTasks.Count;
 
         /// <summary>
         /// The base thread is assumed to be the thread on which the constructor is run.

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -123,20 +123,24 @@ namespace osu.Framework.Threading
 
                         if (sd.Cancelled) continue;
 
-                        if (sd.RepeatInterval >= 0)
+                        if (sd.RepeatInterval == 0)
+                        {
+                            // handling of every-frame tasks is slightly different to reduce overhead.
+                            perUpdateTasks.Add(sd);
+                            continue;
+                        }
+
+                        if (sd.RepeatInterval > 0)
                         {
                             if (timedTasks.Count > 1000)
                                 throw new ArgumentException("Too many timed tasks are in the queue!");
 
+                            // schedule the next repeat of the task.
                             sd.SetNextExecution(currentTimeLocal);
-
                             tasksToSchedule.Add(sd);
                         }
 
-                        if (sd.RepeatInterval == 0)
-                            perUpdateTasks.Add(sd);
-                        else if (!sd.Completed)
-                            runQueue.Enqueue(sd);
+                        if (!sd.Completed) runQueue.Enqueue(sd);
                     }
                 }
 

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -133,7 +133,9 @@ namespace osu.Framework.Threading
                             tasksToSchedule.Add(sd);
                         }
 
-                        if (!sd.Completed)
+                        if (sd.RepeatInterval == 0)
+                            perUpdateTasks.Add(sd);
+                        else if (!sd.Completed)
                             runQueue.Enqueue(sd);
                     }
                 }
@@ -233,12 +235,7 @@ namespace osu.Framework.Threading
                 throw new InvalidOperationException($"Can not add a {nameof(ScheduledDelegate)} that has been already {nameof(ScheduledDelegate.Completed)}");
 
             lock (queueLock)
-            {
-                if (task.RepeatInterval == 0)
-                    perUpdateTasks.Add(task);
-                else
-                    timedTasks.AddInPlace(task);
-            }
+                timedTasks.AddInPlace(task);
         }
 
         /// <summary>


### PR DESCRIPTION
A bit of an oversight that we somehow hadn't encountered until now.

The conditional was far too early in the flow, meaning that `ExecutionTime` is completely ignored in the case that `RepeatInterval` is zero.