### PR TITLE
Fix display changing on transition to borderless on Windows

### DIFF
--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -41,10 +41,11 @@ namespace osu.Framework.Platform.Windows
             Size positionOffsetHack = new Size(1, 1);
 
             var newSize = CurrentDisplay.Bounds.Size + positionOffsetHack;
+            var newPosition = CurrentDisplay.Bounds.Location - positionOffsetHack;
 
             // for now let's use the same 1px hack that we've always used to force borderless.
             SDL.SDL_SetWindowSize(SDLWindowHandle, newSize.Width, newSize.Height);
-            SDL.SDL_SetWindowPosition(SDLWindowHandle, -positionOffsetHack.Width, -positionOffsetHack.Height);
+            SDL.SDL_SetWindowPosition(SDLWindowHandle, newPosition.X, newPosition.Y);
 
             return newSize;
         }


### PR DESCRIPTION
Reproduction requires at least 2 displays, one of which has to have a non-zero `Bounds.Location`.

On `master`, moving a framework window to that secondary display and entering borderless will then switch displays to the one with `Location` at `(0, 0)`.