### PR TITLE
Store full namespace for last accessed test in test browser

### DIFF
--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -336,7 +336,16 @@ namespace osu.Framework.Testing
             base.LoadComplete();
 
             if (CurrentTest == null)
-                LoadTest(TestTypes.Find(t => t.Name == config.Get<string>(TestBrowserSetting.LastTest)));
+            {
+                var lastTest = config.Get<string>(TestBrowserSetting.LastTest);
+
+                var foundTest = TestTypes.Find(t => t.FullName == lastTest)
+                                // full name was not always stored in this value, so fallback to matching on just test name.
+                                // can be removed 20210622
+                                ?? TestTypes.Find(t => t.Name == lastTest);
+
+                LoadTest(foundTest);
+            }
         }
 
         private void toggleTestList()
@@ -419,7 +428,7 @@ namespace osu.Framework.Testing
             if (testType == null && TestTypes.Count > 0)
                 testType = TestTypes[0];
 
-            config.Set(TestBrowserSetting.LastTest, testType?.Name ?? string.Empty);
+            config.Set(TestBrowserSetting.LastTest, testType?.FullName ?? string.Empty);
 
             if (testType == null)
                 return;


### PR DESCRIPTION
Without this, two test scenes with the same name but different namespace didn't behave as expected (the first instance would always be loaded on starting the test browser up).