### PR TITLE
Add support for horizontal mouse scroll wheels

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -78,9 +78,10 @@ namespace osu.Framework.Tests.Visual.Input
             }
         }
 
-        private void scrollMouseWheel(int dy)
+        private void scrollMouseWheel(int dx, int dy)
         {
-            AddStep($"scroll wheel {dy}", () => InputManager.ScrollVerticalBy(dy));
+            if (dx != 0) AddStep($"scroll wheel horizontally {dx}", () => InputManager.ScrollHorizontalBy(dx));
+            if (dy != 0) AddStep($"scroll wheel {dy}", () => InputManager.ScrollVerticalBy(dy));
         }
 
         private void check(TestAction action, params CheckConditions[] entries)
@@ -245,12 +246,18 @@ namespace osu.Framework.Tests.Visual.Input
                     new CheckConditions(all, 1, 1)
                 };
 
-                scrollMouseWheel(1);
+                scrollMouseWheel(0, 1);
                 check(TestAction.WheelUp, allPressAndReleased);
-                scrollMouseWheel(-1);
+                scrollMouseWheel(0, -1);
                 check(TestAction.WheelDown, allPressAndReleased);
+
+                scrollMouseWheel(-1, 0);
+                check(TestAction.WheelLeft, allPressAndReleased);
+                scrollMouseWheel(1, 0);
+                check(TestAction.WheelRight, allPressAndReleased);
+
                 toggleKey(Key.ControlLeft);
-                scrollMouseWheel(1);
+                scrollMouseWheel(0, 1);
                 toggleKey(Key.ControlLeft);
                 check(TestAction.Ctrl_and_WheelUp, allPressAndReleased);
                 toggleMouseButton(MouseButton.Left);
@@ -276,12 +283,12 @@ namespace osu.Framework.Tests.Visual.Input
                     new ScrollCheckConditions(all, 1, 1, 1, amount)
                 };
 
-                scrollMouseWheel(2);
+                scrollMouseWheel(0, 2);
                 check(TestAction.WheelUp, allPressAndReleased(2));
-                scrollMouseWheel(-3);
+                scrollMouseWheel(0, -3);
                 check(TestAction.WheelDown, allPressAndReleased(3));
                 toggleKey(Key.ControlLeft);
-                scrollMouseWheel(4);
+                scrollMouseWheel(0, 4);
                 toggleKey(Key.ControlLeft);
                 check(TestAction.Ctrl_and_WheelUp, allPressAndReleased(4));
             });
@@ -348,6 +355,8 @@ namespace osu.Framework.Tests.Visual.Input
             RightMouse,
             WheelUp,
             WheelDown,
+            WheelLeft,
+            WheelRight,
             Ctrl_and_WheelUp,
         }
 
@@ -398,6 +407,8 @@ namespace osu.Framework.Tests.Visual.Input
 
                 new KeyBinding(new[] { InputKey.MouseWheelUp }, TestAction.WheelUp),
                 new KeyBinding(new[] { InputKey.MouseWheelDown }, TestAction.WheelDown),
+                new KeyBinding(new[] { InputKey.MouseWheelLeft }, TestAction.WheelLeft),
+                new KeyBinding(new[] { InputKey.MouseWheelRight }, TestAction.WheelRight),
                 new KeyBinding(new[] { InputKey.Control, InputKey.MouseWheelUp }, TestAction.Ctrl_and_WheelUp),
             };
 

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -477,7 +477,7 @@ namespace osu.Framework.Tests.Visual.Input
                 actionText = action.ToString().Replace('_', ' ');
 
                 RelativeSizeAxes = Axes.X;
-                Height = 35;
+                Height = 30;
                 Width = 0.3f;
                 Padding = new MarginPadding(2);
 
@@ -541,13 +541,14 @@ namespace osu.Framework.Tests.Visual.Input
             }
         }
 
-        private class KeyBindingTester : Container
+        private class KeyBindingTester : FillFlowContainer
         {
             private readonly TestButton[] testButtons;
 
             public KeyBindingTester(SimultaneousBindingMode concurrency, KeyCombinationMatchingMode matchingMode)
             {
                 RelativeSizeAxes = Axes.Both;
+                Direction = FillDirection.Vertical;
 
                 testButtons = Enum.GetValues(typeof(TestAction)).Cast<TestAction>().Select(t =>
                 {
@@ -565,7 +566,6 @@ namespace osu.Framework.Tests.Visual.Input
                     },
                     new TestInputManager(concurrency, matchingMode)
                     {
-                        Y = 30,
                         RelativeSizeAxes = Axes.Both,
                         Child = new FillFlowContainer
                         {

--- a/osu.Framework/Input/Bindings/InputKey.cs
+++ b/osu.Framework/Input/Bindings/InputKey.cs
@@ -761,6 +761,18 @@ namespace osu.Framework.Input.Bindings
         MouseWheelDown = 146,
 
         /// <summary>
+        /// Mouse wheel rolled right.
+        /// Only supported by some mice with a secondary horizontal scroll wheel.
+        /// </summary>
+        MouseWheelRight = 147,
+
+        /// <summary>
+        /// Mouse wheel rolled left.
+        /// Only supported by some mice with a secondary horizontal scroll wheel.
+        /// </summary>
+        MouseWheelLeft = 148,
+
+        /// <summary>
         /// The media mute key.
         /// </summary>
         Mute = 256,

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -137,11 +137,14 @@ namespace osu.Framework.Input.Bindings
 
                 case ScrollEvent scroll:
                 {
-                    var key = KeyCombination.FromScrollDelta(scroll.ScrollDelta);
-                    if (key == InputKey.None) return false;
+                    var keys = KeyCombination.FromScrollDelta(scroll.ScrollDelta);
+                    bool handled = false;
 
-                    var handled = handleNewPressed(state, key, false, scroll.ScrollDelta, scroll.IsPrecise);
-                    handleNewReleased(state, key);
+                    foreach (var key in keys)
+                    {
+                        handled |= handleNewPressed(state, key, false, scroll.ScrollDelta, scroll.IsPrecise);
+                        handleNewReleased(state, key);
+                    }
 
                     return handled;
                 }
@@ -152,11 +155,7 @@ namespace osu.Framework.Input.Bindings
 
         private bool handleNewPressed(InputState state, InputKey newKey, bool repeat, Vector2? scrollDelta = null, bool isPrecise = false)
         {
-            float scrollAmount = 0;
-            if (newKey == InputKey.MouseWheelUp)
-                scrollAmount = scrollDelta?.Y ?? 0;
-            else if (newKey == InputKey.MouseWheelDown)
-                scrollAmount = -(scrollDelta?.Y ?? 0);
+            var scrollAmount = getScrollAmount(newKey, scrollDelta);
             var pressedCombination = KeyCombination.FromInputState(state, scrollDelta);
 
             bool handled = false;
@@ -210,6 +209,27 @@ namespace osu.Framework.Input.Bindings
             }
 
             return handled;
+        }
+
+        private static float getScrollAmount(InputKey newKey, Vector2? scrollDelta)
+        {
+            switch (newKey)
+            {
+                case InputKey.MouseWheelUp:
+                    return scrollDelta?.Y ?? 0;
+
+                case InputKey.MouseWheelDown:
+                    return -(scrollDelta?.Y ?? 0);
+
+                case InputKey.MouseWheelRight:
+                    return scrollDelta?.X ?? 0;
+
+                case InputKey.MouseWheelLeft:
+                    return -(scrollDelta?.X ?? 0);
+
+                default:
+                    return 0;
+            }
         }
 
         protected virtual Drawable PropagatePressed(IEnumerable<Drawable> drawables, T pressed, float scrollAmount = 0, bool isPrecise = false)

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -343,6 +343,12 @@ namespace osu.Framework.Input.Bindings
                 case InputKey.MouseWheelUp:
                     return "Wheel Up";
 
+                case InputKey.MouseWheelLeft:
+                    return "Wheel Left";
+
+                case InputKey.MouseWheelRight:
+                    return "Wheel Right";
+
                 default:
                     return key.ToString();
             }
@@ -388,12 +394,19 @@ namespace osu.Framework.Input.Bindings
             return InputKey.FirstJoystickButton + (button - JoystickButton.FirstButton);
         }
 
-        public static InputKey FromScrollDelta(Vector2 scrollDelta)
+        public static IEnumerable<InputKey> FromScrollDelta(Vector2 scrollDelta)
         {
-            if (scrollDelta.Y > 0) return InputKey.MouseWheelUp;
-            if (scrollDelta.Y < 0) return InputKey.MouseWheelDown;
+            if (scrollDelta.Y > 0)
+                yield return InputKey.MouseWheelUp;
 
-            return InputKey.None;
+            if (scrollDelta.Y < 0)
+                yield return InputKey.MouseWheelDown;
+
+            if (scrollDelta.X > 0)
+                yield return InputKey.MouseWheelRight;
+
+            if (scrollDelta.X < 0)
+                yield return InputKey.MouseWheelLeft;
         }
 
         public static InputKey FromMidiKey(MidiKey key) => (InputKey)((int)InputKey.MidiA0 + key - MidiKey.A0);
@@ -415,8 +428,8 @@ namespace osu.Framework.Input.Bindings
                     keys.Add(FromMouseButton(button));
             }
 
-            if (scrollDelta is Vector2 v && v.Y != 0)
-                keys.Add(FromScrollDelta(v));
+            if (scrollDelta is Vector2 v && (v.X != 0 || v.Y != 0))
+                keys.AddRange(FromScrollDelta(v));
 
             if (state.Keyboard != null)
             {

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Input.Bindings
         /// <param name="keys">A comma-separated (KeyCode in integer) string representation of the keys.</param>
         /// <remarks>This constructor is not optimized. Hot paths are assumed to use <see cref="FromInputState(InputState, Vector2?)"/>.</remarks>
         public KeyCombination(string keys)
-            : this(keys.Split(',').Select(s => (InputKey)int.Parse(s)))
+            : this(keys.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => (InputKey)int.Parse(s)))
         {
         }
 

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -273,7 +273,8 @@ namespace osu.Framework.Testing.Input
 
                 protected override bool OnScroll(ScrollEvent e)
                 {
-                    circle.MoveTo(circle.Position - e.ScrollDelta * 10).MoveTo(Vector2.Zero, 500, Easing.OutQuint);
+                    var delta = new Vector2(e.ScrollDelta.X, -e.ScrollDelta.Y);
+                    circle.MoveTo(circle.Position + delta * 10).MoveTo(Vector2.Zero, 500, Easing.OutQuint);
                     return base.OnScroll(e);
                 }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/11326.

First commit makes the game not-crash if the wheel is used in a binding, second adds actual support.

Tested with the `xdotool` as suggested in the issue thread and it seems to work fine, however - @bob8677 - it'd be nice if you were able to test this game-side with a framework checkout (steps how to do this are described [here](https://github.com/ppy/osu-framework/wiki/Testing-local-framework-checkout-with-other-projects)).