### PR TITLE
Allow parsing same-type bindables

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -57,7 +57,7 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestParseSameTypeBindable()
+        public void TestParseBindableOfExactSameType()
         {
             var bindable1 = new BindableInt();
             var bindable2 = new BindableDouble();
@@ -79,13 +79,14 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestParseSameInheritanceBindable()
+        public void TestParseBindableOfMatchingInterfaceType()
         {
+            // both of these implement IBindable<int>
             var bindable1 = new BindableInt(10) { MaxValue = 15 };
             var bindable2 = new Bindable<int>(20);
 
             bindable1.Parse(bindable2);
-            // ensure bindable allowed range is still respected.
+            // ensure MaxValue is still respected.
             Assert.That(bindable1.Value, Is.EqualTo(15));
 
             bindable2.Parse(bindable1);

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -56,6 +56,25 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(bindable3.Disabled, Is.True); // Only have access to disabled
         }
 
+        [Test]
+        public void TestParseSameTypeBindable()
+        {
+            var bindable1 = new BindableInt();
+            var bindable2 = new BindableDouble();
+            var bindable3 = new BindableBool();
+
+            bindable1.Parse(new BindableInt(3));
+            bindable2.Parse(new BindableDouble(2.5));
+            bindable3.Parse(new BindableBool(true));
+
+            Assert.That(bindable1.Value, Is.EqualTo(3));
+            Assert.That(bindable2.Value, Is.EqualTo(2.5));
+            Assert.That(bindable3.Value, Is.EqualTo(true));
+
+            // parsing bindable of different type should throw exception.
+            Assert.Throws<ArgumentException>(() => bindable1.Parse(new BindableDouble(3.0)));
+        }
+
         [TestCaseSource(nameof(getParsingConversionTests))]
         public void TestParse(Type type, object input, object output)
         {

--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -62,17 +62,34 @@ namespace osu.Framework.Tests.Bindables
             var bindable1 = new BindableInt();
             var bindable2 = new BindableDouble();
             var bindable3 = new BindableBool();
+            var bindable4 = new Bindable<string>();
 
             bindable1.Parse(new BindableInt(3));
             bindable2.Parse(new BindableDouble(2.5));
             bindable3.Parse(new BindableBool(true));
+            bindable4.Parse(new Bindable<string>("string value"));
 
             Assert.That(bindable1.Value, Is.EqualTo(3));
             Assert.That(bindable2.Value, Is.EqualTo(2.5));
             Assert.That(bindable3.Value, Is.EqualTo(true));
+            Assert.That(bindable4.Value, Is.EqualTo("string value"));
 
             // parsing bindable of different type should throw exception.
             Assert.Throws<ArgumentException>(() => bindable1.Parse(new BindableDouble(3.0)));
+        }
+
+        [Test]
+        public void TestParseSameInheritanceBindable()
+        {
+            var bindable1 = new BindableInt(10) { MaxValue = 15 };
+            var bindable2 = new Bindable<int>(20);
+
+            bindable1.Parse(bindable2);
+            // ensure bindable allowed range is still respected.
+            Assert.That(bindable1.Value, Is.EqualTo(15));
+
+            bindable2.Parse(bindable1);
+            Assert.That(bindable2.Value, Is.EqualTo(15));
         }
 
         [TestCaseSource(nameof(getParsingConversionTests))]

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -245,7 +245,10 @@ namespace osu.Framework.Bindables
                     Value = t;
                     break;
 
-                case IBindable<T> bindable:
+                case IBindable _:
+                    if (!(input is IBindable<T> bindable))
+                        throw new ArgumentException($"Attempting to parse {input.GetType()}, which has differnet value type from {typeof(T)}", nameof(input));
+
                     Value = bindable.Value;
                     break;
 

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -247,7 +247,7 @@ namespace osu.Framework.Bindables
 
                 case IBindable _:
                     if (!(input is IBindable<T> bindable))
-                        throw new ArgumentException($"Attempting to parse {input.GetType()}, which has differnet value type from {typeof(T)}", nameof(input));
+                        throw new ArgumentException($"Expected bindable of type {nameof(IBindable)}<{typeof(T)}>, got {input.GetType()}", nameof(input));
 
                     Value = bindable.Value;
                     break;

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -245,6 +245,10 @@ namespace osu.Framework.Bindables
                     Value = t;
                     break;
 
+                case IBindable<T> bindable:
+                    Value = bindable.Value;
+                    break;
+
                 case string s when underlyingType.IsEnum:
                     Value = (T)Enum.Parse(underlyingType, s);
                     break;


### PR DESCRIPTION
Fixes a case osu!-side in testing where invoking `ToMod()` on a non-deserialized (manually constructed) `APIMod` instance would attempt to parse a `Bindable`, and would result in an "Type must be IConvertible" exception because of falling to the `default` case in the parse method. Upon discussing, parsing `Bindable`s sounds OK to do.