### PR TITLE
Preserve bindable list items if parsing equivalent list

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -100,6 +100,32 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(list));
         }
 
+        [Test]
+        public void TestBindCollectionChangedNotRunIfBoundToSequenceEqualList()
+        {
+            var list = new BindableList<int>(new[] { 1, 3, 5, 6 });
+            var otherList = new BindableList<int>(new[] { 1, 3, 5, 6 });
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.BindCollectionChanged((_, args) => triggeredArgs = args);
+            list.BindTo(otherList);
+
+            Assert.That(triggeredArgs, Is.Null);
+        }
+
+        [Test]
+        public void TestBindCollectionChangedNotRunIfParsingSequenceEqualEnumerable()
+        {
+            var list = new BindableList<int>(new[] { 99, 100, 101, 102 });
+            var enumerable = Enumerable.Range(99, 4);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.BindCollectionChanged((_, args) => triggeredArgs = args);
+            list.Parse(enumerable);
+
+            Assert.That(triggeredArgs, Is.Null);
+        }
+
         #endregion
 
         #region list[index]

--- a/osu.Framework.Tests/Bindables/BindableListTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableListTest.cs
@@ -126,6 +126,29 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(triggeredArgs, Is.Null);
         }
 
+        [Test]
+        public void TestBindCollectionChangedEventsRanIfBoundToDifferentList()
+        {
+            var list = new BindableList<string>(new[] { "first", "list", "here" });
+            var otherList = new BindableList<string>(new[] { "other", "list" });
+
+            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            list.BindCollectionChanged((_, args) => triggeredArgs.Add(args));
+            list.BindTo(otherList);
+
+            Assert.That(triggeredArgs, Has.Count.EqualTo(2));
+
+            var removeEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyCollectionChangedAction.Remove);
+            Assert.That(removeEvent, Is.Not.Null);
+            Assert.That(removeEvent.OldStartingIndex, Is.EqualTo(0));
+            Assert.That(removeEvent.OldItems, Is.EquivalentTo(new[] { "first", "list", "here" }));
+
+            var addEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyCollectionChangedAction.Add);
+            Assert.That(addEvent, Is.Not.Null);
+            Assert.That(addEvent.NewStartingIndex, Is.EqualTo(0));
+            Assert.That(addEvent.NewItems, Is.EquivalentTo(otherList));
+        }
+
         #endregion
 
         #region list[index]

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -390,8 +390,14 @@ namespace osu.Framework.Bindables
                     break;
 
                 case IEnumerable<T> enumerable:
+                    // enumerate once locally before proceeding.
+                    var newItems = enumerable.ToList();
+
+                    if (this.SequenceEqual(newItems))
+                        return;
+
                     Clear();
-                    AddRange(enumerable);
+                    AddRange(newItems);
                     break;
 
                 default:


### PR DESCRIPTION
As noted in https://github.com/ppy/osu/pull/11320 and [on discord](https://discord.com/channels/188630481301012481/188630652340404224/792367615229427712). Also means no collection change events raised anymore in that scenario (as evidenced by the added tests).

Just a basic change, nothing fancy or too breaking. Considered not always eating the list copy but it's painful in general to write (`ICollection<T>` and `IReadOnlyCollection<T>` have no common supertype), and I figure this isn't going to get called that often anyway. Will change on request.