### PR TITLE
Fix hex-parsing #RGBA colours returning #RGRR based colours

### DIFF
--- a/osu.Framework.Tests/Graphics/ColourTest.cs
+++ b/osu.Framework.Tests/Graphics/ColourTest.cs
@@ -138,19 +138,47 @@ namespace osu.Framework.Tests.Graphics
             assertAlmostEqual(new Vector4(expected.Item1, expected.Item2, expected.Item3, expected.Item4), convert.ToHSV(), "HSVA");
 
         [Test]
-        public void TestHex()
+        public void TestToHex()
         {
             Assert.AreEqual("#D2B48C", Colour4.Tan.ToHex());
             Assert.AreEqual("#D2B48CFF", Colour4.Tan.ToHex(true));
             Assert.AreEqual("#6495ED80", Colour4.CornflowerBlue.Opacity(half_alpha).ToHex());
+        }
 
-            Assert.AreEqual(Colour4.White, Colour4.FromHex("#fff"));
-            Assert.AreEqual(Colour4.Red, Colour4.FromHex("#ff0000"));
-            Assert.AreEqual(Colour4.Yellow.Opacity(half_alpha), Colour4.FromHex("ffff0080"));
-            Assert.AreEqual(Colour4.Lime.Opacity(half_alpha), Colour4.FromHex("00ff0080"));
-            Assert.Throws<ArgumentException>(() => Colour4.FromHex("#1"));
-            Assert.Throws<ArgumentException>(() => Colour4.FromHex("#12"));
-            Assert.Throws<ArgumentException>(() => Colour4.FromHex("12345"));
+        private static readonly object[][] valid_hex_colours =
+        {
+            new object[] { Colour4.White, Colour4.FromHex("#fff") },
+            new object[] { Colour4.Red, Colour4.FromHex("#ff0000") },
+            new object[] { Colour4.Yellow.Opacity(half_alpha), Colour4.FromHex("ffff0080") },
+            new object[] { Colour4.Lime.Opacity(half_alpha), Colour4.FromHex("00ff0080") },
+            new object[] { new Colour4(17, 34, 51, 255), Colour4.FromHex("123") },
+            new object[] { new Colour4(17, 34, 51, 255), Colour4.FromHex("#123") },
+            new object[] { new Colour4(17, 34, 51, 68), Colour4.FromHex("1234") },
+            new object[] { new Colour4(17, 34, 51, 68), Colour4.FromHex("#1234") },
+            new object[] { new Colour4(18, 52, 86, 255), Colour4.FromHex("123456") },
+            new object[] { new Colour4(18, 52, 86, 255), Colour4.FromHex("#123456") },
+            new object[] { new Colour4(18, 52, 86, 120), Colour4.FromHex("12345678") },
+            new object[] { new Colour4(18, 52, 86, 120), Colour4.FromHex("#12345678") }
+        };
+
+        [TestCaseSource(nameof(valid_hex_colours))]
+        public void TestFromHex(Colour4 expected, Colour4 actual) => Assert.AreEqual(expected, actual);
+
+        [TestCase("1")]
+        [TestCase("#1")]
+        [TestCase("12")]
+        [TestCase("#12")]
+        [TestCase("12345")]
+        [TestCase("#12345")]
+        [TestCase("1234567")]
+        [TestCase("#1234567")]
+        [TestCase("123456789")]
+        [TestCase("#123456789")]
+        [TestCase("gg00zz")]
+        public void TestFromHexFailsOnInvalidColours(string invalidColour)
+        {
+            // Assert.Catch allows any exception type, contrary to .Throws<T>() (which expects exactly T)
+            Assert.Catch(() => Colour4.FromHex(invalidColour));
         }
 
         [Test]

--- a/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
+++ b/osu.Framework/Extensions/Color4Extensions/Color4Extensions.cs
@@ -142,8 +142,8 @@ namespace osu.Framework.Extensions.Color4Extensions
                     return new Color4(
                         (byte)(byte.Parse(hexSpan.Slice(0, 1), NumberStyles.HexNumber) * 17),
                         (byte)(byte.Parse(hexSpan.Slice(1, 1), NumberStyles.HexNumber) * 17),
-                        (byte)(byte.Parse(hexSpan.Slice(0, 1), NumberStyles.HexNumber) * 17),
-                        (byte)(byte.Parse(hexSpan.Slice(0, 1), NumberStyles.HexNumber) * 17));
+                        (byte)(byte.Parse(hexSpan.Slice(2, 1), NumberStyles.HexNumber) * 17),
+                        (byte)(byte.Parse(hexSpan.Slice(3, 1), NumberStyles.HexNumber) * 17));
 
                 case 8:
                     return new Color4(

--- a/osu.Framework/Graphics/Colour4.cs
+++ b/osu.Framework/Graphics/Colour4.cs
@@ -309,8 +309,8 @@ namespace osu.Framework.Graphics
                     return new Colour4(
                         (byte)(byte.Parse(hexSpan.Slice(0, 1), NumberStyles.HexNumber) * 17),
                         (byte)(byte.Parse(hexSpan.Slice(1, 1), NumberStyles.HexNumber) * 17),
-                        (byte)(byte.Parse(hexSpan.Slice(0, 1), NumberStyles.HexNumber) * 17),
-                        (byte)(byte.Parse(hexSpan.Slice(0, 1), NumberStyles.HexNumber) * 17));
+                        (byte)(byte.Parse(hexSpan.Slice(2, 1), NumberStyles.HexNumber) * 17),
+                        (byte)(byte.Parse(hexSpan.Slice(3, 1), NumberStyles.HexNumber) * 17));
 
                 case 8:
                     return new Colour4(


### PR DESCRIPTION
As an example, previously, attempting to parse `#1ABF` would return the value coresponding to `#1A11`

Not sure if this test-worthy