### PR TITLE
Improve exception handling in WebRequest

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -210,7 +210,7 @@ namespace osu.Framework.Tests.IO
         [Test, Retry(5)]
         public void TestJsonWebRequestThrowsCorrectlyOnMultipleErrors([Values(true, false)] bool async)
         {
-            var request = new JsonWebRequest<Drawable>($"badrequest://www.google.com")
+            var request = new JsonWebRequest<Drawable>("badrequest://www.google.com")
             {
                 AllowInsecureRequests = true,
             };

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using osu.Framework.Graphics;
 using osu.Framework.IO.Network;
 using WebRequest = osu.Framework.IO.Network.WebRequest;
 
@@ -202,6 +203,31 @@ namespace osu.Framework.Tests.IO
             Assert.IsTrue(request.Aborted);
 
             Assert.IsEmpty(request.GetResponseString());
+
+            Assert.IsTrue(hasThrown);
+        }
+
+        [Test, Retry(5)]
+        public void TestJsonWebRequestThrowsCorrectlyOnMultipleErrors([Values(true, false)] bool async)
+        {
+            var request = new JsonWebRequest<Drawable>($"badrequest://www.google.com")
+            {
+                AllowInsecureRequests = true,
+            };
+
+            bool hasThrown = false;
+            request.Failed += exception => hasThrown = exception != null;
+
+            if (async)
+                Assert.ThrowsAsync<ArgumentException>(request.PerformAsync);
+            else
+                Assert.Throws<ArgumentException>(request.Perform);
+
+            Assert.IsTrue(request.Completed);
+            Assert.IsTrue(request.Aborted);
+
+            Assert.IsNull(request.GetResponseString());
+            Assert.IsNull(request.ResponseObject);
 
             Assert.IsTrue(hasThrown);
         }

--- a/osu.Framework/IO/Network/JsonWebRequest.cs
+++ b/osu.Framework/IO/Network/JsonWebRequest.cs
@@ -18,7 +18,11 @@ namespace osu.Framework.IO.Network
         {
         }
 
-        protected override void ProcessResponse() => ResponseObject = JsonConvert.DeserializeObject<T>(GetResponseString());
+        protected override void ProcessResponse()
+        {
+            if (ResponseStream != null)
+                ResponseObject = JsonConvert.DeserializeObject<T>(GetResponseString());
+        }
 
         public T ResponseObject { get; private set; }
     }

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -10,6 +10,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Logging;
@@ -162,6 +163,7 @@ namespace osu.Framework.IO.Network
         /// Retrieve the full response body as a UTF8 encoded string.
         /// </summary>
         /// <returns>The response body.</returns>
+        [CanBeNull]
         public string GetResponseString()
         {
             try

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -486,6 +486,8 @@ namespace osu.Framework.IO.Network
             else
                 logger.Add($@"Request to {Url} successfully completed!");
 
+            // if a failure happened on performing the request, there are still situations where we want to process the response.
+            // consider the case of a server returned error code which triggers a WebException, but the server is also returning details on the error in the response.
             try
             {
                 if (!wasTimeout)
@@ -493,8 +495,12 @@ namespace osu.Framework.IO.Network
             }
             catch (Exception se)
             {
-                logger.Add($"Processing response from {Url} failed with {se}.");
-                e = e == null ? se : new AggregateException(e, se);
+                // that said, we don't really care about an error when processing the response if there is already a higher level exception.
+                if (e != null)
+                {
+                    logger.Add($"Processing response from {Url} failed with {se}.");
+                    e = se;
+                }
             }
 
             if (e == null)

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -501,7 +501,10 @@ namespace osu.Framework.IO.Network
                 if (e != null)
                 {
                     logger.Add($"Processing response from {Url} failed with {se}.");
-                    e = se;
+                    Failed?.Invoke(e);
+                    Completed = true;
+                    Aborted = true;
+                    throw;
                 }
             }
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -498,10 +498,10 @@ namespace osu.Framework.IO.Network
             catch (Exception se)
             {
                 // that said, we don't really care about an error when processing the response if there is already a higher level exception.
-                if (e != null)
+                if (e == null)
                 {
                     logger.Add($"Processing response from {Url} failed with {se}.");
-                    Failed?.Invoke(e);
+                    Failed?.Invoke(se);
                     Completed = true;
                     Aborted = true;
                     throw;


### PR DESCRIPTION
- No longer throw AggregateExceptions where we really don't need to.
- No longer attempt to deserialise a potentially null json response.

Helps to solve https://github.com/ppy/osu/issues/11347. I guess touches on the issue reported in https://github.com/ppy/osu-framework/issues/4112 too.