### PR TITLE
Remove duplicated license header

### DIFF
--- a/osu.Framework/Bindables/BindableNumberWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableNumberWithCurrent.cs
@@ -1,9 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence text.
-
 using System;
 using osu.Framework.Graphics.UserInterface;
 


### PR DESCRIPTION
Came across that one while looking at BindableNumberWithCurrent class source.