### PR TITLE
Fix slider bar crashing upon binding to disabled current

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableLeasingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableLeasingTest.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Tests.Bindables
 
             // end a lease with an incorrect bindable
             original.BeginLease(true);
-            Assert.Throws<InvalidOperationException>(() => original.EndLease(original));
+            Assert.Throws<InvalidOperationException>(() => original.EndLease(new Bindable<int>().BeginLease(true)));
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -219,6 +219,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 });
             });
 
+            AddStep("change via lease", () =>
+            {
+                var lease = testSlider.Current.BeginLease(false);
+                lease.Value = 3;
+                lease.Return();
+            });
+
             AddStep("set enabled current", () => testSlider.Current = new BindableNumber<double>(10) { MinValue = 1, MaxValue = 10 });
         }
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -203,6 +203,25 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkValue(-5, disabled);
         }
 
+        [Test]
+        public void TestSliderWithDisabledCurrent()
+        {
+            TestSliderBar testSlider = null;
+
+            AddStep("create slider with disabled current", () =>
+            {
+                Add(testSlider = new TestSliderBar
+                {
+                    Anchor = Anchor.BottomLeft,
+                    Origin = Anchor.BottomLeft,
+                    Size = new Vector2(200, 50),
+                    Current = new BindableNumber<double>(5) { MinValue = 1, MaxValue = 10, Disabled = true },
+                });
+            });
+
+            AddStep("set enabled current", () => testSlider.Current = new BindableNumber<double>(10) { MinValue = 1, MaxValue = 10 });
+        }
+
         private void checkValue(int expected, bool disabled)
         {
             if (disabled)

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -421,7 +421,7 @@ namespace osu.Framework.Bindables
             Value = serializer.Deserialize<T>(reader);
         }
 
-        private LeasedBindable<T> leasedBindable;
+        private ILeasedBindable leasedBindable;
 
         private bool isLeased => leasedBindable != null;
 
@@ -432,12 +432,16 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="revertValueOnReturn">Whether the <see cref="Value"/> when <see cref="BeginLease"/> was called should be restored when the lease ends.</param>
         /// <returns>A bindable with a lease.</returns>
-        public LeasedBindable<T> BeginLease(bool revertValueOnReturn)
+        public LeasedBindable<T> BeginLease(bool revertValueOnReturn) => BeginLeaseTo(new LeasedBindable<T>(this, revertValueOnReturn));
+
+        protected TLeased BeginLeaseTo<TLeased>(TLeased instance)
+            where TLeased : ILeasedBindable<T>
         {
             if (checkForLease(this))
                 throw new InvalidOperationException("Attempted to lease a bindable that is already in a leased state.");
 
-            return leasedBindable = new LeasedBindable<T>(this, revertValueOnReturn);
+            leasedBindable = instance;
+            return instance;
         }
 
         private bool checkForLease(Bindable<T> source)
@@ -462,8 +466,8 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// Called internally by a <see cref="LeasedBindable{T}"/> to end a lease.
         /// </summary>
-        /// <param name="returnedBindable">The <see cref="LeasedBindable{T}"/> that was provided as a return of a <see cref="BeginLease"/> call.</param>
-        internal void EndLease(Bindable<T> returnedBindable)
+        /// <param name="returnedBindable">The <see cref="ILeasedBindable{T}"/> that was provided as a return of a <see cref="BeginLease"/> call.</param>
+        internal void EndLease(ILeasedBindable<T> returnedBindable)
         {
             if (!isLeased)
                 throw new InvalidOperationException("Attempted to end a lease without beginning one.");

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -39,7 +40,7 @@ namespace osu.Framework.Bindables
 
         private T precision;
 
-        public T Precision
+        public virtual T Precision
         {
             get => precision;
             set
@@ -47,10 +48,7 @@ namespace osu.Framework.Bindables
                 if (precision.Equals(value))
                     return;
 
-                if (value.CompareTo(default) <= 0)
-                    throw new ArgumentOutOfRangeException(nameof(Precision), value, "Must be greater than 0.");
-
-                SetPrecision(value, true, this);
+                SetPrecision(value, true);
             }
         }
 
@@ -59,16 +57,20 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="precision">The new precision.</param>
         /// <param name="updateCurrentValue">Whether to update the current value after the precision is set.</param>
+        /// <param name="bypassChecks">Whether to bypass checks, used for leased bindables.</param>
         /// <param name="source">The bindable that triggered this. A null value represents the current bindable instance.</param>
-        internal void SetPrecision(T precision, bool updateCurrentValue, BindableNumber<T> source)
+        internal void SetPrecision(T precision, bool updateCurrentValue, bool bypassChecks = false, BindableNumber<T> source = null)
         {
+            if (precision.CompareTo(default) <= 0)
+                throw new ArgumentOutOfRangeException(nameof(precision), precision, "Must be greater than 0.");
+
             this.precision = precision;
-            TriggerPrecisionChange(source);
+            TriggerPrecisionChange(source ?? this, true, bypassChecks);
 
             if (updateCurrentValue)
             {
                 // Re-apply the current value to apply the new precision
-                SetValue(Value);
+                SetValue(Value, bypassChecks);
             }
         }
 
@@ -78,22 +80,35 @@ namespace osu.Framework.Bindables
             set => SetValue(value);
         }
 
-        internal void SetValue(T value)
+        internal void SetValue(T value, bool bypassChecks = false)
         {
-            if (Precision.CompareTo(DefaultPrecision) > 0)
-            {
-                double doubleValue = clamp(value, MinValue, MaxValue).ToDouble(NumberFormatInfo.InvariantInfo);
-                doubleValue = Math.Round(doubleValue / Precision.ToDouble(NumberFormatInfo.InvariantInfo)) * Precision.ToDouble(NumberFormatInfo.InvariantInfo);
+            value = computeFinalValue(value);
 
-                base.Value = (T)Convert.ChangeType(doubleValue, typeof(T), CultureInfo.InvariantCulture);
-            }
+            if (!bypassChecks)
+                base.Value = value;
             else
-                base.Value = clamp(value, MinValue, MaxValue);
+            {
+                if (EqualityComparer<T>.Default.Equals(Value, value))
+                    return;
+
+                SetValue(Value, value, true);
+            }
+        }
+
+        private T computeFinalValue(T value)
+        {
+            if (Precision.CompareTo(DefaultPrecision) <= 0)
+                return clamp(value, MinValue, MaxValue);
+
+            double doubleValue = clamp(value, MinValue, MaxValue).ToDouble(NumberFormatInfo.InvariantInfo);
+            doubleValue = Math.Round(doubleValue / Precision.ToDouble(NumberFormatInfo.InvariantInfo)) * Precision.ToDouble(NumberFormatInfo.InvariantInfo);
+
+            return (T)Convert.ChangeType(doubleValue, typeof(T), CultureInfo.InvariantCulture);
         }
 
         private T minValue;
 
-        public T MinValue
+        public virtual T MinValue
         {
             get => minValue;
             set
@@ -101,7 +116,7 @@ namespace osu.Framework.Bindables
                 if (minValue.Equals(value))
                     return;
 
-                SetMinValue(value, true, this);
+                SetMinValue(value, true);
             }
         }
 
@@ -110,22 +125,23 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="minValue">The new minimum value.</param>
         /// <param name="updateCurrentValue">Whether to update the current value after the minimum value is set.</param>
+        /// <param name="bypassChecks">Whether to bypass checks, used for leased bindables.</param>
         /// <param name="source">The bindable that triggered this. A null value represents the current bindable instance.</param>
-        internal void SetMinValue(T minValue, bool updateCurrentValue, BindableNumber<T> source)
+        internal void SetMinValue(T minValue, bool updateCurrentValue, bool bypassChecks = false, BindableNumber<T> source = null)
         {
             this.minValue = minValue;
-            TriggerMinValueChange(source);
+            TriggerMinValueChange(source ?? this, true, bypassChecks);
 
             if (updateCurrentValue)
             {
                 // Re-apply the current value to apply the new minimum value
-                SetValue(Value);
+                SetValue(Value, bypassChecks);
             }
         }
 
         private T maxValue;
 
-        public T MaxValue
+        public virtual T MaxValue
         {
             get => maxValue;
             set
@@ -133,7 +149,7 @@ namespace osu.Framework.Bindables
                 if (maxValue.Equals(value))
                     return;
 
-                SetMaxValue(value, true, this);
+                SetMaxValue(value, true);
             }
         }
 
@@ -142,16 +158,17 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="maxValue">The new maximum value.</param>
         /// <param name="updateCurrentValue">Whether to update the current value after the maximum value is set.</param>
+        /// <param name="bypassChecks">Whether to bypass checks, used for leased bindables.</param>
         /// <param name="source">The bindable that triggered this. A null value represents the current bindable instance.</param>
-        internal void SetMaxValue(T maxValue, bool updateCurrentValue, BindableNumber<T> source)
+        internal void SetMaxValue(T maxValue, bool updateCurrentValue, bool bypassChecks = false, BindableNumber<T> source = null)
         {
             this.maxValue = maxValue;
-            TriggerMaxValueChange(source);
+            TriggerMaxValueChange(source ?? this, true, bypassChecks);
 
             if (updateCurrentValue)
             {
                 // Re-apply the current value to apply the new maximum value
-                SetValue(Value);
+                SetValue(Value, bypassChecks);
             }
         }
 
@@ -258,7 +275,7 @@ namespace osu.Framework.Bindables
             TriggerMaxValueChange(this, false);
         }
 
-        protected void TriggerPrecisionChange(BindableNumber<T> source = null, bool propagateToBindings = true)
+        protected void TriggerPrecisionChange(BindableNumber<T> source, bool propagateToBindings = true, bool bypassChecks = false)
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = precision;
@@ -270,7 +287,7 @@ namespace osu.Framework.Bindables
                     if (b == source) continue;
 
                     if (b is BindableNumber<T> bn)
-                        bn.SetPrecision(precision, false, this);
+                        bn.SetPrecision(precision, false, bypassChecks, this);
                 }
             }
 
@@ -278,7 +295,7 @@ namespace osu.Framework.Bindables
                 PrecisionChanged?.Invoke(precision);
         }
 
-        protected void TriggerMinValueChange(BindableNumber<T> source = null, bool propagateToBindings = true)
+        protected void TriggerMinValueChange(BindableNumber<T> source, bool propagateToBindings = true, bool bypassChecks = false)
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = minValue;
@@ -290,7 +307,7 @@ namespace osu.Framework.Bindables
                     if (b == source) continue;
 
                     if (b is BindableNumber<T> bn)
-                        bn.SetMinValue(minValue, false, this);
+                        bn.SetMinValue(minValue, false, bypassChecks, this);
                 }
             }
 
@@ -298,7 +315,7 @@ namespace osu.Framework.Bindables
                 MinValueChanged?.Invoke(minValue);
         }
 
-        protected void TriggerMaxValueChange(BindableNumber<T> source = null, bool propagateToBindings = true)
+        protected void TriggerMaxValueChange(BindableNumber<T> source, bool propagateToBindings = true, bool bypassChecks = false)
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = maxValue;
@@ -310,7 +327,7 @@ namespace osu.Framework.Bindables
                     if (b == source) continue;
 
                     if (b is BindableNumber<T> bn)
-                        bn.SetMaxValue(maxValue, false, this);
+                        bn.SetMaxValue(maxValue, false, bypassChecks, this);
                 }
             }
 
@@ -423,6 +440,8 @@ namespace osu.Framework.Bindables
         public new BindableNumber<T> GetBoundCopy() => (BindableNumber<T>)base.GetBoundCopy();
 
         public new BindableNumber<T> GetUnboundCopy() => (BindableNumber<T>)base.GetUnboundCopy();
+
+        public new LeasedBindableNumber<T> BeginLease(bool revertPropertiesOnReturn) => BeginLeaseTo(new LeasedBindableNumber<T>(this, revertPropertiesOnReturn));
 
         public override string ToString() => Value.ToString(NumberFormatInfo.InvariantInfo);
 

--- a/osu.Framework/Bindables/BindableNumberWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableNumberWithCurrent.cs
@@ -23,7 +23,12 @@ namespace osu.Framework.Bindables
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                if (currentBound != null) UnbindFrom(currentBound);
+                if (currentBound != null)
+                    UnbindFrom(currentBound);
+
+                // must be re-enabled before binding below, see https://github.com/ppy/osu-framework/issues/3218.
+                Disabled = false;
+
                 BindTo(currentBound = (BindableNumber<T>)value);
             }
         }

--- a/osu.Framework/Bindables/BindableWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableWithCurrent.cs
@@ -22,7 +22,12 @@ namespace osu.Framework.Bindables
                 if (value == null)
                     throw new ArgumentNullException(nameof(value));
 
-                if (currentBound != null) UnbindFrom(currentBound);
+                if (currentBound != null)
+                    UnbindFrom(currentBound);
+
+                // must be re-enabled before binding below, see https://github.com/ppy/osu-framework/issues/3218.
+                Disabled = false;
+
                 BindTo(currentBound = value);
             }
         }

--- a/osu.Framework/Bindables/ILeasedBindable.cs
+++ b/osu.Framework/Bindables/ILeasedBindable.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Bindables
+{
+    /// <summary>
+    /// An interface that represents a read-only leased bindable.
+    /// </summary>
+    public interface ILeasedBindable : IBindable
+    {
+        /// <summary>
+        /// End the lease on the source <see cref="Bindable{T}"/>.
+        /// </summary>
+        void Return();
+    }
+
+    /// <summary>
+    /// An interface that representes a read-only leased bindable.
+    /// </summary>
+    /// <typeparam name="T">The value type of the bindable.</typeparam>
+    public interface ILeasedBindable<T> : ILeasedBindable, IBindable<T>
+    {
+    }
+}

--- a/osu.Framework/Bindables/LeasedBindableNumber.cs
+++ b/osu.Framework/Bindables/LeasedBindableNumber.cs
@@ -7,28 +7,27 @@ using JetBrains.Annotations;
 
 namespace osu.Framework.Bindables
 {
-    /// <summary>
-    /// A bindable carrying a mutually exclusive lease on another bindable.
-    /// Can only be retrieved via <see cref="Bindable{T}.BeginLease"/>.
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public class LeasedBindable<T> : Bindable<T>, ILeasedBindable<T>
+    public class LeasedBindableNumber<T> : BindableNumber<T>, ILeasedBindable<T>
+        where T : struct, IConvertible, IComparable<T>, IEquatable<T>
     {
-        private readonly Bindable<T> source;
+        private readonly BindableNumber<T> source;
 
-        private readonly T valueBeforeLease;
+        private readonly T valueBeforeLease, minValueBeforeLease, maxValueBeforeLease, precisionBeforeLease;
         private readonly bool disabledBeforeLease;
-        private readonly bool revertValueOnReturn;
+        private readonly bool revertPropertiesOnReturn;
 
-        internal LeasedBindable([NotNull] Bindable<T> source, bool revertValueOnReturn)
+        internal LeasedBindableNumber([NotNull] BindableNumber<T> source, bool revertPropertiesOnReturn)
         {
             BindTo(source);
 
             this.source = source ?? throw new ArgumentNullException(nameof(source));
 
-            if (revertValueOnReturn)
+            if (revertPropertiesOnReturn)
             {
-                this.revertValueOnReturn = true;
+                this.revertPropertiesOnReturn = true;
+                precisionBeforeLease = Precision;
+                minValueBeforeLease = MinValue;
+                maxValueBeforeLease = MaxValue;
                 valueBeforeLease = Value;
             }
 
@@ -37,11 +36,11 @@ namespace osu.Framework.Bindables
             Disabled = true;
         }
 
-        [UsedImplicitly]
-        public LeasedBindable(T value)
-            : base(value)
+        public LeasedBindableNumber(T defaultValue = default)
+            : base(defaultValue)
         {
-            // used for GetBoundCopy, where we don't want a source.
+            // required for GetBoundCopy, where we don't want a source.
+            // it's also usable for components that don't need a source bindable while using leased.
         }
 
         private bool hasBeenReturned;
@@ -63,7 +62,7 @@ namespace osu.Framework.Bindables
         public override T Value
         {
             get => base.Value;
-            set => setLeased(Value, value, () => SetValue(Value, value, true));
+            set => setLeased(Value, value, () => SetValue(value, true));
         }
 
         public override T Default
@@ -78,12 +77,35 @@ namespace osu.Framework.Bindables
             set => setLeased(Disabled, value, () => SetDisabled(value, true));
         }
 
+        public override T Precision
+        {
+            get => base.Precision;
+            set => setLeased(Precision, value, () => SetPrecision(value, true, true));
+        }
+
+        public override T MinValue
+        {
+            get => base.MinValue;
+            set => setLeased(base.MinValue, value, () => SetMinValue(value, true, true));
+        }
+
+        public override T MaxValue
+        {
+            get => base.MaxValue;
+            set => setLeased(base.MaxValue, value, () => SetMaxValue(value, true, true));
+        }
+
         public override void UnbindAll()
         {
             if (source != null && !hasBeenReturned)
             {
-                if (revertValueOnReturn)
+                if (revertPropertiesOnReturn)
+                {
+                    Precision = precisionBeforeLease;
+                    MinValue = minValueBeforeLease;
+                    MaxValue = maxValueBeforeLease;
                     Value = valueBeforeLease;
+                }
 
                 Disabled = disabledBeforeLease;
 
@@ -92,12 +114,6 @@ namespace osu.Framework.Bindables
             }
 
             base.UnbindAll();
-        }
-
-        private void checkValid()
-        {
-            if (source != null && hasBeenReturned)
-                throw new InvalidOperationException($"Cannot perform operations on a {nameof(LeasedBindable<T>)} that has been {nameof(Return)}ed.");
         }
 
         private void setLeased<TValue>(TValue previous, TValue current, Action setProperty)

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -43,20 +43,10 @@ namespace osu.Framework.Graphics.UserInterface
 
         private readonly BindableNumberWithCurrent<T> current = new BindableNumberWithCurrent<T>();
 
-        protected BindableNumber<T> CurrentNumber => current;
-
         public Bindable<T> Current
         {
             get => current;
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                current.Current = value;
-
-                currentNumberInstantaneous.Default = current.Default;
-            }
+            set => current.Current = value;
         }
 
         protected SliderBar()
@@ -64,6 +54,7 @@ namespace osu.Framework.Graphics.UserInterface
             currentNumberInstantaneous = new BindableNumber<T>();
 
             current.ValueChanged += e => currentNumberInstantaneous.Value = e.NewValue;
+            current.DefaultChanged += e => currentNumberInstantaneous.Default = e.NewValue;
             current.MinValueChanged += v => currentNumberInstantaneous.MinValue = v;
             current.MaxValueChanged += v => currentNumberInstantaneous.MaxValue = v;
             current.PrecisionChanged += v => currentNumberInstantaneous.Precision = v;

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected SliderBar()
         {
-            currentNumberInstantaneous = new BindableNumber<T>();
+            currentNumberInstantaneous = new LeasedBindableNumber<T>();
 
             current.ValueChanged += e => currentNumberInstantaneous.Value = e.NewValue;
             current.DefaultChanged += e => currentNumberInstantaneous.Default = e.NewValue;

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -43,6 +43,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         private readonly BindableNumberWithCurrent<T> current = new BindableNumberWithCurrent<T>();
 
+        protected BindableNumber<T> CurrentNumber => current;
+
         public Bindable<T> Current
         {
             get => current;

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -60,11 +60,11 @@ namespace osu.Framework.Graphics.UserInterface
             current.MinValueChanged += v => currentNumberInstantaneous.MinValue = v;
             current.MaxValueChanged += v => currentNumberInstantaneous.MaxValue = v;
             current.PrecisionChanged += v => currentNumberInstantaneous.Precision = v;
-            current.DisabledChanged += v => currentNumberInstantaneous.Disabled = v;
+            // intentionally not updating disabled state to "currentNumberInstantaneous" to handle value changes from disabled current.
 
             currentNumberInstantaneous.ValueChanged += e =>
             {
-                if (!TransferValueOnCommit)
+                if (!TransferValueOnCommit && !current.Disabled)
                     current.Value = e.NewValue;
             };
         }
@@ -153,7 +153,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnKeyDown(KeyDownEvent e)
         {
-            if (currentNumberInstantaneous.Disabled)
+            if (current.Disabled)
                 return false;
 
             bool shouldHandle = IsHovered || AllowKeyboardInputWhenNotHovered;
@@ -202,7 +202,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             var xPosition = ToLocalSpace(e.ScreenSpaceMousePosition).X - RangePadding;
 
-            if (currentNumberInstantaneous.Disabled)
+            if (current.Disabled)
                 return;
 
             currentNumberInstantaneous.SetProportional(xPosition / UsableWidth, e.ShiftPressed ? KeyboardStep : 0);


### PR DESCRIPTION
Another issue of https://github.com/ppy/osu-framework/issues/3218, also handles value changes from disabled current while at it, added test step to ensure `SliderBar` never crashes on disabled current again.

Also updates that outdated `instantaneous.Default = current.Default` line into a `current.DefaultChanged += e => instantaneous.Default = e.NewValue`.

- [ ] Depends on #4130 