### PR TITLE
Improve reliability and performance of GL disposals

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneStressGLDisposal.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneStressGLDisposal.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    [Ignore("This test needs a game host to be useful.")]
+    public class TestSceneStressGLDisposal : FrameworkTestScene
+    {
+        private FillFlowContainer fillFlow;
+
+        protected override double TimePerAction => 0.001;
+
+        [SetUp]
+        public void SetUp() => Schedule(() =>
+        {
+            Add(fillFlow = new FillFlowContainer
+            {
+                RelativeSizeAxes = Axes.Both,
+                Direction = FillDirection.Full
+            });
+        });
+
+        [Test]
+        public void TestAddRemoveDrawable()
+        {
+            AddRepeatStep("add/remove drawables", () =>
+            {
+                for (int i = 0; i < 50; i++)
+                {
+                    fillFlow.Add(new Box { Size = new Vector2(5) });
+
+                    if (fillFlow.Count > 100)
+                    {
+                        fillFlow.Remove(fillFlow.First());
+                    }
+                }
+            }, 100000);
+        }
+    }
+}

--- a/osu.Framework/Graphics/OpenGL/GLDisposalQueue.cs
+++ b/osu.Framework/Graphics/OpenGL/GLDisposalQueue.cs
@@ -1,0 +1,74 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace osu.Framework.Graphics.OpenGL
+{
+    /// <summary>
+    /// Helper class used to manage GL disposals in a thread-safe manner.
+    /// </summary>
+    internal class GLDisposalQueue
+    {
+        private readonly List<PendingDisposal> newDisposals;
+        private readonly List<PendingDisposal> pendingDisposals;
+
+        public GLDisposalQueue()
+        {
+            newDisposals = new List<PendingDisposal>();
+            pendingDisposals = new List<PendingDisposal>();
+        }
+
+        /// <summary>
+        /// Schedules a new disposal action to be executed at a later point in time.
+        /// This method can be called concurrently from multiple threads.
+        /// By default the disposal will run <see cref="GLWrapper.MAX_DRAW_NODES"/> frames after enqueueing.
+        /// </summary>
+        /// <param name="disposalAction">The disposal action to be executed.</param>
+        public void ScheduleDisposal(Action disposalAction)
+        {
+            lock (newDisposals)
+                newDisposals.Add(new PendingDisposal(disposalAction));
+        }
+
+        /// <summary>
+        /// Checks pending disposals and executes ones whose frame delay has expired.
+        /// This method can NOT be called concurrently from multiple threads.
+        /// </summary>
+        public void CheckPendingDisposals()
+        {
+            lock (newDisposals)
+            {
+                pendingDisposals.AddRange(newDisposals);
+                newDisposals.Clear();
+            }
+
+            for (var i = 0; i < pendingDisposals.Count; i++)
+            {
+                var item = pendingDisposals[i];
+
+                if (item.RemainingFrameDelay-- == 0)
+                {
+                    item.Action();
+
+                    Debug.Assert(i == 0);
+                    pendingDisposals.RemoveAt(i--);
+                }
+            }
+        }
+
+        private class PendingDisposal
+        {
+            public int RemainingFrameDelay = GLWrapper.MAX_DRAW_NODES;
+
+            public readonly Action Action;
+
+            public PendingDisposal(Action action)
+            {
+                Action = action;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -116,49 +116,19 @@ namespace osu.Framework.Graphics.OpenGL
             reset_scheduler.AddDelayed(checkPendingDisposals, 0, true);
         }
 
-        private static readonly List<PendingDisposal> pending_disposal_actions = new List<PendingDisposal>();
-
-        private class PendingDisposal
-        {
-            public int RemainingFrameDelay = MAX_DRAW_NODES;
-
-            public readonly Action Action;
-
-            public PendingDisposal(Action action)
-            {
-                Action = action;
-            }
-        }
+        private static readonly GLDisposalQueue disposal_queue = new GLDisposalQueue();
 
         internal static void ScheduleDisposal(Action disposalAction)
         {
             if (host != null && host.TryGetTarget(out _))
-            {
-                lock (pending_disposal_actions)
-                    pending_disposal_actions.Add(new PendingDisposal(disposalAction));
-            }
+                disposal_queue.ScheduleDisposal(disposalAction);
             else
                 disposalAction.Invoke();
         }
 
         private static void checkPendingDisposals()
         {
-            // use for loop to avoid need for locking
-            for (var i = 0; i < pending_disposal_actions.Count; i++)
-            {
-                var item = pending_disposal_actions[i];
-
-                if (item.RemainingFrameDelay-- == 0)
-                {
-                    item.Action();
-
-                    lock (pending_disposal_actions)
-                    {
-                        Debug.Assert(i == 0);
-                        pending_disposal_actions.RemoveAt(i--);
-                    }
-                }
-            }
+            disposal_queue.CheckPendingDisposals();
         }
 
         private static readonly GlobalStatistic<int> stat_expensive_operations_queued = GlobalStatistics.Get<int>(nameof(GLWrapper), "Expensive operation queue length");


### PR DESCRIPTION
Resolves #4108.

To quote my comment there:

> Commit messages and inline comments should hopefully explain the main idea. From testing:
>
> * It passes the 100k drawable stress test given above.
> * I've benchmarked it on the test using dotTrace. Also tried adding a Benchmark.NET, but it's not trivial as it requires an actual game host and measuring that would probably be useless. It doesn't seem to be worse with the reworked concept, and it certainly seems to be better with the optimisation (times given are total times of the appropriate operations, measurement was once each time, over 2 minutes of running the stress test):
>
> | | current `master` | with `GLDisposalQueue` | with optimised `GLDisposalQueue` |
> | :- | -: | -: | -: |
> | scheduling disposals | 342ms | 311ms | 301ms |
> | checking disposals | 2267ms | 2179ms | 622ms |

I've also benchmarked against the game using dotTrace. Testing procedure was: release build, one-time run, from intro, through one map, to game exit - around 4 mins of operation overall each time. The results there are less impressive, but maybe that was to be expected, as the stress test case was a pretty degenerate one. Table for reference:

| | current `master` | with `GLDisposalQueue` | with optimised `GLDisposalQueue` |
| :- | -: | -: | -: |
| scheduling disposals | 19ms | 22ms | 9.3ms |
| checking disposals | 473ms | 744ms | 394ms |

That middle result might be an artifact of thermal throttling on my box, but I don't think it's all that relevant of a result as the optimisation in 5971ae2 seems like a safe optimisation to make (previous code was operating off of a similar assumption anyway - see the `Debug.Assert(i == 0)` before removal), and it's not like it's a super jarring difference - might just be normal-ish fluctuation.