### PR TITLE
Enforce thread safety on common transform operations

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -447,7 +447,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>False if <paramref name="drawable"/> was not a child of this <see cref="CompositeDrawable"/> and true otherwise.</returns>
         protected internal virtual bool RemoveInternal(Drawable drawable)
         {
-            EnsureMutationAllowed();
+            EnsureChildMutationAllowed();
 
             if (drawable == null)
                 throw new ArgumentNullException(nameof(drawable));
@@ -485,7 +485,7 @@ namespace osu.Framework.Graphics.Containers
         /// </param>
         protected internal virtual void ClearInternal(bool disposeChildren = true)
         {
-            EnsureMutationAllowed();
+            EnsureChildMutationAllowed();
 
             if (internalChildren.Count == 0) return;
 
@@ -523,7 +523,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected internal virtual void AddInternal(Drawable drawable)
         {
-            EnsureMutationAllowed();
+            EnsureChildMutationAllowed();
 
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Disposed Drawables may not have children added.");
@@ -574,7 +574,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="newDepth">The new depth value to be set.</param>
         protected internal void ChangeInternalChildDepth(Drawable child, float newDepth)
         {
-            EnsureMutationAllowed();
+            EnsureChildMutationAllowed();
 
             if (child.Depth == newDepth) return;
 
@@ -607,7 +607,7 @@ namespace osu.Framework.Graphics.Containers
         /// </remarks>
         protected internal void SortInternal()
         {
-            EnsureMutationAllowed();
+            EnsureChildMutationAllowed();
 
             internalChildren.Sort();
             aliveInternalChildren.Sort();
@@ -1181,7 +1181,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override void ApplyTransformsAt(double time, bool propagateChildren = false)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             base.ApplyTransformsAt(time, propagateChildren);
 
@@ -1194,7 +1194,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override void ClearTransformsAfter(double time, bool propagateChildren = false, string targetMember = null)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             base.ClearTransformsAfter(time, propagateChildren, targetMember);
 
@@ -1223,7 +1223,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override IDisposable BeginAbsoluteSequence(double newTransformStartTime, bool recursive = true)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             var baseDisposalAction = base.BeginAbsoluteSequence(newTransformStartTime, recursive);
             if (!recursive)
@@ -1242,7 +1242,7 @@ namespace osu.Framework.Graphics.Containers
 
         public override void FinishTransforms(bool propagateChildren = false, string targetMember = null)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             base.FinishTransforms(propagateChildren, targetMember);
 
@@ -1278,6 +1278,8 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected TransformSequence<CompositeDrawable> TweenEdgeEffectTo(EdgeEffectParameters newParams, double duration = 0, Easing easing = Easing.None) =>
             this.TransformTo(nameof(EdgeEffect), newParams, duration, easing);
+
+        internal void EnsureChildMutationAllowed() => EnsureMutationAllowed(nameof(InternalChildren));
 
         #endregion
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -447,7 +447,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>False if <paramref name="drawable"/> was not a child of this <see cref="CompositeDrawable"/> and true otherwise.</returns>
         protected internal virtual bool RemoveInternal(Drawable drawable)
         {
-            ensureChildMutationAllowed();
+            EnsureMutationAllowed();
 
             if (drawable == null)
                 throw new ArgumentNullException(nameof(drawable));
@@ -485,7 +485,7 @@ namespace osu.Framework.Graphics.Containers
         /// </param>
         protected internal virtual void ClearInternal(bool disposeChildren = true)
         {
-            ensureChildMutationAllowed();
+            EnsureMutationAllowed();
 
             if (internalChildren.Count == 0) return;
 
@@ -523,7 +523,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected internal virtual void AddInternal(Drawable drawable)
         {
-            ensureChildMutationAllowed();
+            EnsureMutationAllowed();
 
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Disposed Drawables may not have children added.");
@@ -574,7 +574,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="newDepth">The new depth value to be set.</param>
         protected internal void ChangeInternalChildDepth(Drawable child, float newDepth)
         {
-            ensureChildMutationAllowed();
+            EnsureMutationAllowed();
 
             if (child.Depth == newDepth) return;
 
@@ -607,38 +607,10 @@ namespace osu.Framework.Graphics.Containers
         /// </remarks>
         protected internal void SortInternal()
         {
-            ensureChildMutationAllowed();
+            EnsureMutationAllowed();
 
             internalChildren.Sort();
             aliveInternalChildren.Sort();
-        }
-
-        private void ensureChildMutationAllowed()
-        {
-            switch (LoadState)
-            {
-                case LoadState.NotLoaded:
-                    break;
-
-                case LoadState.Loading:
-                    if (Thread.CurrentThread != LoadThread)
-                        throw new InvalidThreadForChildMutationException(LoadState, "not on the load thread");
-
-                    break;
-
-                case LoadState.Ready:
-                    // Allow mutating from the load thread since parenting containers may still be in the loading state
-                    if (Thread.CurrentThread != LoadThread && !ThreadSafety.IsUpdateThread)
-                        throw new InvalidThreadForChildMutationException(LoadState, "not on the load or update threads");
-
-                    break;
-
-                case LoadState.Loaded:
-                    if (!ThreadSafety.IsUpdateThread)
-                        throw new InvalidThreadForChildMutationException(LoadState, "not on the update thread");
-
-                    break;
-            }
         }
 
         #endregion
@@ -1209,6 +1181,8 @@ namespace osu.Framework.Graphics.Containers
 
         public override void ApplyTransformsAt(double time, bool propagateChildren = false)
         {
+            EnsureMutationAllowed();
+
             base.ApplyTransformsAt(time, propagateChildren);
 
             if (!propagateChildren)
@@ -1220,6 +1194,8 @@ namespace osu.Framework.Graphics.Containers
 
         public override void ClearTransformsAfter(double time, bool propagateChildren = false, string targetMember = null)
         {
+            EnsureMutationAllowed();
+
             base.ClearTransformsAfter(time, propagateChildren, targetMember);
 
             if (!propagateChildren)
@@ -1247,6 +1223,8 @@ namespace osu.Framework.Graphics.Containers
 
         public override IDisposable BeginAbsoluteSequence(double newTransformStartTime, bool recursive = true)
         {
+            EnsureMutationAllowed();
+
             var baseDisposalAction = base.BeginAbsoluteSequence(newTransformStartTime, recursive);
             if (!recursive)
                 return baseDisposalAction;
@@ -1264,6 +1242,8 @@ namespace osu.Framework.Graphics.Containers
 
         public override void FinishTransforms(bool propagateChildren = false, string targetMember = null)
         {
+            EnsureMutationAllowed();
+
             base.FinishTransforms(propagateChildren, targetMember);
 
             if (propagateChildren)
@@ -1893,14 +1873,5 @@ namespace osu.Framework.Graphics.Containers
         }
 
         #endregion
-
-        public class InvalidThreadForChildMutationException : InvalidOperationException
-        {
-            public InvalidThreadForChildMutationException(LoadState loadState, string description)
-                : base($"Cannot mutate the children of a {loadState} {nameof(CompositeDrawable)} while {description}. "
-                       + $"Consider using {nameof(Schedule)} to schedule the mutation operation.")
-            {
-            }
-        }
     }
 }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2540,6 +2540,11 @@ namespace osu.Framework.Graphics
 
         internal sealed override void EnsureTransformMutationAllowed() => EnsureMutationAllowed(nameof(Transforms));
 
+        /// <summary>
+        /// Check whether the current thread is valid for operating on thread-safe properties.
+        /// </summary>
+        /// <param name="member">The member to be operated on, used only for describing failures in exception messages.</param>
+        /// <exception cref="InvalidThreadForMutationException">If the current thread is not valid.</exception>
         internal void EnsureMutationAllowed(string member)
         {
             switch (LoadState)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2658,7 +2658,7 @@ namespace osu.Framework.Graphics
         public class InvalidThreadForMutationException : InvalidOperationException
         {
             public InvalidThreadForMutationException(LoadState loadState, string description)
-                : base($"Cannot mutate the children of a {loadState} {nameof(CompositeDrawable)} while {description}. "
+                : base($"Cannot mutate the state of a {loadState} {nameof(Drawable)} while {description}. "
                        + $"Consider using {nameof(Schedule)} to schedule the mutation operation.")
             {
             }

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -372,6 +372,6 @@ namespace osu.Framework.Graphics.Transforms
         /// Check whether this transformable is in a state where mutation of thread-safe properties is allowed.
         /// Will throw on failure.
         /// </summary>
-        internal virtual void EnsureMutationAllowed() { }
+        internal abstract void EnsureMutationAllowed();
     }
 }

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -369,7 +369,7 @@ namespace osu.Framework.Graphics.Transforms
         }
 
         /// <summary>
-        /// Check whether this transformable is in a state where mutation of thread-safe properties is allowed.
+        /// Check whether the current thread is valid for operating on thread-safe properties.
         /// Will throw on failure.
         /// </summary>
         internal abstract void EnsureTransformMutationAllowed();

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -138,6 +138,8 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="toRemove">The <see cref="Transform"/> to remove.</param>
         public void RemoveTransform(Transform toRemove)
         {
+            EnsureMutationAllowed();
+
             getTrackerForGrouping(toRemove.TargetGrouping, false)?.RemoveTransform(toRemove);
 
             toRemove.OnAbort?.Invoke();
@@ -151,8 +153,12 @@ namespace osu.Framework.Graphics.Transforms
         /// An optional <see cref="Transform.TargetMember"/> name of <see cref="Transform"/>s to clear.
         /// Null for clearing all <see cref="Transform"/>s.
         /// </param>
-        public virtual void ClearTransforms(bool propagateChildren = false, string targetMember = null) =>
+        public virtual void ClearTransforms(bool propagateChildren = false, string targetMember = null)
+        {
+            EnsureMutationAllowed();
+
             ClearTransformsAfter(double.NegativeInfinity, propagateChildren, targetMember);
+        }
 
         /// <summary>
         /// Removes <see cref="Transform"/>s that start after <paramref name="time"/>.
@@ -165,6 +171,8 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void ClearTransformsAfter(double time, bool propagateChildren = false, string targetMember = null)
         {
+            EnsureMutationAllowed();
+
             if (targetMember != null)
             {
                 getTrackerFor(targetMember)?.ClearTransformsAfter(time, targetMember);
@@ -187,6 +195,8 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="propagateChildren">Whether to also apply children's <see cref="Transform"/>s at <paramref name="time"/>.</param>
         public virtual void ApplyTransformsAt(double time, bool propagateChildren = false)
         {
+            EnsureMutationAllowed();
+
             if (RemoveCompletedTransforms) throw new InvalidOperationException($"Cannot arbitrarily apply transforms with {nameof(RemoveCompletedTransforms)} active.");
 
             updateTransforms(time);
@@ -202,6 +212,8 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void FinishTransforms(bool propagateChildren = false, string targetMember = null)
         {
+            EnsureMutationAllowed();
+
             if (targetMember != null)
             {
                 getTrackerFor(targetMember)?.FinishTransforms(targetMember);
@@ -230,6 +242,8 @@ namespace osu.Framework.Graphics.Transforms
         /// <returns>An <see cref="InvokeOnDisposal"/> to be used in a using() statement.</returns>
         public IDisposable BeginDelayedSequence(double delay, bool recursive = true)
         {
+            EnsureMutationAllowed();
+
             if (delay == 0)
                 return null;
 
@@ -275,6 +289,8 @@ namespace osu.Framework.Graphics.Transforms
         /// <exception cref="InvalidOperationException">Absolute sequences should never be nested inside another existing sequence.</exception>
         public virtual IDisposable BeginAbsoluteSequence(double newTransformStartTime, bool recursive = true)
         {
+            EnsureMutationAllowed();
+
             double oldTransformDelay = TransformDelay;
             double newTransformDelay = TransformDelay = newTransformStartTime - (Clock?.CurrentTime ?? 0);
 
@@ -317,6 +333,8 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="customTransformID">When not null, the <see cref="Transform.TransformID"/> to assign for ordering.</param>
         public void AddTransform(Transform transform, ulong? customTransformID = null)
         {
+            EnsureMutationAllowed();
+
             if (transform == null)
                 throw new ArgumentNullException(nameof(transform));
 
@@ -349,5 +367,11 @@ namespace osu.Framework.Graphics.Transforms
             if (transform.StartTime < Time.Current || transform.EndTime <= Time.Current)
                 updateTransforms(Time.Current, !RemoveCompletedTransforms && transform.StartTime <= Time.Current);
         }
+
+        /// <summary>
+        /// Check whether this transformable is in a state where mutation of thread-safe properties is allowed.
+        /// Will throw on failure.
+        /// </summary>
+        internal virtual void EnsureMutationAllowed() { }
     }
 }

--- a/osu.Framework/Graphics/Transforms/Transformable.cs
+++ b/osu.Framework/Graphics/Transforms/Transformable.cs
@@ -138,7 +138,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="toRemove">The <see cref="Transform"/> to remove.</param>
         public void RemoveTransform(Transform toRemove)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             getTrackerForGrouping(toRemove.TargetGrouping, false)?.RemoveTransform(toRemove);
 
@@ -155,7 +155,7 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void ClearTransforms(bool propagateChildren = false, string targetMember = null)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             ClearTransformsAfter(double.NegativeInfinity, propagateChildren, targetMember);
         }
@@ -171,7 +171,7 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void ClearTransformsAfter(double time, bool propagateChildren = false, string targetMember = null)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             if (targetMember != null)
             {
@@ -195,7 +195,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="propagateChildren">Whether to also apply children's <see cref="Transform"/>s at <paramref name="time"/>.</param>
         public virtual void ApplyTransformsAt(double time, bool propagateChildren = false)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             if (RemoveCompletedTransforms) throw new InvalidOperationException($"Cannot arbitrarily apply transforms with {nameof(RemoveCompletedTransforms)} active.");
 
@@ -212,7 +212,7 @@ namespace osu.Framework.Graphics.Transforms
         /// </param>
         public virtual void FinishTransforms(bool propagateChildren = false, string targetMember = null)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             if (targetMember != null)
             {
@@ -242,7 +242,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <returns>An <see cref="InvokeOnDisposal"/> to be used in a using() statement.</returns>
         public IDisposable BeginDelayedSequence(double delay, bool recursive = true)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             if (delay == 0)
                 return null;
@@ -289,7 +289,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <exception cref="InvalidOperationException">Absolute sequences should never be nested inside another existing sequence.</exception>
         public virtual IDisposable BeginAbsoluteSequence(double newTransformStartTime, bool recursive = true)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             double oldTransformDelay = TransformDelay;
             double newTransformDelay = TransformDelay = newTransformStartTime - (Clock?.CurrentTime ?? 0);
@@ -333,7 +333,7 @@ namespace osu.Framework.Graphics.Transforms
         /// <param name="customTransformID">When not null, the <see cref="Transform.TransformID"/> to assign for ordering.</param>
         public void AddTransform(Transform transform, ulong? customTransformID = null)
         {
-            EnsureMutationAllowed();
+            EnsureTransformMutationAllowed();
 
             if (transform == null)
                 throw new ArgumentNullException(nameof(transform));
@@ -372,6 +372,6 @@ namespace osu.Framework.Graphics.Transforms
         /// Check whether this transformable is in a state where mutation of thread-safe properties is allowed.
         /// Will throw on failure.
         /// </summary>
-        internal abstract void EnsureMutationAllowed();
+        internal abstract void EnsureTransformMutationAllowed();
     }
 }


### PR DESCRIPTION
Until now, thread safety has been enforced only on child mutation (in `CompositeDrawable`). This extends the same checks to `Transformable`, covering common operations which can lead to game crashes from cross-thread enumeration and other weirdness.

I implemented this out of necessity after crashing twice from cross-thread enumeration in the transform stack and wanting to find the bad actor. It helped locate this and several other cases, which I will be fixing as follow-up pull requests (~2 osu! side, one harder one framework side in `VisibilityContainer`, only affecting custom implementations).

# Breaking changes

## Games will now throw (and crash) immediately on performing cross-thread transform operations

This may mean that as a framework consumer you need to re-think how you are performing operations between drawables. The easiest way to avoid issue is to use `Schedule` to force the target code to be on the correct thread.