### PR TITLE
Fix potential crash on shutdown due to thread race condition

### DIFF
--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -135,7 +135,15 @@ namespace osu.Framework.Platform
             Threads.ForEach(t => t.Exit());
             Threads.Where(t => t.Running).ForEach(t =>
             {
-                if (!t.Thread.Join(thread_join_timeout))
+                var thread = t.Thread;
+
+                if (thread == null)
+                {
+                    // has already been cleaned up (or never started)
+                    return;
+                }
+
+                if (!thread.Join(thread_join_timeout))
                     Logger.Log($"Thread {t.Name} failed to exit in allocated time ({thread_join_timeout}ms).", LoggingTarget.Runtime, LogLevel.Important);
             });
 

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -8,6 +8,7 @@ using osu.Framework.Timing;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Development;
 
@@ -20,7 +21,10 @@ namespace osu.Framework.Threading
 
         internal PerformanceMonitor Monitor { get; }
         public ThrottledFrameClock Clock { get; }
+
+        [CanBeNull]
         public Thread Thread { get; private set; }
+
         public Scheduler Scheduler { get; }
 
         /// <summary>
@@ -240,7 +244,10 @@ namespace osu.Framework.Threading
             paused = false;
 
             if (Thread == null)
+            {
                 createThread();
+                Debug.Assert(Thread != null);
+            }
 
             Thread.Start();
         }


### PR DESCRIPTION
Null checks were missing from `GameThread.Thread` access. It can actually become null on a different thread due to execution completing normally.

I repro'd this on osu!-side, but unfortunately didn't save the log. Should be pretty straight-forward though.