### PR TITLE
Update references to current year

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,7 @@
   <PropertyGroup Label="NuGet">
     <Authors>ppy Pty Ltd</Authors>
     <Company>ppy Pty Ltd</Company>
-    <Copyright>Copyright (c) 2020 ppy Pty Ltd</Copyright>
+    <Copyright>Copyright (c) 2021 ppy Pty Ltd</Copyright>
     <Product>osu!framework</Product>
     <PackageReleaseNotes>Automated release.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/LICENCE
+++ b/LICENCE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 ppy Pty Ltd <contact@ppy.sh>.
+Copyright (c) 2021 ppy Pty Ltd <contact@ppy.sh>.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/osu.Framework/Graphics/Sprites/Sprite.cs
+++ b/osu.Framework/Graphics/Sprites/Sprite.cs
@@ -34,9 +34,6 @@ namespace osu.Framework.Graphics.Sprites
 
         public IShader RoundedTextureShader { get; protected set; }
 
-        [Obsolete("Has no effect. Use TextureRectangle instead.")] // can be removed 20201201
-        public bool WrapTexture { get; set; }
-
         private RectangleF textureRectangle = new RectangleF(0, 0, 1, 1);
 
         /// <summary>


### PR DESCRIPTION
Late for the first release of 2021, but ¯\\\_(ツ)\_/¯

Also trims a stale obsolete member I found along the way.