### PR TITLE
Close MIDI devices when disposing of / disabling MIDI input handler

### DIFF
--- a/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
@@ -44,6 +44,7 @@ namespace osu.Framework.Input.Handlers.Midi
 
                     foreach (var value in openedDevices.Values)
                     {
+                        value.CloseAsync().Wait();
                         value.MessageReceived -= onMidiMessageReceived;
                     }
 

--- a/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
@@ -42,11 +42,8 @@ namespace osu.Framework.Input.Handlers.Midi
                 {
                     scheduledRefreshDevices?.Cancel();
 
-                    foreach (var value in openedDevices.Values)
-                    {
-                        value.CloseAsync().Wait();
-                        value.MessageReceived -= onMidiMessageReceived;
-                    }
+                    foreach (var device in openedDevices.Values)
+                        closeDevice(device);
 
                     openedDevices.Clear();
                 }
@@ -64,15 +61,14 @@ namespace osu.Framework.Input.Handlers.Midi
                 // check removed devices
                 foreach (string key in openedDevices.Keys.ToArray())
                 {
-                    var value = openedDevices[key];
+                    var device = openedDevices[key];
 
                     if (inputs.All(i => i.Id != key))
                     {
-                        value.CloseAsync().Wait();
-                        value.MessageReceived -= onMidiMessageReceived;
+                        closeDevice(device);
                         openedDevices.Remove(key);
 
-                        Logger.Log($"Disconnected MIDI device: {value.Details.Name}");
+                        Logger.Log($"Disconnected MIDI device: {device.Details.Name}");
                     }
                 }
 
@@ -100,6 +96,12 @@ namespace osu.Framework.Input.Handlers.Midi
                 Enabled.Value = false;
                 return false;
             }
+        }
+
+        private void closeDevice(IMidiInput device)
+        {
+            device.CloseAsync().Wait();
+            device.MessageReceived -= onMidiMessageReceived;
         }
 
         private void onMidiMessageReceived(object sender, MidiReceivedEventArgs e)


### PR DESCRIPTION
May (resolve) #4141 

Same to what https://github.com/ppy/osu-framework/pull/4037 does, but this is in the case `MidiInputHandler` is disabled / [disposed of](https://github.com/ppy/osu-framework/blob/9901b9648ef316d62afaeb05cff5b129ea1922d5/osu.Framework/Input/Handlers/InputHandler.cs#L64).

Also, I don't have a MIDI device to test this, so I would appreciate someone testing this for me.