### PR TITLE
Fix `GetLoadableTypes()` extension potentially including null `Type` instances

### DIFF
--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -162,7 +162,9 @@ namespace osu.Framework.Extensions
             }
             catch (ReflectionTypeLoadException e)
             {
-                return e.Types ?? Enumerable.Empty<Type>();
+                // ReSharper disable once ConditionIsAlwaysTrueOrFalse (this may contain null types, as stated in docs.)
+                // https://docs.microsoft.com/en-us/dotnet/api/system.reflection.reflectiontypeloadexception.types?view=net-5.0#property-value
+                return e.Types?.Where(t => t != null) ?? Enumerable.Empty<Type>();
             }
         }
 


### PR DESCRIPTION
As [stated in the docs](https://docs.microsoft.com/en-us/dotnet/api/system.reflection.reflectiontypeloadexception.types?view=net-5.0#property-value), `ReflectionTypeLoadException.`could potentially include null types instances in the array, causing `TestBrowser` to eat a null reference exception as it uses it:
https://github.com/ppy/osu-framework/blob/99a640861a45a4e9f5c2e32c8dffb483c5ecf457/osu.Framework/Testing/TestBrowser.cs#L72 https://github.com/ppy/osu-framework/blob/99a640861a45a4e9f5c2e32c8dffb483c5ecf457/osu.Framework/Testing/TestBrowser.cs#L87

This fixes test browser no longer working for me due to the above.

---

Also not entirely sure how to handle that `ConditionIsAlwaysTrueOrFalse` resharper warning, the array is declared as `Type[]?`, which, if I understand correctly, means it's either a null array, or an array with non-null type elements. But the array indeed had a null `Type` element sticking inside...