### PR TITLE
Add IKeyBinding interface type for flexibility in key bindings

### DIFF
--- a/osu.Framework.Tests/Input/KeybindingInputTest.cs
+++ b/osu.Framework.Tests/Input/KeybindingInputTest.cs
@@ -115,7 +115,7 @@ namespace osu.Framework.Tests.Input
             {
             }
 
-            public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
+            public override IEnumerable<IKeyBinding> DefaultKeyBindings => new[]
             {
                 new KeyBinding(InputKey.Up, TestKeyBinding.Binding1),
                 new KeyBinding(InputKey.Down, TestKeyBinding.Binding2),

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Tests.Visual.Input
 
         private class TestKeyBindingContainer : KeyBindingContainer<TestAction>
         {
-            public override IEnumerable<KeyBinding> DefaultKeyBindings => null;
+            public override IEnumerable<IKeyBinding> DefaultKeyBindings => null;
         }
 
         private enum TestAction

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingInputQueueChange.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingInputQueueChange.cs
@@ -102,7 +102,7 @@ namespace osu.Framework.Tests.Visual.Input
 
         private class TestKeyBindingContainer : KeyBindingContainer<TestAction>
         {
-            public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
+            public override IEnumerable<IKeyBinding> DefaultKeyBindings => new[]
             {
                 new KeyBinding(InputKey.MouseLeft, TestAction.Action1)
             };

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -367,7 +367,7 @@ namespace osu.Framework.Tests.Visual.Input
             {
             }
 
-            public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
+            public override IEnumerable<IKeyBinding> DefaultKeyBindings => new[]
             {
                 new KeyBinding(InputKey.A, TestAction.A),
                 new KeyBinding(InputKey.S, TestAction.S),

--- a/osu.Framework/Input/Bindings/IKeyBinding.cs
+++ b/osu.Framework/Input/Bindings/IKeyBinding.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Input.Bindings
+{
+    /// <summary>
+    /// A binding of a <see cref="Bindings.KeyCombination"/> to an action.
+    /// </summary>
+    public interface IKeyBinding
+    {
+        /// <summary>
+        /// The combination of keys which will trigger this binding.
+        /// </summary>
+        KeyCombination KeyCombination { get; set; }
+
+        /// <summary>
+        /// The resultant action which is triggered by this binding.
+        /// </summary>
+        object Action { get; set; }
+
+        /// <summary>
+        /// Get the action associated with this binding, cast to the required enum type.
+        /// </summary>
+        /// <typeparam name="T">The enum type.</typeparam>
+        /// <returns>A cast <typeparamref name="T"/> representation of <see cref="KeyBinding.Action"/>.</returns>
+        T GetAction<T>()
+            where T : Enum;
+    }
+}

--- a/osu.Framework/Input/Bindings/IKeyBinding.cs
+++ b/osu.Framework/Input/Bindings/IKeyBinding.cs
@@ -15,6 +15,7 @@ namespace osu.Framework.Input.Bindings
 
         /// <summary>
         /// The resultant action which is triggered by this binding.
+        /// Generally an enum type, but may also be an int representing an enum (converted via <see cref="KeyBindingExtensions.GetAction{T}"/>
         /// </summary>
         object Action { get; set; }
     }

--- a/osu.Framework/Input/Bindings/IKeyBinding.cs
+++ b/osu.Framework/Input/Bindings/IKeyBinding.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-
 namespace osu.Framework.Input.Bindings
 {
     /// <summary>
@@ -26,6 +24,6 @@ namespace osu.Framework.Input.Bindings
         /// <typeparam name="T">The enum type.</typeparam>
         /// <returns>A cast <typeparamref name="T"/> representation of <see cref="KeyBinding.Action"/>.</returns>
         T GetAction<T>()
-            where T : Enum;
+            where T : struct;
     }
 }

--- a/osu.Framework/Input/Bindings/IKeyBinding.cs
+++ b/osu.Framework/Input/Bindings/IKeyBinding.cs
@@ -17,13 +17,5 @@ namespace osu.Framework.Input.Bindings
         /// The resultant action which is triggered by this binding.
         /// </summary>
         object Action { get; set; }
-
-        /// <summary>
-        /// Get the action associated with this binding, cast to the required enum type.
-        /// </summary>
-        /// <typeparam name="T">The enum type.</typeparam>
-        /// <returns>A cast <typeparamref name="T"/> representation of <see cref="KeyBinding.Action"/>.</returns>
-        T GetAction<T>()
-            where T : struct;
     }
 }

--- a/osu.Framework/Input/Bindings/KeyBinding.cs
+++ b/osu.Framework/Input/Bindings/KeyBinding.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-
 namespace osu.Framework.Input.Bindings
 {
     public class KeyBinding : IKeyBinding
@@ -41,7 +39,7 @@ namespace osu.Framework.Input.Bindings
         }
 
         public virtual T GetAction<T>()
-            where T : Enum => (T)Action;
+            where T : struct => (T)Action;
 
         public override string ToString() => $"{KeyCombination}=>{Action}";
     }

--- a/osu.Framework/Input/Bindings/KeyBinding.cs
+++ b/osu.Framework/Input/Bindings/KeyBinding.cs
@@ -38,9 +38,6 @@ namespace osu.Framework.Input.Bindings
         {
         }
 
-        public virtual T GetAction<T>()
-            where T : struct => (T)Action;
-
         public override string ToString() => $"{KeyCombination}=>{Action}";
     }
 }

--- a/osu.Framework/Input/Bindings/KeyBinding.cs
+++ b/osu.Framework/Input/Bindings/KeyBinding.cs
@@ -1,22 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+
 namespace osu.Framework.Input.Bindings
 {
-    /// <summary>
-    /// A binding of a <see cref="Bindings.KeyCombination"/> to an action.
-    /// </summary>
-    public class KeyBinding
+    public class KeyBinding : IKeyBinding
     {
-        /// <summary>
-        /// The combination of keys which will trigger this binding.
-        /// </summary>
-        public KeyCombination KeyCombination;
+        public KeyCombination KeyCombination { get; set; }
 
-        /// <summary>
-        /// The resultant action which is triggered by this binding.
-        /// </summary>
-        public object Action;
+        public object Action { get; set; }
 
         /// <summary>
         /// Construct a new instance.
@@ -47,12 +40,8 @@ namespace osu.Framework.Input.Bindings
         {
         }
 
-        /// <summary>
-        /// Get the action associated with this binding, cast to the required enum type.
-        /// </summary>
-        /// <typeparam name="T">The enum type.</typeparam>
-        /// <returns>A cast <typeparamref name="T"/> representation of <see cref="Action"/>.</returns>
-        public virtual T GetAction<T>() => (T)Action;
+        public virtual T GetAction<T>()
+            where T : Enum => (T)Action;
 
         public override string ToString() => $"{KeyCombination}=>{Action}";
     }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Input.Bindings
             this.matchingMode = matchingMode;
         }
 
-        private readonly List<KeyBinding> pressedBindings = new List<KeyBinding>();
+        private readonly List<IKeyBinding> pressedBindings = new List<IKeyBinding>();
 
         private readonly List<T> pressedActions = new List<T>();
 
@@ -46,7 +46,7 @@ namespace osu.Framework.Input.Bindings
         /// </summary>
         public IEnumerable<T> PressedActions => pressedActions;
 
-        private readonly Dictionary<KeyBinding, List<Drawable>> keyBindingQueues = new Dictionary<KeyBinding, List<Drawable>>();
+        private readonly Dictionary<IKeyBinding, List<Drawable>> keyBindingQueues = new Dictionary<IKeyBinding, List<Drawable>>();
         private readonly List<Drawable> queue = new List<Drawable>();
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace osu.Framework.Input.Bindings
             var pressedCombination = KeyCombination.FromInputState(state, scrollDelta);
 
             bool handled = false;
-            var bindings = (repeat ? KeyBindings : KeyBindings?.Except(pressedBindings)) ?? Enumerable.Empty<KeyBinding>();
+            var bindings = (repeat ? KeyBindings : KeyBindings?.Except(pressedBindings)) ?? Enumerable.Empty<IKeyBinding>();
             var newlyPressed = bindings.Where(m =>
                 m.KeyCombination.Keys.Contains(newKey) // only handle bindings matching current key (not required for correct logic)
                 && m.KeyCombination.IsPressed(pressedCombination, matchingMode));
@@ -306,7 +306,7 @@ namespace osu.Framework.Input.Bindings
             PropagatePressed(KeyBindingInputQueue, pressed);
         }
 
-        private List<Drawable> getInputQueue(KeyBinding binding, bool rebuildIfEmpty = false)
+        private List<Drawable> getInputQueue(IKeyBinding binding, bool rebuildIfEmpty = false)
         {
             if (!keyBindingQueues.ContainsKey(binding))
                 keyBindingQueues.Add(binding, new List<Drawable>());
@@ -325,9 +325,9 @@ namespace osu.Framework.Input.Bindings
     /// </summary>
     public abstract class KeyBindingContainer : Container
     {
-        protected IEnumerable<KeyBinding> KeyBindings;
+        protected IEnumerable<IKeyBinding> KeyBindings;
 
-        public abstract IEnumerable<KeyBinding> DefaultKeyBindings { get; }
+        public abstract IEnumerable<IKeyBinding> DefaultKeyBindings { get; }
 
         protected override void LoadComplete()
         {

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -168,7 +168,7 @@ namespace osu.Framework.Input.Bindings
             {
                 // if the current key pressed was a modifier, only handle modifier-only bindings.
                 // lambda expression is used so that the delegate is cached (see: https://github.com/dotnet/roslyn/issues/5835)
-                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(key => KeyCombination.IsModifierKey(key)));
+                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(KeyCombination.IsModifierKey));
             }
 
             // we want to always handle bindings with more keys before bindings with less.

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -168,7 +168,7 @@ namespace osu.Framework.Input.Bindings
             {
                 // if the current key pressed was a modifier, only handle modifier-only bindings.
                 // lambda expression is used so that the delegate is cached (see: https://github.com/dotnet/roslyn/issues/5835)
-                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(KeyCombination.IsModifierKey));
+                newlyPressed = newlyPressed.Where(b => b.KeyCombination.Keys.All(key => KeyCombination.IsModifierKey(key)));
             }
 
             // we want to always handle bindings with more keys before bindings with less.

--- a/osu.Framework/Input/Bindings/KeyBindingExtensions.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingExtensions.cs
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Input.Bindings
+{
+    public static class KeyBindingExtensions
+    {
+        /// <summary>
+        /// Get the action associated with this binding, cast to the required enum type.
+        /// </summary>
+        /// <typeparam name="T">The enum type.</typeparam>
+        /// <returns>A cast <typeparamref name="T"/> representation of <see cref="KeyBinding.Action"/>.</returns>
+        public static T GetAction<T>(this IKeyBinding obj)
+            where T : struct
+        {
+            return (T)obj.Action;
+        }
+    }
+}

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Input
 {
     internal class FrameworkActionContainer : KeyBindingContainer<FrameworkAction>
     {
-        public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
+        public override IEnumerable<IKeyBinding> DefaultKeyBindings => new[]
         {
             new KeyBinding(new[] { InputKey.Control, InputKey.F1 }, FrameworkAction.ToggleDrawVisualiser),
             new KeyBinding(new[] { InputKey.Control, InputKey.F2 }, FrameworkAction.ToggleGlobalStatistics),

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -24,7 +24,7 @@ namespace osu.Framework.Input
         {
         }
 
-        public override IEnumerable<KeyBinding> DefaultKeyBindings => host.PlatformKeyBindings;
+        public override IEnumerable<IKeyBinding> DefaultKeyBindings => host.PlatformKeyBindings;
 
         protected override bool Prioritised => true;
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -377,7 +377,7 @@ namespace osu.Framework.Testing
             return base.OnKeyDown(e);
         }
 
-        public override IEnumerable<KeyBinding> DefaultKeyBindings => new[]
+        public override IEnumerable<IKeyBinding> DefaultKeyBindings => new[]
         {
             new KeyBinding(new[] { InputKey.Control, InputKey.F }, TestBrowserAction.Search),
             new KeyBinding(new[] { InputKey.Control, InputKey.R }, TestBrowserAction.Reload), // for macOS


### PR DESCRIPTION
This is a prerequisite for my realm `KeyBindingStore` implementation.

When working with realm, it is beneficial to have interfacing defining the underlying model types due to the restrictions on inheritance. I think in general having interfaces for model types like this is a good step forward, regardless.

Probably resulting in a breaking change for rulesets, but not sure that is avoidable (or an issue at this point in development).