### PR TITLE
Run initial ReloadMappings call during async load

### DIFF
--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -329,9 +330,9 @@ namespace osu.Framework.Input.Bindings
 
         public abstract IEnumerable<KeyBinding> DefaultKeyBindings { get; }
 
-        protected override void LoadComplete()
+        protected override void LoadAsyncComplete()
         {
-            base.LoadComplete();
+            base.LoadAsyncComplete();
             ReloadMappings();
         }
 

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;


### PR DESCRIPTION
Fixes a case of potentially querying a data source in LoadComplete causing an unknown overhead. No real reason not to run this initial call at the end of the async load process. Note that this can't go into the `load()` method directly as overridden implementations of this may depend on dependencies that are not yet available.