### PR TITLE
Add global.json to templates

### DIFF
--- a/osu.Framework.Templates/templates/template-empty/global.json
+++ b/osu.Framework.Templates/templates/template-empty/global.json
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "allowPrerelease": false,
+    "rollForward": "minor",
+    "version": "3.1.100"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.Traversal": "3.0.2"
+  }
+}

--- a/osu.Framework.Templates/templates/template-flappy/global.json
+++ b/osu.Framework.Templates/templates/template-flappy/global.json
@@ -1,0 +1,10 @@
+{
+  "sdk": {
+    "allowPrerelease": false,
+    "rollForward": "minor",
+    "version": "3.1.100"
+  },
+  "msbuild-sdks": {
+    "Microsoft.Build.Traversal": "3.0.2"
+  }
+}


### PR DESCRIPTION
Closes #4138

Fixes dynamic compilation failing in templates due to MSBuild selecting the wrong .NET SDK version in `RoslynTypeReferenceBuilder` when user has newer versions installed.
Files are the same as those present in `osu-framework` and `osu`.

As mentioned in https://github.com/ppy/osu-framework/issues/4138#issuecomment-755862428, it would be nice to see these files as well as the templates as a whole addressed upon migration to .NET 5