### PR TITLE
Add a method of retrieving sample channels which can layer multiple playbacks

### DIFF
--- a/osu.Framework.Tests/Audio/AudioComponentTest.cs
+++ b/osu.Framework.Tests/Audio/AudioComponentTest.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
 using osu.Framework.IO.Stores;
 using osu.Framework.Threading;

--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -93,7 +93,7 @@ namespace osu.Framework.Tests.Audio
         [Test]
         public void TestLayeredPlaybackConcurrency()
         {
-            channel.PlayStopsPreviousPlayback = false;
+            channel.ConcurrentPlayback = true;
 
             Assert.Throws<InvalidOperationException>(() => channel.Looping = true);
             Assert.Throws<ArgumentException>(() => channel.Play(false));

--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -77,6 +77,34 @@ namespace osu.Framework.Tests.Audio
             Assert.IsFalse(channel.Playing);
         }
 
+        [Test]
+        public void TestStandardPlaybackConcurrency()
+        {
+            channel.Play();
+            updateSample();
+            channel.Play();
+            updateSample();
+            channel.Play();
+            updateSample();
+
+            Assert.AreEqual(1, Bass.SampleGetChannels(sample.SampleId).Length);
+        }
+
+        [Test]
+        public void TestLayeredPlaybackConcurrency()
+        {
+            channel.PlayStopsPreviousPlayback = false;
+
+            channel.Play();
+            updateSample();
+            channel.Play();
+            updateSample();
+            channel.Play();
+            updateSample();
+
+            Assert.AreEqual(Sample.DEFAULT_CONCURRENCY, Bass.SampleGetChannels(sample.SampleId).Length);
+        }
+
         private void updateSample() => runOnAudioThread(() =>
         {
             sample.Update();

--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -95,6 +95,10 @@ namespace osu.Framework.Tests.Audio
         {
             channel.PlayStopsPreviousPlayback = false;
 
+            Assert.Throws<InvalidOperationException>(() => channel.Looping = true);
+            Assert.Throws<ArgumentException>(() => channel.Play(false));
+            Assert.Throws<InvalidOperationException>(() => channel.Stop());
+
             channel.Play();
             updateSample();
             channel.Play();

--- a/osu.Framework.Tests/Visual/Audio/TestSceneSampleAmplitudes.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneSampleAmplitudes.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Containers;

--- a/osu.Framework.Tests/Visual/Audio/TestSceneSamples.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneSamples.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
-using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;

--- a/osu.Framework.Tests/Visual/Audio/TestSceneSamples.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneSamples.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;

--- a/osu.Framework/Audio/Sample/ISampleChannel.cs
+++ b/osu.Framework/Audio/Sample/ISampleChannel.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Audio.Sample
     {
         /// <summary>
         /// Start a new playback of this sample.
-        /// Note that this will not stop previous playbacks (but concurrency will be limited by the source <see cref="ISampleStore.PlaybackConcurrency"/>.
+        /// Note that this will not stop previous playbacks unless <see cref="Looping"/> is true (but concurrency will be limited by the source <see cref="ISampleStore.PlaybackConcurrency"/>.
         /// </summary>
         /// <param name="restart">Whether to restart the sample from the beginning.</param>
         void Play(bool restart = true);

--- a/osu.Framework/Audio/Sample/ISampleChannel.cs
+++ b/osu.Framework/Audio/Sample/ISampleChannel.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Audio.Track;
-
 namespace osu.Framework.Audio.Sample
 {
     /// <summary>

--- a/osu.Framework/Audio/Sample/ISampleChannel.cs
+++ b/osu.Framework/Audio/Sample/ISampleChannel.cs
@@ -9,10 +9,9 @@ namespace osu.Framework.Audio.Sample
     public interface ISampleChannel : IHasAmplitudes
     {
         /// <summary>
-        /// Start a new playback of this sample.
-        /// Note that this will not stop previous playbacks unless <see cref="Looping"/> is true (but concurrency will be limited by the source <see cref="ISampleStore.PlaybackConcurrency"/>.
+        /// Start a playback of this sample.
         /// </summary>
-        /// <param name="restart">Whether to restart the sample from the beginning.</param>
+        /// <param name="restart">Whether to restart the sample from the beginning. If true, any existing playback of the channel will be stopped.</param>
         void Play(bool restart = true);
 
         /// <summary>

--- a/osu.Framework/Audio/Sample/ISampleChannel.cs
+++ b/osu.Framework/Audio/Sample/ISampleChannel.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Audio.Sample
         void Play(bool restart = true);
 
         /// <summary>
-        /// Stop playback.
+        /// Stop playback and reset position to beginning of sample.
         /// </summary>
         void Stop();
 

--- a/osu.Framework/Audio/Sample/ISampleChannel.cs
+++ b/osu.Framework/Audio/Sample/ISampleChannel.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Audio.Track;
+
 namespace osu.Framework.Audio.Sample
 {
     /// <summary>
@@ -9,7 +11,8 @@ namespace osu.Framework.Audio.Sample
     public interface ISampleChannel : IHasAmplitudes
     {
         /// <summary>
-        /// Start playback.
+        /// Start a new playback of this sample.
+        /// Note that this will not stop previous playbacks (but concurrency will be limited by the source <see cref="ISampleStore.PlaybackConcurrency"/>.
         /// </summary>
         /// <param name="restart">Whether to restart the sample from the beginning.</param>
         void Play(bool restart = true);

--- a/osu.Framework/Audio/Sample/ISampleStore.cs
+++ b/osu.Framework/Audio/Sample/ISampleStore.cs
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Audio.Sample;
-
-namespace osu.Framework.Audio.Track
+namespace osu.Framework.Audio.Sample
 {
     public interface ISampleStore : IAdjustableResourceStore<SampleChannel>
     {

--- a/osu.Framework/Audio/Sample/ISampleStore.cs
+++ b/osu.Framework/Audio/Sample/ISampleStore.cs
@@ -9,5 +9,19 @@ namespace osu.Framework.Audio.Sample
         /// How many instances of a single sample should be allowed to playback concurrently before stopping the longest playing.
         /// </summary>
         int PlaybackConcurrency { get; set; }
+
+        /// <summary>
+        /// Retrieves a new channel for the specified sample.
+        /// </summary>
+        /// <param name="sampleName">The name of the sample.</param>
+        /// <returns>A new channel for the specified sample..</returns>
+        new SampleChannel Get(string sampleName);
+
+        /// <summary>
+        /// Retrieves a new channel for the specified sample which will play a new layered instance when <see cref="SampleChannel.Play"/> is invoked.
+        /// </summary>
+        /// <param name="sampleName">The name of the sample.</param>
+        /// <returns>A new channel for the specified sample.</returns>
+        SampleChannel GetLayerable(string sampleName);
     }
 }

--- a/osu.Framework/Audio/Sample/ISampleStore.cs
+++ b/osu.Framework/Audio/Sample/ISampleStore.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Audio.Sample
         new SampleChannel Get(string sampleName);
 
         /// <summary>
-        /// Retrieves a new channel for the specified sample which will play a new layered instance when <see cref="SampleChannel.Play"/> is invoked.
+        /// Retrieves a new channel for the specified sample which will play a new layered instance when <see cref="SampleChannel.Play"/> is invoked (up to <see cref="PlaybackConcurrency"/> concurrent playbacks).
         /// </summary>
         /// <param name="sampleName">The name of the sample.</param>
         /// <returns>A new channel for the specified sample.</returns>

--- a/osu.Framework/Audio/Sample/SampleBass.cs
+++ b/osu.Framework/Audio/Sample/SampleBass.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Audio.Sample
 {
     internal sealed class SampleBass : Sample, IBassAudio
     {
-        internal volatile int SampleId;
+        internal int SampleId { get; private set; }
 
         public override bool IsLoaded => SampleId != 0;
 
@@ -39,6 +39,8 @@ namespace osu.Framework.Audio.Sample
             if (IsLoaded)
             {
                 Bass.SampleFree(SampleId);
+                SampleId = 0;
+
                 memoryLease?.Dispose();
             }
 

--- a/osu.Framework/Audio/Sample/SampleBass.cs
+++ b/osu.Framework/Audio/Sample/SampleBass.cs
@@ -12,9 +12,9 @@ namespace osu.Framework.Audio.Sample
 {
     internal sealed class SampleBass : Sample, IBassAudio
     {
-        private volatile int sampleId;
+        internal volatile int SampleId;
 
-        public override bool IsLoaded => sampleId != 0;
+        public override bool IsLoaded => SampleId != 0;
 
         private NativeMemoryTracker.NativeMemoryLease memoryLease;
 
@@ -28,7 +28,7 @@ namespace osu.Framework.Audio.Sample
             {
                 EnqueueAction(() =>
                 {
-                    sampleId = loadSample(data);
+                    SampleId = loadSample(data);
                     memoryLease = NativeMemoryTracker.AddMemory(this, data.Length);
                 });
             }
@@ -38,7 +38,7 @@ namespace osu.Framework.Audio.Sample
         {
             if (IsLoaded)
             {
-                Bass.SampleFree(sampleId);
+                Bass.SampleFree(SampleId);
                 memoryLease?.Dispose();
             }
 
@@ -51,11 +51,11 @@ namespace osu.Framework.Audio.Sample
                 return;
 
             // counter-intuitively, this is the correct API to use to migrate a sample to a new device.
-            Bass.ChannelSetDevice(sampleId, deviceIndex);
+            Bass.ChannelSetDevice(SampleId, deviceIndex);
             BassUtils.CheckFaulted(true);
         }
 
-        public int CreateChannel() => Bass.SampleGetChannel(sampleId);
+        public int CreateChannel() => Bass.SampleGetChannel(SampleId);
 
         private int loadSample(byte[] data)
         {

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -11,6 +11,11 @@ namespace osu.Framework.Audio.Sample
     {
         protected bool WasStarted;
 
+        /// <summary>
+        /// Whether calling <see cref="Play"/> should forcefully stop an existing playback of this channel.
+        /// </summary>
+        internal bool PlayStopsPreviousPlayback;
+
         protected Sample Sample { get; set; }
 
         private readonly Action<SampleChannel> onPlay;
@@ -23,6 +28,9 @@ namespace osu.Framework.Audio.Sample
 
         public virtual void Play(bool restart = true)
         {
+            if (PlayStopsPreviousPlayback && Looping)
+                throw new InvalidOperationException($"Cannot play a layered sample playback if {nameof(Looping)} is enabled.");
+
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not play disposed samples.");
 
@@ -32,6 +40,9 @@ namespace osu.Framework.Audio.Sample
 
         public virtual void Stop()
         {
+            if (PlayStopsPreviousPlayback)
+                throw new InvalidOperationException($"Cannot call {nameof(Stop)} on a layered sample playback.");
+
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not stop disposed samples.");
         }

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -13,6 +13,7 @@ namespace osu.Framework.Audio.Sample
 
         /// <summary>
         /// Whether calling <see cref="Play"/> should forcefully stop an existing playback of this channel.
+        /// Setting this to false will result in "layered" playback, with each call to Play triggering a new overlapping playback.
         /// </summary>
         internal bool PlayStopsPreviousPlayback = true;
 
@@ -28,8 +29,14 @@ namespace osu.Framework.Audio.Sample
 
         public virtual void Play(bool restart = true)
         {
-            if (!PlayStopsPreviousPlayback && Looping)
-                throw new InvalidOperationException($"Cannot play a layered sample playback if {nameof(Looping)} is enabled.");
+            if (!PlayStopsPreviousPlayback)
+            {
+                if (Looping)
+                    throw new InvalidOperationException($"Cannot play a layered sample playback if {nameof(Looping)} is enabled.");
+
+                if (!restart)
+                    throw new ArgumentException("Cannot resume playback of a layered sample playback.", nameof(restart));
+            }
 
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not play disposed samples.");

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Audio.Sample
 
         protected override void Dispose(bool disposing)
         {
-            if (!IsDisposed)
+            if (!IsDisposed && PlayStopsPreviousPlayback)
                 Stop();
 
             base.Dispose(disposing);

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -12,10 +12,9 @@ namespace osu.Framework.Audio.Sample
         protected bool WasStarted;
 
         /// <summary>
-        /// Whether calling <see cref="Play"/> should forcefully stop an existing playback of this channel.
-        /// Setting this to false will result in "layered" playback, with each call to Play triggering a new overlapping playback.
+        /// Whether each invocation of <see cref="Play"/> results in a new (potentially concurrent) playback.
         /// </summary>
-        internal bool PlayStopsPreviousPlayback = true;
+        internal bool ConcurrentPlayback;
 
         protected Sample Sample { get; set; }
 
@@ -29,7 +28,7 @@ namespace osu.Framework.Audio.Sample
 
         public virtual void Play(bool restart = true)
         {
-            if (!PlayStopsPreviousPlayback)
+            if (ConcurrentPlayback)
             {
                 if (Looping)
                     throw new InvalidOperationException($"Cannot play a layered sample playback if {nameof(Looping)} is enabled.");
@@ -47,7 +46,7 @@ namespace osu.Framework.Audio.Sample
 
         public virtual void Stop()
         {
-            if (!PlayStopsPreviousPlayback)
+            if (ConcurrentPlayback)
                 throw new InvalidOperationException($"Cannot call {nameof(Stop)} on a layered sample playback.");
 
             if (IsDisposed)
@@ -56,7 +55,7 @@ namespace osu.Framework.Audio.Sample
 
         protected override void Dispose(bool disposing)
         {
-            if (!IsDisposed && PlayStopsPreviousPlayback)
+            if (!IsDisposed && !ConcurrentPlayback)
                 Stop();
 
             base.Dispose(disposing);

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Audio.Sample
         /// <summary>
         /// Whether calling <see cref="Play"/> should forcefully stop an existing playback of this channel.
         /// </summary>
-        internal bool PlayStopsPreviousPlayback;
+        internal bool PlayStopsPreviousPlayback = true;
 
         protected Sample Sample { get; set; }
 
@@ -28,7 +28,7 @@ namespace osu.Framework.Audio.Sample
 
         public virtual void Play(bool restart = true)
         {
-            if (PlayStopsPreviousPlayback && Looping)
+            if (!PlayStopsPreviousPlayback && Looping)
                 throw new InvalidOperationException($"Cannot play a layered sample playback if {nameof(Looping)} is enabled.");
 
             if (IsDisposed)
@@ -40,7 +40,7 @@ namespace osu.Framework.Audio.Sample
 
         public virtual void Stop()
         {
-            if (PlayStopsPreviousPlayback)
+            if (!PlayStopsPreviousPlayback)
                 throw new InvalidOperationException($"Cannot call {nameof(Stop)} on a layered sample playback.");
 
             if (IsDisposed)

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -78,9 +78,7 @@ namespace osu.Framework.Audio.Sample
                     if (!restart)
                         return;
 
-                    // in the case of looping samples, we don't want to end up with multiple underlying channels playing, so the previous instance should be stopped.
-                    if (Looping)
-                        Stop();
+                    Stop();
                 }
 
                 channel = ((SampleBass)Sample).CreateChannel();

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -78,7 +78,8 @@ namespace osu.Framework.Audio.Sample
                     if (!restart)
                         return;
 
-                    Stop();
+                    if (PlayStopsPreviousPlayback)
+                        Stop();
                 }
 
                 channel = ((SampleBass)Sample).CreateChannel();

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -48,7 +48,7 @@ namespace osu.Framework.Audio.Sample
             relativeFrequencyHandler.SetFrequency(AggregateFrequency.Value);
         }
 
-        public sealed override bool Looping
+        public override bool Looping
         {
             get => base.Looping;
             set

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -70,9 +70,9 @@ namespace osu.Framework.Audio.Sample
                     return;
                 }
 
-                bool currentChannelPlaying = Bass.ChannelIsActive(channel) == PlaybackState.Playing;
+                bool existingChannelAvailable = Bass.ChannelIsActive(channel) != PlaybackState.Stopped;
 
-                if (currentChannelPlaying)
+                if (existingChannelAvailable)
                 {
                     // if restart is not requested and the sample is currently playing, nothing needs to be done.
                     if (!restart)

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -70,10 +70,9 @@ namespace osu.Framework.Audio.Sample
                     return;
                 }
 
-                // Free previous channels as we're creating a new channel for every playback, since old channels
-                // may be overriden when too many other channels are created from the same sample.
-                if (Bass.ChannelIsActive(channel) != PlaybackState.Stopped)
-                    Bass.ChannelStop(channel);
+                // if restart is not requested and the sample is currently playing, nothing needs to be done.
+                if (!restart && Bass.ChannelIsActive(channel) == PlaybackState.Playing)
+                    return;
 
                 channel = ((SampleBass)Sample).CreateChannel();
 

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -48,11 +48,14 @@ namespace osu.Framework.Audio.Sample
             relativeFrequencyHandler.SetFrequency(AggregateFrequency.Value);
         }
 
-        public override bool Looping
+        public sealed override bool Looping
         {
             get => base.Looping;
             set
             {
+                if (!PlayStopsPreviousPlayback)
+                    throw new InvalidOperationException($"Cannot change {nameof(Looping)} on a sample layered sample");
+
                 base.Looping = value;
                 setLoopFlag(Looping);
             }

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -70,9 +70,18 @@ namespace osu.Framework.Audio.Sample
                     return;
                 }
 
-                // if restart is not requested and the sample is currently playing, nothing needs to be done.
-                if (!restart && Bass.ChannelIsActive(channel) == PlaybackState.Playing)
-                    return;
+                bool currentChannelPlaying = Bass.ChannelIsActive(channel) == PlaybackState.Playing;
+
+                if (currentChannelPlaying)
+                {
+                    // if restart is not requested and the sample is currently playing, nothing needs to be done.
+                    if (!restart)
+                        return;
+
+                    // in the case of looping samples, we don't want to end up with multiple underlying channels playing, so the previous instance should be stopped.
+                    if (Looping)
+                        Stop();
+                }
 
                 channel = ((SampleBass)Sample).CreateChannel();
 

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Audio.Sample
             get => base.Looping;
             set
             {
-                if (!PlayStopsPreviousPlayback)
+                if (ConcurrentPlayback)
                     throw new InvalidOperationException($"Cannot change {nameof(Looping)} on a sample layered sample");
 
                 base.Looping = value;
@@ -81,7 +81,7 @@ namespace osu.Framework.Audio.Sample
                     if (!restart)
                         return;
 
-                    if (PlayStopsPreviousPlayback)
+                    if (!ConcurrentPlayback)
                         Stop();
                 }
 

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -5,11 +5,10 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using osu.Framework.IO.Stores;
-using osu.Framework.Statistics;
 using System.Linq;
 using System.Threading.Tasks;
-using osu.Framework.Audio.Track;
+using osu.Framework.IO.Stores;
+using osu.Framework.Statistics;
 
 namespace osu.Framework.Audio.Sample
 {

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Audio.Sample
         {
             var channel = Get(sampleName);
 
-            channel.PlayStopsPreviousPlayback = true;
+            channel.PlayStopsPreviousPlayback = false;
 
             return channel;
         }

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -55,6 +55,15 @@ namespace osu.Framework.Audio.Sample
             }
         }
 
+        public SampleChannel GetLayerable(string sampleName)
+        {
+            var channel = Get(sampleName);
+
+            channel.PlayStopsPreviousPlayback = true;
+
+            return channel;
+        }
+
         public Task<SampleChannel> GetAsync(string name) => Task.Run(() => Get(name));
 
         internal override void UpdateDevice(int deviceIndex)

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Audio.Sample
         {
             var channel = Get(sampleName);
 
-            channel.PlayStopsPreviousPlayback = false;
+            channel.ConcurrentPlayback = true;
 
             return channel;
         }


### PR DESCRIPTION
Currently retrieving a sample channel and attempting to play it back will stop previous playback. This isn't always what we want. This adds a new flow for retrieving samples which will automatically layer, up to playback concurrency limits.

- [x] Depends on #4139