### PR TITLE
Attempt to fix macOS crash

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -219,8 +219,9 @@ namespace osu.Framework.Graphics.OpenGL
                     break;
             }
 
-            Array.Clear(last_bound_texture, 0, last_bound_texture.Length);
-            Array.Clear(last_bound_texture_is_atlas, 0, last_bound_texture_is_atlas.Length);
+            last_bound_texture.AsSpan().Clear();
+            last_bound_texture_is_atlas.AsSpan().Clear();
+            last_bound_buffers.AsSpan().Clear();
         }
 
         private static ClearInfo currentClearInfo;


### PR DESCRIPTION
I think this is harmless to get in without testing if it fixes the crash. Some drivers may reset the internal GL bind states on a new frame, so `last_bound_buffers` should be reset on our side to prevent early returns.

Crash reported by @peppy:
```
Thread 37 Crashed:
0   libsystem_kernel.dylib            0x00007fff202ec462 __pthread_kill + 10
1   libsystem_pthread.dylib           0x00007fff2031a610 pthread_kill + 263
2   libsystem_c.dylib                 0x00007fff2026d720 abort + 120
3   libGPUSupportMercury.dylib        0x00007fff46bf60a8 gpusGenerateCrashLog.cold.1 + 95
4   libGPUSupportMercury.dylib        0x00007fff46bed20d gpusGenerateCrashLog + 89
5   com.apple.AMDRadeonX4000GLDriver    0x0000000113651622 gpusKillClientExt + 9
6   libGPUSupportMercury.dylib        0x00007fff46bee5cf gpusSubmitDataBuffers + 164
7   com.apple.AMDRadeonX4000GLDriver    0x000000011362be87 glrATI_Hwl_SubmitPacketsWithToken + 91
8   com.apple.AMDRadeonX4000GLDriver    0x0000000113631057 glrATI_SI_BindKernelResources + 92
9   com.apple.AMDRadeonX4000GLDriver    0x0000000113631ccd glrATI_SI_ResourceMgrValidateConstantState + 1038
10  com.apple.AMDRadeonX4000GLDriver    0x000000011367debc glrdATI_VI_RenderIndexed + 168
11  com.apple.AMDRadeonX4000GLDriver    0x0000000113679193 glrdAMD_RenderVertexArray + 3205
12  GLEngine                          0x00007fff6cae85a3 glDrawElements_ACC_Exec + 473
13  ???                               0x000000011a968461 0 + 4741039201
```
I've traced this down quite far, it seems related to a [bugzilla report](https://bugzilla.mozilla.org/show_bug.cgi?id=1576767) but it's hard to say if it comes as a result of Apple reportedly [fixing the bugzilla issue in 11.1](https://github.com/steven-michaud/PatchBug1576767/issues/2#issuecomment-753017240) and breaking something else in the process, or if it's a completely different issue altogether - we crash in `glDrawElements` whereas Firefox crashes in `glDeleteTexture` / swapbuffers).

The change from `Array.Clear()` to `.AsSpan().Clear()` is intentional as `Span.Clear()` is faster than `Array.Clear()` (though a very small improvement in the grand scheme of things):

```csharp
[Params(2, 4, 8, 16, 32)]
public int N { get; set; }

private int[] array = new int[3];

[GlobalSetup]
public void GlobalSetup()
{
    array = new int[N];
}

[Benchmark(Baseline = true)]
public int[] ArrayClear()
{
    Array.Clear(array, 0, array.Length);
    return array;
}

[Benchmark]
public int[] SpanClear()
{
    array.AsSpan().Clear();
    return array;
}
```
```
|     Method |  N |      Mean |     Error |    StdDev | Ratio |
|----------- |--- |----------:|----------:|----------:|------:|
| ArrayClear |  2 | 13.076 ns | 0.1193 ns | 0.1116 ns |  1.00 |
|  SpanClear |  2 |  5.692 ns | 0.0004 ns | 0.0003 ns |  0.44 |
|            |    |           |           |           |       |
| ArrayClear |  4 | 13.745 ns | 0.2229 ns | 0.2085 ns |  1.00 |
|  SpanClear |  4 |  5.747 ns | 0.0654 ns | 0.0612 ns |  0.42 |
|            |    |           |           |           |       |
| ArrayClear |  8 | 12.804 ns | 0.3272 ns | 0.3769 ns |  1.00 |
|  SpanClear |  8 |  5.153 ns | 0.0011 ns | 0.0009 ns |  0.40 |
|            |    |           |           |           |       |
| ArrayClear | 16 | 13.070 ns | 0.3304 ns | 0.3393 ns |  1.00 |
|  SpanClear | 16 |  5.158 ns | 0.0033 ns | 0.0028 ns |  0.39 |
|            |    |           |           |           |       |
| ArrayClear | 32 | 12.897 ns | 0.3148 ns | 0.3625 ns |  1.00 |
|  SpanClear | 32 |  5.088 ns | 0.0075 ns | 0.0066 ns |  0.39 |
```