### PR TITLE
Fix video looping failing when frames are in available post-seek

### DIFF
--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -141,7 +141,7 @@ namespace osu.Framework.Graphics.Video
 
             var frameTime = CurrentFrameTime;
 
-            while (availableFrames.Count > 0 && availableFrames.Peek().Time <= PlaybackPosition && Math.Abs(availableFrames.Peek().Time - PlaybackPosition) < lenience_before_seek)
+            while (availableFrames.Count > 0 && checkNextFrameValid(availableFrames.Peek()))
             {
                 if (lastFrame != null) decoder.ReturnFrames(new[] { lastFrame });
                 lastFrame = availableFrames.Dequeue();
@@ -166,6 +166,15 @@ namespace osu.Framework.Graphics.Video
 
             if (frameTime != CurrentFrameTime)
                 FramesProcessed++;
+        }
+
+        private bool checkNextFrameValid(DecodedFrame frame)
+        {
+            // in the case of looping, we may start a seek back to the beginning but still receive some lingering frames from the end of the last loop. these should be allowed to continue playing.
+            if (Loop && Math.Abs((frame.Time - Duration) - PlaybackPosition) < lenience_before_seek)
+                return true;
+
+            return frame.Time <= PlaybackPosition && Math.Abs(frame.Time - PlaybackPosition) < lenience_before_seek;
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
Depending on the timing of the decode loop, it is possible for there to still be frames arriving (or already arrived) from the end of the last playback when a loop is requested. We weren't accounting for this, meaning that some videos would fail the initial loop and only begin playing again after the seek lenience is exceeded.

Tested against and closes https://github.com/ppy/osu/issues/11490.