### PR TITLE
Fix dependency injection potentially resolving dependency to the declaring instance

### DIFF
--- a/osu.Framework.Tests/Dependencies/CachedModelDependenciesTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedModelDependenciesTest.cs
@@ -265,6 +265,26 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(null, resolver.BindableString.Value);
         }
 
+        [Test]
+        public void TestResolveFromInsideCachedContainer()
+        {
+            var parent = new SameTypeResolver();
+            var resolver = new SameTypeResolver();
+
+            var parentDependencies = new DependencyContainer();
+            parentDependencies.Cache(parent);
+
+            var modelDependencies = new CachedModelDependencyContainer<FieldModel>(parentDependencies);
+            modelDependencies.Model.Value = new FieldModel();
+
+            var dependencies = new DependencyContainer(modelDependencies);
+            dependencies.Cache(resolver);
+
+            dependencies.Inject(resolver);
+
+            Assert.AreSame(parent, resolver.Parent);
+        }
+
         private class NonBindablePublicFieldModel
         {
 #pragma warning disable 649
@@ -323,6 +343,12 @@ namespace osu.Framework.Tests.Dependencies
 
             [Resolved(typeof(DerivedFieldModel))]
             public Bindable<string> BindableString { get; private set; }
+        }
+
+        public class SameTypeResolver
+        {
+            [Resolved(CanBeNull = true)]
+            public SameTypeResolver Parent { get; private set; }
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -255,6 +255,23 @@ namespace osu.Framework.Tests.Dependencies
         }
 
         [Test]
+        public void TestResolveFromInsideCachedContainer()
+        {
+            var receiver = new Receiver14();
+            var parent = new Receiver14();
+
+            var parentDependencies = new DependencyContainer();
+            parentDependencies.Cache(parent);
+
+            var dependencies = new DependencyContainer(parentDependencies);
+            dependencies.Cache(receiver);
+
+            dependencies.Inject(receiver);
+
+            Assert.AreSame(parent, receiver.Parent);
+        }
+
+        [Test]
         public void TestCacheAsNullableInternal()
         {
             int? testObject = 5;
@@ -432,6 +449,17 @@ namespace osu.Framework.Tests.Dependencies
 
             [BackgroundDependencyLoader(true)]
             private void load(int testObject) => TestObject = testObject;
+        }
+
+        private class Receiver14
+        {
+            public Receiver14 Parent { get; private set; }
+
+            [BackgroundDependencyLoader(true)]
+            private void load(Receiver14 parent)
+            {
+                Parent = parent;
+            }
         }
     }
 }

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -187,9 +187,32 @@ namespace osu.Framework.Tests.Dependencies
             Assert.AreEqual(bindable.Value, receiver.Obj2.Value);
         }
 
+        [Test]
+        public void TestResolveFromInsideCachedContainer()
+        {
+            var receiver = new Receiver17();
+            var parent = new Receiver17();
+
+            var parentDependencies = createDependencies(parent);
+            var dependencies = createDependenciesWithParent(parentDependencies, receiver);
+
+            dependencies.Inject(receiver);
+
+            Assert.AreSame(receiver.Parent, parent);
+        }
+
         private DependencyContainer createDependencies(params object[] toCache)
         {
             var dependencies = new DependencyContainer();
+
+            toCache?.ForEach(o => dependencies.Cache(o));
+
+            return dependencies;
+        }
+
+        private DependencyContainer createDependenciesWithParent(IReadOnlyDependencyContainer parent, params object[] toCache)
+        {
+            var dependencies = new DependencyContainer(parent);
 
             toCache?.ForEach(o => dependencies.Cache(o));
 
@@ -303,6 +326,12 @@ namespace osu.Framework.Tests.Dependencies
 
             [Resolved]
             public IBindable<int> Obj2 { get; private set; }
+        }
+
+        private class Receiver17
+        {
+            [Resolved(CanBeNull = true)]
+            public Receiver17 Parent { get; private set; }
         }
     }
 }

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Allocation
                         {
                             var parameterArray = new object[parameterGetters.Length];
                             for (int i = 0; i < parameterGetters.Length; i++)
-                                parameterArray[i] = parameterGetters[i](dc);
+                                parameterArray[i] = parameterGetters[i](dc, target);
 
                             method.Invoke(target, parameterArray);
                         }
@@ -82,9 +82,9 @@ namespace osu.Framework.Allocation
             }
         }
 
-        private static Func<IReadOnlyDependencyContainer, object> getDependency(Type type, Type requestingType, bool permitNulls) => dc =>
+        private static Func<IReadOnlyDependencyContainer, object, object> getDependency(Type type, Type requestingType, bool permitNulls) => (dc, requester) =>
         {
-            var val = dc.Get(type);
+            var val = dc.Get(type, default, new[] { requester });
             if (val == null && !permitNulls)
                 throw new DependencyNotRegisteredException(requestingType, type);
 

--- a/osu.Framework/Allocation/CachedModelDependencyContainer.cs
+++ b/osu.Framework/Allocation/CachedModelDependencyContainer.cs
@@ -55,14 +55,14 @@ namespace osu.Framework.Allocation
 
         public object Get(Type type) => Get(type, default);
 
-        public object Get(Type type, CacheInfo info)
+        public object Get(Type type, CacheInfo info, object[] exclusion = null)
         {
             if (info.Parent == null)
-                return type == typeof(TModel) ? createChildShadowModel() : parent?.Get(type, info);
+                return type == typeof(TModel) ? createChildShadowModel() : parent?.Get(type, info, exclusion);
             if (info.Parent == typeof(TModel))
-                return shadowDependencies.Get(type, info) ?? parent?.Get(type, info);
+                return shadowDependencies.Get(type, info, exclusion) ?? parent?.Get(type, info, exclusion);
 
-            return parent?.Get(type, info);
+            return parent?.Get(type, info, exclusion);
         }
 
         public void Inject<T>(T instance) where T : class => DependencyActivator.Activate(instance, this);

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -162,15 +162,17 @@ namespace osu.Framework.Allocation
             cache[info] = instance;
         }
 
-        public object Get(Type type)
-            => Get(type, default);
+        public object Get(Type type) => Get(type, default);
 
-        public object Get(Type type, CacheInfo info)
+        public object Get(Type type, CacheInfo info, object[] exclusion = null)
         {
             info = info.WithType(type.GetUnderlyingNullableType() ?? type);
 
             if (cache.TryGetValue(info, out var existing))
-                return existing;
+            {
+                if (exclusion == null || Array.IndexOf(exclusion, existing) == -1)
+                    return existing;
+            }
 
             return parentContainer?.Get(type, info);
         }

--- a/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
+++ b/osu.Framework/Allocation/IReadOnlyDependencyContainer.cs
@@ -23,8 +23,9 @@ namespace osu.Framework.Allocation
         /// </summary>
         /// <param name="type">The dependency type to query for.</param>
         /// <param name="info">Extra information that identifies the cached dependency.</param>
+        /// <param name="exclusion">An optional array of instances to exclude while searching.</param>
         /// <returns>The requested dependency, or null if not found.</returns>
-        object Get(Type type, CacheInfo info);
+        object Get(Type type, CacheInfo info, object[] exclusion = null);
 
         /// <summary>
         /// Injects dependencies into the given instance.

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -97,7 +97,7 @@ namespace osu.Framework.Allocation
 
                 var fieldGetter = getDependency(property.PropertyType, type, attribute.CanBeNull || property.PropertyType.IsNullable(), cacheInfo);
 
-                activators.Add((target, dc) => property.SetValue(target, fieldGetter(dc)));
+                activators.Add((target, dc) => property.SetValue(target, fieldGetter(dc, target)));
             }
 
             return (target, dc) =>
@@ -107,9 +107,9 @@ namespace osu.Framework.Allocation
             };
         }
 
-        private static Func<IReadOnlyDependencyContainer, object> getDependency(Type type, Type requestingType, bool permitNulls, CacheInfo info) => dc =>
+        private static Func<IReadOnlyDependencyContainer, object, object> getDependency(Type type, Type requestingType, bool permitNulls, CacheInfo info) => (dc, requester) =>
         {
-            var val = dc.Get(type, info);
+            var val = dc.Get(type, info, new[] { requester });
             if (val == null && !permitNulls)
                 throw new DependencyNotRegisteredException(requestingType, type);
 


### PR DESCRIPTION
Found while doing some work lazer-side.

The issue is that on certain component patterns like the one below, `Foo` may be cached before its own dependencies are resolved, in that case, the `parent` dependency will be resolved to the same declaring instance (`Foo`).
```csharp
[Cached]
public FooType Foo = new FooType();

public class FooType
{
    // expected: some parent instance from ancestor composites.
    // actual: this class's instance.
    [Resolved(CanBeNull = true)]
    private FooType parent { get; set; }
}
```

Therefore I've fixed the issue by adding a parameter that accepts a list of instances to exclude while searching for the dependency in the container, and let both `ResolvedAttribute` and `BackgroundDependencyLoaderAttribute` exclude the declaring instance from the searching process.
