### PR TITLE
Fix key combination display ordering

### DIFF
--- a/osu.Framework.Tests/Input/KeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationTest.cs
@@ -3,37 +3,22 @@
 
 using NUnit.Framework;
 using osu.Framework.Input.Bindings;
-using osu.Framework.Input.States;
-using osuTK.Input;
-using KeyboardState = osu.Framework.Input.States.KeyboardState;
 
 namespace osu.Framework.Tests.Input
 {
     [TestFixture]
     public class KeyCombinationTest
     {
-        [Test]
-        public void TestKeyCombinationDisplayTrueOrder()
+        private static readonly object[][] key_combination_display_test_cases =
         {
-            var keyCombination1 = new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.R);
-            var keyCombination2 = new KeyCombination(InputKey.R, InputKey.Shift, InputKey.Control);
+            new object[] { new KeyCombination(InputKey.Alt, InputKey.F4), "Alt-F4" },
+            new object[] { new KeyCombination(InputKey.D, InputKey.Control), "Ctrl-D" },
+            new object[] { new KeyCombination(InputKey.Shift, InputKey.F, InputKey.Control), "Ctrl-Shift-F" },
+            new object[] { new KeyCombination(InputKey.Alt, InputKey.Control, InputKey.Super, InputKey.Shift), "Ctrl-Alt-Shift-Win" }
+        };
 
-            Assert.AreEqual(keyCombination1.ReadableString(), keyCombination2.ReadableString());
-        }
-
-        [Test]
-        public void TestKeyCombinationFromKeyboardStateDisplayTrueOrder()
-        {
-            var keyboardState = new KeyboardState();
-
-            keyboardState.Keys.Add(Key.R);
-            keyboardState.Keys.Add(Key.LShift);
-            keyboardState.Keys.Add(Key.LControl);
-
-            var keyCombination1 = KeyCombination.FromInputState(new InputState(keyboard: keyboardState));
-            var keyCombination2 = new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.R);
-
-            Assert.AreEqual(keyCombination1.ReadableString(), keyCombination2.ReadableString());
-        }
+        [TestCaseSource(nameof(key_combination_display_test_cases))]
+        public void TestKeyCombinationDisplayOrder(KeyCombination keyCombination, string expectedRepresentation)
+            => Assert.That(keyCombination.ReadableString(), Is.EqualTo(expectedRepresentation));
     }
 }

--- a/osu.Framework.Tests/Input/KeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationTest.cs
@@ -19,7 +19,6 @@ namespace osu.Framework.Tests.Input
             var keyCombination2 = new KeyCombination(InputKey.R, InputKey.Shift, InputKey.Control);
 
             Assert.AreEqual(keyCombination1.ReadableString(), keyCombination2.ReadableString());
-            Assert.AreEqual(keyCombination1.ToString(), keyCombination2.ToString());
         }
 
         [Test]
@@ -35,7 +34,6 @@ namespace osu.Framework.Tests.Input
             var keyCombination2 = new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.R);
 
             Assert.AreEqual(keyCombination1.ReadableString(), keyCombination2.ReadableString());
-            Assert.AreEqual(keyCombination1.ToString(), keyCombination2.ToString());
         }
     }
 }

--- a/osu.Framework.Tests/Input/KeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationTest.cs
@@ -1,0 +1,49 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Input.States;
+using osuTK.Input;
+using KeyboardState = osu.Framework.Input.States.KeyboardState;
+
+namespace osu.Framework.Tests.Input
+{
+    [TestFixture]
+    public class KeyCombinationTest
+    {
+        [Test]
+        public void TestKeyCombinationSortKeysWithTrueOrder()
+        {
+            var keyCombination = new KeyCombination(InputKey.R, InputKey.Shift, InputKey.Control);
+
+            Assert.AreEqual(keyCombination.Keys[0], InputKey.Control);
+            Assert.AreEqual(keyCombination.Keys[1], InputKey.Shift);
+            Assert.AreEqual(keyCombination.Keys[2], InputKey.R);
+        }
+
+        [Test]
+        public void TestKeyCombinationReadableStringDisplayTrueOrder()
+        {
+            var keyCombination1 = new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.R);
+            var keyCombination2 = new KeyCombination(InputKey.R, InputKey.Shift, InputKey.Control);
+
+            Assert.AreEqual(keyCombination1.ReadableString(), keyCombination2.ReadableString());
+        }
+
+        [Test]
+        public void TestKeyCombinationFromKeyboardStateReadableStringDisplayTrueOrder()
+        {
+            var keyboardState = new KeyboardState();
+
+            keyboardState.Keys.Add(Key.R);
+            keyboardState.Keys.Add(Key.LShift);
+            keyboardState.Keys.Add(Key.LControl);
+
+            var keyCombination1 = KeyCombination.FromInputState(new InputState(keyboard: keyboardState));
+            var keyCombination2 = new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.R);
+
+            Assert.AreEqual(keyCombination1.ReadableString(), keyCombination2.ReadableString());
+        }
+    }
+}

--- a/osu.Framework.Tests/Input/KeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationTest.cs
@@ -13,26 +13,17 @@ namespace osu.Framework.Tests.Input
     public class KeyCombinationTest
     {
         [Test]
-        public void TestKeyCombinationSortKeysWithTrueOrder()
-        {
-            var keyCombination = new KeyCombination(InputKey.R, InputKey.Shift, InputKey.Control);
-
-            Assert.AreEqual(keyCombination.Keys[0], InputKey.Control);
-            Assert.AreEqual(keyCombination.Keys[1], InputKey.Shift);
-            Assert.AreEqual(keyCombination.Keys[2], InputKey.R);
-        }
-
-        [Test]
-        public void TestKeyCombinationReadableStringDisplayTrueOrder()
+        public void TestKeyCombinationDisplayTrueOrder()
         {
             var keyCombination1 = new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.R);
             var keyCombination2 = new KeyCombination(InputKey.R, InputKey.Shift, InputKey.Control);
 
             Assert.AreEqual(keyCombination1.ReadableString(), keyCombination2.ReadableString());
+            Assert.AreEqual(keyCombination1.ToString(), keyCombination2.ToString());
         }
 
         [Test]
-        public void TestKeyCombinationFromKeyboardStateReadableStringDisplayTrueOrder()
+        public void TestKeyCombinationFromKeyboardStateDisplayTrueOrder()
         {
             var keyboardState = new KeyboardState();
 
@@ -44,6 +35,7 @@ namespace osu.Framework.Tests.Input
             var keyCombination2 = new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.R);
 
             Assert.AreEqual(keyCombination1.ReadableString(), keyCombination2.ReadableString());
+            Assert.AreEqual(keyCombination1.ToString(), keyCombination2.ToString());
         }
     }
 }

--- a/osu.Framework/Extensions/EnumExtensions/EnumExtensions.cs
+++ b/osu.Framework/Extensions/EnumExtensions/EnumExtensions.cs
@@ -8,7 +8,7 @@ using osu.Framework.Utils;
 
 namespace osu.Framework.Extensions.EnumExtensions
 {
-    public static class OrderedEnumExtensions
+    public static class EnumExtensions
     {
         /// <summary>
         /// Get values of an enum in order. Supports custom ordering via <see cref="OrderAttribute"/>.

--- a/osu.Framework/Extensions/EnumExtensions/OrderedEnumExtensions.cs
+++ b/osu.Framework/Extensions/EnumExtensions/OrderedEnumExtensions.cs
@@ -1,0 +1,57 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Utils;
+
+namespace osu.Framework.Extensions.EnumExtensions
+{
+    public static class OrderedEnumExtensions
+    {
+        /// <summary>
+        /// Get values of an enum in order. Supports custom ordering via <see cref="OrderAttribute"/>.
+        /// </summary>
+        public static IEnumerable<T> GetValuesInOrder<T>()
+            where T : struct, Enum
+        {
+            var type = typeof(T);
+
+            if (!type.IsEnum)
+                throw new InvalidOperationException($"{typeof(T)} must be an enum");
+
+            IEnumerable<T> items = (T[])Enum.GetValues(type);
+
+            return GetValuesInOrder(items);
+        }
+
+        /// <summary>
+        /// Get values of a collection of enum values in order. Supports custom ordering via <see cref="OrderAttribute"/>.
+        /// </summary>
+        public static IEnumerable<T> GetValuesInOrder<T>(this IEnumerable<T> items)
+            where T : struct, Enum
+        {
+            var type = typeof(T);
+
+            if (!type.IsEnum)
+                throw new InvalidOperationException($"{typeof(T)} must be an enum");
+
+            if (!(Attribute.GetCustomAttribute(type, typeof(HasOrderedElementsAttribute)) is HasOrderedElementsAttribute orderedAttr))
+                return items;
+
+            return items.OrderBy(i =>
+            {
+                var fieldInfo = type.GetField(i.ToString());
+
+                if (fieldInfo?.GetCustomAttributes(typeof(OrderAttribute), false).FirstOrDefault() is OrderAttribute attr)
+                    return attr.Order;
+
+                if (orderedAttr.AllowPartialOrdering)
+                    return Convert.ToInt32(i);
+
+                throw new ArgumentException($"Not all values of {typeof(T)} have {nameof(OrderAttribute)} specified.");
+            });
+        }
+    }
+}

--- a/osu.Framework/Input/Bindings/InputKey.cs
+++ b/osu.Framework/Input/Bindings/InputKey.cs
@@ -1,11 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Utils;
+
 namespace osu.Framework.Input.Bindings
 {
     /// <summary>
     /// A collection of keys, mouse and other controllers' buttons.
     /// </summary>
+    [HasOrderedElements(AllowPartialOrdering = true)]
     public enum InputKey
     {
         /// <summary>
@@ -16,21 +19,25 @@ namespace osu.Framework.Input.Bindings
         /// <summary>
         /// The shift key.
         /// </summary>
+        [Order(3)]
         Shift = 1,
 
         /// <summary>
         /// The control key.
         /// </summary>
+        [Order(1)]
         Control = 3,
 
         /// <summary>
         /// The alt key.
         /// </summary>
+        [Order(2)]
         Alt = 5,
 
         /// <summary>
         /// The win key.
         /// </summary>
+        [Order(4)]
         Super = 7,
 
         /// <summary>

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -142,11 +142,7 @@ namespace osu.Framework.Input.Bindings
         /// Get a string representation can be used with <see cref="KeyCombination(string)"/>.
         /// </summary>
         /// <returns>The string representation.</returns>
-        public override string ToString()
-        {
-            var sortedKeys = OrderAttributeUtils.GetValuesInOrder(Keys);
-            return string.Join(',', sortedKeys.Select(k => (int)k));
-        }
+        public override string ToString() => string.Join(',', Keys.Select(k => (int)k));
 
         public string ReadableString()
         {

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -7,8 +7,8 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.States;
-using osu.Framework.Utils;
 using osuTK;
 using osuTK.Input;
 
@@ -146,7 +146,7 @@ namespace osu.Framework.Input.Bindings
 
         public string ReadableString()
         {
-            var sortedKeys = OrderAttributeUtils.GetValuesInOrder(Keys);
+            var sortedKeys = Keys.GetValuesInOrder();
             return string.Join('-', sortedKeys.Select(getReadableKey));
         }
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -33,7 +33,7 @@ namespace osu.Framework.Input.Bindings
         /// <remarks>This constructor is not optimized. Hot paths are assumed to use <see cref="FromInputState(InputState, Vector2?)"/>.</remarks>
         public KeyCombination(IEnumerable<InputKey> keys)
         {
-            Keys = keys?.Any() == true ? OrderAttributeUtils.GetValuesInOrder(keys.Distinct()).ToImmutableArray() : none;
+            Keys = keys?.Any() == true ? keys.Distinct().OrderBy(k => (int)k).ToImmutableArray() : none;
         }
 
         /// <summary>
@@ -142,9 +142,17 @@ namespace osu.Framework.Input.Bindings
         /// Get a string representation can be used with <see cref="KeyCombination(string)"/>.
         /// </summary>
         /// <returns>The string representation.</returns>
-        public override string ToString() => string.Join(',', Keys.Select(k => (int)k));
+        public override string ToString()
+        {
+            var sortedKeys = OrderAttributeUtils.GetValuesInOrder(Keys);
+            return string.Join(',', sortedKeys.Select(k => (int)k));
+        }
 
-        public string ReadableString() => string.Join('-', Keys.Select(getReadableKey));
+        public string ReadableString()
+        {
+            var sortedKeys = OrderAttributeUtils.GetValuesInOrder(Keys);
+            return string.Join('-', sortedKeys.Select(getReadableKey));
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsModifierKey(InputKey key) => key == InputKey.Control || key == InputKey.Shift || key == InputKey.Alt || key == InputKey.Super;
@@ -469,8 +477,8 @@ namespace osu.Framework.Input.Bindings
                 keys.AddRange(state.Midi.Keys.Select(FromMidiKey));
 
             Debug.Assert(!keys.Contains(InputKey.None)); // Having None in pressed keys will break IsPressed
-
-            return new KeyCombination(OrderAttributeUtils.GetValuesInOrder(keys).ToImmutableArray());
+            keys.Sort();
+            return new KeyCombination(keys.ToImmutable());
         }
     }
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -8,6 +8,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using osu.Framework.Input.States;
+using osu.Framework.Utils;
 using osuTK;
 using osuTK.Input;
 
@@ -32,7 +33,7 @@ namespace osu.Framework.Input.Bindings
         /// <remarks>This constructor is not optimized. Hot paths are assumed to use <see cref="FromInputState(InputState, Vector2?)"/>.</remarks>
         public KeyCombination(IEnumerable<InputKey> keys)
         {
-            Keys = keys?.Any() == true ? keys.Distinct().OrderBy(k => (int)k).ToImmutableArray() : none;
+            Keys = keys?.Any() == true ? OrderAttributeUtils.GetValuesInOrder(keys.Distinct()).ToImmutableArray() : none;
         }
 
         /// <summary>
@@ -468,8 +469,8 @@ namespace osu.Framework.Input.Bindings
                 keys.AddRange(state.Midi.Keys.Select(FromMidiKey));
 
             Debug.Assert(!keys.Contains(InputKey.None)); // Having None in pressed keys will break IsPressed
-            keys.Sort();
-            return new KeyCombination(keys.ToImmutable());
+
+            return new KeyCombination(OrderAttributeUtils.GetValuesInOrder(keys).ToImmutableArray());
         }
     }
 

--- a/osu.Framework/Utils/HasOrderedElementsAttribute.cs
+++ b/osu.Framework/Utils/HasOrderedElementsAttribute.cs
@@ -2,9 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Extensions.EnumExtensions;
 
 namespace osu.Framework.Utils
 {
+    /// <summary>
+    /// Marker attribute for <see cref="Enum"/> classes whose members are annotated with <see cref="OrderAttribute"/>.
+    /// Methods from the <see cref="EnumExtensions"/> static class use the order defined with these attributes.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Enum)]
     public class HasOrderedElementsAttribute : Attribute
     {

--- a/osu.Framework/Utils/HasOrderedElementsAttribute.cs
+++ b/osu.Framework/Utils/HasOrderedElementsAttribute.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Utils
+{
+    [AttributeUsage(AttributeTargets.Enum)]
+    public class HasOrderedElementsAttribute : Attribute
+    {
+        /// <summary>
+        /// Allow for partially ordering <see cref="Enum"/> members.
+        /// Members without an <see cref="OrderAttribute"/> will default to their value as ordering key.
+        /// </summary>
+        public bool AllowPartialOrdering { get; set; }
+    }
+}

--- a/osu.Framework/Utils/OrderAttribute.cs
+++ b/osu.Framework/Utils/OrderAttribute.cs
@@ -13,6 +13,7 @@ namespace osu.Framework.Utils
         /// Get values of an enum in order. Supports custom ordering via <see cref="OrderAttribute"/>.
         /// </summary>
         public static IEnumerable<T> GetValuesInOrder<T>()
+            where T : struct, Enum
         {
             var type = typeof(T);
 
@@ -28,6 +29,7 @@ namespace osu.Framework.Utils
         /// Get values of a collection of enum values in order. Supports custom ordering via <see cref="OrderAttribute"/>.
         /// </summary>
         public static IEnumerable<T> GetValuesInOrder<T>(IEnumerable<T> items)
+            where T : struct, Enum
         {
             var type = typeof(T);
 

--- a/osu.Framework/Utils/OrderAttribute.cs
+++ b/osu.Framework/Utils/OrderAttribute.cs
@@ -39,7 +39,7 @@ namespace osu.Framework.Utils
 
             return items.OrderBy(i =>
             {
-                if (type.GetField(i.ToString()).GetCustomAttributes(typeof(OrderAttribute), false).FirstOrDefault() is OrderAttribute attr)
+                if (type.GetField(i.ToString())?.GetCustomAttributes(typeof(OrderAttribute), false).FirstOrDefault() is OrderAttribute attr)
                     return attr.Order;
 
                 if (orderedAttr.AllowPartialOrdering)

--- a/osu.Framework/Utils/OrderAttribute.cs
+++ b/osu.Framework/Utils/OrderAttribute.cs
@@ -2,12 +2,24 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Extensions.EnumExtensions;
 
 namespace osu.Framework.Utils
 {
+    /// <summary>
+    /// Allows specifying ordering of <see cref="Enum"/> members, separate from the actual enum values.
+    /// Only has an effect on members of <see cref="Enum"/> classes annotated with <see cref="HasOrderedElementsAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// Usually used for pretty-printing purposes.
+    /// Methods from the <see cref="EnumExtensions"/> static class can be used to leverage the order defined with these attributes.
+    /// </remarks>
     [AttributeUsage(AttributeTargets.Field)]
     public class OrderAttribute : Attribute
     {
+        /// <summary>
+        /// The sorting order of the annotated enum member.
+        /// </summary>
         public readonly int Order;
 
         public OrderAttribute(int order)

--- a/osu.Framework/Utils/OrderAttribute.cs
+++ b/osu.Framework/Utils/OrderAttribute.cs
@@ -2,58 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace osu.Framework.Utils
 {
-    public static class OrderAttributeUtils
-    {
-        /// <summary>
-        /// Get values of an enum in order. Supports custom ordering via <see cref="OrderAttribute"/>.
-        /// </summary>
-        public static IEnumerable<T> GetValuesInOrder<T>()
-            where T : struct, Enum
-        {
-            var type = typeof(T);
-
-            if (!type.IsEnum)
-                throw new InvalidOperationException($"{typeof(T)} must be an enum");
-
-            IEnumerable<T> items = (T[])Enum.GetValues(type);
-
-            return GetValuesInOrder(items);
-        }
-
-        /// <summary>
-        /// Get values of a collection of enum values in order. Supports custom ordering via <see cref="OrderAttribute"/>.
-        /// </summary>
-        public static IEnumerable<T> GetValuesInOrder<T>(IEnumerable<T> items)
-            where T : struct, Enum
-        {
-            var type = typeof(T);
-
-            if (!type.IsEnum)
-                throw new InvalidOperationException($"{typeof(T)} must be an enum");
-
-            if (!(Attribute.GetCustomAttribute(type, typeof(HasOrderedElementsAttribute)) is HasOrderedElementsAttribute orderedAttr))
-                return items;
-
-            return items.OrderBy(i =>
-            {
-                var fieldInfo = type.GetField(i.ToString());
-
-                if (fieldInfo?.GetCustomAttributes(typeof(OrderAttribute), false).FirstOrDefault() is OrderAttribute attr)
-                    return attr.Order;
-
-                if (orderedAttr.AllowPartialOrdering)
-                    return Convert.ToInt32(i);
-
-                throw new ArgumentException($"Not all values of {typeof(T)} have {nameof(OrderAttribute)} specified.");
-            });
-        }
-    }
-
     [AttributeUsage(AttributeTargets.Field)]
     public class OrderAttribute : Attribute
     {
@@ -63,15 +14,5 @@ namespace osu.Framework.Utils
         {
             Order = order;
         }
-    }
-
-    [AttributeUsage(AttributeTargets.Enum)]
-    public class HasOrderedElementsAttribute : Attribute
-    {
-        /// <summary>
-        /// Allow for partially ordering <see cref="Enum"/> members.
-        /// Members without an <see cref="OrderAttribute"/> will default to their value as ordering key.
-        /// </summary>
-        public bool AllowPartialOrdering { get; set; }
     }
 }

--- a/osu.Framework/Utils/OrderAttribute.cs
+++ b/osu.Framework/Utils/OrderAttribute.cs
@@ -1,0 +1,73 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace osu.Framework.Utils
+{
+    public static class OrderAttributeUtils
+    {
+        /// <summary>
+        /// Get values of an enum in order. Supports custom ordering via <see cref="OrderAttribute"/>.
+        /// </summary>
+        public static IEnumerable<T> GetValuesInOrder<T>()
+        {
+            var type = typeof(T);
+
+            if (!type.IsEnum)
+                throw new InvalidOperationException("T must be an enum");
+
+            IEnumerable<T> items = (T[])Enum.GetValues(type);
+
+            return GetValuesInOrder(items);
+        }
+
+        /// <summary>
+        /// Get values of a collection of enum values in order. Supports custom ordering via <see cref="OrderAttribute"/>.
+        /// </summary>
+        public static IEnumerable<T> GetValuesInOrder<T>(IEnumerable<T> items)
+        {
+            var type = typeof(T);
+
+            if (!type.IsEnum)
+                throw new InvalidOperationException("T must be an enum");
+
+            if (!(Attribute.GetCustomAttribute(type, typeof(HasOrderedElementsAttribute)) is HasOrderedElementsAttribute orderedAttr))
+                return items;
+
+            return items.OrderBy(i =>
+            {
+                if (type.GetField(i.ToString()).GetCustomAttributes(typeof(OrderAttribute), false).FirstOrDefault() is OrderAttribute attr)
+                    return attr.Order;
+
+                if (orderedAttr.AllowPartialOrdering)
+                    return (int)Enum.Parse(type, i.ToString());
+
+                throw new ArgumentException($"Not all values of {nameof(T)} have {nameof(OrderAttribute)} specified.");
+            });
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Field)]
+    public class OrderAttribute : Attribute
+    {
+        public readonly int Order;
+
+        public OrderAttribute(int order)
+        {
+            Order = order;
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.Enum)]
+    public class HasOrderedElementsAttribute : Attribute
+    {
+        /// <summary>
+        /// Allow for partially ordering Enum members.
+        /// Members without an Order Attribute will default to their value as ordering key.
+        /// </summary>
+        public bool AllowPartialOrdering { get; set; }
+    }
+}

--- a/osu.Framework/Utils/OrderAttribute.cs
+++ b/osu.Framework/Utils/OrderAttribute.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Utils
             var type = typeof(T);
 
             if (!type.IsEnum)
-                throw new InvalidOperationException("T must be an enum");
+                throw new InvalidOperationException($"{typeof(T)} must be an enum");
 
             IEnumerable<T> items = (T[])Enum.GetValues(type);
 
@@ -32,7 +32,7 @@ namespace osu.Framework.Utils
             var type = typeof(T);
 
             if (!type.IsEnum)
-                throw new InvalidOperationException("T must be an enum");
+                throw new InvalidOperationException($"{typeof(T)} must be an enum");
 
             if (!(Attribute.GetCustomAttribute(type, typeof(HasOrderedElementsAttribute)) is HasOrderedElementsAttribute orderedAttr))
                 return items;
@@ -45,7 +45,7 @@ namespace osu.Framework.Utils
                 if (orderedAttr.AllowPartialOrdering)
                     return (int)Enum.Parse(type, i.ToString());
 
-                throw new ArgumentException($"Not all values of {nameof(T)} have {nameof(OrderAttribute)} specified.");
+                throw new ArgumentException($"Not all values of {typeof(T)} have {nameof(OrderAttribute)} specified.");
             });
         }
     }

--- a/osu.Framework/Utils/OrderAttribute.cs
+++ b/osu.Framework/Utils/OrderAttribute.cs
@@ -39,11 +39,13 @@ namespace osu.Framework.Utils
 
             return items.OrderBy(i =>
             {
-                if (type.GetField(i.ToString())?.GetCustomAttributes(typeof(OrderAttribute), false).FirstOrDefault() is OrderAttribute attr)
+                var fieldInfo = type.GetField(i.ToString());
+
+                if (fieldInfo?.GetCustomAttributes(typeof(OrderAttribute), false).FirstOrDefault() is OrderAttribute attr)
                     return attr.Order;
 
                 if (orderedAttr.AllowPartialOrdering)
-                    return (int)Enum.Parse(type, i.ToString());
+                    return Convert.ToInt32(i);
 
                 throw new ArgumentException($"Not all values of {typeof(T)} have {nameof(OrderAttribute)} specified.");
             });

--- a/osu.Framework/Utils/OrderAttribute.cs
+++ b/osu.Framework/Utils/OrderAttribute.cs
@@ -65,8 +65,8 @@ namespace osu.Framework.Utils
     public class HasOrderedElementsAttribute : Attribute
     {
         /// <summary>
-        /// Allow for partially ordering Enum members.
-        /// Members without an Order Attribute will default to their value as ordering key.
+        /// Allow for partially ordering <see cref="Enum"/> members.
+        /// Members without an <see cref="OrderAttribute"/> will default to their value as ordering key.
         /// </summary>
         public bool AllowPartialOrdering { get; set; }
     }


### PR DESCRIPTION
Fixes #4153
 
- Introduce OrderAttribute from osu.Game
- To avoid adding an order to all `InputKeys`,  an `AllowPartialOrdering` flag was added on the `HasOrderedElements` to allow for only certain member to define a custom order as the current implementation of `GetValuesInOrder` would throw an exception. For now when a member does not define the OrderAttribute it will default back to the Enum value to keep ordering.
- Added simple tests to verify correct ordering of KeyCombination 

Unsure what to do with the current osu.Game `OrderAttribute`, removing it would introduce a dependency on this change ? Please let me know if I have to do anything else.
