### PR TITLE
Add ability to seed RNG class number generator

### DIFF
--- a/osu.Framework/Utils/RNG.cs
+++ b/osu.Framework/Utils/RNG.cs
@@ -10,8 +10,13 @@ namespace osu.Framework.Utils
     /// </summary>
     public static class RNG
     {
-        // Base RNG. Maybe expose methods for re-seeding in the future?
-        private static readonly Random random = new Random();
+        private static Random random = new Random();
+
+        /// <summary>
+        /// Seeds the random number generator with the specified number.
+        /// </summary>
+        /// <param name="seed">The number to use to seed the random number generator.</param>
+        public static void Seed(int seed) => random = new Random(seed);
 
         /// <summary>
         /// Returns a non-negative signed integer.


### PR DESCRIPTION
# Summary
This adds the ability to seed `RNG`'s  underlying random number generator through the `Seed()` static method (I was surprised to see it wasn't implemented at first when I looked up IntelliSense on `RNG` class to seed it).

The `Random` class from .NET Standard lib doesn't support changing the seed at runtime so the instance gets recreated on each manual seeding.