### PR TITLE
Stop handling unobserved exceptions

### DIFF
--- a/osu.Framework.Tests/IO/TestLogging.cs
+++ b/osu.Framework.Tests/IO/TestLogging.cs
@@ -121,6 +121,32 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test]
+        public void TestGameUnobservedExceptionDoesntCrashGame()
+        {
+            using (var host = new HeadlessGameHost())
+            {
+                TaskCrashTestGame game = new TaskCrashTestGame();
+                host.Run(game);
+            }
+        }
+
+        private class TaskCrashTestGame : Game
+        {
+            private int frameCount;
+
+            protected override void Update()
+            {
+                base.Update();
+
+                Task.Run(() => throw new TestException());
+
+                // only start counting frames once the task has completed, to allow some time for the unobserved exception to be handled.
+                if (frameCount++ > 10)
+                    Exit();
+            }
+        }
+
+        [Test]
         public void TestTaskExceptionLogging()
         {
             Exception resolvedException = null;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -244,7 +244,7 @@ namespace osu.Framework.Platform
         {
             var exception = (Exception)args.ExceptionObject;
 
-            logException(exception, "unobserved");
+            logException(exception, "unhandled");
             abortExecutionFromException(sender, exception);
         }
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -243,61 +243,72 @@ namespace osu.Framework.Platform
         private void unhandledExceptionHandler(object sender, UnhandledExceptionEventArgs args)
         {
             var exception = (Exception)args.ExceptionObject;
-            exception.Data["unhandled"] = "unhandled";
-            handleException(sender, exception);
+
+            logException(exception, "unobserved");
+            abortExecutionFromException(sender, exception);
         }
 
         private void unobservedExceptionHandler(object sender, UnobservedTaskExceptionEventArgs args)
         {
-            args.Exception.Data["unhandled"] = "unobserved";
-            handleException(sender, args.Exception);
+            // unobserved exceptions are logged but left unhandled (most of the time they are not intended to be critical).
+            logException(args.Exception, "unobserved");
         }
 
-        private void handleException(object sender, Exception exception)
+        private void logException(Exception exception, string type)
         {
-            if (ExceptionThrown?.Invoke(exception) != true)
+            Logger.Error(exception, $"An {type} error has occurred.", recursive: true);
+        }
+
+        /// <summary>
+        /// Give the running application a last change to handle an otherwise unhandled exception, and potentially ignore it.
+        /// </summary>
+        /// <param name="sender">The source, generally a <see cref="GameThread"/>.</param>
+        /// <param name="exception">The unhandled exception.</param>
+        private void abortExecutionFromException(object sender, Exception exception)
+        {
+            // nothing needs to be done if the consumer has requested continuing execution.
+            if (ExceptionThrown?.Invoke(exception) == true) return;
+
+            // otherwise, we need to unwind and abort execution.
+
+            AppDomain.CurrentDomain.UnhandledException -= unhandledExceptionHandler;
+            TaskScheduler.UnobservedTaskException -= unobservedExceptionHandler;
+
+            var captured = ExceptionDispatchInfo.Capture(exception);
+            var thrownEvent = new ManualResetEventSlim(false);
+
+            //we want to throw this exception on the input thread to interrupt window and also headless execution.
+            InputThread.Scheduler.Add(() =>
             {
-                AppDomain.CurrentDomain.UnhandledException -= unhandledExceptionHandler;
-                TaskScheduler.UnobservedTaskException -= unobservedExceptionHandler;
-
-                var captured = ExceptionDispatchInfo.Capture(exception);
-                var thrownEvent = new ManualResetEventSlim(false);
-
-                //we want to throw this exception on the input thread to interrupt window and also headless execution.
-                InputThread.Scheduler.Add(() =>
+                try
                 {
-                    try
-                    {
-                        captured.Throw();
-                    }
-                    finally
-                    {
-                        thrownEvent.Set();
-                    }
-                });
-
-                // Stopping running threads before the exception is rethrown on the input thread causes some debuggers (e.g. Rider 2020.2) to not properly display the stack.
-                // To avoid this, pause the exceptioning thread until the rethrow takes place.
-                waitForThrow();
-
-                // schedule an exit to the input thread.
-                // this is required for single threaded execution, else the draw thread may get stuck looping before the above schedule finishes.
-                PerformExit(false);
-
-                void waitForThrow()
-                {
-                    // This is bypassed for GameThread sources in two situations where deadlocks can occur:
-                    // 1. When the exceptioning thread is the input thread.
-                    // 2. When the game is running in single-threaded mode. Single threaded stacks will be displayed correctly at the point of rethrow.
-                    if (sender is GameThread && (sender == InputThread || executionMode.Value == ExecutionMode.SingleThread))
-                        return;
-
-                    // The process can deadlock in an extreme case such as the input thread dying before the delegate executes, so wait up to a maximum of 10 seconds at all times.
-                    thrownEvent.Wait(TimeSpan.FromSeconds(10));
+                    captured.Throw();
                 }
-            }
+                finally
+                {
+                    thrownEvent.Set();
+                }
+            });
 
-            Logger.Error(exception, $"An {exception.Data["unhandled"]} error has occurred.", recursive: true);
+            // Stopping running threads before the exception is rethrown on the input thread causes some debuggers (e.g. Rider 2020.2) to not properly display the stack.
+            // To avoid this, pause the exceptioning thread until the rethrow takes place.
+            waitForThrow();
+
+            // schedule an exit to the input thread.
+            // this is required for single threaded execution, else the draw thread may get stuck looping before the above schedule finishes.
+            PerformExit(false);
+
+            void waitForThrow()
+            {
+                // This is bypassed for GameThread sources in two situations where deadlocks can occur:
+                // 1. When the exceptioning thread is the input thread.
+                // 2. When the game is running in single-threaded mode. Single threaded stacks will be displayed correctly at the point of rethrow.
+                if (sender is GameThread && (sender == InputThread || executionMode.Value == ExecutionMode.SingleThread))
+                    return;
+
+                // The process can deadlock in an extreme case such as the input thread dying before the delegate executes, so wait up to a maximum of 10 seconds at all times.
+                thrownEvent.Wait(TimeSpan.FromSeconds(10));
+            }
         }
 
         protected virtual void OnActivated() => UpdateThread.Scheduler.Add(() => Activated?.Invoke());


### PR DESCRIPTION
We have generally agreed that these should be left unobserved, as it is quite common to fire a `Task.Run` without expecting it to cause the whole application to crash.

I've left logging in as that part will definitely be useful for tracking down edge cases where we actually do care about the exceptions.

Aims to fix issue observed in https://github.com/ppy/osu/issues/11608#issuecomment-767839973.