### PR TITLE
Drop type constraints on `EnumExtensions` methods

### DIFF
--- a/osu.Framework/Extensions/EnumExtensions/EnumExtensions.cs
+++ b/osu.Framework/Extensions/EnumExtensions/EnumExtensions.cs
@@ -14,7 +14,6 @@ namespace osu.Framework.Extensions.EnumExtensions
         /// Get values of an enum in order. Supports custom ordering via <see cref="OrderAttribute"/>.
         /// </summary>
         public static IEnumerable<T> GetValuesInOrder<T>()
-            where T : struct, Enum
         {
             var type = typeof(T);
 
@@ -30,7 +29,6 @@ namespace osu.Framework.Extensions.EnumExtensions
         /// Get values of a collection of enum values in order. Supports custom ordering via <see cref="OrderAttribute"/>.
         /// </summary>
         public static IEnumerable<T> GetValuesInOrder<T>(this IEnumerable<T> items)
-            where T : struct, Enum
         {
             var type = typeof(T);
 


### PR DESCRIPTION
Turns out there was a [game-side usage that used a naked open generic type](https://github.com/ppy/osu/blob/15e455231edd6556b67fe61d9fe0a337fec4051e/osu.Game/Overlays/BeatmapListing/BeatmapSearchFilterRow.cs#L81-L85) that wasn't scoped to `Enum`, and which as such could not be bound to the ordering static methods.

This sucks on multiple levels, is my fault for not checking, and is perhaps the worst timing imaginable, but the C# type system is only as strong.

I tried a few ways of circumventing game-side but they're just flat out dumb compared to this solution, due to how the aforementioned usage site is structured.

(I don't even know how to tag this pull. Not tagging as `code-quality` as code quality this does not improve.)