### PR TITLE
Fix framework templates not updated with API changes

### DIFF
--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/Bird.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/Bird.cs
@@ -1,6 +1,6 @@
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Audio.Track;
+using osu.Framework.Audio.Sample;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Graphics.Audio;


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/4174.

As per https://github.com/ppy/osu-framework/issues/4174#issuecomment-770377429, have checked the other projet but no issues in there.

May be worth looking at a way to run CI on templates projects ensuring templates build just fine.