### PR TITLE
Make window render to the cutout areas of android devices

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -55,6 +55,9 @@ namespace osu.Framework.Android
                 }
             };
 
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.P)
+                Window.Attributes.LayoutInDisplayCutoutMode = LayoutInDisplayCutoutMode.ShortEdges;
+
             gameView.HostStarted += host =>
             {
                 host.AllowScreenSuspension.BindValueChanged(allow =>


### PR DESCRIPTION
As said in https://github.com/ppy/osu/issues/11630#issuecomment-770571982, this makes it in line with iOS, but introduces the same issue of not being able to click stuff near the cutout area until the UI-side stuff is implemented. Can still use the scaling workaround in osu!-side, or just rotate device when viewing settings, etc. Won't cause any issues in gameplay.

Tested with Pixel 3a using the display cutout toggle in developer options (punch hole cutout):

Before:
![Screenshot_20210131-222043](https://user-images.githubusercontent.com/35318437/106506207-3ef78d80-647e-11eb-97c6-2569e41335f2.png)

After:
![Screenshot_20210131-222357](https://user-images.githubusercontent.com/35318437/106506211-4028ba80-647e-11eb-8680-85df55df16fe.png)
