### PR TITLE
Add cancellation support to WebRequest

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -327,6 +327,90 @@ namespace osu.Framework.Tests.IO
         }
 
         /// <summary>
+        /// Tests cancelling the <see cref="WebRequest"/> after response has been received from the server
+        /// but before data has been read.
+        /// </summary>
+        [Test, Retry(5)]
+        public void TestCancelReceive()
+        {
+            var cancellationSource = new CancellationTokenSource();
+            var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
+            {
+                Method = HttpMethod.Get,
+                AllowInsecureRequests = true,
+            };
+
+            bool hasThrown = false;
+            request.Failed += exception => hasThrown = exception != null;
+            request.Started += () => cancellationSource.Cancel();
+
+            Assert.DoesNotThrowAsync(() => request.PerformAsync(cancellationSource.Token));
+
+            Assert.IsTrue(request.Completed);
+            Assert.IsTrue(request.Aborted);
+
+            Assert.IsTrue(request.ResponseObject == null);
+            Assert.IsFalse(hasThrown);
+        }
+
+        /// <summary>
+        /// Tests aborting the <see cref="WebRequest"/> before the request is sent to the server.
+        /// </summary>
+        [Test, Retry(5)]
+        public async Task TestCancelRequest()
+        {
+            var cancellationSource = new CancellationTokenSource();
+            var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
+            {
+                Method = HttpMethod.Get,
+                AllowInsecureRequests = true,
+            };
+
+            bool hasThrown = false;
+            request.Failed += exception => hasThrown = exception != null;
+
+            cancellationSource.Cancel();
+            await request.PerformAsync(cancellationSource.Token);
+
+            Assert.IsTrue(request.Completed);
+            Assert.IsTrue(request.Aborted);
+
+            Assert.IsTrue(request.ResponseObject == null);
+
+            Assert.IsFalse(hasThrown);
+        }
+
+        /// <summary>
+        /// Tests being able to cancel + restart a request.
+        /// </summary>
+        [Test, Retry(5)]
+        public void TestRestartAfterAbort()
+        {
+            var cancellationSource = new CancellationTokenSource();
+            var request = new JsonWebRequest<HttpBinGetResponse>($"{default_protocol}://{host}/get")
+            {
+                Method = HttpMethod.Get,
+                AllowInsecureRequests = true,
+            };
+
+            bool hasThrown = false;
+            request.Failed += exception => hasThrown = exception != null;
+
+            cancellationSource.Cancel();
+            request.PerformAsync(cancellationSource.Token);
+
+            Assert.ThrowsAsync<InvalidOperationException>(request.PerformAsync);
+
+            Assert.IsTrue(request.Completed);
+            Assert.IsTrue(request.Aborted);
+
+            var responseObject = request.ResponseObject;
+
+            Assert.IsTrue(responseObject == null);
+            Assert.IsFalse(hasThrown);
+        }
+
+        /// <summary>
         /// Tests that specifically-crafted <see cref="WebRequest"/> is completed after one timeout.
         /// </summary>
         [Test, Retry(5)]

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -365,11 +365,7 @@ namespace osu.Framework.IO.Network
                     Complete(new WebException($"Request to {url} timed out after {timeSinceLastAction / 1000} seconds idle (read {responseBytesRead} bytes, retried {RetryCount} times).",
                         WebExceptionStatus.Timeout));
                 }
-                catch (Exception) when (cancellationToken.IsCancellationRequested)
-                {
-                    onAborted();
-                }
-                catch (Exception) when (abortToken.IsCancellationRequested)
+                catch (Exception) when (abortToken.IsCancellationRequested || cancellationToken.IsCancellationRequested)
                 {
                     onAborted();
                 }

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -199,6 +199,7 @@ namespace osu.Framework.IO.Network
 
         public HttpResponseHeaders ResponseHeaders => response.Headers;
 
+        private CancellationToken? userToken;
         private CancellationTokenSource abortToken;
         private CancellationTokenSource timeoutToken;
 
@@ -214,14 +215,20 @@ namespace osu.Framework.IO.Network
         /// <summary>
         /// Performs the request asynchronously.
         /// </summary>
-        public async Task PerformAsync()
+        public async Task PerformAsync() => await PerformAsync(default);
+
+        /// <summary>
+        /// Performs the request asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">A token to cancel the request.</param>
+        public async Task PerformAsync(CancellationToken cancellationToken)
         {
             if (Completed)
                 throw new InvalidOperationException($"The {nameof(WebRequest)} has already been run.");
 
             try
             {
-                await internalPerform();
+                await internalPerform(cancellationToken);
             }
             catch (AggregateException ae)
             {
@@ -229,7 +236,7 @@ namespace osu.Framework.IO.Network
             }
         }
 
-        private async Task internalPerform()
+        private async Task internalPerform(CancellationToken cancellationToken = default)
         {
             var url = Url;
 
@@ -239,9 +246,13 @@ namespace osu.Framework.IO.Network
                 url = @"https://" + url.Replace(@"http://", @"");
             }
 
+            // If a user token already exists, keep it. Otherwise, take on the previous user token, as this could be a retry of the request.
+            userToken ??= cancellationToken;
+            cancellationToken = userToken.Value;
+
             using (abortToken ??= new CancellationTokenSource()) // don't recreate if already non-null. is used during retry logic.
             using (timeoutToken = new CancellationTokenSource())
-            using (var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(abortToken.Token, timeoutToken.Token))
+            using (var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(abortToken.Token, timeoutToken.Token, cancellationToken))
             {
                 try
                 {
@@ -354,9 +365,13 @@ namespace osu.Framework.IO.Network
                     Complete(new WebException($"Request to {url} timed out after {timeSinceLastAction / 1000} seconds idle (read {responseBytesRead} bytes, retried {RetryCount} times).",
                         WebExceptionStatus.Timeout));
                 }
+                catch (Exception) when (cancellationToken.IsCancellationRequested)
+                {
+                    onAborted();
+                }
                 catch (Exception) when (abortToken.IsCancellationRequested)
                 {
-                    Complete(new WebException($"Request to {url} aborted by user.", WebExceptionStatus.RequestCanceled));
+                    onAborted();
                 }
                 catch (Exception e)
                 {
@@ -366,6 +381,14 @@ namespace osu.Framework.IO.Network
 
                     Complete(e);
                 }
+            }
+
+            void onAborted()
+            {
+                // Aborting via the cancellation token will not set the correct aborted/completion states. Make sure they're set here.
+                Abort();
+
+                Complete(new WebException($"Request to {url} aborted by user.", WebExceptionStatus.RequestCanceled));
             }
         }
 


### PR DESCRIPTION
This will come in handly when adding cancellation support to `OnlineStore`.

I overloaded `PerformAsync` instead of adding an optional parameter to not break o!f consumers.