### PR TITLE
Update NUnit and pull in dependent (removed) code locally

### DIFF
--- a/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
+++ b/osu.Framework.Benchmarks/osu.Framework.Benchmarks.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <!-- The following two are unused, but resolves warning MSB3277. -->
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
   </ItemGroup>

--- a/osu.Framework/Development/ReflectionUtils.cs
+++ b/osu.Framework/Development/ReflectionUtils.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace osu.Framework.Development
+{
+    internal static class ReflectionUtils
+    {
+        // taken from https://github.com/nunit/nunit/blob/73dbcce0896a6897a2add4281cc48734eca546a2/src/NUnitFramework/framework/Internal/Reflect.cs
+        // was removed in nunit 3.13.1
+
+        private const BindingFlags all_members = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+
+        /// <summary>
+        /// Returns all methods declared by the specified fixture type that have the specified attribute, optionally
+        /// including base classes. Methods from a base class are always returned before methods from a class that
+        /// inherits from it.
+        /// </summary>
+        /// <param name="fixtureType">The type to examine.</param>
+        /// <param name="attributeType">Only methods to which this attribute is applied will be returned.</param>
+        /// <param name="inherit">Specifies whether to search the fixture type inheritance chain.</param>
+        internal static MethodInfo[] GetMethodsWithAttribute(Type fixtureType, Type attributeType, bool inherit)
+        {
+            if (!inherit)
+            {
+                return fixtureType
+                       .GetMethods(all_members | BindingFlags.DeclaredOnly)
+                       .Where(method => method.IsDefined(attributeType, inherit: false))
+                       .ToArray();
+            }
+
+            var methodsByDeclaringType = fixtureType
+                                         .GetMethods(all_members | BindingFlags.FlattenHierarchy) // FlattenHierarchy is complex to replicate by looping over base types with DeclaredOnly.
+                                         .Where(method => method.IsDefined(attributeType, inherit: true))
+                                         .ToLookup(method => method.DeclaringType);
+
+            return typeAndBaseTypes(fixtureType)
+                   .Reverse()
+                   .SelectMany(declaringType => methodsByDeclaringType[declaringType])
+                   .ToArray();
+        }
+
+        private static IEnumerable<Type> typeAndBaseTypes(Type type)
+        {
+            for (; type != null; type = type.GetTypeInfo().BaseType)
+            {
+                yield return type;
+            }
+        }
+    }
+}

--- a/osu.Framework/Development/ReflectionUtils.cs
+++ b/osu.Framework/Development/ReflectionUtils.cs
@@ -11,7 +11,30 @@ namespace osu.Framework.Development
     internal static class ReflectionUtils
     {
         // taken from https://github.com/nunit/nunit/blob/73dbcce0896a6897a2add4281cc48734eca546a2/src/NUnitFramework/framework/Internal/Reflect.cs
-        // was removed in nunit 3.13.1
+        // as it was removed/refactored in nunit 3.13.1
+
+        // ***********************************************************************
+        // Copyright (c) 2007-2018 Charlie Poole, Rob Prouse
+        //
+        // Permission is hereby granted, free of charge, to any person obtaining
+        // a copy of this software and associated documentation files (the
+        // "Software"), to deal in the Software without restriction, including
+        // without limitation the rights to use, copy, modify, merge, publish,
+        // distribute, sublicense, and/or sell copies of the Software, and to
+        // permit persons to whom the Software is furnished to do so, subject to
+        // the following conditions:
+        //
+        // The above copyright notice and this permission notice shall be
+        // included in all copies or substantial portions of the Software.
+        //
+        // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+        // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+        // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+        // NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+        // LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+        // OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+        // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+        // ***********************************************************************
 
         private const BindingFlags all_members = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -12,6 +12,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
+using osu.Framework.Development;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
@@ -573,8 +574,8 @@ namespace osu.Framework.Testing
 
             void addSetUpSteps()
             {
-                var setUpMethods = Reflect.GetMethodsWithAttribute(newTest.GetType(), typeof(SetUpAttribute), true)
-                                          .Where(m => m.Name != nameof(TestScene.SetUpTestForNUnit));
+                var setUpMethods = ReflectionUtils.GetMethodsWithAttribute(newTest.GetType(), typeof(SetUpAttribute), true)
+                                                  .Where(m => m.Name != nameof(TestScene.SetUpTestForNUnit));
 
                 if (setUpMethods.Any())
                 {

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -4,21 +4,21 @@
 using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
+using NUnit.Framework.Internal;
+using osu.Framework.Development;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Platform;
 using osu.Framework.Testing.Drawables.Steps;
 using osu.Framework.Threading;
 using osuTK;
 using osuTK.Graphics;
-using System.Threading.Tasks;
-using System.Threading;
-using NUnit.Framework.Internal;
-using osu.Framework.Development;
-using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Testing
 {
@@ -393,14 +393,14 @@ namespace osu.Framework.Testing
         internal void RunSetUpSteps()
         {
             addStepsAsSetupSteps = true;
-            foreach (var method in Reflect.GetMethodsWithAttribute(GetType(), typeof(SetUpStepsAttribute), true))
+            foreach (var method in ReflectionUtils.GetMethodsWithAttribute(GetType(), typeof(SetUpStepsAttribute), true))
                 method.Invoke(this, null);
             addStepsAsSetupSteps = false;
         }
 
         internal void RunTearDownSteps()
         {
-            foreach (var method in Reflect.GetMethodsWithAttribute(GetType(), typeof(TearDownStepsAttribute), true))
+            foreach (var method in ReflectionUtils.GetMethodsWithAttribute(GetType(), typeof(TearDownStepsAttribute), true))
                 method.Invoke(this, null);
         }
 

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="ManagedBass" Version="2.0.4" />
     <PackageReference Include="ManagedBass.Fx" Version="2.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />


### PR DESCRIPTION
At NUnit's end this method changed to a generic method, which doesn't suit our use case. So I just copied the code across for our own use.

Only did this because it causes weird errors when triggering dynamic compilation on a consumer project that has a newer version of NUnit referenced.