### PR TITLE
Improve the exception message when Child is accessed with incorrect Children count

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -335,7 +335,7 @@ namespace osu.Framework.Graphics.Containers
             get
             {
                 if (InternalChildren.Count != 1)
-                    throw new InvalidOperationException($"{nameof(InternalChild)} is only available when there's only 1 in {nameof(InternalChildren)}!");
+                    throw new InvalidOperationException($"Cannot call {nameof(InternalChild)} unless there's exactly one {nameof(Drawable)} in {nameof(InternalChildren)} (currently {InternalChildren.Count})!");
 
                 return InternalChildren[0];
             }

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -150,7 +150,7 @@ namespace osu.Framework.Graphics.Containers
             get
             {
                 if (Children.Count != 1)
-                    throw new InvalidOperationException($"{nameof(Child)} is only available when there's only 1 in {nameof(Children)}!");
+                    throw new InvalidOperationException($"Cannot call {nameof(InternalChild)} unless there's exactly one {nameof(Drawable)} in {nameof(InternalChildren)} (currently {InternalChildren.Count})!");
 
                 return Children[0];
             }

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -150,7 +150,7 @@ namespace osu.Framework.Graphics.Containers
             get
             {
                 if (Children.Count != 1)
-                    throw new InvalidOperationException($"Cannot call {nameof(InternalChild)} unless there's exactly one {nameof(Drawable)} in {nameof(InternalChildren)} (currently {InternalChildren.Count})!");
+                    throw new InvalidOperationException($"Cannot call {nameof(InternalChild)} unless there's exactly one {nameof(Drawable)} in {nameof(Children)} (currently {Children.Count})!");
 
                 return Children[0];
             }


### PR DESCRIPTION
Mainly to change it from explicitly reading "only one", when the children could actually be empty. Since that was just misleading.