### PR TITLE
Internalise per-sample playback concurrency for now

### DIFF
--- a/osu.Framework/Audio/Sample/SampleBassFactory.cs
+++ b/osu.Framework/Audio/Sample/SampleBassFactory.cs
@@ -20,7 +20,10 @@ namespace osu.Framework.Audio.Sample
 
         public double Length { get; private set; }
 
-        public readonly Bindable<int> PlaybackConcurrency = new Bindable<int>(Sample.DEFAULT_CONCURRENCY);
+        /// <summary>
+        /// Todo: Expose this to support per-sample playback concurrency once ManagedBass has been updated (https://github.com/ManagedBass/ManagedBass/pull/85).
+        /// </summary>
+        internal readonly Bindable<int> PlaybackConcurrency = new Bindable<int>(Sample.DEFAULT_CONCURRENCY);
 
         private NativeMemoryTracker.NativeMemoryLease memoryLease;
 


### PR DESCRIPTION
Although the PR has been merged in, it still requires a new nupkg and for us to update to it, which is a non-trivial task considering their recent removal of dllmap.