### PR TITLE
Fix TextureStore and ResourceStore locks being held globally across all lookups

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
@@ -38,18 +38,22 @@ namespace osu.Framework.Tests.Visual.Sprites
         {
             Avatar avatar1 = null;
             Avatar avatar2 = null;
-            TextureWithRefCount texture = null;
+            Texture texture = null;
 
             AddStep("add disposable sprite", () => avatar1 = addSprite("https://a.ppy.sh/3"));
             AddStep("add disposable sprite", () => avatar2 = addSprite("https://a.ppy.sh/3"));
 
-            AddUntilStep("wait for texture load", () => (texture = (TextureWithRefCount)avatar1.Texture) != null && avatar2.Texture != null);
+            AddUntilStep("wait for texture load", () => avatar1.Texture != null && avatar2.Texture != null);
+
+            AddAssert("both textures are RefCount", () => avatar1.Texture is TextureWithRefCount && avatar2.Texture is TextureWithRefCount);
 
             AddAssert("textures share gl texture", () => avatar1.Texture.TextureGL == avatar2.Texture.TextureGL);
             AddAssert("textures have different refcount textures", () => avatar1.Texture != avatar2.Texture);
 
             AddStep("dispose children", () =>
             {
+                texture = avatar1.Texture;
+
                 Clear();
                 avatar1.Dispose();
                 avatar2.Dispose();

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
@@ -189,7 +189,7 @@ namespace osu.Framework.Tests.Visual.Sprites
             public int TotalInitiatedLookups { get; private set; }
 
             /// <summary>
-            /// The total number of completed lookup.
+            /// The total number of completed lookups.
             /// </summary>
             public int TotalCompletedLookups { get; private set; }
 
@@ -200,7 +200,7 @@ namespace osu.Framework.Tests.Visual.Sprites
             /// <summary>
             /// Block load until <see cref="AllowLoad"/> is called.
             /// </summary>
-            /// <param name="blockingUrl">An optional URL to limit load blocking to a specification.</param>
+            /// <param name="blockingUrl">If not <c>null</c> or empty, only lookups for this particular URL will be blocked.</param>
             public void StartBlocking(string blockingUrl = null)
             {
                 this.blockingUrl = blockingUrl;

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -126,10 +126,10 @@ namespace osu.Framework.Graphics.Textures
 
             lock (retrievalCompletionSources)
             {
-                // check if an existing lookup was already started for this name.
-                if (!retrievalCompletionSources.TryGetValue(name, out task))
+                // check if an existing lookup was already started for this key.
+                if (!retrievalCompletionSources.TryGetValue(key, out task))
                     // if not, take responsibility for the lookup.
-                    retrievalCompletionSources[name] = (tcs = new TaskCompletionSource<Texture>()).Task;
+                    retrievalCompletionSources[key] = (tcs = new TaskCompletionSource<Texture>()).Task;
             }
 
             if (task != null)

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -159,7 +159,7 @@ namespace osu.Framework.Graphics.Textures
                     Debug.Assert(tcs != null);
 
                     tcs.SetResult(tex);
-                    retrievalCompletionSources.Remove(name);
+                    retrievalCompletionSources.Remove(key);
                 }
             }
 

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -17,7 +17,6 @@ namespace osu.Framework.Graphics.Textures
     public class TextureStore : ResourceStore<TextureUpload>
     {
         private readonly Dictionary<string, Texture> textureCache = new Dictionary<string, Texture>();
-        private readonly object retrievalLock = new object();
 
         private readonly All filteringMode;
         private readonly bool manualMipmaps;

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -116,15 +116,15 @@ namespace osu.Framework.Graphics.Textures
 
             string key = $"{name}:wrap-{(int)wrapModeS}-{(int)wrapModeT}";
 
-            // Check if the texture exists in the cache.
-            if (TryGetCached(key, out var cached))
-                return cached;
-
             TaskCompletionSource<Texture> tcs = null;
             Task task;
 
             lock (retrievalCompletionSources)
             {
+                // Check if the texture exists in the cache.
+                if (TryGetCached(key, out var cached))
+                    return cached;
+
                 // check if an existing lookup was already started for this key.
                 if (!retrievalCompletionSources.TryGetValue(key, out task))
                     // if not, take responsibility for the lookup.
@@ -137,7 +137,7 @@ namespace osu.Framework.Graphics.Textures
                 task.Wait();
 
                 // always perform re-lookups through TryGetCached (see LargeTextureStore which has a custom implementation of this where it matters).
-                if (TryGetCached(key, out cached))
+                if (TryGetCached(key, out var cached))
                     return cached;
 
                 return null;

--- a/osu.Framework/IO/Stores/OnlineStore.cs
+++ b/osu.Framework/IO/Stores/OnlineStore.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.IO.Stores
             }
         }
 
-        public byte[] Get(string url)
+        public virtual byte[] Get(string url)
         {
             if (!url.StartsWith(@"https://", StringComparison.Ordinal))
                 return null;

--- a/osu.Framework/IO/Stores/ResourceStore.cs
+++ b/osu.Framework/IO/Stores/ResourceStore.cs
@@ -89,14 +89,7 @@ namespace osu.Framework.IO.Stores
 
             var filenames = GetFilenames(name);
 
-            // required for locking
-            IResourceStore<T>[] localStores;
-
-            lock (stores)
-                localStores = stores.ToArray();
-
-            // Cache miss - get the resource
-            foreach (IResourceStore<T> store in localStores)
+            foreach (IResourceStore<T> store in getStores())
             {
                 foreach (string f in filenames)
                 {
@@ -121,17 +114,13 @@ namespace osu.Framework.IO.Stores
 
             var filenames = GetFilenames(name);
 
-            // Cache miss - get the resource
-            lock (stores)
+            foreach (IResourceStore<T> store in getStores())
             {
-                foreach (IResourceStore<T> store in stores)
+                foreach (string f in filenames)
                 {
-                    foreach (string f in filenames)
-                    {
-                        T result = store.Get(f);
-                        if (result != null)
-                            return result;
-                    }
+                    T result = store.Get(f);
+                    if (result != null)
+                        return result;
                 }
             }
 
@@ -145,17 +134,13 @@ namespace osu.Framework.IO.Stores
 
             var filenames = GetFilenames(name);
 
-            // Cache miss - get the resource
-            lock (stores)
+            foreach (IResourceStore<T> store in getStores())
             {
-                foreach (IResourceStore<T> store in stores)
+                foreach (string f in filenames)
                 {
-                    foreach (string f in filenames)
-                    {
-                        var result = store.GetStream(f);
-                        if (result != null)
-                            return result;
-                    }
+                    var result = store.GetStream(f);
+                    if (result != null)
+                        return result;
                 }
             }
 
@@ -202,6 +187,11 @@ namespace osu.Framework.IO.Stores
         public virtual IEnumerable<string> GetAvailableResources()
         {
             lock (stores) return stores.SelectMany(s => s.GetAvailableResources()).ExcludeSystemFileNames();
+        }
+
+        private IResourceStore<T>[] getStores()
+        {
+            lock (stores) return stores.ToArray();
         }
 
         #region IDisposable Support


### PR DESCRIPTION
- [x] Add test coverage

PRing this for feedback. I believe the code could be further simplified by using `Task.Run` instead of `TaskCompletionSource`, but in an effort to not add more new unknowns I went with this to avoid TPL usage.

Closes ppy/osu#11141.