### PR TITLE
Fix samples allowing retrieval after they are disposed

### DIFF
--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -40,6 +40,17 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
+        public void TestGetChannelOnDisposed()
+        {
+            sample.Dispose();
+
+            sample.Update();
+
+            Assert.Throws<ObjectDisposedException>(() => sample.GetChannel());
+            Assert.Throws<ObjectDisposedException>(() => sample.Play());
+        }
+
+        [Test]
         public void TestStart()
         {
             channel = sample.Play();

--- a/osu.Framework/Audio/Sample/Sample.cs
+++ b/osu.Framework/Audio/Sample/Sample.cs
@@ -25,6 +25,9 @@ namespace osu.Framework.Audio.Sample
 
         public SampleChannel GetChannel()
         {
+            if (IsDisposed)
+                throw new ObjectDisposedException(ToString(), "Can not get a channel from a disposed sample.");
+
             var channel = CreateChannel();
 
             if (channel != null)


### PR DESCRIPTION
This used to be a thing before the recent sample changes, and it seems like the safer thing to do. Will regress https://github.com/ppy/osu/issues/5798, which was temporarily alleviated by this local regression (but this is intentional).

Closes #4198.