### PR TITLE
Fix RawCachingGlyphStore performing operations on same files from multiple threads

### DIFF
--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -35,7 +35,16 @@ namespace osu.Framework.IO.Stores
         protected override TextureUpload LoadCharacter(Character character)
         {
             if (!pageLookup.TryGetValue(character.Page, out var pageInfo))
-                pageInfo = createCachedPageInfo(character.Page);
+            {
+                // Use simple global locking for the time being.
+                // If necessary, a per-lookup-key (page number) locking mechanism could be implemented similar to TextureStore.
+                lock (pageLookup)
+                {
+                    // second lookup within lock for safety
+                    if (!pageLookup.TryGetValue(character.Page, out pageInfo))
+                        pageInfo = createCachedPageInfo(character.Page);
+                }
+            }
 
             return createTextureUpload(character, pageInfo);
         }


### PR DESCRIPTION
As seen in https://ci.appveyor.com/project/peppy/osu/builds/37847069/tests. Regressed in https://github.com/ppy/osu-framework/pull/4197 (due to increased concurrency of underlying lookups from `TextureStore`).

To test this, modifying `TestSceneSpriteText` to [load asynchronously](https://gist.github.com/peppy/7d48f0fdb6cb138306f7769969447d0c) can work quite well (will result in corruption of characters if not working correctly).