### PR TITLE
Fix remaining portion of glyph store lookup happening outside of locked region

### DIFF
--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -34,19 +34,15 @@ namespace osu.Framework.IO.Stores
 
         protected override TextureUpload LoadCharacter(Character character)
         {
-            if (!pageLookup.TryGetValue(character.Page, out var pageInfo))
+            // Use simple global locking for the time being.
+            // If necessary, a per-lookup-key (page number) locking mechanism could be implemented similar to TextureStore.
+            lock (pageLookup)
             {
-                // Use simple global locking for the time being.
-                // If necessary, a per-lookup-key (page number) locking mechanism could be implemented similar to TextureStore.
-                lock (pageLookup)
-                {
-                    // second lookup within lock for safety
-                    if (!pageLookup.TryGetValue(character.Page, out pageInfo))
-                        pageInfo = createCachedPageInfo(character.Page);
-                }
-            }
+                if (!pageLookup.TryGetValue(character.Page, out var pageInfo))
+                    pageInfo = createCachedPageInfo(character.Page);
 
-            return createTextureUpload(character, pageInfo);
+                return createTextureUpload(character, pageInfo);
+            }
         }
 
         private PageInfo createCachedPageInfo(int page)


### PR DESCRIPTION
As it turns out, the actual texture upload creation accesses cached stream handles, which can cause mayhem when accessed from multiple threads. Aiming to keep this as a simple fix for now; the inline comment still applies to the scenario where we want to improve performance.

Closes ppy/osu#11838.