### PR TITLE
Make `IAdjustableAudioComponent` inherit `IAggregateAudioAdjustment`

### DIFF
--- a/osu.Framework/Audio/AdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/AdjustableAudioComponent.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Audio
     /// <summary>
     /// An audio component which allows for basic bindable adjustments to be applied.
     /// </summary>
-    public class AdjustableAudioComponent : AudioComponent, IAggregateAudioAdjustment, IAdjustableAudioComponent
+    public class AdjustableAudioComponent : AudioComponent, IAdjustableAudioComponent
     {
         private readonly AudioAdjustments adjustments = new AudioAdjustments();
 

--- a/osu.Framework/Audio/AudioAdjustments.cs
+++ b/osu.Framework/Audio/AudioAdjustments.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Audio
     /// Provides adjustable and bindable attributes for an audio component.
     /// Aggregates results as a <see cref="IAggregateAudioAdjustment"/>.
     /// </summary>
-    public class AudioAdjustments : IAggregateAudioAdjustment, IAdjustableAudioComponent
+    public class AudioAdjustments : IAdjustableAudioComponent
     {
         /// <summary>
         /// The volume of this component.

--- a/osu.Framework/Audio/IAdjustableAudioComponent.cs
+++ b/osu.Framework/Audio/IAdjustableAudioComponent.cs
@@ -8,7 +8,7 @@ using osu.Framework.Graphics.Transforms;
 
 namespace osu.Framework.Audio
 {
-    public interface IAdjustableAudioComponent
+    public interface IAdjustableAudioComponent : IAggregateAudioAdjustment
     {
         /// <summary>
         /// The volume of this component.

--- a/osu.Framework/Audio/IAdjustableResourceStore.cs
+++ b/osu.Framework/Audio/IAdjustableResourceStore.cs
@@ -5,7 +5,7 @@ using osu.Framework.IO.Stores;
 
 namespace osu.Framework.Audio
 {
-    public interface IAdjustableResourceStore<T> : IResourceStore<T>, IAdjustableAudioComponent, IAggregateAudioAdjustment
+    public interface IAdjustableResourceStore<T> : IResourceStore<T>, IAdjustableAudioComponent
         where T : AudioComponent
     {
     }

--- a/osu.Framework/Audio/Track/ITrack.cs
+++ b/osu.Framework/Audio/Track/ITrack.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Audio.Track
     /// <summary>
     /// An audio track.
     /// </summary>
-    public interface ITrack : IAdjustableClock, IHasAmplitudes, IAdjustableAudioComponent
+    public interface ITrack : IAdjustableClock, IHasAmplitudes, IAdjustableAudioComponent, IAggregateAudioAdjustment
     {
         /// <summary>
         /// Invoked when this track has completed.

--- a/osu.Framework/Audio/Track/ITrack.cs
+++ b/osu.Framework/Audio/Track/ITrack.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Audio.Track
     /// <summary>
     /// An audio track.
     /// </summary>
-    public interface ITrack : IAdjustableClock, IHasAmplitudes, IAdjustableAudioComponent, IAggregateAudioAdjustment
+    public interface ITrack : IAdjustableClock, IHasAmplitudes, IAdjustableAudioComponent
     {
         /// <summary>
         /// Invoked when this track has completed.

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Graphics.Audio
     /// A wrapper which allows audio components (or adjustments) to exist in the draw hierarchy.
     /// </summary>
     [Cached(typeof(IAggregateAudioAdjustment))]
-    public abstract class DrawableAudioWrapper : CompositeDrawable, IAggregateAudioAdjustment, IAdjustableAudioComponent
+    public abstract class DrawableAudioWrapper : CompositeDrawable, IAdjustableAudioComponent
     {
         /// <summary>
         /// The volume of this component.


### PR DESCRIPTION
Exposes the Aggregate[Adjustment] bindables in ITrack.

Closes #4208 