### PR TITLE
Fix leak of pinned sample handles

### DIFF
--- a/osu.Framework/Audio/Sample/SampleBassFactory.cs
+++ b/osu.Framework/Audio/Sample/SampleBassFactory.cs
@@ -76,9 +76,6 @@ namespace osu.Framework.Audio.Sample
         {
             const BassFlags flags = BassFlags.Default | BassFlags.SampleOverrideLongestPlaying;
 
-            if (RuntimeInfo.SupportsJIT)
-                return Bass.SampleLoad(data, 0, data.Length, PlaybackConcurrency.Value, flags);
-
             using (var handle = new ObjectHandle<byte[]>(data, GCHandleType.Pinned))
                 return Bass.SampleLoad(handle.Address, 0, data.Length, PlaybackConcurrency.Value, flags);
         }


### PR DESCRIPTION
Internally, `ManagedBass` does a similar thing to our own `ObjectHandle`: https://github.com/ManagedBass/ManagedBass/blob/0cdc873a3b2eeb33bb338d254a76d20fc4f36c1b/src/Bass/Shared/GCPin.cs#L27-L38, with the difference that it only frees the handle when Bass provides `SyncFlags.Free`.

In the context of samples, this leaks the pinned handle, as bass will not invoke sync callbacks for `HSAMPLE`s. See [`Bass_ChannelSetSync`](http://www.un4seen.com/doc/#bass/BASS_ChannelSetSync.html) which is documented as accepting a handle of type `HMUSIC`, `HSTREAM` or `HRECORD`, and not `HSAMPLE`.

Don't really know how to benchmark this, but I've tested that the sync callback is not invoked, and have seen the reduction in pinned handles via dotMemory.