### PR TITLE
Switch order of parameters on RomanisableString to make the original version come first

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -146,7 +146,7 @@ namespace osu.Framework.Tests.Localisation
             const string non_unicode = "non unicode";
             const string unicode = "unicode";
 
-            var text = manager.GetLocalisedString(new RomanisableString(non_unicode, unicode));
+            var text = manager.GetLocalisedString(new RomanisableString(unicode, non_unicode));
 
             config.Set(FrameworkSetting.ShowUnicode, true);
             Assert.AreEqual(unicode, text.Value);
@@ -163,18 +163,18 @@ namespace osu.Framework.Tests.Localisation
             const string unicode_1 = "unicode 1";
             const string unicode_2 = "unicode 2";
 
-            var text = manager.GetLocalisedString(new RomanisableString(non_unicode_1, unicode_1));
+            var text = manager.GetLocalisedString(new RomanisableString(unicode_1, non_unicode_1));
 
             config.Set(FrameworkSetting.ShowUnicode, false);
             Assert.AreEqual(non_unicode_1, text.Value);
 
-            text.Text = new RomanisableString(non_unicode_2, unicode_1);
+            text.Text = new RomanisableString(unicode_1, non_unicode_2);
             Assert.AreEqual(non_unicode_2, text.Value);
 
             config.Set(FrameworkSetting.ShowUnicode, true);
             Assert.AreEqual(unicode_1, text.Value);
 
-            text.Text = new RomanisableString(non_unicode_2, unicode_2);
+            text.Text = new RomanisableString(unicode_2, non_unicode_2);
             Assert.AreEqual(unicode_2, text.Value);
         }
 
@@ -184,12 +184,12 @@ namespace osu.Framework.Tests.Localisation
             const string non_unicode_fallback = "non unicode";
             const string unicode_fallback = "unicode";
 
-            var text = manager.GetLocalisedString(new RomanisableString(emptyValue, unicode_fallback));
+            var text = manager.GetLocalisedString(new RomanisableString(unicode_fallback, emptyValue));
 
             config.Set(FrameworkSetting.ShowUnicode, false);
             Assert.AreEqual(unicode_fallback, text.Value);
 
-            text = manager.GetLocalisedString(new RomanisableString(non_unicode_fallback, emptyValue));
+            text = manager.GetLocalisedString(new RomanisableString(emptyValue, non_unicode_fallback));
 
             config.Set(FrameworkSetting.ShowUnicode, true);
             Assert.AreEqual(non_unicode_fallback, text.Value);

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
@@ -36,9 +36,9 @@ namespace osu.Framework.Tests.Visual.Sprites
                 }
             };
 
-            flow.Add(new SpriteText { Text = new RomanisableString("music", "ongaku") });
-            flow.Add(new SpriteText { Text = new RomanisableString("music", "") });
-            flow.Add(new SpriteText { Text = new RomanisableString("", "ongaku") });
+            flow.Add(new SpriteText { Text = new RomanisableString("ongaku", "music") });
+            flow.Add(new SpriteText { Text = new RomanisableString("", "music") });
+            flow.Add(new SpriteText { Text = new RomanisableString("ongaku", "") });
         }
 
         [Resolved]

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Localisation
         public readonly string Romanised;
         public readonly string Unicode;
 
-        public RomanisableString(string romanised, string unicode)
+        public RomanisableString(string unicode, string romanised)
         {
             Romanised = romanised;
             Unicode = unicode;

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -16,22 +16,25 @@ namespace osu.Framework.Localisation
         /// <summary>
         /// The string in its original script. May be null.
         /// </summary>
-        public readonly string Original;
+        public readonly string? Original;
 
         /// <summary>
         /// The romanised version of the string. May be null.
         /// </summary>
-        public readonly string Romanised;
+        public readonly string? Romanised;
 
         /// <summary>
         /// Construct a new romanisable string.
         /// </summary>
+        /// <remarks>
+        /// For flexibility, both of the provided strings are allowed to be null. If both are null, the returned string value from <see cref="GetPreferred"/> will be <see cref="string.Empty"/>.
+        /// </remarks>
         /// <param name="original">The string in its original script. If null, the <paramref name="romanised"/> version will always be used.</param>
         /// <param name="romanised">The romanised version of the string. If null, the <paramref name="original"/> version will always be used.</param>
-        public RomanisableString(string original, string romanised)
+        public RomanisableString(string? original, string? romanised)
         {
-            Romanised = romanised;
             Original = original;
+            Romanised = romanised;
         }
 
         /// <summary>
@@ -41,8 +44,8 @@ namespace osu.Framework.Localisation
         /// <returns>The best match for the provided criteria.</returns>
         public string GetPreferred(bool preferUnicode)
         {
-            if (string.IsNullOrEmpty(Romanised)) return Original;
-            if (string.IsNullOrEmpty(Original)) return Romanised;
+            if (string.IsNullOrEmpty(Romanised)) return Original ?? string.Empty;
+            if (string.IsNullOrEmpty(Original)) return Romanised ?? string.Empty;
 
             return preferUnicode ? Original : Romanised;
         }

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -1,30 +1,50 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Configuration;
+
 #nullable enable
 
 namespace osu.Framework.Localisation
 {
     /// <summary>
-    /// A string that has variations in Unicode and Romanised form.
+    /// A string that has a romanised fallback to allow a better experience for users that potentially can't read the original script.
+    /// See <see cref="FrameworkSetting.ShowUnicode"/>, which can toggle the display of romanised variants.
     /// </summary>
     public class RomanisableString
     {
-        public readonly string Romanised;
-        public readonly string Unicode;
+        /// <summary>
+        /// The string in its original script. May be null.
+        /// </summary>
+        public readonly string Original;
 
-        public RomanisableString(string unicode, string romanised)
+        /// <summary>
+        /// The romanised version of the string. May be null.
+        /// </summary>
+        public readonly string Romanised;
+
+        /// <summary>
+        /// Construct a new romanisable string.
+        /// </summary>
+        /// <param name="original">The string in its original script. If null, the <paramref name="romanised"/> version will always be used.</param>
+        /// <param name="romanised">The romanised version of the string. If null, the <paramref name="original"/> version will always be used.</param>
+        public RomanisableString(string original, string romanised)
         {
             Romanised = romanised;
-            Unicode = unicode;
+            Original = original;
         }
 
+        /// <summary>
+        /// Get the best match for this string based on a user preference for which should be displayed.
+        /// </summary>
+        /// <param name="preferUnicode">Whether to prefer the unicode (aka original) version where available.</param>
+        /// <returns>The best match for the provided criteria.</returns>
         public string GetPreferred(bool preferUnicode)
         {
-            if (string.IsNullOrEmpty(Romanised)) return Unicode;
-            if (string.IsNullOrEmpty(Unicode)) return Romanised;
+            if (string.IsNullOrEmpty(Romanised)) return Original;
+            if (string.IsNullOrEmpty(Original)) return Romanised;
 
-            return preferUnicode ? Unicode : Romanised;
+            return preferUnicode ? Original : Romanised;
         }
 
         public override string ToString() => GetPreferred(false);


### PR DESCRIPTION
I think it makes more sense to put the unicode (or as it is now named, original) string first, as it represents the "main" display version of the string. Or so you would think, but `ShowUnicode` is set to `false` by default sooo...

I believe this feels better anyway. Also added xmldoc.