### PR TITLE
Add optimised HasFlagFast<T> extension to Enum

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -209,3 +209,6 @@ dotnet_diagnostic.IDE0073.severity = warning
 
 #Disable operator overloads requiring alternate named methods
 dotnet_diagnostic.CA2225.severity = none
+
+# Banned APIs
+dotnet_diagnostic.RS0030.severity = error

--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -2,3 +2,4 @@ M:System.Object.Equals(System.Object,System.Object)~System.Boolean;Don't use obj
 M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Use IEquatable<T> or EqualityComparer<T>.Default instead.
 M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
+M:System.Enum.HasFlag(System.Enum);Use osu.Framework.Extensions.EnumExtensions.HasFlagFast<T>() instead.

--- a/osu.Framework.Benchmarks/BenchmarkEnum.cs
+++ b/osu.Framework.Benchmarks/BenchmarkEnum.cs
@@ -1,0 +1,61 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.CompilerServices;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Extensions.EnumExtensions;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkEnum
+    {
+        [Benchmark]
+        public bool HasFlag()
+        {
+            bool result = false;
+
+#pragma warning disable RS0030 // (banned API)
+            for (int i = 0; i < 1000000; i++)
+                result |= getFlags(i).HasFlag((FlagsEnum)i);
+#pragma warning restore RS0030
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool BitwiseAnd()
+        {
+            bool result = false;
+
+            for (int i = 0; i < 1000000; i++)
+                result |= (getFlags(i) & (FlagsEnum)i) > 0;
+
+            return result;
+        }
+
+        [Benchmark]
+        public bool HasFlagFast()
+        {
+            bool result = false;
+
+            for (int i = 0; i < 1000000; i++)
+                result |= getFlags(i).HasFlagFast((FlagsEnum)i);
+
+            return result;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private FlagsEnum getFlags(int i) => (FlagsEnum)i;
+
+        [Flags]
+        private enum FlagsEnum
+        {
+            Flag1 = 1,
+            Flag2 = 2,
+            Flag3 = 4,
+            Flag4 = 8
+        }
+    }
+}

--- a/osu.Framework.Benchmarks/BenchmarkEnum.cs
+++ b/osu.Framework.Benchmarks/BenchmarkEnum.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Runtime.CompilerServices;
 using BenchmarkDotNet.Attributes;
 using osu.Framework.Extensions.EnumExtensions;
 
@@ -14,40 +13,22 @@ namespace osu.Framework.Benchmarks
         [Benchmark]
         public bool HasFlag()
         {
-            bool result = false;
-
 #pragma warning disable RS0030 // (banned API)
-            for (int i = 0; i < 1000000; i++)
-                result |= getFlags(i).HasFlag((FlagsEnum)i);
+            return (FlagsEnum.Flag2 | FlagsEnum.Flag3).HasFlag(FlagsEnum.Flag2);
 #pragma warning restore RS0030
-
-            return result;
         }
 
         [Benchmark]
         public bool BitwiseAnd()
         {
-            bool result = false;
-
-            for (int i = 0; i < 1000000; i++)
-                result |= (getFlags(i) & (FlagsEnum)i) > 0;
-
-            return result;
+            return ((FlagsEnum.Flag2 | FlagsEnum.Flag3) & FlagsEnum.Flag2) > 0;
         }
 
         [Benchmark]
         public bool HasFlagFast()
         {
-            bool result = false;
-
-            for (int i = 0; i < 1000000; i++)
-                result |= getFlags(i).HasFlagFast((FlagsEnum)i);
-
-            return result;
+            return (FlagsEnum.Flag2 | FlagsEnum.Flag3).HasFlagFast(FlagsEnum.Flag2);
         }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private FlagsEnum getFlags(int i) => (FlagsEnum)i;
 
         [Flags]
         private enum FlagsEnum

--- a/osu.Framework.Benchmarks/Program.cs
+++ b/osu.Framework.Benchmarks/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Running;
 
 namespace osu.Framework.Benchmarks
@@ -11,7 +12,7 @@ namespace osu.Framework.Benchmarks
         {
             BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
-                .Run(args);
+                .Run(args, DefaultConfig.Instance.WithOption(ConfigOptions.DisableOptimizationsValidator, true));
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaOverrides.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaOverrides.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -38,10 +39,10 @@ namespace osu.Framework.Tests.Visual.Containers
 
         private void addBoxAssert(OverrideTestContainer container)
         {
-            bool leftOverridden = container.SafeAreaContainer.SafeAreaOverrideEdges.HasFlag(Edges.Left);
-            bool topOverridden = container.SafeAreaContainer.SafeAreaOverrideEdges.HasFlag(Edges.Top);
-            bool rightOverridden = container.SafeAreaContainer.SafeAreaOverrideEdges.HasFlag(Edges.Right);
-            bool bottomOverridden = container.SafeAreaContainer.SafeAreaOverrideEdges.HasFlag(Edges.Bottom);
+            bool leftOverridden = container.SafeAreaContainer.SafeAreaOverrideEdges.HasFlagFast(Edges.Left);
+            bool topOverridden = container.SafeAreaContainer.SafeAreaOverrideEdges.HasFlagFast(Edges.Top);
+            bool rightOverridden = container.SafeAreaContainer.SafeAreaOverrideEdges.HasFlagFast(Edges.Right);
+            bool bottomOverridden = container.SafeAreaContainer.SafeAreaOverrideEdges.HasFlagFast(Edges.Bottom);
 
             AddAssert($"\"{container.Name}\" overrides correctly", () =>
                 leftOverridden == container.SafeAreaContainer.Padding.Left < 0

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneIsMaskedAway.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneIsMaskedAway.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using NUnit.Framework;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -82,7 +83,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                         Anchor = anchor,
                         Origin = anchor,
                         Size = new Vector2(10),
-                        Position = new Vector2(anchor.HasFlag(Anchor.x0) ? -5 : 5, anchor.HasFlag(Anchor.y0) ? -5 : 5),
+                        Position = new Vector2(anchor.HasFlagFast(Anchor.x0) ? -5 : 5, anchor.HasFlagFast(Anchor.y0) ? -5 : 5),
                     }
                 };
             });
@@ -115,7 +116,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                         Anchor = anchor,
                         Origin = anchor,
                         Size = new Vector2(10),
-                        Position = new Vector2(anchor.HasFlag(Anchor.x0) ? -20 : 20, anchor.HasFlag(Anchor.y0) ? -20 : 20),
+                        Position = new Vector2(anchor.HasFlagFast(Anchor.x0) ? -20 : 20, anchor.HasFlagFast(Anchor.y0) ? -20 : 20),
                     }
                 };
             });

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using NUnit.Framework;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
@@ -152,14 +153,14 @@ namespace osu.Framework.Tests.Visual.UserInterface
             {
                 box.Anchor = anchor;
 
-                if (anchor.HasFlag(Anchor.x0))
+                if (anchor.HasFlagFast(Anchor.x0))
                     box.X -= contextMenuContainer.CurrentMenu.DrawWidth + 10;
-                else if (anchor.HasFlag(Anchor.x2))
+                else if (anchor.HasFlagFast(Anchor.x2))
                     box.X += 10;
 
-                if (anchor.HasFlag(Anchor.y0))
+                if (anchor.HasFlagFast(Anchor.y0))
                     box.Y -= contextMenuContainer.CurrentMenu.DrawHeight + 10;
-                else if (anchor.HasFlag(Anchor.y2))
+                else if (anchor.HasFlagFast(Anchor.y2))
                     box.Y += 10;
             });
 

--- a/osu.Framework/Extensions/EnumExtensions/EnumExtensions.cs
+++ b/osu.Framework/Extensions/EnumExtensions/EnumExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using osu.Framework.Utils;
 
 namespace osu.Framework.Extensions.EnumExtensions
@@ -50,6 +51,47 @@ namespace osu.Framework.Extensions.EnumExtensions
 
                 throw new ArgumentException($"Not all values of {typeof(T)} have {nameof(OrderAttribute)} specified.");
             });
+        }
+
+        /// <summary>
+        /// A fast alternative functionally equivalent to <see cref="Enum.HasFlag"/>, eliminating boxing in all scenarios.
+        /// </summary>
+        /// <param name="enumValue">The enum to check.</param>
+        /// <param name="flag">The flag to check for.</param>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static unsafe bool HasFlagFast<T>(this T enumValue, T flag) where T : unmanaged, Enum
+        {
+            // Note: Using a switch statement would eliminate inlining.
+
+            if (sizeof(T) == 1)
+            {
+                var value1 = Unsafe.As<T, byte>(ref enumValue);
+                var value2 = Unsafe.As<T, byte>(ref flag);
+                return (value1 & value2) > 0;
+            }
+
+            if (sizeof(T) == 2)
+            {
+                var value1 = Unsafe.As<T, short>(ref enumValue);
+                var value2 = Unsafe.As<T, short>(ref flag);
+                return (value1 & value2) > 0;
+            }
+
+            if (sizeof(T) == 4)
+            {
+                var value1 = Unsafe.As<T, int>(ref enumValue);
+                var value2 = Unsafe.As<T, int>(ref flag);
+                return (value1 & value2) > 0;
+            }
+
+            if (sizeof(T) == 8)
+            {
+                var value1 = Unsafe.As<T, long>(ref enumValue);
+                var value2 = Unsafe.As<T, long>(ref flag);
+                return (value1 & value2) > 0;
+            }
+
+            throw new ArgumentException($"Invalid enum type provided: {typeof(T)}.");
         }
     }
 }

--- a/osu.Framework/Extensions/EnumExtensions/EnumExtensions.cs
+++ b/osu.Framework/Extensions/EnumExtensions/EnumExtensions.cs
@@ -53,11 +53,13 @@ namespace osu.Framework.Extensions.EnumExtensions
             });
         }
 
+#pragma warning disable RS0030 // (banned API)
         /// <summary>
         /// A fast alternative functionally equivalent to <see cref="Enum.HasFlag"/>, eliminating boxing in all scenarios.
         /// </summary>
         /// <param name="enumValue">The enum to check.</param>
         /// <param name="flag">The flag to check for.</param>
+#pragma warning restore RS0030
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool HasFlagFast<T>(this T enumValue, T flag) where T : unmanaged, Enum
         {

--- a/osu.Framework/Graphics/Containers/AudioContainer.cs
+++ b/osu.Framework/Graphics/Containers/AudioContainer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using osu.Framework.Audio;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Audio;
 using osu.Framework.Graphics.Effects;
 using osuTK;
@@ -40,8 +41,8 @@ namespace osu.Framework.Graphics.Containers
             set
             {
                 base.Size = new Vector2(
-                    RelativeSizeAxes.HasFlag(Axes.X) ? 1 : value.X,
-                    RelativeSizeAxes.HasFlag(Axes.Y) ? 1 : value.Y);
+                    RelativeSizeAxes.HasFlagFast(Axes.X) ? 1 : value.X,
+                    RelativeSizeAxes.HasFlagFast(Axes.Y) ? 1 : value.Y);
 
                 container.Size = value;
             }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -21,6 +21,7 @@ using osu.Framework.Statistics;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Development;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Primitives;
@@ -666,9 +667,9 @@ namespace osu.Framework.Graphics.Containers
             {
                 var state = checkChildLife(internalChildren[i]);
 
-                anyAliveChanged |= state.HasFlag(ChildLifeStateChange.MadeAlive) || state.HasFlag(ChildLifeStateChange.MadeDead);
+                anyAliveChanged |= state.HasFlagFast(ChildLifeStateChange.MadeAlive) || state.HasFlagFast(ChildLifeStateChange.MadeDead);
 
-                if (state.HasFlag(ChildLifeStateChange.Removed))
+                if (state.HasFlagFast(ChildLifeStateChange.Removed))
                     i--;
             }
 
@@ -1706,7 +1707,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.X))
+                if (!isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlagFast(Axes.X))
                     updateChildrenSizeDependencies();
                 return base.Width;
             }
@@ -1724,7 +1725,7 @@ namespace osu.Framework.Graphics.Containers
         {
             get
             {
-                if (!isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlag(Axes.Y))
+                if (!isComputingChildrenSizeDependencies && AutoSizeAxes.HasFlagFast(Axes.Y))
                     updateChildrenSizeDependencies();
                 return base.Height;
             }
@@ -1780,16 +1781,16 @@ namespace osu.Framework.Graphics.Containers
 
                     Vector2 cBound = c.RequiredParentSizeToFit;
 
-                    if (!c.BypassAutoSizeAxes.HasFlag(Axes.X))
+                    if (!c.BypassAutoSizeAxes.HasFlagFast(Axes.X))
                         maxBoundSize.X = Math.Max(maxBoundSize.X, cBound.X);
 
-                    if (!c.BypassAutoSizeAxes.HasFlag(Axes.Y))
+                    if (!c.BypassAutoSizeAxes.HasFlagFast(Axes.Y))
                         maxBoundSize.Y = Math.Max(maxBoundSize.Y, cBound.Y);
                 }
 
-                if (!AutoSizeAxes.HasFlag(Axes.X))
+                if (!AutoSizeAxes.HasFlagFast(Axes.X))
                     maxBoundSize.X = DrawSize.X;
-                if (!AutoSizeAxes.HasFlag(Axes.Y))
+                if (!AutoSizeAxes.HasFlagFast(Axes.Y))
                     maxBoundSize.Y = DrawSize.Y;
 
                 return new Vector2(maxBoundSize.X, maxBoundSize.Y);
@@ -1809,8 +1810,8 @@ namespace osu.Framework.Graphics.Containers
             Vector2 b = computeAutoSize() + Padding.Total;
 
             autoSizeResizeTo(new Vector2(
-                AutoSizeAxes.HasFlag(Axes.X) ? b.X : base.Width,
-                AutoSizeAxes.HasFlag(Axes.Y) ? b.Y : base.Height
+                AutoSizeAxes.HasFlagFast(Axes.X) ? b.X : base.Width,
+                AutoSizeAxes.HasFlagFast(Axes.Y) ? b.Y : base.Height
             ), AutoSizeDuration, AutoSizeEasing);
 
             //note that this is called before autoSize becomes valid. may be something to consider down the line.

--- a/osu.Framework/Graphics/Containers/ContainerExtensions.cs
+++ b/osu.Framework/Graphics/Containers/ContainerExtensions.cs
@@ -4,6 +4,7 @@
 using osuTK;
 using System;
 using System.Collections.Generic;
+using osu.Framework.Extensions.EnumExtensions;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -43,13 +44,13 @@ namespace osu.Framework.Graphics.Containers
 
             // For anchor/origin positioning to be preserved correctly,
             // relatively sized axes must be lifted to the wrapping container.
-            if (container.RelativeSizeAxes.HasFlag(Axes.X))
+            if (container.RelativeSizeAxes.HasFlagFast(Axes.X))
             {
                 container.Width = drawable.Width;
                 drawable.Width = 1;
             }
 
-            if (container.RelativeSizeAxes.HasFlag(Axes.Y))
+            if (container.RelativeSizeAxes.HasFlagFast(Axes.Y))
             {
                 container.Height = drawable.Height;
                 drawable.Height = 1;

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using osuTK;
 using System.Linq;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Utils;
 
 namespace osu.Framework.Graphics.Containers
@@ -87,9 +88,9 @@ namespace osu.Framework.Graphics.Containers
         private Vector2 spacingFactor(Drawable c)
         {
             Vector2 result = c.RelativeOriginPosition;
-            if (c.Anchor.HasFlag(Anchor.x2))
+            if (c.Anchor.HasFlagFast(Anchor.x2))
                 result.X = 1 - result.X;
-            if (c.Anchor.HasFlag(Anchor.y2))
+            if (c.Anchor.HasFlagFast(Anchor.y2))
                 result.Y = 1 - result.Y;
             return result;
         }
@@ -104,8 +105,8 @@ namespace osu.Framework.Graphics.Containers
 
                 // If we are autosize and haven't specified a maximum size, we should allow infinite expansion.
                 // If we are inheriting then we need to use the parent size (our ActualSize).
-                max.X = AutoSizeAxes.HasFlag(Axes.X) ? float.MaxValue : s.X;
-                max.Y = AutoSizeAxes.HasFlag(Axes.Y) ? float.MaxValue : s.Y;
+                max.X = AutoSizeAxes.HasFlagFast(Axes.X) ? float.MaxValue : s.X;
+                max.Y = AutoSizeAxes.HasFlagFast(Axes.Y) ? float.MaxValue : s.Y;
             }
 
             var children = FlowingChildren.ToArray();
@@ -262,17 +263,17 @@ namespace osu.Framework.Graphics.Containers
                         break;
                 }
 
-                if (c.Anchor.HasFlag(Anchor.x1))
+                if (c.Anchor.HasFlagFast(Anchor.x1))
                     // Begin flow at centre of row
                     result[i].X += rowOffsetsToMiddle[rowIndices[i]];
-                else if (c.Anchor.HasFlag(Anchor.x2))
+                else if (c.Anchor.HasFlagFast(Anchor.x2))
                     // Flow right-to-left
                     result[i].X = -result[i].X;
 
-                if (c.Anchor.HasFlag(Anchor.y1))
+                if (c.Anchor.HasFlagFast(Anchor.y1))
                     // Begin flow at centre of total height
                     result[i].Y -= height / 2;
-                else if (c.Anchor.HasFlag(Anchor.y2))
+                else if (c.Anchor.HasFlagFast(Anchor.y2))
                     // Flow bottom-to-top
                     result[i].Y = -result[i].Y;
             }

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -10,6 +10,7 @@ using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
 using osu.Framework.Allocation;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Sprites;
 using osuTK;
 
@@ -37,7 +38,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
             get => base.AutoSizeAxes;
             set
             {
-                if (value.HasFlag(Axes.X))
+                if (value.HasFlagFast(Axes.X))
                     throw new ArgumentException($"{nameof(MarkdownContainer)} does not support an {nameof(AutoSizeAxes)} of {value}");
 
                 base.AutoSizeAxes = value;

--- a/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Layout;
 
@@ -76,10 +77,10 @@ namespace osu.Framework.Graphics.Containers
 
             return new MarginPadding
             {
-                Left = SafeAreaOverrideEdges.HasFlag(Edges.Left) ? nonSafeLocalSpace.TopLeft.X : Math.Clamp(localTopLeft.X, 0, DrawSize.X),
-                Right = SafeAreaOverrideEdges.HasFlag(Edges.Right) ? DrawRectangle.BottomRight.X - nonSafeLocalSpace.BottomRight.X : Math.Clamp(DrawSize.X - localBottomRight.X, 0, DrawSize.X),
-                Top = SafeAreaOverrideEdges.HasFlag(Edges.Top) ? nonSafeLocalSpace.TopLeft.Y : Math.Clamp(localTopLeft.Y, 0, DrawSize.Y),
-                Bottom = SafeAreaOverrideEdges.HasFlag(Edges.Bottom) ? DrawRectangle.BottomRight.Y - nonSafeLocalSpace.BottomRight.Y : Math.Clamp(DrawSize.Y - localBottomRight.Y, 0, DrawSize.Y)
+                Left = SafeAreaOverrideEdges.HasFlagFast(Edges.Left) ? nonSafeLocalSpace.TopLeft.X : Math.Clamp(localTopLeft.X, 0, DrawSize.X),
+                Right = SafeAreaOverrideEdges.HasFlagFast(Edges.Right) ? DrawRectangle.BottomRight.X - nonSafeLocalSpace.BottomRight.X : Math.Clamp(DrawSize.X - localBottomRight.X, 0, DrawSize.X),
+                Top = SafeAreaOverrideEdges.HasFlagFast(Edges.Top) ? nonSafeLocalSpace.TopLeft.Y : Math.Clamp(localTopLeft.Y, 0, DrawSize.Y),
+                Bottom = SafeAreaOverrideEdges.HasFlagFast(Edges.Bottom) ? DrawRectangle.BottomRight.Y - nonSafeLocalSpace.BottomRight.Y : Math.Clamp(DrawSize.Y - localBottomRight.Y, 0, DrawSize.Y)
             };
         }
     }

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using osu.Framework.Extensions.EnumExtensions;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -192,7 +193,7 @@ namespace osu.Framework.Graphics.Containers
         {
             // FillFlowContainer will reverse the ordering of right-anchored words such that the (previously) first word would be
             // the right-most word, whereas it should still be flowed left-to-right. This is achieved by reversing the comparator.
-            if (TextAnchor.HasFlag(Anchor.x2))
+            if (TextAnchor.HasFlagFast(Anchor.x2))
                 return base.Compare(y, x);
 
             return base.Compare(x, y);

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -25,6 +25,7 @@ using System.Threading;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Development;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Input.Bindings;
@@ -661,10 +662,10 @@ namespace osu.Framework.Graphics
                 {
                     offset = Parent.RelativeChildOffset;
 
-                    if (!RelativePositionAxes.HasFlag(Axes.X))
+                    if (!RelativePositionAxes.HasFlagFast(Axes.X))
                         offset.X = 0;
 
-                    if (!RelativePositionAxes.HasFlag(Axes.Y))
+                    if (!RelativePositionAxes.HasFlagFast(Axes.Y))
                         offset.Y = 0;
                 }
 
@@ -790,8 +791,8 @@ namespace osu.Framework.Graphics
 
                 relativeSizeAxes = value;
 
-                if (relativeSizeAxes.HasFlag(Axes.X) && Width == 0) Width = 1;
-                if (relativeSizeAxes.HasFlag(Axes.Y) && Height == 0) Height = 1;
+                if (relativeSizeAxes.HasFlagFast(Axes.X) && Width == 0) Width = 1;
+                if (relativeSizeAxes.HasFlagFast(Axes.Y) && Height == 0) Height = 1;
 
                 updateBypassAutoSizeAxes();
 
@@ -885,9 +886,9 @@ namespace osu.Framework.Graphics
             {
                 Vector2 conversion = relativeToAbsoluteFactor;
 
-                if (relativeAxes.HasFlag(Axes.X))
+                if (relativeAxes.HasFlagFast(Axes.X))
                     v.X *= conversion.X;
-                if (relativeAxes.HasFlag(Axes.Y))
+                if (relativeAxes.HasFlagFast(Axes.Y))
                     v.Y *= conversion.Y;
 
                 // FillMode only makes sense if both axes are relatively sized as the general rule
@@ -1122,14 +1123,14 @@ namespace osu.Framework.Graphics
                     throw new InvalidOperationException(@"Can not obtain relative origin position for custom origins.");
 
                 Vector2 result = Vector2.Zero;
-                if (origin.HasFlag(Anchor.x1))
+                if (origin.HasFlagFast(Anchor.x1))
                     result.X = 0.5f;
-                else if (origin.HasFlag(Anchor.x2))
+                else if (origin.HasFlagFast(Anchor.x2))
                     result.X = 1;
 
-                if (origin.HasFlag(Anchor.y1))
+                if (origin.HasFlagFast(Anchor.y1))
                     result.Y = 0.5f;
-                else if (origin.HasFlag(Anchor.y2))
+                else if (origin.HasFlagFast(Anchor.y2))
                     result.Y = 1;
 
                 return result;
@@ -1211,14 +1212,14 @@ namespace osu.Framework.Graphics
                     return customRelativeAnchorPosition;
 
                 Vector2 result = Vector2.Zero;
-                if (anchor.HasFlag(Anchor.x1))
+                if (anchor.HasFlagFast(Anchor.x1))
                     result.X = 0.5f;
-                else if (anchor.HasFlag(Anchor.x2))
+                else if (anchor.HasFlagFast(Anchor.x2))
                     result.X = 1;
 
-                if (anchor.HasFlag(Anchor.y1))
+                if (anchor.HasFlagFast(Anchor.y1))
                     result.Y = 0.5f;
-                else if (anchor.HasFlag(Anchor.y2))
+                else if (anchor.HasFlagFast(Anchor.y2))
                     result.Y = 1;
 
                 return result;
@@ -1256,14 +1257,14 @@ namespace osu.Framework.Graphics
         {
             Vector2 result = Vector2.Zero;
 
-            if (anchor.HasFlag(Anchor.x1))
+            if (anchor.HasFlagFast(Anchor.x1))
                 result.X = size.X / 2f;
-            else if (anchor.HasFlag(Anchor.x2))
+            else if (anchor.HasFlagFast(Anchor.x2))
                 result.X = size.X;
 
-            if (anchor.HasFlag(Anchor.y1))
+            if (anchor.HasFlagFast(Anchor.y1))
                 result.Y = size.Y / 2f;
-            else if (anchor.HasFlag(Anchor.y2))
+            else if (anchor.HasFlagFast(Anchor.y2))
                 result.Y = size.Y;
 
             return result;

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Shaders;
 using osu.Framework.Allocation;
 using System.Collections.Generic;
 using osu.Framework.Caching;
+using osu.Framework.Extensions.EnumExtensions;
 using osuTK.Graphics;
 using osuTK.Graphics.ES30;
 
@@ -113,7 +114,7 @@ namespace osu.Framework.Graphics.Lines
         {
             get
             {
-                if (AutoSizeAxes.HasFlag(Axes.X))
+                if (AutoSizeAxes.HasFlagFast(Axes.X))
                     return base.Width = vertexBounds.Width;
 
                 return base.Width;
@@ -131,7 +132,7 @@ namespace osu.Framework.Graphics.Lines
         {
             get
             {
-                if (AutoSizeAxes.HasFlag(Axes.Y))
+                if (AutoSizeAxes.HasFlagFast(Axes.Y))
                     return base.Height = vertexBounds.Height;
 
                 return base.Height;

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
 using osu.Framework.Threading;
@@ -117,7 +118,7 @@ namespace osu.Framework.Graphics.Pooling
 
         protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)
         {
-            if (source != InvalidationSource.Child && invalidation.HasFlag(Invalidation.Parent))
+            if (source != InvalidationSource.Child && invalidation.HasFlagFast(Invalidation.Parent))
             {
                 if (IsInUse && Parent == null)
                     Return();

--- a/osu.Framework/Graphics/Textures/Texture.cs
+++ b/osu.Framework/Graphics/Textures/Texture.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.Primitives;
@@ -73,8 +74,8 @@ namespace osu.Framework.Graphics.Textures
             if (relativeSizeAxes != Axes.None)
             {
                 Vector2 scale = new Vector2(
-                    relativeSizeAxes.HasFlag(Axes.X) ? Width : 1,
-                    relativeSizeAxes.HasFlag(Axes.Y) ? Height : 1
+                    relativeSizeAxes.HasFlagFast(Axes.X) ? Width : 1,
+                    relativeSizeAxes.HasFlagFast(Axes.Y) ? Height : 1
                 );
                 cropRectangle *= scale;
             }

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osuTK.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -362,8 +363,8 @@ namespace osu.Framework.Graphics.UserInterface
                 height = Math.Min(MaxHeight, height);
 
                 // Regardless of the above result, if we are relative-sizing, just use the stored width/height
-                width = RelativeSizeAxes.HasFlag(Axes.X) ? Width : width;
-                height = RelativeSizeAxes.HasFlag(Axes.Y) ? Height : height;
+                width = RelativeSizeAxes.HasFlagFast(Axes.X) ? Width : width;
+                height = RelativeSizeAxes.HasFlagFast(Axes.Y) ? Height : height;
 
                 if (State == MenuState.Closed && Direction == Direction.Horizontal)
                     width = 0;

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
@@ -168,8 +169,8 @@ namespace osu.Framework.Graphics.UserInterface
 
                 AddInternal(Dropdown);
 
-                Trace.Assert(Dropdown.Header.Anchor.HasFlag(Anchor.x2), $@"The {nameof(Dropdown)} implementation should use a right-based anchor inside a TabControl.");
-                Trace.Assert(!Dropdown.Header.RelativeSizeAxes.HasFlag(Axes.X), $@"The {nameof(Dropdown)} implementation's header should have a specific size.");
+                Trace.Assert(Dropdown.Header.Anchor.HasFlagFast(Anchor.x2), $@"The {nameof(Dropdown)} implementation should use a right-based anchor inside a TabControl.");
+                Trace.Assert(!Dropdown.Header.RelativeSizeAxes.HasFlagFast(Axes.X), $@"The {nameof(Dropdown)} implementation's header should have a specific size.");
             }
 
             AddInternal(TabContainer = CreateTabFlow());

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKMouseState.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKMouseState.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Extensions.EnumExtensions;
 using osuTK;
 using osuTK.Input;
 
@@ -29,7 +30,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             }
 
             Scroll = new Vector2(-tkState.Scroll.X, tkState.Scroll.Y);
-            HasPreciseScroll = tkState.Flags.HasFlag(MouseStateFlags.HasPreciseScroll);
+            HasPreciseScroll = tkState.Flags.HasFlagFast(MouseStateFlags.HasPreciseScroll);
             Position = new Vector2(mappedPosition?.X ?? tkState.X, mappedPosition?.Y ?? tkState.Y);
         }
 

--- a/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/OsuTKRawMouseHandler.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using System.Linq;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Platform;
 using osu.Framework.Threading;
 using osuTK;
@@ -71,7 +72,7 @@ namespace osu.Framework.Input.Handlers.Mouse
 
                                 var newState = new OsuTKPollMouseState(rawState, host.IsActive.Value, getUpdatedPosition(rawState, lastState));
 
-                                HandleState(newState, lastState, rawState.Flags.HasFlag(MouseStateFlags.MoveAbsolute));
+                                HandleState(newState, lastState, rawState.Flags.HasFlagFast(MouseStateFlags.MoveAbsolute));
 
                                 lastEachDeviceStates[i] = newState;
                                 lastUnfocusedState = null;
@@ -116,7 +117,7 @@ namespace osu.Framework.Input.Handlers.Mouse
         {
             Vector2 currentPosition;
 
-            if (state.Flags.HasFlag(MouseStateFlags.MoveAbsolute))
+            if (state.Flags.HasFlagFast(MouseStateFlags.MoveAbsolute))
             {
                 const int raw_input_resolution = 65536;
 
@@ -129,7 +130,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                 }
                 else
                 {
-                    Rectangle screenRect = state.Flags.HasFlag(MouseStateFlags.VirtualDesktop)
+                    Rectangle screenRect = state.Flags.HasFlagFast(MouseStateFlags.VirtualDesktop)
                         ? Platform.Windows.Native.Input.GetVirtualScreenRect()
                         : new Rectangle(0, 0, DisplayDevice.Default.Width, DisplayDevice.Default.Height);
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Immutable;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.StateChanges.Events;
@@ -34,7 +35,7 @@ namespace osu.Framework.Input
                     var mouse = mousePositionChange.State.Mouse;
 
                     // confine cursor
-                    if (Host.Window != null && Host.Window.CursorState.HasFlag(CursorState.Confined))
+                    if (Host.Window != null && Host.Window.CursorState.HasFlagFast(CursorState.Confined))
                     {
                         var clientSize = Host.Window.ClientSize;
                         mouse.Position = Vector2.Clamp(mouse.Position, Vector2.Zero, new Vector2(clientSize.Width, clientSize.Height));

--- a/osu.Framework/Platform/MacOS/OsuTKMacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/OsuTKMacOSWindow.cs
@@ -12,6 +12,7 @@ using osu.Framework.Logging;
 using osu.Framework.Platform.MacOS.Native;
 using osuTK;
 using System.Diagnostics;
+using osu.Framework.Extensions.EnumExtensions;
 
 namespace osu.Framework.Platform.MacOS
 {
@@ -140,7 +141,7 @@ namespace osu.Framework.Platform.MacOS
         private const NSApplicationPresentationOptions default_fullscreen_presentation_options =
             NSApplicationPresentationOptions.AutoHideDock | NSApplicationPresentationOptions.AutoHideMenuBar | NSApplicationPresentationOptions.FullScreen;
 
-        private bool isCursorHidden => CursorState.HasFlag(CursorState.Hidden);
+        private bool isCursorHidden => CursorState.HasFlagFast(CursorState.Hidden);
 
         private NSApplicationPresentationOptions fullscreenPresentationOptions =>
             default_fullscreen_presentation_options | (isCursorHidden ? NSApplicationPresentationOptions.DisableCursorLocationAssistance : 0);
@@ -164,7 +165,7 @@ namespace osu.Framework.Platform.MacOS
             {
                 pendingWindowMode = null;
 
-                bool currentFullScreen = styleMask.HasFlag(NSWindowStyleMask.FullScreen);
+                bool currentFullScreen = styleMask.HasFlagFast(NSWindowStyleMask.FullScreen);
                 bool toggleFullScreen = mode.Value == Configuration.WindowMode.Fullscreen ? !currentFullScreen : currentFullScreen;
 
                 if (toggleFullScreen)
@@ -195,42 +196,42 @@ namespace osu.Framework.Platform.MacOS
             {
                 case MacOSKeyCodes.LShift:
                     key = osuTK.Input.Key.LShift;
-                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.LeftShift);
+                    keyDown = modifierFlags.HasFlagFast(CocoaKeyModifiers.LeftShift);
                     break;
 
                 case MacOSKeyCodes.RShift:
                     key = osuTK.Input.Key.RShift;
-                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.RightShift);
+                    keyDown = modifierFlags.HasFlagFast(CocoaKeyModifiers.RightShift);
                     break;
 
                 case MacOSKeyCodes.LControl:
                     key = osuTK.Input.Key.LControl;
-                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.LeftControl);
+                    keyDown = modifierFlags.HasFlagFast(CocoaKeyModifiers.LeftControl);
                     break;
 
                 case MacOSKeyCodes.RControl:
                     key = osuTK.Input.Key.RControl;
-                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.RightControl);
+                    keyDown = modifierFlags.HasFlagFast(CocoaKeyModifiers.RightControl);
                     break;
 
                 case MacOSKeyCodes.LAlt:
                     key = osuTK.Input.Key.LAlt;
-                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.LeftAlt);
+                    keyDown = modifierFlags.HasFlagFast(CocoaKeyModifiers.LeftAlt);
                     break;
 
                 case MacOSKeyCodes.RAlt:
                     key = osuTK.Input.Key.RAlt;
-                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.RightAlt);
+                    keyDown = modifierFlags.HasFlagFast(CocoaKeyModifiers.RightAlt);
                     break;
 
                 case MacOSKeyCodes.LCommand:
                     key = osuTK.Input.Key.LWin;
-                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.LeftCommand);
+                    keyDown = modifierFlags.HasFlagFast(CocoaKeyModifiers.LeftCommand);
                     break;
 
                 case MacOSKeyCodes.RCommand:
                     key = osuTK.Input.Key.RWin;
-                    keyDown = modifierFlags.HasFlag(CocoaKeyModifiers.RightCommand);
+                    keyDown = modifierFlags.HasFlagFast(CocoaKeyModifiers.RightCommand);
                     break;
 
                 default:

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -16,6 +16,7 @@ using System.Drawing;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Threading;
 
 namespace osu.Framework.Platform
@@ -193,11 +194,11 @@ namespace osu.Framework.Platform
             {
                 cursorState = value;
 
-                OsuTKGameWindow.Cursor = cursorState.HasFlag(CursorState.Hidden) ? MouseCursor.Empty : MouseCursor.Default;
+                OsuTKGameWindow.Cursor = cursorState.HasFlagFast(CursorState.Hidden) ? MouseCursor.Empty : MouseCursor.Default;
 
                 try
                 {
-                    OsuTKGameWindow.CursorGrabbed = cursorState.HasFlag(CursorState.Confined);
+                    OsuTKGameWindow.CursorGrabbed = cursorState.HasFlagFast(CursorState.Confined);
                 }
                 catch
                 {

--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input;
 using osuTK.Input;
 using SDL2;
@@ -13,7 +14,7 @@ namespace osu.Framework.Platform.SDL2
         {
             // Apple devices don't have the notion of NumLock (they have a Clear key instead).
             // treat them as if they always have NumLock on (the numpad always performs its primary actions).
-            bool numLockOn = sdlKeysym.mod.HasFlag(SDL.SDL_Keymod.KMOD_NUM) || RuntimeInfo.IsApple;
+            bool numLockOn = sdlKeysym.mod.HasFlagFast(SDL.SDL_Keymod.KMOD_NUM) || RuntimeInfo.IsApple;
 
             switch (sdlKeysym.scancode)
             {
@@ -446,18 +447,18 @@ namespace osu.Framework.Platform.SDL2
         public static WindowState ToWindowState(this SDL.SDL_WindowFlags windowFlags)
         {
             // NOTE: on macOS, SDL2 does not differentiate between "maximised" and "fullscreen desktop"
-            if (windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP) ||
-                windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_BORDERLESS) ||
-                windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED) && RuntimeInfo.OS == RuntimeInfo.Platform.MacOsx)
+            if (windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP) ||
+                windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_BORDERLESS) ||
+                windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED) && RuntimeInfo.OS == RuntimeInfo.Platform.MacOsx)
                 return WindowState.FullscreenBorderless;
 
-            if (windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_MINIMIZED))
+            if (windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_MINIMIZED))
                 return WindowState.Minimised;
 
-            if (windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN))
+            if (windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN))
                 return WindowState.Fullscreen;
 
-            if (windowFlags.HasFlag(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED))
+            if (windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED))
                 return WindowState.Maximised;
 
             return WindowState.Normal;

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Input;
 using osu.Framework.Platform.SDL2;
@@ -351,8 +352,8 @@ namespace osu.Framework.Platform
 
             CursorStateBindable.ValueChanged += evt =>
             {
-                CursorVisible = !evt.NewValue.HasFlag(CursorState.Hidden);
-                CursorConfined = evt.NewValue.HasFlag(CursorState.Confined);
+                CursorVisible = !evt.NewValue.HasFlagFast(CursorState.Hidden);
+                CursorConfined = evt.NewValue.HasFlagFast(CursorState.Confined);
             };
 
             cursorInWindow.ValueChanged += evt =>


### PR DESCRIPTION
On a RELEASE (this is important, will be explained later) startup of osu!, I noticed that a few enum values would thrash about in Gen0. This doesn't appear in dotMemory, but they're revealed via dotnet-sos:

```
> dumpheap -type Axes
         
         Address               MT     Size
...
00007f938cd7f680 00007f93b9b12b88       24

Statistics:
              MT    Count    TotalSize Class Name
00007f93b9b12b88     4222       101328 osu.Framework.Graphics.Axes
Total 4222 objects

> gcwhere 00007f938cd7f680

Address            Gen   Heap   segment            begin              allocated           size
00007F938CD7F680   0      0     00007F9383FFE000   00007F9383FFF000   00007F938CFD9FE8    0x18(24)
```

I originally noticed this issue with `CompositeDrawable.ChildLifeStateChange`, however I was originally testing with the DEBUG configuration.

In trying to isolate this, I constructed the following test:
```csharp
class Program
{
    private static DotNetRuntimeListener listener;

    static void Main(string[] args)
    {
        listener = new DotNetRuntimeListener();

        bool b = false;
        for (long i = 0; i < long.MaxValue - 1; i++)
            b = getFlag(Environment.TickCount).HasFlag(FlagsEnum.Flag2 | FlagsEnum.Flag3);

        Console.WriteLine(b);
    }

    [MethodImpl(MethodImplOptions.NoInlining)]
    private static FlagsEnum getFlag(int i) => (FlagsEnum)i;

    [Flags]
    private enum FlagsEnum
    {
        Flag1 = 1,
        Flag2 = 2,
        Flag3 = 4,
        Flag4 = 8
    }

    // https://medium.com/criteo-labs/c-in-process-clr-event-listeners-with-net-core-2-2-ef4075c14e87
    internal sealed class DotNetRuntimeListener : EventListener
    {
        private const int gc_keyword = 0x0000001;

        private const string statistics_grouping = "GC";

        protected override void OnEventSourceCreated(EventSource eventSource)
        {
            if (eventSource.Name == "Microsoft-Windows-DotNETRuntime")
                EnableEvents(eventSource, EventLevel.Verbose, (EventKeywords)gc_keyword);
        }

        protected override void OnEventWritten(EventWrittenEventArgs data)
        {
            switch ((EventType)data.EventId)
            {
                case EventType.GCStart_V1 when data.Payload != null:
                    // https://docs.microsoft.com/en-us/dotnet/framework/performance/garbage-collection-etw-events#gcstart_v1_event
                    Console.WriteLine($"GC | Gen: {data.Payload[1]} Reason: {data.Payload[2]} Type: {data.Payload[3]}");
                    break;
            }
        }

        private enum EventType
        {
            GCStart_V1 = 1,
            GCHeapStats_V1 = 4,
        }
    }
}

public static class EnumExtensions
{
    [MethodImpl(MethodImplOptions.AggressiveInlining)]
    public static unsafe bool HasFlagFast<T>(this T enumValue, T flag) where T : unmanaged, Enum
    {
        int intVal1 = Unsafe.As<T, int>(ref enumValue);
        int intVal2 = Unsafe.As<T, int>(ref flag);

        return (intVal1 & intVal2) > 0;
    }
}
```
When run in DEBUG this prints many lines of `GC | Gen: 0 Reason: 0 Type: 0` to the console. When run in RELEASE, this does not print at all. It looks like the de-boxing of `Enum.HasFlag` is dependent on:
1) The JIT.
2) The build config, which probably relates to (1).

As you can see in the above isolation, I also implemented a custom `HasFlagFast` method which doesn't exhibit this behaviour in any build config. Further benchmarking (via BenchmarkDotNet) leads to the following results:
```
DEBUG:
|      Method |      Mean |     Error |    StdDev |     Gen 0 | Gen 1 | Gen 2 |  Allocated |
|------------ |----------:|----------:|----------:|----------:|------:|------:|-----------:|
|     HasFlag | 29.483 ms | 0.3228 ms | 0.2862 ms | 1406.2500 |     - |     - | 48000009 B |
|  BitwiseAnd |  4.416 ms | 0.0017 ms | 0.0016 ms |         - |     - |     - |        2 B |
| HasFlagFast | 10.017 ms | 0.0106 ms | 0.0088 ms |         - |     - |     - |        4 B |

RELEASE:
|      Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|----------:|----------:|------:|------:|------:|----------:|
|     HasFlag | 1.894 ms | 0.0010 ms | 0.0009 ms |     - |     - |     - |       1 B |
|  BitwiseAnd | 1.894 ms | 0.0004 ms | 0.0003 ms |     - |     - |     - |       1 B |
| HasFlagFast | 1.894 ms | 0.0010 ms | 0.0009 ms |     - |     - |     - |       1 B |
```
Keep in mind, however, that this isn't always a DEBUG thing - I was seeing `Axes` in Gen0 in RELEASE-mode osu!.

In this PR, I've built upon the above method to support all enum types (byte/short/int/long), and replaced all existing usages of `Enum.HasFlag` with the new `HasFlagFast` method. I've also banned `Enum.HasFlag` from use.

Now, the same steps as above shows 0 `Axes` objects in Gen0:
```
> dumpheap -type Axes

         Address               MT     Size

Statistics:
              MT    Count    TotalSize Class Name
Total 0 objects
```