### PR TITLE
Add implicit conversion and string comparer to LocalisableString

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -1,0 +1,63 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Localisation;
+
+namespace osu.Framework.Tests.Localisation
+{
+    [TestFixture]
+    public class LocalisableStringTest
+    {
+        private const string first_string = "abc123";
+        private const string second_string = "123abc";
+
+        [Test]
+        public void TestNUnitEqualTo()
+        {
+            LocalisableString localisable = first_string;
+
+            Assert.That(localisable, Is.EqualTo(first_string));
+            Assert.That(localisable, Is.Not.EqualTo(second_string));
+        }
+
+        [Test]
+        public void TestObjectEqualsTo()
+        {
+            LocalisableString localisable = first_string;
+
+#pragma warning disable RS0030
+            Assert.That(Equals(localisable, first_string));
+            Assert.That(!Equals(localisable, second_string));
+#pragma warning restore RS0030
+        }
+
+        [Test]
+        public void TestOperatorEqualsString()
+        {
+            LocalisableString localisable = first_string;
+
+            Assert.That(localisable == first_string);
+            Assert.That(localisable != second_string);
+        }
+
+        [Test]
+        public void TestEqualityStringComparerEquals()
+        {
+            LocalisableString localisable = first_string;
+
+            Assert.That(EqualityComparer<string>.Default.Equals(localisable, first_string));
+            Assert.That(!EqualityComparer<string>.Default.Equals(localisable, second_string));
+        }
+
+        [Test]
+        public void TestEqualityLocalisableComparerEquals()
+        {
+            LocalisableString localisable = first_string;
+
+            Assert.That(EqualityComparer<LocalisableString>.Default.Equals(localisable, first_string));
+            Assert.That(!EqualityComparer<LocalisableString>.Default.Equals(localisable, second_string));
+        }
+    }
+}

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Localisation
     /// <summary>
     /// A descriptor representing text that can be localised and formatted.
     /// </summary>
-    public readonly struct LocalisableString : IEquatable<LocalisableString>
+    public readonly struct LocalisableString : IEquatable<LocalisableString>, IEquatable<string>
     {
         /// <summary>
         /// The underlying data, can be <see cref="string"/>, <see cref="TranslatableString"/>, or <see cref="RomanisableString"/>.
@@ -31,7 +31,20 @@ namespace osu.Framework.Localisation
         public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
         public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);
 
-        public override bool Equals(object? obj) => obj is LocalisableString other && Equals(other);
+        public static implicit operator string(LocalisableString localisable) => localisable.ToString();
+        public bool Equals(string other) => ToString().Equals(other);
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is LocalisableString localisable)
+                return Equals(localisable);
+
+            if (obj is string str)
+                return Equals(str);
+
+            return false;
+        }
+
         public override int GetHashCode() => Data?.GetHashCode() ?? 0;
     }
 }


### PR DESCRIPTION
Adds implicit conversion of `LocalisableString` to `string` via `LocalisableString.ToString()`, and adds some string-based comparers so that it doesn't exhibit strange behaviours in various situations.

- `Equals(string other)` used for NUnit's `Is.EqualTo` comparison.
- `Equals(object other)` used for `object.Equals` (banned API).