### PR TITLE
Don't use transforms in frame statistics

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -359,8 +359,8 @@ namespace osu.Framework.Graphics.Performance
 
             timeBar.Sprite.Texture.SetData(upload);
 
-            timeBars[timeBarIndex].MoveToX(WIDTH - timeBarX);
-            timeBars[(timeBarIndex + 1) % timeBars.Length].MoveToX(-timeBarX);
+            timeBars[timeBarIndex].X = WIDTH - timeBarX;
+            timeBars[(timeBarIndex + 1) % timeBars.Length].X = -timeBarX;
             currentX = (currentX + 1) % (timeBars.Length * WIDTH);
 
             foreach (Drawable e in timeBars[(timeBarIndex + 1) % timeBars.Length].Children)


### PR DESCRIPTION
This is done every frame. Drops allocations from 11MB/sec to 5MB/sec @ 4000UPS in main menu.