### PR TITLE
Fix enumerating HoveredDrawables causing excessive allocations

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -107,7 +107,7 @@ namespace osu.Framework.Input
         /// Top-down in this case means reverse draw order, i.e. the front-most visible
         /// <see cref="Drawable"/> first, and <see cref="Container"/>s after their children.
         /// </summary>
-        public IReadOnlyList<Drawable> HoveredDrawables => hoveredDrawables;
+        public IReadOnlyList<Drawable> HoveredDrawables => hoveredDrawables.AsSlimReadOnly();
 
         /// <summary>
         /// Contains all <see cref="Drawable"/>s in top-down order which are considered

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -107,7 +107,7 @@ namespace osu.Framework.Input
         /// Top-down in this case means reverse draw order, i.e. the front-most visible
         /// <see cref="Drawable"/> first, and <see cref="Container"/>s after their children.
         /// </summary>
-        public IReadOnlyList<Drawable> HoveredDrawables => hoveredDrawables.AsSlimReadOnly();
+        public SlimReadOnlyListWrapper<Drawable> HoveredDrawables => hoveredDrawables.AsSlimReadOnly();
 
         /// <summary>
         /// Contains all <see cref="Drawable"/>s in top-down order which are considered


### PR DESCRIPTION
Screenshots should only be compared using relative % (run times were different):

Before:
![20210226 163606 (Safari app)](https://user-images.githubusercontent.com/191335/109270026-c1daf080-7850-11eb-916d-954cc139733e.png)


After:
![20210226 163358 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/109269847-77f20a80-7850-11eb-9bd4-8a4ad35fbd81.png)
