### PR TITLE
Remove remaining enumerator allocations from frame time display updates

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -363,7 +363,7 @@ namespace osu.Framework.Graphics.Performance
             timeBars[(timeBarIndex + 1) % timeBars.Length].X = -timeBarX;
             currentX = (currentX + 1) % (timeBars.Length * WIDTH);
 
-            foreach (Drawable e in timeBars[(timeBarIndex + 1) % timeBars.Length].Children)
+            foreach (Drawable e in timeBars[(timeBarIndex + 1) % timeBars.Length])
             {
                 if (e is Box && e.DrawPosition.X <= timeBarX)
                     e.Expire();


### PR DESCRIPTION
Before:

![20210226 171544 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/109274143-7d525380-7856-11eb-9e1c-b51aec5fcd57.png)

After:

![20210226 171750 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/109274197-8f33f680-7856-11eb-9877-7a033c001d1b.png)
