### PR TITLE
Reuse TextBuilder when validating SpriteText

### DIFF
--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -464,12 +464,7 @@ namespace osu.Framework.Graphics.Sprites
                 if (string.IsNullOrEmpty(displayedText))
                     return;
 
-                TextBuilder textBuilder;
-
-                if (textBuilderBacking.IsValid)
-                    textBuilder = textBuilderBacking.Value;
-                else
-                    textBuilder = textBuilderBacking.Value = CreateTextBuilder(store);
+                TextBuilder textBuilder = getTextBuilder();
 
                 textBuilder.Reset();
                 textBuilder.AddText(displayedText);
@@ -614,6 +609,14 @@ namespace osu.Framework.Graphics.Sprites
 
             return new TextBuilder(store, Font, builderMaxWidth, UseFullGlyphHeight, new Vector2(Padding.Left, Padding.Top), Spacing, charactersBacking,
                 excludeCharacters, FallbackCharacter, FixedWidthReferenceCharacter);
+        }
+
+        private TextBuilder getTextBuilder()
+        {
+            if (!textBuilderBacking.IsValid)
+                textBuilderBacking.Value = CreateTextBuilder(store);
+
+            return textBuilderBacking.Value;
         }
 
         public override string ToString() => $@"""{displayedText}"" " + base.ToString();

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -131,7 +131,7 @@ namespace osu.Framework.Graphics.Sprites
             {
                 font = value;
 
-                invalidate(true);
+                invalidate(true, true);
                 shadowOffsetCache.Invalidate();
             }
         }
@@ -156,8 +156,7 @@ namespace osu.Framework.Graphics.Sprites
                     Truncate = false;
 
                 allowMultiline = value;
-
-                invalidate(true);
+                invalidate(true, true);
             }
         }
 
@@ -235,7 +234,7 @@ namespace osu.Framework.Graphics.Sprites
 
                 useFullGlyphHeight = value;
 
-                invalidate(true);
+                invalidate(true, true);
             }
         }
 
@@ -259,7 +258,7 @@ namespace osu.Framework.Graphics.Sprites
                     AllowMultiline = false;
 
                 truncate = value;
-                invalidate(true);
+                invalidate(true, true);
             }
         }
 
@@ -277,7 +276,7 @@ namespace osu.Framework.Graphics.Sprites
                 if (ellipsisString == value) return;
 
                 ellipsisString = value;
-                invalidate(true);
+                invalidate(true, true);
             }
         }
 
@@ -306,7 +305,7 @@ namespace osu.Framework.Graphics.Sprites
                 base.Width = value;
                 explicitWidth = value;
 
-                invalidate(true);
+                invalidate(true, true);
             }
         }
 
@@ -327,7 +326,7 @@ namespace osu.Framework.Graphics.Sprites
                     return;
 
                 maxWidth = value;
-                invalidate(true);
+                invalidate(true, true);
             }
         }
 
@@ -352,7 +351,7 @@ namespace osu.Framework.Graphics.Sprites
                 base.Height = value;
                 explicitHeight = value;
 
-                invalidate(true);
+                invalidate(true, true);
             }
         }
 
@@ -389,7 +388,7 @@ namespace osu.Framework.Graphics.Sprites
 
                 spacing = value;
 
-                invalidate(true);
+                invalidate(true, true);
             }
         }
 
@@ -410,7 +409,7 @@ namespace osu.Framework.Graphics.Sprites
 
                 padding = value;
 
-                invalidate(true);
+                invalidate(true, true);
             }
         }
 
@@ -544,10 +543,14 @@ namespace osu.Framework.Graphics.Sprites
 
         #region Invalidation
 
-        private void invalidate(bool layout = false)
+        private void invalidate(bool characters = false, bool textBuilder = false)
         {
-            if (layout)
+            if (characters)
                 charactersCache.Invalidate();
+
+            if (textBuilder)
+                InvalidateTextBuilder();
+
             parentScreenSpaceCache.Invalidate();
             localScreenSpaceCache.Invalidate();
 

--- a/osu.Framework/Text/TextBuilder.cs
+++ b/osu.Framework/Text/TextBuilder.cs
@@ -71,6 +71,19 @@ namespace osu.Framework.Text
         }
 
         /// <summary>
+        /// Resets this <see cref="TextBuilder"/> to a default state.
+        /// </summary>
+        public virtual void Reset()
+        {
+            Bounds = Vector2.Zero;
+            Characters.Clear();
+
+            currentPos = startOffset;
+            currentLineHeight = 0;
+            currentNewLine = true;
+        }
+
+        /// <summary>
         /// Whether characters can be added to this <see cref="TextBuilder"/>.
         /// </summary>
         protected virtual bool CanAddCharacters => true;

--- a/osu.Framework/Text/TruncatingTextBuilder.cs
+++ b/osu.Framework/Text/TruncatingTextBuilder.cs
@@ -17,6 +17,9 @@ namespace osu.Framework.Text
         private readonly bool useFontSizeAsHeight;
         private readonly Vector2 spacing;
 
+        private bool ellipsisAdded;
+        private bool addingEllipsis; // Only used temporarily during the addition of the ellipsis.
+
         /// <summary>
         /// Creates a new <see cref="TextBuilder"/>.
         /// </summary>
@@ -44,8 +47,12 @@ namespace osu.Framework.Text
             this.fallbackCharacter = fallbackCharacter;
         }
 
-        private bool addingEllipsis;
-        private bool ellipsisAdded;
+        public override void Reset()
+        {
+            base.Reset();
+
+            ellipsisAdded = false;
+        }
 
         protected override bool CanAddCharacters => (base.CanAddCharacters && !ellipsisAdded) || addingEllipsis;
 


### PR DESCRIPTION
Before:
![Screenshot_2021-02-26_17-24-25](https://user-images.githubusercontent.com/1329837/109276379-492c6200-7859-11eb-8b91-c48ae928391e.png)

After:
![Screenshot_2021-02-26_17-35-45](https://user-images.githubusercontent.com/1329837/109276390-4c275280-7859-11eb-931e-a13cb9f572fd.png)

Provides the `InvalidateTextBuilder()` method for any consumers that have a custom `TextBuilder` and provide properties to control it other than truncate/ellipsisstring/multiline.