### PR TITLE
Fix number formatter allocating many arrays

### DIFF
--- a/osu.Framework/Utils/NumberFormatter.cs
+++ b/osu.Framework/Utils/NumberFormatter.cs
@@ -10,6 +10,8 @@ namespace osu.Framework.Utils
     /// </summary>
     public static class NumberFormatter
     {
+        private static readonly string[] suffixes = { "y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "G", "T", "P", "E", "Z", "Y" };
+
         /// <summary>
         /// Prints the number with at most two decimal digits, followed by a magnitude suffic (k, M, G, T, etc.) depending on the magnitude of the number. If the number is
         /// too large or small this will print the number using scientific notation instead.
@@ -25,14 +27,14 @@ namespace osu.Framework.Utils
 
             var isNeg = number < 0;
             number = Math.Abs(number);
-            var strs = new[] { "y", "z", "a", "f", "p", "n", "µ", "m", "", "k", "M", "G", "T", "P", "E", "Z", "Y" };
+
             int log1000 = (int)Math.Floor(Math.Log(number, 1000));
             int index = log1000 + 8;
 
-            if (index >= strs.Length)
+            if (index >= suffixes.Length)
                 return $"{(isNeg ? "-" : "")}{number:E}";
 
-            return $"{(isNeg ? "-" : "")}{number / Math.Pow(1000, log1000):G3}{strs[index]}";
+            return $"{(isNeg ? "-" : "")}{number / Math.Pow(1000, log1000):G3}{suffixes[index]}";
         }
     }
 }


### PR DESCRIPTION
Before:
![Screenshot_2021-02-26_18-19-47](https://user-images.githubusercontent.com/1329837/109283969-b4c6fd00-7862-11eb-9539-90858b2abdef.png)

After:
![Screenshot_2021-02-26_18-41-54](https://user-images.githubusercontent.com/1329837/109283983-b8f31a80-7862-11eb-8109-538bb4f3bfa0.png)

By holding down ctrl to show text in the frame statistics.