### PR TITLE
Dispose .NET runtime listener when not in use

### DIFF
--- a/osu.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/GlobalStatisticsDisplay.cs
@@ -43,8 +43,6 @@ namespace osu.Framework.Graphics.Performance
         [BackgroundDependencyLoader]
         private void load(GameHost host)
         {
-            listener = new DotNetRuntimeListener();
-
             performanceLogging = host.PerformanceLogging.GetBoundCopy();
         }
 
@@ -76,7 +74,12 @@ namespace osu.Framework.Graphics.Performance
             performanceLogging.Value = state.NewValue == Visibility.Visible;
 
             if (state.NewValue == Visibility.Visible)
+            {
                 GlobalStatistics.OutputToLog();
+                listener = new DotNetRuntimeListener();
+            }
+            else
+                listener?.Dispose();
         }
 
         private void remove(IEnumerable<IGlobalStatistic> stats) => Schedule(() =>


### PR DESCRIPTION
Just something I noticed a few days ago. I'm not sure on the performance cost of this / have not profiled.

The disadvantage is we don't get accurate output to logs when F2 is opened, so merging of this PR is dependent upon whether that's fine.