### PR TITLE
Remove finalizer from video texture uploads

### DIFF
--- a/osu.Framework/Graphics/Video/VideoTextureUpload.cs
+++ b/osu.Framework/Graphics/Video/VideoTextureUpload.cs
@@ -29,7 +29,7 @@ namespace osu.Framework.Graphics.Video
         /// </summary>
         /// <param name="frame">The frame to upload.</param>
         /// <param name="freeFrameDelegate">A function to free the frame on disposal.</param>
-        public VideoTextureUpload(AVFrame* frame, FFmpegFuncs.AvFrameFreeDelegate freeFrameDelegate)
+        internal VideoTextureUpload(AVFrame* frame, FFmpegFuncs.AvFrameFreeDelegate freeFrameDelegate)
         {
             Frame = frame;
             this.freeFrameDelegate = freeFrameDelegate;

--- a/osu.Framework/Graphics/Video/VideoTextureUpload.cs
+++ b/osu.Framework/Graphics/Video/VideoTextureUpload.cs
@@ -1,19 +1,25 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics.Textures;
 using osuTK.Graphics.ES30;
 using FFmpeg.AutoGen;
+using osu.Framework.Graphics.Primitives;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Video
 {
-    public unsafe class VideoTextureUpload : ArrayPoolTextureUpload
+    public unsafe class VideoTextureUpload : ITextureUpload
     {
         public AVFrame* Frame;
 
         private readonly FFmpegFuncs.AvFrameFreeDelegate freeFrame;
 
-        public override PixelFormat Format => PixelFormat.Red;
+        public ReadOnlySpan<Rgba32> Data => ReadOnlySpan<Rgba32>.Empty;
+        public int Level => 0;
+        public RectangleI Bounds { get; set; }
+        public PixelFormat Format => PixelFormat.Red;
 
         /// <summary>
         /// Sets the frame cotaining the data to be uploaded
@@ -21,7 +27,6 @@ namespace osu.Framework.Graphics.Video
         /// <param name="frame">The libav frame to upload.</param>
         /// <param name="free">A function to free the frame on disposal.</param>
         public VideoTextureUpload(AVFrame* frame, FFmpegFuncs.AvFrameFreeDelegate free)
-            : base(0, 0)
         {
             Frame = frame;
             freeFrame = free;
@@ -29,12 +34,10 @@ namespace osu.Framework.Graphics.Video
 
         #region IDisposable Support
 
-        protected override void Dispose(bool disposing)
+        public void Dispose()
         {
             fixed (AVFrame** ptr = &Frame)
                 freeFrame(ptr);
-
-            base.Dispose(disposing);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Video/VideoTextureUpload.cs
+++ b/osu.Framework/Graphics/Video/VideoTextureUpload.cs
@@ -10,7 +10,7 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Video
 {
-    public unsafe class VideoTextureUpload : ITextureUpload
+    public sealed unsafe class VideoTextureUpload : ITextureUpload
     {
         public readonly AVFrame* Frame;
 

--- a/osu.Framework/Graphics/Video/VideoTextureUpload.cs
+++ b/osu.Framework/Graphics/Video/VideoTextureUpload.cs
@@ -12,24 +12,27 @@ namespace osu.Framework.Graphics.Video
 {
     public unsafe class VideoTextureUpload : ITextureUpload
     {
-        public AVFrame* Frame;
+        public readonly AVFrame* Frame;
 
-        private readonly FFmpegFuncs.AvFrameFreeDelegate freeFrame;
+        private readonly FFmpegFuncs.AvFrameFreeDelegate freeFrameDelegate;
 
         public ReadOnlySpan<Rgba32> Data => ReadOnlySpan<Rgba32>.Empty;
+
         public int Level => 0;
+
         public RectangleI Bounds { get; set; }
+
         public PixelFormat Format => PixelFormat.Red;
 
         /// <summary>
-        /// Sets the frame cotaining the data to be uploaded
+        /// Sets the frame containing the data to be uploaded.
         /// </summary>
-        /// <param name="frame">The libav frame to upload.</param>
-        /// <param name="free">A function to free the frame on disposal.</param>
-        public VideoTextureUpload(AVFrame* frame, FFmpegFuncs.AvFrameFreeDelegate free)
+        /// <param name="frame">The frame to upload.</param>
+        /// <param name="freeFrameDelegate">A function to free the frame on disposal.</param>
+        public VideoTextureUpload(AVFrame* frame, FFmpegFuncs.AvFrameFreeDelegate freeFrameDelegate)
         {
             Frame = frame;
-            freeFrame = free;
+            this.freeFrameDelegate = freeFrameDelegate;
         }
 
         #region IDisposable Support
@@ -37,7 +40,7 @@ namespace osu.Framework.Graphics.Video
         public void Dispose()
         {
             fixed (AVFrame** ptr = &Frame)
-                freeFrame(ptr);
+                freeFrameDelegate(ptr);
         }
 
         #endregion


### PR DESCRIPTION
This is one rare case outside of `FrameStatisticsDisplay` that we are performing many texture uploads, where the finalizer of the uploads can, as we have seen, add considerable overhead.

I've confirmed that all loss-of-reference paths result in disposal of these instances (but failing that, one would hope that ffmpeg would clean up when the owning video is freed).