### PR TITLE
Remove finalizers from TextureUpload classes

### DIFF
--- a/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
@@ -51,24 +51,12 @@ namespace osu.Framework.Graphics.Textures
         private bool disposed;
 #pragma warning restore IDE0032 // Use auto property
 
-        protected virtual void Dispose(bool disposing)
+        public virtual void Dispose()
         {
-            if (!disposed)
-            {
-                disposed = true;
-                memoryOwner.Dispose();
-            }
-        }
+            if (disposed) return;
 
-        ~ArrayPoolTextureUpload()
-        {
-            Dispose(false);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            disposed = true;
+            memoryOwner.Dispose();
         }
 
         #endregion

--- a/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
@@ -49,16 +49,22 @@ namespace osu.Framework.Graphics.Textures
 
         #region IDisposable Support
 
-#pragma warning disable IDE0032 // Use auto property
         private bool disposed;
-#pragma warning restore IDE0032 // Use auto property
 
-        public virtual void Dispose()
+        public void Dispose()
         {
-            if (disposed) return;
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (disposed)
+                return;
+
+            memoryOwner?.Dispose();
 
             disposed = true;
-            memoryOwner.Dispose();
         }
 
         #endregion

--- a/osu.Framework/Graphics/Textures/TextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/TextureUpload.cs
@@ -113,10 +113,23 @@ namespace osu.Framework.Graphics.Textures
 
         #region IDisposable Support
 
+        private bool disposed;
+
         public void Dispose()
         {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (disposed)
+                return;
+
             image?.Dispose();
             pixelMemory.Dispose();
+
+            disposed = true;
         }
 
         #endregion

--- a/osu.Framework/Graphics/Textures/TextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/TextureUpload.cs
@@ -112,28 +112,10 @@ namespace osu.Framework.Graphics.Textures
 
         #region IDisposable Support
 
-        private bool disposed;
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!disposed)
-            {
-                disposed = true;
-
-                image?.Dispose();
-                pixelMemory.Dispose();
-            }
-        }
-
-        ~TextureUpload()
-        {
-            Dispose(false);
-        }
-
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            image?.Dispose();
+            pixelMemory.Dispose();
         }
 
         #endregion

--- a/osu.Framework/Graphics/Textures/TextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/TextureUpload.cs
@@ -18,6 +18,7 @@ namespace osu.Framework.Graphics.Textures
 {
     /// <summary>
     /// Low level class for queueing texture uploads to the GPU.
+    /// Should be manually disposed if not queued for upload via <see cref="Texture.SetData"/>.
     /// </summary>
     public class TextureUpload : ITextureUpload
     {


### PR DESCRIPTION
I've checked every usage and this looks safe.

- [x] Depends on https://github.com/ppy/osu-framework/pull/4239.

Partly addresses #4229.