### PR TITLE
Allow specifying a custom MemoryAllocator in ArrayPoolTextureUploads

### DIFF
--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -18,14 +18,16 @@ using System.Linq;
 using osu.Framework.Input.Events;
 using osuTK;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Performance
 {
     internal class FrameStatisticsDisplay : Container, IStateful<FrameStatisticsMode>
     {
+        internal const int HEIGHT = 100;
+
         protected const int WIDTH = 800;
-        protected const int HEIGHT = 100;
 
         private const int amount_count_steps = 5;
 
@@ -51,6 +53,8 @@ namespace osu.Framework.Graphics.Performance
 
         private readonly Container mainContainer;
         private readonly Container timeBarsContainer;
+
+        private readonly MemoryAllocator uploadAllocator;
 
         private readonly Drawable[] legendMapping = new Drawable[FrameStatistics.NUM_PERFORMANCE_COLLECTION_TYPES];
         private readonly Dictionary<StatisticsCounterType, CounterBar> counterBars = new Dictionary<StatisticsCounterType, CounterBar>();
@@ -99,10 +103,11 @@ namespace osu.Framework.Graphics.Performance
             }
         }
 
-        public FrameStatisticsDisplay(GameThread thread)
+        public FrameStatisticsDisplay(GameThread thread, MemoryAllocator uploadAllocator)
         {
             Name = thread.Name;
             monitor = thread.Monitor;
+            this.uploadAllocator = uploadAllocator;
 
             Origin = Anchor.TopRight;
             AutoSizeAxes = Axes.Both;
@@ -346,7 +351,7 @@ namespace osu.Framework.Graphics.Performance
         private void applyFrameTime(FrameStatistics frame)
         {
             TimeBar timeBar = timeBars[timeBarIndex];
-            var upload = new ArrayPoolTextureUpload(1, HEIGHT)
+            var upload = new ArrayPoolTextureUpload(1, HEIGHT, uploadAllocator)
             {
                 Bounds = new RectangleI(timeBarX, 0, 1, HEIGHT)
             };

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -5,12 +5,16 @@ using System;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Threading;
 using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Performance
 {
     internal class PerformanceOverlay : FillFlowContainer<FrameStatisticsDisplay>, IStateful<FrameStatisticsMode>
     {
-        private readonly IEnumerable<GameThread> threads;
+        private readonly GameThread[] threads;
         private FrameStatisticsMode state;
 
         public event Action<FrameStatisticsMode> StateChanged;
@@ -50,8 +54,11 @@ namespace osu.Framework.Graphics.Performance
                     if (!initialised)
                     {
                         initialised = true;
+
+                        var uploadPool = createUploadPool();
+
                         foreach (GameThread t in threads)
-                            Add(new FrameStatisticsDisplay(t) { State = state });
+                            Add(new FrameStatisticsDisplay(t, uploadPool) { State = state });
                     }
 
                     this.FadeIn(100);
@@ -64,9 +71,22 @@ namespace osu.Framework.Graphics.Performance
             StateChanged?.Invoke(State);
         }
 
+        private ArrayPoolMemoryAllocator createUploadPool()
+        {
+            int uploadSize = FrameStatisticsDisplay.HEIGHT * Unsafe.SizeOf<Rgba32>();
+
+            // bucket size should be enough to allow some overhead when running multi-threaded with draw at 60hz.
+            const int max_expected_thread_update_rate = 2000;
+
+            int bucketSize = threads.Length * (max_expected_thread_update_rate / 60);
+
+            // we already know the fixed size of uploads so there's no need to use i#'s two-tiered pooling system.
+            return new ArrayPoolMemoryAllocator(uploadSize, uploadSize, 1, bucketSize);
+        }
+
         public PerformanceOverlay(IEnumerable<GameThread> threads)
         {
-            this.threads = threads;
+            this.threads = threads.ToArray();
             Direction = FillDirection.Vertical;
         }
     }

--- a/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
@@ -5,6 +5,7 @@ using System;
 using System.Buffers;
 using osu.Framework.Graphics.Primitives;
 using osuTK.Graphics.ES30;
+using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Textures
@@ -37,9 +38,10 @@ namespace osu.Framework.Graphics.Textures
         /// </summary>
         /// <param name="width">The width of the texture.</param>
         /// <param name="height">The height of the texture.</param>
-        public ArrayPoolTextureUpload(int width, int height)
+        /// <param name="memoryAllocator">The source to retrieve memory from. Shared default is used if null.</param>
+        public ArrayPoolTextureUpload(int width, int height, MemoryAllocator memoryAllocator = null)
         {
-            memoryOwner = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<Rgba32>(width * height);
+            memoryOwner = (memoryAllocator ?? SixLabors.ImageSharp.Configuration.Default.MemoryAllocator).Allocate<Rgba32>(width * height);
         }
 
         // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter


### PR DESCRIPTION
This fixes the frame statistics display potentially doing huge allocations in the case a user is running at low draw FPS (uploads only happen every 16ms) but have threads running at full 1000hz (ie. input/audio), causing exhaustion of the source bucket in the default/shared `MemoryAllocator`.

The memory overhead of this (when the FrameStatisticsDisplay has been shown at least once) is around 52kb (400bytes * 132bucketsize):

![20210302 140916 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/109600857-37043980-7b61-11eb-90a9-c8b10959790d.png)

Before:

![20210302 141403 (dotnet)](https://user-images.githubusercontent.com/191335/109601048-906c6880-7b61-11eb-94b7-ccf0213dd9b8.gif)

After:

![20210302 141306 (dotnet)](https://user-images.githubusercontent.com/191335/109600990-76cb2100-7b61-11eb-8a72-06a53c79eef8.gif)
