### PR TITLE
Remove finalizer from Drawable and DrawNode

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -96,15 +96,9 @@ namespace osu.Framework.Graphics
         /// </summary>
         internal void ResetCurrentEffectBuffer() => currentEffectBuffer = -1;
 
-        ~BufferedDrawNodeSharedData()
-        {
-            GLWrapper.ScheduleDisposal(() => Dispose(false));
-        }
-
         public void Dispose()
         {
             GLWrapper.ScheduleDisposal(() => Dispose(true));
-            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool isDisposing)

--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -99,6 +99,7 @@ namespace osu.Framework.Graphics
         public void Dispose()
         {
             GLWrapper.ScheduleDisposal(() => Dispose(true));
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool isDisposing)

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -290,6 +290,9 @@ namespace osu.Framework.Graphics.Containers
 
         protected override void Dispose(bool isDisposing)
         {
+            if (IsDisposed)
+                return;
+
             disposalCancellationSource?.Cancel();
             disposalCancellationSource?.Dispose();
 

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -288,14 +288,17 @@ namespace osu.Framework.Graphics
 
         public void Dispose()
         {
-            if (referenceCount.Decrement() != 0)
-                return;
-
-            GLWrapper.ScheduleDisposal(() => Dispose(true));
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool isDisposing)
         {
+            if (referenceCount.Decrement() != 0)
+                return;
+
+            GLWrapper.ScheduleDisposal(() => Dispose(true));
+
             Source = null;
             IsDisposed = true;
         }

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -288,15 +288,15 @@ namespace osu.Framework.Graphics
 
         public void Dispose()
         {
+            if (referenceCount.Decrement() != 0)
+                return;
+
             GLWrapper.ScheduleDisposal(() => Dispose(true));
             GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool isDisposing)
         {
-            if (referenceCount.Decrement() != 0)
-                return;
-
             Source = null;
             IsDisposed = true;
         }

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -288,7 +288,7 @@ namespace osu.Framework.Graphics
 
         public void Dispose()
         {
-            Dispose(true);
+            GLWrapper.ScheduleDisposal(() => Dispose(true));
             GC.SuppressFinalize(this);
         }
 
@@ -296,8 +296,6 @@ namespace osu.Framework.Graphics
         {
             if (referenceCount.Decrement() != 0)
                 return;
-
-            GLWrapper.ScheduleDisposal(() => Dispose(true));
 
             Source = null;
             IsDisposed = true;

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -284,11 +284,6 @@ namespace osu.Framework.Graphics
         /// </remarks>
         internal void Reference() => referenceCount.Increment();
 
-        ~DrawNode()
-        {
-            GLWrapper.ScheduleDisposal(() => Dispose(false));
-        }
-
         protected internal bool IsDisposed { get; private set; }
 
         public void Dispose()
@@ -297,7 +292,6 @@ namespace osu.Framework.Graphics
                 return;
 
             GLWrapper.ScheduleDisposal(() => Dispose(true));
-            GC.SuppressFinalize(this);
         }
 
         protected virtual void Dispose(bool isDisposing)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -66,14 +66,7 @@ namespace osu.Framework.Graphics
             AddLayout(requiredParentSizeToFitBacking);
         }
 
-        ~Drawable()
-        {
-            dispose(false);
-            finalize_disposals.Value++;
-        }
-
-        private static readonly GlobalStatistic<int> total_count = GlobalStatistics.Get<int>(nameof(Drawable), $"Total {nameof(Drawable)}s");
-        private static readonly GlobalStatistic<int> finalize_disposals = GlobalStatistics.Get<int>(nameof(Drawable), "Finalizer disposals");
+        private static readonly GlobalStatistic<int> total_count = GlobalStatistics.Get<int>(nameof(Drawable), $"Total constructed");
 
         internal bool IsLongRunning => GetType().GetCustomAttribute<LongRunningLoadAttribute>() != null;
 
@@ -82,30 +75,12 @@ namespace osu.Framework.Graphics
         /// </summary>
         public void Dispose()
         {
-            dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected internal bool IsDisposed { get; private set; }
-
-        /// <summary>
-        /// Disposes this drawable.
-        /// </summary>
-        protected virtual void Dispose(bool isDisposing)
-        {
-        }
-
-        private void dispose(bool isDisposing)
-        {
             //we can't dispose if we are mid-load, else our children may get in a bad state.
             lock (LoadLock)
             {
                 if (IsDisposed)
                     return;
 
-                total_count.Value--;
-
-                Dispose(isDisposing);
                 UnbindAllBindables();
 
                 // Bypass expensive operations as a result of setting the Parent property, by setting the field directly.
@@ -123,6 +98,15 @@ namespace osu.Framework.Graphics
 
                 IsDisposed = true;
             }
+        }
+
+        protected internal bool IsDisposed { get; private set; }
+
+        /// <summary>
+        /// Disposes this drawable.
+        /// </summary>
+        protected virtual void Dispose(bool isDisposing)
+        {
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.Graphics
             AddLayout(requiredParentSizeToFitBacking);
         }
 
-        private static readonly GlobalStatistic<int> total_count = GlobalStatistics.Get<int>(nameof(Drawable), $"Total constructed");
+        private static readonly GlobalStatistic<int> total_count = GlobalStatistics.Get<int>(nameof(Drawable), "Total constructed");
 
         internal bool IsLongRunning => GetType().GetCustomAttribute<LongRunningLoadAttribute>() != null;
 
@@ -414,7 +414,7 @@ namespace osu.Framework.Graphics
         internal event Action<Drawable> Invalidated;
 
         /// <summary>
-        /// Fired after the <see cref="dispose(bool)"/> method is called.
+        /// Fired after the <see cref="Dispose(bool)"/> method is called.
         /// </summary>
         internal event Action OnDispose;
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -76,28 +76,9 @@ namespace osu.Framework.Graphics
         public void Dispose()
         {
             //we can't dispose if we are mid-load, else our children may get in a bad state.
-            lock (LoadLock)
-            {
-                if (IsDisposed)
-                    return;
+            lock (LoadLock) Dispose(true);
 
-                UnbindAllBindables();
-
-                // Bypass expensive operations as a result of setting the Parent property, by setting the field directly.
-                parent = null;
-                ChildID = 0;
-
-                OnUpdate = null;
-                Invalidated = null;
-
-                OnDispose?.Invoke();
-                OnDispose = null;
-
-                for (int i = 0; i < drawNodes.Length; i++)
-                    drawNodes[i]?.Dispose();
-
-                IsDisposed = true;
-            }
+            GC.SuppressFinalize(this);
         }
 
         protected internal bool IsDisposed { get; private set; }
@@ -107,6 +88,25 @@ namespace osu.Framework.Graphics
         /// </summary>
         protected virtual void Dispose(bool isDisposing)
         {
+            if (IsDisposed)
+                return;
+
+            UnbindAllBindables();
+
+            // Bypass expensive operations as a result of setting the Parent property, by setting the field directly.
+            parent = null;
+            ChildID = 0;
+
+            OnUpdate = null;
+            Invalidated = null;
+
+            OnDispose?.Invoke();
+            OnDispose = null;
+
+            for (int i = 0; i < drawNodes.Length; i++)
+                drawNodes[i]?.Dispose();
+
+            IsDisposed = true;
         }
 
         /// <summary>


### PR DESCRIPTION
These are the bigger ones. Will address the remaining finalizers (on lesser used classes) in a separate PR.

I haven't done intensive testing on this yet, only checked at a code-level, so please consider when reviewing.

Partly addresses #4229.