### PR TITLE
Remove finalizer from AudioComponent

### DIFF
--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -86,6 +86,18 @@ namespace osu.Framework.Tests.Audio
             Assert.IsFalse(channel.Playing);
         }
 
+        [Test]
+        public void TestStopsWhenFactoryDisposed()
+        {
+            channel = sample.Play();
+            updateSample();
+
+            sampleFactory.Dispose();
+            updateSample();
+
+            Assert.IsFalse(channel.Playing);
+        }
+
         private void updateSample() => runOnAudioThread(() => sampleFactory.Update());
 
         /// <summary>

--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -86,11 +86,7 @@ namespace osu.Framework.Tests.Audio
             Assert.IsFalse(channel.Playing);
         }
 
-        private void updateSample() => runOnAudioThread(() =>
-        {
-            sampleFactory.Update();
-            channel?.Update();
-        });
+        private void updateSample() => runOnAudioThread(() => sampleFactory.Update());
 
         /// <summary>
         /// Certain actions are invoked on the audio thread.

--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Tests.Audio
 
             resources = new DllResourceStore(typeof(TrackBassTest).Assembly);
             sampleFactory = new SampleBassFactory(resources.Get("Resources.Tracks.sample-track.mp3"));
-            sample = new SampleBass(sampleFactory);
+            sample = sampleFactory.CreateSample();
 
             updateSample();
         }

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -112,11 +112,6 @@ namespace osu.Framework.Audio
 
         #region IDisposable Support
 
-        ~AudioComponent()
-        {
-            Dispose(false);
-        }
-
         protected volatile bool IsDisposed;
 
         public void Dispose()

--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -119,17 +119,17 @@ namespace osu.Framework.Audio
 
         protected volatile bool IsDisposed;
 
-        protected virtual void Dispose(bool disposing)
-        {
-            IsDisposed = true;
-        }
-
-        public virtual void Dispose()
+        public void Dispose()
         {
             acceptingActions = false;
             PendingActions.Enqueue(new Task(() => Dispose(true)));
 
             GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            IsDisposed = true;
         }
 
         #endregion

--- a/osu.Framework/Audio/Sample/SampleBassFactory.cs
+++ b/osu.Framework/Audio/Sample/SampleBassFactory.cs
@@ -87,8 +87,16 @@ namespace osu.Framework.Audio.Sample
             AddItem(sample);
         }
 
+        ~SampleBassFactory()
+        {
+            Dispose(false);
+        }
+
         protected override void Dispose(bool disposing)
         {
+            if (IsDisposed)
+                return;
+
             if (IsLoaded)
             {
                 Bass.SampleFree(SampleId);

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -181,9 +181,10 @@ namespace osu.Framework.Audio.Sample
             bassAmplitudeProcessor?.SetChannel(channel);
         });
 
-        public override void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            base.Dispose();
+            if (IsDisposed)
+                return;
 
             if (hasChannel)
             {
@@ -192,6 +193,8 @@ namespace osu.Framework.Audio.Sample
             }
 
             playing = false;
+
+            base.Dispose(disposing);
         }
     }
 }

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -181,6 +181,11 @@ namespace osu.Framework.Audio.Sample
             bassAmplitudeProcessor?.SetChannel(channel);
         });
 
+        ~SampleChannelBass()
+        {
+            Dispose(false);
+        }
+
         protected override void Dispose(bool disposing)
         {
             if (IsDisposed)

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -215,8 +215,16 @@ namespace osu.Framework.Audio.Track
             bassAmplitudeProcessor?.Update();
         }
 
+        ~TrackBass()
+        {
+            Dispose(false);
+        }
+
         protected override void Dispose(bool disposing)
         {
+            if (IsDisposed)
+                return;
+
             if (activeStream != 0)
             {
                 isRunning = false;


### PR DESCRIPTION
I tried to get this to work with `SafeHandle`, however I still need to figure out:
1. Best practices for passing safe handles downwards. Intuitively I'd think to pass with `ownsHandle = false` and have each level call `handle.Dispose()`, but this doesn't seem to be right.
2. Why it's causing a _huge_ stutter with every creation/disposal.

So for now I just did it locally in the cases it's required (all BASS classes). Additionally, I've also made `Dispose()` non-virtual to abide by the disposable reference implementation, which was overridden and implemented incorrectly in `SampleChannelBass` (it would occur on the executing thread rather than the audio thread).

One thing I don't like is the usage of `IsDisposed` - proper standards would have us declare a local `isDisposed` at every step of the way, but this also means declaring it in `Sample`, `SampleChannel`, `SampleStore`, `Track` and `TrackStore`, all of which reference it for various purposes (but generally to throw exceptions). If you want me to declare local fields in this PR, let me know :)