### PR TITLE
Reduce finalizer allocation log level

### DIFF
--- a/osu.Framework/Statistics/DotNetRuntimeListener.cs
+++ b/osu.Framework/Statistics/DotNetRuntimeListener.cs
@@ -95,7 +95,7 @@ namespace osu.Framework.Statistics
                             Debug.Assert(finalizeMethod != null); // All objects have this.
 
                             if (finalizeMethod.DeclaringType != typeof(object))
-                                Logger.Log($"Allocated finalizable object: {name}", LoggingTarget.Performance, LogLevel.Important);
+                                Logger.Log($"Allocated finalizable object: {name}", LoggingTarget.Performance);
 
                             break;
                     }


### PR DESCRIPTION
Just so that it doesn't trigger osu!-side notifications.