### PR TITLE
Fix text builder not invalidating on indirect relative size changes 

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextMaxWidth.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextMaxWidth.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Text;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Sprites
@@ -70,6 +71,8 @@ namespace osu.Framework.Tests.Visual.Sprites
         [Test]
         public void TestMaxWidthWithRelativeSize()
         {
+            float textWidth = 0;
+
             createTest(s =>
             {
                 s.RelativeSizeAxes = Axes.X;
@@ -77,9 +80,11 @@ namespace osu.Framework.Tests.Visual.Sprites
                 s.Text = "some very long text that should exceed the max width";
                 s.Truncate = true;
             }, Axes.Y);
+            AddStep("store text width", () => textWidth = display.Text.TextBuilder.Bounds.X);
 
             AddStep("set parent size", () => display.Width = 100);
             AddAssert("size <= max", () => display.Text.DrawWidth <= 50);
+            AddAssert("width increased", () => display.Text.TextBuilder.Bounds.X > textWidth);
         }
 
         private void createTest(Action<SpriteText> initFunc, Axes autoSizeAxes = Axes.Both)
@@ -93,7 +98,7 @@ namespace osu.Framework.Tests.Visual.Sprites
 
         private class VisualDisplay : CompositeDrawable
         {
-            public readonly SpriteText Text;
+            public readonly TestSpriteText Text;
 
             public VisualDisplay(Action<SpriteText> initFunc, Axes autoSizeAxes = Axes.Both)
             {
@@ -109,11 +114,19 @@ namespace osu.Framework.Tests.Visual.Sprites
                         Alpha = 0.2f,
                         Colour = Color4.Pink
                     },
-                    Text = new SpriteText { AllowMultiline = false }
+                    Text = new TestSpriteText { AllowMultiline = false }
                 };
 
                 initFunc?.Invoke(Text);
             }
+        }
+
+        private class TestSpriteText : SpriteText
+        {
+            public TextBuilder TextBuilder { get; private set; }
+
+            protected override TextBuilder CreateTextBuilder(ITexturedGlyphLookupStore store)
+                => TextBuilder = base.CreateTextBuilder(store);
         }
     }
 }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -575,7 +575,7 @@ namespace osu.Framework.Graphics.Sprites
         /// </summary>
         protected virtual char FallbackCharacter => '?';
 
-        private readonly LayoutValue<TextBuilder> textBuilderCache = new LayoutValue<TextBuilder>(Invalidation.DrawSize);
+        private readonly LayoutValue<TextBuilder> textBuilderCache = new LayoutValue<TextBuilder>(Invalidation.DrawSize, InvalidationSource.Parent);
 
         /// <summary>
         /// Invalidates the current <see cref="TextBuilder"/>, causing a new one to be created next time it's required via <see cref="CreateTextBuilder"/>.

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Caching;
 using osu.Framework.Development;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics.Containers;
@@ -55,6 +54,7 @@ namespace osu.Framework.Graphics.Sprites
             AddLayout(parentScreenSpaceCache);
             AddLayout(localScreenSpaceCache);
             AddLayout(shadowOffsetCache);
+            AddLayout(textBuilderCache);
         }
 
         [BackgroundDependencyLoader]
@@ -575,12 +575,12 @@ namespace osu.Framework.Graphics.Sprites
         /// </summary>
         protected virtual char FallbackCharacter => '?';
 
-        private readonly Cached<TextBuilder> textBuilderBacking = new Cached<TextBuilder>();
+        private readonly LayoutValue<TextBuilder> textBuilderCache = new LayoutValue<TextBuilder>(Invalidation.DrawSize);
 
         /// <summary>
         /// Invalidates the current <see cref="TextBuilder"/>, causing a new one to be created next time it's required via <see cref="CreateTextBuilder"/>.
         /// </summary>
-        protected void InvalidateTextBuilder() => textBuilderBacking.Invalidate();
+        protected void InvalidateTextBuilder() => textBuilderCache.Invalidate();
 
         /// <summary>
         /// Creates a <see cref="TextBuilder"/> to generate the character layout for this <see cref="SpriteText"/>.
@@ -613,10 +613,10 @@ namespace osu.Framework.Graphics.Sprites
 
         private TextBuilder getTextBuilder()
         {
-            if (!textBuilderBacking.IsValid)
-                textBuilderBacking.Value = CreateTextBuilder(store);
+            if (!textBuilderCache.IsValid)
+                textBuilderCache.Value = CreateTextBuilder(store);
 
-            return textBuilderBacking.Value;
+            return textBuilderCache.Value;
         }
 
         public override string ToString() => $@"""{displayedText}"" " + base.ToString();


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/4248.

As it turns out this was covered by framework tests, but only visually. I've hacked up something not-overly-pretty that will fail a test if this breaks again.

Not entirely sure I did this 100% correctly. It seems to work at least, but `DrawSize` might not be enough? I'm always confused by those flags.

Also this will technically invalidate `DrawSize` twice when setting `Width`/`Height` (once via base, once via the manual `invalidate(true, true);` call), but I wasn't sure if I should trim it and explain with a comment, and it shouldn't have any performance impact anyways.

Figured I'd open this for the test, at the very least.