### PR TITLE
Remove WeakReference overhead when FrameStatisticsDisplay is visible

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                     bool allTransparentBlack = true;
                     int index = sideIndices[i];
 
-                    var sideUpload = new ArrayPoolTextureUpload(sideBounds.Width, sideBounds.Height) { Bounds = sideBounds };
+                    var sideUpload = new MemoryAllocatorTextureUpload(sideBounds.Width, sideBounds.Height) { Bounds = sideBounds };
 
                     for (int y = 0; y < sideBounds.Height; ++y)
                     {
@@ -129,7 +129,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                     bool allTransparentBlack = true;
                     int index = sideIndices[i];
 
-                    var sideUpload = new ArrayPoolTextureUpload(sideBounds.Width, sideBounds.Height) { Bounds = sideBounds };
+                    var sideUpload = new MemoryAllocatorTextureUpload(sideBounds.Width, sideBounds.Height) { Bounds = sideBounds };
 
                     int stride = middleBounds.Width;
 
@@ -181,7 +181,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 // Only upload if we have a non-zero size and if the colour isn't already transparent black
                 if (nCornerPixels > 0 && cornerPixel != transparent_black)
                 {
-                    var cornerUpload = new ArrayPoolTextureUpload(cornerBounds.Width, cornerBounds.Height) { Bounds = cornerBounds };
+                    var cornerUpload = new MemoryAllocatorTextureUpload(cornerBounds.Width, cornerBounds.Height) { Bounds = cornerBounds };
                     for (int j = 0; j < nCornerPixels; ++j)
                         cornerUpload.RawData[j] = cornerPixel;
 

--- a/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
+++ b/osu.Framework/Graphics/Performance/FrameStatisticsDisplay.cs
@@ -13,12 +13,12 @@ using osu.Framework.Utils;
 using osu.Framework.Statistics;
 using osu.Framework.Threading;
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using osu.Framework.Input.Events;
 using osuTK;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Performance
@@ -54,7 +54,7 @@ namespace osu.Framework.Graphics.Performance
         private readonly Container mainContainer;
         private readonly Container timeBarsContainer;
 
-        private readonly MemoryAllocator uploadAllocator;
+        private readonly ArrayPool<Rgba32> uploadPool;
 
         private readonly Drawable[] legendMapping = new Drawable[FrameStatistics.NUM_PERFORMANCE_COLLECTION_TYPES];
         private readonly Dictionary<StatisticsCounterType, CounterBar> counterBars = new Dictionary<StatisticsCounterType, CounterBar>();
@@ -103,11 +103,11 @@ namespace osu.Framework.Graphics.Performance
             }
         }
 
-        public FrameStatisticsDisplay(GameThread thread, MemoryAllocator uploadAllocator)
+        public FrameStatisticsDisplay(GameThread thread, ArrayPool<Rgba32> uploadPool)
         {
             Name = thread.Name;
             monitor = thread.Monitor;
-            this.uploadAllocator = uploadAllocator;
+            this.uploadPool = uploadPool;
 
             Origin = Anchor.TopRight;
             AutoSizeAxes = Axes.Both;
@@ -351,7 +351,7 @@ namespace osu.Framework.Graphics.Performance
         private void applyFrameTime(FrameStatistics frame)
         {
             TimeBar timeBar = timeBars[timeBarIndex];
-            var upload = new ArrayPoolTextureUpload(1, HEIGHT, uploadAllocator)
+            var upload = new ArrayPoolTextureUpload(1, HEIGHT, uploadPool)
             {
                 Bounds = new RectangleI(timeBarX, 0, 1, HEIGHT)
             };

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -7,8 +7,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Threading;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Performance

--- a/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
+++ b/osu.Framework/Graphics/Performance/PerformanceOverlay.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Buffers;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Threading;
 using System.Collections.Generic;
@@ -71,17 +72,14 @@ namespace osu.Framework.Graphics.Performance
             StateChanged?.Invoke(State);
         }
 
-        private ArrayPoolMemoryAllocator createUploadPool()
+        private ArrayPool<Rgba32> createUploadPool()
         {
-            int uploadSize = FrameStatisticsDisplay.HEIGHT * Unsafe.SizeOf<Rgba32>();
-
             // bucket size should be enough to allow some overhead when running multi-threaded with draw at 60hz.
             const int max_expected_thread_update_rate = 2000;
 
             int bucketSize = threads.Length * (max_expected_thread_update_rate / 60);
 
-            // we already know the fixed size of uploads so there's no need to use i#'s two-tiered pooling system.
-            return new ArrayPoolMemoryAllocator(uploadSize, uploadSize, 1, bucketSize);
+            return ArrayPool<Rgba32>.Create(FrameStatisticsDisplay.HEIGHT, bucketSize);
         }
 
         public PerformanceOverlay(IEnumerable<GameThread> threads)

--- a/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/ArrayPoolTextureUpload.cs
@@ -5,68 +5,40 @@ using System;
 using System.Buffers;
 using osu.Framework.Graphics.Primitives;
 using osuTK.Graphics.ES30;
-using SixLabors.ImageSharp.Memory;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Graphics.Textures
 {
     public class ArrayPoolTextureUpload : ITextureUpload
     {
-        public Span<Rgba32> RawData => memoryOwner.Memory.Span;
+        private readonly ArrayPool<Rgba32> arrayPool;
 
-        public ReadOnlySpan<Rgba32> Data => RawData;
-
-        private readonly IMemoryOwner<Rgba32> memoryOwner;
-
-        /// <summary>
-        /// The target mipmap level to upload into.
-        /// </summary>
-        public int Level { get; set; }
-
-        /// <summary>
-        /// The texture format for this upload.
-        /// </summary>
-        public virtual PixelFormat Format => PixelFormat.Rgba;
-
-        /// <summary>
-        /// The target bounds for this upload. If not specified, will assume to be (0, 0, width, height).
-        /// </summary>
-        public RectangleI Bounds { get; set; }
+        private readonly Rgba32[] data;
 
         /// <summary>
         /// Create an empty raw texture with an efficient shared memory backing.
         /// </summary>
         /// <param name="width">The width of the texture.</param>
         /// <param name="height">The height of the texture.</param>
-        /// <param name="memoryAllocator">The source to retrieve memory from. Shared default is used if null.</param>
-        public ArrayPoolTextureUpload(int width, int height, MemoryAllocator memoryAllocator = null)
+        /// <param name="arrayPool">The source pool to retrieve memory from. Shared default is used if null.</param>
+        public ArrayPoolTextureUpload(int width, int height, ArrayPool<Rgba32> arrayPool = null)
         {
-            memoryOwner = (memoryAllocator ?? SixLabors.ImageSharp.Configuration.Default.MemoryAllocator).Allocate<Rgba32>(width * height);
+            data = (this.arrayPool ??= ArrayPool<Rgba32>.Shared).Rent(width * height);
         }
-
-        // ReSharper disable once ConvertToAutoPropertyWithPrivateSetter
-        public bool HasBeenUploaded => disposed;
-
-        #region IDisposable Support
-
-        private bool disposed;
 
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            arrayPool.Return(data);
         }
 
-        protected virtual void Dispose(bool isDisposing)
-        {
-            if (disposed)
-                return;
+        public Span<Rgba32> RawData => data;
 
-            memoryOwner?.Dispose();
+        public ReadOnlySpan<Rgba32> Data => data;
 
-            disposed = true;
-        }
+        public int Level { get; set; }
 
-        #endregion
+        public virtual PixelFormat Format => PixelFormat.Rgba;
+
+        public RectangleI Bounds { get; set; }
     }
 }

--- a/osu.Framework/Graphics/Textures/ITextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/ITextureUpload.cs
@@ -10,9 +10,24 @@ namespace osu.Framework.Graphics.Textures
 {
     public interface ITextureUpload : IDisposable
     {
+        /// <summary>
+        /// The raw data to be uploaded.
+        /// </summary>
         ReadOnlySpan<Rgba32> Data { get; }
+
+        /// <summary>
+        /// The target mipmap level to upload into.
+        /// </summary>
         int Level { get; }
+
+        /// <summary>
+        /// The target bounds for this upload. If not specified, will assume to be (0, 0, width, height).
+        /// </summary>
         RectangleI Bounds { get; set; }
+
+        /// <summary>
+        /// The texture format for this upload.
+        /// </summary>
         PixelFormat Format { get; }
     }
 }

--- a/osu.Framework/Graphics/Textures/MemoryAllocatorTextureUpload.cs
+++ b/osu.Framework/Graphics/Textures/MemoryAllocatorTextureUpload.cs
@@ -1,0 +1,60 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Buffers;
+using osu.Framework.Graphics.Primitives;
+using osuTK.Graphics.ES30;
+using SixLabors.ImageSharp.Memory;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace osu.Framework.Graphics.Textures
+{
+    public class MemoryAllocatorTextureUpload : ITextureUpload
+    {
+        public Span<Rgba32> RawData => memoryOwner.Memory.Span;
+
+        public ReadOnlySpan<Rgba32> Data => RawData;
+
+        private readonly IMemoryOwner<Rgba32> memoryOwner;
+
+        public int Level { get; set; }
+
+        public virtual PixelFormat Format => PixelFormat.Rgba;
+
+        public RectangleI Bounds { get; set; }
+
+        /// <summary>
+        /// Create an empty raw texture with an efficient shared memory backing.
+        /// </summary>
+        /// <param name="width">The width of the texture.</param>
+        /// <param name="height">The height of the texture.</param>
+        /// <param name="memoryAllocator">The source to retrieve memory from. Shared default is used if null.</param>
+        public MemoryAllocatorTextureUpload(int width, int height, MemoryAllocator memoryAllocator = null)
+        {
+            memoryOwner = (memoryAllocator ?? SixLabors.ImageSharp.Configuration.Default.MemoryAllocator).Allocate<Rgba32>(width * height);
+        }
+
+        #region IDisposable Support
+
+        private bool disposed;
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool isDisposing)
+        {
+            if (disposed)
+                return;
+
+            memoryOwner?.Dispose();
+
+            disposed = true;
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
While we optimised away the overflow of the array pool, it turns out that the `MemoryAllocator` structure offered by ImageSharp uses a `WeakReference` internally, which has a finalizer.

This renames the existing upload class to `MemoryAllocatorTextureUpload` and refactors the existing implementation to actually use `ArrayPool` directly. I've only replaced the usage in `FrameStatisticsDisplay` for now (unsure about the remaining padding ones; need to check what kind of usage patterns they follow before making any calls there I think).