### PR TITLE
Add another event for tracking finalizations

### DIFF
--- a/osu.Framework/Statistics/DotNetRuntimeListener.cs
+++ b/osu.Framework/Statistics/DotNetRuntimeListener.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.Reflection;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Logging;
 
 namespace osu.Framework.Statistics
@@ -101,11 +102,56 @@ namespace osu.Framework.Statistics
                                 Logger.Log($"Allocated finalizable object: {name}", LoggingTarget.Performance);
 
                             break;
+
+                        case GCEventType.FinalizeObject when data.Payload != null:
+                            if (data.Payload[0] == null)
+                                break;
+
+                            var type = getTypeFromHandle((IntPtr)data.Payload[0]);
+                            if (type == null)
+                                break;
+
+                            Logger.Log($"Finalizing object: {type.ReadableName()}");
+
+                            break;
                     }
 
                     break;
             }
         }
+
+        /// <summary>
+        /// Retrieves a <see cref="Type"/> from a CLR type id.
+        /// </summary>
+        /// <remarks>
+        /// Attrib: https://stackoverflow.com/questions/26972066/type-from-intptr-handle/54469241#54469241
+        /// </remarks>
+        // ReSharper disable once RedundantUnsafeContext
+        private static unsafe Type getTypeFromHandle(IntPtr handle)
+        {
+#if NET5_0
+            // This is super unsafe code which is dependent upon internal CLR structures.
+            TypedReferenceAccess tr = new TypedReferenceAccess { Type = handle };
+            return __reftype(*(TypedReference*)&tr);
+#else
+            return null;
+#endif
+        }
+
+#if NET5_0
+        /// <summary>
+        /// Matches the internal layout of <see cref="TypedReference"/>.
+        /// See: https://source.dot.net/#System.Private.CoreLib/src/System/TypedReference.cs
+        /// </summary>
+        private struct TypedReferenceAccess
+        {
+            [JetBrains.Annotations.UsedImplicitly]
+            public IntPtr Value;
+
+            [JetBrains.Annotations.UsedImplicitly]
+            public IntPtr Type;
+        }
+#endif
 
         private void addStatistic<T>(string name, object data)
             => GlobalStatistics.Get<T>(gc_statistics_grouping, name).Value = (T)data;
@@ -121,7 +167,8 @@ namespace osu.Framework.Statistics
         {
             GCStart_V1 = 1,
             GCHeapStats_V1 = 4,
-            GCAllocationTick_V2 = 10
+            GCAllocationTick_V2 = 10,
+            FinalizeObject = 29
         }
     }
 }

--- a/osu.Framework/Statistics/DotNetRuntimeListener.cs
+++ b/osu.Framework/Statistics/DotNetRuntimeListener.cs
@@ -111,7 +111,7 @@ namespace osu.Framework.Statistics
                             if (type == null)
                                 break;
 
-                            Logger.Log($"Finalizing object: {type.ReadableName()}");
+                            Logger.Log($"Finalizing object: {type.ReadableName()}", LoggingTarget.Performance);
 
                             break;
                     }


### PR DESCRIPTION
As per suggestions in https://github.com/dotnet/runtime/issues/48937#issuecomment-789352441, I've added logging for `FinalizeObject` ETW events. It only provides the type id, so we have to jump some hoops to get the type name.

Although it doesn't catch `WeakReference<T>`, it does give a better indication as to exactly how many objects are being finalized. Sample log changing beatmaps in song select:
```
[performance] 2021-03-03 05:06:01 [verbose]: Allocated finalizable object: osu.Framework.Audio.Sample.SampleChannelBass
[runtime] 2021-03-03 05:06:03 [verbose]: updating selection with beatmap:2053 ruleset:0
[runtime] 2021-03-03 05:06:03 [verbose]: beatmap changed from "Sasaki Sayaka - Zzz (Sumisola) [Normal]" to "Sasaki Sayaka - Zzz (Sumisola) [Okamiroy's Hard]"
[runtime] 2021-03-03 05:06:03 [verbose]: working beatmap updated to Sasaki Sayaka - Zzz (Sumisola) [Okamiroy's Hard]
[network] 2021-03-03 05:06:03 [verbose]: Performing request osu.Game.Online.API.Requests.GetUpdatesRequest
[performance] 2021-03-03 05:06:03 [verbose]: Allocated finalizable object: System.WeakReference`1[osu.Framework.Bindables.Bindable`1[System.Int32]]
[performance] 2021-03-03 05:06:03 [verbose]: Allocated finalizable object: System.WeakReference`1[osu.Framework.Bindables.Bindable`1[System.Int32]]
[network] 2021-03-03 05:06:03 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/updates successfully completed!
[network] 2021-03-03 05:06:03 [verbose]: Performing request osu.Game.Online.API.Requests.GetBeatmapRequest
[network] 2021-03-03 05:06:03 [verbose]: Request to https://dev.ppy.sh/api/v2/beatmaps/lookup?id=105952&checksum=917d06f57c4770dc338f252abfbe90d7&filename=Sasaki%20Sayaka%20-%20Zzz%20(Sumisola)%20[Okamiroy's%20Hard].osu successfully completed!
[runtime] 2021-03-03 05:06:05 [debug]: Pressed (SelectNext) handled by BeatmapCarousel.
[runtime] 2021-03-03 05:06:05 [debug]: KeyDownEvent(Down, False) handled by GlobalActionContainer.
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: TextureWithRefCount
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: ConditionalWeakTable<TKey,TValue>+Container<Object>
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: ConditionalWeakTable<TKey,TValue>+Container<Object>
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: SampleChannelBass
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: TextureWithRefCount
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: ConditionalWeakTable<TKey,TValue>+Container<Object>
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: TextureWithRefCount
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: SampleChannelBass
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: SampleChannelBass
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: FrameBuffer
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: FrameBuffer
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: ConditionalWeakTable<TKey,TValue>+Container<Object>
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: FrameBuffer
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: ConditionalWeakTable<TKey,TValue>+Container<Object>
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: ConditionalWeakTable<TKey,TValue>+Container<Object>
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: SampleChannelBass
[runtime] 2021-03-03 05:06:05 [verbose]: Finalizing object: Thread
[runtime] 2021-03-03 05:06:05 [verbose]: updating selection with beatmap:2054 ruleset:0
[runtime] 2021-03-03 05:06:05 [verbose]: beatmap changed from "Sasaki Sayaka - Zzz (Sumisola) [Okamiroy's Hard]" to "Sasaki Sayaka - Zzz (Sumisola) [Aria]"
[runtime] 2021-03-03 05:06:05 [verbose]: working beatmap updated to Sasaki Sayaka - Zzz (Sumisola) [Aria]
[network] 2021-03-03 05:06:05 [verbose]: Performing request osu.Game.Online.API.Requests.GetBeatmapRequest
[performance] 2021-03-03 05:06:05 [verbose]: Allocated finalizable object: System.WeakReference`1[osu.Framework.Bindables.Bindable`1[System.Int32]]
[performance] 2021-03-03 05:06:05 [verbose]: Allocated finalizable object: System.WeakReference`1[osu.Framework.Bindables.Bindable`1[System.Int32]]
[performance] 2021-03-03 05:06:05 [verbose]: Allocated finalizable object: System.WeakReference`1[osu.Framework.Bindables.Bindable`1[System.Int32]]
[network] 2021-03-03 05:06:05 [verbose]: Request to https://dev.ppy.sh/api/v2/beatmaps/lookup?id=107277&checksum=3ba779313a8a0f43282b080d9002d164&filename=Sasaki%20Sayaka%20-%20Zzz%20(Sumisola)%20[Aria].osu successfully completed!
[network] 2021-03-03 05:06:09 [verbose]: Performing request osu.Game.Online.API.Requests.GetUpdatesRequest
[network] 2021-03-03 05:06:09 [verbose]: Request to https://dev.ppy.sh/api/v2/chat/updates successfully completed!

```