### PR TITLE
Remove SampleChannelBass finalizer

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -181,11 +181,6 @@ namespace osu.Framework.Audio.Sample
             bassAmplitudeProcessor?.SetChannel(channel);
         });
 
-        ~SampleChannelBass()
-        {
-            Dispose(false);
-        }
-
         protected override void Dispose(bool disposing)
         {
             if (IsDisposed)


### PR DESCRIPTION
`Dispose()` only exists to stop the sample playback early upon disposal, however the lifetime of this object is completely managed by `SampleBass`. Channels don't need cleanup BASS-level cleanup.