### PR TITLE
Add RuntimeInfo's determined OS to log output

### DIFF
--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -531,7 +531,7 @@ namespace osu.Framework.Graphics.Video
                 // "lib" prefix and extensions are resolved by .net core
                 switch (RuntimeInfo.OS)
                 {
-                    case RuntimeInfo.Platform.MacOsx:
+                    case RuntimeInfo.Platform.macOS:
                         libraryName = $"{name}.{version}";
                         break;
 

--- a/osu.Framework/Host.cs
+++ b/osu.Framework/Host.cs
@@ -22,7 +22,7 @@ namespace osu.Framework
 
             switch (RuntimeInfo.OS)
             {
-                case RuntimeInfo.Platform.MacOsx:
+                case RuntimeInfo.Platform.macOS:
                     return new MacOSGameHost(gameName, bindIPC, toolkitOptions, portableInstallation, useOsuTK);
 
                 case RuntimeInfo.Platform.Linux:

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -408,8 +408,8 @@ namespace osu.Framework.Logging
 
             add("----------------------------------------------------------", outputToListeners: false);
             add($"{Name} Log for {UserIdentifier} (LogLevel: {Level})", outputToListeners: false);
-            add($"{GameIdentifier} {VersionIdentifier}", outputToListeners: false);
-            add($"Running on {Environment.OSVersion}, {Environment.ProcessorCount} cores", outputToListeners: false);
+            add($"Running {GameIdentifier} {VersionIdentifier} on .NET {Environment.Version}", outputToListeners: false);
+            add($"Environment: {RuntimeInfo.OS} ({Environment.OSVersion}), {Environment.ProcessorCount} cores ", outputToListeners: false);
             add("----------------------------------------------------------", outputToListeners: false);
         }
 

--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -449,7 +449,7 @@ namespace osu.Framework.Platform.SDL2
             // NOTE: on macOS, SDL2 does not differentiate between "maximised" and "fullscreen desktop"
             if (windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP) ||
                 windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_BORDERLESS) ||
-                windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED) && RuntimeInfo.OS == RuntimeInfo.Platform.MacOsx)
+                windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED) && RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
                 return WindowState.FullscreenBorderless;
 
             if (windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_MINIMIZED))
@@ -475,7 +475,7 @@ namespace osu.Framework.Platform.SDL2
                     return SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN;
 
                 case WindowState.Maximised:
-                    return RuntimeInfo.OS == RuntimeInfo.Platform.MacOsx
+                    return RuntimeInfo.OS == RuntimeInfo.Platform.macOS
                         ? SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP
                         : SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED;
 

--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -31,9 +31,9 @@ namespace osu.Framework
         public static bool IsUnix => OS != Platform.Windows;
 
         public static bool SupportsJIT => OS != Platform.iOS;
-        public static bool IsDesktop => OS == Platform.Linux || OS == Platform.MacOsx || OS == Platform.Windows;
+        public static bool IsDesktop => OS == Platform.Linux || OS == Platform.macOS || OS == Platform.Windows;
         public static bool IsMobile => OS == Platform.iOS || OS == Platform.Android;
-        public static bool IsApple => OS == Platform.iOS || OS == Platform.MacOsx;
+        public static bool IsApple => OS == Platform.iOS || OS == Platform.macOS;
 
         static RuntimeInfo()
         {
@@ -44,7 +44,7 @@ namespace osu.Framework
             if (osuTK.Configuration.RunningOnAndroid)
                 OS = OS == 0 ? Platform.Android : throw new InvalidOperationException($"Tried to set OS Platform to {nameof(Platform.Android)}, but is already {Enum.GetName(typeof(Platform), OS)}");
             if (OS != Platform.iOS && RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                OS = OS == 0 ? Platform.MacOsx : throw new InvalidOperationException($"Tried to set OS Platform to {nameof(Platform.MacOsx)}, but is already {Enum.GetName(typeof(Platform), OS)}");
+                OS = OS == 0 ? Platform.macOS : throw new InvalidOperationException($"Tried to set OS Platform to {nameof(Platform.macOS)}, but is already {Enum.GetName(typeof(Platform), OS)}");
             if (OS != Platform.Android && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 OS = OS == 0 ? Platform.Linux : throw new InvalidOperationException($"Tried to set OS Platform to {nameof(Platform.Linux)}, but is already {Enum.GetName(typeof(Platform), OS)}");
 
@@ -56,7 +56,7 @@ namespace osu.Framework
         {
             Windows = 1,
             Linux = 2,
-            MacOsx = 3,
+            macOS = 3,
             iOS = 4,
             Android = 5
         }


### PR DESCRIPTION
Before:

```
2021-03-02 06:46:01 [verbose]: ----------------------------------------------------------
2021-03-02 06:46:01 [verbose]: runtime Log for dean (LogLevel: Debug)
2021-03-02 06:46:01 [verbose]: visual-tests 1.0.0.0
2021-03-02 06:46:01 [verbose]: Running on Unix 11.0.0, 32 cores
2021-03-02 06:46:01 [verbose]: ----------------------------------------------------------
```

After:

```
2021-03-03 06:03:45 [verbose]: ----------------------------------------------------------
2021-03-03 06:03:45 [verbose]: runtime Log for dean (LogLevel: Debug)
2021-03-03 06:03:45 [verbose]: Running visual-tests 1.0.0.0 on .NET 5.0.3
2021-03-03 06:03:45 [verbose]: Environment: macOS, (Unix 11.0.0), 32 cores
2021-03-03 06:03:45 [verbose]: ----------------------------------------------------------
```