### PR TITLE
Move TextureGL's finalizer local to TextureGLSingle

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -32,11 +32,6 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         #region Disposal
 
-        ~TextureGL()
-        {
-            Dispose(false);
-        }
-
         internal virtual bool IsQueuedForUpload { get; set; }
 
         /// <summary>

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -88,6 +88,11 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         #region Disposal
 
+        ~TextureGLSingle()
+        {
+            Dispose(false);
+        }
+
         protected override void Dispose(bool isDisposing)
         {
             base.Dispose(isDisposing);


### PR DESCRIPTION
No other framework-level texture implementations should require this immediately.