### PR TITLE
Disable macOS cursor location assistance if not visible

### DIFF
--- a/osu.Framework/Platform/MacOS/MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindow.cs
@@ -22,6 +22,16 @@ namespace osu.Framework.Platform.MacOS
         private IntPtr originalScrollWheel;
         private ScrollWheelDelegate scrollWheelHandler;
 
+        public override bool CursorVisible
+        {
+            get => base.CursorVisible;
+            set
+            {
+                base.CursorVisible = value;
+                updateCursorAssistanceState();
+            }
+        }
+
         public override void Create()
         {
             base.Create();
@@ -30,6 +40,16 @@ namespace osu.Framework.Platform.MacOS
             var viewClass = Class.Get("SDLView");
             scrollWheelHandler = scrollWheel;
             originalScrollWheel = Class.SwizzleMethod(viewClass, "scrollWheel:", "v@:@", scrollWheelHandler);
+
+            CursorInWindow.BindValueChanged(_ => updateCursorAssistanceState(), true);
+        }
+
+        private void updateCursorAssistanceState()
+        {
+            if (CursorInWindow.Value && !CursorVisible)
+                NSApplication.PresentationOptions |= NSApplicationPresentationOptions.DisableCursorLocationAssistance;
+            else
+                NSApplication.PresentationOptions &= ~NSApplicationPresentationOptions.DisableCursorLocationAssistance;
         }
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -177,7 +177,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Returns or sets the cursor's visibility within the window.
         /// </summary>
-        public bool CursorVisible
+        public virtual bool CursorVisible
         {
             get => cursorVisible;
             set


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/11772

Just realized such code for disabling this existed in the osuTK window implementation, added it here in a pretty simple way, and it seems to work perfectly.

Also made the shake feature enable itself back when cursor is not in window, wasn't feeling alright leaving it disabled there.