### PR TITLE
Update usages of await to always call ConfigureAwait(false)

### DIFF
--- a/CodeAnalysis/osu-framework.ruleset
+++ b/CodeAnalysis/osu-framework.ruleset
@@ -36,7 +36,7 @@
     <Rule Id="CA1819" Action="None" />
     <Rule Id="CA1822" Action="None" />
     <Rule Id="CA1823" Action="None" />
-    <Rule Id="CA2007" Action="None" />
+    <Rule Id="CA2007" Action="Warning" />
     <Rule Id="CA2119" Action="None" />
     <Rule Id="CA2211" Action="None" />
     <Rule Id="CA2214" Action="None" />

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -370,7 +370,7 @@ namespace osu.Framework.Tests.IO
             request.Failed += exception => hasThrown = exception != null;
 
             cancellationSource.Cancel();
-            await request.PerformAsync(cancellationSource.Token);
+            await request.PerformAsync(cancellationSource.Token).ConfigureAwait(false);
 
             Assert.IsTrue(request.Completed);
             Assert.IsTrue(request.Aborted);

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -231,7 +231,7 @@ namespace osu.Framework.Tests.Localisation
                 EffectiveCulture = new CultureInfo(locale);
             }
 
-            public async Task<string> GetAsync(string name) => await Task.Run(() => Get(name));
+            public async Task<string> GetAsync(string name) => await Task.Run(() => Get(name)).ConfigureAwait(false);
 
             public string Get(string name)
             {

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneConcurrentLoad.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneConcurrentLoad.cs
@@ -91,7 +91,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             [BackgroundDependencyLoader]
             private async Task load()
             {
-                await Task.Delay((int)(1000 / Clock.Rate));
+                await Task.Delay((int)(1000 / Clock.Rate)).ConfigureAwait(false);
             }
         }
     }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
@@ -289,7 +289,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 EffectiveCulture = new CultureInfo(locale);
             }
 
-            public async Task<string> GetAsync(string name) => await Task.Run(() => Get(name));
+            public async Task<string> GetAsync(string name) => await Task.Run(() => Get(name)).ConfigureAwait(false);
 
             public string Get(string name)
             {

--- a/osu.Framework.Tests/Visual/Sprites/TestVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestVideo.cs
@@ -3,6 +3,7 @@
 
 using System.IO;
 using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Video;
 using osu.Framework.IO.Network;
@@ -14,7 +15,7 @@ namespace osu.Framework.Tests.Visual.Sprites
         private static MemoryStream consumeVideoStream()
         {
             var wr = new WebRequest("https://assets.ppy.sh/media/landing.mp4");
-            wr.PerformAsync();
+            Task.Run(() => wr.PerformAsync());
 
             while (!wr.Completed)
                 Thread.Sleep(100);

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -325,7 +325,7 @@ namespace osu.Framework.Audio.Track
             double conservativeLength = Length == 0 ? double.MaxValue : lastSeekablePosition;
             double conservativeClamped = Math.Clamp(seek, 0, conservativeLength);
 
-            await EnqueueAction(() => seekInternal(seek));
+            await EnqueueAction(() => seekInternal(seek)).ConfigureAwait(false);
 
             return conservativeClamped == seek;
         }

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -185,7 +185,7 @@ namespace osu.Framework.Audio.Track
             if (pointCount == 0 || readTask == null)
                 return new Waveform(null);
 
-            await readTask;
+            await readTask.ConfigureAwait(false);
 
             return await Task.Run(() =>
             {
@@ -256,7 +256,7 @@ namespace osu.Framework.Audio.Track
                     points = generatedPoints,
                     channels = channels
                 };
-            }, cancellationToken);
+            }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -272,7 +272,8 @@ namespace osu.Framework.Audio.Track
             if (readTask == null)
                 return points;
 
-            await readTask;
+            await readTask.ConfigureAwait(false);
+
             return points;
         }
 
@@ -289,7 +290,8 @@ namespace osu.Framework.Audio.Track
             if (readTask == null)
                 return channels;
 
-            await readTask;
+            await readTask.ConfigureAwait(false);
+
             return channels;
         }
 

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Graphics.Textures
             }
         }
 
-        private async Task<Texture> getTextureAsync(string name, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None) => loadRaw(await base.GetAsync(name), wrapModeS, wrapModeT);
+        private async Task<Texture> getTextureAsync(string name, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None) => loadRaw(await base.GetAsync(name).ConfigureAwait(false), wrapModeS, wrapModeT);
 
         private Texture getTexture(string name, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None) => loadRaw(base.Get(name), wrapModeS, wrapModeT);
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -223,7 +223,7 @@ namespace osu.Framework.IO.Network
         /// <summary>
         /// Performs the request asynchronously.
         /// </summary>
-        public async Task PerformAsync() => await PerformAsync(default);
+        public Task PerformAsync() => PerformAsync(default);
 
         /// <summary>
         /// Performs the request asynchronously.

--- a/osu.Framework/IO/Stores/DllResourceStore.cs
+++ b/osu.Framework/IO/Stores/DllResourceStore.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.IO.Stores
                     return null;
 
                 byte[] buffer = new byte[input.Length];
-                await input.ReadAsync(buffer.AsMemory());
+                await input.ReadAsync(buffer.AsMemory()).ConfigureAwait(false);
                 return buffer;
             }
         }

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -98,12 +98,12 @@ namespace osu.Framework.IO.Stores
             childStoreLoadTasks = Task.Run(async () =>
             {
                 if (previousLoadStream != null)
-                    await previousLoadStream;
+                    await previousLoadStream.ConfigureAwait(false);
 
                 try
                 {
                     Logger.Log($"Loading Font {store.FontName}...", level: LogLevel.Debug);
-                    await store.LoadFontAsync();
+                    await store.LoadFontAsync().ConfigureAwait(false);
                     Logger.Log($"Loaded Font {store.FontName}!", level: LogLevel.Debug);
                 }
                 catch

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -132,7 +132,7 @@ namespace osu.Framework.IO.Stores
             if (name.Length > 1 && !name.StartsWith($@"{FontName}/", StringComparison.Ordinal))
                 return null;
 
-            return !(await completionSource.Task).Characters.TryGetValue(name.Last(), out Character c) ? null : LoadCharacter(c);
+            return !(await completionSource.Task.ConfigureAwait(false)).Characters.TryGetValue(name.Last(), out Character c) ? null : LoadCharacter(c);
         }
 
         protected int LoadedGlyphCount;

--- a/osu.Framework/IO/Stores/OnlineStore.cs
+++ b/osu.Framework/IO/Stores/OnlineStore.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.IO.Stores
             {
                 using (WebRequest req = new WebRequest($@"{url}"))
                 {
-                    await req.PerformAsync();
+                    await req.PerformAsync().ConfigureAwait(false);
                     return req.GetResponseData();
                 }
             }

--- a/osu.Framework/IO/Stores/ResourceStore.cs
+++ b/osu.Framework/IO/Stores/ResourceStore.cs
@@ -93,7 +93,7 @@ namespace osu.Framework.IO.Stores
             {
                 foreach (string f in filenames)
                 {
-                    T result = await store.GetAsync(f);
+                    T result = await store.GetAsync(f).ConfigureAwait(false);
                     if (result != null)
                         return result;
                 }

--- a/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
+++ b/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.IO.Stores
                 if (stream == null) return null;
 
                 byte[] buffer = new byte[stream.Length];
-                await stream.ReadAsync(buffer.AsMemory());
+                await stream.ReadAsync(buffer.AsMemory()).ConfigureAwait(false);
                 return buffer;
             }
         }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -482,7 +482,7 @@ namespace osu.Framework.Platform
                 });
 
                 // this is required as attempting to use a TaskCompletionSource blocks the thread calling SetResult on some configurations.
-                await Task.Run(completionEvent.Wait);
+                await Task.Run(completionEvent.Wait).ConfigureAwait(false);
 
                 var image = Image.LoadPixelData<Rgba32>(pixelData.Memory.Span, width, height);
                 image.Mutate(c => c.Flip(FlipMode.Vertical));

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -53,20 +53,20 @@ namespace osu.Framework.Platform
                 {
                     while (!listener.Pending())
                     {
-                        await Task.Delay(10, token);
+                        await Task.Delay(10, token).ConfigureAwait(false);
                         if (token.IsCancellationRequested)
                             return;
                     }
 
-                    using (var client = await listener.AcceptTcpClientAsync())
+                    using (var client = await listener.AcceptTcpClientAsync().ConfigureAwait(false))
                     {
                         using (var stream = client.GetStream())
                         {
                             byte[] header = new byte[sizeof(int)];
-                            await stream.ReadAsync(header.AsMemory(), token);
+                            await stream.ReadAsync(header.AsMemory(), token).ConfigureAwait(false);
                             int len = BitConverter.ToInt32(header, 0);
                             byte[] data = new byte[len];
-                            await stream.ReadAsync(data.AsMemory(), token);
+                            await stream.ReadAsync(data.AsMemory(), token).ConfigureAwait(false);
                             var str = Encoding.UTF8.GetString(data);
                             var json = JToken.Parse(str);
 
@@ -106,16 +106,16 @@ namespace osu.Framework.Platform
         {
             using (var client = new TcpClient())
             {
-                await client.ConnectAsync(IPAddress.Loopback, ipc_port);
+                await client.ConnectAsync(IPAddress.Loopback, ipc_port).ConfigureAwait(false);
 
                 using (var stream = client.GetStream())
                 {
                     var str = JsonConvert.SerializeObject(message, Formatting.None);
                     byte[] data = Encoding.UTF8.GetBytes(str);
                     byte[] header = BitConverter.GetBytes(data.Length);
-                    await stream.WriteAsync(header.AsMemory());
-                    await stream.WriteAsync(data.AsMemory());
-                    await stream.FlushAsync();
+                    await stream.WriteAsync(header.AsMemory()).ConfigureAwait(false);
+                    await stream.WriteAsync(data.AsMemory()).ConfigureAwait(false);
+                    await stream.FlushAsync().ConfigureAwait(false);
                 }
             }
         }

--- a/osu.Framework/Testing/DynamicClassCompiler.cs
+++ b/osu.Framework/Testing/DynamicClassCompiler.cs
@@ -70,7 +70,7 @@ namespace osu.Framework.Testing
                 if (!Directory.Exists(basePath))
                     return;
 
-                await referenceBuilder.Initialise(Directory.GetFiles(getSolutionPath(di), "*.sln").First());
+                await referenceBuilder.Initialise(Directory.GetFiles(getSolutionPath(di), "*.sln").First()).ConfigureAwait(false);
 
                 foreach (var dir in Directory.GetDirectories(basePath))
                 {
@@ -104,7 +104,7 @@ namespace osu.Framework.Testing
             return d.GetFiles().Any(f => f.Extension == ".sln") ? d.FullName : getSolutionPath(d.Parent);
         }
 
-        private void onChange(object sender, FileSystemEventArgs args) => Task.Run(async () => await recompileAsync(target?.GetType(), args.FullPath));
+        private void onChange(object sender, FileSystemEventArgs args) => Task.Run(async () => await recompileAsync(target?.GetType(), args.FullPath).ConfigureAwait(false));
 
         private int currentVersion;
         private bool isCompiling;
@@ -125,10 +125,10 @@ namespace osu.Framework.Testing
 
                 CompilationStarted?.Invoke();
 
-                foreach (var f in await referenceBuilder.GetReferencedFiles(targetType, changedFile))
+                foreach (var f in await referenceBuilder.GetReferencedFiles(targetType, changedFile).ConfigureAwait(false))
                     requiredFiles.Add(f);
 
-                var assemblies = await referenceBuilder.GetReferencedAssemblies(targetType, changedFile);
+                var assemblies = await referenceBuilder.GetReferencedAssemblies(targetType, changedFile).ConfigureAwait(false);
 
                 using (var pdbStream = new MemoryStream())
                 using (var peStream = new MemoryStream())

--- a/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/EmptyTypeReferenceBuilder.cs
@@ -12,10 +12,10 @@ namespace osu.Framework.Testing
         public Task Initialise(string solutionFile) => Task.CompletedTask;
 
         public async Task<IReadOnlyCollection<string>> GetReferencedFiles(Type testType, string changedFile)
-            => await Task.FromResult(Array.Empty<string>());
+            => await Task.FromResult(Array.Empty<string>()).ConfigureAwait(false);
 
         public async Task<IReadOnlyCollection<AssemblyReference>> GetReferencedAssemblies(Type testType, string changedFile)
-            => await Task.FromResult(Array.Empty<AssemblyReference>());
+            => await Task.FromResult(Array.Empty<AssemblyReference>()).ConfigureAwait(false);
 
         public void Reset()
         {


### PR DESCRIPTION
This should have been quite obvious from the start (I have dealt with simlar issues in a distant past) but it didn't cross my mind that Xamarin.iOS' window initialisation could have been setting a `SynchronizationContext`.

This is the simplest recommended solution to resolve the issue. I'm not sure whether we want to further suppress the `SynchronizationContext` from being visible to our tasks - further issues (and unnecessary blocking overhead) may still exist. Fixing the deadlock scenarios is the first goal, though.

I've turned on the analyser to require this everywhere.

Closes https://github.com/ppy/osu-framework/issues/4214.

Huge thanks to @TheDomco for investigating this issue and pointing out the root cause. Further reading for people wishing to get more familiar with the cause and solutions should check [this faq](https://devblogs.microsoft.com/dotnet/configureawait-faq/).