### PR TITLE
Usage of unused variable

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -371,7 +371,7 @@ namespace osu.Framework.Graphics.Containers
             if (ScrollDirection == Direction.Horizontal && scrollDelta.X != 0)
                 scrollDeltaFloat = scrollDelta.X;
 
-            scrollByOffset((isPrecise ? 10 : 80) * -scrollDeltaFloat, true, isPrecise ? 0.05 : DistanceDecayScroll);
+            scrollByOffset((isPrecise ? 10 : ScrollDistance) * -scrollDeltaFloat, true, isPrecise ? 0.05 : DistanceDecayScroll);
             return true;
         }
 


### PR DESCRIPTION
While debugging my game I noticed that [ScrollDistance](https://github.com/ppy/osu-framework/blob/74a3308d505ffd45b646b246ca598d07e7419473/osu.Framework/Graphics/Containers/ScrollContainer.cs#L78) has no effect. It turns out the value is hardcoded and the variable is not being used.