### PR TITLE
Fix crash on startup on iOS due to host being null?

### DIFF
--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -23,9 +23,6 @@ namespace osu.Framework.Input.Bindings
     public abstract class KeyBindingContainer<T> : KeyBindingContainer
         where T : struct
     {
-        [Resolved]
-        protected GameHost Host { get; private set; }
-
         private readonly SimultaneousBindingMode simultaneousMode;
         private readonly KeyCombinationMatchingMode matchingMode;
 
@@ -330,6 +327,12 @@ namespace osu.Framework.Input.Bindings
     /// </summary>
     public abstract class KeyBindingContainer : Container
     {
+        // This is only specified here (rather than in PlatformContainer, where it is consumed) to workaround
+        // a critical iOS / Xamarin bug. It should not need to be here.
+        // See https://github.com/ppy/osu-framework/pull/4263 for discussion.
+        [Resolved]
+        protected GameHost Host { get; private set; }
+
         protected IEnumerable<IKeyBinding> KeyBindings;
 
         public abstract IEnumerable<IKeyBinding> DefaultKeyBindings { get; }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -328,7 +328,8 @@ namespace osu.Framework.Input.Bindings
     public abstract class KeyBindingContainer : Container
     {
         // This is only specified here (rather than in PlatformContainer, where it is consumed) to workaround
-        // a critical iOS / Xamarin bug. It should not need to be here.
+        // a critical iOS / Xamarin bug, where consumer applications may crash during startup at an unmanaged level.
+        // It should eventually be removed when the issue is identified and fixed upstream.
         // See https://github.com/ppy/osu-framework/pull/4263 for discussion.
         [Resolved]
         protected GameHost Host { get; private set; }

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -4,12 +4,14 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Logging;
+using osu.Framework.Platform;
 using osuTK;
 
 namespace osu.Framework.Input.Bindings
@@ -21,6 +23,9 @@ namespace osu.Framework.Input.Bindings
     public abstract class KeyBindingContainer<T> : KeyBindingContainer
         where T : struct
     {
+        [Resolved]
+        protected GameHost Host { get; private set; }
+
         private readonly SimultaneousBindingMode simultaneousMode;
         private readonly KeyCombinationMatchingMode matchingMode;
 

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -2,9 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using osu.Framework.Allocation;
 using osu.Framework.Input.Bindings;
-using osu.Framework.Platform;
 
 namespace osu.Framework.Input
 {
@@ -16,15 +14,12 @@ namespace osu.Framework.Input
     /// </summary>
     public class PlatformActionContainer : KeyBindingContainer<PlatformAction>, IHandleGlobalKeyboardInput
     {
-        [Resolved]
-        private GameHost host { get; set; }
-
         public PlatformActionContainer()
             : base(SimultaneousBindingMode.None, KeyCombinationMatchingMode.Modifiers)
         {
         }
 
-        public override IEnumerable<IKeyBinding> DefaultKeyBindings => host.PlatformKeyBindings;
+        public override IEnumerable<IKeyBinding> DefaultKeyBindings => Host.PlatformKeyBindings;
 
         protected override bool Prioritised => true;
 


### PR DESCRIPTION
I'm not sure I understand how this is happening, but this does fix the hard crash on osu! startup when running under iOS/Release (with debugger mode disabled). 

This is the only change required to make iOS work again. That said, I still think we want to get the `ConfigureAwait` changes in (#4261) because it's only a matter of time before we cause a deadlock like that.

This would explain why the await specific cases in `osu.Framework.Tests` where reproducible in the simulator while the osu! side crash was not.

A few things:

- The exception is silently eaten, causing the game to startup (and the draw thread to be waiting to draw). Not sure if this is an iOS specific issue, or if we are handling exceptions incorrectly across all platforms in some code path. We definitely need to investigate and fix this either way.
- This looks to somehow be caused by a race condition (or specific timing). Turning on Xamarin debugging support causes it to no longer fail. Also, testing on desktop platforms shows that the dependency is always available.

![20210308 161954 (Xcode)](https://user-images.githubusercontent.com/191335/110287577-1f79f480-802a-11eb-8915-734e17d2e640.png)

If any further debug information is required, I can run anything `lldb` from this point.

Note that this is probably not to be considered a final fix for the issue, without understanding how/why/what is going wrong.