### PR TITLE
Fix LocalisableString operator== failing for non-interned strings

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Localisation;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkLocalisableString
+    {
+        private LocalisableString str1;
+        private LocalisableString str2;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            str1 = new RomanisableString("a", "b");
+            str2 = new RomanisableString("c", "d");
+        }
+
+        [Benchmark]
+        public bool BenchmarkEquals() => str1.Equals(str2);
+
+        [Benchmark]
+        public int BenchmarkGetHashCode() => str1.GetHashCode();
+    }
+}

--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -1,0 +1,37 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Localisation;
+
+namespace osu.Framework.Tests.Localisation
+{
+    [TestFixture]
+    public class LocalisableStringTest
+    {
+        private const string string_a = "a";
+        private const string string_b = "b";
+
+        [Test]
+        public void TestTranslatableStringEqualsTranslatableString()
+        {
+            var str1 = new TranslatableString(string_a, string_b, string_a, string_b);
+            var str2 = new TranslatableString(string_b, string_a, string_a, string_b);
+
+            Assert.That(str1.Equals(str1));
+            Assert.That(str1.Equals(new TranslatableString(string_a, string_b, string_a, string_b))); // Structurally equal
+            Assert.That(!str1.Equals(str2));
+        }
+
+        [Test]
+        public void TestRomanisableStringEqualsRomanisableString()
+        {
+            var str1 = new RomanisableString(string_a, string_b);
+            var str2 = new RomanisableString(string_b, string_a);
+
+            Assert.That(str1.Equals(str1));
+            Assert.That(str1.Equals(new RomanisableString(string_a, string_b))); // Structurally equal
+            Assert.That(!str1.Equals(str2));
+        }
+    }
+}

--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Tests.Localisation
         public void TestTranslatableStringEqualsTranslatableString()
         {
             var str1 = new TranslatableString(string_a, string_b, string_a, string_b);
-            var str2 = new TranslatableString(string_b, string_a, string_a, string_b);
+            var str2 = new TranslatableString(string_a, string_b);
 
             Assert.That(str1.Equals(str1));
             Assert.That(str1.Equals(new TranslatableString(string_a, string_b, string_a, string_b))); // Structurally equal
@@ -33,5 +33,38 @@ namespace osu.Framework.Tests.Localisation
             Assert.That(str1.Equals(new RomanisableString(string_a, string_b))); // Structurally equal
             Assert.That(!str1.Equals(str2));
         }
+
+        [Test]
+        public void TestLocalisableStringEqualsString()
+        {
+            LocalisableString localisable = makeString('a');
+
+            Assert.That(localisable.Equals(string_a));
+            Assert.That(!localisable.Equals(string_b));
+        }
+
+        [Test]
+        public void TestLocalisableStringEqualsTranslatableString()
+        {
+            LocalisableString localisable = new TranslatableString(string_a, string_b, string_a, string_b);
+
+            Assert.That(localisable.Equals(new TranslatableString(string_a, string_b, string_a, string_b))); // Structurally equal
+            Assert.That(!localisable.Equals(new TranslatableString(string_b, string_a)));
+            Assert.That(!localisable.Equals(makeString('a')));
+            Assert.That(!localisable.Equals(new RomanisableString(string_a, string_b)));
+        }
+
+        [Test]
+        public void TestLocalisableStringEqualsRomanisableString()
+        {
+            LocalisableString localisable = new RomanisableString(string_a, string_b);
+
+            Assert.That(localisable.Equals(new RomanisableString(string_a, string_b))); // Structurally equal
+            Assert.That(!localisable.Equals(new RomanisableString(string_b, string_a)));
+            Assert.That(!localisable.Equals(makeString('a')));
+            Assert.That(!localisable.Equals(new TranslatableString(string_a, string_b)));
+        }
+
+        private string makeString(params char[] chars) => new string(chars);
     }
 }

--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestNullEqualsNull()
         {
-            testEquals(false, new LocalisableString(), new LocalisableString());
+            testEquals(true, new LocalisableString(), new LocalisableString());
         }
 
         [Test]

--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -9,62 +9,62 @@ namespace osu.Framework.Tests.Localisation
     [TestFixture]
     public class LocalisableStringTest
     {
-        private const string string_a = "a";
-        private const string string_b = "b";
+        private string makeStringA => makeString('a');
+        private string makeStringB => makeString('b');
 
         [Test]
         public void TestTranslatableStringEqualsTranslatableString()
         {
-            var str1 = new TranslatableString(string_a, string_b, string_a, string_b);
-            var str2 = new TranslatableString(string_a, string_b);
+            var str1 = new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB);
+            var str2 = new TranslatableString(makeStringA, makeStringB);
 
             Assert.That(str1.Equals(str1));
-            Assert.That(str1.Equals(new TranslatableString(string_a, string_b, string_a, string_b))); // Structurally equal
+            Assert.That(str1.Equals(new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB))); // Structurally equal
             Assert.That(!str1.Equals(str2));
         }
 
         [Test]
         public void TestRomanisableStringEqualsRomanisableString()
         {
-            var str1 = new RomanisableString(string_a, string_b);
-            var str2 = new RomanisableString(string_b, string_a);
+            var str1 = new RomanisableString(makeStringA, makeStringB);
+            var str2 = new RomanisableString(makeStringB, makeStringA);
 
             Assert.That(str1.Equals(str1));
-            Assert.That(str1.Equals(new RomanisableString(string_a, string_b))); // Structurally equal
+            Assert.That(str1.Equals(new RomanisableString(makeStringA, makeStringB))); // Structurally equal
             Assert.That(!str1.Equals(str2));
         }
 
         [Test]
         public void TestLocalisableStringEqualsString()
         {
-            LocalisableString localisable = makeString('a');
+            LocalisableString localisable = makeStringA;
 
-            Assert.That(localisable.Equals(string_a));
-            Assert.That(!localisable.Equals(string_b));
+            Assert.That(localisable.Equals(makeStringA));
+            Assert.That(!localisable.Equals(makeStringB));
         }
 
         [Test]
         public void TestLocalisableStringEqualsTranslatableString()
         {
-            LocalisableString localisable = new TranslatableString(string_a, string_b, string_a, string_b);
+            LocalisableString localisable = new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB);
 
-            Assert.That(localisable.Equals(new TranslatableString(string_a, string_b, string_a, string_b))); // Structurally equal
-            Assert.That(!localisable.Equals(new TranslatableString(string_b, string_a)));
-            Assert.That(!localisable.Equals(makeString('a')));
-            Assert.That(!localisable.Equals(new RomanisableString(string_a, string_b)));
+            Assert.That(localisable.Equals(new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB))); // Structurally equal
+            Assert.That(!localisable.Equals(new TranslatableString(makeStringB, makeStringA)));
+            Assert.That(!localisable.Equals(makeStringA));
+            Assert.That(!localisable.Equals(new RomanisableString(makeStringA, makeStringB)));
         }
 
         [Test]
         public void TestLocalisableStringEqualsRomanisableString()
         {
-            LocalisableString localisable = new RomanisableString(string_a, string_b);
+            LocalisableString localisable = new RomanisableString(makeStringA, makeStringB);
 
-            Assert.That(localisable.Equals(new RomanisableString(string_a, string_b))); // Structurally equal
-            Assert.That(!localisable.Equals(new RomanisableString(string_b, string_a)));
-            Assert.That(!localisable.Equals(makeString('a')));
-            Assert.That(!localisable.Equals(new TranslatableString(string_a, string_b)));
+            Assert.That(localisable.Equals(new RomanisableString(makeStringA, makeStringB))); // Structurally equal
+            Assert.That(!localisable.Equals(new RomanisableString(makeStringB, makeStringA)));
+            Assert.That(!localisable.Equals(makeStringA));
+            Assert.That(!localisable.Equals(new TranslatableString(makeStringA, makeStringB)));
         }
 
-        private string makeString(params char[] chars) => new string(chars);
+        private static string makeString(params char[] chars) => new string(chars);
     }
 }

--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Localisation;
 
@@ -18,9 +19,9 @@ namespace osu.Framework.Tests.Localisation
             var str1 = new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB);
             var str2 = new TranslatableString(makeStringA, makeStringB);
 
-            Assert.That(str1.Equals(str1));
-            Assert.That(str1.Equals(new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB))); // Structurally equal
-            Assert.That(!str1.Equals(str2));
+            testEquals(true, str1, str1);
+            testEquals(true, str1, new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB)); // Structural equality.
+            testEquals(false, str1, str2);
         }
 
         [Test]
@@ -29,9 +30,9 @@ namespace osu.Framework.Tests.Localisation
             var str1 = new RomanisableString(makeStringA, makeStringB);
             var str2 = new RomanisableString(makeStringB, makeStringA);
 
-            Assert.That(str1.Equals(str1));
-            Assert.That(str1.Equals(new RomanisableString(makeStringA, makeStringB))); // Structurally equal
-            Assert.That(!str1.Equals(str2));
+            testEquals(true, str1, str1);
+            testEquals(true, str1, new RomanisableString(makeStringA, makeStringB)); // Structural equality.
+            testEquals(false, str1, str2);
         }
 
         [Test]
@@ -39,8 +40,8 @@ namespace osu.Framework.Tests.Localisation
         {
             LocalisableString localisable = makeStringA;
 
-            Assert.That(localisable.Equals(makeStringA));
-            Assert.That(!localisable.Equals(makeStringB));
+            testEquals(true, localisable, makeStringA);
+            testEquals(false, localisable, makeStringB);
         }
 
         [Test]
@@ -48,10 +49,10 @@ namespace osu.Framework.Tests.Localisation
         {
             LocalisableString localisable = new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB);
 
-            Assert.That(localisable.Equals(new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB))); // Structurally equal
-            Assert.That(!localisable.Equals(new TranslatableString(makeStringB, makeStringA)));
-            Assert.That(!localisable.Equals(makeStringA));
-            Assert.That(!localisable.Equals(new RomanisableString(makeStringA, makeStringB)));
+            testEquals(true, localisable, new TranslatableString(makeStringA, makeStringB, makeStringA, makeStringB));
+            testEquals(false, localisable, new TranslatableString(makeStringB, makeStringA));
+            testEquals(false, localisable, makeStringA);
+            testEquals(false, localisable, new RomanisableString(makeStringA, makeStringB));
         }
 
         [Test]
@@ -59,10 +60,30 @@ namespace osu.Framework.Tests.Localisation
         {
             LocalisableString localisable = new RomanisableString(makeStringA, makeStringB);
 
-            Assert.That(localisable.Equals(new RomanisableString(makeStringA, makeStringB))); // Structurally equal
-            Assert.That(!localisable.Equals(new RomanisableString(makeStringB, makeStringA)));
-            Assert.That(!localisable.Equals(makeStringA));
-            Assert.That(!localisable.Equals(new TranslatableString(makeStringA, makeStringB)));
+            testEquals(true, localisable, new RomanisableString(makeStringA, makeStringB));
+            testEquals(false, localisable, new RomanisableString(makeStringB, makeStringA));
+            testEquals(false, localisable, makeStringA);
+            testEquals(false, localisable, new TranslatableString(makeStringA, makeStringB));
+        }
+
+        [Test]
+        public void TestNullEqualsNull()
+        {
+            testEquals(false, new LocalisableString(), new LocalisableString());
+        }
+
+        [Test]
+        public void TestLocalisableStringDoesNotEqualNull()
+        {
+            testEquals(false, new LocalisableString(), new RomanisableString(makeStringA, makeStringB));
+        }
+
+        private static void testEquals<T>(bool expected, T a, T b)
+        {
+            var comparer = EqualityComparer<T>.Default;
+
+            Assert.That(comparer.Equals(a, b), Is.EqualTo(expected));
+            Assert.That(comparer.GetHashCode(a) == comparer.GetHashCode(b), Is.EqualTo(expected));
         }
 
         private static string makeString(params char[] chars) => new string(chars);

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTest.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTest.cs
@@ -94,7 +94,7 @@ namespace osu.Framework.Tests.Visual.Testing
             // Under both nUnit and the test browser, this should be invoked once _after_ each test method.
             AddAssert("correct teardown step run", () => teardownStepsDummyRun == testRunCountDummyRun - 1);
 
-            AddAssert("setup step marked as such", () => StepsContainer.OfType<StepButton>().First(s => s.Text == "set up second step").IsSetupStep);
+            AddAssert("setup step marked as such", () => StepsContainer.OfType<StepButton>().First(s => s.Text.ToString() == "set up second step").IsSetupStep);
 
             testRunCount++;
         }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -97,7 +97,7 @@ namespace osu.Framework.Graphics.Sprites
             get => text;
             set
             {
-                if (text == value)
+                if (text.Equals(value))
                     return;
 
                 text = value;

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -22,7 +22,32 @@ namespace osu.Framework.Localisation
         // it's somehow common to call default(LocalisableString), and we should return empty string then.
         public override string ToString() => Data?.ToString() ?? string.Empty;
 
-        public bool Equals(LocalisableString other) => Data == other.Data;
+        public bool Equals(LocalisableString other)
+        {
+            if (Data is string strThis)
+            {
+                if (other.Data is string strOther)
+                    return strThis.Equals(strOther);
+
+                return false;
+            }
+
+            if (Data is TranslatableString translatableThis)
+            {
+                if (other.Data is TranslatableString translatableOther)
+                    return translatableThis.Equals(translatableOther);
+
+                return false;
+            }
+
+            if (Data is RomanisableString romanisableThis)
+            {
+                if (other.Data is RomanisableString romanisableOther)
+                    return romanisableThis.Equals(romanisableOther);
+            }
+
+            return false;
+        }
 
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
         public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -2,8 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 
 #nullable enable
 
@@ -24,64 +22,9 @@ namespace osu.Framework.Localisation
         // it's somehow common to call default(LocalisableString), and we should return empty string then.
         public override string ToString() => Data?.ToString() ?? string.Empty;
 
-        public bool Equals(LocalisableString other)
-        {
-            bool thisIsNull = ReferenceEquals(null, Data);
-            bool otherIsNull = ReferenceEquals(null, other.Data);
-
-            // Nullability differs.
-            if (thisIsNull != otherIsNull)
-                return false;
-
-            // Both are null.
-            if (thisIsNull)
-            {
-                Debug.Assert(otherIsNull);
-                return true;
-            }
-
-            if (Data is string strThis)
-            {
-                if (other.Data is string strOther)
-                    return strThis.Equals(strOther, StringComparison.Ordinal);
-
-                return false;
-            }
-
-            if (Data is TranslatableString translatableThis)
-            {
-                if (other.Data is TranslatableString translatableOther)
-                    return translatableThis.Equals(translatableOther);
-
-                return false;
-            }
-
-            if (Data is RomanisableString romanisableThis)
-            {
-                if (other.Data is RomanisableString romanisableOther)
-                    return romanisableThis.Equals(romanisableOther);
-            }
-
-            Debug.Assert(Data != null);
-            Debug.Assert(other.Data != null);
-            return EqualityComparer<object>.Default.Equals(Data, other.Data);
-        }
-
+        public bool Equals(LocalisableString other) => LocalisableStringEqualityComparer.Default.Equals(this, other);
         public override bool Equals(object? obj) => obj is LocalisableString other && Equals(other);
-
-        public override int GetHashCode()
-        {
-            if (Data is string str)
-                return str.GetHashCode();
-
-            if (Data is TranslatableString translatable)
-                return translatable.GetHashCode();
-
-            if (Data is RomanisableString romanisable)
-                return romanisable.GetHashCode();
-
-            return Data?.GetHashCode() ?? 0;
-        }
+        public override int GetHashCode() => LocalisableStringEqualityComparer.Default.GetHashCode(this);
 
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
         public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Localisation
             if (Data is string strThis)
             {
                 if (other.Data is string strOther)
-                    return strThis.Equals(strOther);
+                    return strThis.Equals(strOther, StringComparison.Ordinal);
 
                 return false;
             }
@@ -52,9 +52,6 @@ namespace osu.Framework.Localisation
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
         public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
         public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
-
-        public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
-        public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);
 
         public override bool Equals(object? obj) => obj is LocalisableString other && Equals(other);
         public override int GetHashCode() => Data?.GetHashCode() ?? 0;

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -29,5 +29,8 @@ namespace osu.Framework.Localisation
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
         public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
         public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
+
+        public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
+        public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);
     }
 }

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 #nullable enable
 
@@ -24,6 +26,20 @@ namespace osu.Framework.Localisation
 
         public bool Equals(LocalisableString other)
         {
+            bool thisIsNull = ReferenceEquals(null, Data);
+            bool otherIsNull = ReferenceEquals(null, other.Data);
+
+            // Nullability differs.
+            if (thisIsNull != otherIsNull)
+                return false;
+
+            // Both are null.
+            if (thisIsNull)
+            {
+                Debug.Assert(otherIsNull);
+                return true;
+            }
+
             if (Data is string strThis)
             {
                 if (other.Data is string strOther)
@@ -46,7 +62,9 @@ namespace osu.Framework.Localisation
                     return romanisableThis.Equals(romanisableOther);
             }
 
-            return false;
+            Debug.Assert(Data != null);
+            Debug.Assert(other.Data != null);
+            return EqualityComparer<object>.Default.Equals(Data, other.Data);
         }
 
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -67,11 +67,24 @@ namespace osu.Framework.Localisation
             return EqualityComparer<object>.Default.Equals(Data, other.Data);
         }
 
+        public override bool Equals(object? obj) => obj is LocalisableString other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            if (Data is string str)
+                return str.GetHashCode();
+
+            if (Data is TranslatableString translatable)
+                return translatable.GetHashCode();
+
+            if (Data is RomanisableString romanisable)
+                return romanisable.GetHashCode();
+
+            return Data?.GetHashCode() ?? 0;
+        }
+
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
         public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
         public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
-
-        public override bool Equals(object? obj) => obj is LocalisableString other && Equals(other);
-        public override int GetHashCode() => Data?.GetHashCode() ?? 0;
     }
 }

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace osu.Framework.Localisation
 {

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -1,0 +1,89 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace osu.Framework.Localisation
+{
+    /// <summary>
+    /// An equality comparer for the <see cref="LocalisableString"/> type.
+    /// </summary>
+    public class LocalisableStringEqualityComparer : IEqualityComparer<LocalisableString>
+    {
+        // ReSharper disable once InconsistentNaming (follows EqualityComparer<T>.Default)
+        public static readonly LocalisableStringEqualityComparer Default = new LocalisableStringEqualityComparer();
+
+        public bool Equals(LocalisableString x, LocalisableString y)
+        {
+            bool xIsNull = ReferenceEquals(null, x.Data);
+            bool yIsNull = ReferenceEquals(null, y.Data);
+
+            // Nullability differs.
+            if (xIsNull != yIsNull)
+                return false;
+
+            // Both are null.
+            if (xIsNull)
+            {
+                Debug.Assert(yIsNull);
+                return true;
+            }
+
+            if (x.Data is string strX)
+            {
+                if (y.Data is string strY)
+                    return strX.Equals(strY, StringComparison.Ordinal);
+
+                return false;
+            }
+
+            if (x.Data is TranslatableString translatableX)
+            {
+                if (y.Data is TranslatableString translatableY)
+                    return translatableX.Equals(translatableY);
+
+                return false;
+            }
+
+            if (x.Data is RomanisableString romanisableX)
+            {
+                if (y.Data is RomanisableString romanisableY)
+                    return romanisableX.Equals(romanisableY);
+
+                return false;
+            }
+
+            Debug.Assert(x.Data != null);
+            Debug.Assert(y.Data != null);
+            return EqualityComparer<object>.Default.Equals(x.Data, y.Data);
+        }
+
+        public int GetHashCode(LocalisableString obj)
+        {
+            if (ReferenceEquals(null, obj.Data))
+                return 0;
+
+            var hashCode = new HashCode();
+            hashCode.Add(obj.Data.GetType().GetHashCode());
+
+            switch (obj.Data)
+            {
+                case string str:
+                    hashCode.Add(str.GetHashCode());
+                    break;
+
+                case TranslatableString translatable:
+                    hashCode.Add(translatable.GetHashCode());
+                    break;
+
+                case RomanisableString romanisable:
+                    hashCode.Add(romanisable.GetHashCode());
+                    break;
+            }
+
+            return hashCode.ToHashCode();
+        }
+    }
+}

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -17,47 +17,34 @@ namespace osu.Framework.Localisation
 
         public bool Equals(LocalisableString x, LocalisableString y)
         {
-            bool xIsNull = ReferenceEquals(null, x.Data);
-            bool yIsNull = ReferenceEquals(null, y.Data);
+            var xData = x.Data;
+            var yData = y.Data;
 
-            // Nullability differs.
-            if (xIsNull != yIsNull)
+            if (ReferenceEquals(null, xData) != ReferenceEquals(null, yData))
                 return false;
 
-            // Both are null.
-            if (xIsNull)
+            if (ReferenceEquals(null, xData))
             {
-                Debug.Assert(yIsNull);
+                Debug.Assert(ReferenceEquals(null, yData));
                 return true;
             }
 
-            if (x.Data is string strX)
-            {
-                if (y.Data is string strY)
-                    return strX.Equals(strY, StringComparison.Ordinal);
+            if (xData.GetType() != yData.GetType())
+                return EqualityComparer<object>.Default.Equals(xData, yData);
 
-                return false;
+            switch (xData)
+            {
+                case string strX:
+                    return strX.Equals((string)yData, StringComparison.Ordinal);
+
+                case TranslatableString translatableX:
+                    return translatableX.Equals((TranslatableString)yData);
+
+                case RomanisableString romanisableX:
+                    return romanisableX.Equals((RomanisableString)yData);
             }
 
-            if (x.Data is TranslatableString translatableX)
-            {
-                if (y.Data is TranslatableString translatableY)
-                    return translatableX.Equals(translatableY);
-
-                return false;
-            }
-
-            if (x.Data is RomanisableString romanisableX)
-            {
-                if (y.Data is RomanisableString romanisableY)
-                    return romanisableX.Equals(romanisableY);
-
-                return false;
-            }
-
-            Debug.Assert(x.Data != null);
-            Debug.Assert(y.Data != null);
-            return EqualityComparer<object>.Default.Equals(x.Data, y.Data);
+            return false;
         }
 
         public int GetHashCode(LocalisableString obj)

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -24,10 +24,7 @@ namespace osu.Framework.Localisation
                 return false;
 
             if (ReferenceEquals(null, xData))
-            {
-                Debug.Assert(ReferenceEquals(null, yData));
                 return true;
-            }
 
             if (xData.GetType() != yData.GetType())
                 return EqualityComparer<object>.Default.Equals(xData, yData);

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -51,7 +51,7 @@ namespace osu.Framework.Localisation
             {
                 set
                 {
-                    if (text == value)
+                    if (text.Equals(value))
                         return;
 
                     text = value;

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -58,7 +58,8 @@ namespace osu.Framework.Localisation
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
 
-            return Original == other.Original && Romanised == other.Romanised;
+            return Original == other.Original
+                   && Romanised == other.Romanised;
         }
 
         public override bool Equals(object? obj)

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Configuration;
 
 #nullable enable
@@ -11,7 +12,7 @@ namespace osu.Framework.Localisation
     /// A string that has a romanised fallback to allow a better experience for users that potentially can't read the original script.
     /// See <see cref="FrameworkSetting.ShowUnicode"/>, which can toggle the display of romanised variants.
     /// </summary>
-    public class RomanisableString
+    public class RomanisableString : IEquatable<RomanisableString>
     {
         /// <summary>
         /// The string in its original script. May be null.
@@ -51,5 +52,27 @@ namespace osu.Framework.Localisation
         }
 
         public override string ToString() => GetPreferred(false);
+
+        public bool Equals(RomanisableString? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return Original == other.Original && Romanised == other.Romanised;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+
+            return Equals((RomanisableString)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Original, Romanised);
+        }
     }
 }

--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Globalization;
+using System.Linq;
 using osu.Framework.Logging;
 
 namespace osu.Framework.Localisation
@@ -12,7 +13,7 @@ namespace osu.Framework.Localisation
     /// <summary>
     /// A string that can be translated with optional formattable arguments.
     /// </summary>
-    public class TranslatableString
+    public class TranslatableString : IEquatable<TranslatableString>
     {
         public readonly string Key;
         public readonly string Fallback;
@@ -68,5 +69,34 @@ namespace osu.Framework.Localisation
         }
 
         public override string ToString() => string.Format(CultureInfo.InvariantCulture, Fallback, Args);
+
+        public bool Equals(TranslatableString? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return Key == other.Key
+                   && Fallback == other.Fallback
+                   && Args.SequenceEqual(other.Args);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+
+            return Equals((TranslatableString)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = new HashCode();
+            hashCode.Add(Key);
+            hashCode.Add(Fallback);
+            foreach (var arg in Args)
+                hashCode.Add(arg);
+            return hashCode.ToHashCode();
+        }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/11974

Preferring `.Equals()` implementations to `operator==` for internal comparison of LocalisableString data. Note that `operator==` forwards to `string.Equals(a, b, StringComparison.Ordinal)` internally (though it does this via a by-byte-span helper so it's not immediately obvious).

I've left in `operator==` and `operator!=` because removal would be a breaking change. I can obsolete them if people think that's the right path forward, but I'm not convinced on that.

In short:
```csharp
LocalisableString localisable = "a";
string str = "a";

// Ordinal comparisons
localisable.Equals(str);
str.Equals(localisable);

// Ordinal comparisons
localisable == str;
str == localisable;

// Culture-specific comparisons
localisable.ToString().Equals(str, StringComparison.OrdinalIgnoreCase);
str.Equals(localisable.ToString(), StringComparison.OrdinalIgnoreCase);
string.Equals(localisable.ToString(), str, StringComparison.OrdinalIgnoreCase);
```