### PR TITLE
Add missed `ConfigureAwait(false)` calls for netstandard

### DIFF
--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -322,7 +322,7 @@ namespace osu.Framework.IO.Network
 #if NET5_0
                             postContent = await formData.ReadAsStreamAsync(linkedToken.Token).ConfigureAwait(false);
 #else
-                            postContent = await formData.ReadAsStreamAsync();
+                            postContent = await formData.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
                         }
 
@@ -430,7 +430,9 @@ namespace osu.Framework.IO.Network
                                                       .ReadAsStreamAsync(cancellationToken)
                                                       .ConfigureAwait(false))
 #else
-            using (var responseStream = await response.Content.ReadAsStreamAsync())
+            using (var responseStream = await response.Content
+                                                      .ReadAsStreamAsync()
+                                                      .ConfigureAwait(false))
 #endif
             {
                 reportForwardProgress();


### PR DESCRIPTION
Resolves some build warnings I just noticed today. Missed by CI because *grumbles about dual-targeting and conditional compilation*.

.NET 6 can't come soon enough...