### PR TITLE
Fix midi events not making RequestsNonPositionalInput=true

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2346,7 +2346,9 @@ namespace osu.Framework.Graphics
                 nameof(OnKeyUp),
                 nameof(OnJoystickPress),
                 nameof(OnJoystickRelease),
-                nameof(OnJoystickAxisMove)
+                nameof(OnJoystickAxisMove),
+                nameof(OnMidiDown),
+                nameof(OnMidiUp)
             };
 
             private static readonly Type[] positional_input_interfaces =


### PR DESCRIPTION
Can/will cause midi events to not be received by drawables implementing `OnMidiDown`/`OnMidiUp`. Something I found along the way of reviewing the OTD PR.