### PR TITLE
Add new configuration store for InputHandlers

### DIFF
--- a/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
+++ b/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
@@ -1,0 +1,111 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Input.Handlers;
+using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Tests.Configuration
+{
+    [TestFixture]
+    public class InputConfigManagerTest
+    {
+        private Storage storage;
+
+        [Test]
+        public void TestOldConfigPersists()
+        {
+            using (var host = new TestHeadlessGameHost(@"input-config-host"))
+            {
+                host.Run(new TestGame((h, config) =>
+                {
+                    storage = h.Storage;
+#pragma warning disable 618
+                    config.Set(FrameworkSetting.CursorSensitivity, 5.0);
+#pragma warning restore 618
+                }));
+            }
+
+            // test with only InputConfigManager configuration file present
+            storage.Delete(InputConfigManager.FILENAME);
+
+            double sensitivity = 0;
+
+            using (var host = new TestHeadlessGameHost(@"input-config-host"))
+            {
+                host.Run(new TestGame((h, config) => sensitivity = h.AvailableInputHandlers.OfType<MouseHandler>().First().Sensitivity.Value));
+            }
+
+            Assert.AreEqual(5, sensitivity);
+        }
+
+        [Test]
+        public void TestNewConfigPersists()
+        {
+            using (var host = new TestHeadlessGameHost(@"input-config-host"))
+            {
+                host.Run(new TestGame((h, config) =>
+                {
+                    storage = h.Storage;
+                    h.AvailableInputHandlers.OfType<MouseHandler>().First().Sensitivity.Value = 5;
+                }));
+            }
+
+            // test with only InputConfigManager configuration file present
+            storage.Delete(FrameworkConfigManager.FILENAME);
+
+            double sensitivity = 0;
+
+            using (var host = new TestHeadlessGameHost(@"input-config-host"))
+            {
+                host.Run(new TestGame((h, config) => sensitivity = h.AvailableInputHandlers.OfType<MouseHandler>().First().Sensitivity.Value));
+            }
+
+            Assert.AreEqual(5, sensitivity);
+        }
+
+        public class TestHeadlessGameHost : HeadlessGameHost
+        {
+            public TestHeadlessGameHost(string name)
+                : base(name)
+            {
+            }
+
+            protected override IEnumerable<InputHandler> CreateAvailableInputHandlers() => new[]
+            {
+                new MouseHandler()
+            };
+        }
+
+        private class TestGame : Game
+        {
+            private readonly Action<GameHost, FrameworkConfigManager> action;
+
+            [Resolved]
+            private FrameworkConfigManager config { get; set; }
+
+            public TestGame(Action<GameHost, FrameworkConfigManager> action)
+            {
+                this.action = action;
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+                action(Host, config);
+            }
+
+            protected override void Update()
+            {
+                base.Update();
+                Exit();
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
+++ b/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Tests.Configuration
                 }));
             }
 
-            // test with only InputConfigManager configuration file present
+            // test with only FrameworkConfigManager configuration file present
             storage.Delete(InputConfigManager.FILENAME);
 
             double sensitivity = 0;

--- a/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
+++ b/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
@@ -21,7 +22,7 @@ namespace osu.Framework.Tests.Configuration
         [Test]
         public void TestOldConfigPersists()
         {
-            using (var host = new TestHeadlessGameHost(@"input-config-host"))
+            using (var host = new TestHeadlessGameHost())
             {
                 host.Run(new TestGame((h, config) =>
                 {
@@ -37,7 +38,7 @@ namespace osu.Framework.Tests.Configuration
 
             double sensitivity = 0;
 
-            using (var host = new TestHeadlessGameHost(@"input-config-host"))
+            using (var host = new TestHeadlessGameHost())
             {
                 host.Run(new TestGame((h, config) => sensitivity = h.AvailableInputHandlers.OfType<MouseHandler>().First().Sensitivity.Value));
             }
@@ -48,7 +49,7 @@ namespace osu.Framework.Tests.Configuration
         [Test]
         public void TestNewConfigPersists()
         {
-            using (var host = new TestHeadlessGameHost(@"input-config-host"))
+            using (var host = new TestHeadlessGameHost())
             {
                 host.Run(new TestGame((h, config) =>
                 {
@@ -62,7 +63,7 @@ namespace osu.Framework.Tests.Configuration
 
             double sensitivity = 0;
 
-            using (var host = new TestHeadlessGameHost(@"input-config-host"))
+            using (var host = new TestHeadlessGameHost())
             {
                 host.Run(new TestGame((h, config) => sensitivity = h.AvailableInputHandlers.OfType<MouseHandler>().First().Sensitivity.Value));
             }
@@ -72,8 +73,8 @@ namespace osu.Framework.Tests.Configuration
 
         public class TestHeadlessGameHost : HeadlessGameHost
         {
-            public TestHeadlessGameHost(string name)
-                : base(name)
+            public TestHeadlessGameHost([CallerMemberName] string caller = "")
+                : base(caller)
             {
             }
 

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -182,7 +182,7 @@ namespace osu.Framework.Tests.Visual.Input
         {
             AddSliderStep("Cursor sensivity", 0.5, 5, 1, setCursorSensivityConfig);
             setCursorSensivityConfig(1);
-            AddToggleStep("Toggle relative move", setRelativeMode);
+            AddToggleStep("Toggle relative mode", setRelativeMode);
             setRelativeMode(false);
             AddToggleStep("Toggle ConfineMouseMode", setConfineMouseModeConfig);
             setConfineMouseModeConfig(false);

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -183,26 +183,35 @@ namespace osu.Framework.Tests.Visual.Input
             AddSliderStep("Cursor sensivity", 0.5, 5, 1, setCursorSensivityConfig);
             setCursorSensivityConfig(1);
             AddToggleStep("Toggle relative mode", setRelativeMode);
-            setRelativeMode(false);
             AddToggleStep("Toggle ConfineMouseMode", setConfineMouseModeConfig);
+
+            setRelativeMode(false);
             setConfineMouseModeConfig(false);
         }
 
-        private void setCursorSensivityConfig(double x)
+        private void setCursorSensivityConfig(double sensitivity)
         {
-#pragma warning disable 618
-            config.Set(FrameworkSetting.CursorSensitivity, x);
-#pragma warning restore 618
+            var mouseHandler = getMousehHandler();
+
+            if (mouseHandler == null)
+                return;
+
+            mouseHandler.Sensitivity.Value = sensitivity;
         }
 
         private void setRelativeMode(bool enabled)
         {
-            var mouseHandler = host.AvailableInputHandlers.OfType<MouseHandler>().FirstOrDefault();
+            var mouseHandler = getMousehHandler();
 
             if (mouseHandler == null)
                 return;
 
             mouseHandler.UseRelativeMode = enabled;
+        }
+
+        private MouseHandler getMousehHandler()
+        {
+            return host.AvailableInputHandlers.OfType<MouseHandler>().FirstOrDefault();
         }
 
         private void setConfineMouseModeConfig(bool enabled)

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
@@ -9,7 +10,8 @@ using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
-using osu.Framework.Platform.Windows;
+using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
 
@@ -172,13 +174,16 @@ namespace osu.Framework.Tests.Visual.Input
         [Resolved]
         private FrameworkConfigManager config { get; set; }
 
+        [Resolved]
+        private GameHost host { get; set; }
+
         [BackgroundDependencyLoader]
         private void load()
         {
             AddSliderStep("Cursor sensivity", 0.5, 5, 1, setCursorSensivityConfig);
             setCursorSensivityConfig(1);
-            AddToggleStep("Toggle raw input", setRawInputConfig);
-            setRawInputConfig(false);
+            AddToggleStep("Toggle relative move", setRelativeMode);
+            setRelativeMode(false);
             AddToggleStep("Toggle ConfineMouseMode", setConfineMouseModeConfig);
             setConfineMouseModeConfig(false);
         }
@@ -190,16 +195,19 @@ namespace osu.Framework.Tests.Visual.Input
 #pragma warning restore 618
         }
 
-        private void setRawInputConfig(bool x)
+        private void setRelativeMode(bool enabled)
         {
-#pragma warning disable 618
-            config.Set(FrameworkSetting.IgnoredInputHandlers, x ? string.Empty : $"{nameof(WindowsRawInputMouseHandler)}");
-#pragma warning restore 618
+            var mouseHandler = host.AvailableInputHandlers.OfType<MouseHandler>().FirstOrDefault();
+
+            if (mouseHandler == null)
+                return;
+
+            mouseHandler.UseRelativeMode = enabled;
         }
 
-        private void setConfineMouseModeConfig(bool x)
+        private void setConfineMouseModeConfig(bool enabled)
         {
-            config.Set(FrameworkSetting.ConfineMouseMode, x ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen);
+            config.Set(FrameworkSetting.ConfineMouseMode, enabled ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -185,12 +185,16 @@ namespace osu.Framework.Tests.Visual.Input
 
         private void setCursorSensivityConfig(double x)
         {
+#pragma warning disable 618
             config.Set(FrameworkSetting.CursorSensitivity, x);
+#pragma warning restore 618
         }
 
         private void setRawInputConfig(bool x)
         {
+#pragma warning disable 618
             config.Set(FrameworkSetting.IgnoredInputHandlers, x ? string.Empty : $"{nameof(WindowsRawInputMouseHandler)}");
+#pragma warning restore 618
         }
 
         private void setConfineMouseModeConfig(bool x)

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -191,7 +191,7 @@ namespace osu.Framework.Tests.Visual.Input
 
         private void setCursorSensivityConfig(double sensitivity)
         {
-            var mouseHandler = getMousehHandler();
+            var mouseHandler = getMouseHandler();
 
             if (mouseHandler == null)
                 return;
@@ -201,7 +201,7 @@ namespace osu.Framework.Tests.Visual.Input
 
         private void setRelativeMode(bool enabled)
         {
-            var mouseHandler = getMousehHandler();
+            var mouseHandler = getMouseHandler();
 
             if (mouseHandler == null)
                 return;
@@ -209,7 +209,7 @@ namespace osu.Framework.Tests.Visual.Input
             mouseHandler.UseRelativeMode = enabled;
         }
 
-        private MouseHandler getMousehHandler()
+        private MouseHandler getMouseHandler()
         {
             return host.AvailableInputHandlers.OfType<MouseHandler>().FirstOrDefault();
         }

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using osu.Framework.Configuration.Tracking;
@@ -23,7 +24,6 @@ namespace osu.Framework.Configuration
 
             Set(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480));
             Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen);
-            Set(FrameworkSetting.MapAbsoluteInputToWindow, false);
             Set(FrameworkSetting.ExecutionMode, ExecutionMode.MultiThreaded);
             Set(FrameworkSetting.WindowedPositionX, 0.5, -0.5, 1.5);
             Set(FrameworkSetting.WindowedPositionY, 0.5, -0.5, 1.5);
@@ -36,9 +36,13 @@ namespace osu.Framework.Configuration
             Set(FrameworkSetting.FrameSync, FrameSync.Limit2x);
             Set(FrameworkSetting.WindowMode, WindowMode.Windowed);
             Set(FrameworkSetting.ShowUnicode, false);
+            Set(FrameworkSetting.Locale, string.Empty);
+
+#pragma warning disable 618
+            Set(FrameworkSetting.MapAbsoluteInputToWindow, false);
             Set(FrameworkSetting.IgnoredInputHandlers, string.Empty);
             Set(FrameworkSetting.CursorSensitivity, 1.0, 0.1, 6, 0.01);
-            Set(FrameworkSetting.Locale, string.Empty);
+#pragma warning restore 618
         }
 
         public FrameworkConfigManager(Storage storage, IDictionary<FrameworkSetting, object> defaultOverrides = null)
@@ -52,13 +56,15 @@ namespace osu.Framework.Configuration
             new TrackedSetting<string>(FrameworkSetting.AudioDevice, v => new SettingDescription(v, "Audio Device", string.IsNullOrEmpty(v) ? "Default" : v, v)),
             new TrackedSetting<bool>(FrameworkSetting.ShowLogOverlay, v => new SettingDescription(v, "Debug Logs", v ? "visible" : "hidden", "Ctrl+F10")),
             new TrackedSetting<Size>(FrameworkSetting.WindowedSize, v => new SettingDescription(v, "Screen resolution", $"{v.Width}x{v.Height}")),
+            new TrackedSetting<WindowMode>(FrameworkSetting.WindowMode, v => new SettingDescription(v, "Screen Mode", v.ToString(), "Alt+Enter")),
+#pragma warning disable 618
             new TrackedSetting<double>(FrameworkSetting.CursorSensitivity, v => new SettingDescription(v, "Cursor Sensitivity", v.ToString(@"0.##x"), "Ctrl+Alt+R to reset")),
             new TrackedSetting<string>(FrameworkSetting.IgnoredInputHandlers, v =>
             {
                 bool raw = !v.Contains("Raw");
                 return new SettingDescription(raw, "Raw Input", raw ? "enabled" : "disabled", "Ctrl+Alt+R to reset");
             }),
-            new TrackedSetting<WindowMode>(FrameworkSetting.WindowMode, v => new SettingDescription(v, "Screen Mode", v.ToString(), "Alt+Enter"))
+#pragma warning restore 618
         };
     }
 
@@ -85,8 +91,14 @@ namespace osu.Framework.Configuration
 
         ShowUnicode,
         Locale,
+
+        [Obsolete("Input-related settings are now stored in InputConfigManager. Adjustments should be made via Host.AvailableInputHandlers bindables directly.")] // can be removed 20210911
         IgnoredInputHandlers,
+
+        [Obsolete("Input-related settings are now stored in InputConfigManager. Adjustments should be made via Host.AvailableInputHandlers bindables directly.")] // can be removed 20210911
         CursorSensitivity,
+
+        [Obsolete("Input-related settings are now stored in InputConfigManager. Adjustments should be made via Host.AvailableInputHandlers bindables directly.")] // can be removed 20210911
         MapAbsoluteInputToWindow,
     }
 }

--- a/osu.Framework/Configuration/InputConfigManager.cs
+++ b/osu.Framework/Configuration/InputConfigManager.cs
@@ -14,7 +14,7 @@ using osu.Framework.Platform;
 namespace osu.Framework.Configuration
 {
     [Serializable]
-    public class InputConfigManager
+    public class InputConfigManager : ConfigManager
     {
         public const string FILENAME = "input.json";
 
@@ -28,6 +28,21 @@ namespace osu.Framework.Configuration
             this.storage = storage;
             InputHandlers = inputHandlers;
 
+            Load();
+        }
+
+        protected override bool PerformSave()
+        {
+            using (var stream = storage.GetStream(FILENAME, FileAccess.Write, FileMode.Create))
+            using (var sw = new StreamWriter(stream))
+            {
+                sw.Write(JsonConvert.SerializeObject(this));
+                return true;
+            }
+        }
+
+        protected override void PerformLoad()
+        {
             if (storage.Exists(FILENAME))
             {
                 try
@@ -46,15 +61,6 @@ namespace osu.Framework.Configuration
                 {
                     Logger.Log($"Error occurred when parsing input configuration: {e}");
                 }
-            }
-        }
-
-        public void Save()
-        {
-            using (var stream = storage.GetStream(FILENAME, FileAccess.Write, FileMode.Create))
-            using (var sw = new StreamWriter(stream))
-            {
-                sw.Write(JsonConvert.SerializeObject(this));
             }
         }
     }

--- a/osu.Framework/Configuration/InputConfigManager.cs
+++ b/osu.Framework/Configuration/InputConfigManager.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Configuration
                 }
                 catch (Exception e)
                 {
-                    Logger.Log($"Error occurred when parsing input configuration: {e}");
+                    Logger.Error(e, "Error occurred when parsing input configuration");
                 }
             }
         }

--- a/osu.Framework/Configuration/InputConfigManager.cs
+++ b/osu.Framework/Configuration/InputConfigManager.cs
@@ -33,12 +33,21 @@ namespace osu.Framework.Configuration
 
         protected override bool PerformSave()
         {
-            using (var stream = storage.GetStream(FILENAME, FileAccess.Write, FileMode.Create))
-            using (var sw = new StreamWriter(stream))
+            try
             {
-                sw.Write(JsonConvert.SerializeObject(this));
-                return true;
+                using (var stream = storage.GetStream(FILENAME, FileAccess.Write, FileMode.Create))
+                using (var sw = new StreamWriter(stream))
+                {
+                    sw.Write(JsonConvert.SerializeObject(this));
+                    return true;
+                }
             }
+            catch (Exception e)
+            {
+                Logger.Error(e, "Error occurred when saving input configuration");
+            }
+
+            return false;
         }
 
         protected override void PerformLoad()

--- a/osu.Framework/Configuration/InputConfigManager.cs
+++ b/osu.Framework/Configuration/InputConfigManager.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Configuration
     [Serializable]
     public class InputConfigManager
     {
-        private const string filename = "input.json";
+        public const string FILENAME = "input.json";
 
         private readonly Storage storage;
 
@@ -28,11 +28,11 @@ namespace osu.Framework.Configuration
             this.storage = storage;
             InputHandlers = inputHandlers;
 
-            if (storage.Exists(filename))
+            if (storage.Exists(FILENAME))
             {
                 try
                 {
-                    using (Stream stream = storage.GetStream(filename, FileAccess.Read, FileMode.Open))
+                    using (Stream stream = storage.GetStream(FILENAME, FileAccess.Read, FileMode.Open))
                     using (var sr = new StreamReader(stream))
                     {
                         JsonConvert.PopulateObject(sr.ReadToEnd(), this, new JsonSerializerSettings
@@ -51,7 +51,7 @@ namespace osu.Framework.Configuration
 
         public void Save()
         {
-            using (var stream = storage.GetStream(filename, FileAccess.Write, FileMode.Create))
+            using (var stream = storage.GetStream(FILENAME, FileAccess.Write, FileMode.Create))
             using (var sw = new StreamWriter(stream))
             {
                 sw.Write(JsonConvert.SerializeObject(this));

--- a/osu.Framework/Configuration/TypedRepopulatingConverter.cs
+++ b/osu.Framework/Configuration/TypedRepopulatingConverter.cs
@@ -1,0 +1,62 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace osu.Framework.Configuration
+{
+    /// <summary>
+    /// A type of <see cref="JsonConverter"/> that serializes an <see cref="IReadOnlyList{T}"/> alongside
+    /// each object's type in order to allow population of matching types via <see cref="JsonConvert.PopulateObject(string,object)"/>
+    /// reconstruct the objects with their original types.
+    /// </summary>
+    /// <typeparam name="T">The type of objects contained in the <see cref="IReadOnlyList{T}"/> this attribute is attached to.</typeparam>
+    internal class TypedRepopulatingConverter<T> : JsonConverter<IReadOnlyList<T>>
+    {
+        public override IReadOnlyList<T> ReadJson(JsonReader reader, Type objectType, IReadOnlyList<T> existingList, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (!hasExistingValue)
+                throw new InvalidOperationException($"This converter is only meant to be used via {nameof(JsonConvert.PopulateObject)}");
+
+            var obj = JToken.ReadFrom(reader);
+
+            foreach (var tok in obj)
+            {
+                string typeName = tok["$type"]?.ToString();
+
+                if (typeName == null)
+                    throw new JsonException("Expected $type token.");
+
+                var existing = existingList.FirstOrDefault(h => h.GetType() == Type.GetType(typeName));
+
+                if (existing != null)
+                    serializer.Populate(tok.CreateReader(), existing);
+            }
+
+            return existingList;
+        }
+
+        public override void WriteJson(JsonWriter writer, IReadOnlyList<T> value, JsonSerializer serializer)
+        {
+            var objects = new List<JObject>();
+
+            foreach (var item in value)
+            {
+                var type = item.GetType();
+                var assemblyName = type.Assembly.GetName();
+
+                var typeString = $"{type.FullName}, {assemblyName.Name}";
+
+                var itemObject = JObject.FromObject(item, serializer);
+                itemObject.AddFirst(new JProperty("$type", typeString));
+                objects.Add(itemObject);
+            }
+
+            serializer.Serialize(writer, objects);
+        }
+    }
+}

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -834,6 +834,7 @@ namespace osu.Framework.Platform
                 MaximumUpdateHz = updateLimiter;
             };
 
+#pragma warning disable 618
             ignoredInputHandlers = Config.GetBindable<string>(FrameworkSetting.IgnoredInputHandlers);
             ignoredInputHandlers.ValueChanged += e =>
             {
@@ -859,6 +860,7 @@ namespace osu.Framework.Platform
             };
 
             cursorSensitivity = Config.GetBindable<double>(FrameworkSetting.CursorSensitivity);
+#pragma warning restore 618
 
             PerformanceLogging.BindValueChanged(logging =>
             {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -934,7 +934,7 @@ namespace osu.Framework.Platform
 
             stoppedEvent.Dispose();
 
-            InputConfig?.Save();
+            InputConfig?.Dispose();
             Config?.Dispose();
             DebugConfig?.Dispose();
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -774,7 +774,6 @@ namespace osu.Framework.Platform
 
             Dependencies.Cache(DebugConfig = new FrameworkDebugConfigManager());
             Dependencies.Cache(Config = new FrameworkConfigManager(Storage, defaultOverrides));
-            Dependencies.Cache(InputConfig = new InputConfigManager(Storage, AvailableInputHandlers));
 
             windowMode = Config.GetBindable<WindowMode>(FrameworkSetting.WindowMode);
             windowMode.BindValueChanged(mode =>
@@ -888,6 +887,9 @@ namespace osu.Framework.Platform
                     t.Scheduler.Add(() => { t.CurrentCulture = culture; });
                 }
             }, true);
+
+            // intentionally done after everything above to ensure the new configuration location has priority over obsoleted values.
+            Dependencies.Cache(InputConfig = new InputConfigManager(Storage, AvailableInputHandlers));
         }
 
         private void setVSyncMode()

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -709,12 +709,7 @@ namespace osu.Framework.Platform
             foreach (var handler in AvailableInputHandlers)
             {
                 if (!handler.Initialize(this))
-                {
                     handler.Enabled.Value = false;
-                    continue;
-                }
-
-                (handler as IHasCursorSensitivity)?.Sensitivity.BindTo(cursorSensitivity);
             }
         }
 
@@ -863,6 +858,13 @@ namespace osu.Framework.Platform
             };
 
             Config.BindWith(FrameworkSetting.CursorSensitivity, cursorSensitivity);
+
+            // one way binding to preserve compatibility.
+            cursorSensitivity.BindValueChanged(val =>
+            {
+                foreach (var h in AvailableInputHandlers.OfType<IHasCursorSensitivity>())
+                    h.Sensitivity.Value = val.NewValue;
+            }, true);
 #pragma warning restore 618
 
             PerformanceLogging.BindValueChanged(logging =>


### PR DESCRIPTION
This paves a path forward to allow individual `InputHandlers` to specify their own settings. Intended to be consumed via reflection (portions of that may arrive at the framework in a future PR).

Using `json` as the storage format will allow, as an example, per-device configurations in `TabletHandler` without further implementation from our end.

- [x] Needs background save support.