### PR TITLE
Fix potential null reference when iterating open midi devices

### DIFF
--- a/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
@@ -42,10 +42,13 @@ namespace osu.Framework.Input.Handlers.Midi
                 {
                     scheduledRefreshDevices?.Cancel();
 
-                    foreach (var device in openedDevices.Values)
-                        closeDevice(device);
+                    lock (openedDevices)
+                    {
+                        foreach (var device in openedDevices.Values)
+                            closeDevice(device);
 
-                    openedDevices.Clear();
+                        openedDevices.Clear();
+                    }
                 }
             }, true);
 
@@ -58,33 +61,33 @@ namespace osu.Framework.Input.Handlers.Midi
             {
                 var inputs = MidiAccessManager.Default.Inputs.ToList();
 
-                // check removed devices
-                foreach (string key in openedDevices.Keys.ToArray())
+                lock (openedDevices)
                 {
-                    if (string.IsNullOrEmpty(key))
-                        continue;
-
-                    var device = openedDevices[key];
-
-                    if (inputs.All(i => i.Id != key))
+                    // check removed devices
+                    foreach (string key in openedDevices.Keys.ToArray())
                     {
-                        closeDevice(device);
-                        openedDevices.Remove(key);
+                        var device = openedDevices[key];
 
-                        Logger.Log($"Disconnected MIDI device: {device.Details.Name}");
+                        if (inputs.All(i => i.Id != key))
+                        {
+                            closeDevice(device);
+                            openedDevices.Remove(key);
+
+                            Logger.Log($"Disconnected MIDI device: {device.Details.Name}");
+                        }
                     }
-                }
 
-                // check added devices
-                foreach (IMidiPortDetails input in inputs)
-                {
-                    if (openedDevices.All(x => x.Key != input.Id))
+                    // check added devices
+                    foreach (IMidiPortDetails input in inputs)
                     {
-                        var newInput = MidiAccessManager.Default.OpenInputAsync(input.Id).Result;
-                        newInput.MessageReceived += onMidiMessageReceived;
-                        openedDevices[input.Id] = newInput;
+                        if (openedDevices.All(x => x.Key != input.Id))
+                        {
+                            var newInput = MidiAccessManager.Default.OpenInputAsync(input.Id).Result;
+                            newInput.MessageReceived += onMidiMessageReceived;
+                            openedDevices[input.Id] = newInput;
 
-                        Logger.Log($"Connected MIDI device: {newInput.Details.Name}");
+                            Logger.Log($"Connected MIDI device: {newInput.Details.Name}");
+                        }
                     }
                 }
 

--- a/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiInputHandler.cs
@@ -61,6 +61,9 @@ namespace osu.Framework.Input.Handlers.Midi
                 // check removed devices
                 foreach (string key in openedDevices.Keys.ToArray())
                 {
+                    if (string.IsNullOrEmpty(key))
+                        continue;
+
                     var device = openedDevices[key];
 
                     if (inputs.All(i => i.Id != key))


### PR DESCRIPTION
Reproduced once while testing, you'll have to take my word on this one. The fail case was where there were two items in the array, first being `null`, second being the single device I actually have connected.