### PR TITLE
Fix CursorInWindow not updating as expected

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneActiveState.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneActiveState.cs
@@ -13,12 +13,16 @@ namespace osu.Framework.Tests.Visual.Platform
     public class TestSceneActiveState : FrameworkTestScene
     {
         private IBindable<bool> isActive;
+        private IBindable<bool> cursorInWindow;
+
         private Box isActiveBox;
+        private Box cursorInWindowBox;
 
         [BackgroundDependencyLoader]
         private void load(GameHost host)
         {
             isActive = host.IsActive.GetBoundCopy();
+            cursorInWindow = host.Window.CursorInWindow.GetBoundCopy();
         }
 
         protected override void LoadComplete()
@@ -30,11 +34,21 @@ namespace osu.Framework.Tests.Visual.Platform
                 isActiveBox = new Box
                 {
                     Colour = Color4.Black,
+                    Width = 0.5f,
                     RelativeSizeAxes = Axes.Both,
+                },
+                cursorInWindowBox = new Box
+                {
+                    Colour = Color4.Black,
+                    RelativeSizeAxes = Axes.Both,
+                    Width = 0.5f,
+                    Anchor = Anchor.TopRight,
+                    Origin = Anchor.TopRight,
                 },
             };
 
-            isActive.BindValueChanged(active => isActiveBox.Colour = active.NewValue ? Color4.Green : Color4.Red);
+            isActive.BindValueChanged(active => isActiveBox.Colour = active.NewValue ? Color4.Green : Color4.Red, true);
+            cursorInWindow.BindValueChanged(active => cursorInWindowBox.Colour = active.NewValue ? Color4.Green : Color4.Red, true);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Platform/TestSceneActiveState.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneActiveState.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Tests.Visual.Platform
         private void load(GameHost host)
         {
             isActive = host.IsActive.GetBoundCopy();
-            cursorInWindow = host.Window.CursorInWindow.GetBoundCopy();
+            cursorInWindow = host.Window?.CursorInWindow.GetBoundCopy();
         }
 
         protected override void LoadComplete()
@@ -48,7 +48,7 @@ namespace osu.Framework.Tests.Visual.Platform
             };
 
             isActive.BindValueChanged(active => isActiveBox.Colour = active.NewValue ? Color4.Green : Color4.Red, true);
-            cursorInWindow.BindValueChanged(active => cursorInWindowBox.Colour = active.NewValue ? Color4.Green : Color4.Red, true);
+            cursorInWindow?.BindValueChanged(active => cursorInWindowBox.Colour = active.NewValue ? Color4.Green : Color4.Red, true);
         }
     }
 }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2346,7 +2346,9 @@ namespace osu.Framework.Graphics
                 nameof(OnKeyUp),
                 nameof(OnJoystickPress),
                 nameof(OnJoystickRelease),
-                nameof(OnJoystickAxisMove)
+                nameof(OnJoystickAxisMove),
+                nameof(OnMidiDown),
+                nameof(OnMidiUp)
             };
 
             private static readonly Type[] positional_input_interfaces =

--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -47,6 +47,7 @@ namespace osu.Framework.Input.Handlers.Mouse
         private Vector2? lastPosition;
 
         private IBindable<bool> isActive;
+        private IBindable<bool> cursorInWindow;
 
         /// <summary>
         /// Whether a non-relative mouse event has ever been received.
@@ -63,6 +64,9 @@ namespace osu.Framework.Input.Handlers.Mouse
 
             isActive = window.IsActive.GetBoundCopy();
             isActive.BindValueChanged(_ => updateRelativeMode());
+
+            cursorInWindow = host.Window.CursorInWindow.GetBoundCopy();
+            cursorInWindow.BindValueChanged(_ => updateRelativeMode());
 
             Enabled.BindValueChanged(enabled =>
             {
@@ -94,10 +98,10 @@ namespace osu.Framework.Input.Handlers.Mouse
             if (!Enabled.Value)
                 return;
 
-            updateRelativeMode();
-
             if (window.RelativeMouseMode)
             {
+                updateRelativeMode();
+
                 // store the last mouse position to propagate back to the host window manager when exiting relative mode.
                 lastPosition = position;
 


### PR DESCRIPTION
It turns out with the introduction of relative mouse support in `MouseHandler`, we were toggling the state far more often than necessary. It was feasible that feedback loops when at the edge of the window could cause the state to flip-flop multiple times, causing what seems to be race conditions inside SDL or winapi. This is likely also the reason for https://github.com/libsdl-org/SDL/issues/4165 occurring (this change does greatly reduce the chance of this triggering, to the point I don't think users will ever encounter the issue).

FWIW, the underlying issue here is that the `SDL_WINDOWEVENT_ENTER` / `LEAVE` events stop arriving altogether.

@smoogipoo this resolves the issue you pointed out where the framework test cursor gets stuck at the edge of the window.

- [x] Depends on https://github.com/ppy/osu-framework/pull/4276 (because toggling raw input before this is a bit... weird).