### PR TITLE
Move SpriteText's bind logic to LoadComplete to alleviate potential threading issues

### DIFF
--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -61,6 +61,21 @@ namespace osu.Framework.Graphics.Sprites
         private void load(ShaderManager shaders)
         {
             localisedText = localisation.GetLocalisedString(text);
+
+            TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+            RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
+
+            // Pre-cache the characters in the texture store
+            foreach (var character in localisedText.Value)
+            {
+                var unused = store.Get(font.FontName, character) ?? store.Get(null, character);
+            }
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
             localisedText.BindValueChanged(str =>
             {
                 current.Value = localisedText.Value;
@@ -76,15 +91,6 @@ namespace osu.Framework.Graphics.Sprites
 
                 invalidate(true);
             }, true);
-
-            TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
-            RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE_ROUNDED);
-
-            // Pre-cache the characters in the texture store
-            foreach (var character in displayedText)
-            {
-                var unused = store.Get(font.FontName, character) ?? store.Get(null, character);
-            }
         }
 
         private LocalisableString text = string.Empty;


### PR DESCRIPTION
This comes as the result of @smoogipoo discovering a deadlock osu!-side, which can be considered a regression of the localisation changes we made recently. The case is where a `Bindable` is assigned to `text.Current` during BDL (in a `LoadComponentAsync` context) while the `SpriteText` is also changing the value of `current` via the localised implementation. This could cause a deadlock in `GetEnumerator` as `Bindable`s are not intended to be thread safe for this kind of usage.

Example case:

thread 1:

![20210313 235040 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/111033979-f1941600-8456-11eb-841e-513f931ae26a.png)

thread 2:

![20210313 235136 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/111034002-0d97b780-8457-11eb-8227-e35535fa8b45.png)
...
![20210313 235155 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/111034023-1ab4a680-8457-11eb-98e4-aa1d82a8e3fb.png)

