### PR TITLE
Make ConfigManager.Set protected to avoid accidentally setting default values

### DIFF
--- a/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
+++ b/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Tests.Configuration
                 {
                     storage = h.Storage;
 #pragma warning disable 618
-                    config.Set(FrameworkSetting.CursorSensitivity, 5.0);
+                    config.GetBindable<double>(FrameworkSetting.CursorSensitivity).Value = 5.0;
 #pragma warning restore 618
                 }));
             }

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Localisation;
 
@@ -19,19 +20,25 @@ namespace osu.Framework.Tests.Localisation
         private FrameworkConfigManager config;
         private LocalisationManager manager;
 
+        private Bindable<string> localeBindable;
+        private Bindable<bool> showUnicodeBindable;
+
         [SetUp]
         public void Setup()
         {
             config = new FakeFrameworkConfigManager();
             manager = new LocalisationManager(config);
             manager.AddLanguage("en", new FakeStorage("en"));
+
+            localeBindable = config.GetBindable<string>(FrameworkSetting.Locale);
+            showUnicodeBindable = config.GetBindable<bool>(FrameworkSetting.ShowUnicode);
         }
 
         [Test]
         public void TestNotLocalised()
         {
             manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
-            config.Set(FrameworkSetting.Locale, "ja-JP");
+            localeBindable.Value = "ja-JP";
 
             var localisedText = manager.GetLocalisedString(FakeStorage.LOCALISABLE_STRING_EN);
 
@@ -51,7 +58,7 @@ namespace osu.Framework.Tests.Localisation
 
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
 
-            config.Set(FrameworkSetting.Locale, "ja-JP");
+            localeBindable.Value = "ja-JP";
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP, localisedText.Value);
         }
 
@@ -60,7 +67,7 @@ namespace osu.Framework.Tests.Localisation
         {
             manager.AddLanguage("ja", new FakeStorage("ja"));
 
-            config.Set(FrameworkSetting.Locale, "ja-JP");
+            localeBindable.Value = "ja-JP";
 
             var localisedText = manager.GetLocalisedString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
 
@@ -87,7 +94,7 @@ namespace osu.Framework.Tests.Localisation
             const string arg_0 = "formatted";
 
             manager.AddLanguage("ja-JP", new FakeStorage("ja"));
-            config.Set(FrameworkSetting.Locale, "ja-JP");
+            localeBindable.Value = "ja-JP";
 
             string expectedResult = string.Format(FakeStorage.LOCALISABLE_FORMAT_STRING_JA, arg_0);
 
@@ -104,7 +111,7 @@ namespace osu.Framework.Tests.Localisation
             string expectedResult = string.Format(FakeStorage.LOCALISABLE_FORMAT_STRING_JA, arg_0);
 
             manager.AddLanguage("ja", new FakeStorage("ja"));
-            config.Set(FrameworkSetting.Locale, "ja");
+            localeBindable.Value = "ja";
 
             var formattedText = manager.GetLocalisedString(new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, arg_0));
 
@@ -117,7 +124,7 @@ namespace osu.Framework.Tests.Localisation
             const double value = 1.23;
 
             manager.AddLanguage("fr", new FakeStorage("fr"));
-            config.Set(FrameworkSetting.Locale, "fr");
+            localeBindable.Value = "fr";
 
             var expectedResult = string.Format(new CultureInfo("fr"), FakeStorage.LOCALISABLE_NUMBER_FORMAT_STRING_FR, value);
             Assert.AreEqual("number 1,23 FR", expectedResult); // FR uses comma for decimal point.
@@ -131,7 +138,7 @@ namespace osu.Framework.Tests.Localisation
         public void TestStorageNotFound()
         {
             manager.AddLanguage("ja", new FakeStorage("ja"));
-            config.Set(FrameworkSetting.Locale, "ja");
+            localeBindable.Value = "ja";
 
             const string expected_fallback = "fallback string";
 
@@ -148,10 +155,10 @@ namespace osu.Framework.Tests.Localisation
 
             var text = manager.GetLocalisedString(new RomanisableString(unicode, non_unicode));
 
-            config.Set(FrameworkSetting.ShowUnicode, true);
+            showUnicodeBindable.Value = true;
             Assert.AreEqual(unicode, text.Value);
 
-            config.Set(FrameworkSetting.ShowUnicode, false);
+            showUnicodeBindable.Value = false;
             Assert.AreEqual(non_unicode, text.Value);
         }
 
@@ -165,13 +172,13 @@ namespace osu.Framework.Tests.Localisation
 
             var text = manager.GetLocalisedString(new RomanisableString(unicode_1, non_unicode_1));
 
-            config.Set(FrameworkSetting.ShowUnicode, false);
+            showUnicodeBindable.Value = false;
             Assert.AreEqual(non_unicode_1, text.Value);
 
             text.Text = new RomanisableString(unicode_1, non_unicode_2);
             Assert.AreEqual(non_unicode_2, text.Value);
 
-            config.Set(FrameworkSetting.ShowUnicode, true);
+            showUnicodeBindable.Value = true;
             Assert.AreEqual(unicode_1, text.Value);
 
             text.Text = new RomanisableString(unicode_2, non_unicode_2);
@@ -186,12 +193,12 @@ namespace osu.Framework.Tests.Localisation
 
             var text = manager.GetLocalisedString(new RomanisableString(unicode_fallback, emptyValue));
 
-            config.Set(FrameworkSetting.ShowUnicode, false);
+            showUnicodeBindable.Value = false;
             Assert.AreEqual(unicode_fallback, text.Value);
 
             text = manager.GetLocalisedString(new RomanisableString(emptyValue, non_unicode_fallback));
 
-            config.Set(FrameworkSetting.ShowUnicode, true);
+            showUnicodeBindable.Value = true;
             Assert.AreEqual(non_unicode_fallback, text.Value);
         }
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -29,6 +30,8 @@ namespace osu.Framework.Tests.Visual.Containers
         private SpriteText labelFrag2;
         private float currentScale = 1;
 
+        private Bindable<bool> frontToBack;
+
         private const int cell_count = 4;
 
         protected override DrawNode CreateDrawNode() => drawNode = new QueryingCompositeDrawableDrawNode(this);
@@ -41,6 +44,8 @@ namespace osu.Framework.Tests.Visual.Containers
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager debugConfig, TextureStore store)
         {
+            frontToBack = debugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass);
+
             var texture = store.Get(@"sample-texture");
             var repeatedTexture = store.Get(@"sample-texture", WrapMode.Repeat, WrapMode.Repeat);
             var edgeClampedTexture = store.Get(@"sample-texture", WrapMode.ClampToEdge, WrapMode.ClampToEdge);
@@ -54,7 +59,7 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep("add boxes", () => addMoreDrawables(Texture.WhitePixel, new RectangleF(0, 0, 1, 1)));
             AddToggleStep("disable front to back", val =>
             {
-                debugConfig.Set(DebugSetting.BypassFrontToBackPass, val);
+                frontToBack.Value = val;
                 Invalidate(Invalidation.DrawNode); // reset counts
             });
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBox.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBox.cs
@@ -21,7 +21,9 @@ namespace osu.Framework.Tests.Visual.Containers
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager debugConfig)
         {
-            AddToggleStep("disable front to back", val => debugConfig.Set(DebugSetting.BypassFrontToBackPass, val));
+            var frontToBack = debugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass);
+
+            AddToggleStep("disable front to back", val => frontToBack.Value = val);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -19,6 +20,8 @@ namespace osu.Framework.Tests.Visual.Input
 {
     public class TestSceneInputManager : FrameworkTestScene
     {
+        private Bindable<ConfineMouseMode> confineModeBindable;
+
         public TestSceneInputManager()
         {
             Add(new Container
@@ -172,14 +175,13 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Resolved]
-        private FrameworkConfigManager config { get; set; }
-
-        [Resolved]
         private GameHost host { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load()
+        private void load(FrameworkConfigManager config)
         {
+            confineModeBindable = config.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode);
+
             AddSliderStep("Cursor sensivity", 0.5, 5, 1, setCursorSensivityConfig);
             setCursorSensivityConfig(1);
             AddToggleStep("Toggle relative mode", setRelativeMode);
@@ -217,7 +219,7 @@ namespace osu.Framework.Tests.Visual.Input
 
         private void setConfineMouseModeConfig(bool enabled)
         {
-            config.Set(FrameworkSetting.ConfineMouseMode, enabled ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen);
+            confineModeBindable.Value = enabled ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen;
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -137,7 +137,9 @@ namespace osu.Framework.Tests.Visual.Platform
         private void load(FrameworkConfigManager config, GameHost host)
         {
             window = host.Window as SDL2DesktopWindow;
+
             config.BindWith(FrameworkSetting.WindowMode, windowMode);
+            var windowedSizeBindable = config.GetBindable<Size>(FrameworkSetting.WindowedSize);
 
             if (window == null)
             {
@@ -159,7 +161,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
                 // set up window
                 AddStep("switch to windowed", () => windowMode.Value = WindowMode.Windowed);
-                AddStep("set client size to 1280x720", () => config.Set(FrameworkSetting.WindowedSize, new Size(1280, 720)));
+                AddStep("set client size to 1280x720", () => windowedSizeBindable.Value = new Size(1280, 720));
                 AddStep("store window position", () => originalWindowPosition = window.Position);
 
                 // borderless alignment tests

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -31,6 +31,8 @@ namespace osu.Framework.Tests.Visual.Platform
         private readonly BindableSize sizeFullscreen = new BindableSize();
         private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
 
+        private Bindable<ConfineMouseMode> confineModeBindable;
+
         public TestSceneFullscreen()
         {
             var currentBindableSize = new SpriteText();
@@ -61,8 +63,11 @@ namespace osu.Framework.Tests.Visual.Platform
         private void load(GameHost host)
         {
             window = host.Window;
+
             config.BindWith(FrameworkSetting.SizeFullscreen, sizeFullscreen);
             config.BindWith(FrameworkSetting.WindowMode, windowMode);
+            confineModeBindable = config.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode);
+
             currentWindowMode.Text = $"Window Mode: {windowMode}";
 
             if (window == null)
@@ -131,9 +136,9 @@ namespace osu.Framework.Tests.Visual.Platform
         [Test]
         public void TestConfineModes()
         {
-            AddStep("set confined to never", () => config.Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Never));
-            AddStep("set confined to fullscreen", () => config.Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen));
-            AddStep("set confined to always", () => config.Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Always));
+            AddStep("set confined to never", () => confineModeBindable.Value = ConfineMouseMode.Never);
+            AddStep("set confined to fullscreen", () => confineModeBindable.Value = ConfineMouseMode.Fullscreen);
+            AddStep("set confined to always", () => confineModeBindable.Value = ConfineMouseMode.Always);
         }
 
         protected override void Update()

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -15,6 +16,8 @@ namespace osu.Framework.Tests.Visual.Sprites
     public class TestSceneRomanisableSpriteText : FrameworkTestScene
     {
         private readonly FillFlowContainer flow;
+
+        private Bindable<bool> showUnicodeBindable;
 
         public TestSceneRomanisableSpriteText()
         {
@@ -41,16 +44,19 @@ namespace osu.Framework.Tests.Visual.Sprites
             flow.Add(new SpriteText { Text = new RomanisableString("ongaku", "") });
         }
 
-        [Resolved]
-        private FrameworkConfigManager config { get; set; }
+        [BackgroundDependencyLoader]
+        private void load(FrameworkConfigManager config)
+        {
+            showUnicodeBindable = config.GetBindable<bool>(FrameworkSetting.ShowUnicode);
+        }
 
         [Test]
         public void TestToggleRomanisedState()
         {
-            AddStep("prefer romanised", () => config.Set(FrameworkSetting.ShowUnicode, false));
+            AddStep("prefer romanised", () => showUnicodeBindable.Value = false);
             AddAssert("check strings correct", () => flow.OfType<SpriteText>().Select(st => st.Current.Value).SequenceEqual(new[] { "music", "music", "ongaku" }));
 
-            AddStep("prefer unicode", () => config.Set(FrameworkSetting.ShowUnicode, true));
+            AddStep("prefer unicode", () => showUnicodeBindable.Value = true);
             AddAssert("check strings correct", () => flow.OfType<SpriteText>().Select(st => st.Current.Value).SequenceEqual(new[] { "ongaku", "music", "ongaku" }));
         }
     }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
@@ -254,7 +254,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 localisation.AddLanguage("en", new FakeStorage("en"));
                 localisation.AddLanguage("ja", new FakeStorage("ja"));
 
-                config.Set(FrameworkSetting.Locale, "ja");
+                config.GetBindable<string>(FrameworkSetting.Locale).Value = "ja";
             }
         }
 

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -79,7 +79,7 @@ namespace osu.Framework.iOS
 
             base.SetupConfig(defaultOverrides);
 
-            DebugConfig.Set(DebugSetting.BypassFrontToBackPass, true);
+            DebugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass).Value = true;
         }
 
         protected override void PerformExit(bool immediately)

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Configuration
         {
         }
 
-        public BindableDouble Set(TLookup lookup, double value, double? min = null, double? max = null, double? precision = null)
+        protected BindableDouble Set(TLookup lookup, double value, double? min = null, double? max = null, double? precision = null)
         {
             value = getDefault(lookup, value);
 
@@ -62,7 +62,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        public BindableFloat Set(TLookup lookup, float value, float? min = null, float? max = null, float? precision = null)
+        protected BindableFloat Set(TLookup lookup, float value, float? min = null, float? max = null, float? precision = null)
         {
             value = getDefault(lookup, value);
 
@@ -84,7 +84,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        public BindableInt Set(TLookup lookup, int value, int? min = null, int? max = null)
+        protected BindableInt Set(TLookup lookup, int value, int? min = null, int? max = null)
         {
             value = getDefault(lookup, value);
 
@@ -105,7 +105,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        public BindableBool Set(TLookup lookup, bool value)
+        protected BindableBool Set(TLookup lookup, bool value)
         {
             value = getDefault(lookup, value);
 
@@ -124,7 +124,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        public BindableSize Set(TLookup lookup, Size value, Size? min = null, Size? max = null)
+        protected BindableSize Set(TLookup lookup, Size value, Size? min = null, Size? max = null)
         {
             value = getDefault(lookup, value);
 
@@ -145,7 +145,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        public Bindable<TValue> Set<TValue>(TLookup lookup, TValue value)
+        protected Bindable<TValue> Set<TValue>(TLookup lookup, TValue value)
         {
             value = getDefault(lookup, value);
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -429,7 +429,7 @@ namespace osu.Framework.Testing
             if (testType == null && TestTypes.Count > 0)
                 testType = TestTypes[0];
 
-            config.Set(TestBrowserSetting.LastTest, testType?.FullName ?? string.Empty);
+            config.GetBindable<string>(TestBrowserSetting.LastTest).Value = testType?.FullName ?? string.Empty;
 
             if (testType == null)
                 return;

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -48,6 +48,7 @@ namespace osu.Framework.Testing
         public readonly List<Type> TestTypes = new List<Type>();
 
         private ConfigManager<TestBrowserSetting> config;
+        private Bindable<string> lastTestBindable;
 
         private DynamicClassCompiler<TestScene> backgroundCompiler;
 
@@ -129,7 +130,9 @@ namespace osu.Framework.Testing
         private void load(Storage storage, GameHost host, FrameworkConfigManager frameworkConfig, FontStore fonts, Game game, AudioManager audio)
         {
             interactive = host.Window != null;
+
             config = new TestBrowserConfig(storage);
+            lastTestBindable = config.GetBindable<string>(TestBrowserSetting.LastTest);
 
             exit = host.Exit;
 
@@ -338,12 +341,10 @@ namespace osu.Framework.Testing
 
             if (CurrentTest == null)
             {
-                var lastTest = config.Get<string>(TestBrowserSetting.LastTest);
-
-                var foundTest = TestTypes.Find(t => t.FullName == lastTest)
+                var foundTest = TestTypes.Find(t => t.FullName == lastTestBindable.Value)
                                 // full name was not always stored in this value, so fallback to matching on just test name.
                                 // can be removed 20210622
-                                ?? TestTypes.Find(t => t.Name == lastTest);
+                                ?? TestTypes.Find(t => t.Name == lastTestBindable.Value);
 
                 LoadTest(foundTest);
             }
@@ -429,7 +430,7 @@ namespace osu.Framework.Testing
             if (testType == null && TestTypes.Count > 0)
                 testType = TestTypes[0];
 
-            config.GetBindable<string>(TestBrowserSetting.LastTest).Value = testType?.FullName ?? string.Empty;
+            lastTestBindable.Value = testType?.FullName ?? string.Empty;
 
             if (testType == null)
                 return;


### PR DESCRIPTION
## Breaking Changes

### ConfigManager.Set is now protected

Previously this method was `public` for convenience, but as it implicitly set the `Default` value of bindables it touched, could cause unexpected behaviour.

- For initialising defaults, continue to use `Set` from `InitialiseDefaults`
- For changing configuration values externally, first retrieve the `Bindable` and then change its value, ie.

```csharp
// previously
config.Set(ConfigType.Name, true);

// now
config.GetBindable<bool>(ConfigType.Name).Value = true;
```