### PR TITLE
Fix SDL2 mouse position warping not respecting DPI scaling

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1236,7 +1236,7 @@ namespace osu.Framework.Platform
         /// </summary>
         /// <param name="position">A position inside the window.</param>
         public void UpdateMousePosition(Vector2 position) => ScheduleCommand(() =>
-            SDL.SDL_WarpMouseInWindow(SDLWindowHandle, (int)position.X, (int)position.Y));
+            SDL.SDL_WarpMouseInWindow(SDLWindowHandle, (int)(position.X / Scale), (int)(position.Y / Scale)));
 
         public void SetIconFromStream(Stream stream)
         {


### PR DESCRIPTION
Noticed it while I was trying the relative mouse mode, was causing mouse to jump far away from the window when exiting in retina screens:

<img src="https://user-images.githubusercontent.com/22781491/110015896-784d4280-7d35-11eb-8347-00ead0648b3d.gif" width=500/>