### PR TITLE
Expose required bindables via ITabletHandler interface for end-user configurability

### DIFF
--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -1,0 +1,23 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Drawing;
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Input.Handlers.Tablet
+{
+    /// <summary>
+    /// An interface to access OpenTabletDriverHandler.
+    /// Can be removed when we no longer require dual targeting against netstandard5.0.
+    /// </summary>
+    public interface ITabletHandler
+    {
+        BindableSize AreaOffset { get; }
+
+        BindableSize AreaSize { get; }
+
+        IBindable<Size> TabletSize { get; }
+
+        BindableBool Enabled { get; }
+    }
+}

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -1,8 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Drawing;
 using osu.Framework.Bindables;
+using osuTK;
 
 namespace osu.Framework.Input.Handlers.Tablet
 {
@@ -12,13 +12,20 @@ namespace osu.Framework.Input.Handlers.Tablet
     /// </summary>
     public interface ITabletHandler
     {
-        BindableSize AreaOffset { get; }
+        /// <summary>
+        /// The offset of the area which should be mapped to the game window.
+        /// </summary>
+        Bindable<Vector2> AreaOffset { get; }
 
-        BindableSize AreaSize { get; }
+        /// <summary>
+        /// The size of the area which should be mapped to the game window.
+        /// </summary>
+        Bindable<Vector2> AreaSize { get; }
 
-        IBindable<Size> TabletSize { get; }
-
-        string DeviceName { get; }
+        /// <summary>
+        /// Information on the currently connected tablet device./ May be null if no tablet is detected.
+        /// </summary>
+        IBindable<TabletInfo> Tablet { get; }
 
         BindableBool Enabled { get; }
     }

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Input.Handlers.Tablet
         Bindable<Vector2> AreaSize { get; }
 
         /// <summary>
-        /// Information on the currently connected tablet device./ May be null if no tablet is detected.
+        /// Information on the currently connected tablet device. May be null if no tablet is detected.
         /// </summary>
         IBindable<TabletInfo> Tablet { get; }
 

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Input.Handlers.Tablet
 {
     /// <summary>
     /// An interface to access OpenTabletDriverHandler.
-    /// Can be removed when we no longer require dual targeting against netstandard5.0.
+    /// Can be considered for removal when we no longer require dual targeting against netstandard.
     /// </summary>
     public interface ITabletHandler
     {

--- a/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/ITabletHandler.cs
@@ -18,6 +18,8 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         IBindable<Size> TabletSize { get; }
 
+        string DeviceName { get; }
+
         BindableBool Enabled { get; }
     }
 }

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -29,6 +29,8 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         public IBindable<Size> TabletSize { get; } = new BindableSize(new Size(160, 100));
 
+        public string DeviceName => tabletDriver.Tablet?.TabletProperties.Name ?? string.Empty;
+
         public override bool Initialize(GameHost host)
         {
             tabletDriver = new TabletDriver

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -26,7 +26,9 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         public Bindable<Vector2> AreaSize { get; } = new Bindable<Vector2>();
 
-        public IBindable<TabletInfo> Tablet { get; } = new Bindable<TabletInfo>();
+        public IBindable<TabletInfo> Tablet => tablet;
+
+        private readonly Bindable<TabletInfo> tablet = new Bindable<TabletInfo>();
 
         public override bool Initialize(GameHost host)
         {
@@ -100,15 +102,20 @@ namespace osu.Framework.Input.Handlers.Tablet
         private void updateInputArea()
         {
             if (tabletDriver.Tablet == null)
+            {
+                tablet.Value = null;
                 return;
+            }
+
+            float inputWidth = tabletDriver.Tablet.Digitizer.Width;
+            float inputHeight = tabletDriver.Tablet.Digitizer.Height;
+
+            tablet.Value = new TabletInfo(tabletDriver.Tablet.TabletProperties.Name, new Vector2(inputWidth, inputHeight));
 
             switch (tabletDriver.OutputMode)
             {
                 case AbsoluteOutputMode absoluteOutputMode:
                 {
-                    float inputWidth = tabletDriver.Tablet.Digitizer.Width;
-                    float inputHeight = tabletDriver.Tablet.Digitizer.Height;
-
                     // Set input area in millimeters
                     absoluteOutputMode.Input = new Area
                     {

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -2,8 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 #if NET5_0
-using System.Drawing;
-using System.Numerics;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Platform.Pointer;
@@ -12,6 +10,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
+using osuTK;
 
 namespace osu.Framework.Input.Handlers.Tablet
 {
@@ -23,13 +22,11 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private TabletDriver tabletDriver;
 
-        public BindableSize AreaOffset { get; } = new BindableSize();
+        public Bindable<Vector2> AreaOffset { get; } = new Bindable<Vector2>();
 
-        public BindableSize AreaSize { get; } = new BindableSize();
+        public Bindable<Vector2> AreaSize { get; } = new Bindable<Vector2>();
 
-        public IBindable<Size> TabletSize { get; } = new BindableSize(new Size(160, 100));
-
-        public string DeviceName => tabletDriver.Tablet?.TabletProperties.Name ?? string.Empty;
+        public IBindable<TabletInfo> Tablet { get; } = new Bindable<TabletInfo>();
 
         public override bool Initialize(GameHost host)
         {
@@ -74,11 +71,11 @@ namespace osu.Framework.Input.Handlers.Tablet
             return true;
         }
 
-        void IAbsolutePointer.SetPosition(Vector2 pos) => enqueueInput(new MousePositionAbsoluteInput { Position = new osuTK.Vector2(pos.X, pos.Y) });
+        void IAbsolutePointer.SetPosition(System.Numerics.Vector2 pos) => enqueueInput(new MousePositionAbsoluteInput { Position = new Vector2(pos.X, pos.Y) });
 
         void IVirtualTablet.SetPressure(float percentage) => enqueueInput(new MouseButtonInput(osuTK.Input.MouseButton.Left, percentage > 0));
 
-        void IRelativePointer.Translate(Vector2 delta) => enqueueInput(new MousePositionRelativeInput { Delta = new osuTK.Vector2(delta.X, delta.Y) });
+        void IRelativePointer.Translate(System.Numerics.Vector2 delta) => enqueueInput(new MousePositionRelativeInput { Delta = new Vector2(delta.X, delta.Y) });
 
         private void updateOutputArea(IWindow window)
         {
@@ -93,7 +90,7 @@ namespace osu.Framework.Input.Handlers.Tablet
                     {
                         Width = outputWidth = window.ClientSize.Width,
                         Height = outputHeight = window.ClientSize.Height,
-                        Position = new Vector2(outputWidth / 2, outputHeight / 2)
+                        Position = new System.Numerics.Vector2(outputWidth / 2, outputHeight / 2)
                     };
                     break;
                 }
@@ -117,7 +114,7 @@ namespace osu.Framework.Input.Handlers.Tablet
                     {
                         Width = inputWidth,
                         Height = inputHeight,
-                        Position = new Vector2(inputWidth / 2, inputHeight / 2),
+                        Position = new System.Numerics.Vector2(inputWidth / 2, inputHeight / 2),
                         Rotation = 0
                     };
                     break;

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -125,7 +125,7 @@ namespace osu.Framework.Input.Handlers.Tablet
             if (AreaOffset.Value == Vector2.Zero)
                 AreaOffset.SetDefault();
 
-            tablet.Value = new TabletInfo(tabletDriver.Tablet.TabletProperties.Name, AreaSize.Value);
+            tablet.Value = new TabletInfo(tabletDriver.Tablet.TabletProperties.Name, AreaSize.Default);
 
             switch (tabletDriver.OutputMode)
             {

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -7,6 +7,7 @@ using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Output;
 using OpenTabletDriver.Plugin.Platform.Pointer;
 using OpenTabletDriver.Plugin.Tablet;
+using osu.Framework.Bindables;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
@@ -20,6 +21,10 @@ namespace osu.Framework.Input.Handlers.Tablet
         public override int Priority => 0;
 
         private TabletDriver tabletDriver;
+
+        public Bindable<Vector2> AreaOffset { get; } = new Bindable<Vector2>();
+
+        public Bindable<Vector2> AreaSize { get; } = new Bindable<Vector2>();
 
         public override bool Initialize(GameHost host)
         {

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 #if NET5_0
+using System.Drawing;
 using System.Numerics;
 using OpenTabletDriver.Plugin;
 using OpenTabletDriver.Plugin.Output;
@@ -14,7 +15,7 @@ using osu.Framework.Statistics;
 
 namespace osu.Framework.Input.Handlers.Tablet
 {
-    public class OpenTabletDriverHandler : InputHandler, IAbsolutePointer, IVirtualTablet, IRelativePointer
+    public class OpenTabletDriverHandler : InputHandler, IAbsolutePointer, IVirtualTablet, IRelativePointer, ITabletHandler
     {
         public override bool IsActive => tabletDriver.EnableInput;
 
@@ -22,9 +23,11 @@ namespace osu.Framework.Input.Handlers.Tablet
 
         private TabletDriver tabletDriver;
 
-        public Bindable<Vector2> AreaOffset { get; } = new Bindable<Vector2>();
+        public BindableSize AreaOffset { get; } = new BindableSize();
 
-        public Bindable<Vector2> AreaSize { get; } = new Bindable<Vector2>();
+        public BindableSize AreaSize { get; } = new BindableSize();
+
+        public IBindable<Size> TabletSize { get; } = new BindableSize(new Size(160, 100));
 
         public override bool Initialize(GameHost host)
         {

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -112,14 +112,18 @@ namespace osu.Framework.Input.Handlers.Tablet
             float inputWidth = tabletDriver.Tablet.Digitizer.Width;
             float inputHeight = tabletDriver.Tablet.Digitizer.Height;
 
+            AreaSize.Default = new Vector2(inputWidth, inputHeight);
+
             // if it's clear the user has not configured the area, take the full area from the tablet that was just found.
             if (AreaSize.Value == Vector2.Zero)
-                AreaSize.Value = new Vector2(inputWidth, inputHeight);
+                AreaSize.SetDefault();
+
+            AreaOffset.Default = new Vector2(inputWidth / 2, inputHeight / 2);
 
             // likewise with the position, use the centre point if it has not been configured.
             // it's safe to assume no user would set their centre point to 0,0 for now.
             if (AreaOffset.Value == Vector2.Zero)
-                AreaOffset.Value = new Vector2(inputWidth / 2, inputHeight / 2);
+                AreaOffset.SetDefault();
 
             tablet.Value = new TabletInfo(tabletDriver.Tablet.TabletProperties.Name, AreaSize.Value);
 

--- a/osu.Framework/Input/Handlers/Tablet/TabletInfo.cs
+++ b/osu.Framework/Input/Handlers/Tablet/TabletInfo.cs
@@ -7,7 +7,7 @@ namespace osu.Framework.Input.Handlers.Tablet
 {
     /// <summary>
     /// A class that carries the information we care about from the tablet provider.
-    /// Note that we are note using the exposed classes from OTD due to conditional compilation pains.
+    /// Can be considered for removal when we no longer require dual targeting against netstandard.
     /// </summary>
     public class TabletInfo
     {

--- a/osu.Framework/Input/Handlers/Tablet/TabletInfo.cs
+++ b/osu.Framework/Input/Handlers/Tablet/TabletInfo.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osuTK;
+
+namespace osu.Framework.Input.Handlers.Tablet
+{
+    /// <summary>
+    /// A class that carries the information we care about from the tablet provider.
+    /// Note that we are note using the exposed classes from OTD due to conditional compilation pains.
+    /// </summary>
+    public class TabletInfo
+    {
+        /// <summary>
+        /// The name of this tablet.
+        /// </summary>
+        public string Name { get; }
+
+        /// <summary>
+        /// The size (in millimetres) of the connected tablet's full area.
+        /// </summary>
+        public Vector2 Size { get; }
+
+        public TabletInfo(string name, Vector2 size)
+        {
+            Size = size;
+            Name = name;
+        }
+    }
+}


### PR DESCRIPTION
This exposes the bare minimum required for osu!-side configuration. Intended to be an initial MVP. Depending on how quickly this is merged, I may also add rotation.

Note that the `TabletInfo` class is required to ferry information away from the .netcore OTD library and avoid conditional compilation nightmares. It may eventually disappear.

- [x] Depends on #4285.