### PR TITLE
Show tooltip with full text when sprite text is truncated

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTruncate.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTruncate.cs
@@ -3,6 +3,7 @@
 
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osuTK;
@@ -18,12 +19,13 @@ namespace osu.Framework.Tests.Visual.Sprites
         {
             Children = new Drawable[]
             {
-                new BasicScrollContainer
+                new TooltipContainer
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Children = new[]
+                    Child = new BasicScrollContainer
                     {
-                        flow = new FillFlowContainer
+                        RelativeSizeAxes = Axes.Both,
+                        Child = flow = new FillFlowContainer
                         {
                             Anchor = Anchor.TopLeft,
                             AutoSizeAxes = Axes.Y,

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -18,13 +18,14 @@ using osu.Framework.Utils;
 using osu.Framework.Text;
 using osuTK;
 using osuTK.Graphics;
+using osu.Framework.Graphics.Cursor;
 
 namespace osu.Framework.Graphics.Sprites
 {
     /// <summary>
     /// A container for simple text rendering purposes. If more complex text rendering is required, use <see cref="TextFlowContainer"/> instead.
     /// </summary>
-    public partial class SpriteText : Drawable, IHasLineBaseHeight, ITexturedShaderDrawable, IHasText, IHasFilterTerms, IFillFlowContainer, IHasCurrentValue<string>
+    public partial class SpriteText : Drawable, IHasLineBaseHeight, ITexturedShaderDrawable, IHasText, IHasFilterTerms, IFillFlowContainer, IHasCurrentValue<string>, IHasTooltip
     {
         private const float default_text_size = 20;
         private static readonly char[] default_never_fixed_width_characters = { '.', ',', ':', ' ' };
@@ -419,6 +420,26 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
+        private string tooltipText;
+
+        /// <summary>
+        /// Tooltip text that shows when hovering this <see cref="SpriteText"/>.
+        /// </summary>
+        /// <remarks>
+        /// Cannot be set if <see cref="Truncate"/> is enabled because the tooltip will display the full <see cref="Text"/> when <see cref="TruncatingTextBuilder.EllipsisAdded"/> is true.
+        /// </remarks>
+        public string TooltipText
+        {
+            get => tooltipText;
+            set
+            {
+                if (Truncate)
+                    throw new InvalidOperationException($"Cannot set {nameof(TooltipText)} when {nameof(Truncate)} is enabled.");
+
+                tooltipText = value;
+            }
+        }
+
         public override bool IsPresent => base.IsPresent && (AlwaysPresent || !string.IsNullOrEmpty(displayedText));
 
         #region Characters
@@ -475,6 +496,9 @@ namespace osu.Framework.Graphics.Sprites
                 textBuilder.Reset();
                 textBuilder.AddText(displayedText);
                 textBounds = textBuilder.Bounds;
+
+                if (textBuilder is TruncatingTextBuilder)
+                    tooltipText = ((TruncatingTextBuilder)textBuilder).EllipsisAdded ? Text.ToString() : null;
             }
             finally
             {

--- a/osu.Framework/Text/TruncatingTextBuilder.cs
+++ b/osu.Framework/Text/TruncatingTextBuilder.cs
@@ -9,6 +9,11 @@ namespace osu.Framework.Text
 {
     public sealed class TruncatingTextBuilder : TextBuilder
     {
+        /// <summary>
+        /// Whether an ellipsis was added, indicating <see cref="SpriteText.Text"/> has been truncated.
+        /// </summary>
+        public bool EllipsisAdded { get; private set; }
+
         private readonly char[] neverFixedWidthCharacters;
         private readonly char fallbackCharacter;
         private readonly ITexturedGlyphLookupStore store;
@@ -17,7 +22,6 @@ namespace osu.Framework.Text
         private readonly bool useFontSizeAsHeight;
         private readonly Vector2 spacing;
 
-        private bool ellipsisAdded;
         private bool addingEllipsis; // Only used temporarily during the addition of the ellipsis.
 
         /// <summary>
@@ -51,10 +55,10 @@ namespace osu.Framework.Text
         {
             base.Reset();
 
-            ellipsisAdded = false;
+            EllipsisAdded = false;
         }
 
-        protected override bool CanAddCharacters => (base.CanAddCharacters && !ellipsisAdded) || addingEllipsis;
+        protected override bool CanAddCharacters => (base.CanAddCharacters && !EllipsisAdded) || addingEllipsis;
 
         protected override bool HasAvailableSpace(float length) => base.HasAvailableSpace(length) || addingEllipsis;
 
@@ -102,7 +106,7 @@ namespace osu.Framework.Text
             finally
             {
                 addingEllipsis = false;
-                ellipsisAdded = true;
+                EllipsisAdded = true;
             }
         }
     }


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/6120.

![xACKTQO9I5](https://user-images.githubusercontent.com/35318437/111416778-cbae8180-86a1-11eb-8a4f-72c6b816460a.gif)
