### PR TITLE
Add public `SetValue()` method to `ConfigManager`

### DIFF
--- a/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
+++ b/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Tests.Configuration
                 {
                     storage = h.Storage;
 #pragma warning disable 618
-                    config.GetBindable<double>(FrameworkSetting.CursorSensitivity).Value = 5.0;
+                    config.Set(FrameworkSetting.CursorSensitivity, 5.0);
 #pragma warning restore 618
                 }));
             }

--- a/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
+++ b/osu.Framework.Tests/Configuration/InputConfigManagerTest.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Tests.Configuration
                 {
                     storage = h.Storage;
 #pragma warning disable 618
-                    config.Set(FrameworkSetting.CursorSensitivity, 5.0);
+                    config.SetValue(FrameworkSetting.CursorSensitivity, 5.0);
 #pragma warning restore 618
                 }));
             }

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Tests.Localisation
         public void TestNotLocalised()
         {
             manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
-            config.Set(FrameworkSetting.Locale, "ja-JP");
+            config.SetValue(FrameworkSetting.Locale, "ja-JP");
 
             var localisedText = manager.GetLocalisedString(FakeStorage.LOCALISABLE_STRING_EN);
 
@@ -51,7 +51,7 @@ namespace osu.Framework.Tests.Localisation
 
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
 
-            config.Set(FrameworkSetting.Locale, "ja-JP");
+            config.SetValue(FrameworkSetting.Locale, "ja-JP");
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP, localisedText.Value);
         }
 
@@ -60,7 +60,7 @@ namespace osu.Framework.Tests.Localisation
         {
             manager.AddLanguage("ja", new FakeStorage("ja"));
 
-            config.Set(FrameworkSetting.Locale, "ja-JP");
+            config.SetValue(FrameworkSetting.Locale, "ja-JP");
 
             var localisedText = manager.GetLocalisedString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
 
@@ -87,7 +87,7 @@ namespace osu.Framework.Tests.Localisation
             const string arg_0 = "formatted";
 
             manager.AddLanguage("ja-JP", new FakeStorage("ja"));
-            config.Set(FrameworkSetting.Locale, "ja-JP");
+            config.SetValue(FrameworkSetting.Locale, "ja-JP");
 
             string expectedResult = string.Format(FakeStorage.LOCALISABLE_FORMAT_STRING_JA, arg_0);
 
@@ -104,7 +104,7 @@ namespace osu.Framework.Tests.Localisation
             string expectedResult = string.Format(FakeStorage.LOCALISABLE_FORMAT_STRING_JA, arg_0);
 
             manager.AddLanguage("ja", new FakeStorage("ja"));
-            config.Set(FrameworkSetting.Locale, "ja");
+            config.SetValue(FrameworkSetting.Locale, "ja");
 
             var formattedText = manager.GetLocalisedString(new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, arg_0));
 
@@ -117,7 +117,7 @@ namespace osu.Framework.Tests.Localisation
             const double value = 1.23;
 
             manager.AddLanguage("fr", new FakeStorage("fr"));
-            config.Set(FrameworkSetting.Locale, "fr");
+            config.SetValue(FrameworkSetting.Locale, "fr");
 
             var expectedResult = string.Format(new CultureInfo("fr"), FakeStorage.LOCALISABLE_NUMBER_FORMAT_STRING_FR, value);
             Assert.AreEqual("number 1,23 FR", expectedResult); // FR uses comma for decimal point.
@@ -131,7 +131,7 @@ namespace osu.Framework.Tests.Localisation
         public void TestStorageNotFound()
         {
             manager.AddLanguage("ja", new FakeStorage("ja"));
-            config.Set(FrameworkSetting.Locale, "ja");
+            config.SetValue(FrameworkSetting.Locale, "ja");
 
             const string expected_fallback = "fallback string";
 
@@ -148,10 +148,10 @@ namespace osu.Framework.Tests.Localisation
 
             var text = manager.GetLocalisedString(new RomanisableString(unicode, non_unicode));
 
-            config.Set(FrameworkSetting.ShowUnicode, true);
+            config.SetValue(FrameworkSetting.ShowUnicode, true);
             Assert.AreEqual(unicode, text.Value);
 
-            config.Set(FrameworkSetting.ShowUnicode, false);
+            config.SetValue(FrameworkSetting.ShowUnicode, false);
             Assert.AreEqual(non_unicode, text.Value);
         }
 
@@ -165,13 +165,13 @@ namespace osu.Framework.Tests.Localisation
 
             var text = manager.GetLocalisedString(new RomanisableString(unicode_1, non_unicode_1));
 
-            config.Set(FrameworkSetting.ShowUnicode, false);
+            config.SetValue(FrameworkSetting.ShowUnicode, false);
             Assert.AreEqual(non_unicode_1, text.Value);
 
             text.Text = new RomanisableString(unicode_1, non_unicode_2);
             Assert.AreEqual(non_unicode_2, text.Value);
 
-            config.Set(FrameworkSetting.ShowUnicode, true);
+            config.SetValue(FrameworkSetting.ShowUnicode, true);
             Assert.AreEqual(unicode_1, text.Value);
 
             text.Text = new RomanisableString(unicode_2, non_unicode_2);
@@ -186,12 +186,12 @@ namespace osu.Framework.Tests.Localisation
 
             var text = manager.GetLocalisedString(new RomanisableString(unicode_fallback, emptyValue));
 
-            config.Set(FrameworkSetting.ShowUnicode, false);
+            config.SetValue(FrameworkSetting.ShowUnicode, false);
             Assert.AreEqual(unicode_fallback, text.Value);
 
             text = manager.GetLocalisedString(new RomanisableString(emptyValue, non_unicode_fallback));
 
-            config.Set(FrameworkSetting.ShowUnicode, true);
+            config.SetValue(FrameworkSetting.ShowUnicode, true);
             Assert.AreEqual(non_unicode_fallback, text.Value);
         }
 
@@ -206,8 +206,8 @@ namespace osu.Framework.Tests.Localisation
 
             protected override void InitialiseDefaults()
             {
-                Set(FrameworkSetting.Locale, "");
-                Set(FrameworkSetting.ShowUnicode, true);
+                SetDefault(FrameworkSetting.Locale, "");
+                SetDefault(FrameworkSetting.ShowUnicode, true);
             }
         }
 

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -8,7 +8,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Localisation;
 
@@ -20,25 +19,19 @@ namespace osu.Framework.Tests.Localisation
         private FrameworkConfigManager config;
         private LocalisationManager manager;
 
-        private Bindable<string> localeBindable;
-        private Bindable<bool> showUnicodeBindable;
-
         [SetUp]
         public void Setup()
         {
             config = new FakeFrameworkConfigManager();
             manager = new LocalisationManager(config);
             manager.AddLanguage("en", new FakeStorage("en"));
-
-            localeBindable = config.GetBindable<string>(FrameworkSetting.Locale);
-            showUnicodeBindable = config.GetBindable<bool>(FrameworkSetting.ShowUnicode);
         }
 
         [Test]
         public void TestNotLocalised()
         {
             manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
-            localeBindable.Value = "ja-JP";
+            config.Set(FrameworkSetting.Locale, "ja-JP");
 
             var localisedText = manager.GetLocalisedString(FakeStorage.LOCALISABLE_STRING_EN);
 
@@ -58,7 +51,7 @@ namespace osu.Framework.Tests.Localisation
 
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
 
-            localeBindable.Value = "ja-JP";
+            config.Set(FrameworkSetting.Locale, "ja-JP");
             Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP, localisedText.Value);
         }
 
@@ -67,7 +60,7 @@ namespace osu.Framework.Tests.Localisation
         {
             manager.AddLanguage("ja", new FakeStorage("ja"));
 
-            localeBindable.Value = "ja-JP";
+            config.Set(FrameworkSetting.Locale, "ja-JP");
 
             var localisedText = manager.GetLocalisedString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
 
@@ -94,7 +87,7 @@ namespace osu.Framework.Tests.Localisation
             const string arg_0 = "formatted";
 
             manager.AddLanguage("ja-JP", new FakeStorage("ja"));
-            localeBindable.Value = "ja-JP";
+            config.Set(FrameworkSetting.Locale, "ja-JP");
 
             string expectedResult = string.Format(FakeStorage.LOCALISABLE_FORMAT_STRING_JA, arg_0);
 
@@ -111,7 +104,7 @@ namespace osu.Framework.Tests.Localisation
             string expectedResult = string.Format(FakeStorage.LOCALISABLE_FORMAT_STRING_JA, arg_0);
 
             manager.AddLanguage("ja", new FakeStorage("ja"));
-            localeBindable.Value = "ja";
+            config.Set(FrameworkSetting.Locale, "ja");
 
             var formattedText = manager.GetLocalisedString(new TranslatableString(FakeStorage.LOCALISABLE_FORMAT_STRING_EN, FakeStorage.LOCALISABLE_FORMAT_STRING_EN, arg_0));
 
@@ -124,7 +117,7 @@ namespace osu.Framework.Tests.Localisation
             const double value = 1.23;
 
             manager.AddLanguage("fr", new FakeStorage("fr"));
-            localeBindable.Value = "fr";
+            config.Set(FrameworkSetting.Locale, "fr");
 
             var expectedResult = string.Format(new CultureInfo("fr"), FakeStorage.LOCALISABLE_NUMBER_FORMAT_STRING_FR, value);
             Assert.AreEqual("number 1,23 FR", expectedResult); // FR uses comma for decimal point.
@@ -138,7 +131,7 @@ namespace osu.Framework.Tests.Localisation
         public void TestStorageNotFound()
         {
             manager.AddLanguage("ja", new FakeStorage("ja"));
-            localeBindable.Value = "ja";
+            config.Set(FrameworkSetting.Locale, "ja");
 
             const string expected_fallback = "fallback string";
 
@@ -155,10 +148,10 @@ namespace osu.Framework.Tests.Localisation
 
             var text = manager.GetLocalisedString(new RomanisableString(unicode, non_unicode));
 
-            showUnicodeBindable.Value = true;
+            config.Set(FrameworkSetting.ShowUnicode, true);
             Assert.AreEqual(unicode, text.Value);
 
-            showUnicodeBindable.Value = false;
+            config.Set(FrameworkSetting.ShowUnicode, false);
             Assert.AreEqual(non_unicode, text.Value);
         }
 
@@ -172,13 +165,13 @@ namespace osu.Framework.Tests.Localisation
 
             var text = manager.GetLocalisedString(new RomanisableString(unicode_1, non_unicode_1));
 
-            showUnicodeBindable.Value = false;
+            config.Set(FrameworkSetting.ShowUnicode, false);
             Assert.AreEqual(non_unicode_1, text.Value);
 
             text.Text = new RomanisableString(unicode_1, non_unicode_2);
             Assert.AreEqual(non_unicode_2, text.Value);
 
-            showUnicodeBindable.Value = true;
+            config.Set(FrameworkSetting.ShowUnicode, true);
             Assert.AreEqual(unicode_1, text.Value);
 
             text.Text = new RomanisableString(unicode_2, non_unicode_2);
@@ -193,12 +186,12 @@ namespace osu.Framework.Tests.Localisation
 
             var text = manager.GetLocalisedString(new RomanisableString(unicode_fallback, emptyValue));
 
-            showUnicodeBindable.Value = false;
+            config.Set(FrameworkSetting.ShowUnicode, false);
             Assert.AreEqual(unicode_fallback, text.Value);
 
             text = manager.GetLocalisedString(new RomanisableString(emptyValue, non_unicode_fallback));
 
-            showUnicodeBindable.Value = true;
+            config.Set(FrameworkSetting.ShowUnicode, true);
             Assert.AreEqual(non_unicode_fallback, text.Value);
         }
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
@@ -54,7 +54,7 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep("add boxes", () => addMoreDrawables(Texture.WhitePixel, new RectangleF(0, 0, 1, 1)));
             AddToggleStep("disable front to back", val =>
             {
-                debugConfig.Set(DebugSetting.BypassFrontToBackPass, val);
+                debugConfig.SetValue(DebugSetting.BypassFrontToBackPass, val);
                 Invalidate(Invalidation.DrawNode); // reset counts
             });
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBack.cs
@@ -3,7 +3,6 @@
 
 using System;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -30,8 +29,6 @@ namespace osu.Framework.Tests.Visual.Containers
         private SpriteText labelFrag2;
         private float currentScale = 1;
 
-        private Bindable<bool> frontToBack;
-
         private const int cell_count = 4;
 
         protected override DrawNode CreateDrawNode() => drawNode = new QueryingCompositeDrawableDrawNode(this);
@@ -44,8 +41,6 @@ namespace osu.Framework.Tests.Visual.Containers
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager debugConfig, TextureStore store)
         {
-            frontToBack = debugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass);
-
             var texture = store.Get(@"sample-texture");
             var repeatedTexture = store.Get(@"sample-texture", WrapMode.Repeat, WrapMode.Repeat);
             var edgeClampedTexture = store.Get(@"sample-texture", WrapMode.ClampToEdge, WrapMode.ClampToEdge);
@@ -59,7 +54,7 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep("add boxes", () => addMoreDrawables(Texture.WhitePixel, new RectangleF(0, 0, 1, 1)));
             AddToggleStep("disable front to back", val =>
             {
-                frontToBack.Value = val;
+                debugConfig.Set(DebugSetting.BypassFrontToBackPass, val);
                 Invalidate(Invalidation.DrawNode); // reset counts
             });
 

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBox.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBox.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Tests.Visual.Containers
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager debugConfig)
         {
-            AddToggleStep("disable front to back", val => debugConfig.Set(DebugSetting.BypassFrontToBackPass, val));
+            AddToggleStep("disable front to back", val => debugConfig.SetValue(DebugSetting.BypassFrontToBackPass, val));
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBox.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneFrontToBackBox.cs
@@ -21,9 +21,7 @@ namespace osu.Framework.Tests.Visual.Containers
         [BackgroundDependencyLoader]
         private void load(FrameworkDebugConfigManager debugConfig)
         {
-            var frontToBack = debugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass);
-
-            AddToggleStep("disable front to back", val => frontToBack.Value = val);
+            AddToggleStep("disable front to back", val => debugConfig.Set(DebugSetting.BypassFrontToBackPass, val));
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -3,7 +3,6 @@
 
 using System.Linq;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -20,8 +19,6 @@ namespace osu.Framework.Tests.Visual.Input
 {
     public class TestSceneInputManager : FrameworkTestScene
     {
-        private Bindable<ConfineMouseMode> confineModeBindable;
-
         public TestSceneInputManager()
         {
             Add(new Container
@@ -175,13 +172,14 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Resolved]
+        private FrameworkConfigManager config { get; set; }
+
+        [Resolved]
         private GameHost host { get; set; }
 
         [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager config)
+        private void load()
         {
-            confineModeBindable = config.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode);
-
             AddSliderStep("Cursor sensivity", 0.5, 5, 1, setCursorSensivityConfig);
             setCursorSensivityConfig(1);
             AddToggleStep("Toggle relative mode", setRelativeMode);
@@ -219,7 +217,7 @@ namespace osu.Framework.Tests.Visual.Input
 
         private void setConfineMouseModeConfig(bool enabled)
         {
-            confineModeBindable.Value = enabled ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen;
+            config.Set(FrameworkSetting.ConfineMouseMode, enabled ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -217,7 +217,7 @@ namespace osu.Framework.Tests.Visual.Input
 
         private void setConfineMouseModeConfig(bool enabled)
         {
-            config.Set(FrameworkSetting.ConfineMouseMode, enabled ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen);
+            config.SetValue(FrameworkSetting.ConfineMouseMode, enabled ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen);
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -159,7 +159,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
                 // set up window
                 AddStep("switch to windowed", () => windowMode.Value = WindowMode.Windowed);
-                AddStep("set client size to 1280x720", () => config.Set(FrameworkSetting.WindowedSize, new Size(1280, 720)));
+                AddStep("set client size to 1280x720", () => config.SetValue(FrameworkSetting.WindowedSize, new Size(1280, 720)));
                 AddStep("store window position", () => originalWindowPosition = window.Position);
 
                 // borderless alignment tests

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -137,9 +137,7 @@ namespace osu.Framework.Tests.Visual.Platform
         private void load(FrameworkConfigManager config, GameHost host)
         {
             window = host.Window as SDL2DesktopWindow;
-
             config.BindWith(FrameworkSetting.WindowMode, windowMode);
-            var windowedSizeBindable = config.GetBindable<Size>(FrameworkSetting.WindowedSize);
 
             if (window == null)
             {
@@ -161,7 +159,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
                 // set up window
                 AddStep("switch to windowed", () => windowMode.Value = WindowMode.Windowed);
-                AddStep("set client size to 1280x720", () => windowedSizeBindable.Value = new Size(1280, 720));
+                AddStep("set client size to 1280x720", () => config.Set(FrameworkSetting.WindowedSize, new Size(1280, 720)));
                 AddStep("store window position", () => originalWindowPosition = window.Position);
 
                 // borderless alignment tests

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -131,9 +131,9 @@ namespace osu.Framework.Tests.Visual.Platform
         [Test]
         public void TestConfineModes()
         {
-            AddStep("set confined to never", () => config.Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Never));
-            AddStep("set confined to fullscreen", () => config.Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen));
-            AddStep("set confined to always", () => config.Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Always));
+            AddStep("set confined to never", () => config.SetValue(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Never));
+            AddStep("set confined to fullscreen", () => config.SetValue(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen));
+            AddStep("set confined to always", () => config.SetValue(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Always));
         }
 
         protected override void Update()

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -92,7 +92,7 @@ namespace osu.Framework.Tests.Visual.Platform
             if (window.SupportedWindowModes.Contains(WindowMode.Windowed))
             {
                 AddStep("change to windowed", () => windowMode.Value = WindowMode.Windowed);
-                AddStep("change window size", () => config.SetValue(FrameworkSetting.WindowedSize, new Size(640, 640));
+                AddStep("change window size", () => config.SetValue(FrameworkSetting.WindowedSize, new Size(640, 640)));
             }
 
             // if we support borderless, test that it can be used

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -31,8 +31,6 @@ namespace osu.Framework.Tests.Visual.Platform
         private readonly BindableSize sizeFullscreen = new BindableSize();
         private readonly Bindable<WindowMode> windowMode = new Bindable<WindowMode>();
 
-        private Bindable<ConfineMouseMode> confineModeBindable;
-
         public TestSceneFullscreen()
         {
             var currentBindableSize = new SpriteText();
@@ -63,11 +61,8 @@ namespace osu.Framework.Tests.Visual.Platform
         private void load(GameHost host)
         {
             window = host.Window;
-
             config.BindWith(FrameworkSetting.SizeFullscreen, sizeFullscreen);
             config.BindWith(FrameworkSetting.WindowMode, windowMode);
-            confineModeBindable = config.GetBindable<ConfineMouseMode>(FrameworkSetting.ConfineMouseMode);
-
             currentWindowMode.Text = $"Window Mode: {windowMode}";
 
             if (window == null)
@@ -136,9 +131,9 @@ namespace osu.Framework.Tests.Visual.Platform
         [Test]
         public void TestConfineModes()
         {
-            AddStep("set confined to never", () => confineModeBindable.Value = ConfineMouseMode.Never);
-            AddStep("set confined to fullscreen", () => confineModeBindable.Value = ConfineMouseMode.Fullscreen);
-            AddStep("set confined to always", () => confineModeBindable.Value = ConfineMouseMode.Always);
+            AddStep("set confined to never", () => config.Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Never));
+            AddStep("set confined to fullscreen", () => config.Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen));
+            AddStep("set confined to always", () => config.Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Always));
         }
 
         protected override void Update()

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -92,7 +92,7 @@ namespace osu.Framework.Tests.Visual.Platform
             if (window.SupportedWindowModes.Contains(WindowMode.Windowed))
             {
                 AddStep("change to windowed", () => windowMode.Value = WindowMode.Windowed);
-                AddStep("change window size", () => config.GetBindable<Size>(FrameworkSetting.WindowedSize).Value = new Size(640, 640));
+                AddStep("change window size", () => config.SetValue(FrameworkSetting.WindowedSize, new Size(640, 640));
             }
 
             // if we support borderless, test that it can be used

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
@@ -47,10 +47,10 @@ namespace osu.Framework.Tests.Visual.Sprites
         [Test]
         public void TestToggleRomanisedState()
         {
-            AddStep("prefer romanised", () => config.Set(FrameworkSetting.ShowUnicode, false));
+            AddStep("prefer romanised", () => config.SetValue(FrameworkSetting.ShowUnicode, false));
             AddAssert("check strings correct", () => flow.OfType<SpriteText>().Select(st => st.Current.Value).SequenceEqual(new[] { "music", "music", "ongaku" }));
 
-            AddStep("prefer unicode", () => config.Set(FrameworkSetting.ShowUnicode, true));
+            AddStep("prefer unicode", () => config.SetValue(FrameworkSetting.ShowUnicode, true));
             AddAssert("check strings correct", () => flow.OfType<SpriteText>().Select(st => st.Current.Value).SequenceEqual(new[] { "ongaku", "music", "ongaku" }));
         }
     }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneRomanisableSpriteText.cs
@@ -4,7 +4,6 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -16,8 +15,6 @@ namespace osu.Framework.Tests.Visual.Sprites
     public class TestSceneRomanisableSpriteText : FrameworkTestScene
     {
         private readonly FillFlowContainer flow;
-
-        private Bindable<bool> showUnicodeBindable;
 
         public TestSceneRomanisableSpriteText()
         {
@@ -44,19 +41,16 @@ namespace osu.Framework.Tests.Visual.Sprites
             flow.Add(new SpriteText { Text = new RomanisableString("ongaku", "") });
         }
 
-        [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager config)
-        {
-            showUnicodeBindable = config.GetBindable<bool>(FrameworkSetting.ShowUnicode);
-        }
+        [Resolved]
+        private FrameworkConfigManager config { get; set; }
 
         [Test]
         public void TestToggleRomanisedState()
         {
-            AddStep("prefer romanised", () => showUnicodeBindable.Value = false);
+            AddStep("prefer romanised", () => config.Set(FrameworkSetting.ShowUnicode, false));
             AddAssert("check strings correct", () => flow.OfType<SpriteText>().Select(st => st.Current.Value).SequenceEqual(new[] { "music", "music", "ongaku" }));
 
-            AddStep("prefer unicode", () => showUnicodeBindable.Value = true);
+            AddStep("prefer unicode", () => config.Set(FrameworkSetting.ShowUnicode, true));
             AddAssert("check strings correct", () => flow.OfType<SpriteText>().Select(st => st.Current.Value).SequenceEqual(new[] { "ongaku", "music", "ongaku" }));
         }
     }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
@@ -254,7 +254,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 localisation.AddLanguage("en", new FakeStorage("en"));
                 localisation.AddLanguage("ja", new FakeStorage("ja"));
 
-                config.Set(FrameworkSetting.Locale, "ja");
+                config.SetValue(FrameworkSetting.Locale, "ja");
             }
         }
 
@@ -269,8 +269,8 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             protected override void InitialiseDefaults()
             {
-                Set(FrameworkSetting.Locale, "ja");
-                Set(FrameworkSetting.ShowUnicode, false);
+                SetDefault(FrameworkSetting.Locale, "ja");
+                SetDefault(FrameworkSetting.ShowUnicode, false);
             }
         }
 

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
@@ -254,7 +254,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 localisation.AddLanguage("en", new FakeStorage("en"));
                 localisation.AddLanguage("ja", new FakeStorage("ja"));
 
-                config.GetBindable<string>(FrameworkSetting.Locale).Value = "ja";
+                config.Set(FrameworkSetting.Locale, "ja");
             }
         }
 

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -79,7 +79,7 @@ namespace osu.Framework.iOS
 
             base.SetupConfig(defaultOverrides);
 
-            DebugConfig.GetBindable<bool>(DebugSetting.BypassFrontToBackPass).Value = true;
+            DebugConfig.SetValue(DebugSetting.BypassFrontToBackPass, true);
         }
 
         protected override void PerformExit(bool immediately)

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -41,10 +41,10 @@ namespace osu.Framework.Configuration
         }
 
         /// <summary>
-        /// Sets a configuration value.
+        /// Sets a configuration's value.
         /// </summary>
         /// <param name="lookup">The lookup key.</param>
-        /// <param name="value">The configuration value. Will also become the default value if one has not already been initialised.</param>
+        /// <param name="value">The value. Will also become the default value if one has not already been initialised.</param>
         /// <typeparam name="TValue">The type of value.</typeparam>
         public void SetValue<TValue>(TLookup lookup, TValue value)
         {
@@ -74,6 +74,15 @@ namespace osu.Framework.Configuration
         [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
         public Bindable<TValue> Set<TValue>(TLookup lookup, TValue value) => SetDefault(lookup, value);
 
+        /// <summary>
+        /// Sets a configuration's default value.
+        /// </summary>
+        /// <param name="lookup">The lookup key.</param>
+        /// <param name="value">The default value.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="precision">The value precision.</param>
+        /// <returns>The original bindable (not a bound copy).</returns>
         protected BindableDouble SetDefault(TLookup lookup, double value, double? min = null, double? max = null, double? precision = null)
         {
             value = getDefault(lookup, value);
@@ -96,6 +105,15 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
+        /// <summary>
+        /// Sets a configuration's default value.
+        /// </summary>
+        /// <param name="lookup">The lookup key.</param>
+        /// <param name="value">The default value.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <param name="precision">The value precision.</param>
+        /// <returns>The original bindable (not a bound copy).</returns>
         protected BindableFloat SetDefault(TLookup lookup, float value, float? min = null, float? max = null, float? precision = null)
         {
             value = getDefault(lookup, value);
@@ -118,6 +136,14 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
+        /// <summary>
+        /// Sets a configuration's default value.
+        /// </summary>
+        /// <param name="lookup">The lookup key.</param>
+        /// <param name="value">The default value.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <returns>The original bindable (not a bound copy).</returns>
         protected BindableInt SetDefault(TLookup lookup, int value, int? min = null, int? max = null)
         {
             value = getDefault(lookup, value);
@@ -139,6 +165,12 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
+        /// <summary>
+        /// Sets a configuration's default value.
+        /// </summary>
+        /// <param name="lookup">The lookup key.</param>
+        /// <param name="value">The default value.</param>
+        /// <returns>The original bindable (not a bound copy).</returns>
         protected BindableBool SetDefault(TLookup lookup, bool value)
         {
             value = getDefault(lookup, value);
@@ -158,6 +190,14 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
+        /// <summary>
+        /// Sets a configuration's default value.
+        /// </summary>
+        /// <param name="lookup">The lookup key.</param>
+        /// <param name="value">The default value.</param>
+        /// <param name="min">The minimum value.</param>
+        /// <param name="max">The maximum value.</param>
+        /// <returns>The original bindable (not a bound copy).</returns>
         protected BindableSize SetDefault(TLookup lookup, Size value, Size? min = null, Size? max = null)
         {
             value = getDefault(lookup, value);
@@ -179,6 +219,12 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
+        /// <summary>
+        /// Sets a configuration's default value.
+        /// </summary>
+        /// <param name="lookup">The lookup key.</param>
+        /// <param name="value">The default value.</param>
+        /// <returns>The original bindable (not a bound copy).</returns>
         protected Bindable<TValue> SetDefault<TValue>(TLookup lookup, TValue value)
         {
             value = getDefault(lookup, value);

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -51,12 +51,30 @@ namespace osu.Framework.Configuration
             var bindable = GetOriginalBindable<TValue>(lookup);
 
             if (bindable == null)
-                Set(lookup, value);
+                SetDefault(lookup, value);
             else
                 bindable.Value = value;
         }
 
-        protected BindableDouble Set(TLookup lookup, double value, double? min = null, double? max = null, double? precision = null)
+        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
+        public BindableDouble Set(TLookup lookup, double value, double? min = null, double? max = null, double? precision = null) => SetDefault(lookup, value, min, max, precision);
+
+        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
+        public BindableFloat Set(TLookup lookup, float value, float? min = null, float? max = null, float? precision = null) => SetDefault(lookup, value, min, max, precision);
+
+        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
+        public BindableInt Set(TLookup lookup, int value, int? min = null, int? max = null) => SetDefault(lookup, value, min, max);
+
+        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
+        public BindableBool Set(TLookup lookup, bool value) => SetDefault(lookup, value);
+
+        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
+        public BindableSize Set(TLookup lookup, Size value, Size? min = null, Size? max = null) => SetDefault(lookup, value, min, max);
+
+        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
+        public Bindable<TValue> Set<TValue>(TLookup lookup, TValue value) => SetDefault(lookup, value);
+
+        protected BindableDouble SetDefault(TLookup lookup, double value, double? min = null, double? max = null, double? precision = null)
         {
             value = getDefault(lookup, value);
 
@@ -78,7 +96,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        protected BindableFloat Set(TLookup lookup, float value, float? min = null, float? max = null, float? precision = null)
+        protected BindableFloat SetDefault(TLookup lookup, float value, float? min = null, float? max = null, float? precision = null)
         {
             value = getDefault(lookup, value);
 
@@ -100,7 +118,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        protected BindableInt Set(TLookup lookup, int value, int? min = null, int? max = null)
+        protected BindableInt SetDefault(TLookup lookup, int value, int? min = null, int? max = null)
         {
             value = getDefault(lookup, value);
 
@@ -121,7 +139,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        protected BindableBool Set(TLookup lookup, bool value)
+        protected BindableBool SetDefault(TLookup lookup, bool value)
         {
             value = getDefault(lookup, value);
 
@@ -140,7 +158,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        protected BindableSize Set(TLookup lookup, Size value, Size? min = null, Size? max = null)
+        protected BindableSize SetDefault(TLookup lookup, Size value, Size? min = null, Size? max = null)
         {
             value = getDefault(lookup, value);
 
@@ -161,7 +179,7 @@ namespace osu.Framework.Configuration
             return bindable;
         }
 
-        protected Bindable<TValue> Set<TValue>(TLookup lookup, TValue value)
+        protected Bindable<TValue> SetDefault<TValue>(TLookup lookup, TValue value)
         {
             value = getDefault(lookup, value);
 

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -40,6 +40,22 @@ namespace osu.Framework.Configuration
         {
         }
 
+        /// <summary>
+        /// Sets a configuration value.
+        /// </summary>
+        /// <param name="lookup">The lookup key.</param>
+        /// <param name="value">The configuration value. Will also become the default value if one has not already been initialised.</param>
+        /// <typeparam name="TValue">The type of value.</typeparam>
+        public void SetValue<TValue>(TLookup lookup, TValue value)
+        {
+            var bindable = GetOriginalBindable<TValue>(lookup);
+
+            if (bindable == null)
+                Set(lookup, value);
+            else
+                bindable.Value = value;
+        }
+
         protected BindableDouble Set(TLookup lookup, double value, double? min = null, double? max = null, double? precision = null)
         {
             value = getDefault(lookup, value);

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -20,28 +20,28 @@ namespace osu.Framework.Configuration
 
         protected override void InitialiseDefaults()
         {
-            Set(FrameworkSetting.ShowLogOverlay, false);
+            SetDefault(FrameworkSetting.ShowLogOverlay, false);
 
-            Set(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480));
-            Set(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen);
-            Set(FrameworkSetting.ExecutionMode, ExecutionMode.MultiThreaded);
-            Set(FrameworkSetting.WindowedPositionX, 0.5, -0.5, 1.5);
-            Set(FrameworkSetting.WindowedPositionY, 0.5, -0.5, 1.5);
-            Set(FrameworkSetting.LastDisplayDevice, DisplayIndex.Default);
-            Set(FrameworkSetting.AudioDevice, string.Empty);
-            Set(FrameworkSetting.VolumeUniversal, 1.0, 0.0, 1.0, 0.01);
-            Set(FrameworkSetting.VolumeMusic, 1.0, 0.0, 1.0, 0.01);
-            Set(FrameworkSetting.VolumeEffect, 1.0, 0.0, 1.0, 0.01);
-            Set(FrameworkSetting.SizeFullscreen, new Size(9999, 9999), new Size(320, 240));
-            Set(FrameworkSetting.FrameSync, FrameSync.Limit2x);
-            Set(FrameworkSetting.WindowMode, WindowMode.Windowed);
-            Set(FrameworkSetting.ShowUnicode, false);
-            Set(FrameworkSetting.Locale, string.Empty);
+            SetDefault(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480));
+            SetDefault(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen);
+            SetDefault(FrameworkSetting.ExecutionMode, ExecutionMode.MultiThreaded);
+            SetDefault(FrameworkSetting.WindowedPositionX, 0.5, -0.5, 1.5);
+            SetDefault(FrameworkSetting.WindowedPositionY, 0.5, -0.5, 1.5);
+            SetDefault(FrameworkSetting.LastDisplayDevice, DisplayIndex.Default);
+            SetDefault(FrameworkSetting.AudioDevice, string.Empty);
+            SetDefault(FrameworkSetting.VolumeUniversal, 1.0, 0.0, 1.0, 0.01);
+            SetDefault(FrameworkSetting.VolumeMusic, 1.0, 0.0, 1.0, 0.01);
+            SetDefault(FrameworkSetting.VolumeEffect, 1.0, 0.0, 1.0, 0.01);
+            SetDefault(FrameworkSetting.SizeFullscreen, new Size(9999, 9999), new Size(320, 240));
+            SetDefault(FrameworkSetting.FrameSync, FrameSync.Limit2x);
+            SetDefault(FrameworkSetting.WindowMode, WindowMode.Windowed);
+            SetDefault(FrameworkSetting.ShowUnicode, false);
+            SetDefault(FrameworkSetting.Locale, string.Empty);
 
 #pragma warning disable 618
-            Set(FrameworkSetting.MapAbsoluteInputToWindow, false);
-            Set(FrameworkSetting.IgnoredInputHandlers, string.Empty);
-            Set(FrameworkSetting.CursorSensitivity, 1.0, 0.1, 6, 0.01);
+            SetDefault(FrameworkSetting.MapAbsoluteInputToWindow, false);
+            SetDefault(FrameworkSetting.IgnoredInputHandlers, string.Empty);
+            SetDefault(FrameworkSetting.CursorSensitivity, 1.0, 0.1, 6, 0.01);
 #pragma warning restore 618
         }
 

--- a/osu.Framework/Configuration/FrameworkDebugConfig.cs
+++ b/osu.Framework/Configuration/FrameworkDebugConfig.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Configuration
         {
             base.InitialiseDefaults();
 
-            Set(DebugSetting.BypassFrontToBackPass, false);
+            SetDefault(DebugSetting.BypassFrontToBackPass, false);
         }
     }
 

--- a/osu.Framework/Configuration/IniConfigManager.cs
+++ b/osu.Framework/Configuration/IniConfigManager.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Configuration
                             }
                         }
                         else if (AddMissingEntries)
-                            Set(lookup, val);
+                            SetDefault(lookup, val);
                     }
                 }
             }

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -429,7 +429,7 @@ namespace osu.Framework.Testing
             if (testType == null && TestTypes.Count > 0)
                 testType = TestTypes[0];
 
-            config.Set(TestBrowserSetting.LastTest, testType?.FullName ?? string.Empty);
+            config.SetValue(TestBrowserSetting.LastTest, testType?.FullName ?? string.Empty);
 
             if (testType == null)
                 return;

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -429,7 +429,7 @@ namespace osu.Framework.Testing
             if (testType == null && TestTypes.Count > 0)
                 testType = TestTypes[0];
 
-            config.GetBindable<string>(TestBrowserSetting.LastTest).Value = testType?.FullName ?? string.Empty;
+            config.Set(TestBrowserSetting.LastTest, testType?.FullName ?? string.Empty);
 
             if (testType == null)
                 return;

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -48,7 +48,6 @@ namespace osu.Framework.Testing
         public readonly List<Type> TestTypes = new List<Type>();
 
         private ConfigManager<TestBrowserSetting> config;
-        private Bindable<string> lastTestBindable;
 
         private DynamicClassCompiler<TestScene> backgroundCompiler;
 
@@ -130,9 +129,7 @@ namespace osu.Framework.Testing
         private void load(Storage storage, GameHost host, FrameworkConfigManager frameworkConfig, FontStore fonts, Game game, AudioManager audio)
         {
             interactive = host.Window != null;
-
             config = new TestBrowserConfig(storage);
-            lastTestBindable = config.GetBindable<string>(TestBrowserSetting.LastTest);
 
             exit = host.Exit;
 
@@ -341,10 +338,12 @@ namespace osu.Framework.Testing
 
             if (CurrentTest == null)
             {
-                var foundTest = TestTypes.Find(t => t.FullName == lastTestBindable.Value)
+                var lastTest = config.Get<string>(TestBrowserSetting.LastTest);
+
+                var foundTest = TestTypes.Find(t => t.FullName == lastTest)
                                 // full name was not always stored in this value, so fallback to matching on just test name.
                                 // can be removed 20210622
-                                ?? TestTypes.Find(t => t.Name == lastTestBindable.Value);
+                                ?? TestTypes.Find(t => t.Name == lastTest);
 
                 LoadTest(foundTest);
             }
@@ -430,7 +429,7 @@ namespace osu.Framework.Testing
             if (testType == null && TestTypes.Count > 0)
                 testType = TestTypes[0];
 
-            lastTestBindable.Value = testType?.FullName ?? string.Empty;
+            config.GetBindable<string>(TestBrowserSetting.LastTest).Value = testType?.FullName ?? string.Empty;
 
             if (testType == null)
                 return;

--- a/osu.Framework/Testing/TestBrowserConfig.cs
+++ b/osu.Framework/Testing/TestBrowserConfig.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Testing
         protected override void InitialiseDefaults()
         {
             base.InitialiseDefaults();
-            Set(TestBrowserSetting.LastTest, string.Empty);
+            SetDefault(TestBrowserSetting.LastTest, string.Empty);
         }
     }
 


### PR DESCRIPTION
1. Public `Set()` methods added back as obsolete.
2. Protected `Set()` methods renamed to `SetDefault()`.
3. Public `SetValue()` method added as a shortcut to `GetBindable<>().Value = value`.  This also sets the default if one hasn't already been set, as a conscious decision in order to not throw exceptions.