### PR TITLE
Fix macOS hard crash when performing non-precise scroll on titlebar

### DIFF
--- a/osu.Framework/Platform/MacOS/MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindow.cs
@@ -43,7 +43,10 @@ namespace osu.Framework.Platform.MacOS
             if (!hasPrecise)
             {
                 // calls the unswizzled [SDLView scrollWheel:(NSEvent *)] method if this is a regular scroll wheel event
-                Cocoa.SendVoid(receiver, originalScrollWheel, theEvent);
+                // the receiver may sometimes not be SDLView, use original scroll method nonexistence to indicate that.
+                if (Cocoa.SendBool(receiver, sel_respondstoselector_, originalScrollWheel))
+                    Cocoa.SendVoid(receiver, originalScrollWheel, theEvent);
+
                 return;
             }
 

--- a/osu.Framework/Platform/MacOS/MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindow.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Platform.MacOS
             if (!hasPrecise)
             {
                 // calls the unswizzled [SDLView scrollWheel:(NSEvent *)] method if this is a regular scroll wheel event
-                // the receiver may sometimes not be SDLView, use original scroll method nonexistence to indicate that.
+                // the receiver may sometimes not be SDLView, ensure it has a scroll wheel selector implemented before attempting to call.
                 if (Cocoa.SendBool(receiver, sel_respondstoselector_, originalScrollWheel))
                     Cocoa.SendVoid(receiver, originalScrollWheel, theEvent);
 


### PR DESCRIPTION
```
2021-03-19 07:30:45.649 dotnet[74568:4030645] -[NSTextField orig_scrollWheel:]: unrecognized selector sent to instance 0x7fdad08669b0
2021-03-19 07:30:45.651 dotnet[74568:4030645] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSTextField orig_scrollWheel:]: unrecognized selector sent to instance 0x7fdad08669b0'
*** First throw call stack:
(
        0   CoreFoundation                      0x00007fff204b46af __exceptionPreprocess + 242
        1   libobjc.A.dylib                     0x00007fff201ec3c9 objc_exception_throw + 48
        2   CoreFoundation                      0x00007fff20536c85 -[NSObject(NSObject) __retain_OA] + 0
        3   CoreFoundation                      0x00007fff2041c07d ___forwarding___ + 1467
        4   CoreFoundation                      0x00007fff2041ba38 _CF_forwarding_prep_0 + 120
        5   ???                                 0x000000011840d088 0x0 + 4701868168
        6   ???                                 0x000000011a4f2d10 0x0 + 4736363792
        7   ???                                 0x000000011a4f2766 0x0 + 4736362342
        8   AppKit                              0x00007fff22de3b08 -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:] + 6482
        9   AppKit                              0x00007fff22de1f9a -[NSWindow(NSEventRouting) sendEvent:] + 347
        10  libSDL2.dylib                       0x000000010c46c842 -[SDLWindow sendEvent:] + 50
        11  AppKit                              0x00007fff22de0b58 -[NSApplication(NSEvent) sendEvent:] + 2356
        12  libSDL2.dylib                       0x000000010c4660aa -[SDLApplication sendEvent:] + 138
        13  libSDL2.dylib                       0x000000010c467087 Cocoa_PumpEvents + 263
        14  libSDL2.dylib                       0x000000010c3ad010 SDL_WaitEventTimeout_REAL + 224
        15  ???                                 0x000000011a4985c4 0x0 + 4735993284
        16  ???                                 0x000000011a49824b 0x0 + 4735992395
        17  ???                                 0x000000011a4974a9 0x0 + 4735988905
        18  ???                                 0x0000000117a9279c 0x0 + 4691928988
        19  ???                                 0x0000000117a78da0 0x0 + 4691824032
        20  libcoreclr.dylib                    0x0000000108f1b3d9 CallDescrWorkerInternal + 124
        21  libcoreclr.dylib                    0x0000000108d702ef _ZN18MethodDescCallSite16CallTargetWorkerEPKmPmi + 1519
        22  libcoreclr.dylib                    0x0000000108c4b9ba _Z7RunMainP10MethodDescsPiPP8PtrArray + 746
        23  libcoreclr.dylib                    0x0000000108c4bcf3 _ZN8Assembly17ExecuteMainMethodEPP8PtrArrayi + 387
        24  libcoreclr.dylib                    0x0000000108c8883d _ZN8CorHost215ExecuteAssemblyEjPKDsiPS1_Pj + 509
        25  libcoreclr.dylib                    0x0000000108c35222 coreclr_execute_assembly + 242
        26  libhostpolicy.dylib                 0x0000000108b92923 _Z19run_app_for_contextRK20hostpolicy_context_tiPPKc + 1443
        27  libhostpolicy.dylib                 0x0000000108b93c2a corehost_main + 234
        28  libhostfxr.dylib                    0x0000000108b25981 _ZN10fx_muxer_t24handle_exec_host_commandERKNSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEERK19host_startup_info_tS8_RKNS0_13unordered_mapI13known_optionsNS0_6vectorIS6_NS4_IS6_EEEE18known_options_hashNS0_8equal_toISD_EENS4_INS0_4pairIKSD_SG_EEEEEEiPPKci11host_mode_tPciPi + 1281
        29  libhostfxr.dylib                    0x0000000108b24ad3 _ZN10fx_muxer_t7executeENSt3__112basic_stringIcNS0_11char_traitsIcEENS0_9allocatorIcEEEEiPPKcRK19host_startup_info_tPciPi + 611
        30  libhostfxr.dylib                    0x0000000108b2247a hostfxr_main_startupinfo + 138
        31  dotnet                              0x0000000108ae3beb _Z9exe_startiPPKc + 1355
        32  dotnet                              0x0000000108ae3ddf main + 143
        33  libdyld.dylib                       0x00007fff2035d621 start + 1
        34  ???                                 0x0000000000000002 0x0 + 2
)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

The hard crash can be reproduced just by performing a non-precise scroll on the window title bar, i.e. hitting this line while `receiver` isn't `SDLView`:

<img width="729" alt="image" src="https://user-images.githubusercontent.com/22781491/111731556-c3626c00-8884-11eb-8234-dbb2bf210783.png">

It appears our swizzled `scrollWheel` method can be invoked to a receiver that is not `SDLView`, I can't confirm how that can happen, but a guard must be added to check whether the receiver class implements `scrollWheel` to avoid invoking a not existing selector, causing a hard crash.

Therefore I fixed the issue by guarding it as so.