### PR TITLE
Specify precision for mouse handler sensitivity bindable

### DIFF
--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -25,7 +25,12 @@ namespace osu.Framework.Input.Handlers.Mouse
             Description = "Allows for sensitivity adjustment and tighter control of input",
         };
 
-        public BindableDouble Sensitivity { get; } = new BindableDouble(1) { MinValue = 0.1, MaxValue = 10 };
+        public BindableDouble Sensitivity { get; } = new BindableDouble(1)
+        {
+            MinValue = 0.1,
+            MaxValue = 10,
+            Precision = 0.01
+        };
 
         public override string Description => "Mouse";
 


### PR DESCRIPTION
In the old sensitivity setting flow (via the framework config), the precision was set via a `SetDefault()` call:

https://github.com/ppy/osu-framework/blob/add64ff760caaa9a44569994573ed2aabdda14f7/osu.Framework/Configuration/FrameworkConfigManager.cs#L44

but the mouse handler's bindable had no precision specified, therefore defaulting to `double.Epsilon`. This PR applies that same precision value of `0.01` to the mouse handler's sensitivity bindable.

This also incidentally closes https://github.com/ppy/osu/issues/12112, since game-side setting sliders automagically read the precision of the bindables they're bound to, and use it to format their tooltip text.