### PR TITLE
Remove artificial memory pressure from VBOs

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.OpenGL.Vertices;
 using osuTK.Graphics.ES30;
 using osu.Framework.Statistics;
 using osu.Framework.Development;
-using osu.Framework.Platform;
 using SixLabors.ImageSharp.Memory;
 
 namespace osu.Framework.Graphics.OpenGL.Buffers
@@ -21,7 +20,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         private Memory<DepthWrappingVertex<T>> vertexMemory;
         private IMemoryOwner<DepthWrappingVertex<T>> memoryOwner;
-        private NativeMemoryTracker.NativeMemoryLease memoryLease;
 
         private int vboId = -1;
 
@@ -69,7 +67,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
             int size = Size * STRIDE;
 
-            memoryLease = NativeMemoryTracker.AddMemory(this, Size * STRIDE);
             GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)size, IntPtr.Zero, usage);
         }
 
@@ -176,9 +173,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
             if (vboId != -1)
             {
                 Unbind();
-
-                memoryLease?.Dispose();
-                memoryLease = null;
 
                 GL.DeleteBuffer(vboId);
                 vboId = -1;


### PR DESCRIPTION
In my profiling, I was lucky to spot `AddMemoryPressure` causing gen2 GC collections exceeding 16ms. This comes from our usages of `NativeMemoryTracker`.

For VBOs specifically, native memory lifetime is very tightly controlled by us such that any VBO unused for 300 frames is deleted: 
https://github.com/ppy/osu-framework/blob/322245a44f6c65cb107ca993319c0b0b9a4e9fda/osu.Framework/Graphics/OpenGL/GLWrapper.cs#L371-L383
In this case, we're basically telling the GC that a 24KB object is allocated quite frequently, but there's rarely an useful work it can do by running more frequently due to our tight control over native memory. In most cases it ends up promoting "200MB" of VBOs to gen2 that then results in the blocking collection.

Similar reasoning could be applied to all other GL objects - for example FBOs are "deleted" once the drawable is disposed, which in most cases happens as a result of exiting screens and is deterministic (albeit async). However there's a possibility of Drawables just getting lost at which point GL objects need to rely on the finalizer, and is the reason why I haven't applied this change to other GL objects yet.

Think of this as a bit of a stop-gap measure. I have WIP changes that reduce total VBO allocations by a further 10x and plans of removing the CPU-side storage completely.

Testing methodology:
Beatmap: https://osu.ppy.sh/beatmapsets/1181343#osu/2463210

1. Start gameplay
2. Clear caches
3. Start trace
4. Skip + wait 1 minute (total trace time = 1min).

Before:
![before-1min](https://user-images.githubusercontent.com/1329837/111937238-a76ffc00-8b0a-11eb-986a-c3e0ddf3f844.png)

After:
![after-1min](https://user-images.githubusercontent.com/1329837/111937246-a9d25600-8b0a-11eb-8679-ebac9d64e761.png)

In previous testing I ran this for 2 minutes on the same beatmap, and also observed 0 gen2s, so it holds up over longer periods:
![unknown](https://user-images.githubusercontent.com/1329837/111937492-30873300-8b0b-11eb-86d8-f20c7f6a0350.png)

1. Start gameplay
2. Clear caches
3. Start trace
4. Fast forward to end of map, wait for results screen to fully load.
5. Total trace time = 12sec.

Before:
![before-ffwd](https://user-images.githubusercontent.com/1329837/111937287-c2427080-8b0a-11eb-8517-02bdd9992f3f.png)

After:
![after-ffwd](https://user-images.githubusercontent.com/1329837/111937294-c66e8e00-8b0a-11eb-89e5-c5c61b6a0b95.png)