### PR TITLE
Don't throw when attempting to `Stop` a `SampleChannel` post-disposal

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -22,8 +22,6 @@ namespace osu.Framework.Audio.Sample
 
         public virtual void Stop()
         {
-            if (IsDisposed)
-                throw new ObjectDisposedException(ToString(), "Can not stop disposed sample channels.");
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
This felt like a very anti-user method of handling this. At the point the channel is disposed, it's guaranteed to be stopped, meaning subsequent `Stop` calls are noop anyway.