### PR TITLE
Avoid using DI for audio component adjustment lookup to better support pooling

### DIFF
--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -6,7 +6,6 @@ using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Layout;
 

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -88,7 +88,10 @@ namespace osu.Framework.Graphics.Audio
             // because these components may be pooled, relying on DI is not feasible.
             // in the majority of cases the traversal should be quite short. may require later attention if a use case comes up which this is not true for.
             if (parentAdjustment != null)
+            {
                 adjustments.UnbindAdjustments(parentAdjustment);
+                parentAdjustment = null;
+            }
 
             Drawable cursor = this;
 

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -80,7 +80,10 @@ namespace osu.Framework.Graphics.Audio
             base.Update();
 
             if (!parentAdjustmentLayout.IsValid)
+            {
                 refreshAdjustments();
+                parentAdjustmentLayout.Validate();
+            }
         }
 
         private void refreshAdjustments()


### PR DESCRIPTION
This is a second attempt at https://github.com/ppy/osu-framework/pull/4212, minus the breakage.

The only part of this I'm not 100% sure about is the logic added to ensure no self-references. An alternative to this is to fix each occurrence that uses interface delegation (see https://github.com/ppy/osu/compare/master...peppy:audio-interafce-delegation-fixes?expand=1). In theory this looks like a better approach, until you realise that to make it works, `PoolableSkinnableSample` needs to have similar code to this framework-side change in order to get the parent adjustments (since it is pretending to be a wrapper without actually being one).

Tested to work well osu! side. Not sure if it's worth adding test coverage for this.