### PR TITLE
Ensure disposal of drawables within DrawablePool

### DIFF
--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -149,14 +149,14 @@ namespace osu.Framework.Graphics.Pooling
         {
             base.Dispose(isDisposing);
 
+            foreach (var x in pool)
+                x.Dispose();
+
             CountInUse = 0;
             CountConstructed = 0;
             CountAvailable = 0;
 
             GlobalStatistics.Remove(statistic);
-
-            foreach (var x in pool)
-                x.Dispose();
 
             // Disallow any further Gets/Returns to adjust the statistics.
             statistic = null;

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -149,8 +149,8 @@ namespace osu.Framework.Graphics.Pooling
         {
             base.Dispose(isDisposing);
 
-            foreach (var x in pool)
-                x.Dispose();
+            foreach (var p in pool)
+                p.Dispose();
 
             CountInUse = 0;
             CountConstructed = 0;

--- a/osu.Framework/Graphics/Pooling/DrawablePool.cs
+++ b/osu.Framework/Graphics/Pooling/DrawablePool.cs
@@ -155,6 +155,9 @@ namespace osu.Framework.Graphics.Pooling
 
             GlobalStatistics.Remove(statistic);
 
+            foreach (var x in pool)
+                x.Dispose();
+
             // Disallow any further Gets/Returns to adjust the statistics.
             statistic = null;
         }


### PR DESCRIPTION
After the removal of finalizers from `Drawables` in #4242, disposals must be invoked manually.

`Drawables` within the draw hierarchy do get properly disposed since the disposal of a parent drawable would also trigger a disposal on their children. 
https://github.com/peppy/osu-framework/blob/master/osu.Framework/Graphics/Containers/CompositeDrawable.cs#L299

However, in `DrawablePool`, a stack is used to store `PoolableDrawable`s, which means that they aren't within the drawable hierarchy, so the pool's contents aren't disposed properly. 

This PR adds a change that ensures that the pool's contents are disposed properly.

<sub>This is something I've noticed when pooling drawables within another pooled drawable in my ruleset, and the failure to properly dispose drawables within the pool led to the nested pool's statistic entry not being removed from the global statistics panel. The actual pool is properly disposed though.

(`DrawablePool<DrawableHitObject>` > `DHO` > [`Piece` > `DrawablePool<Drawable>`](https://github.com/LumpBloom7/sentakki/blob/master/osu.Game.Rulesets.Sentakki/Objects/Drawables/Pieces/SlideVisual.cs#L62))
[Image showing potential problem caused by this fault](https://user-images.githubusercontent.com/12001167/112043372-e1f88980-8b48-11eb-9827-58173e3b4b80.png)</sub>

