### PR TITLE
Remove finaliser from AsyncBufferStream

### DIFF
--- a/osu.Framework/IO/AsyncBufferStream.cs
+++ b/osu.Framework/IO/AsyncBufferStream.cs
@@ -64,11 +64,6 @@ namespace osu.Framework.IO
             Task.Factory.StartNew(loadRequiredBlocks, cancellationToken.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
         }
 
-        ~AsyncBufferStream()
-        {
-            Dispose(false);
-        }
-
         private void loadRequiredBlocks()
         {
             if (isLoaded)


### PR DESCRIPTION
This is `internal` and the only usages are in `TrackBass`, which has its own finaliser. This one is unnecessary. Note that finalizer suppression is already handled along with the rest of the disposal flow in `Stream`.

Closes #4229.