### PR TITLE
Allow caps lock events to fire via KeyDown / KeyUp

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -882,7 +882,7 @@ namespace osu.Framework.Platform
         {
             Key key = evtKey.keysym.ToKey();
 
-            if (key == Key.Unknown || key == Key.CapsLock)
+            if (key == Key.Unknown)
                 return;
 
             switch (evtKey.type)


### PR DESCRIPTION
Have tested on windows and macOS. Seems to work as expected.

Also tested on windows with the osu! side caps lock warning and that works once again.

As such, closes https://github.com/ppy/osu/issues/12165.