### PR TITLE
Add caps lock state querying support for the general desktop platform case

### DIFF
--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -70,6 +70,8 @@ namespace osu.Framework.Platform
 
         public bool IsPortableInstallation { get; }
 
+        public override bool CapsLockEnabled => (Window as SDL2DesktopWindow)?.CapsLockPressed == true;
+
         public override void OpenFileExternally(string filename) => openUsingShellExecute(filename);
 
         public override void OpenUrlExternally(string url) => openUsingShellExecute(url);

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -384,6 +384,8 @@ namespace osu.Framework.Platform
             }
         }
 
+        public bool CapsLockPressed => SDL.SDL_GetModState().HasFlagFast(SDL.SDL_Keymod.KMOD_CAPS);
+
         private bool firstDraw = true;
 
         private readonly BindableSize sizeFullscreen = new BindableSize();


### PR DESCRIPTION
Idea taken from https://github.com/ppy/osu/issues/11731#issuecomment-806177375. I've left the windows specific implementation in place because it doesn't seem to be causing any harm. Could be removed on request I guess.

Tested on macOS; should probably be checked on linux as well.

Closes https://github.com/ppy/osu/issues/11731.