### PR TITLE
Ensure relative mouse mode is never set when the cursor has not been hidden

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -184,6 +184,7 @@ namespace osu.Framework.Tests.Visual.Input
             setCursorSensivityConfig(1);
             AddToggleStep("Toggle relative mode", setRelativeMode);
             AddToggleStep("Toggle ConfineMouseMode", setConfineMouseModeConfig);
+            AddToggleStep("Toggle cursor visibility", setCursorVisibility);
 
             setRelativeMode(false);
             setConfineMouseModeConfig(false);
@@ -213,6 +214,17 @@ namespace osu.Framework.Tests.Visual.Input
         private MouseHandler getMouseHandler()
         {
             return host.AvailableInputHandlers.OfType<MouseHandler>().FirstOrDefault();
+        }
+
+        private void setCursorVisibility(bool visible)
+        {
+            if (host.Window == null)
+                return;
+
+            if (visible)
+                host.Window.CursorState &= ~CursorState.Hidden;
+            else
+                host.Window.CursorState |= CursorState.Hidden;
         }
 
         private void setConfineMouseModeConfig(bool enabled)

--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -3,6 +3,7 @@
 
 using System.Diagnostics;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
@@ -112,7 +113,7 @@ namespace osu.Framework.Input.Handlers.Mouse
 
                 // handle the case where relative / raw input is active, but the cursor may have exited the window
                 // bounds and is not intended to be confined.
-                if (!window.CursorConfined)
+                if (!window.CursorState.HasFlagFast(CursorState.Confined))
                 {
                     bool positionOutsideWindow = position.X < 0 || position.Y < 0 || position.X >= window.Size.Width || position.Y >= window.Size.Height;
 
@@ -135,7 +136,7 @@ namespace osu.Framework.Input.Handlers.Mouse
 
         private void updateRelativeMode()
         {
-            window.RelativeMouseMode = UseRelativeMode.Value && Enabled.Value && absolutePositionReceived && (isActive.Value && (window.CursorInWindow.Value || window.CursorConfined));
+            window.RelativeMouseMode = UseRelativeMode.Value && Enabled.Value && absolutePositionReceived && (isActive.Value && (window.CursorInWindow.Value || window.CursorState.HasFlagFast(CursorState.Confined)));
 
             if (!window.RelativeMouseMode)
                 transferLastPositionToHostCursor();

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -123,6 +123,9 @@ namespace osu.Framework.Platform
                 if (relativeMouseMode == value)
                     return;
 
+                if (value && !CursorState.HasFlagFast(CursorState.Hidden))
+                    throw new InvalidOperationException($"Cannot set {nameof(RelativeMouseMode)} to true when the cursor is not hidden via {nameof(CursorState)}.");
+
                 relativeMouseMode = value;
                 ScheduleCommand(() => SDL.SDL_SetRelativeMouseMode(value ? SDL.SDL_bool.SDL_TRUE : SDL.SDL_bool.SDL_FALSE));
             }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -222,36 +222,11 @@ namespace osu.Framework.Platform
             }
         }
 
-        private bool cursorVisible = true;
+        private void updateCursorVisibility(bool visible) =>
+            ScheduleCommand(() => SDL.SDL_ShowCursor(visible ? SDL.SDL_ENABLE : SDL.SDL_DISABLE));
 
-        /// <summary>
-        /// Returns or sets the cursor's visibility within the window.
-        /// </summary>
-        public bool CursorVisible
-        {
-            get => cursorVisible;
-            set
-            {
-                cursorVisible = value;
-                ScheduleCommand(() => SDL.SDL_ShowCursor(value ? SDL.SDL_ENABLE : SDL.SDL_DISABLE));
-            }
-        }
-
-        private bool cursorConfined;
-
-        /// <summary>
-        /// Returns or sets whether the cursor is confined to the window's
-        /// drawable area.
-        /// </summary>
-        public bool CursorConfined
-        {
-            get => cursorConfined;
-            set
-            {
-                cursorConfined = value;
-                ScheduleCommand(() => SDL.SDL_SetWindowGrab(SDLWindowHandle, value ? SDL.SDL_bool.SDL_TRUE : SDL.SDL_bool.SDL_FALSE));
-            }
-        }
+        private void updateCursorConfined(bool confined) =>
+            ScheduleCommand(() => SDL.SDL_SetWindowGrab(SDLWindowHandle, confined ? SDL.SDL_bool.SDL_TRUE : SDL.SDL_bool.SDL_FALSE));
 
         private WindowState windowState = WindowState.Normal;
 
@@ -404,8 +379,8 @@ namespace osu.Framework.Platform
 
             CursorStateBindable.ValueChanged += evt =>
             {
-                CursorVisible = !evt.NewValue.HasFlagFast(CursorState.Hidden);
-                CursorConfined = evt.NewValue.HasFlagFast(CursorState.Confined);
+                updateCursorVisibility(!evt.NewValue.HasFlagFast(CursorState.Hidden));
+                updateCursorConfined(evt.NewValue.HasFlagFast(CursorState.Confined));
             };
 
             cursorInWindow.ValueChanged += evt =>


### PR DESCRIPTION
It turns out this was quite simple to implement due to `MouseHandler` already preferring relative mode given circumstances of the game. The result now is that even if the `MouseHandler` is set to prefer relative mode, it will automatically be disabled when the OS cursor is visible. I think this makes sense.

Closes https://github.com/ppy/osu-framework/issues/4309.