### PR TITLE
Add bounding box method for circular arcs

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneCircularArcBoundingBox.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneCircularArcBoundingBox.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Lines;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Utils;
@@ -26,17 +27,21 @@ namespace osu.Framework.Tests.Visual.Drawables
         [BackgroundDependencyLoader]
         private void load()
         {
-            Children = new Drawable[]
+            Child = new Container
             {
-                boundingBox = new Box
+                AutoSizeAxes = Axes.Both,
+                Children = new Drawable[]
                 {
-                    RelativeSizeAxes = Axes.None,
-                    Colour = Color4.Red
-                },
-                path = new SmoothPath
-                {
-                    Colour = Color4.White,
-                    PathRadius = 2
+                    boundingBox = new Box
+                    {
+                        RelativeSizeAxes = Axes.None,
+                        Colour = Color4.Red
+                    },
+                    path = new SmoothPath
+                    {
+                        Colour = Color4.White,
+                        PathRadius = 2
+                    }
                 }
             };
 
@@ -71,6 +76,27 @@ namespace osu.Framework.Tests.Visual.Drawables
 
                 var bounds = PathApproximator.CircularArcBoundingBox(copy);
                 boundingBox.Size = bounds.Size;
+
+                // because SmoothPath's bounding box is not exact,
+                // adjust our box's anchoring so that it's always aligned correctly to encapsulate the arc.
+
+                Anchor anchor = 0;
+
+                if (path.Vertices.All(v => v.X < 0))
+                    anchor |= Anchor.x0;
+                else if (path.Vertices.All(v => v.X > 0))
+                    anchor |= Anchor.x2;
+                else
+                    anchor |= Anchor.x1;
+
+                if (path.Vertices.All(v => v.Y < 0))
+                    anchor |= Anchor.y0;
+                else if (path.Vertices.All(v => v.Y > 0))
+                    anchor |= Anchor.y2;
+                else
+                    anchor |= Anchor.y1;
+
+                boundingBox.Anchor = boundingBox.Origin = anchor;
             });
         }
 

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneCircularArcBoundingBox.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneCircularArcBoundingBox.cs
@@ -1,0 +1,95 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Linq;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Lines;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Utils;
+using osuTK;
+using osuTK.Graphics;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    public class TestSceneCircularArcBoundingBox : FrameworkTestScene
+    {
+        private SmoothPath path;
+        private Box boundingBox;
+
+        private readonly BindableList<Vector2> controlPoints = new BindableList<Vector2>();
+
+        private float startAngle, endAngle, radius;
+
+        [BackgroundDependencyLoader]
+        private void load()
+        {
+            Children = new Drawable[]
+            {
+                boundingBox = new Box
+                {
+                    RelativeSizeAxes = Axes.None,
+                    Colour = Color4.Red
+                },
+                path = new SmoothPath
+                {
+                    Colour = Color4.White,
+                    PathRadius = 2
+                }
+            };
+
+            AddSliderStep("starting angle", 0, 360, 90, angle =>
+            {
+                startAngle = angle;
+                generateControlPoints();
+            });
+
+            AddSliderStep("end angle", 0, 360, 270, angle =>
+            {
+                endAngle = angle;
+                generateControlPoints();
+            });
+
+            AddSliderStep("radius", 1, 300, 150, radius =>
+            {
+                this.radius = radius;
+                generateControlPoints();
+            });
+        }
+
+        protected override void LoadComplete()
+        {
+            controlPoints.BindCollectionChanged((_, __) =>
+            {
+                var copy = controlPoints.ToArray();
+                if (copy.Length != 3)
+                    return;
+
+                path.Vertices = PathApproximator.ApproximateCircularArc(copy);
+
+                var bounds = PathApproximator.CircularArcBoundingBox(copy);
+                boundingBox.Size = bounds.Size;
+            });
+        }
+
+        private void generateControlPoints()
+        {
+            float midpoint = (startAngle + endAngle) / 2;
+
+            Vector2 polarToCartesian(float r, float theta) =>
+                new Vector2(
+                    r * MathF.Cos(MathHelper.DegreesToRadians(theta)),
+                    r * MathF.Sin(MathHelper.DegreesToRadians(theta)));
+
+            controlPoints.Clear();
+            controlPoints.AddRange(new[]
+            {
+                polarToCartesian(radius, startAngle),
+                polarToCartesian(radius, midpoint),
+                polarToCartesian(radius, endAngle)
+            });
+        }
+    }
+}

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -213,6 +213,10 @@ namespace osu.Framework.Utils
             double step = right_angle * pr.Direction;
 
             double quotient = pr.ThetaStart / right_angle;
+            // choose an initial right angle, closest to ThetaStart, going in the direction of the arc.
+            // if the direction/step is positive - choose the smallest multiple of PI / 2 greater than ThetaStart.
+            // if the direction/step is negative - choose the greatest multiple of PI / 2 smaller than ThetaStart.
+            // thanks to this, when looping over quadrant points to check if they lie on the arc, we only need to check against ThetaEnd.
             double closestRightAngle = right_angle * (pr.Direction > 0 ? Math.Ceiling(quotient) : Math.Floor(quotient));
 
             // at most, four quadrant points must be considered.
@@ -220,7 +224,7 @@ namespace osu.Framework.Utils
             {
                 double angle = closestRightAngle + step * i;
 
-                // check whether angle exceeds the range [ThetaStart, ThetaEnd].
+                // check whether angle has exceeded ThetaEnd.
                 // multiplying by Direction eliminates branching caused by the fact that step can be either positive or negative.
                 if (Precision.DefinitelyBigger((angle - pr.ThetaEnd) * pr.Direction, 0))
                     break;

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -214,8 +214,6 @@ namespace osu.Framework.Utils
 
             double quotient = pr.ThetaStart / right_angle;
             // choose an initial right angle, closest to ThetaStart, going in the direction of the arc.
-            // if the direction/step is positive - choose the smallest multiple of PI / 2 greater than ThetaStart.
-            // if the direction/step is negative - choose the greatest multiple of PI / 2 smaller than ThetaStart.
             // thanks to this, when looping over quadrant points to check if they lie on the arc, we only need to check against ThetaEnd.
             double closestRightAngle = right_angle * (pr.Direction > 0 ? Math.Ceiling(quotient) : Math.Floor(quotient));
 

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -280,7 +280,7 @@ namespace osu.Framework.Utils
 
             return new RectangleF(minX, minY, maxX - minX, maxY - minY);
         }
-        
+
         /// <summary>
         /// Computes all arguments necessary to approximate a circular arc given its control points.
         /// These arguments are then passed to the given function, the result of which is returned.

--- a/osu.Framework/Utils/PathApproximator.cs
+++ b/osu.Framework/Utils/PathApproximator.cs
@@ -167,7 +167,7 @@ namespace osu.Framework.Utils
         public static List<Vector2> ApproximateCircularArc(ReadOnlySpan<Vector2> controlPoints)
         {
             CircularArcProperties pr = circularArcProperties(controlPoints);
-            if (pr == null)
+            if (!pr.IsValid)
                 return ApproximateBezier(controlPoints);
 
             // We select the amount of points for the approximation by requiring the discrete curvature
@@ -198,7 +198,7 @@ namespace osu.Framework.Utils
         public static RectangleF CircularArcBoundingBox(ReadOnlySpan<Vector2> controlPoints)
         {
             CircularArcProperties pr = circularArcProperties(controlPoints);
-            if (pr == null)
+            if (!pr.IsValid)
                 return RectangleF.Empty;
 
             // We find the bounding box using the end-points, as well as
@@ -288,18 +288,20 @@ namespace osu.Framework.Utils
             return result;
         }
 
-        private class CircularArcProperties
+        private readonly struct CircularArcProperties
         {
+            public readonly bool IsValid;
             public readonly double ThetaStart;
             public readonly double ThetaRange;
             public readonly double Direction;
-            public double ThetaEnd => ThetaStart + ThetaRange * Direction;
-
             public readonly float Radius;
             public readonly Vector2 Centre;
 
+            public double ThetaEnd => ThetaStart + ThetaRange * Direction;
+
             public CircularArcProperties(double thetaStart, double thetaRange, double direction, float radius, Vector2 centre)
             {
+                IsValid = true;
                 ThetaStart = thetaStart;
                 ThetaRange = thetaRange;
                 Direction = direction;
@@ -321,7 +323,7 @@ namespace osu.Framework.Utils
 
             // If we have a degenerate triangle where a side-length is almost zero, then give up and fallback to a more numerically stable method.
             if (Precision.AlmostEquals(0, (b.Y - a.Y) * (c.X - a.X) - (b.X - a.X) * (c.Y - a.Y)))
-                return null;
+                return default; // Implicitly sets `IsValid` to false
 
             // See: https://en.wikipedia.org/wiki/Circumscribed_circle#Cartesian_coordinates_2
             float d = 2 * (a.X * (b - c).Y + b.X * (c - a).Y + c.X * (a - b).Y);


### PR DESCRIPTION
We only need the end-points and each side of the arc to compute the bounding box. This method should be less intensive and marginally more accurate compared to approximating the entire circular arc and then computing the bounding box from resulting points.

Math logic used is the same, hence `circularArcHelper`. Because the interesting output from that helper method is not just one value, it passes them on to a given function instead. An alternative to this would be using the `out` keyword, or a custom struct, not sure which is preferred.

---

Main use case is https://github.com/ppy/osu/pull/12122. Here the bounding box is used as a limit for how large a PerfectCurve path is allowed to be before defaulting to Bezier. Said bounding box is computed every time the control points update, for example while dragging nodes or initially placing sliders.