### PR TITLE
Avoid feedback from input devices reporting via multiple handlers

### DIFF
--- a/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
+++ b/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
@@ -23,8 +23,6 @@ namespace osu.Framework.Android.Input
 
         public override bool IsActive => true;
 
-        public override int Priority => 0;
-
         public override bool Initialize(GameHost host) => true;
 
         private void keyDown(Keycode keycode, KeyEvent e)

--- a/osu.Framework.Android/Input/AndroidTouchHandler.cs
+++ b/osu.Framework.Android/Input/AndroidTouchHandler.cs
@@ -19,8 +19,6 @@ namespace osu.Framework.Android.Input
 
         public override bool IsActive => true;
 
-        public override int Priority => 0;
-
         public AndroidTouchHandler(AndroidGameView view)
         {
             this.view = view;

--- a/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSKeyboardHandler.cs
@@ -251,8 +251,6 @@ namespace osu.Framework.iOS.Input
         internal bool KeyboardActive;
         public override bool IsActive => KeyboardActive;
 
-        public override int Priority => 0;
-
         protected override void Dispose(bool disposing)
         {
             view.KeyboardTextField.HandleShouldChangeCharacters -= handleShouldChangeCharacters;

--- a/osu.Framework.iOS/Input/IOSMouseHandler.cs
+++ b/osu.Framework.iOS/Input/IOSMouseHandler.cs
@@ -33,7 +33,6 @@ namespace osu.Framework.iOS.Input
         }
 
         public override bool IsActive => true;
-        public override int Priority => 1; // Touches always take priority
 
         public override bool Initialize(GameHost host)
         {

--- a/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
+++ b/osu.Framework.iOS/Input/IOSRawKeyboardHandler.cs
@@ -15,8 +15,6 @@ namespace osu.Framework.iOS.Input
         internal bool KeyboardActive = true;
         public override bool IsActive => KeyboardActive;
 
-        public override int Priority => 0;
-
         public override bool Initialize(GameHost host)
         {
             if (!(UIApplication.SharedApplication is GameUIApplication game))

--- a/osu.Framework.iOS/Input/IOSTouchHandler.cs
+++ b/osu.Framework.iOS/Input/IOSTouchHandler.cs
@@ -159,8 +159,6 @@ namespace osu.Framework.iOS.Input
 
         public override bool IsActive => true;
 
-        public override int Priority => 0;
-
         public override bool Initialize(GameHost host) => true;
     }
 }

--- a/osu.Framework/Input/CustomInputManager.cs
+++ b/osu.Framework/Input/CustomInputManager.cs
@@ -21,9 +21,7 @@ namespace osu.Framework.Input
         {
             if (!handler.Initialize(Host)) return;
 
-            var existingHandlers = new List<InputHandler>(inputHandlers);
-            existingHandlers.Add(handler);
-            inputHandlers = existingHandlers.ToImmutableArray();
+            inputHandlers = inputHandlers.Append(handler).ToImmutableArray();
         }
 
         protected void RemoveHandler(InputHandler handler)

--- a/osu.Framework/Input/CustomInputManager.cs
+++ b/osu.Framework/Input/CustomInputManager.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using osu.Framework.Input.Handlers;

--- a/osu.Framework/Input/CustomInputManager.cs
+++ b/osu.Framework/Input/CustomInputManager.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -23,16 +22,7 @@ namespace osu.Framework.Input
             if (!handler.Initialize(Host)) return;
 
             var existingHandlers = new List<InputHandler>(inputHandlers);
-
-            // find the correct location to insert based on priority.
-            int index = existingHandlers.BinarySearch(handler, new InputHandlerPriorityComparer());
-
-            if (index < 0)
-            {
-                index = ~index;
-            }
-
-            existingHandlers.Insert(index, handler);
+            existingHandlers.Add(handler);
             inputHandlers = existingHandlers.ToImmutableArray();
         }
 
@@ -47,17 +37,6 @@ namespace osu.Framework.Input
                 h.Dispose();
 
             base.Dispose(isDisposing);
-        }
-
-        private class InputHandlerPriorityComparer : IComparer<InputHandler>
-        {
-            public int Compare(InputHandler h1, InputHandler h2)
-            {
-                if (h1 == null) throw new ArgumentNullException(nameof(h1));
-                if (h2 == null) throw new ArgumentNullException(nameof(h2));
-
-                return h2.Priority.CompareTo(h1.Priority);
-            }
         }
     }
 }

--- a/osu.Framework/Input/Handlers/InputHandler.cs
+++ b/osu.Framework/Input/Handlers/InputHandler.cs
@@ -61,11 +61,6 @@ namespace osu.Framework.Input.Handlers
         public abstract bool IsActive { get; }
 
         /// <summary>
-        /// Indicated how high of a priority this handler has. The active handler with the highest priority is controlling the cursor at any given time.
-        /// </summary>
-        public abstract int Priority { get; }
-
-        /// <summary>
         /// A user-readable description of this input handler, for display in settings.
         /// </summary>
         public virtual string Description => ToString().Replace("Handler", string.Empty);

--- a/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
+++ b/osu.Framework/Input/Handlers/Joystick/JoystickHandler.cs
@@ -18,8 +18,6 @@ namespace osu.Framework.Input.Handlers.Joystick
 
         public override bool IsActive => true;
 
-        public override int Priority => 0;
-
         public override bool Initialize(GameHost host)
         {
             if (!base.Initialize(host))

--- a/osu.Framework/Input/Handlers/Keyboard/KeyboardHandler.cs
+++ b/osu.Framework/Input/Handlers/Keyboard/KeyboardHandler.cs
@@ -14,8 +14,6 @@ namespace osu.Framework.Input.Handlers.Keyboard
 
         public override bool IsActive => true;
 
-        public override int Priority => 0;
-
         public override bool Initialize(GameHost host)
         {
             if (!base.Initialize(host))

--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -19,8 +19,6 @@ namespace osu.Framework.Input.Handlers.Midi
     {
         public override string Description => "MIDI";
         public override bool IsActive => active;
-        public override int Priority => 0;
-
         private bool active = true;
 
         private ScheduledDelegate scheduledRefreshDevices;

--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -37,8 +37,6 @@ namespace osu.Framework.Input.Handlers.Mouse
 
         public override bool IsActive => true;
 
-        public override int Priority => 0;
-
         private SDL2DesktopWindow window;
 
         private Vector2? lastPosition;

--- a/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
+++ b/osu.Framework/Input/Handlers/Tablet/OpenTabletDriverHandler.cs
@@ -18,8 +18,6 @@ namespace osu.Framework.Input.Handlers.Tablet
     {
         public override bool IsActive => tabletDriver.EnableInput;
 
-        public override int Priority => 0;
-
         private TabletDriver tabletDriver;
 
         public Bindable<Vector2> AreaOffset { get; } = new Bindable<Vector2>();

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -532,7 +532,7 @@ namespace osu.Framework.Input
                     // report mouse position data at a time. Handlers are given priority based on their constructed order.
                     // Devices which higher priority are allowed to take over control immediately, after which a delay is enforced (on every subsequent positional report)
                     // before a lower priority device can obtain control.
-                    if (i is MousePositionAbsoluteInput)
+                    if (i is MousePositionAbsoluteInput || i is MousePositionRelativeInput)
                     {
                         if (mouseSource == null // a new device taking control when no existing preference is present.
                             || mouseSource == h // if this is the device which currently has control, renew the debounce delay.

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -500,7 +500,7 @@ namespace osu.Framework.Input
 
         private InputHandler mouseSource;
 
-        private double sourceDebounceTimeRemaining;
+        private double mouseSourceDebounceTimeRemaining;
 
         private double lastPendingInputRetrievalTime;
 
@@ -537,10 +537,10 @@ namespace osu.Framework.Input
                         if (mouseSource == null // a new device taking control when no existing preference is present.
                             || mouseSource == h // if this is the device which currently has control, renew the debounce delay.
                             || !reachedPreviousMouseSource // we have not reached the previous mouse source, so a higher priority device can take over control.
-                            || sourceDebounceTimeRemaining <= 0) // a lower priority device taking over control if the debounce delay has elapsed.
+                            || mouseSourceDebounceTimeRemaining <= 0) // a lower priority device taking over control if the debounce delay has elapsed.
                         {
                             mouseSource = h;
-                            sourceDebounceTimeRemaining = mouse_source_debounce_time;
+                            mouseSourceDebounceTimeRemaining = mouse_source_debounce_time;
                         }
                         else
                         {
@@ -557,7 +557,7 @@ namespace osu.Framework.Input
                     reachedPreviousMouseSource = true;
             }
 
-            sourceDebounceTimeRemaining -= elapsed;
+            mouseSourceDebounceTimeRemaining -= elapsed;
             return inputs;
         }
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -553,6 +553,7 @@ namespace osu.Framework.Input
                 }
 
                 // track whether we have passed the handler which is currently in control of positional handling.
+                // importantly, this is updated regardless of whether the handler has reported any new inputs.
                 if (mouseSource == h)
                     reachedPreviousMouseSource = true;
             }

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -88,12 +88,13 @@ namespace osu.Framework.Platform
             new InputHandler[]
             {
                 new KeyboardHandler(),
+#if NET5_0
+                // tablet should get priority over mouse to correctly handle cases where tablet drivers report as mice as well.
+                new Input.Handlers.Tablet.OpenTabletDriverHandler(),
+#endif
                 new MouseHandler(),
                 new JoystickHandler(),
                 new MidiHandler(),
-#if NET5_0
-                new Input.Handlers.Tablet.OpenTabletDriverHandler(),
-#endif
             };
 
         public override Task SendMessageAsync(IpcMessage message) => ipcProvider.SendMessageAsync(message);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -904,6 +904,9 @@ namespace osu.Framework.Platform
             DrawThread.Scheduler.Add(() => Window.VerticalSync = frameSyncMode.Value == FrameSync.VSync);
         }
 
+        /// <summary>
+        /// Construct all input handlers for this host. The order here decides the priority given to handlers, with the earliest occurring having higher priority.
+        /// </summary>
         protected abstract IEnumerable<InputHandler> CreateAvailableInputHandlers();
 
         public ImmutableArray<InputHandler> AvailableInputHandlers { get; private set; }

--- a/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
+++ b/osu.Framework/Platform/Windows/WindowsMouseHandler.cs
@@ -24,7 +24,6 @@ namespace osu.Framework.Platform.Windows
         private SDL2DesktopWindow window;
 
         public override bool IsActive => Enabled.Value;
-        public override int Priority => 0;
 
         public override bool Initialize(GameHost host)
         {

--- a/osu.Framework/Testing/Input/ManualInputManager.cs
+++ b/osu.Framework/Testing/Input/ManualInputManager.cs
@@ -137,7 +137,6 @@ namespace osu.Framework.Testing.Input
         {
             public override bool Initialize(GameHost host) => true;
             public override bool IsActive => true;
-            public override int Priority => 0;
 
             public void EnqueueInput(IInput input)
             {


### PR DESCRIPTION
With the introduction of tablet support, there have been a number of users reporting their mouse jumping or "rubber banding" between two locations. The cause of this is having tablet drivers or software running external to a game, reporting back as mouse cursor updates, in addition to our local handling of tablets via OTD.

Until now, the general advice for such cases is to "close the other drivers/software", but this is a pretty bad user experience. For instance, an illustration may use the wacom software for their graphical work while also using the tablet to play games.

This PR aims to ignore externally occuring mouse events while a tablet is reporting via OTD. It may also be used in the futrue for other input handler where similar patterns can occur. This is done via a simple debounce pattern with a few basic rules:

- `InputHandler`s which are initialised higher in the construction order via `CreateAvailableInputHandlers` have priority over positional input. If a lower priority device was previously updating the cursor, a higher (or "earlier") device can immediately take over.
- A lower priority (or "later") device can take over the positional input flow after a short debounce window. This is set to 50ms, but as mentioned in the inline comments can be shortened if required. It feels quite okay as is, though.


https://user-images.githubusercontent.com/191335/112793588-824a3300-90a0-11eb-88fc-e6e7372aa9ba.mp4



Closes https://github.com/ppy/osu/issues/12171.


# Breaking Changes

## InputHandler no longer has a Priority property

Priority is now decided by the construction order of `InputHandler`s in `CreateAvailableInputHandlers`.