### PR TITLE
Transfer cursor position updates from non-mouse input handlers back to OS cursor

### DIFF
--- a/osu.Framework/Input/Handlers/INeedsMousePositionFeedback.cs
+++ b/osu.Framework/Input/Handlers/INeedsMousePositionFeedback.cs
@@ -14,6 +14,7 @@ namespace osu.Framework.Input.Handlers
         /// Receives the final mouse position from an <see cref="InputManager"/>.
         /// </summary>
         /// <param name="position">The final mouse position.</param>
-        void FeedbackMousePositionChange(Vector2 position);
+        /// <param name="isSelfFeedback">Whether the feedback was triggered from this handler.</param>
+        void FeedbackMousePositionChange(Vector2 position, bool isSelfFeedback);
     }
 }

--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -101,10 +101,15 @@ namespace osu.Framework.Input.Handlers.Mouse
             return true;
         }
 
-        public void FeedbackMousePositionChange(Vector2 position)
+        public void FeedbackMousePositionChange(Vector2 position, bool isSelfFeedback)
         {
             if (!Enabled.Value)
                 return;
+
+            if (!isSelfFeedback)
+                // if another handler has updated the cursor position, handle updating the OS cursor so we can seamlessly revert
+                // to mouse control at any point.
+                window.UpdateMousePosition(position);
 
             if (window.RelativeMouseMode)
             {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -808,7 +808,7 @@ namespace osu.Framework.Input
             foreach (var h in InputHandlers)
             {
                 if (h.Enabled.Value && h is INeedsMousePositionFeedback handler)
-                    handler.FeedbackMousePositionChange(mouse.Position);
+                    handler.FeedbackMousePositionChange(mouse.Position, h == mouseSource);
             }
 
             handleMouseMove(state, e.LastPosition);


### PR DESCRIPTION
Tested on windows and macOS to not break anything.

Closes #4317.