### PR TITLE
Improve messaging from SDL2 GL context failures

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2GraphicsBackend.cs
+++ b/osu.Framework/Platform/SDL2/SDL2GraphicsBackend.cs
@@ -22,7 +22,12 @@ namespace osu.Framework.Platform.SDL2
         protected override IntPtr CreateContext()
         {
             SDL.SDL_GL_SetAttribute(SDL.SDL_GLattr.SDL_GL_CONTEXT_PROFILE_MASK, SDL.SDL_GLprofile.SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);
-            return SDL.SDL_GL_CreateContext(sdlWindowHandle);
+
+            IntPtr context = SDL.SDL_GL_CreateContext(sdlWindowHandle);
+            if (context == IntPtr.Zero)
+                throw new InvalidOperationException($"Failed to create an SDL2 GL context ({SDL.SDL_GetError()})");
+
+            return context;
         }
 
         protected override void MakeCurrent(IntPtr context) => SDL.SDL_GL_MakeCurrent(sdlWindowHandle, context);


### PR DESCRIPTION
As seen in https://github.com/ppy/osu-framework/issues/4324

Shows up as something like:
```
Unhandled exception. System.InvalidOperationException: Failed to create an SDL2 GL context (Invalid window)
   at osu.Framework.Platform.SDL2.SDL2GraphicsBackend.CreateContext() in /home/smgi/Repos/osu-framework/osu.Framework/Platform/SDL2/SDL2GraphicsBackend.cs:line 28
   at osu.Framework.Platform.PassthroughGraphicsBackend.Initialise(IWindow window) in /home/smgi/Repos/osu-framework/osu.Framework/Platform/PassthroughGraphicsBackend.cs:line 40
   at osu.Framework.Platform.SDL2.SDL2GraphicsBackend.Initialise(IWindow window) in /home/smgi/Repos/osu-framework/osu.Framework/Platform/SDL2/SDL2GraphicsBackend.cs:line 45
   at osu.Framework.Platform.SDL2DesktopWindow.Create() in /home/smgi/Repos/osu-framework/osu.Framework/Platform/SDL2DesktopWindow.cs:line 418
   at osu.Framework.Platform.GameHost.Run(Game game) in /home/smgi/Repos/osu-framework/osu.Framework/Platform/GameHost.cs:line 595
   at osu.Framework.Tests.Program.Main(String[] args) in /home/smgi/Repos/osu-framework/osu.Framework.Tests/Program.cs:line 23
```