### PR TITLE
Remove unnecessary redirection methods when triggering SDL window events

### DIFF
--- a/osu.Framework/Platform/MacOS/MacOSWindow.cs
+++ b/osu.Framework/Platform/MacOS/MacOSWindow.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Platform.MacOS
             float scrollingDeltaX = Cocoa.SendFloat(theEvent, sel_scrollingdeltax);
             float scrollingDeltaY = Cocoa.SendFloat(theEvent, sel_scrollingdeltay);
 
-            ScheduleEvent(() => OnMouseWheel(new Vector2(scrollingDeltaX * scale_factor, scrollingDeltaY * scale_factor), true));
+            ScheduleEvent(() => TriggerMouseWheel(new Vector2(scrollingDeltaX * scale_factor, scrollingDeltaY * scale_factor), true));
         }
     }
 }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -144,7 +144,7 @@ namespace osu.Framework.Platform
                 if (value.Equals(size)) return;
 
                 size = value;
-                ScheduleEvent(() => OnResized());
+                ScheduleEvent(() => Resized?.Invoke());
             }
         }
 
@@ -385,14 +385,6 @@ namespace osu.Framework.Platform
                 updateCursorVisibility(!evt.NewValue.HasFlagFast(CursorState.Hidden));
                 updateCursorConfined(evt.NewValue.HasFlagFast(CursorState.Confined));
             };
-
-            cursorInWindow.ValueChanged += evt =>
-            {
-                if (evt.NewValue)
-                    OnMouseEntered();
-                else
-                    OnMouseLeft();
-            };
         }
 
         /// <summary>
@@ -465,10 +457,10 @@ namespace osu.Framework.Platform
 
                 eventScheduler.Update();
 
-                OnUpdate();
+                Update?.Invoke();
             }
 
-            OnExited();
+            Exited?.Invoke();
 
             if (SDLWindowHandle != IntPtr.Zero)
                 SDL.SDL_DestroyWindow(SDLWindowHandle);
@@ -500,7 +492,7 @@ namespace osu.Framework.Platform
         /// </summary>
         public void RequestClose() => ScheduleEvent(() =>
         {
-            if (!OnExitRequested())
+            if (ExitRequested?.Invoke() != true)
                 Close();
         });
 
@@ -530,15 +522,15 @@ namespace osu.Framework.Platform
         {
             // SDL reports axis values in the range short.MinValue to short.MaxValue, so we scale and clamp it to the range of -1f to 1f
             var clamped = Math.Clamp((float)axisValue / short.MaxValue, -1f, 1f);
-            ScheduleEvent(() => OnJoystickAxisChanged(new JoystickAxis(axisSource, clamped)));
+            ScheduleEvent(() => JoystickAxisChanged?.Invoke(new JoystickAxis(axisSource, clamped)));
         }
 
         private void enqueueJoystickButtonInput(JoystickButton button, bool isPressed)
         {
             if (isPressed)
-                ScheduleEvent(() => OnJoystickButtonDown(button));
+                ScheduleEvent(() => JoystickButtonDown?.Invoke(button));
             else
-                ScheduleEvent(() => OnJoystickButtonUp(button));
+                ScheduleEvent(() => JoystickButtonUp?.Invoke(button));
         }
 
         /// <summary>
@@ -577,7 +569,7 @@ namespace osu.Framework.Platform
             var rx = x - pos.X;
             var ry = y - pos.Y;
 
-            ScheduleEvent(() => OnMouseMove(new Vector2(rx * Scale, ry * Scale)));
+            ScheduleEvent(() => MouseMove?.Invoke(new Vector2(rx * Scale, ry * Scale)));
         }
 
         #region SDL Event Handling
@@ -699,7 +691,7 @@ namespace osu.Framework.Platform
                 case SDL.SDL_EventType.SDL_DROPFILE:
                     var str = SDL.UTF8_ToManaged(evtDrop.file, true);
                     if (str != null)
-                        ScheduleEvent(() => OnDragDrop(str));
+                        ScheduleEvent(() => DragDrop?.Invoke(str));
 
                     break;
             }
@@ -816,7 +808,7 @@ namespace osu.Framework.Platform
         }
 
         private void handleMouseWheelEvent(SDL.SDL_MouseWheelEvent evtWheel) =>
-            ScheduleEvent(() => OnMouseWheel(new Vector2(evtWheel.x, evtWheel.y), false));
+            ScheduleEvent(() => TriggerMouseWheel(new Vector2(evtWheel.x, evtWheel.y), false));
 
         private void handleMouseButtonEvent(SDL.SDL_MouseButtonEvent evtButton)
         {
@@ -825,11 +817,11 @@ namespace osu.Framework.Platform
             switch (evtButton.type)
             {
                 case SDL.SDL_EventType.SDL_MOUSEBUTTONDOWN:
-                    ScheduleEvent(() => OnMouseDown(button));
+                    ScheduleEvent(() => MouseDown?.Invoke(button));
                     break;
 
                 case SDL.SDL_EventType.SDL_MOUSEBUTTONUP:
-                    ScheduleEvent(() => OnMouseUp(button));
+                    ScheduleEvent(() => MouseUp?.Invoke(button));
                     break;
             }
         }
@@ -837,9 +829,9 @@ namespace osu.Framework.Platform
         private void handleMouseMotionEvent(SDL.SDL_MouseMotionEvent evtMotion)
         {
             if (SDL.SDL_GetRelativeMouseMode() == SDL.SDL_bool.SDL_FALSE)
-                ScheduleEvent(() => OnMouseMove(new Vector2(evtMotion.x * Scale, evtMotion.y * Scale)));
+                ScheduleEvent(() => MouseMove?.Invoke(new Vector2(evtMotion.x * Scale, evtMotion.y * Scale)));
             else
-                ScheduleEvent(() => OnMouseMoveRelative(new Vector2(evtMotion.xrel * Scale, evtMotion.yrel * Scale)));
+                ScheduleEvent(() => MouseMoveRelative?.Invoke(new Vector2(evtMotion.xrel * Scale, evtMotion.yrel * Scale)));
         }
 
         private unsafe void handleTextInputEvent(SDL.SDL_TextInputEvent evtText)
@@ -851,7 +843,7 @@ namespace osu.Framework.Platform
             string text = Marshal.PtrToStringUTF8(ptr) ?? "";
 
             foreach (char c in text)
-                ScheduleEvent(() => OnKeyTyped(c));
+                ScheduleEvent(() => KeyTyped?.Invoke(c));
         }
 
         private void handleTextEditingEvent(SDL.SDL_TextEditingEvent evtEdit)
@@ -868,11 +860,11 @@ namespace osu.Framework.Platform
             switch (evtKey.type)
             {
                 case SDL.SDL_EventType.SDL_KEYDOWN:
-                    ScheduleEvent(() => OnKeyDown(key));
+                    ScheduleEvent(() => KeyDown?.Invoke(key));
                     break;
 
                 case SDL.SDL_EventType.SDL_KEYUP:
-                    ScheduleEvent(() => OnKeyUp(key));
+                    ScheduleEvent(() => KeyUp?.Invoke(key));
                     break;
             }
         }
@@ -883,14 +875,6 @@ namespace osu.Framework.Platform
 
             switch (evtWindow.windowEvent)
             {
-                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SHOWN:
-                    ScheduleEvent(OnShown);
-                    break;
-
-                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_HIDDEN:
-                    ScheduleEvent(OnHidden);
-                    break;
-
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MOVED:
                     // explicitly requery as there are occasions where what SDL has provided us with is not up-to-date.
                     SDL.SDL_GetWindowPosition(SDLWindowHandle, out int x, out int y);
@@ -900,7 +884,7 @@ namespace osu.Framework.Platform
                     {
                         position = newPosition;
                         storeWindowPositionToConfig();
-                        ScheduleEvent(() => OnMoved(newPosition));
+                        ScheduleEvent(() => Moved?.Invoke(newPosition));
                     }
 
                     break;
@@ -914,22 +898,22 @@ namespace osu.Framework.Platform
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_ENTER:
                     cursorInWindow.Value = true;
-                    ScheduleEvent(OnMouseEntered);
+                    ScheduleEvent(() => MouseEntered?.Invoke());
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_LEAVE:
                     cursorInWindow.Value = false;
-                    ScheduleEvent(OnMouseLeft);
+                    ScheduleEvent(() => MouseLeft?.Invoke());
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESTORED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_GAINED:
-                    ScheduleEvent(OnFocusGained);
+                    ScheduleEvent(() => Focused = true);
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_FOCUS_LOST:
-                    ScheduleEvent(OnFocusLost);
+                    ScheduleEvent(() => Focused = false);
                     break;
 
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
@@ -963,7 +947,7 @@ namespace osu.Framework.Platform
 
             if (windowState != stateBefore)
             {
-                ScheduleEvent(() => OnWindowStateChanged(windowState));
+                ScheduleEvent(() => WindowStateChanged?.Invoke(windowState));
                 updateMaximisedState();
             }
 
@@ -973,7 +957,10 @@ namespace osu.Framework.Platform
             {
                 displayIndex = newDisplayIndex;
                 currentDisplay = Displays.ElementAtOrDefault(displayIndex) ?? PrimaryDisplay;
-                ScheduleEvent(() => OnDisplayChanged(currentDisplay));
+                ScheduleEvent(() =>
+                {
+                    CurrentDisplayBindable.Value = currentDisplay;
+                });
             }
         }
 
@@ -1093,18 +1080,6 @@ namespace osu.Framework.Platform
 
             return currentDisplay.Bounds.Size;
         }
-
-        protected void OnHidden() { }
-
-        protected void OnShown() { }
-
-        protected void OnWindowStateChanged(WindowState state) => WindowStateChanged?.Invoke(state);
-
-        protected void OnDisplayChanged(Display display) => CurrentDisplayBindable.Value = display;
-
-        protected void OnFocusGained() => Focused = true;
-
-        protected void OnFocusLost() => Focused = false;
 
         private MouseButton mouseButtonFromEvent(byte button)
         {
@@ -1338,7 +1313,7 @@ namespace osu.Framework.Platform
         public event Action<WindowState> WindowStateChanged;
 
         /// <summary>
-        /// Invoked when the user attempts to close the window.
+        /// Invoked when the user attempts to close the window. Return value of true will cancel exit.
         /// </summary>
         public event Func<bool> ExitRequested;
 
@@ -1366,6 +1341,8 @@ namespace osu.Framework.Platform
         /// Invoked when the user scrolls the mouse wheel over the window.
         /// </summary>
         public event Action<Vector2, bool> MouseWheel;
+
+        protected void TriggerMouseWheel(Vector2 delta, bool precise) => MouseWheel?.Invoke(delta, precise);
 
         /// <summary>
         /// Invoked when the user moves the mouse cursor within the window.
@@ -1421,32 +1398,6 @@ namespace osu.Framework.Platform
         /// Invoked when the user drops a file into the window.
         /// </summary>
         public event Action<string> DragDrop;
-
-        #endregion
-
-        #region Event Invocation
-
-        protected void OnUpdate() => Update?.Invoke();
-
-        protected void OnResized() => Resized?.Invoke();
-
-        protected bool OnExitRequested() => ExitRequested?.Invoke() ?? false;
-        protected void OnExited() => Exited?.Invoke();
-        protected void OnMouseEntered() => MouseEntered?.Invoke();
-        protected void OnMouseLeft() => MouseLeft?.Invoke();
-        protected void OnMoved(Point point) => Moved?.Invoke(point);
-        protected void OnMouseWheel(Vector2 delta, bool precise) => MouseWheel?.Invoke(delta, precise);
-        protected void OnMouseMove(Vector2 position) => MouseMove?.Invoke(position);
-        protected void OnMouseMoveRelative(Vector2 position) => MouseMoveRelative?.Invoke(position);
-        protected void OnMouseDown(MouseButton button) => MouseDown?.Invoke(button);
-        protected void OnMouseUp(MouseButton button) => MouseUp?.Invoke(button);
-        protected void OnKeyDown(Key key) => KeyDown?.Invoke(key);
-        protected void OnKeyUp(Key key) => KeyUp?.Invoke(key);
-        protected void OnKeyTyped(char c) => KeyTyped?.Invoke(c);
-        protected void OnJoystickAxisChanged(JoystickAxis axis) => JoystickAxisChanged?.Invoke(axis);
-        protected void OnJoystickButtonDown(JoystickButton button) => JoystickButtonDown?.Invoke(button);
-        protected void OnJoystickButtonUp(JoystickButton button) => JoystickButtonUp?.Invoke(button);
-        protected void OnDragDrop(string file) => DragDrop?.Invoke(file);
 
         #endregion
 


### PR DESCRIPTION
Just looking to make tracking flow a touch easier when working with this class. These were left over from a forgotten time.