### PR TITLE
Add left/right modifier support to KeyBindingContainer

### DIFF
--- a/osu.Framework.Tests/Input/KeyCombinationModifierTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationModifierTest.cs
@@ -1,0 +1,43 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Framework.Tests.Input
+{
+    [TestFixture]
+    public class KeyCombinationModifierTest
+    {
+        private static readonly object[][] key_combination_display_test_cases =
+        {
+            // test single combination matches.
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.LShift), false, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.RShift), false, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift), false, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.RShift), false, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.RShift), false, true },
+
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.LShift), true, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.RShift), true, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift), true, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.RShift), true, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.RShift), true, true },
+
+            // test multiple combination matches.
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.LShift), false, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.RShift), false, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.Shift, InputKey.RShift), false, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.Shift, InputKey.RShift), false, true },
+
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.LShift), true, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.RShift), true, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.Shift, InputKey.RShift), true, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.Shift, InputKey.RShift), true, true },
+        };
+
+        [TestCaseSource(nameof(key_combination_display_test_cases))]
+        public void TestLeftRightModifierHandling(KeyCombination candidate, KeyCombination pressed, bool exactModifiers, bool shouldContain)
+            => Assert.AreEqual(shouldContain, KeyCombination.ContainsAll(candidate.Keys, pressed.Keys, exactModifiers));
+    }
+}

--- a/osu.Framework.Tests/Input/KeyCombinationModifierTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationModifierTest.cs
@@ -12,32 +12,43 @@ namespace osu.Framework.Tests.Input
         private static readonly object[][] key_combination_display_test_cases =
         {
             // test single combination matches.
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.LShift), false, true },
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.RShift), false, true },
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift), false, true },
-            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.RShift), false, false },
-            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.RShift), false, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.LShift), KeyCombinationMatchingMode.Any, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.RShift), KeyCombinationMatchingMode.Any, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift), KeyCombinationMatchingMode.Any, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.RShift), KeyCombinationMatchingMode.Any, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.RShift), KeyCombinationMatchingMode.Any, true },
 
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.LShift), true, true },
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.RShift), true, true },
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift), true, true },
-            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.RShift), true, false },
-            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.RShift), true, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.LShift), KeyCombinationMatchingMode.Exact, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.RShift), KeyCombinationMatchingMode.Exact, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift), KeyCombinationMatchingMode.Exact, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.RShift), KeyCombinationMatchingMode.Exact, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.RShift), KeyCombinationMatchingMode.Exact, true },
+
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.LShift), KeyCombinationMatchingMode.Modifiers, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.RShift), KeyCombinationMatchingMode.Modifiers, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift), KeyCombinationMatchingMode.Modifiers, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.RShift), KeyCombinationMatchingMode.Modifiers, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.RShift), KeyCombinationMatchingMode.Modifiers, true },
 
             // test multiple combination matches.
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.LShift), false, true },
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.RShift), false, true },
-            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.Shift, InputKey.RShift), false, false },
-            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.Shift, InputKey.RShift), false, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.LShift), KeyCombinationMatchingMode.Any, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.RShift), KeyCombinationMatchingMode.Any, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.Shift, InputKey.RShift), KeyCombinationMatchingMode.Any, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.Shift, InputKey.RShift), KeyCombinationMatchingMode.Any, true },
 
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.LShift), true, true },
-            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.RShift), true, true },
-            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.Shift, InputKey.RShift), true, false },
-            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.Shift, InputKey.RShift), true, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.LShift), KeyCombinationMatchingMode.Exact, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.RShift), KeyCombinationMatchingMode.Exact, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.Shift, InputKey.RShift), KeyCombinationMatchingMode.Exact, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.Shift, InputKey.RShift), KeyCombinationMatchingMode.Exact, true },
+
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.LShift), KeyCombinationMatchingMode.Modifiers, true },
+            new object[] { new KeyCombination(InputKey.Shift), new KeyCombination(InputKey.Shift, InputKey.RShift), KeyCombinationMatchingMode.Modifiers, true },
+            new object[] { new KeyCombination(InputKey.LShift), new KeyCombination(InputKey.Shift, InputKey.RShift), KeyCombinationMatchingMode.Modifiers, false },
+            new object[] { new KeyCombination(InputKey.RShift), new KeyCombination(InputKey.Shift, InputKey.RShift), KeyCombinationMatchingMode.Modifiers, true },
         };
 
         [TestCaseSource(nameof(key_combination_display_test_cases))]
-        public void TestLeftRightModifierHandling(KeyCombination candidate, KeyCombination pressed, bool exactModifiers, bool shouldContain)
-            => Assert.AreEqual(shouldContain, KeyCombination.ContainsAll(candidate.Keys, pressed.Keys, exactModifiers));
+        public void TestLeftRightModifierHandling(KeyCombination candidate, KeyCombination pressed, KeyCombinationMatchingMode matchingMode, bool shouldContain)
+            => Assert.AreEqual(shouldContain, KeyCombination.ContainsAll(candidate.Keys, pressed.Keys, matchingMode));
     }
 }

--- a/osu.Framework.Tests/Input/KeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationTest.cs
@@ -11,10 +11,14 @@ namespace osu.Framework.Tests.Input
     {
         private static readonly object[][] key_combination_display_test_cases =
         {
-            new object[] { new KeyCombination(InputKey.LAlt, InputKey.F4), "Alt-F4" },
-            new object[] { new KeyCombination(InputKey.D, InputKey.LControl), "Ctrl-D" },
-            new object[] { new KeyCombination(InputKey.LShift, InputKey.F, InputKey.LControl), "Ctrl-Shift-F" },
-            new object[] { new KeyCombination(InputKey.LAlt, InputKey.LControl, InputKey.LSuper, InputKey.LShift), "Ctrl-Alt-Shift-Win" }
+            new object[] { new KeyCombination(InputKey.Alt, InputKey.F4), "Alt-F4" },
+            new object[] { new KeyCombination(InputKey.D, InputKey.Control), "Ctrl-D" },
+            new object[] { new KeyCombination(InputKey.Shift, InputKey.F, InputKey.Control), "Ctrl-Shift-F" },
+            new object[] { new KeyCombination(InputKey.Alt, InputKey.Control, InputKey.Super, InputKey.Shift), "Ctrl-Alt-Shift-Win" },
+            new object[] { new KeyCombination(InputKey.LAlt, InputKey.F4), "LAlt-F4" },
+            new object[] { new KeyCombination(InputKey.D, InputKey.LControl), "LCtrl-D" },
+            new object[] { new KeyCombination(InputKey.LShift, InputKey.F, InputKey.LControl), "LCtrl-LShift-F" },
+            new object[] { new KeyCombination(InputKey.LAlt, InputKey.LControl, InputKey.LSuper, InputKey.LShift), "LCtrl-LAlt-LShift-LWin" }
         };
 
         [TestCaseSource(nameof(key_combination_display_test_cases))]

--- a/osu.Framework.Tests/Input/KeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationTest.cs
@@ -11,10 +11,10 @@ namespace osu.Framework.Tests.Input
     {
         private static readonly object[][] key_combination_display_test_cases =
         {
-            new object[] { new KeyCombination(InputKey.Alt, InputKey.F4), "Alt-F4" },
-            new object[] { new KeyCombination(InputKey.D, InputKey.Control), "Ctrl-D" },
-            new object[] { new KeyCombination(InputKey.Shift, InputKey.F, InputKey.Control), "Ctrl-Shift-F" },
-            new object[] { new KeyCombination(InputKey.Alt, InputKey.Control, InputKey.Super, InputKey.Shift), "Ctrl-Alt-Shift-Win" }
+            new object[] { new KeyCombination(InputKey.LAlt, InputKey.F4), "Alt-F4" },
+            new object[] { new KeyCombination(InputKey.D, InputKey.LControl), "Ctrl-D" },
+            new object[] { new KeyCombination(InputKey.LShift, InputKey.F, InputKey.LControl), "Ctrl-Shift-F" },
+            new object[] { new KeyCombination(InputKey.LAlt, InputKey.LControl, InputKey.LSuper, InputKey.LShift), "Ctrl-Alt-Shift-Win" }
         };
 
         [TestCaseSource(nameof(key_combination_display_test_cases))]

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -197,9 +197,9 @@ namespace osu.Framework.Tests.Visual.Input
 
                 toggleKey(Key.ShiftLeft);
                 toggleKey(Key.AltLeft);
-                checkPressed(TestAction.Alt_and_Shift, 1, 1, 1, 1, 1);
+                checkPressed(TestAction.Alt_and_LShift, 1, 1, 1, 1, 1);
                 toggleKey(Key.A);
-                checkPressed(TestAction.Shift_A, 1, 0, 0, 1, 1);
+                checkPressed(TestAction.LShift_A, 1, 0, 0, 1, 1);
                 toggleKey(Key.AltLeft);
                 toggleKey(Key.ShiftLeft);
             });
@@ -211,24 +211,24 @@ namespace osu.Framework.Tests.Visual.Input
             wrapTest(() =>
             {
                 toggleKey(Key.ShiftLeft);
-                checkPressed(TestAction.Shift, 1, 1, 1, 1, 1);
+                checkPressed(TestAction.LShift, 1, 1, 1, 1, 1);
                 toggleKey(Key.A);
-                checkReleased(TestAction.Shift, 1, 1, 1, 0, 0);
-                checkPressed(TestAction.Shift_A, 1, 1, 1, 1, 1);
+                checkReleased(TestAction.LShift, 1, 1, 1, 0, 0);
+                checkPressed(TestAction.LShift_A, 1, 1, 1, 1, 1);
                 toggleKey(Key.ShiftRight);
-                checkPressed(TestAction.Shift, 0, 0, 0, 0, 0);
-                checkReleased(TestAction.Shift_A, 0, 0, 0, 0, 0);
+                checkPressed(TestAction.LShift, 0, 0, 0, 0, 0);
+                checkReleased(TestAction.LShift_A, 0, 0, 0, 0, 0);
                 toggleKey(Key.ShiftLeft);
-                checkReleased(TestAction.Shift, 0, 0, 0, 0, 0);
-                checkReleased(TestAction.Shift_A, 0, 0, 0, 0, 0);
+                checkReleased(TestAction.LShift, 0, 0, 0, 0, 0);
+                checkReleased(TestAction.LShift_A, 0, 0, 0, 0, 0);
                 toggleKey(Key.ShiftRight);
-                checkReleased(TestAction.Shift, 0, 0, 0, 1, 1);
-                checkReleased(TestAction.Shift_A, 1, 1, 1, 1, 1);
+                checkReleased(TestAction.LShift, 0, 0, 0, 1, 1);
+                checkReleased(TestAction.LShift_A, 1, 1, 1, 1, 1);
                 toggleKey(Key.A);
 
                 toggleKey(Key.ControlLeft);
                 toggleKey(Key.ShiftLeft);
-                checkPressed(TestAction.Ctrl_and_Shift, 1, 1, 1, 1, 1);
+                checkPressed(TestAction.Ctrl_and_LShift, 1, 1, 1, 1, 1);
             });
         }
 
@@ -339,8 +339,8 @@ namespace osu.Framework.Tests.Visual.Input
             Alt_A,
             Alt_S,
             Alt_D_or_F,
-            Shift_A,
-            Shift_S,
+            LShift_A,
+            LShift_S,
             Shift_D_or_F,
             RShift_A,
             RShift_S,
@@ -350,10 +350,10 @@ namespace osu.Framework.Tests.Visual.Input
             Ctrl_Shift_D_or_F,
             Ctrl,
             RShift,
-            Shift,
+            LShift,
             Alt,
-            Alt_and_Shift,
-            Ctrl_and_Shift,
+            Alt_and_LShift,
+            Ctrl_and_LShift,
             Ctrl_or_Shift,
             LeftMouse,
             RightMouse,
@@ -383,10 +383,10 @@ namespace osu.Framework.Tests.Visual.Input
                 new KeyBinding(new[] { InputKey.Control, InputKey.D }, TestAction.Ctrl_D_or_F),
                 new KeyBinding(new[] { InputKey.Control, InputKey.F }, TestAction.Ctrl_D_or_F),
 
-                new KeyBinding(new[] { InputKey.Shift, InputKey.A }, TestAction.Shift_A),
-                new KeyBinding(new[] { InputKey.Shift, InputKey.S }, TestAction.Shift_S),
-                new KeyBinding(new[] { InputKey.Shift, InputKey.D }, TestAction.Shift_D_or_F),
-                new KeyBinding(new[] { InputKey.Shift, InputKey.F }, TestAction.Shift_D_or_F),
+                new KeyBinding(new[] { InputKey.LShift, InputKey.A }, TestAction.LShift_A),
+                new KeyBinding(new[] { InputKey.LShift, InputKey.S }, TestAction.LShift_S),
+                new KeyBinding(new[] { InputKey.LShift, InputKey.D }, TestAction.Shift_D_or_F),
+                new KeyBinding(new[] { InputKey.LShift, InputKey.F }, TestAction.Shift_D_or_F),
 
                 new KeyBinding(new[] { InputKey.RShift, InputKey.A }, TestAction.RShift_A),
                 new KeyBinding(new[] { InputKey.RShift, InputKey.S }, TestAction.RShift_S),
@@ -404,13 +404,13 @@ namespace osu.Framework.Tests.Visual.Input
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.F }, TestAction.Ctrl_Shift_D_or_F),
 
                 new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl),
-                new KeyBinding(new[] { InputKey.Shift }, TestAction.Shift),
+                new KeyBinding(new[] { InputKey.LShift }, TestAction.LShift),
                 new KeyBinding(new[] { InputKey.RShift }, TestAction.RShift),
                 new KeyBinding(new[] { InputKey.Alt }, TestAction.Alt),
-                new KeyBinding(new[] { InputKey.Alt, InputKey.Shift }, TestAction.Alt_and_Shift),
-                new KeyBinding(new[] { InputKey.Control, InputKey.Shift }, TestAction.Ctrl_and_Shift),
+                new KeyBinding(new[] { InputKey.Alt, InputKey.LShift }, TestAction.Alt_and_LShift),
+                new KeyBinding(new[] { InputKey.Control, InputKey.LShift }, TestAction.Ctrl_and_LShift),
                 new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl_or_Shift),
-                new KeyBinding(new[] { InputKey.Shift }, TestAction.Ctrl_or_Shift),
+                new KeyBinding(new[] { InputKey.LShift }, TestAction.Ctrl_or_Shift),
 
                 new KeyBinding(new[] { InputKey.MouseLeft }, TestAction.LeftMouse),
                 new KeyBinding(new[] { InputKey.MouseRight }, TestAction.RightMouse),

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -206,6 +206,36 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Test]
+        public void PerSideModifierKeys()
+        {
+            wrapTest(() =>
+            {
+                toggleKey(Key.ShiftLeft);
+                checkPressed(TestAction.AnyShift, 1, 1, 1, 1, 1);
+                checkPressed(TestAction.LShift, 0, 0, 0, 1, 1);
+                checkPressed(TestAction.RShift, 0, 0, 0, 0, 0);
+
+                toggleKey(Key.A);
+                checkPressed(TestAction.AnyShift_A, 0, 0, 0, 1, 1);
+                checkPressed(TestAction.LShift_A, 1, 1, 1, 1, 1);
+                checkReleased(TestAction.AnyShift, 1, 1, 1, 0, 0);
+
+                toggleKey(Key.ShiftRight);
+                checkReleased(TestAction.LShift_A, 1, 0, 0, 0, 0);
+                checkPressed(TestAction.RShift, 1, 0, 0, 1, 1);
+                checkPressed(TestAction.AnyShift, 0, 0, 0, 0, 0);
+
+                toggleKey(Key.ShiftLeft);
+                checkReleased(TestAction.LShift, 0, 0, 0, 1, 1);
+                checkReleased(TestAction.LShift_A, 0, 1, 1, 1, 1);
+                checkReleased(TestAction.AnyShift, 0, 0, 0, 0, 0);
+
+                toggleKey(Key.ShiftRight);
+                checkReleased(TestAction.AnyShift, 0, 0, 0, 1, 1);
+            });
+        }
+
+        [Test]
         public void BothSideModifierKeys()
         {
             wrapTest(() =>

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -206,29 +206,29 @@ namespace osu.Framework.Tests.Visual.Input
         }
 
         [Test]
-        public void ModifierKeys()
+        public void BothSideModifierKeys()
         {
             wrapTest(() =>
             {
-                toggleKey(Key.ShiftLeft);
-                checkPressed(TestAction.LShift, 1, 1, 1, 1, 1);
+                toggleKey(Key.AltLeft);
+                checkPressed(TestAction.Alt, 1, 1, 1, 1, 1);
                 toggleKey(Key.A);
-                checkReleased(TestAction.LShift, 1, 1, 1, 0, 0);
-                checkPressed(TestAction.LShift_A, 1, 1, 1, 1, 1);
-                toggleKey(Key.ShiftRight);
-                checkPressed(TestAction.LShift, 0, 0, 0, 0, 0);
-                checkReleased(TestAction.LShift_A, 0, 0, 0, 0, 0);
-                toggleKey(Key.ShiftLeft);
-                checkReleased(TestAction.LShift, 0, 0, 0, 0, 0);
-                checkReleased(TestAction.LShift_A, 0, 0, 0, 0, 0);
-                toggleKey(Key.ShiftRight);
-                checkReleased(TestAction.LShift, 0, 0, 0, 1, 1);
-                checkReleased(TestAction.LShift_A, 1, 1, 1, 1, 1);
+                checkReleased(TestAction.Alt, 1, 1, 1, 0, 0);
+                checkPressed(TestAction.Alt_A, 1, 1, 1, 1, 1);
+                toggleKey(Key.AltRight);
+                checkPressed(TestAction.Alt, 0, 0, 0, 0, 0);
+                checkReleased(TestAction.Alt_A, 0, 0, 0, 0, 0);
+                toggleKey(Key.AltLeft);
+                checkReleased(TestAction.Alt, 0, 0, 0, 0, 0);
+                checkReleased(TestAction.Alt_A, 0, 0, 0, 0, 0);
+                toggleKey(Key.AltRight);
+                checkReleased(TestAction.Alt, 0, 0, 0, 1, 1);
+                checkReleased(TestAction.Alt_A, 1, 1, 1, 1, 1);
                 toggleKey(Key.A);
 
                 toggleKey(Key.ControlLeft);
-                toggleKey(Key.ShiftLeft);
-                checkPressed(TestAction.Ctrl_and_LShift, 1, 1, 1, 1, 1);
+                toggleKey(Key.AltLeft);
+                checkPressed(TestAction.Ctrl_and_Alt, 1, 1, 1, 1, 1);
             });
         }
 
@@ -341,7 +341,7 @@ namespace osu.Framework.Tests.Visual.Input
             Alt_D_or_F,
             LShift_A,
             LShift_S,
-            Shift_D_or_F,
+            LShift_D_or_F,
             RShift_A,
             RShift_S,
             RShift_D_or_F,
@@ -353,7 +353,7 @@ namespace osu.Framework.Tests.Visual.Input
             LShift,
             Alt,
             Alt_and_LShift,
-            Ctrl_and_LShift,
+            Ctrl_and_Alt,
             Ctrl_or_Shift,
             LeftMouse,
             RightMouse,
@@ -362,6 +362,8 @@ namespace osu.Framework.Tests.Visual.Input
             WheelLeft,
             WheelRight,
             Ctrl_and_WheelUp,
+            AnyShift_A,
+            AnyShift
         }
 
         private class TestInputManager : KeyBindingContainer<TestAction>
@@ -385,13 +387,15 @@ namespace osu.Framework.Tests.Visual.Input
 
                 new KeyBinding(new[] { InputKey.LShift, InputKey.A }, TestAction.LShift_A),
                 new KeyBinding(new[] { InputKey.LShift, InputKey.S }, TestAction.LShift_S),
-                new KeyBinding(new[] { InputKey.LShift, InputKey.D }, TestAction.Shift_D_or_F),
-                new KeyBinding(new[] { InputKey.LShift, InputKey.F }, TestAction.Shift_D_or_F),
+                new KeyBinding(new[] { InputKey.LShift, InputKey.D }, TestAction.LShift_D_or_F),
+                new KeyBinding(new[] { InputKey.LShift, InputKey.F }, TestAction.LShift_D_or_F),
 
                 new KeyBinding(new[] { InputKey.RShift, InputKey.A }, TestAction.RShift_A),
                 new KeyBinding(new[] { InputKey.RShift, InputKey.S }, TestAction.RShift_S),
                 new KeyBinding(new[] { InputKey.RShift, InputKey.D }, TestAction.RShift_D_or_F),
                 new KeyBinding(new[] { InputKey.RShift, InputKey.F }, TestAction.RShift_D_or_F),
+
+                new KeyBinding(new[] { InputKey.Shift, InputKey.A }, TestAction.AnyShift_A),
 
                 new KeyBinding(new[] { InputKey.Alt, InputKey.A }, TestAction.Alt_A),
                 new KeyBinding(new[] { InputKey.Alt, InputKey.S }, TestAction.Alt_S),
@@ -404,13 +408,14 @@ namespace osu.Framework.Tests.Visual.Input
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift, InputKey.F }, TestAction.Ctrl_Shift_D_or_F),
 
                 new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl),
+                new KeyBinding(new[] { InputKey.Shift }, TestAction.AnyShift),
                 new KeyBinding(new[] { InputKey.LShift }, TestAction.LShift),
                 new KeyBinding(new[] { InputKey.RShift }, TestAction.RShift),
                 new KeyBinding(new[] { InputKey.Alt }, TestAction.Alt),
                 new KeyBinding(new[] { InputKey.Alt, InputKey.LShift }, TestAction.Alt_and_LShift),
-                new KeyBinding(new[] { InputKey.Control, InputKey.LShift }, TestAction.Ctrl_and_LShift),
+                new KeyBinding(new[] { InputKey.Control, InputKey.Alt }, TestAction.Ctrl_and_Alt),
                 new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl_or_Shift),
-                new KeyBinding(new[] { InputKey.LShift }, TestAction.Ctrl_or_Shift),
+                new KeyBinding(new[] { InputKey.Shift }, TestAction.Ctrl_or_Shift),
 
                 new KeyBinding(new[] { InputKey.MouseLeft }, TestAction.LeftMouse),
                 new KeyBinding(new[] { InputKey.MouseRight }, TestAction.RightMouse),

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -342,10 +342,14 @@ namespace osu.Framework.Tests.Visual.Input
             Shift_A,
             Shift_S,
             Shift_D_or_F,
+            RShift_A,
+            RShift_S,
+            RShift_D_or_F,
             Ctrl_Shift_A,
             Ctrl_Shift_S,
             Ctrl_Shift_D_or_F,
             Ctrl,
+            RShift,
             Shift,
             Alt,
             Alt_and_Shift,
@@ -384,6 +388,11 @@ namespace osu.Framework.Tests.Visual.Input
                 new KeyBinding(new[] { InputKey.Shift, InputKey.D }, TestAction.Shift_D_or_F),
                 new KeyBinding(new[] { InputKey.Shift, InputKey.F }, TestAction.Shift_D_or_F),
 
+                new KeyBinding(new[] { InputKey.RShift, InputKey.A }, TestAction.RShift_A),
+                new KeyBinding(new[] { InputKey.RShift, InputKey.S }, TestAction.RShift_S),
+                new KeyBinding(new[] { InputKey.RShift, InputKey.D }, TestAction.RShift_D_or_F),
+                new KeyBinding(new[] { InputKey.RShift, InputKey.F }, TestAction.RShift_D_or_F),
+
                 new KeyBinding(new[] { InputKey.Alt, InputKey.A }, TestAction.Alt_A),
                 new KeyBinding(new[] { InputKey.Alt, InputKey.S }, TestAction.Alt_S),
                 new KeyBinding(new[] { InputKey.Alt, InputKey.D }, TestAction.Alt_D_or_F),
@@ -396,6 +405,7 @@ namespace osu.Framework.Tests.Visual.Input
 
                 new KeyBinding(new[] { InputKey.Control }, TestAction.Ctrl),
                 new KeyBinding(new[] { InputKey.Shift }, TestAction.Shift),
+                new KeyBinding(new[] { InputKey.RShift }, TestAction.RShift),
                 new KeyBinding(new[] { InputKey.Alt }, TestAction.Alt),
                 new KeyBinding(new[] { InputKey.Alt, InputKey.Shift }, TestAction.Alt_and_Shift),
                 new KeyBinding(new[] { InputKey.Control, InputKey.Shift }, TestAction.Ctrl_and_Shift),
@@ -524,6 +534,7 @@ namespace osu.Framework.Tests.Visual.Input
                 if (Action == action)
                 {
                     ++OnReleasedCount;
+
                     if (Concurrency != SimultaneousBindingMode.All)
                         Trace.Assert(OnPressedCount == OnReleasedCount);
                     else
@@ -554,8 +565,8 @@ namespace osu.Framework.Tests.Visual.Input
                 {
                     if (t.ToString().Contains("Wheel"))
                         return new ScrollTestButton(t, concurrency);
-                    else
-                        return new TestButton(t, concurrency);
+
+                    return new TestButton(t, concurrency);
                 }).ToArray();
 
                 Children = new Drawable[]

--- a/osu.Framework/Input/Bindings/InputKey.cs
+++ b/osu.Framework/Input/Bindings/InputKey.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Input.Bindings
         Alt = 5,
 
         /// <summary>
-        /// The win key.
+        /// The windows/command key.
         /// </summary>
         [Order(4)]
         Super = 7,
@@ -813,6 +813,54 @@ namespace osu.Framework.Input.Bindings
         /// The media next key.
         /// </summary>
         TrackNext,
+
+        /// <summary>
+        /// The left shift key.
+        /// </summary>
+        [Order(3)]
+        LShift,
+
+        /// <summary>
+        /// The right shift key.
+        /// </summary>
+        [Order(3)]
+        RShift,
+
+        /// <summary>
+        /// The left control key.
+        /// </summary>
+        [Order(1)]
+        LControl,
+
+        /// <summary>
+        /// The right control key.
+        /// </summary>
+        [Order(1)]
+        RControl,
+
+        /// <summary>
+        /// The left alt key.
+        /// </summary>
+        [Order(2)]
+        LAlt,
+
+        /// <summary>
+        /// The right alt key.
+        /// </summary>
+        [Order(2)]
+        RAlt,
+
+        /// <summary>
+        /// The left windows/command key.
+        /// </summary>
+        [Order(4)]
+        LSuper,
+
+        /// <summary>
+        /// The right windows/command key.
+        /// </summary>
+        [Order(4)]
+        RSuper,
 
         /// <summary>
         /// Indicates the first available joystick button.

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -180,8 +181,6 @@ namespace osu.Framework.Input.Bindings
 
         private bool handleNewPressed(InputState state, InputKey newKey, bool repeat, Vector2? scrollDelta = null, bool isPrecise = false)
         {
-            Logger.Log($"new key pressed {newKey}");
-
             var scrollAmount = getScrollAmount(newKey, scrollDelta);
             var pressedCombination = KeyCombination.FromInputState(state, scrollDelta);
 
@@ -213,8 +212,6 @@ namespace osu.Framework.Input.Bindings
 
             foreach (var newBinding in newlyPressed)
             {
-                Logger.Log($"new binding pressed {newBinding}");
-
                 // we handled a new binding and there is an existing one. if we don't want concurrency, let's propagate a released event.
                 if (simultaneousMode == SimultaneousBindingMode.None)
                     releasePressedActions();
@@ -234,7 +231,6 @@ namespace osu.Framework.Input.Bindings
                 // we only want to handle the first valid binding (the one with the most keys) in non-simultaneous mode.
                 if (simultaneousMode == SimultaneousBindingMode.None && handled)
                     break;
-                Logger.Log($"new binding pressed {newBinding}");
             }
 
             return handled;
@@ -297,14 +293,12 @@ namespace osu.Framework.Input.Bindings
 
         private void handleNewReleased(InputState state, InputKey releasedKey)
         {
-            Logger.Log($"new key released {releasedKey}");
-
             var pressedCombination = KeyCombination.FromInputState(state);
 
             // we don't want to consider exact matching here as we are dealing with bindings, not actions.
             var newlyReleased = pressedBindings.Where(b => !b.KeyCombination.IsPressed(pressedCombination, KeyCombinationMatchingMode.Any)).ToList();
 
-            // Trace.Assert(newlyReleased.All(b => KeyCombination.ContainsKey(b.KeyCombination.Keys, releasedKey)));
+            Trace.Assert(newlyReleased.All(b => KeyCombination.ContainsKey(b.KeyCombination.Keys, releasedKey)));
 
             foreach (var binding in newlyReleased)
             {

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -1,4 +1,4 @@
-﻿
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -117,10 +117,18 @@ namespace osu.Framework.Input.Bindings
                     if (keyDown.Repeat && !SendRepeats)
                         return pressedBindings.Count > 0;
 
-                    return handleNewPressed(state, KeyCombination.FromKey(keyDown.Key), keyDown.Repeat);
+                    foreach (var key in KeyCombination.FromKey(keyDown.Key))
+                    {
+                        if (handleNewPressed(state, key, keyDown.Repeat))
+                            return true;
+                    }
+
+                    return false;
 
                 case KeyUpEvent keyUp:
-                    handleNewReleased(state, KeyCombination.FromKey(keyUp.Key));
+                    foreach (var key in KeyCombination.FromKey(keyUp.Key))
+                        handleNewReleased(state, key);
+
                     return false;
 
                 case JoystickPressEvent joystickPress:
@@ -171,6 +179,8 @@ namespace osu.Framework.Input.Bindings
 
         private bool handleNewPressed(InputState state, InputKey newKey, bool repeat, Vector2? scrollDelta = null, bool isPrecise = false)
         {
+            Logger.Log($"new key pressed {newKey}");
+
             var scrollAmount = getScrollAmount(newKey, scrollDelta);
             var pressedCombination = KeyCombination.FromInputState(state, scrollDelta);
 
@@ -203,6 +213,8 @@ namespace osu.Framework.Input.Bindings
 
             foreach (var newBinding in newlyPressed)
             {
+                Logger.Log($"new binding pressed {newBinding}");
+
                 // we handled a new binding and there is an existing one. if we don't want concurrency, let's propagate a released event.
                 if (simultaneousMode == SimultaneousBindingMode.None)
                     releasePressedActions();
@@ -222,6 +234,7 @@ namespace osu.Framework.Input.Bindings
                 // we only want to handle the first valid binding (the one with the most keys) in non-simultaneous mode.
                 if (simultaneousMode == SimultaneousBindingMode.None && handled)
                     break;
+                Logger.Log($"new binding pressed {newBinding}");
             }
 
             return handled;

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -78,25 +78,25 @@ namespace osu.Framework.Input.Bindings
             if (Keys == pressedKeys.Keys) // Fast test for reference equality of underlying array
                 return true;
 
-            return ContainsAll(pressedKeys.Keys, Keys, matchingMode);
+            return ContainsAll(Keys, pressedKeys.Keys, matchingMode);
         }
 
         /// <summary>
         /// Check whether the provided set of pressed keys matches the candidate binding.
         /// </summary>
-        /// <param name="pressedKey">The keys which have been pressed by a user.</param>
         /// <param name="candidateKey">The candidate key binding to match against.</param>
+        /// <param name="pressedKey">The keys which have been pressed by a user.</param>
         /// <param name="matchingMode">The matching mode to be used when checking.</param>
         /// <returns>Whether this is a match.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool ContainsAll(ImmutableArray<InputKey> pressedKey, ImmutableArray<InputKey> candidateKey, KeyCombinationMatchingMode matchingMode)
+        internal static bool ContainsAll(ImmutableArray<InputKey> candidateKey, ImmutableArray<InputKey> pressedKey, KeyCombinationMatchingMode matchingMode)
         {
             // can be local function once attribute on local functions are implemented
             // optimized to avoid allocation
             // Usually Keys.Count <= 3. Does not worth special logic for Contains().
             foreach (var key in candidateKey)
             {
-                if (!pressedKey.Contains(key))
+                if (!PressedKeysRelevantToCandidateKey(pressedKey, key))
                     return false;
             }
 
@@ -122,6 +122,44 @@ namespace osu.Framework.Input.Bindings
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Check whether a single key from a candidate binding is relevant to the currently pressed keys.
+        /// </summary>
+        /// <param name="pressedKeys">The keys which are pressed by the user.</param>
+        /// <param name="candidateKey">A single key from a candidate binding to check against.</param>
+        /// <returns>Whether this is a match.</returns>
+        internal static bool PressedKeysRelevantToCandidateKey(ImmutableArray<InputKey> pressedKeys, InputKey candidateKey)
+        {
+            switch (candidateKey)
+            {
+                case InputKey.Control:
+                    if (pressedKeys.Contains(InputKey.LControl) || pressedKeys.Contains(InputKey.RControl))
+                        return true;
+
+                    break;
+
+                case InputKey.Shift:
+                    if (pressedKeys.Contains(InputKey.LShift) || pressedKeys.Contains(InputKey.RShift))
+                        return true;
+
+                    break;
+
+                case InputKey.Alt:
+                    if (pressedKeys.Contains(InputKey.LAlt) || pressedKeys.Contains(InputKey.RAlt))
+                        return true;
+
+                    break;
+
+                case InputKey.Super:
+                    if (pressedKeys.Contains(InputKey.LSuper) || pressedKeys.Contains(InputKey.RSuper))
+                        return true;
+
+                    break;
+            }
+
+            return pressedKeys.Contains(candidateKey);
         }
 
         /// <summary>

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.Input.Bindings
         /// </summary>
         /// <param name="pressedKey">The keys which have been pressed by a user.</param>
         /// <param name="candidateKey">The candidate key binding to match against.</param>
-        /// <param name="exactModifiers">Whether exact matching should be used (ie. no excess keys can be pressed).</param>
+        /// <param name="exactModifiers">Whether exact matching should be used (ie. no excess modifier keys can be pressed).</param>
         /// <returns>Whether this is a match.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool ContainsAll(ImmutableArray<InputKey> pressedKey, ImmutableArray<InputKey> candidateKey, bool exactModifiers)

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -78,21 +78,7 @@ namespace osu.Framework.Input.Bindings
             if (Keys == pressedKeys.Keys) // Fast test for reference equality of underlying array
                 return true;
 
-            switch (matchingMode)
-            {
-                case KeyCombinationMatchingMode.Any:
-                    return ContainsAll(pressedKeys.Keys, Keys, false);
-
-                case KeyCombinationMatchingMode.Exact:
-                    // Keys are always ordered
-                    return pressedKeys.Keys.SequenceEqual(Keys);
-
-                case KeyCombinationMatchingMode.Modifiers:
-                    return ContainsAll(pressedKeys.Keys, Keys, true);
-
-                default:
-                    return false;
-            }
+            return ContainsAll(pressedKeys.Keys, Keys, matchingMode);
         }
 
         /// <summary>
@@ -100,10 +86,10 @@ namespace osu.Framework.Input.Bindings
         /// </summary>
         /// <param name="pressedKey">The keys which have been pressed by a user.</param>
         /// <param name="candidateKey">The candidate key binding to match against.</param>
-        /// <param name="exactModifiers">Whether exact matching should be used (ie. no excess modifier keys can be pressed).</param>
+        /// <param name="matchingMode">The matching mode to be used when checking.</param>
         /// <returns>Whether this is a match.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool ContainsAll(ImmutableArray<InputKey> pressedKey, ImmutableArray<InputKey> candidateKey, bool exactModifiers)
+        internal static bool ContainsAll(ImmutableArray<InputKey> pressedKey, ImmutableArray<InputKey> candidateKey, KeyCombinationMatchingMode matchingMode)
         {
             // can be local function once attribute on local functions are implemented
             // optimized to avoid allocation
@@ -114,13 +100,25 @@ namespace osu.Framework.Input.Bindings
                     return false;
             }
 
-            if (exactModifiers)
+            switch (matchingMode)
             {
-                foreach (var key in pressedKey)
-                {
-                    if (IsModifierKey(key) && !ContainsKey(candidateKey, key))
-                        return false;
-                }
+                case KeyCombinationMatchingMode.Exact:
+                    foreach (var key in pressedKey)
+                    {
+                        if (!ContainsKey(candidateKey, key))
+                            return false;
+                    }
+
+                    break;
+
+                case KeyCombinationMatchingMode.Modifiers:
+                    foreach (var key in pressedKey)
+                    {
+                        if (IsModifierKey(key) && !ContainsKey(candidateKey, key))
+                            return false;
+                    }
+
+                    break;
             }
 
             return true;

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -275,6 +275,18 @@ namespace osu.Framework.Input.Bindings
                 case InputKey.None:
                     return string.Empty;
 
+                case InputKey.Shift:
+                    return "Shift";
+
+                case InputKey.Control:
+                    return "Ctrl";
+
+                case InputKey.Alt:
+                    return "Alt";
+
+                case InputKey.Super:
+                    return "Win";
+
                 case InputKey.LShift:
                     return "LShift";
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -96,7 +96,7 @@ namespace osu.Framework.Input.Bindings
             // Usually Keys.Count <= 3. Does not worth special logic for Contains().
             foreach (var key in candidateKey)
             {
-                if (!ContainsKey(pressedKey, key))
+                if (!pressedKey.Contains(key))
                     return false;
             }
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -96,7 +96,7 @@ namespace osu.Framework.Input.Bindings
             // Usually Keys.Count <= 3. Does not worth special logic for Contains().
             foreach (var key in candidateKey)
             {
-                if (!PressedKeysRelevantToCandidateKey(pressedKey, key))
+                if (!ContainsKey(pressedKey, key))
                     return false;
             }
 
@@ -105,7 +105,7 @@ namespace osu.Framework.Input.Bindings
                 case KeyCombinationMatchingMode.Exact:
                     foreach (var key in pressedKey)
                     {
-                        if (!ContainsKey(candidateKey, key))
+                        if (!ContainsKeyPermissive(candidateKey, key))
                             return false;
                     }
 
@@ -114,7 +114,7 @@ namespace osu.Framework.Input.Bindings
                 case KeyCombinationMatchingMode.Modifiers:
                     foreach (var key in pressedKey)
                     {
-                        if (IsModifierKey(key) && !ContainsKey(candidateKey, key))
+                        if (IsModifierKey(key) && !ContainsKeyPermissive(candidateKey, key))
                             return false;
                     }
 
@@ -125,50 +125,13 @@ namespace osu.Framework.Input.Bindings
         }
 
         /// <summary>
-        /// Check whether a single key from a candidate binding is relevant to the currently pressed keys.
-        /// </summary>
-        /// <param name="pressedKeys">The keys which are pressed by the user.</param>
-        /// <param name="candidateKey">A single key from a candidate binding to check against.</param>
-        /// <returns>Whether this is a match.</returns>
-        internal static bool PressedKeysRelevantToCandidateKey(ImmutableArray<InputKey> pressedKeys, InputKey candidateKey)
-        {
-            switch (candidateKey)
-            {
-                case InputKey.Control:
-                    if (pressedKeys.Contains(InputKey.LControl) || pressedKeys.Contains(InputKey.RControl))
-                        return true;
-
-                    break;
-
-                case InputKey.Shift:
-                    if (pressedKeys.Contains(InputKey.LShift) || pressedKeys.Contains(InputKey.RShift))
-                        return true;
-
-                    break;
-
-                case InputKey.Alt:
-                    if (pressedKeys.Contains(InputKey.LAlt) || pressedKeys.Contains(InputKey.RAlt))
-                        return true;
-
-                    break;
-
-                case InputKey.Super:
-                    if (pressedKeys.Contains(InputKey.LSuper) || pressedKeys.Contains(InputKey.RSuper))
-                        return true;
-
-                    break;
-            }
-
-            return pressedKeys.Contains(candidateKey);
-        }
-
-        /// <summary>
         /// Check whether the provided key is part of the candidate binding.
+        /// This will match bidirectionally for modifier keys (LShift and Shift being present in both of the two parameters in either order will return true).
         /// </summary>
         /// <param name="candidate">The candidate key binding to match against.</param>
         /// <param name="key">The key which has been pressed by a user.</param>
         /// <returns>Whether this is a match.</returns>
-        internal static bool ContainsKey(ImmutableArray<InputKey> candidate, InputKey key)
+        internal static bool ContainsKeyPermissive(ImmutableArray<InputKey> candidate, InputKey key)
         {
             switch (key)
             {
@@ -199,7 +162,22 @@ namespace osu.Framework.Input.Bindings
                         return true;
 
                     break;
+            }
 
+            return ContainsKey(candidate, key);
+        }
+
+        /// <summary>
+        /// Check whether a single key from a candidate binding is relevant to the currently pressed keys.
+        /// If the <paramref name="key"/> contains a left/right specific modifier, the <paramref name="candidate"/> must also for this to match.
+        /// </summary>
+        /// <param name="candidate">The candidate key binding to match against.</param>
+        /// <param name="key">The key which has been pressed by a user.</param>
+        /// <returns>Whether this is a match.</returns>
+        internal static bool ContainsKey(ImmutableArray<InputKey> candidate, InputKey key)
+        {
+            switch (key)
+            {
                 case InputKey.Control:
                     if (candidate.Contains(InputKey.LControl) || candidate.Contains(InputKey.RControl))
                         return true;


### PR DESCRIPTION
Don't really have much to say about this one. Pretty hellish to get the implementation right, and likely not going to be a simple one to review/understand, but it works.

May need to assess whether the array allocation overhead is an issue (although I think the scenarios where it is called are already limited to when input changes, so should be okay).

Closes https://github.com/ppy/osu-framework/issues/2136.