### PR TITLE
Fix relative mouse mode sometimes not activating when cursor enters window

### DIFF
--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -116,10 +116,10 @@ namespace osu.Framework.Input.Handlers.Mouse
                 // to mouse control at any point.
                 window.UpdateMousePosition(position);
 
-            updateRelativeMode();
-
             if (window.RelativeMouseMode)
             {
+                updateRelativeMode();
+
                 // store the last mouse position to propagate back to the host window manager when exiting relative mode.
                 lastPosition = position;
 

--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -111,10 +111,10 @@ namespace osu.Framework.Input.Handlers.Mouse
                 // to mouse control at any point.
                 window.UpdateMousePosition(position);
 
+            updateRelativeMode();
+
             if (window.RelativeMouseMode)
             {
-                updateRelativeMode();
-
                 // store the last mouse position to propagate back to the host window manager when exiting relative mode.
                 lastPosition = position;
 

--- a/osu.Framework/Input/StateChanges/CursorInWindowChange.cs
+++ b/osu.Framework/Input/StateChanges/CursorInWindowChange.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Input.States;
+using osu.Framework.Input.Handlers.Mouse;
+using osu.Framework.Platform;
+
+namespace osu.Framework.Input.StateChanges
+{
+    /// <summary>
+    /// Denotes a change of <see cref="SDL2DesktopWindow.CursorInWindow"/>.
+    /// Used only to propagate the change back to the <see cref="MouseHandler"/>.
+    /// </summary>
+    public class CursorInWindowChange : IInput
+    {
+        public void Apply(InputState state, IInputStateChangeHandler handler)
+        {
+            if (handler is UserInputManager userInputManager)
+                userInputManager.HandleCursorInWindowChange();
+        }
+    }
+}

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -61,6 +61,6 @@ namespace osu.Framework.Input
             base.HandleInputStateChange(inputStateChange);
         }
 
-        public void HandleCursorInWindowChange() => InputHandlers.OfType<MouseHandler>().FirstOrDefault().FeedbackCursorInWindowChange();
+        public void HandleCursorInWindowChange() => InputHandlers.OfType<MouseHandler>().FirstOrDefault()?.FeedbackCursorInWindowChange();
     }
 }

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Immutable;
+using System.Linq;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.Handlers;
+using osu.Framework.Input.Handlers.Mouse;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.StateChanges.Events;
 using osu.Framework.Platform;
@@ -58,5 +60,7 @@ namespace osu.Framework.Input
 
             base.HandleInputStateChange(inputStateChange);
         }
+
+        public void HandleCursorInWindowChange() => InputHandlers.OfType<MouseHandler>().FirstOrDefault().FeedbackCursorInWindowChange();
     }
 }


### PR DESCRIPTION
Closes #4341 (or at least works around the described problem)

With this PR, the weirdness around the cursor entering the window isn't fixed, But at least `RelativeMouseMode` will be correctly set on the next `FeedbackMousePositionChange`.