### PR TITLE
Listen to midi messages on all channels

### DIFF
--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -205,7 +205,9 @@ namespace osu.Framework.Input.Handlers.Midi
         {
             Logger.Log($"Handling MIDI event {eventType:X2}:{key:X2}:{velocity:X2}");
 
-            switch (eventType)
+            // Low nibble only contains channel data in note on/off messages
+            // Ignore to receive messages from all channels
+            switch (eventType & 0xF0)
             {
                 case MidiEvent.NoteOn when velocity != 0:
                     Logger.Log($"NoteOn: {(MidiKey)key}/{velocity / 128f:P}");


### PR DESCRIPTION
- Should close ppy/osu#12198

Note On/Off messages include channel data on it's status byte's low nibble, which caused messages sent over channels other than 1 (hex 0) to be discarded.
As we only handle Note On/Off messages it should be safe to ignore this nibble.

Tested using a Novation Launchpad Mk2 set to channels 6-8 and 14-16.