### PR TITLE
Make GameHost.AllowScreenSuspension into an AggregateBindable

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -60,7 +60,7 @@ namespace osu.Framework.Android
 
             gameView.HostStarted += host =>
             {
-                host.AllowScreenSuspension.BindValueChanged(allow =>
+                host.AllowScreenSuspension.Result.BindValueChanged(allow =>
                 {
                     RunOnUiThread(() =>
                     {

--- a/osu.Framework.Tests/Visual/Platform/TestSceneAllowSuspension.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneAllowSuspension.cs
@@ -1,27 +1,47 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
 using osu.Framework.Platform;
+using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
     public class TestSceneAllowSuspension : FrameworkTestScene
     {
-        private Bindable<bool> allowSuspension;
+        private readonly Bindable<bool> allowSuspension = new Bindable<bool>(true);
+
+        public TestSceneAllowSuspension()
+        {
+            Child = new SuspensionVisualiser { RelativeSizeAxes = Axes.Both };
+        }
 
         [BackgroundDependencyLoader]
         private void load(GameHost host)
         {
-            allowSuspension = host.AllowScreenSuspension.GetBoundCopy();
+            host.AllowScreenSuspension.AddSource(allowSuspension);
         }
 
-        protected override void LoadComplete()
+        [Test]
+        public void TestToggleSuspension()
         {
-            base.LoadComplete();
+            AddToggleStep("toggle allow suspension", v => allowSuspension.Value = v);
+        }
 
-            AddToggleStep("Toggle Suspension", b => allowSuspension.Value = b);
+        private class SuspensionVisualiser : Box
+        {
+            private readonly IBindable<bool> allowSuspension = new Bindable<bool>();
+
+            [BackgroundDependencyLoader]
+            private void load(GameHost host)
+            {
+                allowSuspension.BindTo(host.AllowScreenSuspension.Result);
+                allowSuspension.BindValueChanged(v => Colour = v.NewValue ? Color4.Green : Color4.Red, true);
+            }
         }
     }
 }

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -65,7 +65,7 @@ namespace osu.Framework.iOS
         {
             base.SetupForRun();
 
-            AllowScreenSuspension.BindValueChanged(allow =>
+            AllowScreenSuspension.Result.BindValueChanged(allow =>
                     InputThread.Scheduler.Add(() => UIApplication.SharedApplication.IdleTimerDisabled = !allow.NewValue),
                 true);
         }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Platform
         /// <remarks>
         /// To preserve battery life on mobile devices, this should be left on whenever possible.
         /// </remarks>
-        public readonly Bindable<bool> AllowScreenSuspension = new Bindable<bool>(true);
+        public readonly AggregateBindable<bool> AllowScreenSuspension = new AggregateBindable<bool>((a, b) => a & b, new Bindable<bool>(true));
 
         public bool IsPrimaryInstance { get; protected set; } = true;
 


### PR DESCRIPTION
In osu!, we're using a component which controls the value of this bindable: https://github.com/ppy/osu/blob/master/osu.Game/Screens/Play/ScreenSuspensionHandler.cs
This is quite fragile due to the assert, and I would like this to not be a thing as I'm showing more players concurrently.

# Breaking Changes

## `GameHost.AllowScreenSuspension` is now an `AggregateBindable`

Can now be controlled by multiple sources via `AllowScreenSuspension.AddSource()` and `AllowScreenSuspension.RemoveSource()`.