### PR TITLE
Set the SDL hint to minimize on focus loss in fullscreen

### DIFF
--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -62,13 +62,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             window = desktopWindow;
 
             isActive = window.IsActive.GetBoundCopy();
-            isActive.BindValueChanged(active =>
-            {
-                // importantly, we shouldn't trigger an update when the window becomes inactive.
-                // this can cause windows to get stuck in fullscreen.
-                if (active.NewValue)
-                    updateRelativeMode();
-            });
+            isActive.BindValueChanged(_ => updateRelativeMode());
 
             cursorInWindow = host.Window.CursorInWindow.GetBoundCopy();
             cursorInWindow.BindValueChanged(_ => updateRelativeMode());

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -399,6 +399,7 @@ namespace osu.Framework.Platform
                                         WindowState.ToFlags();
 
             SDL.SDL_SetHint(SDL.SDL_HINT_WINDOWS_NO_CLOSE_ON_ALT_F4, "1");
+            SDL.SDL_SetHint(SDL.SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "1");
 
             SDLWindowHandle = SDL.SDL_CreateWindow(title, Position.X, Position.Y, Size.Width, Size.Height, flags);
 


### PR DESCRIPTION
The default value for `SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS` has changed in SDL 2.0.14
The change was made in https://github.com/libsdl-org/SDL/commit/1947ca7028ab165cc3e6cbdb0b4b7c4db68d1710

Setting it to `true` restores the expected behavior, which we had before the bump of SDL libraries.

This PR also reverts the change made in #4344 as it's not needed, and that change created more problems.
Closes #4346 because of the revert.