### PR TITLE
Fix PassThroughInputManager ignoring parent HandleHoverEvents state

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -606,7 +606,11 @@ namespace osu.Framework.Input
             return positionalInputQueue.AsSlimReadOnly();
         }
 
-        protected virtual bool HandleHoverEvents => true;
+        /// <summary>
+        /// Whether this input manager is in a state it should handle hover events.
+        /// This could for instance be set to false when the window/target does not have input focus.
+        /// </summary>
+        public virtual bool HandleHoverEvents => true;
 
         private void updateHoverEvents(InputState state)
         {

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -44,6 +44,8 @@ namespace osu.Framework.Input
 
         private bool useParentInput = true;
 
+        public override bool HandleHoverEvents => UseParentInput ? parentInputManager.HandleHoverEvents : base.HandleHoverEvents;
+
         internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
             if (!PropagateNonPositionalInputSubTree) return false;

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -16,7 +16,7 @@ namespace osu.Framework.Input
     {
         protected override ImmutableArray<InputHandler> InputHandlers => Host.AvailableInputHandlers;
 
-        protected override bool HandleHoverEvents => Host.Window?.CursorInWindow.Value ?? true;
+        public override bool HandleHoverEvents => Host.Window?.CursorInWindow.Value ?? true;
 
         protected internal override bool ShouldBeAlive => true;
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/4347 via proposed solution in that issue thread.

I tested this manually using `TestScenePassThroughInputManger` via the hover event count. Not sure it's worth adding automated test coverage of this, but can be done if required.