### PR TITLE
Fix window potentialy having an incorrect focused state on windows

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -163,7 +163,7 @@ namespace osu.Framework.Platform
 
         public Bindable<WindowMode> WindowMode { get; } = new Bindable<WindowMode>();
 
-        private readonly BindableBool isActive = new BindableBool(true);
+        private readonly BindableBool isActive = new BindableBool();
 
         public IBindable<bool> IsActive => isActive;
 


### PR DESCRIPTION
- [x] Depends on https://github.com/libsdl-org/SDL/pull/4293

The local change is required as there is a possibility that the window does not start focused, and it's easier to change this bindable to rely on SDL reporting to us that the focus has been gained (seems to be quite reliable on macOS and windows).

Note that this does introduce a short period during startup where the game may not be considered active (seems to be about one frame). I'm not sure if this will become an issue, but I can't notice any behavioural changes in testing against osu!. The only way I noticed is by starting up the framework `VisualTests` project with the `TestSceneIsActive` as the active test.