### PR TITLE
Fix readable key combination string including main modifier along direction-specific

### DIFF
--- a/osu.Framework.Tests/Input/KeyCombinationTest.cs
+++ b/osu.Framework.Tests/Input/KeyCombinationTest.cs
@@ -18,7 +18,10 @@ namespace osu.Framework.Tests.Input
             new object[] { new KeyCombination(InputKey.LAlt, InputKey.F4), "LAlt-F4" },
             new object[] { new KeyCombination(InputKey.D, InputKey.LControl), "LCtrl-D" },
             new object[] { new KeyCombination(InputKey.LShift, InputKey.F, InputKey.LControl), "LCtrl-LShift-F" },
-            new object[] { new KeyCombination(InputKey.LAlt, InputKey.LControl, InputKey.LSuper, InputKey.LShift), "LCtrl-LAlt-LShift-LWin" }
+            new object[] { new KeyCombination(InputKey.LAlt, InputKey.LControl, InputKey.LSuper, InputKey.LShift), "LCtrl-LAlt-LShift-LWin" },
+            new object[] { new KeyCombination(InputKey.Alt, InputKey.LAlt, InputKey.RControl, InputKey.A), "RCtrl-LAlt-A" },
+            new object[] { new KeyCombination(InputKey.Shift, InputKey.LControl, InputKey.X), "LCtrl-Shift-X" },
+            new object[] { new KeyCombination(InputKey.Control, InputKey.Shift, InputKey.Alt, InputKey.Super, InputKey.LAlt, InputKey.RShift, InputKey.LSuper), "Ctrl-LAlt-RShift-LWin" },
         };
 
         [TestCaseSource(nameof(key_combination_display_test_cases))]

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -232,7 +232,7 @@ namespace osu.Framework.Input.Bindings
 
         public string ReadableString()
         {
-            var sortedKeys = Keys.GetValuesInOrder();
+            var sortedKeys = Keys.GetValuesInOrder().ToArray();
 
             return string.Join('-', sortedKeys.Select(key =>
             {

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -233,7 +233,38 @@ namespace osu.Framework.Input.Bindings
         public string ReadableString()
         {
             var sortedKeys = Keys.GetValuesInOrder();
-            return string.Join('-', sortedKeys.Select(getReadableKey));
+
+            return string.Join('-', sortedKeys.Select(key =>
+            {
+                switch (key)
+                {
+                    case InputKey.Control:
+                        if (sortedKeys.Contains(InputKey.LControl) || sortedKeys.Contains(InputKey.RControl))
+                            return null;
+
+                        break;
+
+                    case InputKey.Shift:
+                        if (sortedKeys.Contains(InputKey.LShift) || sortedKeys.Contains(InputKey.RShift))
+                            return null;
+
+                        break;
+
+                    case InputKey.Alt:
+                        if (sortedKeys.Contains(InputKey.LAlt) || sortedKeys.Contains(InputKey.RAlt))
+                            return null;
+
+                        break;
+
+                    case InputKey.Super:
+                        if (sortedKeys.Contains(InputKey.LSuper) || sortedKeys.Contains(InputKey.RSuper))
+                            return null;
+
+                        break;
+                }
+
+                return getReadableKey(key);
+            }).Where(s => !string.IsNullOrEmpty(s)));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -259,7 +290,7 @@ namespace osu.Framework.Input.Bindings
             return false;
         }
 
-        private string getReadableKey(InputKey key)
+        private static string getReadableKey(InputKey key)
         {
             if (key >= InputKey.FirstTabletAuxiliaryButton)
                 return $"Tablet Aux {key - InputKey.FirstTabletAuxiliaryButton + 1}";


### PR DESCRIPTION
Was causing key combinations like `(Shift, LShift, Control, LControl, R)` to display as `Ctrl-LCtrl-Shift-LShift-R`, instead of `LCtrl-LShift-R`, as can be seen in osu!'s key binding configuration:
<img width="500" alt="CleanShot 2021-04-12 at 09 06 27@2x" src="https://user-images.githubusercontent.com/22781491/114347897-69488400-9b6e-11eb-83ae-c92a959efab6.png">

Now written to hide the main modifier if the direction-specific one exists in the combination, otherwise show it.