### PR TITLE
Allow OverlayContainers to optionally not block scroll

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneFocusedOverlayContainer.cs
@@ -47,8 +47,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("not visible", () => overlayContainer.State.Value == Visibility.Hidden);
         }
 
-        [Test]
-        public void TestScrollBlocking()
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestScrollBlocking(bool isBlocking)
         {
             AddStep("create container", () =>
             {
@@ -57,7 +58,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     RelativeSizeAxes = Axes.Both,
                     Children = new Drawable[]
                     {
-                        overlayContainer = new TestFocusedOverlayContainer()
+                        overlayContainer = new TestFocusedOverlayContainer(blockScrollInput: isBlocking)
                     }
                 };
             });
@@ -75,7 +76,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.ScrollVerticalBy(1);
             });
 
-            AddAssert("scroll not received by parent", () => parentContainer.ScrollReceived == initialScrollCount);
+            if (isBlocking)
+                AddAssert("scroll not received by parent", () => parentContainer.ScrollReceived == initialScrollCount);
+            else
+                AddAssert("scroll received by parent", () => parentContainer.ScrollReceived == ++initialScrollCount);
 
             AddStep("scroll outside", () =>
             {
@@ -94,8 +98,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             protected override bool BlockNonPositionalInput => false;
 
-            public TestFocusedOverlayContainer(bool startHidden = true)
+            protected override bool BlockScrollInput { get; }
+
+            public TestFocusedOverlayContainer(bool startHidden = true, bool blockScrollInput = true)
             {
+                BlockScrollInput = blockScrollInput;
+
                 StartHidden = startHidden;
 
                 Size = new Vector2(0.5f);

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -18,6 +18,13 @@ namespace osu.Framework.Graphics.Containers
         protected virtual bool BlockPositionalInput => true;
 
         /// <summary>
+        /// Scroll events are sometimes required to be handled differently to general positional input.
+        /// This covers whether scroll events that occur within this overlay's bounds are blocked or not.
+        /// Defaults to the same value as <see cref="BlockPositionalInput"/>
+        /// </summary>
+        protected virtual bool BlockScrollInput => BlockPositionalInput;
+
+        /// <summary>
         /// Whether we should block any non-positional input from interacting with things behind us.
         /// </summary>
         protected virtual bool BlockNonPositionalInput => false;
@@ -41,7 +48,7 @@ namespace osu.Framework.Graphics.Containers
             switch (e)
             {
                 case ScrollEvent _:
-                    if (BlockPositionalInput && base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
+                    if (BlockScrollInput && base.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
                         return true;
 
                     break;


### PR DESCRIPTION
As proposed in https://github.com/ppy/osu/pull/12375#issuecomment-817562409.

Will add test coverage if this is seen as an amicable direction.