### PR TITLE
Update OpenTabletDriver package to 0.5.3

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -46,7 +46,7 @@
          See https://github.com/NuGet/Home/issues/4514 and https://github.com/dotnet/sdk/issues/765 . -->
     <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2021.115.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="OpenTabletDriver" Version="0.5.2.3" />
+    <PackageReference Include="OpenTabletDriver" Version="0.5.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0">
       <NoWarn>NU1701</NoWarn> <!-- Requires .NETFramework for MSBuild, but we use Microsoft.Build.Locator which allows this package to work in .NETCoreApp. -->


### PR DESCRIPTION
## Short Changelog

[Full changelog](https://github.com/OpenTabletDriver/OpenTabletDriver/releases/tag/v0.5.3)

- Fixed Wacom touch reports being handled as auxiliary buttons (now reports touch data through `ITouchReport`)
  > Touch implementation is subject to change once we find more touch capable tablets and parse their data structures. 
- Added 26 new tablet configurations (Wacom, Huion, XP-Pen)
- Fixed and/or renamed 33 existing tablet configurations (Gaomon, Huion, Wacom, XP-Pen)
- Improved common exception messages to be more descriptive and link to OpenTabletDriver FAQ
- Workaround bad/partial reports resulting in device detection failing