### PR TITLE
Fix audio device freeing on Linux

### DIFF
--- a/osu.Framework.Tests/Audio/AudioComponentTest.cs
+++ b/osu.Framework.Tests/Audio/AudioComponentTest.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Reflection;
-using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Audio;
@@ -40,9 +39,7 @@ namespace osu.Framework.Tests.Audio
 
             manager?.Dispose();
 
-            Thread.Sleep(500);
-
-            Assert.IsTrue(thread.Exited);
+            AudioThreadTest.WaitForOrAssert(() => thread.Exited, "Audio thread did not exit in time");
         }
 
         [Test]

--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -36,7 +36,9 @@ namespace osu.Framework.Tests.Audio
         [TearDown]
         public void Teardown()
         {
-            Bass.Free();
+            // See AudioThread.freeDevice().
+            if (RuntimeInfo.OS != RuntimeInfo.Platform.Linux)
+                Bass.Free();
         }
 
         [Test]

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -45,7 +45,9 @@ namespace osu.Framework.Tests.Audio
         [TearDown]
         public void Teardown()
         {
-            Bass.Free();
+            // See AudioThread.freeDevice().
+            if (RuntimeInfo.OS != RuntimeInfo.Platform.Linux)
+                Bass.Free();
         }
 
         [Test]

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -100,7 +100,6 @@ namespace osu.Framework.Audio
         private readonly Lazy<TrackStore> globalTrackStore;
         private readonly Lazy<SampleStore> globalSampleStore;
 
-        private bool didInitialise;
         private Thread syncDeviceThread;
 
         /// <summary>
@@ -166,8 +165,6 @@ namespace osu.Framework.Audio
 
             OnNewDevice = null;
             OnLostDevice = null;
-
-            FreeBass();
 
             base.Dispose(disposing);
         }
@@ -253,18 +250,7 @@ namespace osu.Framework.Audio
 
             // initialize new device
             bool initSuccess = InitBass(deviceIndex);
-
-            if (Bass.LastError == Errors.Already)
-            {
-                // We check if the initialization error is that we already initialized the device
-                // If it is, it means we can just tell Bass to use the already initialized device without much
-                // other fuzz.
-                Bass.CurrentDevice = deviceIndex;
-                FreeBass();
-                initSuccess = InitBass(deviceIndex);
-            }
-
-            if (BassUtils.CheckFaulted(false))
+            if (Bass.LastError != Errors.Already && BassUtils.CheckFaulted(false))
                 return false;
 
             if (!initSuccess)
@@ -313,17 +299,19 @@ namespace osu.Framework.Audio
             // ensure there are no brief delays on audio operations (causing stream STALLs etc.) after periods of silence.
             Bass.Configure(ManagedBass.Configuration.DevNonStop, true);
 
-            didInitialise = true;
+            bool didInit = Bass.Init(device);
 
-            return Bass.Init(device);
-        }
+            // If the device was already initialised, the device can be used without much fuss.
+            if (Bass.LastError == Errors.Already)
+            {
+                Bass.CurrentDevice = device;
+                didInit = true;
+            }
 
-        protected void FreeBass()
-        {
-            if (!didInitialise) return;
+            if (didInit)
+                thread.RegisterInitialisedDevice(device);
 
-            Bass.Free();
-            didInitialise = false;
+            return didInit;
         }
 
         private void syncAudioDevices()


### PR DESCRIPTION
Closes #3700, closes #3387

On Linux, freeing the 0 (no-sound) device can sometimes cause a deadlock internal to BASS. I previously tried to repro this in native code, but it seems to happen after quite a few `Init() -> Free()` cycles which I didn't realise was the case before.

I've reworked the whole init/freeing flow a bit here:
1. Init does not `Free()` if BASS gives an `Already` error. Instead, it just sets the current device.
2. When freeing, the target device is selected via `Bass.CurrentDevice`. This is required as per [BASS docs](http://www.un4seen.com/doc/#bass/BASS_Free.html), which was not done previously.
3. On disposal, `AudioManager` joins the sync thread, to prevent any `setDevice()` from potentially happening post-dispose/post-AudioThread-exit.
4. On Linux, the no-sound device is never freed.

This fixes endless test execution on Linux. Needs testing on Windows/macOS.

Test run on linux:
osu!: 
![image](https://user-images.githubusercontent.com/1329837/114520563-8c615980-9c7c-11eb-9e5e-6ca787ad83c5.png)
o!f:
![image](https://user-images.githubusercontent.com/1329837/114520603-95522b00-9c7c-11eb-8a9a-4a9619c3ca22.png)
