### PR TITLE
Update OpenTabletDriver package to v0.5.3.1

### DIFF
--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -46,7 +46,7 @@
          See https://github.com/NuGet/Home/issues/4514 and https://github.com/dotnet/sdk/issues/765 . -->
     <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2021.115.0" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
-    <PackageReference Include="OpenTabletDriver" Version="0.5.3" />
+    <PackageReference Include="OpenTabletDriver" Version="0.5.3.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.9.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="3.9.0">
       <NoWarn>NU1701</NoWarn> <!-- Requires .NETFramework for MSBuild, but we use Microsoft.Build.Locator which allows this package to work in .NETCoreApp. -->


### PR DESCRIPTION
## Changelog

- Fixed report parser dictionary lookup not including `Wacom64bAuxReportParser` (https://github.com/OpenTabletDriver/OpenTabletDriver/pull/985)

Required for touch data parsing,  pretty big oversight in the v0.5.3 package release