### PR TITLE
Revert weird CursorContainer logic that causes incorrect cursor positioning

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneCursorContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCursorContainer.cs
@@ -49,22 +49,30 @@ namespace osu.Framework.Tests.Visual.Containers
                     cursorContainer.ActiveCursor.ScreenSpaceDrawQuad.Centre,
                     container.ScreenSpaceDrawQuad.Centre);
 
+            bool cursorAtMouseScreenSpace() =>
+                Precision.AlmostEquals(
+                    cursorContainer.ActiveCursor.ScreenSpaceDrawQuad.Centre,
+                    InputManager.CurrentState.Mouse.Position);
+
             createContent();
             AddStep("Move cursor to centre", () => InputManager.MoveMouseTo(container.ScreenSpaceDrawQuad.Centre));
-            AddAssert("cursor is centered", cursorCenteredInContainer);
+            AddAssert("cursor is centered", () => cursorCenteredInContainer());
             AddStep("Move container", () => container.Y += 50);
-            AddAssert("cursor is still centered", cursorCenteredInContainer);
+            AddAssert("cursor no longer centered", () => !cursorCenteredInContainer());
+            AddAssert("cursor at mouse position", () => cursorAtMouseScreenSpace());
             AddStep("Resize container", () => container.Size *= new Vector2(1.4f, 1));
-            AddAssert("cursor is still centered", cursorCenteredInContainer);
+            AddAssert("cursor at mouse position", () => cursorAtMouseScreenSpace());
 
             // ensure positional updates work
             AddStep("Move cursor to centre", () => InputManager.MoveMouseTo(container.ScreenSpaceDrawQuad.Centre));
-            AddAssert("cursor is still centered", cursorCenteredInContainer);
+            AddAssert("cursor is not centered", () => cursorCenteredInContainer());
+            AddAssert("cursor at mouse position", () => cursorAtMouseScreenSpace());
 
             // ensure we received the mouse position update from IRequireHighFrequencyMousePosition
             AddStep("Move cursor to test centre", () => InputManager.MoveMouseTo(Content.ScreenSpaceDrawQuad.Centre));
             AddStep("Recreate container with mouse already in place", createContent);
-            AddAssert("cursor is centered", cursorCenteredInContainer);
+            AddAssert("cursor is centered", () => cursorCenteredInContainer());
+            AddAssert("cursor at mouse position", () => cursorAtMouseScreenSpace());
         }
 
         private class TestCursorContainer : CursorContainer

--- a/osu.Framework/Graphics/Cursor/CursorContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorContainer.cs
@@ -7,7 +7,6 @@ using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
-using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
 
@@ -37,21 +36,9 @@ namespace osu.Framework.Graphics.Cursor
 
         public override bool PropagatePositionalInputSubTree => IsPresent; // make sure we are still updating position during possible fade out.
 
-        private Vector2? lastPosition;
-
         protected override bool OnMouseMove(MouseMoveEvent e)
         {
-            // required due to IRequireHighFrequencyMousePosition firing with the last known position even when the source is not in a
-            // valid state (ie. receiving updates from user or otherwise). in this case, we generally want the cursor to remain at its
-            // last *relative* position.
-            if (lastPosition.HasValue && Precision.AlmostEquals(e.ScreenSpaceMousePosition, lastPosition.Value))
-                return false;
-
-            lastPosition = e.ScreenSpaceMousePosition;
-
-            ActiveCursor.RelativePositionAxes = Axes.None;
             ActiveCursor.Position = e.MousePosition;
-            ActiveCursor.RelativePositionAxes = Axes.Both;
             return base.OnMouseMove(e);
         }
 


### PR DESCRIPTION
This logic would result in a displayed cursor drifting from the true cursor position if the `Container` (or any parent hierarchy) is transformed in any way.

Expected behaviour is that no matter how the draw hierarchy is transformed, the cursor is always displayed at the tracking location (based on the parent `InputManager`'s `Mouse` position.

I'm not actually sure if we need to make any further changes osu! side, as the issue referenced by the original pull request does not seem to return, even with this change reverted. Regardless, I'd like to get this into a framework build if it's seen as a more correct direction, then deal with any regressions osu! side if/when they are found.