### PR TITLE
Fix possible nullref when setting DecoupleableInterpolatingFramedClock.Rate

### DIFF
--- a/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
@@ -54,7 +54,11 @@ namespace osu.Framework.Timing
         public override double Rate
         {
             get => Source?.Rate ?? 1;
-            set => adjustableSource.Rate = value;
+            set
+            {
+                if (adjustableSource != null)
+                    adjustableSource.Rate = value;
+            }
         }
 
         public void ResetSpeedAdjustments() => Rate = 1;

--- a/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 
 namespace osu.Framework.Timing
@@ -33,7 +35,7 @@ namespace osu.Framework.Timing
         /// <summary>
         /// We need to be able to pass on adjustments to the source if it supports them.
         /// </summary>
-        private IAdjustableClock adjustableSource => Source as IAdjustableClock;
+        private IAdjustableClock? adjustableSource => Source as IAdjustableClock;
 
         public override double CurrentTime => currentTime;
 
@@ -111,7 +113,7 @@ namespace osu.Framework.Timing
             currentTime = elapsedFrameTime < 0 ? Math.Min(currentTime, proposedTime) : Math.Max(currentTime, proposedTime);
         }
 
-        public override void ChangeSource(IClock source)
+        public override void ChangeSource(IClock? source)
         {
             if (source == null) return;
 

--- a/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/DecoupleableInterpolatingFramedClock.cs
@@ -56,8 +56,10 @@ namespace osu.Framework.Timing
             get => Source?.Rate ?? 1;
             set
             {
-                if (adjustableSource != null)
-                    adjustableSource.Rate = value;
+                if (adjustableSource == null)
+                    throw new NotSupportedException("Source is not adjustable.");
+
+                adjustableSource.Rate = value;
             }
         }
 

--- a/osu.Framework/Timing/FramedClock.cs
+++ b/osu.Framework/Timing/FramedClock.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using osu.Framework.Extensions.TypeExtensions;
 using System;
 
@@ -19,10 +21,12 @@ namespace osu.Framework.Timing
         /// </summary>
         /// <param name="source">A source clock which will be used as the backing time source. If null, a StopwatchClock will be created. When provided, the CurrentTime of <paramref name="source"/> will be transferred instantly.</param>
         /// <param name="processSource">Whether the source clock's <see cref="ProcessFrame"/> method should be called during this clock's process call.</param>
-        public FramedClock(IClock source = null, bool processSource = true)
+        public FramedClock(IClock? source = null, bool processSource = true)
         {
             this.processSource = processSource;
-            ChangeSource(source ?? new StopwatchClock(true));
+            Source = source ?? new StopwatchClock(true);
+
+            ChangeSource(Source);
         }
 
         public FrameTimeInfo TimeInfo => new FrameTimeInfo { Elapsed = ElapsedFrameTime, Current = CurrentTime };
@@ -39,7 +43,7 @@ namespace osu.Framework.Timing
 
         public double ElapsedFrameTime => CurrentTime - LastFrameTime;
 
-        public bool IsRunning => Source?.IsRunning ?? false;
+        public bool IsRunning => Source.IsRunning;
 
         private readonly bool processSource;
 

--- a/osu.Framework/Timing/FramedOffsetClock.cs
+++ b/osu.Framework/Timing/FramedOffsetClock.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 namespace osu.Framework.Timing
 {
     /// <summary>

--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 
 namespace osu.Framework.Timing
@@ -13,9 +15,9 @@ namespace osu.Framework.Timing
     {
         private readonly FramedClock clock = new FramedClock(new StopwatchClock(true));
 
-        public IClock Source { get; private set; }
+        public IClock? Source { get; private set; }
 
-        protected IFrameBasedClock FramedSourceClock;
+        protected IFrameBasedClock? FramedSourceClock;
         protected double LastInterpolatedTime;
         protected double CurrentInterpolatedTime;
 
@@ -23,7 +25,7 @@ namespace osu.Framework.Timing
 
         public double FramesPerSecond => 0;
 
-        public virtual void ChangeSource(IClock source)
+        public virtual void ChangeSource(IClock? source)
         {
             if (source != null)
             {
@@ -35,7 +37,7 @@ namespace osu.Framework.Timing
             CurrentInterpolatedTime = 0;
         }
 
-        public InterpolatingFramedClock(IClock source = null)
+        public InterpolatingFramedClock(IClock? source = null)
         {
             ChangeSource(source);
         }

--- a/osu.Framework/Timing/InterpolatingFramedClock.cs
+++ b/osu.Framework/Timing/InterpolatingFramedClock.cs
@@ -55,13 +55,13 @@ namespace osu.Framework.Timing
 
         public virtual double Rate
         {
-            get => FramedSourceClock.Rate;
+            get => FramedSourceClock?.Rate ?? 1;
             set => throw new NotSupportedException();
         }
 
         public virtual bool IsRunning => sourceIsRunning;
 
-        public virtual double Drift => CurrentTime - FramedSourceClock.CurrentTime;
+        public virtual double Drift => CurrentTime - (FramedSourceClock?.CurrentTime ?? 0);
 
         public virtual double ElapsedFrameTime => CurrentInterpolatedTime - LastInterpolatedTime;
 

--- a/osu.Framework/Timing/ThrottledFrameClock.cs
+++ b/osu.Framework/Timing/ThrottledFrameClock.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Diagnostics;
 using System.Threading;


### PR DESCRIPTION
When the source clock is not an `IAdjustableClock`, setting `DecoupleableInterpolatingFramedClock.Rate` would nullref.