### PR TITLE
Remove IBindable interface inheritance

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableTest.cs
@@ -96,10 +96,10 @@ namespace osu.Framework.Tests.Bindables
         [TestCaseSource(nameof(getParsingConversionTests))]
         public void TestParse(Type type, object input, object output)
         {
-            IBindable bindable = (IBindable)Activator.CreateInstance(typeof(Bindable<>).MakeGenericType(type), type == typeof(string) ? "" : Activator.CreateInstance(type));
+            object bindable = Activator.CreateInstance(typeof(Bindable<>).MakeGenericType(type), type == typeof(string) ? "" : Activator.CreateInstance(type));
             Debug.Assert(bindable != null);
 
-            bindable.Parse(input);
+            ((IParseable)bindable).Parse(input);
             object value = bindable.GetType().GetProperty(nameof(Bindable<object>.Value), BindingFlags.Public | BindingFlags.Instance)?.GetValue(bindable);
 
             Assert.That(value, Is.EqualTo(output));

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -19,7 +19,7 @@ namespace osu.Framework.Bindables
     /// A generic implementation of a <see cref="IBindable"/>
     /// </summary>
     /// <typeparam name="T">The type of our stored <see cref="Value"/>.</typeparam>
-    public class Bindable<T> : IBindable<T>, ISerializableBindable
+    public class Bindable<T> : IBindable<T>, IBindable, IParseable, ISerializableBindable
     {
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed (or manually via <see cref="TriggerValueChange"/>).

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -11,7 +11,7 @@ using osu.Framework.Lists;
 
 namespace osu.Framework.Bindables
 {
-    public class BindableList<T> : IBindableList<T>, IList<T>, IList
+    public class BindableList<T> : IBindableList<T>, IBindable, IParseable, IList<T>, IList
     {
         /// <summary>
         /// An event which is raised when this <see cref="BindableList{T}"/> changes.

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Bindables
     /// <summary>
     /// An interface which can be bound to other <see cref="IBindable"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled">Disabled</see> changes.
     /// </summary>
-    public interface IBindable : IParseable, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
+    public interface IBindable : ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
     {
         /// <summary>
         /// Binds ourselves to another bindable such that we receive any value limitations of the bindable we bind width.
@@ -20,7 +20,7 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        public sealed IBindable BindTarget
+        sealed IBindable BindTarget
         {
             set => BindTo(value);
         }
@@ -38,7 +38,7 @@ namespace osu.Framework.Bindables
     /// An interface which can be bound to other <see cref="IBindable{T}"/>s in order to watch for (and react to) <see cref="ICanBeDisabled.Disabled">Disabled</see> and <see cref="IBindable{T}.Value">Value</see> changes.
     /// </summary>
     /// <typeparam name="T">The type of value encapsulated by this <see cref="IBindable{T}"/>.</typeparam>
-    public interface IBindable<T> : IBindable
+    public interface IBindable<T> : ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
     {
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed.
@@ -65,7 +65,7 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        new IBindable<T> BindTarget
+        IBindable<T> BindTarget
         {
             set => BindTo(value);
         }
@@ -83,6 +83,6 @@ namespace osu.Framework.Bindables
         /// a local reference.
         /// </summary>
         /// <returns>A weakly bound copy of the specified bindable.</returns>
-        new IBindable<T> GetBoundCopy();
+        IBindable<T> GetBoundCopy();
     }
 }

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Bindables
     /// A readonly interface which can be bound to other <see cref="IBindableList{T}"/>s in order to watch for state and content changes.
     /// </summary>
     /// <typeparam name="T">The type of value encapsulated by this <see cref="IBindableList{T}"/>.</typeparam>
-    public interface IBindableList<T> : IReadOnlyList<T>, IBindable, INotifyCollectionChanged
+    public interface IBindableList<T> : IReadOnlyList<T>, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription, INotifyCollectionChanged
     {
         /// <summary>
         /// Binds self to another bindable such that we receive any values and value limitations of the bindable we bind width.
@@ -30,7 +30,7 @@ namespace osu.Framework.Bindables
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
         /// Passes the provided value as the foreign (more permanent) bindable.
         /// </summary>
-        new sealed IBindableList<T> BindTarget
+        sealed IBindableList<T> BindTarget
         {
             set => BindTo(value);
         }
@@ -41,6 +41,6 @@ namespace osu.Framework.Bindables
         /// a local reference.
         /// </summary>
         /// <returns>A weakly bound copy of the specified bindable.</returns>
-        new IBindableList<T> GetBoundCopy();
+        IBindableList<T> GetBoundCopy();
     }
 }

--- a/osu.Framework/Configuration/IniConfigManager.cs
+++ b/osu.Framework/Configuration/IniConfigManager.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 
@@ -59,7 +60,10 @@ namespace osu.Framework.Configuration
                         {
                             try
                             {
-                                b.Parse(val);
+                                if (!(b is IParseable parseable))
+                                    throw new InvalidOperationException($"Bindable type {b.GetType().ReadableName()} is not IParseable.");
+
+                                parseable.Parse(val);
                             }
                             catch (Exception e)
                             {

--- a/osu.Framework/Configuration/IniConfigManager.cs
+++ b/osu.Framework/Configuration/IniConfigManager.cs
@@ -61,7 +61,7 @@ namespace osu.Framework.Configuration
                             try
                             {
                                 if (!(b is IParseable parseable))
-                                    throw new InvalidOperationException($"Bindable type {b.GetType().ReadableName()} is not IParseable.");
+                                    throw new InvalidOperationException($"Bindable type {b.GetType().ReadableName()} is not {nameof(IParseable)}.");
 
                                 parseable.Parse(val);
                             }


### PR DESCRIPTION
Without this, the following appears as a totally valid operation at compile time, but will completely fall over at run time:
```csharp
Bindable<string> bindable = new Bindable<string>();

MyClass c = new MyClass();
c.MyBindable.BindTo(bindable);

public class MyClass
{
    public readonly IBindable<int> MyBindable = new Bindable<int>();
}
```

Note that this is still possible if `MyBindable` is exposed as an `IBindable` instead.

I've also removed `IParseable` from `IBindable` as that allowed directly changing the value of the `IBindable*`, which is something that should only be allowed on `Bindable<T>`/`BindableList<T>`.

# Breaking Changes

## `IBindable`, `IBindable<T>`, and `IBindableList<>` are no longer `IParseable`

`IParseable` is only implemented on the `Bindable<>` and `BindableList<>` classes. Code that relied on this functionality should instead cast to `IParseable`.