### PR TITLE
Allow parsing any enum-parsable value to enum bindables

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableEnumTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableEnumTest.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 
@@ -19,52 +21,35 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(value, bindable.Value);
         }
 
-        [TestCase("Value1", TestEnum.Value1)]
-        [TestCase("Value2", TestEnum.Value2)]
-        [TestCase("-1", TestEnum.Value1 - 1)]
-        [TestCase("2", TestEnum.Value2 + 1)]
-        public void TestParsingString(string value, TestEnum expected)
+        [TestCase(TestEnum.Value1, "Value1", 0, 0f, 0d, 0L, (short)0, (sbyte)0)]
+        [TestCase(TestEnum.Value2, "Value2", 1, 1f, 1d, 1L, (short)1, (sbyte)1)]
+        [TestCase(TestEnum.Value1 - 1, "-1", -1, -1f, -1d, -1L, (short)-1, (sbyte)-1)]
+        [TestCase(TestEnum.Value2 + 1, "2", 2, 2f, 2d, 2L, (short)2, (sbyte)2)]
+        public void TestParsing(TestEnum expected, params object[] values)
         {
             var bindable = new Bindable<TestEnum>();
-            bindable.Parse(value);
+            var nullable = new Bindable<TestEnum?>();
 
-            Assert.AreEqual(expected, bindable.Value);
+            foreach (var value in values.Append(expected))
+            {
+                bindable.Parse(value);
+                nullable.Parse(value);
+
+                Assert.AreEqual(expected, bindable.Value);
+                Assert.AreEqual(expected, nullable.Value);
+            }
         }
 
-        [TestCase("Value1", TestEnum.Value1)]
-        [TestCase("Value2", TestEnum.Value2)]
-        [TestCase("-1", TestEnum.Value1 - 1)]
-        [TestCase("2", TestEnum.Value2 + 1)]
-        public void TestParsingStringToNullableType(string value, TestEnum? expected)
-        {
-            var bindable = new Bindable<TestEnum?>();
-            bindable.Parse(value);
-
-            Assert.AreEqual(expected, bindable.Value);
-        }
-
-        [TestCase(TestEnum.Value1)]
-        [TestCase(TestEnum.Value2)]
-        [TestCase(TestEnum.Value1 - 1)]
-        [TestCase(TestEnum.Value2 + 1)]
-        public void TestParsingEnum(TestEnum value)
+        [TestCase(1.1f)]
+        [TestCase("Not a value")]
+        [TestCase("")]
+        public void TestUnparsaebles(object value)
         {
             var bindable = new Bindable<TestEnum>();
-            bindable.Parse(value);
+            var nullable = new Bindable<TestEnum?>();
 
-            Assert.AreEqual(value, bindable.Value);
-        }
-
-        [TestCase(TestEnum.Value1)]
-        [TestCase(TestEnum.Value2)]
-        [TestCase(TestEnum.Value1 - 1)]
-        [TestCase(TestEnum.Value2 + 1)]
-        public void TestParsingEnumToNullableType(TestEnum value)
-        {
-            var bindable = new Bindable<TestEnum?>();
-            bindable.Parse(value);
-
-            Assert.AreEqual(value, bindable.Value);
+            Assert.Throws<ArgumentException>(() => bindable.Parse(value));
+            Assert.Throws<ArgumentException>(() => nullable.Parse(value));
         }
 
         public enum TestEnum

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -252,12 +252,12 @@ namespace osu.Framework.Bindables
                     Value = bindable.Value;
                     break;
 
-                case string s when underlyingType.IsEnum:
-                    Value = (T)Enum.Parse(underlyingType, s);
-                    break;
-
                 default:
-                    Value = (T)Convert.ChangeType(input, underlyingType, CultureInfo.InvariantCulture);
+                    if (underlyingType.IsEnum)
+                        Value = (T)Enum.Parse(underlyingType, input.ToString());
+                    else
+                        Value = (T)Convert.ChangeType(input, underlyingType, CultureInfo.InvariantCulture);
+
                     break;
             }
         }


### PR DESCRIPTION
Closes ppy/osu#12454

On `master`, only strings are allowed to be parsed to enum bindables, all other object types would fall under `Convert.ChangeType(...)` causing `InvalidCastException`s, which means JSON-deserialized enum values cannot be easily parsed to bindables. 

In the linked thread, the issue was occurring due to attempting parsing enum values (integer types) from the database to their own enum bindables, and the same can happen for web responses.

Therefore I've changed the parser to allow any value to be parsed to an enum bindable, as long as `Enum.Parse(underlyingType, ...)` allows it, as I feel it's more logical to allow as such. Also added test cases showing what can and what can't be parsed in https://github.com/ppy/osu-framework/commit/b5bcdfa9269062bc7a595449557964ea9f69f0a0.

Notes:
 - Not sure about including `0f` and `0d` in the test cases, but those are actually allowed to be parsed with `Enum.Parse`, I guess it's fine kinda maybe?

Alternative solution for the linked issue would be to let bindable serializers serialize enum types to strings, and change osu!web to respect that. We could go that way if this is not a good direction to follow.