### PR TITLE
Add descriptions to rotation directions

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneTransformSequence.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneTransformSequence.cs
@@ -121,12 +121,12 @@ namespace osu.Framework.Tests.Visual.Drawables
         private void animate()
         {
             boxes[0].Delay(500).Then(500).Then(500).Then(
-                b => b.Delay(500).Spin(1000, RotationDirection.CounterClockwise)
+                b => b.Delay(500).Spin(1000, RotationDirection.Counterclockwise)
             );
 
-            boxes[1].Spin(1000, RotationDirection.CounterClockwise);
+            boxes[1].Spin(1000, RotationDirection.Counterclockwise);
 
-            boxes[2].Delay(-2000).Spin(1000, RotationDirection.CounterClockwise);
+            boxes[2].Delay(-2000).Spin(1000, RotationDirection.Counterclockwise);
 
             boxes[3].RotateTo(90)
                     .Then().Delay(1000).RotateTo(0)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -18,6 +18,7 @@ using osu.Framework.Timing;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
@@ -35,6 +36,7 @@ using osu.Framework.Layout;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
 using osuTK.Input;
+using Container = osu.Framework.Graphics.Containers.Container;
 
 namespace osu.Framework.Graphics
 {
@@ -2866,7 +2868,10 @@ namespace osu.Framework.Graphics
 
     public enum RotationDirection
     {
+        [Description("Clockwise")]
         Clockwise,
+
+        [Description("Counter-clockwise")]
         CounterClockwise,
     }
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2871,8 +2871,8 @@ namespace osu.Framework.Graphics
         [Description("Clockwise")]
         Clockwise,
 
-        [Description("Counter-clockwise")]
-        CounterClockwise,
+        [Description("Counterclockwise")]
+        Counterclockwise,
     }
 
     /// <summary>


### PR DESCRIPTION
To make them look more user-friendly when used in dropdowns, like the existing rotation direction setting for barrel roll mod osu!-side.

I wasn't sure about lumping the framework with that at first, but since it's already done in other places and is just about adding description attributes, I think it's fine. 

---

# vNext

## `RotationDirection.CounterClockwise` has been renamed to `Counterclockwise`

As it appears to be often one word, the enum member `CounterClockwise` has been renamed to `Counterclockwise`.