### PR TITLE
Move bitrate assignment to before reversing stream

### DIFF
--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -384,6 +384,12 @@ namespace osu.Framework.Tests.Audio
             Assert.AreEqual(0, track.CurrentTime);
         }
 
+        [Test]
+        public void TestBitrate()
+        {
+            Assert.Greater(track.Bitrate, 0);
+        }
+
         private void takeEffectsAndUpdateAfter(int after)
         {
             updateTrack();

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -105,8 +105,6 @@ namespace osu.Framework.Audio.Track
                     // Bass does not allow seeking to the end of the track, so the last available position is 1 sample before.
                     lastSeekablePosition = Bass.ChannelBytes2Seconds(activeStream, byteLength - BYTES_PER_SAMPLE) * 1000;
 
-                    bitrate = (int)Bass.ChannelGetAttribute(activeStream, ChannelAttribute.Bitrate);
-
                     stopCallback = new SyncCallback((a, b, c, d) => RaiseFailed());
                     endCallback = new SyncCallback((a, b, c, d) =>
                     {
@@ -152,6 +150,8 @@ namespace osu.Framework.Audio.Track
 
             BassFlags flags = Preview ? 0 : BassFlags.Decode | BassFlags.Prescan;
             int stream = Bass.CreateStream(StreamSystem.NoBuffer, flags, fileCallbacks.Callbacks, fileCallbacks.Handle);
+
+            bitrate = (int)Bass.ChannelGetAttribute(stream, ChannelAttribute.Bitrate);
 
             if (!Preview)
             {


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/4375 by setting the bitrate while preparing the stream.

Also adds a test which fails prior to this PR.