### PR TITLE
Fix SDL2 window `Position` property not updated sometimes

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -164,6 +164,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
                 // borderless alignment tests
                 AddStep("switch to borderless", () => windowMode.Value = WindowMode.Borderless);
+                AddAssert("check window position", () => new Point(window.Position.X + 1, window.Position.Y + 1) == display.Bounds.Location);
                 AddAssert("check window size", () => new Size(window.Size.Width - 1, window.Size.Height - 1) == display.Bounds.Size, desc2);
                 AddAssert("check current screen", () => window.CurrentDisplayBindable.Value.Index == display.Index);
 

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -103,6 +103,7 @@ namespace osu.Framework.Tests.Visual.Platform
             if (window.SupportedWindowModes.Contains(WindowMode.Fullscreen))
             {
                 AddStep("change to fullscreen", () => windowMode.Value = WindowMode.Fullscreen);
+                AddAssert("window position updated", () => ((SDL2DesktopWindow)window).Position == new Point(0, 0));
                 testResolution(1920, 1080);
                 testResolution(1280, 960);
                 testResolution(9999, 9999);

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -881,11 +881,13 @@ namespace osu.Framework.Platform
                     SDL.SDL_GetWindowPosition(SDLWindowHandle, out int x, out int y);
                     var newPosition = new Point(x, y);
 
-                    if (WindowMode.Value == Configuration.WindowMode.Windowed && !newPosition.Equals(Position))
+                    if (!newPosition.Equals(Position))
                     {
                         position = newPosition;
-                        storeWindowPositionToConfig();
                         ScheduleEvent(() => Moved?.Invoke(newPosition));
+
+                        if (WindowMode.Value == Configuration.WindowMode.Windowed)
+                            storeWindowPositionToConfig();
                     }
 
                     break;

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Platform.Windows
 
             // for now let's use the same 1px hack that we've always used to force borderless.
             SDL.SDL_SetWindowSize(SDLWindowHandle, newSize.Width, newSize.Height);
-            SDL.SDL_SetWindowPosition(SDLWindowHandle, newPosition.X, newPosition.Y);
+            Position = newPosition;
 
             return newSize;
         }


### PR DESCRIPTION
Should resolve https://github.com/ppy/osu-framework/issues/4323, and resolve https://github.com/ppy/osu/issues/12156.

Not much to say, `WindowsMouseHandler` uses `Window.Position` when calculating the mouse position for absolute input devices, and since `Window.Position` may not be updated sometimes (, the handler miscalculates the cursor position and causes it to be locked in a certain area or potentially completely freeze and not able to move.

Here's a video of reproducing the bug above:

https://user-images.githubusercontent.com/22781491/115179660-7f10f880-a0dc-11eb-9bfb-e50b859f5c11.mp4

There were two I cases I've found where the position property doesn't get updated, and are the only ones apparently:
1. when switching to other window modes https://github.com/ppy/osu-framework/commit/7d59db8b3bbfb62aed25196ae34d3289d0c6885e
2. during the borderless switch in `WindowsWindow` https://github.com/ppy/osu-framework/commit/b54df51d1a95a24e8207638ef7c1d04000b972c3

I'm not entirely sure why the position was first only updated on windowed mode, but I don't see any absolute harm in updating it on borderless and fullscreen modes, and logically makes sense to do so.