### PR TITLE
Only forward feedback cursor updates when the framework window is active

### DIFF
--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -51,6 +51,11 @@ namespace osu.Framework.Input.Handlers.Mouse
         /// </summary>
         private bool absolutePositionReceived;
 
+        /// <summary>
+        /// Whether the application should be handling the cursor.
+        /// </summary>
+        private bool cursorCaptured => isActive.Value && (window.CursorInWindow.Value || window.CursorState.HasFlagFast(CursorState.Confined));
+
         public override bool Initialize(GameHost host)
         {
             if (!base.Initialize(host))
@@ -106,7 +111,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             if (!Enabled.Value)
                 return;
 
-            if (!isSelfFeedback)
+            if (!isSelfFeedback && cursorCaptured)
                 // if another handler has updated the cursor position, handle updating the OS cursor so we can seamlessly revert
                 // to mouse control at any point.
                 window.UpdateMousePosition(position);
@@ -151,7 +156,7 @@ namespace osu.Framework.Input.Handlers.Mouse
                 // relative mode requires at least one absolute input to arrive, to gain an additional position to work with.
                 && absolutePositionReceived
                 // relative mode only works when the window is active and the cursor is contained. aka the OS cursor isn't being displayed outside the window.
-                && (isActive.Value && (window.CursorInWindow.Value || window.CursorState.HasFlagFast(CursorState.Confined)))
+                && cursorCaptured
                 // relative mode shouldn't ever be enabled if the framework or a consumer has chosen not to hide the cursor.
                 && window.CursorState.HasFlagFast(CursorState.Hidden);
 

--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -111,7 +111,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             if (!Enabled.Value)
                 return;
 
-            if (!isSelfFeedback && cursorCaptured)
+            if (!isSelfFeedback && isActive.Value)
                 // if another handler has updated the cursor position, handle updating the OS cursor so we can seamlessly revert
                 // to mouse control at any point.
                 window.UpdateMousePosition(position);


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/4378.

Tested on windows with wacom tablet.