### PR TITLE
Improve bitrate precision

### DIFF
--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -151,7 +151,7 @@ namespace osu.Framework.Audio.Track
             BassFlags flags = Preview ? 0 : BassFlags.Decode | BassFlags.Prescan;
             int stream = Bass.CreateStream(StreamSystem.NoBuffer, flags, fileCallbacks.Callbacks, fileCallbacks.Handle);
 
-            bitrate = (int)Bass.ChannelGetAttribute(stream, ChannelAttribute.Bitrate);
+            bitrate = (int)Math.Round(Bass.ChannelGetAttribute(stream, ChannelAttribute.Bitrate));
 
             if (!Preview)
             {


### PR DESCRIPTION
Currently casts bitrates to `int`, which easily produces errors of ~1 kbps in cases like these:

![image](https://user-images.githubusercontent.com/30292137/115222860-78e64080-a10b-11eb-8f17-6173f7194f6b.png)

Probably best to round before casting to fix that. I don't think storing them as doubles (like I did here to debug) is necessary.

Bitrate in the test doesn't have this problem, so we'd need a separate sample to test this. Not sure where to find one we could use.

![image](https://user-images.githubusercontent.com/30292137/115225694-aa144000-a10e-11eb-965d-400481cb959a.png)