### PR TITLE
Speed up dynamic compilation type resolution

### DIFF
--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -189,8 +189,6 @@ namespace osu.Framework.Testing
         /// <param name="rootReference">The root, where the map should start being build from.</param>
         private async Task buildReferenceMapRecursiveAsync(TypeReference rootReference)
         {
-            var seenSyntaxes = new HashSet<string>();
-
             var searchQueue = new Queue<TypeReference>();
             searchQueue.Enqueue(rootReference);
 
@@ -259,7 +257,7 @@ namespace osu.Framework.Testing
                 return kind != SyntaxKind.UsingDirective
                        && kind != SyntaxKind.NamespaceKeyword
                        && (kind != SyntaxKind.ClassDeclaration || ((ClassDeclarationSyntax)n).Modifiers.All(m => m.Kind() != SyntaxKind.StaticKeyword))
-                       && (kind != SyntaxKind.VariableDeclarator);
+                       && kind != SyntaxKind.VariableDeclarator;
             });
 
             // This hashset is used to prevent re-exploring syntaxes with the same name.
@@ -311,6 +309,7 @@ namespace osu.Framework.Testing
                     return true;
                 }
 
+                // Todo: Reduce the number of cases that fall through here.
                 return false;
             }
 

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -275,7 +275,11 @@ namespace osu.Framework.Testing
                             continue;
 
                         if (semanticModel.GetSymbolInfo(node).Symbol is INamedTypeSymbol t)
+                        {
                             addTypeSymbol(t);
+                            seenSyntaxes.Add(node.ToString());
+                        }
+
                         break;
                     }
 
@@ -290,12 +294,14 @@ namespace osu.Framework.Testing
                             continue;
 
                         if (semanticModel.GetTypeInfo(node).Type is INamedTypeSymbol t)
+                        {
                             addTypeSymbol(t);
+                            seenSyntaxes.Add(node.ToString());
+                        }
+
                         break;
                     }
                 }
-
-                seenSyntaxes.Add(node.ToString());
             }
 
             return result;

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -282,11 +282,13 @@ namespace osu.Framework.Testing
                     case SyntaxKind.CastExpression:
                     case SyntaxKind.ObjectCreationExpression:
                     {
-                        if (seenSyntaxes.Contains(node.ToString()))
+                        string nodeString = node.ToString();
+
+                        if (seenSyntaxes.Contains(nodeString))
                             continue;
 
                         if (tryNode(node))
-                            seenSyntaxes.Add(node.ToString());
+                            seenSyntaxes.Add(nodeString);
 
                         break;
                     }

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -253,10 +253,13 @@ namespace osu.Framework.Testing
                 // - Entire using lines.
                 // - Namespace names (not entire namespaces).
                 // - Entire static classes.
+                // - Variable declarators (names of variables).
+                // - The first IdentifierName child of an assignment expression (variable name), below.
 
                 return kind != SyntaxKind.UsingDirective
                        && kind != SyntaxKind.NamespaceKeyword
-                       && (kind != SyntaxKind.ClassDeclaration || ((ClassDeclarationSyntax)n).Modifiers.All(m => m.Kind() != SyntaxKind.StaticKeyword));
+                       && (kind != SyntaxKind.ClassDeclaration || ((ClassDeclarationSyntax)n).Modifiers.All(m => m.Kind() != SyntaxKind.StaticKeyword))
+                       && (kind != SyntaxKind.VariableDeclarator);
             });
 
             // This hashset is used to prevent re-exploring syntaxes with the same name.
@@ -266,6 +269,10 @@ namespace osu.Framework.Testing
             // Find all the named type symbols in the syntax tree, and mark + recursively iterate through them.
             foreach (var node in descendantNodes)
             {
+                // Ignore the variable name of assignment expressions.
+                if (node.Kind() == SyntaxKind.IdentifierName && node.Parent is AssignmentExpressionSyntax)
+                    continue;
+
                 switch (node.Kind())
                 {
                     case SyntaxKind.GenericName:

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -270,19 +270,6 @@ namespace osu.Framework.Testing
                 {
                     case SyntaxKind.GenericName:
                     case SyntaxKind.IdentifierName:
-                    {
-                        if (seenSyntaxes.Contains(node.ToString()))
-                            continue;
-
-                        if (semanticModel.GetSymbolInfo(node).Symbol is INamedTypeSymbol t)
-                        {
-                            addTypeSymbol(t);
-                            seenSyntaxes.Add(node.ToString());
-                        }
-
-                        break;
-                    }
-
                     case SyntaxKind.AsExpression:
                     case SyntaxKind.IsExpression:
                     case SyntaxKind.SizeOfExpression:
@@ -293,11 +280,8 @@ namespace osu.Framework.Testing
                         if (seenSyntaxes.Contains(node.ToString()))
                             continue;
 
-                        if (semanticModel.GetTypeInfo(node).Type is INamedTypeSymbol t)
-                        {
-                            addTypeSymbol(t);
+                        if (tryNode(node))
                             seenSyntaxes.Add(node.ToString());
-                        }
 
                         break;
                     }
@@ -305,6 +289,23 @@ namespace osu.Framework.Testing
             }
 
             return result;
+
+            bool tryNode(SyntaxNode node)
+            {
+                if (semanticModel.GetSymbolInfo(node).Symbol is INamedTypeSymbol sType)
+                {
+                    addTypeSymbol(sType);
+                    return true;
+                }
+
+                if (semanticModel.GetTypeInfo(node).Type is INamedTypeSymbol tType)
+                {
+                    addTypeSymbol(tType);
+                    return true;
+                }
+
+                return false;
+            }
 
             void addTypeSymbol(INamedTypeSymbol typeSymbol)
             {


### PR DESCRIPTION
1. Adding a HashSet to prevent calling `GetSymbolInfo()` on the same syntax node seen in multiple locations.
    * This is currently only per-file to not run into failed recompilations. Additional perf improvements are possible by using the hashset globally, but the implementation becomes complex so I've added a todo for now.
2. Caching various `.ToString()` invocations.
3. Ignoring variable declarators - the name of a variable.
4. Ignoring variable name of assignment expressions, which is particularly important with our use of object initialisers.

Tested osu!-side by changing `EffectRowAttribute` in `TestSceneTimingScreen`:
Before:
![image](https://user-images.githubusercontent.com/1329837/115490187-8c72e200-a298-11eb-8767-5fa86f1a1581.png)
After:
![image](https://user-images.githubusercontent.com/1329837/115495771-60109300-a2a3-11eb-9390-2c550e1b2418.png)

~50% speedup