### PR TITLE
Fix dynamic compilation culling types without resolving type name

### DIFF
--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -262,7 +262,7 @@ namespace osu.Framework.Testing
 
             // This hashset is used to prevent re-exploring syntaxes with the same name.
             // Todo: This can be used across all files, but care needs to be taken for redefined types (via using X = y), using the same-named type from a different namespace, or via type hiding.
-            var seenSyntaxes = new HashSet<string>();
+            var seenTypes = new HashSet<string>();
 
             // Find all the named type symbols in the syntax tree, and mark + recursively iterate through them.
             foreach (var node in descendantNodes)
@@ -282,13 +282,12 @@ namespace osu.Framework.Testing
                     case SyntaxKind.CastExpression:
                     case SyntaxKind.ObjectCreationExpression:
                     {
-                        string nodeString = node.ToString();
-
-                        if (seenSyntaxes.Contains(nodeString))
+                        if (seenTypes.Contains(node.ToString()))
                             continue;
 
-                        if (tryNode(node))
-                            seenSyntaxes.Add(nodeString);
+                        // The syntax name may differ from the finalised symbol name (e.g. member access).
+                        if (tryNode(node, out var symbol))
+                            seenTypes.Add(symbol.Name);
 
                         break;
                     }
@@ -297,21 +296,24 @@ namespace osu.Framework.Testing
 
             return result;
 
-            bool tryNode(SyntaxNode node)
+            bool tryNode(SyntaxNode node, out INamedTypeSymbol symbol)
             {
                 if (semanticModel.GetSymbolInfo(node).Symbol is INamedTypeSymbol sType)
                 {
                     addTypeSymbol(sType);
+                    symbol = sType;
                     return true;
                 }
 
                 if (semanticModel.GetTypeInfo(node).Type is INamedTypeSymbol tType)
                 {
                     addTypeSymbol(tType);
+                    symbol = tType;
                     return true;
                 }
 
                 // Todo: Reduce the number of cases that fall through here.
+                symbol = null;
                 return false;
             }
 


### PR DESCRIPTION
Fixes a regression caused by https://github.com/ppy/osu-framework/pull/4382 because I was assuming the syntax name matched the type name.

In `TestSceneEditorChangeStates`, the base class has a member named `Editor` which is referenced in code. This `Editor` syntax has the symbol name (i.e. type) `TestEditor`. The previous code would add `Editor` to the cull list.  
Later down the file, `Editor` is found as a type, but it will be culled and not explored due to the above.

This slows down perf a touch (9.4 sec -> 10.3 sec when recompiling `TestSceneTimingScreen`), but I have changes that speed things up another 50% over current.