### PR TITLE
Fix invocation expression arguments not being explored

### DIFF
--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -265,6 +265,7 @@ namespace osu.Framework.Testing
                        && (kind != SyntaxKind.ClassDeclaration || ((ClassDeclarationSyntax)n).Modifiers.All(m => m.Kind() != SyntaxKind.StaticKeyword))
                        && kind != SyntaxKind.VariableDeclarator
                        && (kind != SyntaxKind.QualifiedName || !(n.Parent is NamespaceDeclarationSyntax))
+                       && kind != SyntaxKind.NameColon
                        && (!(n.Parent is InvocationExpressionSyntax invocation) || n != invocation.Expression);
             });
 
@@ -285,10 +286,6 @@ namespace osu.Framework.Testing
                     if (node.Parent is ArgumentSyntax)
                         continue;
                 }
-
-                // Ignore name-colon syntaxes (arguments).
-                if (node.Kind() == SyntaxKind.NameColon)
-                    continue;
 
                 switch (node.Kind())
                 {

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -258,7 +258,7 @@ namespace osu.Framework.Testing
                 // - The single IdentifierName child of an argument syntax (variable name), below.
                 // - The name of namespace declarations.
                 // - Name-colon syntaxes.
-                // - The expression of invocations. Static classes are explicitly disallowed so the target type of an invocation must be available elsewhere in the syntax tree.
+                // - The expression of invocation expressions. Static classes are explicitly disallowed so the target type of an invocation must be available elsewhere in the syntax tree.
 
                 return kind != SyntaxKind.UsingDirective
                        && kind != SyntaxKind.NamespaceKeyword
@@ -266,7 +266,7 @@ namespace osu.Framework.Testing
                        && kind != SyntaxKind.VariableDeclarator
                        && (kind != SyntaxKind.QualifiedName || !(n.Parent is NamespaceDeclarationSyntax))
                        && kind != SyntaxKind.NameColon
-                       && (!(n.Parent is InvocationExpressionSyntax invocation) || n != invocation.Expression);
+                       && (n.Parent?.Kind() != SyntaxKind.InvocationExpression || n != ((InvocationExpressionSyntax)n.Parent).Expression);
             });
 
             // This hashset is used to prevent re-exploring syntaxes with the same name.
@@ -284,6 +284,10 @@ namespace osu.Framework.Testing
 
                     // Ignore the variable name of arguments.
                     if (node.Parent is ArgumentSyntax)
+                        continue;
+
+                    // Ignore a single identifier name expression of an invocation expression (e.g. IdentifierName()).
+                    if (node.Parent.Kind() == SyntaxKind.InvocationExpression)
                         continue;
                 }
 

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -287,7 +287,7 @@ namespace osu.Framework.Testing
                         continue;
 
                     // Ignore a single identifier name expression of an invocation expression (e.g. IdentifierName()).
-                    if (node.Parent.Kind() == SyntaxKind.InvocationExpression)
+                    if (node.Parent?.Kind() == SyntaxKind.InvocationExpression)
                         continue;
                 }
 

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -519,11 +519,16 @@ namespace osu.Framework.Testing
             // Follow through the process for all parents.
             foreach (var p in node.Parents)
             {
+                int nextLevel = level + 1;
+
                 // Right-bound outlier test - exclude parents greater than 3x IQR. Always expand left-bound parents as they are unlikely to cause compilation errors.
                 if (p.ExpansionFactor > rightBound)
+                {
+                    logger.Add($"{(nextLevel > 0 ? $".{new string(' ', nextLevel * 2 - 1)}| " : string.Empty)} {node.ExpansionFactor} (rb: {rightBound}): {node} (!! EXCLUDED !!)");
                     continue;
+                }
 
-                getReferencedFilesRecursive(p, result, seenTypes, level + 1, expansions);
+                getReferencedFilesRecursive(p, result, seenTypes, nextLevel, expansions);
             }
         }
 

--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -258,14 +258,14 @@ namespace osu.Framework.Testing
                 // - The single IdentifierName child of an argument syntax (variable name), below.
                 // - The name of namespace declarations.
                 // - Name-colon syntaxes.
-                // - Invocation expressions. Static classes are explicitly disallowed so the target type of an invocation must be available elsewhere in the syntax tree.
+                // - The expression of invocations. Static classes are explicitly disallowed so the target type of an invocation must be available elsewhere in the syntax tree.
 
                 return kind != SyntaxKind.UsingDirective
                        && kind != SyntaxKind.NamespaceKeyword
                        && (kind != SyntaxKind.ClassDeclaration || ((ClassDeclarationSyntax)n).Modifiers.All(m => m.Kind() != SyntaxKind.StaticKeyword))
                        && kind != SyntaxKind.VariableDeclarator
                        && (kind != SyntaxKind.QualifiedName || !(n.Parent is NamespaceDeclarationSyntax))
-                       && (kind != SyntaxKind.InvocationExpression);
+                       && (!(n.Parent is InvocationExpressionSyntax invocation) || n != invocation.Expression);
             });
 
             // This hashset is used to prevent re-exploring syntaxes with the same name.


### PR DESCRIPTION
Ignoring the complete invocation expression is incorrect, for cases such as `Method(new X())` - `X` needs to be discovered.

This relates to one of the cases in https://github.com/ppy/osu-framework/issues/4387 - `ChannelManager` constructs `InfoMessage`s in exactly this fashion, without referencing them anywhere else.

I've also added some logging output to show the points of exclusion, as these were previously hidden and thus failed to indicate whether something was excluded or just never explored.

Unfortunately, this does slow down recompilation time :( (1.5sec -> 5sec via profiler)