### PR TITLE
Resolve more assemblies for dynamic compilation

### DIFF
--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -69,6 +69,8 @@ namespace osu.Framework.Testing
 
             var assemblies = new HashSet<AssemblyReference>();
 
+            foreach (var asm in compilationCache.Values.SelectMany(c => c.ReferencedAssemblyNames))
+                addReference(Assembly.Load(asm.Name), false);
             foreach (var asm in AppDomain.CurrentDomain.GetAssemblies().Where(a => !a.IsDynamic))
                 addReference(asm, false);
             addReference(typeof(JetBrains.Annotations.NotNullAttribute).Assembly, true);


### PR DESCRIPTION
This seems to work fine, but I'm not sure if there's a possibility of assembly conflicts or something like that as a result of adding too many assemblies.

As it turns out - it seems like assemblies are lazy-loaded upon first reference. In some cases, we're exploring classes that reference the Humanizer assembly, but that class has actually never been used before and so the Humanizer assembly isn't loaded, and thus not present in `AppDomain.CurrentDomain.GetAssemblies()`.

So this change takes all assemblies from the compilation and adds them in too. The current domain assemblies are still required for .NET internal types - there's probably a way around this but I'm not sure yet, various sources say to add some other package and add .csproj attributes, etc... Pretty gross stuff.