### PR TITLE
Fix `InputHandler`s being initialised before enabled state is read from config

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -583,9 +583,11 @@ namespace osu.Framework.Platform
 
                 ExecutionState = ExecutionState.Running;
 
-                initialiseInputHandlers();
+                populateInputHandlers();
 
                 SetupConfig(game.GetFrameworkConfigDefaults() ?? new Dictionary<FrameworkSetting, object>());
+
+                initialiseInputHandlers();
 
                 if (Window != null)
                 {
@@ -704,10 +706,13 @@ namespace osu.Framework.Platform
             Logger.Storage = Storage.GetStorageForDirectory("logs");
         }
 
-        private void initialiseInputHandlers()
+        private void populateInputHandlers()
         {
             AvailableInputHandlers = CreateAvailableInputHandlers().ToImmutableArray();
+        }
 
+        private void initialiseInputHandlers()
+        {
             foreach (var handler in AvailableInputHandlers)
             {
                 (handler as IHasCursorSensitivity)?.Sensitivity.BindTo(cursorSensitivity);


### PR DESCRIPTION
Noticed this while looking into https://github.com/ppy/osu/issues/12543. Specifically the startup case, which seemed odd because if a user has set the `MidiHandler` to disabled, it shoudln't be closing any devices on startup.

Turns out that due to startup order, the initialisation code was run before the config has a chance to set the disabled state.

Have tested against the scenario in the linked issue to no longer run the `Enabled.BindValueChanged` where `NewValue==true` code path on startup.