### PR TITLE
Fix TrackBass not updating current time after seek

### DIFF
--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -390,6 +390,16 @@ namespace osu.Framework.Tests.Audio
             Assert.Greater(track.Bitrate, 0);
         }
 
+        [Test]
+        public void TestCurrentTimeUpdatedAfterSeek()
+        {
+            track.StartAsync();
+            updateTrack();
+
+            runOnAudioThread(() => track.Seek(20000));
+            Assert.That(track.CurrentTime, Is.EqualTo(20000).Within(100));
+        }
+
         private void takeEffectsAndUpdateAfter(int after)
         {
             updateTrack();

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -391,7 +391,7 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
-        public void TestCurrentTimeUpdatedAfterSeek()
+        public void TestCurrentTimeUpdatedAfterInlineSeek()
         {
             track.StartAsync();
             updateTrack();

--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Tests.Audio
         [SetUp]
         public void Setup()
         {
-            track = new TrackVirtual(10000);
+            track = new TrackVirtual(60000);
             updateTrack();
         }
 
@@ -251,6 +251,16 @@ namespace osu.Framework.Tests.Audio
             Assert.AreEqual(1.5, track.Rate);
 
             testPlaybackRate(1.5);
+        }
+
+        [Test]
+        public void TestCurrentTimeUpdatedAfterInlineSeek()
+        {
+            track.Start();
+            updateTrack();
+
+            RunOnAudioThread(() => track.Seek(20000));
+            Assert.That(track.CurrentTime, Is.EqualTo(20000).Within(100));
         }
 
         private void testPlaybackRate(double expectedRate)

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using ManagedBass;
@@ -9,6 +10,7 @@ using ManagedBass.Fx;
 using osu.Framework.IO;
 using System.Threading.Tasks;
 using osu.Framework.Audio.Callbacks;
+using osu.Framework.Development;
 
 namespace osu.Framework.Audio.Track
 {
@@ -203,14 +205,13 @@ namespace osu.Framework.Audio.Track
             base.UpdateState();
 
             var running = isRunningState(Bass.ChannelIsActive(activeStream));
-            var bytePosition = Bass.ChannelGetPosition(activeStream);
 
             // because device validity check isn't done frequently, when switching to "No sound" device,
             // there will be a brief time where this track will be stopped, before we resume it manually (see comments in UpdateDevice(int).)
             // this makes us appear to be playing, even if we may not be.
             isRunning = running || (isPlayed && !hasCompleted);
 
-            Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, bytePosition) * 1000);
+            updateCurrentTime();
 
             bassAmplitudeProcessor?.Update();
         }
@@ -341,6 +342,16 @@ namespace osu.Framework.Audio.Track
 
             if (pos != Bass.ChannelGetPosition(activeStream))
                 Bass.ChannelSetPosition(activeStream, pos);
+
+            updateCurrentTime();
+        }
+
+        private void updateCurrentTime()
+        {
+            Debug.Assert(ThreadSafety.IsAudioThread);
+
+            var bytePosition = Bass.ChannelGetPosition(activeStream);
+            Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, bytePosition) * 1000);
         }
 
         private double currentTime;

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -10,7 +10,6 @@ using ManagedBass.Fx;
 using osu.Framework.IO;
 using System.Threading.Tasks;
 using osu.Framework.Audio.Callbacks;
-using osu.Framework.Development;
 
 namespace osu.Framework.Audio.Track
 {
@@ -348,7 +347,7 @@ namespace osu.Framework.Audio.Track
 
         private void updateCurrentTime()
         {
-            Debug.Assert(ThreadSafety.IsAudioThread);
+            Debug.Assert(CanPerformInline);
 
             var bytePosition = Bass.ChannelGetPosition(activeStream);
             Interlocked.Exchange(ref currentTime, Bass.ChannelBytes2Seconds(activeStream, bytePosition) * 1000);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12541

When seeks are performed in-line, there's a bit of an expectation that the resultant time is updated immediately rather than in the next frame.

This is also an issue with Play() and Stop(), but I'll be making an issue for those to be tackled later - they're a bit involved. (https://github.com/ppy/osu-framework/issues/4396)