### PR TITLE
Fix assertion tripping when seeking from within the mixtime callback

### DIFF
--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -342,7 +342,11 @@ namespace osu.Framework.Audio.Track
             if (pos != Bass.ChannelGetPosition(activeStream))
                 Bass.ChannelSetPosition(activeStream, pos);
 
-            updateCurrentTime();
+            // current time updates are safe to perform from enqueued actions,
+            // but not always safe to perform from BASS callbacks, since those can sometimes use a separate thread.
+            // if it's not safe to update immediately here, the next UpdateState() call is guaranteed to update the time safely anyway.
+            if (CanPerformInline)
+                updateCurrentTime();
         }
 
         private void updateCurrentTime()


### PR DESCRIPTION
The recent changes to `TrackBass` (#4395) added an instantaneous current time value update on a seek. As it turns out, it is not necessarily safe to unconditionally run that update, as BASS callbacks (such as the mixtime callback) could run from a separate unmanaged thread rather than the audio thread, tripping the `CanPerformInline` assertion check if a track had `Looping` and `RestartPoint` set.

This can be reproduced game-side with a framework checkout by seeking to the end of a track in song select and waiting for it to complete.

![2021-04-23-213212_1743x861_scrot](https://user-images.githubusercontent.com/20418176/115921129-62c5e080-a47b-11eb-9889-e60916e26ab2.png)

To fix, add an explicit check for whether the current time update can be safely performed via `seekInternal()` before trying to attempt it.

---

I wanted to write a test case for this, but as it turns out `TrackBassTest` magically sidesteps this issue, because it calls `track.Update()`, which seems to change semantics somehow in that the callback actually executes on the audio thread rather than a BASS-owned one. Not sure how that's possible, but [apparently this is something that we're tangentially aware of](https://discord.com/channels/188630481301012481/188630652340404224/835230809261998121).

Not sure about doubling up the condition, but I kind of wanted to keep the assertion as it was where it was in `updateCurrentTime()`, to let future travelers know when the method is safe to call. That assertion is dead on release builds anyway. I'll move the guard inside `updateCurrentTime()` in place of the assertion on request.