### PR TITLE
Remove Borderless 1px position offset hack

### DIFF
--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -38,14 +38,10 @@ namespace osu.Framework.Platform.Windows
         {
             SDL.SDL_SetWindowBordered(SDLWindowHandle, SDL.SDL_bool.SDL_FALSE);
 
-            Size positionOffsetHack = new Size(1, 1);
+            var newSize = CurrentDisplay.Bounds.Size;
 
-            var newSize = CurrentDisplay.Bounds.Size + positionOffsetHack;
-            var newPosition = CurrentDisplay.Bounds.Location - positionOffsetHack;
-
-            // for now let's use the same 1px hack that we've always used to force borderless.
             SDL.SDL_SetWindowSize(SDLWindowHandle, newSize.Width, newSize.Height);
-            Position = newPosition;
+            Position = CurrentDisplay.Bounds.Location;
 
             return newSize;
         }


### PR DESCRIPTION
It makes the osu window bleed into other monitors in Borderless mode. On Windows, if the other monitor is a lower refresh rate than the main one, the entire osu window is displayed at the lower refresh rate.

I'll admit, I don't really understand the reason this apparently deliberate offset was added in the first place, so this may introduce some sort of regression.

See also: https://github.com/ppy/osu/issues/12535