### PR TITLE
Change dragging states before triggering end event

### DIFF
--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -206,12 +206,15 @@ namespace osu.Framework.Input
         {
             DragStarted = false;
 
-            if (DraggedDrawable == null) return;
-
-            DraggedDrawable.IsDragged = false;
-            PropagateButtonEvent(new[] { DraggedDrawable }, new DragEndEvent(state, Button, MouseDownPosition));
+            var previousDragged = DraggedDrawable;
 
             DraggedDrawable = null;
+
+            if (previousDragged != null)
+            {
+                previousDragged.IsDragged = false;
+                PropagateButtonEvent(new[] { previousDragged }, new DragEndEvent(state, Button, MouseDownPosition));
+            }
         }
     }
 }

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -208,9 +208,9 @@ namespace osu.Framework.Input
 
             if (DraggedDrawable == null) return;
 
+            DraggedDrawable.IsDragged = false;
             PropagateButtonEvent(new[] { DraggedDrawable }, new DragEndEvent(state, Button, MouseDownPosition));
 
-            DraggedDrawable.IsDragged = false;
             DraggedDrawable = null;
         }
     }

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -206,15 +206,13 @@ namespace osu.Framework.Input
         {
             DragStarted = false;
 
-            var previousDragged = DraggedDrawable;
+            if (DraggedDrawable == null) return;
 
+            var previousDragged = DraggedDrawable;
+            previousDragged.IsDragged = false;
             DraggedDrawable = null;
 
-            if (previousDragged != null)
-            {
-                previousDragged.IsDragged = false;
-                PropagateButtonEvent(new[] { previousDragged }, new DragEndEvent(state, Button, MouseDownPosition));
-            }
+            PropagateButtonEvent(new[] { previousDragged }, new DragEndEvent(state, Button, MouseDownPosition));
         }
     }
 }


### PR DESCRIPTION
Matches behaviour as hover lose and focus lose, where the property would have its state changed before triggering the event.

Have checked for any usages of this property, none of them needs any action.

# vNext

## Both `Drawable.IsDragged` and `InputManager.DraggedDrawable` now change their state before triggering event

Both `Drawable.IsDragged` and `InputManager.DraggedDrawable` now change their state before the `DragEndEvent` is triggered, rather than after, matching other similar events like `FocusLostEvent` and `HoverLostEvent`.