### PR TITLE
Expose ThreadSafety

### DIFF
--- a/osu.Framework/Development/ThreadSafety.cs
+++ b/osu.Framework/Development/ThreadSafety.cs
@@ -13,6 +13,12 @@ namespace osu.Framework.Development
     public static class ThreadSafety
     {
         /// <summary>
+        /// Asserts that the current code is executing on the input thread. Debug only.
+        /// </summary>
+        [Conditional("DEBUG")]
+        public static void EnsureInputThread() => Debug.Assert(IsInputThread);
+
+        /// <summary>
         /// Asserts that the current code is executing on the update thread. Debug only.
         /// </summary>
         [Conditional("DEBUG")]

--- a/osu.Framework/Development/ThreadSafety.cs
+++ b/osu.Framework/Development/ThreadSafety.cs
@@ -7,17 +7,67 @@ using osu.Framework.Platform;
 
 namespace osu.Framework.Development
 {
-    internal static class ThreadSafety
+    /// <summary>
+    /// Utilities to ensure correct thread usage throughout a game.
+    /// </summary>
+    public static class ThreadSafety
     {
+        /// <summary>
+        /// Asserts that the current code is executing on the update thread. Debug only.
+        /// </summary>
         [Conditional("DEBUG")]
-        internal static void EnsureUpdateThread() => Debug.Assert(IsUpdateThread);
+        public static void EnsureUpdateThread() => Debug.Assert(IsUpdateThread);
 
+        /// <summary>
+        /// Asserts that the current code is not executing on the update thread. Debug only.
+        /// </summary>
         [Conditional("DEBUG")]
-        internal static void EnsureNotUpdateThread() => Debug.Assert(!IsUpdateThread);
+        public static void EnsureNotUpdateThread() => Debug.Assert(!IsUpdateThread);
 
+        /// <summary>
+        /// Asserts that the current code is executing on the draw thread. Debug only.
+        /// </summary>
         [Conditional("DEBUG")]
-        internal static void EnsureDrawThread() => Debug.Assert(IsDrawThread);
+        public static void EnsureDrawThread() => Debug.Assert(IsDrawThread);
 
+        /// <summary>
+        /// Asserts that the current code is executing on the audio thread. Debug only.
+        /// </summary>
+        [Conditional("DEBUG")]
+        public static void EnsureAudioThread() => Debug.Assert(IsAudioThread);
+
+        /// <summary>
+        /// Whether the current code is executing on the input thread.
+        /// </summary>
+        [field: ThreadStatic]
+        public static bool IsInputThread { get; internal set; }
+
+        /// <summary>
+        /// Whether the current code is executing on the update thread.
+        /// </summary>
+        [field: ThreadStatic]
+        public static bool IsUpdateThread { get; internal set; }
+
+        /// <summary>
+        /// Whether the current code is executing on the draw thread.
+        /// </summary>
+        [field: ThreadStatic]
+        public static bool IsDrawThread { get; internal set; }
+
+        /// <summary>
+        /// Whether the current code is executing on the audio thread.
+        /// </summary>
+        [field: ThreadStatic]
+        public static bool IsAudioThread { get; internal set; }
+
+        /// <summary>
+        /// The current execution mode.
+        /// </summary>
+        internal static ExecutionMode ExecutionMode;
+
+        /// <summary>
+        /// Resets all statics for the current thread.
+        /// </summary>
         internal static void ResetAllForCurrentThread()
         {
             IsInputThread = false;
@@ -25,19 +75,5 @@ namespace osu.Framework.Development
             IsDrawThread = false;
             IsAudioThread = false;
         }
-
-        public static ExecutionMode ExecutionMode;
-
-        [ThreadStatic]
-        public static bool IsInputThread;
-
-        [ThreadStatic]
-        public static bool IsUpdateThread;
-
-        [ThreadStatic]
-        public static bool IsDrawThread;
-
-        [ThreadStatic]
-        public static bool IsAudioThread;
     }
 }

--- a/osu.Framework/Development/ThreadSafety.cs
+++ b/osu.Framework/Development/ThreadSafety.cs
@@ -13,36 +13,6 @@ namespace osu.Framework.Development
     public static class ThreadSafety
     {
         /// <summary>
-        /// Asserts that the current code is executing on the input thread. Debug only.
-        /// </summary>
-        [Conditional("DEBUG")]
-        public static void EnsureInputThread() => Debug.Assert(IsInputThread);
-
-        /// <summary>
-        /// Asserts that the current code is executing on the update thread. Debug only.
-        /// </summary>
-        [Conditional("DEBUG")]
-        public static void EnsureUpdateThread() => Debug.Assert(IsUpdateThread);
-
-        /// <summary>
-        /// Asserts that the current code is not executing on the update thread. Debug only.
-        /// </summary>
-        [Conditional("DEBUG")]
-        public static void EnsureNotUpdateThread() => Debug.Assert(!IsUpdateThread);
-
-        /// <summary>
-        /// Asserts that the current code is executing on the draw thread. Debug only.
-        /// </summary>
-        [Conditional("DEBUG")]
-        public static void EnsureDrawThread() => Debug.Assert(IsDrawThread);
-
-        /// <summary>
-        /// Asserts that the current code is executing on the audio thread. Debug only.
-        /// </summary>
-        [Conditional("DEBUG")]
-        public static void EnsureAudioThread() => Debug.Assert(IsAudioThread);
-
-        /// <summary>
         /// Whether the current code is executing on the input thread.
         /// </summary>
         [field: ThreadStatic]
@@ -65,6 +35,36 @@ namespace osu.Framework.Development
         /// </summary>
         [field: ThreadStatic]
         public static bool IsAudioThread { get; internal set; }
+
+        /// <summary>
+        /// Asserts that the current code is executing on the input thread. Debug only.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal static void EnsureInputThread() => Debug.Assert(IsInputThread);
+
+        /// <summary>
+        /// Asserts that the current code is executing on the update thread. Debug only.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal static void EnsureUpdateThread() => Debug.Assert(IsUpdateThread);
+
+        /// <summary>
+        /// Asserts that the current code is not executing on the update thread. Debug only.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal static void EnsureNotUpdateThread() => Debug.Assert(!IsUpdateThread);
+
+        /// <summary>
+        /// Asserts that the current code is executing on the draw thread. Debug only.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal static void EnsureDrawThread() => Debug.Assert(IsDrawThread);
+
+        /// <summary>
+        /// Asserts that the current code is executing on the audio thread. Debug only.
+        /// </summary>
+        [Conditional("DEBUG")]
+        internal static void EnsureAudioThread() => Debug.Assert(IsAudioThread);
 
         /// <summary>
         /// The current execution mode.

--- a/osu.Framework/Development/ThreadSafety.cs
+++ b/osu.Framework/Development/ThreadSafety.cs
@@ -37,32 +37,47 @@ namespace osu.Framework.Development
         public static bool IsAudioThread { get; internal set; }
 
         /// <summary>
-        /// Asserts that the current code is executing on the input thread. Debug only.
+        /// Asserts that the current code is executing on the input thread.
         /// </summary>
+        /// <remarks>
+        /// Only asserts in debug builds due to performance concerns.
+        /// </remarks>
         [Conditional("DEBUG")]
         internal static void EnsureInputThread() => Debug.Assert(IsInputThread);
 
         /// <summary>
-        /// Asserts that the current code is executing on the update thread. Debug only.
+        /// Asserts that the current code is executing on the update thread.
         /// </summary>
+        /// <remarks>
+        /// Only asserts in debug builds due to performance concerns.
+        /// </remarks>
         [Conditional("DEBUG")]
         internal static void EnsureUpdateThread() => Debug.Assert(IsUpdateThread);
 
         /// <summary>
-        /// Asserts that the current code is not executing on the update thread. Debug only.
+        /// Asserts that the current code is not executing on the update thread.
         /// </summary>
+        /// <remarks>
+        /// Only asserts in debug builds due to performance concerns.
+        /// </remarks>
         [Conditional("DEBUG")]
         internal static void EnsureNotUpdateThread() => Debug.Assert(!IsUpdateThread);
 
         /// <summary>
-        /// Asserts that the current code is executing on the draw thread. Debug only.
+        /// Asserts that the current code is executing on the draw thread.
         /// </summary>
+        /// <remarks>
+        /// Only asserts in debug builds due to performance concerns.
+        /// </remarks>
         [Conditional("DEBUG")]
         internal static void EnsureDrawThread() => Debug.Assert(IsDrawThread);
 
         /// <summary>
-        /// Asserts that the current code is executing on the audio thread. Debug only.
+        /// Asserts that the current code is executing on the audio thread.
         /// </summary>
+        /// <remarks>
+        /// Only asserts in debug builds due to performance concerns.
+        /// </remarks>
         [Conditional("DEBUG")]
         internal static void EnsureAudioThread() => Debug.Assert(IsAudioThread);
 


### PR DESCRIPTION
Would come in useful with components like https://github.com/ppy/osu/pull/11461, which have components that must be run on a specific game thread.

`ExecutionMode` is not exposed as:
1. It's `GameHost`-specific. It should probably be moved out of `ThreadSafety` or be made thread-static.
2. There isn't much reason for the execution mode to be known.

`EnsureInputThread()` + `EnsureAudioThread()` added for conformity.