### PR TITLE
Add headless test runner for templates tests projects

### DIFF
--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TemplateGameTestScene.cs
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TemplateGameTestScene.cs
@@ -1,0 +1,22 @@
+using osu.Framework.Testing;
+
+namespace TemplateGame.Game.Tests.Visual
+{
+    public class TemplateGameTestScene : TestScene
+    {
+        protected override ITestSceneTestRunner CreateRunner() => new TemplateGameTestSceneTestRunner();
+
+        private class TemplateGameTestSceneTestRunner : TemplateGameGameBase, ITestSceneTestRunner
+        {
+            private TestSceneTestRunner.TestRunner runner;
+
+            protected override void LoadAsyncComplete()
+            {
+                base.LoadAsyncComplete();
+                Add(runner = new TestSceneTestRunner.TestRunner());
+            }
+
+            public void RunTestBlocking(TestScene test) => runner.RunTestBlocking(test);
+        }
+    }
+}

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TestSceneMainScreen.cs
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TestSceneMainScreen.cs
@@ -1,10 +1,9 @@
 using osu.Framework.Graphics;
 using osu.Framework.Screens;
-using osu.Framework.Testing;
 
 namespace TemplateGame.Game.Tests.Visual
 {
-    public class TestSceneMainScreen : TestScene
+    public class TestSceneMainScreen : TemplateGameTestScene
     {
         // Add visual tests to ensure correct behaviour of your game: https://github.com/ppy/osu-framework/wiki/Development-and-Testing
         // You can make changes to classes associated with the tests and they will recompile and update immediately.

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TestSceneSpinningBox.cs
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TestSceneSpinningBox.cs
@@ -1,9 +1,8 @@
 using osu.Framework.Graphics;
-using osu.Framework.Testing;
 
 namespace TemplateGame.Game.Tests.Visual
 {
-    public class TestSceneSpinningBox : TestScene
+    public class TestSceneSpinningBox : TemplateGameTestScene
     {
         // Add visual tests to ensure correct behaviour of your game: https://github.com/ppy/osu-framework/wiki/Development-and-Testing
         // You can make changes to classes associated with the tests and they will recompile and update immediately.

--- a/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TestSceneTemplateGameGame.cs
+++ b/osu.Framework.Templates/templates/template-empty/TemplateGame.Game.Tests/Visual/TestSceneTemplateGameGame.cs
@@ -1,10 +1,9 @@
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
-using osu.Framework.Testing;
 
 namespace TemplateGame.Game.Tests.Visual
 {
-    public class TestSceneTemplateGameGame : TestScene
+    public class TestSceneTemplateGameGame : TemplateGameTestScene
     {
         // Add visual tests to ensure correct behaviour of your game: https://github.com/ppy/osu-framework/wiki/Development-and-Testing
         // You can make changes to classes associated with the tests and they will recompile and update immediately.

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/FlappyDonTestScene.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/FlappyDonTestScene.cs
@@ -1,0 +1,22 @@
+using osu.Framework.Testing;
+
+namespace FlappyDon.Game.Tests.Visual
+{
+    public class FlappyDonTestScene : TestScene
+    {
+        protected override ITestSceneTestRunner CreateRunner() => new FlappyDonTestSceneTestRunner();
+
+        private class FlappyDonTestSceneTestRunner : FlappyDonGameBase, ITestSceneTestRunner
+        {
+            private TestSceneTestRunner.TestRunner runner;
+
+            protected override void LoadAsyncComplete()
+            {
+                base.LoadAsyncComplete();
+                Add(runner = new TestSceneTestRunner.TestRunner());
+            }
+
+            public void RunTestBlocking(TestScene test) => runner.RunTestBlocking(test);
+        }
+    }
+}

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/TestSceneBackdrop.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/TestSceneBackdrop.cs
@@ -1,6 +1,5 @@
 using FlappyDon.Game.Elements;
 using osu.Framework.Allocation;
-using osu.Framework.Testing;
 
 namespace FlappyDon.Game.Tests.Visual
 {
@@ -8,7 +7,7 @@ namespace FlappyDon.Game.Tests.Visual
     /// A test scene for testing the alignment
     /// and placement of the sprites that make up the backdrop
     /// </summary>
-    public class TestSceneBackdrop : TestScene
+    public class TestSceneBackdrop : FlappyDonTestScene
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/TestSceneFlappyDonGame.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/TestSceneFlappyDonGame.cs
@@ -1,6 +1,5 @@
 using osu.Framework.Allocation;
 using osu.Framework.Platform;
-using osu.Framework.Testing;
 
 namespace FlappyDon.Game.Tests.Visual
 {
@@ -8,7 +7,7 @@ namespace FlappyDon.Game.Tests.Visual
     /// A test scene wrapping the entire game,
     /// including audio.
     /// </summary>
-    public class TestSceneFlappyDonGame : TestScene
+    public class TestSceneFlappyDonGame : FlappyDonTestScene
     {
         private FlappyDonGame game;
 

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/TestSceneObstacles.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/TestSceneObstacles.cs
@@ -1,14 +1,13 @@
 using FlappyDon.Game.Elements;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Testing;
 
 namespace FlappyDon.Game.Tests.Visual
 {
     /// <summary>
     /// A scene to test the layout and positioning and rotation of two pipe sprites.
     /// </summary>
-    public class TestSceneObstacles : TestScene
+    public class TestSceneObstacles : FlappyDonTestScene
     {
         [BackgroundDependencyLoader]
         private void load()

--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/TestScenePipeObstacle.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game.Tests/Visual/TestScenePipeObstacle.cs
@@ -1,14 +1,13 @@
 using FlappyDon.Game.Elements;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
-using osu.Framework.Testing;
 
 namespace FlappyDon.Game.Tests.Visual
 {
     /// <summary>
     /// A scene to test the layout and positioning and rotation of two pipe sprites.
     /// </summary>
-    public class TestScenePipeObstacle : TestScene
+    public class TestScenePipeObstacle : FlappyDonTestScene
     {
         [BackgroundDependencyLoader]
         private void load()


### PR DESCRIPTION
Must be implemented for providing the correct dependencies for the test scene to run properly, 

I also have another PR almost ready for making `TestScene.CreateTestSceneTestRunner()` abstract as it's very recommended to be implemented per game tests project, rather than using the default `TestSceneTestRunner`.