### PR TITLE
Simplify LifetimeEntry logic, and make SetLifetime overridable

### DIFF
--- a/osu.Framework/Graphics/Performance/LifetimeEntry.cs
+++ b/osu.Framework/Graphics/Performance/LifetimeEntry.cs
@@ -21,13 +21,8 @@ namespace osu.Framework.Graphics.Performance
         public double LifetimeStart
         {
             get => lifetimeStart;
-            set
-            {
-                if (lifetimeStart == value)
-                    return;
-
-                SetLifetime(value, lifetimeEnd);
-            }
+            // A method is used as C# doesn't allow the combination of a non-virtual getter and a virtual setter.
+            set => SetLifetimeStart(value);
         }
 
         private double lifetimeEnd = double.MaxValue;
@@ -38,13 +33,7 @@ namespace osu.Framework.Graphics.Performance
         public double LifetimeEnd
         {
             get => lifetimeEnd;
-            set
-            {
-                if (lifetimeEnd == value)
-                    return;
-
-                SetLifetime(lifetimeStart, value);
-            }
+            set => SetLifetimeEnd(value);
         }
 
         /// <summary>
@@ -53,11 +42,29 @@ namespace osu.Framework.Graphics.Performance
         internal event Action<LifetimeEntry> RequestLifetimeUpdate;
 
         /// <summary>
+        /// Update <see cref="LifetimeStart"/> of this <see cref="LifetimeEntry"/>.
+        /// </summary>
+        protected virtual void SetLifetimeStart(double start)
+        {
+            if (start != lifetimeStart)
+                SetLifetime(start, lifetimeEnd);
+        }
+
+        /// <summary>
+        /// Update <see cref="LifetimeEnd"/> of this <see cref="LifetimeEntry"/>.
+        /// </summary>
+        protected virtual void SetLifetimeEnd(double end)
+        {
+            if (end != lifetimeEnd)
+                SetLifetime(lifetimeStart, end);
+        }
+
+        /// <summary>
         /// Updates the stored lifetimes of this <see cref="LifetimeEntry"/>.
         /// </summary>
         /// <param name="start">The new <see cref="LifetimeStart"/> value.</param>
         /// <param name="end">The new <see cref="LifetimeEnd"/> value.</param>
-        public virtual void SetLifetime(double start, double end)
+        protected virtual void SetLifetime(double start, double end)
         {
             RequestLifetimeUpdate?.Invoke(this);
 

--- a/osu.Framework/Graphics/Performance/LifetimeEntry.cs
+++ b/osu.Framework/Graphics/Performance/LifetimeEntry.cs
@@ -64,7 +64,7 @@ namespace osu.Framework.Graphics.Performance
         /// </summary>
         /// <param name="start">The new <see cref="LifetimeStart"/> value.</param>
         /// <param name="end">The new <see cref="LifetimeEnd"/> value.</param>
-        protected virtual void SetLifetime(double start, double end)
+        protected void SetLifetime(double start, double end)
         {
             RequestLifetimeUpdate?.Invoke(this);
 

--- a/osu.Framework/Graphics/Performance/LifetimeEntry.cs
+++ b/osu.Framework/Graphics/Performance/LifetimeEntry.cs
@@ -26,10 +26,7 @@ namespace osu.Framework.Graphics.Performance
                 if (lifetimeStart == value)
                     return;
 
-                if (RequestLifetimeUpdate != null)
-                    RequestLifetimeUpdate.Invoke(this, value, lifetimeEnd);
-                else
-                    SetLifetime(value, lifetimeEnd);
+                SetLifetime(value, lifetimeEnd);
             }
         }
 
@@ -46,29 +43,24 @@ namespace osu.Framework.Graphics.Performance
                 if (lifetimeEnd == value)
                     return;
 
-                if (RequestLifetimeUpdate != null)
-                    RequestLifetimeUpdate.Invoke(this, lifetimeStart, value);
-                else
-                    SetLifetime(lifetimeStart, value);
+                SetLifetime(lifetimeStart, value);
             }
         }
 
         /// <summary>
-        /// Invoked when this <see cref="LifetimeEntry"/> is attached to a <see cref="LifetimeEntryManager"/> and either
-        /// <see cref="LifetimeStart"/> or <see cref="LifetimeEnd"/> are changed.
+        /// Invoked when <see cref="LifetimeStart"/> or <see cref="LifetimeEnd"/> is going to be changed.
         /// </summary>
-        /// <remarks>
-        /// If this is handled, make sure to call <see cref="SetLifetime"/> to continue with the lifetime update.
-        /// </remarks>
-        internal event RequestLifetimeUpdateDelegate RequestLifetimeUpdate;
+        internal event Action<LifetimeEntry> RequestLifetimeUpdate;
 
         /// <summary>
         /// Updates the stored lifetimes of this <see cref="LifetimeEntry"/>.
         /// </summary>
         /// <param name="start">The new <see cref="LifetimeStart"/> value.</param>
         /// <param name="end">The new <see cref="LifetimeEnd"/> value.</param>
-        internal void SetLifetime(double start, double end)
+        public virtual void SetLifetime(double start, double end)
         {
+            RequestLifetimeUpdate?.Invoke(this);
+
             lifetimeStart = start;
             lifetimeEnd = Math.Max(start, end); // Negative intervals are undesired.
         }
@@ -83,6 +75,4 @@ namespace osu.Framework.Graphics.Performance
         /// </summary>
         internal ulong ChildId { get; set; }
     }
-
-    internal delegate void RequestLifetimeUpdateDelegate(LifetimeEntry entry, double lifetimeStart, double lifetimeEnd);
 }

--- a/osu.Framework/Graphics/Performance/LifetimeEntryManager.cs
+++ b/osu.Framework/Graphics/Performance/LifetimeEntryManager.cs
@@ -156,12 +156,9 @@ namespace osu.Framework.Graphics.Performance
         }
 
         /// <summary>
-        /// Invoked when the lifetime of an entry has changed, so that an appropriate sorting order is maintained.
+        /// Invoked when the lifetime of an entry is going to changed.
         /// </summary>
-        /// <param name="entry">The <see cref="LifetimeEntry"/> that changed.</param>
-        /// <param name="lifetimeStart">The new start time.</param>
-        /// <param name="lifetimeEnd">The new end time.</param>
-        private void requestLifetimeUpdate(LifetimeEntry entry, double lifetimeStart, double lifetimeEnd)
+        private void requestLifetimeUpdate(LifetimeEntry entry)
         {
             // Entries in the past/future sets need to be re-sorted to prevent the comparer from becoming unstable.
             // To prevent, e.g. CompositeDrawable alive children changing during enumeration, the entry's state must not be updated immediately.
@@ -178,9 +175,6 @@ namespace osu.Framework.Graphics.Performance
                 // Enqueue the entry to be processed in the next Update().
                 newEntries.Add(entry);
             }
-
-            // Since the comparer has now been resolved, the lifetime update can proceed.
-            entry.SetLifetime(lifetimeStart, lifetimeEnd);
         }
 
         /// <summary>


### PR DESCRIPTION
`RequestLifetimeUpdate` logic is changed so `SetLifetime` can be safely called from non-internal user and overridden.
For motivation, see osu-side PR: ppy/osu#12592.

Note that I'm not just making `LifetimeStart` and `LifetimeEnd` virtual. This is because those properties are critical to the correctness of the `LifetimeManager`.