### PR TITLE
Migrate osu!framework to GitHub Actions

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -27,7 +27,7 @@
       ]
     },
     "codefilesanity": {
-      "version": "15.0.0",
+      "version": "0.0.36",
       "commands": [
         "CodeFileSanity"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -25,6 +25,12 @@
       "commands": [
         "nvika"
       ]
+    },
+    "codefilesanity": {
+      "version": "15.0.0",
+      "commands": [
+        "CodeFileSanity"
+      ]
     }
   }
 }

--- a/.editorconfig
+++ b/.editorconfig
@@ -212,3 +212,9 @@ dotnet_diagnostic.CA2225.severity = none
 
 # Banned APIs
 dotnet_diagnostic.RS0030.severity = error
+
+[*.{yaml,yml}]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true

--- a/.github/workflows/ci-nativelibs.yml
+++ b/.github/workflows/ci-nativelibs.yml
@@ -19,7 +19,7 @@ jobs:
           fi
   deploy:
     name: Deploy
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     needs: check-if-tag
     steps:
       - name: Checkout
@@ -41,10 +41,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: osu-framework-nativelibs
-          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
+          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}/*.nupkg
 
       - name: Deploy
-        shell: bash
         run: |
           if [ $(echo ${{needs.check-if-tag.outputs.version}} | grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
             echo "Skipping publish, no tag detected."

--- a/.github/workflows/ci-nativelibs.yml
+++ b/.github/workflows/ci-nativelibs.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Set Artifacts Directory
         id: artifactsPath
-        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}/artifacts"
 
       - name: Setup .NET 5.0.x
         uses: actions/setup-dotnet@v1

--- a/.github/workflows/ci-nativelibs.yml
+++ b/.github/workflows/ci-nativelibs.yml
@@ -1,0 +1,54 @@
+on: workflow_dispatch
+name: Continuous Integration - NativeLibs
+
+jobs:
+  check-if-tag:
+    name: Get Git Tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{needs.check-if-tag.outputs.version}}
+    steps:
+      - name: Set Variables
+        id: deployment
+        shell: bash
+        run: |
+          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
+            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
+          else
+            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
+          fi
+  deploy:
+    name: Deploy
+    runs-on: windows-latest
+    needs: check-if-tag
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Artifacts Directory
+        id: artifactsPath
+        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+
+      - name: Setup .NET 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
+
+      - name: Build NativeLibs
+        run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: osu-framework-nativelibs
+          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
+
+      - name: Deploy
+        run: |
+          if [ $(echo {{needs.check-if-tag.outputs.version}}| grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
+            echo "Skipping publish, no tag detected."
+            exit 0;
+          else
+            dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
+            dotnet nuget push ${{github.workspace}}/artifacts/*.nupkg --skip-duplicate --source authed-nuget
+          fi

--- a/.github/workflows/ci-nativelibs.yml
+++ b/.github/workflows/ci-nativelibs.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Deploy
         run: |
-          if [ $(echo ${{needs.check-if-tag.outputs.version}}| grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
+          if [ $(echo ${{needs.check-if-tag.outputs.version}} | grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
             echo "Skipping publish, no tag detected."
             exit 0;
           else

--- a/.github/workflows/ci-nativelibs.yml
+++ b/.github/workflows/ci-nativelibs.yml
@@ -3,7 +3,7 @@ name: Continuous Integration - NativeLibs
 
 jobs:
   check-if-tag:
-    name: Get Git Tag
+    name: Set Package Version
     runs-on: ubuntu-latest
     outputs:
       version: ${{steps.deployment.outputs.version}}

--- a/.github/workflows/ci-nativelibs.yml
+++ b/.github/workflows/ci-nativelibs.yml
@@ -6,7 +6,7 @@ jobs:
     name: Get Git Tag
     runs-on: ubuntu-latest
     outputs:
-      version: ${{needs.check-if-tag.outputs.version}}
+      version: ${{steps.deployment.outputs.version}}
     steps:
       - name: Set Variables
         id: deployment

--- a/.github/workflows/ci-nativelibs.yml
+++ b/.github/workflows/ci-nativelibs.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Deploy
         run: |
-          if [ $(echo {{needs.check-if-tag.outputs.version}}| grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
+          if [ $(echo ${{needs.check-if-tag.outputs.version}}| grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
             echo "Skipping publish, no tag detected."
             exit 0;
           else

--- a/.github/workflows/ci-nativelibs.yml
+++ b/.github/workflows/ci-nativelibs.yml
@@ -44,6 +44,7 @@ jobs:
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
 
       - name: Deploy
+        shell: bash
         run: |
           if [ $(echo ${{needs.check-if-tag.outputs.version}} | grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
             echo "Skipping publish, no tag detected."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - "*"
+    tags:
+      - "*"
 
 name: Continuous Integration
 
@@ -94,7 +96,7 @@ jobs:
         id: deployment
         shell: bash
         run: |
-          if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
+          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
             echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
           else
             echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
@@ -121,7 +123,6 @@ jobs:
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
-        if: ${{ github.event != 'release' }}
         with:
           name: osu-framework
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
@@ -141,7 +142,7 @@ jobs:
         id: deployment
         shell: bash
         run: |
-          if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
+          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
             echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
           else
             echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
@@ -161,7 +162,6 @@ jobs:
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
-        if: ${{ github.event != 'release' }}
         with:
           name: osu-framework-templates
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
@@ -181,7 +181,7 @@ jobs:
         id: deployment
         shell: bash
         run: |
-          if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
+          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
             echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
           else
             echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
@@ -199,7 +199,6 @@ jobs:
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
-        if: ${{ github.event != 'release' }}
         with:
           name: osu-framework-android
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
@@ -218,7 +217,7 @@ jobs:
       - name: Set Variables
         id: deployment
         run: |
-          if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
+          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
             echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
           else
             echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
@@ -237,3 +236,23 @@ jobs:
         with:
           name: osu-framework-ios
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}/*.nupkg
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [pack-android, pack-framework, pack-template, pack-ios]
+    continue-on-error: true
+    steps:
+      - name: Get Git tag
+        id: tag
+        uses: olegtarasov/get-tag@v2.1
+
+      - name: Push to NuGet
+        run: |
+          if [ -z ${{steps.tag.outputs.tag}} ]; 
+            echo "::warn::Skipping publish, no tag detected."
+            exit 0;
+          else
+            echo "TBD! This is just to evaluate if this release pipeline works."
+            exit 0;
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,15 +159,15 @@ jobs:
         with:
           name: osu-framework-templates
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
-  
+
   pack-android:
-     name: Pack (Android)
-     runs-on: windows-latest
-     needs: inspect-code
-     defaults:
+    name: Pack (Android)
+    runs-on: windows-latest
+    needs: inspect-code
+    defaults:
       run:
         shell: powershell
-     steps:
+    steps:
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -184,6 +184,7 @@ jobs:
       - name: Set Artifacts Directory
         id: artifactsPath
         run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
 
@@ -198,13 +199,13 @@ jobs:
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
 
   pack-ios:
-     name: Pack (iOS)
-     runs-on: macos-latest
-     needs: inspect-code
-     defaults:
-       run:
-         shell: bash
-     steps:
+    name: Pack (iOS)
+    runs-on: macos-latest
+    needs: inspect-code
+    defaults:
+      run:
+        shell: bash
+    steps:
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -220,8 +221,6 @@ jobs:
       - name: Set Artifacts Directory
         id: artifactsPath
         run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}/artifacts"
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
 
       - name: Pack (iOS Framework)
         run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.iOS/osu.Framework.iOS.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
 
       - name: Deploy
         run: |
-          if [ $(echo {{needs.check-if-tag.outputs.version}}| grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
+          if [ $(echo ${{needs.check-if-tag.outputs.version}} | grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
             echo "Skipping publish, no tag detected."
             exit 0;
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,22 @@
 on: [push, pull_request]
-
 name: Continuous Integration
 
 jobs:
+  check-if-tag:
+    name: Get Git Tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.deployment.outputs.version}}
+    steps:
+      - name: Set Variables
+        id: deployment
+        shell: bash
+        run: |
+          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
+            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
+          else
+            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
+          fi
   test:
     name: Test
     runs-on: windows-latest
@@ -79,23 +93,13 @@ jobs:
   pack-framework:
     name: Pack (Framework)
     runs-on: windows-latest
-    needs: inspect-code
+    needs: [inspect-code, check-if-tag]
     defaults:
       run:
         shell: powershell
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Set Variables
-        id: deployment
-        shell: bash
-        run: |
-          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
-            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
-          else
-            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
-          fi
 
       - name: Set Artifacts Directory
         id: artifactsPath
@@ -114,7 +118,7 @@ jobs:
           dotnet-version: "5.0.x"
 
       - name: Pack (Framework)
-        run: dotnet pack -c Release osu.Framework /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+        run: dotnet pack -c Release osu.Framework /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
@@ -125,23 +129,13 @@ jobs:
   pack-template:
     name: Pack (Templates)
     runs-on: windows-latest
-    needs: inspect-code
+    needs: [inspect-code, check-if-tag]
     defaults:
       run:
         shell: powershell
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Set Variables
-        id: deployment
-        shell: bash
-        run: |
-          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
-            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
-          else
-            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
-          fi
 
       - name: Set Artifacts Directory
         id: artifactsPath
@@ -153,7 +147,7 @@ jobs:
           dotnet-version: "5.0.x"
 
       - name: Pack (Template)
-        run: dotnet pack -c Release osu.Framework.Templates /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true /p:NoDefaultExcludes=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+        run: dotnet pack -c Release osu.Framework.Templates /p:Configuration=Release /p:Version=${{needs.check-if-tag.outputs.version}} /p:GenerateDocumentationFile=true /p:NoDefaultExcludes=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
@@ -164,23 +158,13 @@ jobs:
   pack-android:
     name: Pack (Android)
     runs-on: windows-latest
-    needs: inspect-code
+    needs: [inspect-code, check-if-tag]
     defaults:
       run:
         shell: powershell
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
-      - name: Set Variables
-        id: deployment
-        shell: bash
-        run: |
-          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
-            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
-          else
-            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
-          fi
 
       - name: Set Artifacts Directory
         id: artifactsPath
@@ -190,7 +174,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1.0.2
 
       - name: Pack (Android Framework)
-        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.Android/osu.Framework.Android.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.Android/osu.Framework.Android.csproj -p:Configuration=Release -p:Version=${{needs.check-if-tag.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
@@ -201,7 +185,7 @@ jobs:
   pack-ios:
     name: Pack (iOS)
     runs-on: macos-latest
-    needs: inspect-code
+    needs: [inspect-code, check-if-tag]
     defaults:
       run:
         shell: bash
@@ -209,21 +193,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set Variables
-        id: deployment
-        run: |
-          if [ $(echo ${{github.ref}} | grep -q "refs/tags/"; echo $?) == 0 ]; then
-            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
-          else
-            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
-          fi
-
       - name: Set Artifacts Directory
         id: artifactsPath
         run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}/artifacts"
 
       - name: Pack (iOS Framework)
-        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.iOS/osu.Framework.iOS.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.iOS/osu.Framework.iOS.csproj -p:Configuration=Release -p:Version=${{needs.check-if-tag.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
@@ -235,14 +210,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [pack-android, pack-framework, pack-template, pack-ios]
+    needs: [check-if-tag, pack-android, pack-framework, pack-template, pack-ios]
     if: ${{ github.event != 'pull_request' }}
-    continue-on-error: true
     steps:
-      - name: Get Git tag
-        id: tag
-        uses: olegtarasov/get-tag@v2.1
-
       - name: Create Artifact Directory
         run: mkdir ${{github.workspace}}/artifacts/
 
@@ -260,11 +230,8 @@ jobs:
           rm -rfv */
 
       - name: Deploy
-        if: ${{ always() }}
         run: |
-          version=${{steps.tag.outputs.tag}}
-
-          if [ -z $version ]; then
+          if [ $(echo {{needs.check-if-tag.outputs.version}}| grep -q "0.0.0+${{github.run_id}}"; echo $?) == 0 ]; then
             echo "Skipping publish, no tag detected."
             exit 0;
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,11 @@
-on: [push, pull_request, release]
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "*"
+
 name: Continuous Integration
 
 jobs:
@@ -68,10 +75,10 @@ jobs:
       - name: .NET Format (Dry Run)
         run: dotnet format --dry-run --check
 
-      - name: InspectCode
-        run: |
-          dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
-          dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors
+      - name: ReSharper
+        uses: glassechidna/resharper-action@master
+        with:
+          report: ${{github.workspace}}/inspectcodereport.xml
 
   pack-framework:
     name: Pack (Framework)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
 
       # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x LTS side by side.
       # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
-
       - name: Install .NET 3.1.x LTS
         uses: actions/setup-dotnet@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,12 @@ jobs:
         - name: Install .NET 5.0.x
           uses: actions/setup-dotnet@v1
           with:
-             dotnet-version: '5.0.x'       
+             dotnet-version: '5.0.x' 
+        
+        - name: Install Native Dependencies
+          run: |
+            sudo apt-get update && \
+            sudo apt-get install ffmpeg;
         
         #TODO: Figure out what build.cake#91 means.
         - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 
 jobs:
   inspect-code:
-     name: CQ Check
+     name: Code Quality
      runs-on: ubuntu-latest
      steps:
         - name: Checkout
@@ -27,7 +27,7 @@ jobs:
         - name: Restore Packages
           run: dotnet restore
 
-        - name: CodeFileSanity Check
+        - name: CodeFileSanity
           run: |
             echo "TBD! This step will not do anything for now!"
             exit 0
@@ -35,7 +35,7 @@ jobs:
         - name: .NET Format (Dry Run)
           run: dotnet format --dry-run --check
 
-        - name: Inspect
+        - name: InspectCode
           run: |
             dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
             dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors 
@@ -58,7 +58,6 @@ jobs:
             sudo apt-get update && \
             sudo apt-get install ffmpeg;
         
-        #TODO: Figure out what build.cake#91 means.
         - name: Test
           run: dotnet test -c Debug osu.Framework.Tests --logger:nunit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x LTS and 2.1 LTS side by side.
+      # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x LTS side by side.
       # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
-      - name: Install .NET 2.1.x LTS
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: "2.1.x"
 
       - name: Install .NET 3.1.x LTS
         uses: actions/setup-dotnet@v1
@@ -77,8 +73,8 @@ jobs:
           dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
           dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors
 
-  pack-n-publish:
-    name: Pack and Publish
+  pack-framework:
+    name: Pack (Framework)
     runs-on: windows-latest
     needs: inspect-code
     defaults:
@@ -114,20 +110,45 @@ jobs:
         with:
           dotnet-version: "5.0.x"
 
-      - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
-
       - name: Pack (Framework)
         run: dotnet pack -c Release osu.Framework /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
-      - name: Pack (iOS Framework)
-        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.iOS/osu.Framework.iOS.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ github.event != 'release' }}
+        with:
+          name: osu-framework
+          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
 
-      - name: Pack (Android Framework)
-        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.Android/osu.Framework.Android.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+  pack-template:
+    name: Pack (Templates)
+    runs-on: windows-latest
+    needs: inspect-code
+    defaults:
+      run:
+        shell: powershell
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-      - name: Pack (Native Libraries)
-        run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+      - name: Set Variables
+        id: deployment
+        shell: bash
+        run: |
+          if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
+            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
+          else
+            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
+          fi
+
+      - name: Set Artifacts Directory
+        id: artifactsPath
+        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+
+      - name: Install .NET 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
 
       - name: Pack (Template)
         run: dotnet pack -c Release osu.Framework.Templates /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true /p:NoDefaultExcludes=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
@@ -136,12 +157,78 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ github.event != 'release' }}
         with:
+          name: osu-framework-templates
+          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
+  
+  pack-android:
+     name: Pack (Android)
+     runs-on: windows-latest
+     needs: inspect-code
+     defaults:
+      run:
+        shell: powershell
+     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Variables
+        id: deployment
+        shell: bash
+        run: |
+          if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
+            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
+          else
+            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
+          fi
+
+      - name: Set Artifacts Directory
+        id: artifactsPath
+        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: Pack (Android Framework)
+        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.Android/osu.Framework.Android.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ github.event != 'release' }}
+        with:
+          name: osu-framework-android
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
 
-######## TODO: Move releases in it's own workflow. For now it's commented out.
-######## Manually authenticate for now as setup-dotnet ignores our auth tokens
-######## See: https://github.com/actions/setup-dotnet/issues/190
-#      - name: Publish to NuGet
-#        run: |
-#          dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
-#          dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --skip-duplicate --source authed-nuget
+  pack-ios:
+     name: Pack (iOS)
+     runs-on: macos-latest
+     needs: inspect-code
+     defaults:
+       run:
+         shell: bash
+     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Variables
+        id: deployment
+        run: |
+          if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
+            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
+          else
+            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
+          fi
+
+      - name: Set Artifacts Directory
+        id: artifactsPath
+        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
+
+      - name: Pack (iOS Framework)
+        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.iOS/osu.Framework.iOS.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ github.event != 'release' }}
+        with:
+          name: osu-framework-ios
+          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,16 @@ jobs:
 
         # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x. 
         # Looks like we won't change this until 6.0 LTS releases on 11/2021.
-        - name: Install .NET
+        - name: Install .NET 5.0.x
+          uses: actions/setup-dotnet@v1
+          with:
+             dotnet-version: '5.0.x'
+
+        - name: Install .NET 3.1.x LTS
           uses: actions/setup-dotnet@v1
           with:
              dotnet-version: '3.1.x'
-        
+  
         - name: Restore Tools
           run: dotnet tool restore
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,6 +241,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: [pack-android, pack-framework, pack-template, pack-ios]
+    if: ${{ github.event != 'pull_request' }}
     continue-on-error: true
     steps:
       - name: Get Git tag
@@ -270,6 +271,6 @@ jobs:
             echo "Skipping publish, no tag detected."
             exit 0;
           else
-            echo "TBD! This is just to evaluate if this release pipeline works."
-            exit 0;
+            dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
+            dotnet nuget push ${{github.workspace}}/artifacts/*.nupkg --skip-duplicate --source authed-nuget
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+on: [push, pull_request]
+name: Continuous Integration
+
+jobs:
+  inspect-code:
+     name: CQ Check
+     runs-on: ubuntu-latest
+     steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        - name: Install .NET
+          uses: actions/setup-dotnet@v1
+          with:
+            dotnet-version: 5.0
+        
+        - name: Restore Tools
+          run: dotnet tool restore
+    
+        - name: Inspect
+          run: |
+            dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml
+           

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,56 @@
-on: [push, pull_request]
+on: [push, pull_request, release]
 name: Continuous Integration
 
 jobs:
-  inspect-code:
-     name: Code Quality
-     runs-on: ubuntu-latest
-     steps:
+  test:
+    name: Test
+    runs-on: windows-latest
+    steps:
         - name: Checkout
           uses: actions/checkout@v2
 
-        # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x LTS side by side.
-        # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
         - name: Install .NET 5.0.x
           uses: actions/setup-dotnet@v1
           with:
              dotnet-version: '5.0.x'
 
+        - name: Compile
+          run: dotnet build -c Debug build/Desktop.proj
+        
+        - name: Test
+          run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger:nunit
+          shell: powershell
+
+        - name: Report NUnit Logs
+          uses: MirrorNG/nunit-reporter@v1.0.9
+          with:
+            path: './TestResults/TestResults.xml'
+            access-token: ${{ secrets.GITHUB_TOKEN }}
+
+  inspect-code:
+     name: Code Quality
+     needs: test
+     runs-on: ubuntu-latest
+     steps:
+        - name: Checkout
+          uses: actions/checkout@v2
+
+        # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x LTS and 2.1 LTS side by side.
+        # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
+        - name: Install .NET 2.1.x LTS
+          uses: actions/setup-dotnet@v1
+          with:
+            dotnet-version: '2.1.x'
+
         - name: Install .NET 3.1.x LTS
           uses: actions/setup-dotnet@v1
           with:
              dotnet-version: '3.1.x'
+
+        - name: Install .NET 5.0.x
+          uses: actions/setup-dotnet@v1
+          with:
+             dotnet-version: '5.0.x'
   
         - name: Restore Tools
           run: dotnet tool restore
@@ -29,8 +60,13 @@ jobs:
 
         - name: CodeFileSanity
           run: |
-            echo "TBD! This step will not do anything for now!"
-            exit 0
+            # Suppress warnings from templates project
+            # https://unix.stackexchange.com/questions/104641/how-can-i-suppress-output-from-grep-so-that-it-only-returns-the-exit-status
+            dotnet codefilesanity | while read -r line; do
+               if [ $(echo $line| grep -q "./osu.Framework.Templates/"; echo $?) == 1 ]; then
+                 echo "::warning::$line"
+               fi
+            done
 
         - name: .NET Format (Dry Run)
           run: dotnet format --dry-run --check
@@ -38,31 +74,79 @@ jobs:
         - name: InspectCode
           run: |
             dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
-            dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors 
- 
-  test:
-    name: Test 
-    needs: inspect-code
-    runs-on: ubuntu-latest
-    steps:
-        - name: Checkout
-          uses: actions/checkout@v2
+            dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors
 
-        - name: Install .NET 5.0.x
-          uses: actions/setup-dotnet@v1
-          with:
-             dotnet-version: '5.0.x' 
-        
-        - name: Install Native Dependencies
-          run: |
-            sudo apt-get update && \
-            sudo apt-get install ffmpeg;
-        
-        - name: Test
-          run: dotnet test -c Debug osu.Framework.Tests --logger:nunit
+  pack-n-publish:
+         name: Pack and Publish
+         runs-on: windows-latest
+         needs: inspect-code
+         defaults:
+           run:
+             shell: powershell
+         steps:
+            - name: Checkout
+              uses: actions/checkout@v2
 
-        - name: Report NUnit Logs
-          uses: MirrorNG/nunit-reporter@v1.0.9
-          with:
-            path: 'osu.Framework.Tests/TestResults/*.xml'
-            access-token: ${{ secrets.GITHUB_TOKEN }}
+            # As we don't have the equivalent of AppVeyor's Local NuGet repos
+            # We're going to use the actor's GHPR instead.
+            # FIXME: GHPR requires authentication, see:https://docs.github.com/en/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.
+            # Workaround to authentication requirement is enabled "improved container support" to allow anonymous pulling.
+            
+            - name: Set Variables
+              id: deployment
+              shell: bash
+              run: |
+               if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
+                 echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
+               else
+                 echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
+               fi
+              
+            - name: Set Artifacts Directory
+              id: artifactsPath
+              run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+                
+
+            # FIXME: 3.1 LTS is required here because iOS builds still uses 3.1.
+            # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
+            - name: Install .NET 3.1.x LTS
+              uses: actions/setup-dotnet@v1
+              with:
+                  dotnet-version: '3.1.x'
+
+            - name: Install .NET 5.0.x
+              uses: actions/setup-dotnet@v1
+              with:
+                dotnet-version: '5.0.x'
+
+            - name: Add msbuild to PATH
+              uses: microsoft/setup-msbuild@v1.0.2
+
+            - name: Pack (Framework)
+              run: dotnet pack -c Release osu.Framework /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+            
+            - name: Pack (iOS Framework)
+              run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.iOS/osu.Framework.iOS.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+            
+            - name: Pack (Android Framework)
+              run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.Android/osu.Framework.Android.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+
+            - name: Pack (Native Libraries)
+              run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+
+            - name: Pack (Template)
+              run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true /p:NoDefaultExcludes=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+
+            - name: Upload Artifacts
+              uses: actions/upload-artifact@v2
+              if: ${{ github.event != 'release' }}
+              with:
+                 path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
+
+            # Manually authenticate for now as setup-dotnet ignores our auth tokens
+            # See: https://github.com/actions/setup-dotnet/issues/190
+            - name: Publish to NuGet
+              if: ${{ github.event == 'release' }}
+              run: |
+                    dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
+                    dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --skip-duplicate --source authed-nuget 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,15 @@
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**/*.cs'
+      - '**/*.csproj'
+      - '**/*.sln'
+  pull_request:
+    paths:
+      - '**/*.cs'
+      - '**/*.csproj'
+      - '**/*.sln'
+
 name: Continuous Integration
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           uses: actions/setup-dotnet@v1
           with:
              dotnet-version: '5.0.x'
- 
+
         - name: Restore Tools
           run: dotnet tool restore
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
         run: dotnet format --dry-run --check
 
       - name: InspectCode
-        run: dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
+        run: dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=$(pwd)/inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
 
       - name: ReSharper
         uses: glassechidna/resharper-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: ${{github.workspace}}/artifacts/
-   
+
         # Artifacts create their own directories. Let's fix that!
         # https://github.com/actions/download-artifact#download-all-artifacts
       - name: Move Artifacts to root of subdirectory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,10 +68,13 @@ jobs:
       - name: .NET Format (Dry Run)
         run: dotnet format --dry-run --check
 
+      - name: InspectCode
+        run: dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
+
       - name: ReSharper
         uses: glassechidna/resharper-action@master
         with:
-          solution: ${{github.workspace}}/osu-framework.Desktop.slnf
+          report: ${{github.workspace}}/inspectcodereport.xml
 
   pack-framework:
     name: Pack (Framework)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
         - name: Compile
           run: dotnet build -c Debug build/Desktop.proj
-        
+
         - name: Test
           run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger:nunit
           shell: powershell
@@ -51,7 +51,7 @@ jobs:
           uses: actions/setup-dotnet@v1
           with:
              dotnet-version: '5.0.x'
-  
+ 
         - name: Restore Tools
           run: dotnet tool restore
         
@@ -86,7 +86,7 @@ jobs:
          steps:
             - name: Checkout
               uses: actions/checkout@v2
-            
+          
             - name: Set Variables
               id: deployment
               shell: bash
@@ -96,11 +96,11 @@ jobs:
                else
                  echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
                fi
-              
+       
             - name: Set Artifacts Directory
               id: artifactsPath
               run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
-                
+   
 
             # FIXME: 3.1 LTS is required here because iOS builds still uses 3.1.
             # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
@@ -119,10 +119,10 @@ jobs:
 
             - name: Pack (Framework)
               run: dotnet pack -c Release osu.Framework /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
-            
+
             - name: Pack (iOS Framework)
               run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.iOS/osu.Framework.iOS.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
-            
+
             - name: Pack (Android Framework)
               run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.Android/osu.Framework.Android.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
 
@@ -144,4 +144,4 @@ jobs:
               if: ${{ github.event == 'release' }}
               run: |
                     dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
-                    dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --skip-duplicate --source authed-nuget 
+                    dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --skip-duplicate --source authed-nuget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
 
   inspect-code:
     name: Code Quality
-    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -61,7 +60,8 @@ jobs:
 
       - name: CodeFileSanity
         run: |
-          # Suppress warnings from templates project
+          # TODO: Add ignore filters and GitHub Workflow Command Reporting in CFS. That way we don't have to do this workaround.
+          # FIXME: Suppress warnings from templates project
           # https://unix.stackexchange.com/questions/104641/how-can-i-suppress-output-from-grep-so-that-it-only-returns-the-exit-status
           dotnet codefilesanity | while read -r line; do
              if [ $(echo $line| grep -q "./osu.Framework.Templates/"; echo $?) == 1 ]; then
@@ -130,7 +130,7 @@ jobs:
         run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
       - name: Pack (Template)
-        run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true /p:NoDefaultExcludes=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+        run: dotnet pack -c Release osu.Framework.Templates /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true /p:NoDefaultExcludes=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
@@ -138,10 +138,10 @@ jobs:
         with:
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
 
-      # Manually authenticate for now as setup-dotnet ignores our auth tokens
-      # See: https://github.com/actions/setup-dotnet/issues/190
+######## TODO: Move releases in it's own workflow. For now it's commented out.
+######## Manually authenticate for now as setup-dotnet ignores our auth tokens
+######## See: https://github.com/actions/setup-dotnet/issues/190
 #      - name: Publish to NuGet
-#        if: ${{ github.event == 'release' }}
 #        run: |
 #          dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
 #          dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --skip-duplicate --source authed-nuget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: ReSharper
         uses: glassechidna/resharper-action@master
         with:
-          report: ${{github.workspace}}/inspectcodereport.xml
+          solution: ${{github.workspace}}/osu-framework.Desktop.slnf
 
   pack-framework:
     name: Pack (Framework)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,4 @@
-on:
-  push:
-    paths:
-      - '**/*.cs'
-      - '**/*.csproj'
-      - '**/*.sln'
-  pull_request:
-    paths:
-      - '**/*.cs'
-      - '**/*.csproj'
-      - '**/*.sln'
-
+on: [push, pull_request]
 name: Continuous Integration
 
 jobs:
@@ -20,8 +9,8 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v2
 
-        # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x. 
-        # Looks like we won't change this until 6.0 LTS releases on 11/2021.
+        # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x LTS side by side.
+        # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
         - name: Install .NET 5.0.x
           uses: actions/setup-dotnet@v1
           with:
@@ -37,19 +26,20 @@ jobs:
         
         - name: Restore Packages
           run: dotnet restore
- 
-        - name: Inspect
-          run: |
-            dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
-            dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors 
-        
-        - name: .NET Format (Dry Run)
-          run: dotnet format --dry-run --check
-        
+
         - name: CodeFileSanity Check
           run: |
             echo "TBD! This step will not do anything for now!"
             exit 0
+
+        - name: .NET Format (Dry Run)
+          run: dotnet format --dry-run --check
+
+        - name: Inspect
+          run: |
+            dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
+            dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors 
+ 
   test:
     name: Test 
     needs: inspect-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,10 +247,27 @@ jobs:
         id: tag
         uses: olegtarasov/get-tag@v2.1
 
-      - name: Push to NuGet
+      - name: Create Artifact Directory
+        run: mkdir ${{github.workspace}}/artifacts/
+
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: ${{github.workspace}}/artifacts/
+        
+        # Artifacts create their own directories. Let's fix that!
+        # https://github.com/actions/download-artifact#download-all-artifacts
+      - name: Move Artifacts to root of subdirectory
+        working-directory: ${{github.workspace}}/artifacts/
         run: |
-          if [ -z ${{steps.tag.outputs.tag}} ]; 
-            echo "::warn::Skipping publish, no tag detected."
+          mv -v **/*.nupkg $(pwd)
+          rm -rfv */
+
+      - name: Deploy
+        if: ${{ always() }}
+        run: |
+          if [ -z ${{steps.tag.outputs.tag}} ];
+            echo "Skipping publish, no tag detected."
             exit 0;
           else
             echo "TBD! This is just to evaluate if this release pipeline works."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,29 @@ jobs:
         
         - name: Restore Packages
           run: dotnet restore
-    
+ 
         - name: Inspect
           run: |
             dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
             dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors 
+  test:
+    name: Test 
+    needs: inspect-code
+    runs-on: ubuntu-latest
+    steps:
+        - name: Checkout
+          uses: actions/checkout@v2
 
+        - name: Install .NET 5.0.x
+          uses: actions/setup-dotnet@v1
+          with:
+             dotnet-version: '5.0.x'       
         
-           
+        - name: Test
+          run: dotnet test --logger:nunit
+
+        - name: Report NUnit Logs
+          uses: MirrorNG/nunit-reporter@v1.0.9
+          with:
+            path: 'osu.Framework.Tests/TestResults/*.xml'
+            access-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
           # FIXME: Suppress warnings from templates project
           # https://unix.stackexchange.com/questions/104641/how-can-i-suppress-output-from-grep-so-that-it-only-returns-the-exit-status
           dotnet codefilesanity | while read -r line; do
-             if [ $(echo $line| grep -q "./osu.Framework.Templates/"; echo $?) == 1 ]; then
+             if [[ "$line" != *"/osu.Framework.Templates/"* ]]; then
                echo "::warning::$line"
              fi
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
 
       - name: Set Artifacts Directory
         id: artifactsPath
-        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}/artifacts"
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.0.2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,7 +254,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           path: ${{github.workspace}}/artifacts/
-        
+   
         # Artifacts create their own directories. Let's fix that!
         # https://github.com/actions/download-artifact#download-all-artifacts
       - name: Move Artifacts to root of subdirectory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,141 +6,141 @@ jobs:
     name: Test
     runs-on: windows-latest
     steps:
-        - name: Checkout
-          uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-        - name: Install .NET 5.0.x
-          uses: actions/setup-dotnet@v1
-          with:
-             dotnet-version: '5.0.x'
+      - name: Install .NET 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
 
-        - name: Compile
-          run: dotnet build -c Debug build/Desktop.proj
+      - name: Compile
+        run: dotnet build -c Debug build/Desktop.proj
 
-        - name: Test
-          run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger:nunit
-          shell: powershell
+      - name: Test
+        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger:nunit
+        shell: powershell
 
-        - name: Report NUnit Logs
-          uses: MirrorNG/nunit-reporter@v1.0.9
-          with:
-            path: './TestResults/TestResults.xml'
-            access-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Report NUnit Logs
+        uses: MirrorNG/nunit-reporter@v1.0.9
+        with:
+          path: "./TestResults/TestResults.xml"
+          access-token: ${{ secrets.GITHUB_TOKEN }}
 
   inspect-code:
-     name: Code Quality
-     needs: test
-     runs-on: ubuntu-latest
-     steps:
-        - name: Checkout
-          uses: actions/checkout@v2
+    name: Code Quality
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-        # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x LTS and 2.1 LTS side by side.
-        # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
-        - name: Install .NET 2.1.x LTS
-          uses: actions/setup-dotnet@v1
-          with:
-            dotnet-version: '2.1.x'
+      # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x LTS and 2.1 LTS side by side.
+      # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
+      - name: Install .NET 2.1.x LTS
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "2.1.x"
 
-        - name: Install .NET 3.1.x LTS
-          uses: actions/setup-dotnet@v1
-          with:
-             dotnet-version: '3.1.x'
+      - name: Install .NET 3.1.x LTS
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "3.1.x"
 
-        - name: Install .NET 5.0.x
-          uses: actions/setup-dotnet@v1
-          with:
-             dotnet-version: '5.0.x'
+      - name: Install .NET 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
 
-        - name: Restore Tools
-          run: dotnet tool restore
+      - name: Restore Tools
+        run: dotnet tool restore
 
-        - name: Restore Packages
-          run: dotnet restore
+      - name: Restore Packages
+        run: dotnet restore
 
-        - name: CodeFileSanity
-          run: |
-            # Suppress warnings from templates project
-            # https://unix.stackexchange.com/questions/104641/how-can-i-suppress-output-from-grep-so-that-it-only-returns-the-exit-status
-            dotnet codefilesanity | while read -r line; do
-               if [ $(echo $line| grep -q "./osu.Framework.Templates/"; echo $?) == 1 ]; then
-                 echo "::warning::$line"
-               fi
-            done
+      - name: CodeFileSanity
+        run: |
+          # Suppress warnings from templates project
+          # https://unix.stackexchange.com/questions/104641/how-can-i-suppress-output-from-grep-so-that-it-only-returns-the-exit-status
+          dotnet codefilesanity | while read -r line; do
+             if [ $(echo $line| grep -q "./osu.Framework.Templates/"; echo $?) == 1 ]; then
+               echo "::warning::$line"
+             fi
+          done
 
-        - name: .NET Format (Dry Run)
-          run: dotnet format --dry-run --check
+      - name: .NET Format (Dry Run)
+        run: dotnet format --dry-run --check
 
-        - name: InspectCode
-          run: |
-            dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
-            dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors
+      - name: InspectCode
+        run: |
+          dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
+          dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors
 
   pack-n-publish:
-         name: Pack and Publish
-         runs-on: windows-latest
-         needs: inspect-code
-         defaults:
-           run:
-             shell: powershell
-         steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-          
-            - name: Set Variables
-              id: deployment
-              shell: bash
-              run: |
-               if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
-                 echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
-               else
-                 echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
-               fi
+    name: Pack and Publish
+    runs-on: windows-latest
+    needs: inspect-code
+    defaults:
+      run:
+        shell: powershell
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-            - name: Set Artifacts Directory
-              id: artifactsPath
-              run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
+      - name: Set Variables
+        id: deployment
+        shell: bash
+        run: |
+          if [ ${{ github.event == 'release' && github.actor == 'peppy' }} == true ]; then
+            echo "::set-output name=VERSION::${GITHUB_REF#/refs\/tags\//}"
+          else
+            echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
+          fi
 
-            # FIXME: 3.1 LTS is required here because iOS builds still uses 3.1.
-            # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
-            - name: Install .NET 3.1.x LTS
-              uses: actions/setup-dotnet@v1
-              with:
-                  dotnet-version: '3.1.x'
+      - name: Set Artifacts Directory
+        id: artifactsPath
+        run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
 
-            - name: Install .NET 5.0.x
-              uses: actions/setup-dotnet@v1
-              with:
-                dotnet-version: '5.0.x'
+      # FIXME: 3.1 LTS is required here because iOS builds still uses 3.1.
+      # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
+      - name: Install .NET 3.1.x LTS
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "3.1.x"
 
-            - name: Add msbuild to PATH
-              uses: microsoft/setup-msbuild@v1.0.2
+      - name: Install .NET 5.0.x
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "5.0.x"
 
-            - name: Pack (Framework)
-              run: dotnet pack -c Release osu.Framework /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+      - name: Add msbuild to PATH
+        uses: microsoft/setup-msbuild@v1.0.2
 
-            - name: Pack (iOS Framework)
-              run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.iOS/osu.Framework.iOS.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+      - name: Pack (Framework)
+        run: dotnet pack -c Release osu.Framework /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true  -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
-            - name: Pack (Android Framework)
-              run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.Android/osu.Framework.Android.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
+      - name: Pack (iOS Framework)
+        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.iOS/osu.Framework.iOS.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
 
-            - name: Pack (Native Libraries)
-              run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+      - name: Pack (Android Framework)
+        run: msbuild -bl:msbuildlog.binlog -v:m -target:Pack -r osu.Framework.Android/osu.Framework.Android.csproj -p:Configuration=Release -p:Version=${{steps.deployment.outputs.version}} -p:PackageOutputPath=${{steps.artifactsPath.outputs.nuget_artifacts}}
 
-            - name: Pack (Template)
-              run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true /p:NoDefaultExcludes=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
+      - name: Pack (Native Libraries)
+        run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
-            - name: Upload Artifacts
-              uses: actions/upload-artifact@v2
-              if: ${{ github.event != 'release' }}
-              with:
-                 path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
+      - name: Pack (Template)
+        run: dotnet pack -c Release osu.Framework.NativeLibs /p:Configuration=Release /p:Version=${{steps.deployment.outputs.version}} /p:GenerateDocumentationFile=true /p:NoDefaultExcludes=true -o ${{steps.artifactsPath.outputs.nuget_artifacts}}
 
-            # Manually authenticate for now as setup-dotnet ignores our auth tokens
-            # See: https://github.com/actions/setup-dotnet/issues/190
-            - name: Publish to NuGet
-              if: ${{ github.event == 'release' }}
-              run: |
-                    dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
-                    dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --skip-duplicate --source authed-nuget
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ github.event != 'release' }}
+        with:
+          path: ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg
+
+      # Manually authenticate for now as setup-dotnet ignores our auth tokens
+      # See: https://github.com/actions/setup-dotnet/issues/190
+      - name: Publish to NuGet
+        if: ${{ github.event == 'release' }}
+        run: |
+          dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
+          dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --skip-duplicate --source authed-nuget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,15 @@ jobs:
         - name: Install .NET
           uses: actions/setup-dotnet@v1
           with:
-            dotnet-version: 5.0
+             dotnet-version: '5.0.x'
         
         - name: Restore Tools
           run: dotnet tool restore
     
         - name: Inspect
           run: |
-            dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml
+            dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
+            dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors 
+        
+        
            

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,12 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v2
 
+        # FIXME: Tools won't run in .NET 5.0 unless you install 3.1.x. 
+        # Looks like we won't change this until 6.0 LTS releases on 11/2021.
         - name: Install .NET
           uses: actions/setup-dotnet@v1
           with:
-             dotnet-version: '5.0.x'
+             dotnet-version: '3.1.x'
         
         - name: Restore Tools
           run: dotnet tool restore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Continuous Integration
 
 jobs:
   check-if-tag:
-    name: Get Git Tag
+    name: Set Package Version
     runs-on: ubuntu-latest
     outputs:
       version: ${{steps.deployment.outputs.version}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,6 @@ jobs:
         run: |
           # TODO: Add ignore filters and GitHub Workflow Command Reporting in CFS. That way we don't have to do this workaround.
           # FIXME: Suppress warnings from templates project
-          # https://unix.stackexchange.com/questions/104641/how-can-i-suppress-output-from-grep-so-that-it-only-returns-the-exit-status
           dotnet codefilesanity | while read -r line; do
              if [[ "$line" != *"/osu.Framework.Templates/"* ]]; then
                echo "::warning::$line"
@@ -202,7 +201,6 @@ jobs:
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v2
-        if: ${{ github.event != 'release' }}
         with:
           name: osu-framework-ios
           path: ${{steps.artifactsPath.outputs.nuget_artifacts}}/*.nupkg

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,14 @@ jobs:
           run: |
             dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
             dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors 
+        
+        - name: .NET Format (Dry Run)
+          run: dotnet format --dry-run --check
+        
+        - name: CodeFileSanity Check
+          run: |
+            echo "TBD! This step will not do anything for now!"
+            exit 0
   test:
     name: Test 
     needs: inspect-code
@@ -55,8 +63,9 @@ jobs:
           with:
              dotnet-version: '5.0.x'       
         
+        #TODO: Figure out what build.cake#91 means.
         - name: Test
-          run: dotnet test --logger:nunit
+          run: dotnet test -c Debug osu.Framework.Tests --logger:nunit
 
         - name: Report NUnit Logs
           uses: MirrorNG/nunit-reporter@v1.0.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Report NUnit Logs
         uses: MirrorNG/nunit-reporter@v1.0.9
+        if: ${{ always() }}
         with:
           path: "./TestResults/TestResults.xml"
           access-token: ${{ secrets.GITHUB_TOKEN }}
@@ -101,7 +102,7 @@ jobs:
         id: artifactsPath
         run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
 
-      # FIXME: 3.1 LTS is required here because iOS builds still uses 3.1.
+      # FIXME: 3.1 LTS is required here because iOS builds refuse to build without it.
       # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e
       - name: Install .NET 3.1.x LTS
         uses: actions/setup-dotnet@v1
@@ -139,8 +140,8 @@ jobs:
 
       # Manually authenticate for now as setup-dotnet ignores our auth tokens
       # See: https://github.com/actions/setup-dotnet/issues/190
-      - name: Publish to NuGet
-        if: ${{ github.event == 'release' }}
-        run: |
-          dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
-          dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --skip-duplicate --source authed-nuget
+#      - name: Publish to NuGet
+#        if: ${{ github.event == 'release' }}
+#        run: |
+#          dotnet nuget add source https://api.nuget.org/v3/index.json -n authed-nuget -u ${{secrets.NUGET_USER_NAME}} -p ${{secrets.NUGET_AUTH_TOKEN}}
+#          dotnet nuget push ${{steps.artifactsPath.outputs.nuget_artifacts}}\*.nupkg --skip-duplicate --source authed-nuget

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
  
         - name: Restore Tools
           run: dotnet tool restore
-        
+
         - name: Restore Packages
           run: dotnet restore
 
@@ -96,11 +96,10 @@ jobs:
                else
                  echo "::set-output name=VERSION::0.0.0+${{github.run_id}}"
                fi
-       
+
             - name: Set Artifacts Directory
               id: artifactsPath
               run: echo "::set-output name=NUGET_ARTIFACTS::${{github.workspace}}\artifacts"
-   
 
             # FIXME: 3.1 LTS is required here because iOS builds still uses 3.1.
             # https://itnext.io/how-to-support-multiple-net-sdks-in-github-actions-workflows-b988daa884e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,11 +23,14 @@ jobs:
   
         - name: Restore Tools
           run: dotnet tool restore
+        
+        - name: Restore Packages
+          run: dotnet restore
     
         - name: Inspect
           run: |
             dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
             dotnet nvika parsereport $(pwd)/inspectcodereport.xml  --treatwarningsaserrors 
-        
+
         
            

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,4 @@
-on:
-  pull_request:
-    branches:
-      - "*"
-  push:
-    branches:
-      - "*"
-    tags:
-      - "*"
+on: [push, pull_request]
 
 name: Continuous Integration
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,7 +262,9 @@ jobs:
       - name: Deploy
         if: ${{ always() }}
         run: |
-          if [ -z ${{steps.tag.outputs.tag}} ];
+          version=${{steps.tag.outputs.tag}}
+
+          if [ -z $version ]; then
             echo "Skipping publish, no tag detected."
             exit 0;
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,6 @@ jobs:
          steps:
             - name: Checkout
               uses: actions/checkout@v2
-
-            # As we don't have the equivalent of AppVeyor's Local NuGet repos
-            # We're going to use the actor's GHPR instead.
-            # FIXME: GHPR requires authentication, see:https://docs.github.com/en/packages/guides/configuring-dotnet-cli-for-use-with-github-packages.
-            # Workaround to authentication requirement is enabled "improved container support" to allow anonymous pulling.
             
             - name: Set Variables
               id: deployment

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="NunitXml.TestLogger" Version="3.0.97" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <!-- 
+      NunitXml.TestLogger is required by the CI, DO NOT REMOVE!
+      See: https://git.io/J3tAb
+    -->
     <PackageReference Include="NunitXml.TestLogger" Version="3.0.97" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Similar vein to GH-4407, but in a feature-complete state. Resolves GH-4288.

### Changes

- We're now using a standardized reporting with NUnit using the NUnit Logger with the NUnit Reporter Action. 

![image](https://user-images.githubusercontent.com/14976516/116262044-cd905800-a7aa-11eb-887c-ff5acccb0363.png)


- CFS, MSBuild, Vika and Roslyn warnings will show up as warning and error annotations natively with no additional change needed.

![image](https://user-images.githubusercontent.com/14976516/116262239-f31d6180-a7aa-11eb-9376-80255616daa5.png)


- Secrets will be managed natively in GitHub, and can be called using a reference, making it much safer to use secrets.

### Caveats

- Currently there is no distinction between artifacts, you have to download the entire archive containing the nuget packages regardless if you have made a change in this specific package.
- Legacy scripts and AppVeyor definitions have not been cleaned out of this PR to allow AppVeyor checks to still pass. This can be tackled on a future PR once transition has started.

### Deprecations

- The cake script will be unused post-merge, so that means it has to be deprecated alongside AppVeyor if you plan to transition fully.
