### PR TITLE
Fix variable declarations not explored by DCC

### DIFF
--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -269,7 +269,6 @@ namespace osu.Framework.Testing
                 return kind != SyntaxKind.UsingDirective
                        && kind != SyntaxKind.NamespaceKeyword
                        && (kind != SyntaxKind.ClassDeclaration || ((ClassDeclarationSyntax)n).Modifiers.All(m => m.Kind() != SyntaxKind.StaticKeyword))
-                       && kind != SyntaxKind.VariableDeclarator
                        && (kind != SyntaxKind.QualifiedName || !(n.Parent is NamespaceDeclarationSyntax))
                        && kind != SyntaxKind.NameColon
                        && (kind != SyntaxKind.QualifiedName || n.Parent?.Kind() != SyntaxKind.NamespaceDeclaration)
@@ -293,6 +292,7 @@ namespace osu.Framework.Testing
 
                     switch (node.Parent.Kind())
                     {
+                        case SyntaxKind.VariableDeclarator: // Ignore the variable name of variable declarators.
                         case SyntaxKind.Argument: // Ignore the variable name of arguments.
                         case SyntaxKind.InvocationExpression: // Ignore a single identifier name expression of an invocation expression (e.g. IdentifierName()).
                         case SyntaxKind.ForEachStatement: // Ignore a single identifier of a foreach statement (the source).


### PR DESCRIPTION
Turns out that ignoring variable declarators completely is wrong. Consider the following snippet from `HitErrorDisplay`:
```
var display = new BarHitErrorMeter(hitWindows, rightAligned)
{
    ...
};


CompilationUnit()
.WithMembers(
    SingletonList<MemberDeclarationSyntax>(
        GlobalStatement(
            LocalDeclarationStatement(
                VariableDeclaration(
                    IdentifierName(
                        Identifier(
                            TriviaList(),
                            SyntaxKind.VarKeyword,
                            "var",
                            "var",
                            TriviaList())))
                .WithVariables(
                    SingletonSeparatedList<VariableDeclaratorSyntax>(
                        VariableDeclarator(
                            Identifier("display"))
                        .WithInitializer(
                            EqualsValueClause(
                                ObjectCreationExpression(
                                    IdentifierName("BarHitErrorMeter"))
                                .WithArgumentList(
                                    ArgumentList(
                                        SeparatedList<ArgumentSyntax>(
                                            new SyntaxNodeOrToken[]{
                                                Argument(
                                                    IdentifierName("hitWindows")),
                                                Token(SyntaxKind.CommaToken),
                                                Argument(
                                                    IdentifierName("rightAligned"))})))
                                .WithInitializer(
                                    InitializerExpression(
                                        SyntaxKind.ObjectInitializerExpression))))))))))
.NormalizeWhitespace()
```
I only intended to ignore the first `IdentifierName` syntax of the variable declarator - the variable name, but the initialiser is a child of it.