### PR TITLE
Fix type arguments not explored by DCC

### DIFF
--- a/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
+++ b/osu.Framework/Testing/RoslynTypeReferenceBuilder.cs
@@ -264,7 +264,6 @@ namespace osu.Framework.Testing
                 // - The single IdentifierName child of a foreach expression (source variable name), below.
                 // - The single 'var' IdentifierName child of a variable declaration, below.
                 // - Element access expressions.
-                // - Generic type argument lists.
 
                 return kind != SyntaxKind.UsingDirective
                        && kind != SyntaxKind.NamespaceKeyword
@@ -274,7 +273,6 @@ namespace osu.Framework.Testing
                        && (kind != SyntaxKind.QualifiedName || n.Parent?.Kind() != SyntaxKind.NamespaceDeclaration)
                        && kind != SyntaxKind.NameColon
                        && kind != SyntaxKind.ElementAccessExpression
-                       && kind != SyntaxKind.TypeArgumentList
                        && (n.Parent?.Kind() != SyntaxKind.InvocationExpression || n != ((InvocationExpressionSyntax)n.Parent).Expression);
             });
 


### PR DESCRIPTION
Consider, in isolation, the following class: https://github.com/ppy/osu/blob/da624deb3223cfb2f041d54a0bebada0696d9209/osu.Game/Skinning/Editor/SkinSelectionHandler.cs

The class `SkinnableHUDComponent` is only ever referenced via type parameters.