### PR TITLE
Fix Test Coverage Reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
         run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults.trx"
         shell: powershell
 
+      # Attempt to upload results even if test fails.
+      # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always
       - name: Upload Test Results
         uses: actions/upload-artifact@v2
         if: ${{ always() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: osu-framework-test-results
-          path: ${{github.workspace}}\TestResults.trx
+          path: ${{github.workspace}}\TestResults\TestResults.trx
 
   inspect-code:
     name: Code Quality

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,15 +33,15 @@ jobs:
         run: dotnet build -c Debug build/Desktop.proj
 
       - name: Test
-        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger:nunit
+        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults.trx"
         shell: powershell
 
-      - name: Report NUnit Logs
-        uses: MirrorNG/nunit-reporter@v1.0.9
+      - name: Upload Test Results
+        uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          path: "./TestResults/TestResults.xml"
-          access-token: ${{ secrets.GITHUB_TOKEN }}
+          name: osu-framework-test-results
+          path: ${{github.workspace}}\TestResults.trx
 
   inspect-code:
     name: Code Quality

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -11,9 +11,8 @@ on:
 jobs:
   report:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     steps:
-      # FIXME: Do not run if workflow is cancelled!
-      # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run
       - name: Continuous Integration Test Report
         uses: dorny/test-reporter@v1.4.2
         with:

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -1,3 +1,7 @@
+# This is a workaround to allow PRs to report their coverage. This will run inside the base repository.
+# See:
+#   * https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories
+#   * https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
 name: "Test Report"
 on:
   workflow_run:

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -1,0 +1,17 @@
+name: "Test Report"
+on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Continuous Integration Test Report
+        uses: dorny/test-reporter@v1.4.2
+        with:
+          artifact: osu-framework-test-results
+          name: Test Results
+          path: "*.trx"
+          reporter: dotnet-trx

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -1,4 +1,4 @@
-# This is a workaround to allow PRs to report their coverage. This will run inside the base repository.
+# HACK: This is a workaround to allow PRs to report their coverage. This will run inside the base repository.
 # See:
 #   * https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories
 #   * https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
@@ -12,6 +12,8 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
+      # FIXME: Do not run if workflow is cancelled!
+      # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_run
       - name: Continuous Integration Test Report
         uses: dorny/test-reporter@v1.4.2
         with:

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -1,4 +1,4 @@
-# HACK: This is a workaround to allow PRs to report their coverage. This will run inside the base repository.
+# This is a workaround to allow PRs to report their coverage. This will run inside the base repository.
 # See:
 #   * https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories
 #   * https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token

--- a/osu.Framework.Tests/osu.Framework.Tests.csproj
+++ b/osu.Framework.Tests/osu.Framework.Tests.csproj
@@ -13,11 +13,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <!-- 
-      NunitXml.TestLogger is required by the CI, DO NOT REMOVE!
-      See: https://git.io/J3tAb
-    -->
-    <PackageReference Include="NunitXml.TestLogger" Version="3.0.97" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes Test coverage not reporting as it should due to GitHub Limitations. This also uses the TRX format instead of requiring a seperate logger for coverage reporting.

**REQUIRES `report-nunit` WORKFLOW TO BE PRESENT IN THE BASE REPO TO ACTUALLY WORK!** 

![image](https://user-images.githubusercontent.com/14976516/116725432-78f01580-aa14-11eb-81e2-87edc85dad6d.png)

![image](https://user-images.githubusercontent.com/14976516/116725485-87d6c800-aa14-11eb-89a8-4099d5657366.png)
