### PR TITLE
Run Test Job as Matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Test
         run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"
-        shell: powershell
+        shell: pwsh
 
       # Attempt to upload results even if test fails.
       # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#always
@@ -50,7 +50,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: osu-framework-test-results
-          path: ${{github.workspace}}\TestResults\TestResults-${{matrix.os.prettyname}}.trx
+          path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}.trx
 
   inspect-code:
     name: Code Quality

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,16 @@ jobs:
   test:
     name: Test
     runs-on: ${{matrix.os.fullname}}
+    continue-on-error: true
+    env:
+      OSU_EXECUTION_MODE: ${{matrix.threadingMode}}
     strategy:
        matrix:
           os:
             - { prettyname: Windows, fullname: windows-latest }
             - { prettyname: macOS, fullname: macos-latest }
             - { prettyname: Linux, fullname: ubuntu-latest }
-          threadingMode: ['SingleThread', 'MultiThread']
+          threadingMode: ['SingleThread', 'MultiThreaded']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,14 @@ jobs:
           fi
   test:
     name: Test
-    runs-on: windows-latest
+    runs-on: ${{matrix.os.fullname}}
+    strategy:
+       matrix:
+          os:
+            - { prettyname: Windows, fullname: windows-latest }
+            - { prettyname: macOS, fullname: macos-latest }
+            - { prettyname: Linux, fullname: ubuntu-latest }
+          threadingMode: ['SingleThread', 'MultiThread']
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -33,7 +40,7 @@ jobs:
         run: dotnet build -c Debug build/Desktop.proj
 
       - name: Test
-        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults.trx"
+        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"
         shell: powershell
 
       # Attempt to upload results even if test fails.
@@ -43,7 +50,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: osu-framework-test-results
-          path: ${{github.workspace}}\TestResults\TestResults.trx
+          path: ${{github.workspace}}\TestResults\TestResults-${{matrix.os.prettyname}}.trx
 
   inspect-code:
     name: Code Quality

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
   test:
     name: Test
     runs-on: ${{matrix.os.fullname}}
-    continue-on-error: true
     env:
       OSU_EXECUTION_MODE: ${{matrix.threadingMode}}
     strategy:
+       fail-fast: false
        matrix:
           os:
             - { prettyname: Windows, fullname: windows-latest }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: osu-framework-test-results
+          name: osu-framework-test-results-${{matrix.os.prettyname}}
           path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}.trx
 
   inspect-code:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
         with:
           dotnet-version: "5.0.x"
 
+      # FIXME: libavformat is not included in Ubuntu. Let's fix that.
+      - name: Install libavformat-dev
+        if: ${{matrix.os.fullname == "ubuntu-latest"}}
+        run: |
+         sudo apt-get update && \
+         sudo apt-get -y install libavformat-dev
+
       - name: Compile
         run: dotnet build -c Debug build/Desktop.proj
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
           dotnet-version: "5.0.x"
 
       # FIXME: libavformat is not included in Ubuntu. Let's fix that.
+      # https://github.com/ppy/osu-framework/issues/4349
+      # Remove this once https://github.com/actions/virtual-environments/issues/3306 has been resolved.
       - name: Install libavformat-dev
         if: ${{matrix.os.fullname == 'ubuntu-latest'}}
         run: |
@@ -50,7 +52,7 @@ jobs:
         run: dotnet build -c Debug build/Desktop.proj
 
       - name: Test
-        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}.trx"
+        run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx"
         shell: pwsh
 
       # Attempt to upload results even if test fails.
@@ -60,7 +62,7 @@ jobs:
         if: ${{ always() }}
         with:
           name: osu-framework-test-results-${{matrix.os.prettyname}}
-          path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}.trx
+          path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx
 
   inspect-code:
     name: Code Quality

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       # FIXME: libavformat is not included in Ubuntu. Let's fix that.
       - name: Install libavformat-dev
-        if: ${{matrix.os.fullname == "ubuntu-latest"}}
+        if: ${{matrix.os.fullname == 'ubuntu-latest'}}
         run: |
          sudo apt-get update && \
          sudo apt-get -y install libavformat-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: osu-framework-test-results-${{matrix.os.prettyname}}
+          name: osu-framework-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}
           path: ${{github.workspace}}/TestResults/TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx
 
   inspect-code:

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -12,11 +12,18 @@ jobs:
   report:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    strategy:
+       fail-fast: false
+       matrix:
+          os:
+            - { prettyname: Windows }
+            - { prettyname: macOS }
+            - { prettyname: Linux }
     steps:
       - name: Continuous Integration Test Report
         uses: dorny/test-reporter@v1.4.2
         with:
-          artifact: osu-framework-test-results
+          artifact: osu-framework-test-results-${{matrix.os.prettyname}}
           name: Test Results
           path: "*.trx"
           reporter: dotnet-trx

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -19,11 +19,12 @@ jobs:
             - { prettyname: Windows }
             - { prettyname: macOS }
             - { prettyname: Linux }
+          threadingMode: ['SingleThread', 'MultiThreaded']
     steps:
       - name: Continuous Integration Test Report
         uses: dorny/test-reporter@v1.4.2
         with:
-          artifact: osu-framework-test-results-${{matrix.os.prettyname}}
+          artifact: osu-framework-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx
           name: Test Results
           path: "*.trx"
           reporter: dotnet-trx

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Continuous Integration Test Report
         uses: dorny/test-reporter@v1.4.2
         with:
-          artifact: osu-framework-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx
+          artifact: osu-framework-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}
           name: Test Results
           path: "*.trx"
           reporter: dotnet-trx


### PR DESCRIPTION
Closes #4426. This will run the `test` job against all supported platform runners in GitHub Actions on SingleThread and MultiThread mode.


Currently tests are flaky so I'm not sure how to fix this.