### PR TITLE
Fix culture changes not working when single-threaded

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -889,10 +889,7 @@ namespace osu.Framework.Platform
                 CultureInfo.DefaultThreadCurrentCulture = culture;
                 CultureInfo.DefaultThreadCurrentUICulture = culture;
 
-                foreach (var t in Threads)
-                {
-                    t.Scheduler.Add(() => { t.CurrentCulture = culture; });
-                }
+                threadRunner.SetCulture(culture);
             }, true);
 
             // intentionally done after everything above to ensure the new configuration location has priority over obsoleted values.


### PR DESCRIPTION
Addresses one of the failures from #4430. At least two others remain.

The culture-switching code would not work if the game was started single-threaded without ever switching to multi-threaded. The cause of this was two-fold:

* First off, when the game is started in single-threaded mode, the four `GameThread`s are never actually created via `ThreadRunner`. Therefore, the `GameThread.CurrentCulture` sets did nothing but set the culture value on the `GameThread`s. They did not actually change any actual real OS thread's culture.

  https://github.com/ppy/osu-framework/blob/0386fd340d147a884606c86f9bc09b34333c2437/osu.Framework/Threading/GameThread.cs#L211-L217

* Secondly, in single-threaded mode, the main thread is actually the one that is running frames of all four types (audio/draw/input/update) - but there was no actual place where the main thread's culture was changed, partly due to the above.

To resolve, extract a `SetCulture(CultureInfo)` method on `ThreadRunner` and explicitly set the culture of that method's caller thread to the desired culture, as well. The method does not branch depending on the current execution mode to avoid desynchronisation of culture values across the two available modes.

---

Not super hot on this resolution but the construction of `ThreadRunner`/`GameThread` makes this a bit awkward (sometimes a thread is an actual thread, and sometimes it's just a puppet being worked by the main thread manually). Open to alternatives. Mostly opening to get one off the list. Not confident I'll get the rest today.