### PR TITLE
Fix SampleChannels with zero frequency not playing in single-threaded execution

### DIFF
--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -159,11 +159,10 @@ namespace osu.Framework.Audio.Sample
                 if (Played && Bass.ChannelIsActive(channel) == PlaybackState.Stopped)
                     return;
 
-                if (relativeFrequencyHandler.IsFrequencyZero)
-                    return;
-
-                Bass.ChannelPlay(channel);
                 playing = true;
+
+                if (!relativeFrequencyHandler.IsFrequencyZero)
+                    Bass.ChannelPlay(channel);
             }
             finally
             {


### PR DESCRIPTION
Fixes the sample channel test failure mentioned in https://github.com/ppy/osu-framework/pull/4430#issuecomment-832154842.

This was caused by the playChannel() callback temporarily setting `Playing` to false by virtue of setting `enqueuedPlaybackStart` to false.

In multi-threaded execution, this is not a problem because `UpdateState` will then run and set `Playing` back to true by setting `playing` to true.

In single-threaded execution, this _is_ a problem because `UpdateState` only runs on the next audio frame, at which point the `SampleChannel` is now dead (due to `Playing = false`) and won't receive the `UpdateState`.