### PR TITLE
Remove early return before bass init

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -242,10 +242,6 @@ namespace osu.Framework.Audio
             if (!device.IsEnabled)
                 return false;
 
-            // same device
-            if (device.IsInitialized && deviceIndex == Bass.CurrentDevice)
-                return true;
-
             // initialize new device
             bool initSuccess = InitBass(deviceIndex);
             if (Bass.LastError != Errors.Already && BassUtils.CheckFaulted(false))


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/4435

It seems like on some platforms, the audio device is initialised by default. Or this is dependent on ordering of tests:

```
 [runtime] 2021-05-05 14:55:09 [important]: Simulating device loss...
 [runtime] 2021-05-05 14:55:09 [important]: Attempting to sync audio devices...
 [runtime] 2021-05-05 14:55:09 [important]: Enumerated devices: No sound
 [runtime] 2021-05-05 14:55:09 [important]: Setting audio device (name: )
 [runtime] 2021-05-05 14:55:09 [important]: Setting audio device (index: -1)
 [runtime] 2021-05-05 14:55:09 [important]: Device ManagedBass.DeviceInfo not enabled.
 [runtime] 2021-05-05 14:55:09 [important]: Setting audio device (index: -1)
 [runtime] 2021-05-05 14:55:09 [important]: Device ManagedBass.DeviceInfo not enabled.
 [runtime] 2021-05-05 14:55:09 [important]: Setting audio device (index: 0)
 [runtime] 2021-05-05 14:55:09 [important]: Device ManagedBass.DeviceInfo already current.
```

The `InitBass` method is overridden by device loss test audio manager to change local states, so this early return was causing the method to not get called.
This is handled right below anyway, and it's not a hot path.

Complete run: https://github.com/smoogipoo/osu-framework/actions/runs/813862558