### PR TITLE
Fix DLW test failing intermittently

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadWrapper.cs
@@ -134,7 +134,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         {
             Container wrapped = null;
             DelayedLoadWrapper wrapper = null;
-            double lifetimeEnd = 0;
+            double lifetimeStart = 0;
 
             AddStep("create child", () =>
             {
@@ -146,7 +146,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                         wrapper = new DelayedLoadWrapper(wrapped = new Container
                         {
                             // this lifetime will be overwritten by the one on the wrapper.
-                            LifetimeEnd = Time.Current + 4000,
+                            LifetimeStart = Time.Current + 4000,
                             RelativeSizeAxes = Axes.Both,
                             Children = new Drawable[]
                             {
@@ -154,7 +154,7 @@ namespace osu.Framework.Tests.Visual.Drawables
                             }
                         })
                         {
-                            LifetimeEnd = lifetimeEnd = Time.Current + 2000,
+                            LifetimeStart = lifetimeStart = Time.Current + 2000,
                         }
                     }
                 });
@@ -162,10 +162,8 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             AddUntilStep("wait for load", () => wrapper.DelayedLoadCompleted);
 
-            AddAssert("wrapper lifetime is correct", () => wrapper.LifetimeEnd == lifetimeEnd);
-            AddAssert("content lifetime is correct", () => wrapped.LifetimeEnd == lifetimeEnd);
-
-            AddUntilStep("wrapper expired", () => !wrapper.IsAlive);
+            AddAssert("wrapper lifetime is correct", () => wrapper.LifetimeStart == lifetimeStart);
+            AddAssert("content lifetime is correct", () => wrapped.LifetimeStart == lifetimeStart);
         }
 
         [TestCase(false)]


### PR DESCRIPTION
As seen in https://github.com/ppy/osu-framework/runs/2511281078.

Can be tested by adding a `Thread.Sleep(1000);` in `TestBox.load()`.

There's technically three problems here, and this (using `LifetimeStart` instead of `LifetimeEnd`) is the easiest way to work around all issues without knowing how to fix them yet. The issues are:
1. `LifetimeEnd` causes the DLW to be expired before the contents finish loading. This immediately causes the DLW to be removed from its parent without overriding `RemoveWhenNotAlive` to `false`.
2. Regardless of the above, an expired DLW stops receiving updates and thus the scheduled addition does not run (scheduled to the DLW itself). One would think that setting `LifetimeEnd` to an absurdly high value would resolve this but also:
3. DLW briefly takes on its content's lifetime during the async load process.