### PR TITLE
Keep anchor and origin when wrapping drawable via `ContainerExtensions.Wrap`

### DIFF
--- a/osu.Framework/Graphics/Containers/ContainerExtensions.cs
+++ b/osu.Framework/Graphics/Containers/ContainerExtensions.cs
@@ -39,8 +39,6 @@ namespace osu.Framework.Graphics.Containers
 
             drawable.Position = Vector2.Zero;
             drawable.Rotation = 0;
-            drawable.Anchor = Anchor.TopLeft;
-            drawable.Origin = Anchor.TopLeft;
 
             // For anchor/origin positioning to be preserved correctly,
             // relatively sized axes must be lifted to the wrapping container.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/12733 as per https://github.com/ppy/osu/issues/12733#issuecomment-835938318

Seems arbitrary to revert the anchor/origin of the wrapped drawable back to `TopLeft` as the container should have the same exact size as the wrapped drawable, rendering that pointless.

And reverting the `Origin` could cause issues to drawables that, for example, rescale themselves from inside the implementation, rather than externally on the wrapper container.