### PR TITLE
Fix incorrect comparison in `Dropdown` resulting in deselection of valid selection

### DIFF
--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Graphics.UserInterface
             foreach (var entry in items)
                 addDropdownItem(GenerateItemText(entry), entry);
 
-            if (Current.Value == null || !itemMap.Any(i => EqualityComparer<T>.Default.Equals(i.Key, Current.Value)))
+            if (Current.Value == null || !itemMap.Keys.Contains(Current.Value, EqualityComparer<T>.Default))
                 Current.Value = itemMap.Keys.FirstOrDefault();
             else
                 Current.TriggerChange();

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Graphics.UserInterface
             foreach (var entry in items)
                 addDropdownItem(GenerateItemText(entry), entry);
 
-            if (Current.Value == null || !itemMap.Keys.Contains(Current.Value))
+            if (Current.Value == null || !itemMap.Any(i => EqualityComparer<T>.Default.Equals(i.Key, Current.Value)))
                 Current.Value = itemMap.Keys.FirstOrDefault();
             else
                 Current.TriggerChange();


### PR DESCRIPTION
The `KeyCollection` class does not use the default `EqualityComparer` as one would expect, falling back to a reference comparison. This was causing the skin dropdown to behave incorrectly osu!-side.

I've added a new test here, but the existing `TestBasic` will already fail with the move away from `string`s as the model type in all dropdown tests.