### PR TITLE
Run Compile Step with `-warnaserror` flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
          sudo apt-get -y install libavformat-dev
 
       - name: Compile
-        run: dotnet build -c Debug build/Desktop.proj
+        run: dotnet build -c Debug -warnaserror build/Desktop.proj
 
       - name: Test
         run: dotnet test $pwd/*.Tests/bin/Debug/*/*.Tests.dll --settings $pwd/build/vstestconfig.runsettings --logger "trx;LogFileName=TestResults-${{matrix.os.prettyname}}-${{matrix.threadingMode}}.trx"


### PR DESCRIPTION
Resolves #4451. this includes `-warnaserror` on the compile step which elevates these warnings to errors. This has been tested locally, refer to following screenshot.

![image](https://user-images.githubusercontent.com/14976516/118265106-4dc4f600-b4eb-11eb-91ed-2bab9e5e853f.png)
