### PR TITLE
Add BindableDictionary<TKey, TValue>

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.Specialized;
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Bindables;
@@ -88,7 +87,7 @@ namespace osu.Framework.Tests.Bindables
         {
             var dict = new BindableDictionary<string, byte> { { "a", 1 } };
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             dict.BindCollectionChanged((_, args) => triggeredArgs = args);
 
             Assert.That(triggeredArgs, Is.Null);
@@ -99,10 +98,10 @@ namespace osu.Framework.Tests.Bindables
         {
             var dict = new BindableDictionary<string, byte> { { "a", 1 } };
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             dict.BindCollectionChanged((_, args) => triggeredArgs = args, true);
 
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Add));
             Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(dict));
         }
 
@@ -125,7 +124,7 @@ namespace osu.Framework.Tests.Bindables
                 { "d", 7 }
             };
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             dict.BindCollectionChanged((_, args) => triggeredArgs = args);
             dict.BindTo(otherDict);
 
@@ -151,7 +150,7 @@ namespace osu.Framework.Tests.Bindables
                 new KeyValuePair<string, byte>("d", 7)
             };
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             dict.BindCollectionChanged((_, args) => triggeredArgs = args);
             dict.Parse(enumerable);
 
@@ -181,17 +180,17 @@ namespace osu.Framework.Tests.Bindables
             var dict = new BindableDictionary<string, byte>(firstDictContents);
             var otherDict = new BindableDictionary<string, byte>(otherDictContents);
 
-            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            var triggeredArgs = new List<NotifyDictionaryChangedEventArgs<string, byte>>();
             dict.BindCollectionChanged((_, args) => triggeredArgs.Add(args));
             dict.BindTo(otherDict);
 
             Assert.That(triggeredArgs, Has.Count.EqualTo(2));
 
-            var removeEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyCollectionChangedAction.Remove);
+            var removeEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyDictionaryChangedAction.Remove);
             Assert.That(removeEvent, Is.Not.Null);
             Assert.That(removeEvent.OldItems, Is.EquivalentTo(firstDictContents));
 
-            var addEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyCollectionChangedAction.Add);
+            var addEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyDictionaryChangedAction.Add);
             Assert.That(addEvent, Is.Not.Null);
             Assert.That(addEvent.NewItems, Is.EquivalentTo(otherDict));
         }
@@ -243,12 +242,12 @@ namespace osu.Framework.Tests.Bindables
         {
             bindableStringByteDictionary.Add("0", 0);
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringByteDictionary["0"] = 1;
 
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Replace));
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Replace));
             Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 0).Yield()));
             Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 1).Yield()));
         }
@@ -261,12 +260,12 @@ namespace osu.Framework.Tests.Bindables
             var dict = new BindableDictionary<string, byte>();
             dict.BindTo(bindableStringByteDictionary);
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             dict.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringByteDictionary["0"] = 1;
 
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Replace));
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Replace));
             Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 0).Yield()));
             Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 1).Yield()));
         }
@@ -288,12 +287,12 @@ namespace osu.Framework.Tests.Bindables
         [TestCase("", 1, Description = "Empty string")]
         public void TestAddWithStringNotifiesSubscriber(string key, byte value)
         {
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringByteDictionary.Add(key, value);
 
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Add));
             Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>(key, value).Yield()));
         }
 
@@ -301,7 +300,7 @@ namespace osu.Framework.Tests.Bindables
         [TestCase("", 1, Description = "Empty string")]
         public void TestAddWithStringNotifiesSubscriberOnce(string key, byte value)
         {
-            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            var triggeredArgs = new List<NotifyDictionaryChangedEventArgs<string, byte>>();
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs.Add(args);
 
             bindableStringByteDictionary.Add(key, value);
@@ -313,9 +312,9 @@ namespace osu.Framework.Tests.Bindables
         [TestCase("", 1, Description = "Empty string")]
         public void TestAddWithStringNotifiesMultipleSubscribers(string key, byte value)
         {
-            NotifyCollectionChangedEventArgs triggeredArgsA = null;
-            NotifyCollectionChangedEventArgs triggeredArgsB = null;
-            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsA = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsB = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsC = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsA = args;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsB = args;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsC = args;
@@ -331,9 +330,9 @@ namespace osu.Framework.Tests.Bindables
         [TestCase("", 1, Description = "Empty string")]
         public void TestAddWithStringNotifiesMultipleSubscribersOnlyAfterTheAdd(string key, byte value)
         {
-            NotifyCollectionChangedEventArgs triggeredArgsA = null;
-            NotifyCollectionChangedEventArgs triggeredArgsB = null;
-            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsA = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsB = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsC = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsA = args;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsB = args;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsC = args;
@@ -446,12 +445,12 @@ namespace osu.Framework.Tests.Bindables
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringByteDictionary.Remove(item);
 
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Remove));
             Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("item", 0).Yield()));
         }
 
@@ -461,7 +460,7 @@ namespace osu.Framework.Tests.Bindables
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
 
             bindableStringByteDictionary.Remove(item);
 
@@ -478,9 +477,9 @@ namespace osu.Framework.Tests.Bindables
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
 
-            NotifyCollectionChangedEventArgs triggeredArgsA = null;
-            NotifyCollectionChangedEventArgs triggeredArgsB = null;
-            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsA = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsB = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsC = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsA = args;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsB = args;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsC = args;
@@ -535,12 +534,12 @@ namespace osu.Framework.Tests.Bindables
             var dict = new BindableDictionary<string, byte>();
             dict.BindTo(bindableStringByteDictionary);
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             dict.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringByteDictionary.Remove(item);
 
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Remove));
             Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>(item, 0).Yield()));
         }
 
@@ -552,16 +551,16 @@ namespace osu.Framework.Tests.Bindables
             var dictA = new BindableDictionary<string, byte>();
             dictA.BindTo(bindableStringByteDictionary);
 
-            NotifyCollectionChangedEventArgs triggeredArgsA1 = null;
-            NotifyCollectionChangedEventArgs triggeredArgsA2 = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsA1 = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsA2 = null;
             dictA.CollectionChanged += (_, args) => triggeredArgsA1 = args;
             dictA.CollectionChanged += (_, args) => triggeredArgsA2 = args;
 
             var dictB = new BindableDictionary<string, byte>();
             dictB.BindTo(bindableStringByteDictionary);
 
-            NotifyCollectionChangedEventArgs triggeredArgsB1 = null;
-            NotifyCollectionChangedEventArgs triggeredArgsB2 = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsB1 = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsB2 = null;
             dictB.CollectionChanged += (_, args) => triggeredArgsB1 = args;
             dictB.CollectionChanged += (_, args) => triggeredArgsB2 = args;
 
@@ -579,7 +578,7 @@ namespace osu.Framework.Tests.Bindables
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
 
             Assert.That(triggeredArgs, Is.Null);
@@ -644,12 +643,12 @@ namespace osu.Framework.Tests.Bindables
             foreach (var (key, value) in items)
                 bindableStringByteDictionary.Add(key, value);
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringByteDictionary.Clear();
 
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Remove));
             Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(items));
         }
 
@@ -659,7 +658,7 @@ namespace osu.Framework.Tests.Bindables
             for (byte i = 0; i < 5; i++)
                 bindableStringByteDictionary.Add($"test{i}", i);
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
 
             Assert.That(triggeredArgs, Is.Null);
@@ -673,9 +672,9 @@ namespace osu.Framework.Tests.Bindables
             for (byte i = 0; i < 5; i++)
                 bindableStringByteDictionary.Add($"test{i}", i);
 
-            NotifyCollectionChangedEventArgs triggeredArgsA = null;
-            NotifyCollectionChangedEventArgs triggeredArgsB = null;
-            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsA = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsB = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgsC = null;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsA = args;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsB = args;
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsC = args;
@@ -938,13 +937,13 @@ namespace osu.Framework.Tests.Bindables
             foreach (var (key, value) in array)
                 bindableStringByteDictionary.Add(key, value);
 
-            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            var triggeredArgs = new List<NotifyDictionaryChangedEventArgs<string, byte>>();
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs.Add(args);
 
             bindableStringByteDictionary.Parse(null);
 
             Assert.That(triggeredArgs, Has.Count.EqualTo(1));
-            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyDictionaryChangedAction.Remove));
             Assert.That(triggeredArgs.First().OldItems, Is.EquivalentTo(array));
         }
 
@@ -959,15 +958,15 @@ namespace osu.Framework.Tests.Bindables
                 new KeyValuePair<string, byte>("testB", 1),
             };
 
-            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            var triggeredArgs = new List<NotifyDictionaryChangedEventArgs<string, byte>>();
             bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs.Add(args);
 
             bindableStringByteDictionary.Parse(array);
 
             Assert.That(triggeredArgs, Has.Count.EqualTo(2));
-            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyDictionaryChangedAction.Remove));
             Assert.That(triggeredArgs.First().OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("test123", 0).Yield()));
-            Assert.That(triggeredArgs.ElementAt(1).Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.ElementAt(1).Action, Is.EqualTo(NotifyDictionaryChangedAction.Add));
             Assert.That(triggeredArgs.ElementAt(1).NewItems, Is.EquivalentTo(array));
         }
 
@@ -980,12 +979,12 @@ namespace osu.Framework.Tests.Bindables
         {
             var boundCopy = bindableStringByteDictionary.GetBoundCopy();
 
-            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
             boundCopy.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringByteDictionary.Add("test", 0);
 
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Add));
             Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>("test", 0).Yield()));
         }
 

--- a/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
@@ -86,10 +86,10 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestBindCollectionChangedWithoutRunningImmediately()
         {
-            var list = new BindableDictionary<string, byte> { { "a", 1 } };
+            var dict = new BindableDictionary<string, byte> { { "a", 1 } };
 
             NotifyCollectionChangedEventArgs triggeredArgs = null;
-            list.BindCollectionChanged((_, args) => triggeredArgs = args);
+            dict.BindCollectionChanged((_, args) => triggeredArgs = args);
 
             Assert.That(triggeredArgs, Is.Null);
         }
@@ -97,19 +97,19 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestBindCollectionChangedWithRunImmediately()
         {
-            var list = new BindableDictionary<string, byte> { { "a", 1 } };
+            var dict = new BindableDictionary<string, byte> { { "a", 1 } };
 
             NotifyCollectionChangedEventArgs triggeredArgs = null;
-            list.BindCollectionChanged((_, args) => triggeredArgs = args, true);
+            dict.BindCollectionChanged((_, args) => triggeredArgs = args, true);
 
             Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
-            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(list));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(dict));
         }
 
         [Test]
-        public void TestBindCollectionChangedNotRunIfBoundToSequenceEqualList()
+        public void TestBindCollectionChangedNotRunIfBoundToSequenceEqualDictionary()
         {
-            var list = new BindableDictionary<string, byte>
+            var dict = new BindableDictionary<string, byte>
             {
                 { "a", 1 },
                 { "b", 3 },
@@ -117,7 +117,7 @@ namespace osu.Framework.Tests.Bindables
                 { "d", 7 }
             };
 
-            var otherList = new BindableDictionary<string, byte>
+            var otherDict = new BindableDictionary<string, byte>
             {
                 { "a", 1 },
                 { "b", 3 },
@@ -126,8 +126,8 @@ namespace osu.Framework.Tests.Bindables
             };
 
             NotifyCollectionChangedEventArgs triggeredArgs = null;
-            list.BindCollectionChanged((_, args) => triggeredArgs = args);
-            list.BindTo(otherList);
+            dict.BindCollectionChanged((_, args) => triggeredArgs = args);
+            dict.BindTo(otherDict);
 
             Assert.That(triggeredArgs, Is.Null);
         }
@@ -135,7 +135,7 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestBindCollectionChangedNotRunIfParsingSequenceEqualEnumerable()
         {
-            var list = new BindableDictionary<string, byte>
+            var dict = new BindableDictionary<string, byte>
             {
                 { "a", 1 },
                 { "b", 3 },
@@ -152,16 +152,16 @@ namespace osu.Framework.Tests.Bindables
             };
 
             NotifyCollectionChangedEventArgs triggeredArgs = null;
-            list.BindCollectionChanged((_, args) => triggeredArgs = args);
-            list.Parse(enumerable);
+            dict.BindCollectionChanged((_, args) => triggeredArgs = args);
+            dict.Parse(enumerable);
 
             Assert.That(triggeredArgs, Is.Null);
         }
 
         [Test]
-        public void TestBindCollectionChangedEventsRanIfBoundToDifferentList()
+        public void TestBindCollectionChangedEventsRanIfBoundToDifferentDictionary()
         {
-            var firstListContents = new[]
+            var firstDictContents = new[]
             {
                 new KeyValuePair<string, byte>("a", 1),
                 new KeyValuePair<string, byte>("b", 3),
@@ -169,7 +169,7 @@ namespace osu.Framework.Tests.Bindables
                 new KeyValuePair<string, byte>("d", 7),
             };
 
-            var otherListContents = new[]
+            var otherDictContents = new[]
             {
                 new KeyValuePair<string, byte>("a", 2),
                 new KeyValuePair<string, byte>("b", 4),
@@ -178,22 +178,22 @@ namespace osu.Framework.Tests.Bindables
                 new KeyValuePair<string, byte>("e", 10),
             };
 
-            var list = new BindableDictionary<string, byte>(firstListContents);
-            var otherList = new BindableDictionary<string, byte>(otherListContents);
+            var dict = new BindableDictionary<string, byte>(firstDictContents);
+            var otherDict = new BindableDictionary<string, byte>(otherDictContents);
 
             var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
-            list.BindCollectionChanged((_, args) => triggeredArgs.Add(args));
-            list.BindTo(otherList);
+            dict.BindCollectionChanged((_, args) => triggeredArgs.Add(args));
+            dict.BindTo(otherDict);
 
             Assert.That(triggeredArgs, Has.Count.EqualTo(2));
 
             var removeEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyCollectionChangedAction.Remove);
             Assert.That(removeEvent, Is.Not.Null);
-            Assert.That(removeEvent.OldItems, Is.EquivalentTo(firstListContents));
+            Assert.That(removeEvent.OldItems, Is.EquivalentTo(firstDictContents));
 
             var addEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyCollectionChangedAction.Add);
             Assert.That(addEvent, Is.Not.Null);
-            Assert.That(addEvent.NewItems, Is.EquivalentTo(otherList));
+            Assert.That(addEvent.NewItems, Is.EquivalentTo(otherDict));
         }
 
         #endregion
@@ -254,15 +254,15 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestSetNotifiesBoundLists()
+        public void TestSetNotifiesBoundDictionaries()
         {
             bindableStringByteDictionary.Add("0", 0);
 
-            var list = new BindableDictionary<string, byte>();
-            list.BindTo(bindableStringByteDictionary);
+            var dict = new BindableDictionary<string, byte>();
+            dict.BindTo(bindableStringByteDictionary);
 
             NotifyCollectionChangedEventArgs triggeredArgs = null;
-            list.CollectionChanged += (_, args) => triggeredArgs = args;
+            dict.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringByteDictionary["0"] = 1;
 
@@ -347,37 +347,37 @@ namespace osu.Framework.Tests.Bindables
 
         [TestCase("a random string", 0)]
         [TestCase("", 1, Description = "Empty string")]
-        public void TestAddWithStringNotifiesBoundList(string key, byte value)
+        public void TestAddWithStringNotifiesBoundDictionary(string key, byte value)
         {
-            var list = new BindableDictionary<string, byte>();
-            list.BindTo(bindableStringByteDictionary);
+            var dict = new BindableDictionary<string, byte>();
+            dict.BindTo(bindableStringByteDictionary);
 
             bindableStringByteDictionary.Add(key, value);
 
-            Assert.That(list, Contains.Key(key));
+            Assert.That(dict, Contains.Key(key));
         }
 
         [TestCase("a random string", 0)]
         [TestCase("", 1, Description = "Empty string")]
-        public void TestAddWithStringNotifiesBoundLists(string key, byte value)
+        public void TestAddWithStringNotifiesBoundDictionaries(string key, byte value)
         {
-            var listA = new BindableDictionary<string, byte>();
-            var listB = new BindableDictionary<string, byte>();
-            var listC = new BindableDictionary<string, byte>();
-            listA.BindTo(bindableStringByteDictionary);
-            listB.BindTo(bindableStringByteDictionary);
-            listC.BindTo(bindableStringByteDictionary);
+            var dictA = new BindableDictionary<string, byte>();
+            var dictB = new BindableDictionary<string, byte>();
+            var dictC = new BindableDictionary<string, byte>();
+            dictA.BindTo(bindableStringByteDictionary);
+            dictB.BindTo(bindableStringByteDictionary);
+            dictC.BindTo(bindableStringByteDictionary);
 
             bindableStringByteDictionary.Add(key, value);
 
-            Assert.That(listA, Contains.Key(key));
-            Assert.That(listB, Contains.Key(key));
-            Assert.That(listC, Contains.Key(key));
+            Assert.That(dictA, Contains.Key(key));
+            Assert.That(dictB, Contains.Key(key));
+            Assert.That(dictC, Contains.Key(key));
         }
 
         [TestCase("a random string", 0)]
         [TestCase("", 1, Description = "Empty string")]
-        public void TestAddWithDisabledListThrowsInvalidOperationException(string key, byte value)
+        public void TestAddWithDisabledDictionaryThrowsInvalidOperationException(string key, byte value)
         {
             bindableStringByteDictionary.Disabled = true;
 
@@ -386,7 +386,7 @@ namespace osu.Framework.Tests.Bindables
 
         [TestCase("a random string", 0)]
         [TestCase("", 1, Description = "Empty string")]
-        public void TestAddWithListContainingItemsDoesNotOverrideItems(string key, byte value)
+        public void TestAddWithDictionaryContainingItemsDoesNotOverrideItems(string key, byte value)
         {
             const string item = "existing string";
             bindableStringByteDictionary.Add(item, 0);
@@ -402,7 +402,7 @@ namespace osu.Framework.Tests.Bindables
         #region .Remove(key)
 
         [Test]
-        public void TestRemoveWithDisabledListThrowsInvalidOperationException()
+        public void TestRemoveWithDisabledDictionaryThrowsInvalidOperationException()
         {
             const string item = "hi";
             bindableStringByteDictionary.Add(item, 0);
@@ -412,7 +412,7 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestRemoveWithAnItemThatIsNotInTheListReturnsFalse()
+        public void TestRemoveWithAnItemThatIsNotInTheDictionaryReturnsFalse()
         {
             bool gotRemoved = bindableStringByteDictionary.Remove("hm");
 
@@ -420,7 +420,7 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestRemoveWhenListIsDisabledThrowsInvalidOperationException()
+        public void TestRemoveWhenDictionaryIsDisabledThrowsInvalidOperationException()
         {
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
@@ -430,7 +430,7 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestRemoveWithAnItemThatIsInTheListReturnsTrue()
+        public void TestRemoveWithAnItemThatIsInTheDictionaryReturnsTrue()
         {
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
@@ -493,50 +493,50 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestRemoveNotifiesBoundList()
+        public void TestRemoveNotifiesBoundDictionary()
         {
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
-            var list = new BindableDictionary<string, byte>();
-            list.BindTo(bindableStringByteDictionary);
+            var dict = new BindableDictionary<string, byte>();
+            dict.BindTo(bindableStringByteDictionary);
 
             bindableStringByteDictionary.Remove(item);
 
-            Assert.IsEmpty(list);
+            Assert.IsEmpty(dict);
         }
 
         [Test]
-        public void TestRemoveNotifiesBoundLists()
+        public void TestRemoveNotifiesBoundDictionaries()
         {
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
-            var listA = new BindableDictionary<string, byte>();
-            listA.BindTo(bindableStringByteDictionary);
-            var listB = new BindableDictionary<string, byte>();
-            listB.BindTo(bindableStringByteDictionary);
-            var listC = new BindableDictionary<string, byte>();
-            listC.BindTo(bindableStringByteDictionary);
+            var dictA = new BindableDictionary<string, byte>();
+            dictA.BindTo(bindableStringByteDictionary);
+            var dictB = new BindableDictionary<string, byte>();
+            dictB.BindTo(bindableStringByteDictionary);
+            var dictC = new BindableDictionary<string, byte>();
+            dictC.BindTo(bindableStringByteDictionary);
 
             bindableStringByteDictionary.Remove(item);
 
             Assert.Multiple(() =>
             {
-                Assert.False(listA.ContainsKey(item));
-                Assert.False(listB.ContainsKey(item));
-                Assert.False(listC.ContainsKey(item));
+                Assert.False(dictA.ContainsKey(item));
+                Assert.False(dictB.ContainsKey(item));
+                Assert.False(dictC.ContainsKey(item));
             });
         }
 
         [Test]
-        public void TestRemoveNotifiesBoundListSubscription()
+        public void TestRemoveNotifiesBoundDictionarySubscription()
         {
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
-            var list = new BindableDictionary<string, byte>();
-            list.BindTo(bindableStringByteDictionary);
+            var dict = new BindableDictionary<string, byte>();
+            dict.BindTo(bindableStringByteDictionary);
 
             NotifyCollectionChangedEventArgs triggeredArgs = null;
-            list.CollectionChanged += (_, args) => triggeredArgs = args;
+            dict.CollectionChanged += (_, args) => triggeredArgs = args;
 
             bindableStringByteDictionary.Remove(item);
 
@@ -545,25 +545,25 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestRemoveNotifiesBoundListSubscriptions()
+        public void TestRemoveNotifiesBoundDictionarySubscriptions()
         {
             const string item = "item";
             bindableStringByteDictionary.Add(item, 0);
-            var listA = new BindableDictionary<string, byte>();
-            listA.BindTo(bindableStringByteDictionary);
+            var dictA = new BindableDictionary<string, byte>();
+            dictA.BindTo(bindableStringByteDictionary);
 
             NotifyCollectionChangedEventArgs triggeredArgsA1 = null;
             NotifyCollectionChangedEventArgs triggeredArgsA2 = null;
-            listA.CollectionChanged += (_, args) => triggeredArgsA1 = args;
-            listA.CollectionChanged += (_, args) => triggeredArgsA2 = args;
+            dictA.CollectionChanged += (_, args) => triggeredArgsA1 = args;
+            dictA.CollectionChanged += (_, args) => triggeredArgsA2 = args;
 
-            var listB = new BindableDictionary<string, byte>();
-            listB.BindTo(bindableStringByteDictionary);
+            var dictB = new BindableDictionary<string, byte>();
+            dictB.BindTo(bindableStringByteDictionary);
 
             NotifyCollectionChangedEventArgs triggeredArgsB1 = null;
             NotifyCollectionChangedEventArgs triggeredArgsB2 = null;
-            listB.CollectionChanged += (_, args) => triggeredArgsB1 = args;
-            listB.CollectionChanged += (_, args) => triggeredArgsB2 = args;
+            dictB.CollectionChanged += (_, args) => triggeredArgsB1 = args;
+            dictB.CollectionChanged += (_, args) => triggeredArgsB2 = args;
 
             bindableStringByteDictionary.Remove(item);
 
@@ -601,7 +601,7 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestClearWithDisabledListThrowsInvalidOperationException()
+        public void TestClearWithDisabledDictionaryThrowsInvalidOperationException()
         {
             for (byte i = 0; i < 5; i++)
                 bindableStringByteDictionary.Add($"test{i}", i);
@@ -611,7 +611,7 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestClearWithEmptyDisabledListThrowsInvalidOperationException()
+        public void TestClearWithEmptyDisabledDictionaryThrowsInvalidOperationException()
         {
             bindableStringByteDictionary.Disabled = true;
 
@@ -690,69 +690,69 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestClearNotifiesBoundBindable()
         {
-            var bindableList = new BindableDictionary<string, byte>();
-            bindableList.BindTo(bindableStringByteDictionary);
+            var bindableDict = new BindableDictionary<string, byte>();
+            bindableDict.BindTo(bindableStringByteDictionary);
             for (byte i = 0; i < 5; i++)
                 bindableStringByteDictionary.Add($"testA{i}", i);
             for (byte i = 0; i < 5; i++)
-                bindableList.Add($"testB{i}", i);
+                bindableDict.Add($"testB{i}", i);
 
             bindableStringByteDictionary.Clear();
 
-            Assert.IsEmpty(bindableList);
+            Assert.IsEmpty(bindableDict);
         }
 
         [Test]
         public void TestClearNotifiesBoundBindables()
         {
-            var bindableListA = new BindableDictionary<string, byte>();
-            bindableListA.BindTo(bindableStringByteDictionary);
-            var bindableListB = new BindableDictionary<string, byte>();
-            bindableListB.BindTo(bindableStringByteDictionary);
-            var bindableListC = new BindableDictionary<string, byte>();
-            bindableListC.BindTo(bindableStringByteDictionary);
+            var bindableDictA = new BindableDictionary<string, byte>();
+            bindableDictA.BindTo(bindableStringByteDictionary);
+            var bindableDictB = new BindableDictionary<string, byte>();
+            bindableDictB.BindTo(bindableStringByteDictionary);
+            var bindableDictC = new BindableDictionary<string, byte>();
+            bindableDictC.BindTo(bindableStringByteDictionary);
             for (byte i = 0; i < 5; i++)
                 bindableStringByteDictionary.Add($"testA{i}", i);
             for (byte i = 0; i < 5; i++)
-                bindableListA.Add($"testB{i}", i);
+                bindableDictA.Add($"testB{i}", i);
             for (byte i = 0; i < 5; i++)
-                bindableListB.Add($"testC{i}", i);
+                bindableDictB.Add($"testC{i}", i);
             for (byte i = 0; i < 5; i++)
-                bindableListC.Add($"testD{i}", i);
+                bindableDictC.Add($"testD{i}", i);
 
             bindableStringByteDictionary.Clear();
 
             Assert.Multiple(() =>
             {
-                Assert.IsEmpty(bindableListA);
-                Assert.IsEmpty(bindableListB);
-                Assert.IsEmpty(bindableListC);
+                Assert.IsEmpty(bindableDictA);
+                Assert.IsEmpty(bindableDictB);
+                Assert.IsEmpty(bindableDictC);
             });
         }
 
         [Test]
         public void TestClearDoesNotNotifyBoundBindablesBeforeClear()
         {
-            var bindableListA = new BindableDictionary<string, byte>();
-            bindableListA.BindTo(bindableStringByteDictionary);
-            var bindableListB = new BindableDictionary<string, byte>();
-            bindableListB.BindTo(bindableStringByteDictionary);
-            var bindableListC = new BindableDictionary<string, byte>();
-            bindableListC.BindTo(bindableStringByteDictionary);
+            var bindableDictA = new BindableDictionary<string, byte>();
+            bindableDictA.BindTo(bindableStringByteDictionary);
+            var bindableDictB = new BindableDictionary<string, byte>();
+            bindableDictB.BindTo(bindableStringByteDictionary);
+            var bindableDictC = new BindableDictionary<string, byte>();
+            bindableDictC.BindTo(bindableStringByteDictionary);
             for (byte i = 0; i < 5; i++)
                 bindableStringByteDictionary.Add($"testA{i}", i);
             for (byte i = 0; i < 5; i++)
-                bindableListA.Add($"testB{i}", i);
+                bindableDictA.Add($"testB{i}", i);
             for (byte i = 0; i < 5; i++)
-                bindableListB.Add($"testC{i}", i);
+                bindableDictB.Add($"testC{i}", i);
             for (byte i = 0; i < 5; i++)
-                bindableListC.Add($"testD{i}", i);
+                bindableDictC.Add($"testD{i}", i);
 
             Assert.Multiple(() =>
             {
-                Assert.IsNotEmpty(bindableListA);
-                Assert.IsNotEmpty(bindableListB);
-                Assert.IsNotEmpty(bindableListC);
+                Assert.IsNotEmpty(bindableDictA);
+                Assert.IsNotEmpty(bindableDictB);
+                Assert.IsNotEmpty(bindableDictC);
             });
 
             bindableStringByteDictionary.Clear();
@@ -819,14 +819,14 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestDisabledNotifiesBoundLists()
+        public void TestDisabledNotifiesBoundDictionaries()
         {
-            var list = new BindableDictionary<string, byte>();
-            list.BindTo(bindableStringByteDictionary);
+            var dict = new BindableDictionary<string, byte>();
+            dict.BindTo(bindableStringByteDictionary);
 
             bindableStringByteDictionary.Disabled = true;
 
-            Assert.IsTrue(list.Disabled);
+            Assert.IsTrue(dict.Disabled);
         }
 
         #endregion
@@ -844,9 +844,9 @@ namespace osu.Framework.Tests.Bindables
         {
             var array = new[] { new KeyValuePair<string, byte>("", 0) };
 
-            var list = new BindableDictionary<string, byte>(array);
+            var dict = new BindableDictionary<string, byte>(array);
 
-            var enumerator = list.GetEnumerator();
+            var enumerator = dict.GetEnumerator();
 
             Assert.AreNotEqual(array.GetEnumerator(), enumerator);
         }
@@ -858,7 +858,7 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestDescriptionWhenSetReturnsSetValue()
         {
-            const string description = "The list used for testing.";
+            const string description = "The dictionary used for testing.";
 
             bindableStringByteDictionary.Description = description;
 
@@ -870,7 +870,7 @@ namespace osu.Framework.Tests.Bindables
         #region .Parse(obj)
 
         [Test]
-        public void TestParseWithNullClearsList()
+        public void TestParseWithNullClearsDictionary()
         {
             bindableStringByteDictionary.Add("a item", 0);
 
@@ -894,7 +894,7 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
-        public void TestParseWithDisabledListThrowsInvalidOperationException()
+        public void TestParseWithDisabledDictionaryThrowsInvalidOperationException()
         {
             bindableStringByteDictionary.Disabled = true;
 

--- a/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
@@ -210,6 +210,34 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
+        public void TestSetNotifiesSubscribersOfAddWhenItemDoesNotExist()
+        {
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary["0"] = 0;
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Add));
+            Assert.That(triggeredArgs.OldItems, Is.Null);
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 0).Yield()));
+        }
+
+        [Test]
+        public void TestSetNotifiesSubscribersOfReplacementWhenItemExists()
+        {
+            bindableStringByteDictionary["0"] = 0;
+
+            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary["0"] = 1;
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Replace));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 0).Yield()));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 1).Yield()));
+        }
+
+        [Test]
         public void TestSetMutatesObjectAtIndex()
         {
             bindableStringByteDictionary.Add("0", 0);
@@ -235,21 +263,6 @@ namespace osu.Framework.Tests.Bindables
             bindableStringByteDictionary.Disabled = true;
 
             Assert.Throws<InvalidOperationException>(() => bindableStringByteDictionary["0"] = 1);
-        }
-
-        [Test]
-        public void TestSetNotifiesSubscribers()
-        {
-            bindableStringByteDictionary.Add("0", 0);
-
-            NotifyDictionaryChangedEventArgs<string, byte> triggeredArgs = null;
-            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
-
-            bindableStringByteDictionary["0"] = 1;
-
-            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyDictionaryChangedAction.Replace));
-            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 0).Yield()));
-            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 1).Yield()));
         }
 
         [Test]

--- a/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableDictionaryTest.cs
@@ -1,0 +1,994 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
+
+namespace osu.Framework.Tests.Bindables
+{
+    [TestFixture]
+    public class BindableDictionaryTest
+    {
+        private BindableDictionary<string, byte> bindableStringByteDictionary;
+
+        [SetUp]
+        public void SetUp()
+        {
+            bindableStringByteDictionary = new BindableDictionary<string, byte>();
+        }
+
+        #region Constructor
+
+        [Test]
+        public void TestConstructorDoesNotAddItemsByDefault()
+        {
+            Assert.IsEmpty(bindableStringByteDictionary);
+        }
+
+        [Test]
+        public void TestConstructorWithItemsAddsItemsInternally()
+        {
+            KeyValuePair<string, byte>[] array =
+            {
+                new KeyValuePair<string, byte>("ok", 0),
+                new KeyValuePair<string, byte>("nope", 1),
+                new KeyValuePair<string, byte>("random", 2),
+                new KeyValuePair<string, byte>("", 4)
+            };
+
+            var dict = new BindableDictionary<string, byte>(array);
+
+            Assert.Multiple(() =>
+            {
+                foreach (var (key, value) in array)
+                {
+                    Assert.That(dict.TryGetValue(key, out var val), Is.True);
+                    Assert.That(val, Is.EqualTo(value));
+                }
+
+                Assert.AreEqual(array.Length, dict.Count);
+            });
+        }
+
+        #endregion
+
+        #region BindTarget
+
+        /// <summary>
+        /// Tests binding via the various <see cref="BindableDictionary{TKey,TValue}"/> methods.
+        /// </summary>
+        [Test]
+        public void TestBindViaBindTarget()
+        {
+            BindableDictionary<string, byte> parentBindable = new BindableDictionary<string, byte>();
+
+            BindableDictionary<string, byte> bindable1 = new BindableDictionary<string, byte>();
+            BindableDictionary<string, byte> bindable2 = new BindableDictionary<string, byte>();
+
+            bindable1.BindTarget = parentBindable;
+            bindable2.BindTarget = parentBindable;
+
+            parentBindable.Add("5", 1);
+
+            Assert.That(bindable1["5"], Is.EqualTo(1));
+            Assert.That(bindable2["5"], Is.EqualTo(1));
+        }
+
+        #endregion
+
+        #region BindCollectionChanged
+
+        [Test]
+        public void TestBindCollectionChangedWithoutRunningImmediately()
+        {
+            var list = new BindableDictionary<string, byte> { { "a", 1 } };
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.BindCollectionChanged((_, args) => triggeredArgs = args);
+
+            Assert.That(triggeredArgs, Is.Null);
+        }
+
+        [Test]
+        public void TestBindCollectionChangedWithRunImmediately()
+        {
+            var list = new BindableDictionary<string, byte> { { "a", 1 } };
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.BindCollectionChanged((_, args) => triggeredArgs = args, true);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(list));
+        }
+
+        [Test]
+        public void TestBindCollectionChangedNotRunIfBoundToSequenceEqualList()
+        {
+            var list = new BindableDictionary<string, byte>
+            {
+                { "a", 1 },
+                { "b", 3 },
+                { "c", 5 },
+                { "d", 7 }
+            };
+
+            var otherList = new BindableDictionary<string, byte>
+            {
+                { "a", 1 },
+                { "b", 3 },
+                { "c", 5 },
+                { "d", 7 }
+            };
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.BindCollectionChanged((_, args) => triggeredArgs = args);
+            list.BindTo(otherList);
+
+            Assert.That(triggeredArgs, Is.Null);
+        }
+
+        [Test]
+        public void TestBindCollectionChangedNotRunIfParsingSequenceEqualEnumerable()
+        {
+            var list = new BindableDictionary<string, byte>
+            {
+                { "a", 1 },
+                { "b", 3 },
+                { "c", 5 },
+                { "d", 7 }
+            };
+
+            var enumerable = new[]
+            {
+                new KeyValuePair<string, byte>("a", 1),
+                new KeyValuePair<string, byte>("b", 3),
+                new KeyValuePair<string, byte>("c", 5),
+                new KeyValuePair<string, byte>("d", 7)
+            };
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.BindCollectionChanged((_, args) => triggeredArgs = args);
+            list.Parse(enumerable);
+
+            Assert.That(triggeredArgs, Is.Null);
+        }
+
+        [Test]
+        public void TestBindCollectionChangedEventsRanIfBoundToDifferentList()
+        {
+            var firstListContents = new[]
+            {
+                new KeyValuePair<string, byte>("a", 1),
+                new KeyValuePair<string, byte>("b", 3),
+                new KeyValuePair<string, byte>("c", 5),
+                new KeyValuePair<string, byte>("d", 7),
+            };
+
+            var otherListContents = new[]
+            {
+                new KeyValuePair<string, byte>("a", 2),
+                new KeyValuePair<string, byte>("b", 4),
+                new KeyValuePair<string, byte>("c", 6),
+                new KeyValuePair<string, byte>("d", 8),
+                new KeyValuePair<string, byte>("e", 10),
+            };
+
+            var list = new BindableDictionary<string, byte>(firstListContents);
+            var otherList = new BindableDictionary<string, byte>(otherListContents);
+
+            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            list.BindCollectionChanged((_, args) => triggeredArgs.Add(args));
+            list.BindTo(otherList);
+
+            Assert.That(triggeredArgs, Has.Count.EqualTo(2));
+
+            var removeEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyCollectionChangedAction.Remove);
+            Assert.That(removeEvent, Is.Not.Null);
+            Assert.That(removeEvent.OldItems, Is.EquivalentTo(firstListContents));
+
+            var addEvent = triggeredArgs.SingleOrDefault(ev => ev.Action == NotifyCollectionChangedAction.Add);
+            Assert.That(addEvent, Is.Not.Null);
+            Assert.That(addEvent.NewItems, Is.EquivalentTo(otherList));
+        }
+
+        #endregion
+
+        #region dictionary[index]
+
+        [Test]
+        public void TestGetRetrievesObjectAtIndex()
+        {
+            bindableStringByteDictionary.Add("0", 0);
+            bindableStringByteDictionary.Add("1", 1);
+            bindableStringByteDictionary.Add("2", 2);
+
+            Assert.AreEqual(1, bindableStringByteDictionary["1"]);
+        }
+
+        [Test]
+        public void TestSetMutatesObjectAtIndex()
+        {
+            bindableStringByteDictionary.Add("0", 0);
+            bindableStringByteDictionary.Add("1", 1);
+            bindableStringByteDictionary["1"] = 2;
+
+            Assert.AreEqual(2, bindableStringByteDictionary["1"]);
+        }
+
+        [Test]
+        public void TestGetWhileDisabledDoesNotThrowInvalidOperationException()
+        {
+            bindableStringByteDictionary.Add("0", 0);
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.AreEqual(0, bindableStringByteDictionary["0"]);
+        }
+
+        [Test]
+        public void TestSetWhileDisabledThrowsInvalidOperationException()
+        {
+            bindableStringByteDictionary.Add("0", 0);
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.Throws<InvalidOperationException>(() => bindableStringByteDictionary["0"] = 1);
+        }
+
+        [Test]
+        public void TestSetNotifiesSubscribers()
+        {
+            bindableStringByteDictionary.Add("0", 0);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary["0"] = 1;
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Replace));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 0).Yield()));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 1).Yield()));
+        }
+
+        [Test]
+        public void TestSetNotifiesBoundLists()
+        {
+            bindableStringByteDictionary.Add("0", 0);
+
+            var list = new BindableDictionary<string, byte>();
+            list.BindTo(bindableStringByteDictionary);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary["0"] = 1;
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Replace));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 0).Yield()));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>("0", 1).Yield()));
+        }
+
+        #endregion
+
+        #region .Add(key, value)
+
+        [TestCase("a random string", 0)]
+        [TestCase("", 1, Description = "Empty string")]
+        public void TestAddWithStringAddsStringToEnumerator(string key, byte value)
+        {
+            bindableStringByteDictionary.Add(key, value);
+
+            Assert.Contains(new KeyValuePair<string, byte>(key, value), bindableStringByteDictionary);
+        }
+
+        [TestCase("a random string", 0)]
+        [TestCase("", 1, Description = "Empty string")]
+        public void TestAddWithStringNotifiesSubscriber(string key, byte value)
+        {
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary.Add(key, value);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>(key, value).Yield()));
+        }
+
+        [TestCase("a random string", 0)]
+        [TestCase("", 1, Description = "Empty string")]
+        public void TestAddWithStringNotifiesSubscriberOnce(string key, byte value)
+        {
+            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs.Add(args);
+
+            bindableStringByteDictionary.Add(key, value);
+
+            Assert.That(triggeredArgs, Has.Count.EqualTo(1));
+        }
+
+        [TestCase("a random string", 0)]
+        [TestCase("", 1, Description = "Empty string")]
+        public void TestAddWithStringNotifiesMultipleSubscribers(string key, byte value)
+        {
+            NotifyCollectionChangedEventArgs triggeredArgsA = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB = null;
+            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsA = args;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsB = args;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsC = args;
+
+            bindableStringByteDictionary.Add(key, value);
+
+            Assert.That(triggeredArgsA, Is.Not.Null);
+            Assert.That(triggeredArgsB, Is.Not.Null);
+            Assert.That(triggeredArgsC, Is.Not.Null);
+        }
+
+        [TestCase("a random string", 0)]
+        [TestCase("", 1, Description = "Empty string")]
+        public void TestAddWithStringNotifiesMultipleSubscribersOnlyAfterTheAdd(string key, byte value)
+        {
+            NotifyCollectionChangedEventArgs triggeredArgsA = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB = null;
+            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsA = args;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsB = args;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsC = args;
+
+            Assert.That(triggeredArgsA, Is.Null);
+            Assert.That(triggeredArgsB, Is.Null);
+            Assert.That(triggeredArgsC, Is.Null);
+
+            bindableStringByteDictionary.Add(key, value);
+        }
+
+        [TestCase("a random string", 0)]
+        [TestCase("", 1, Description = "Empty string")]
+        public void TestAddWithStringNotifiesBoundList(string key, byte value)
+        {
+            var list = new BindableDictionary<string, byte>();
+            list.BindTo(bindableStringByteDictionary);
+
+            bindableStringByteDictionary.Add(key, value);
+
+            Assert.That(list, Contains.Key(key));
+        }
+
+        [TestCase("a random string", 0)]
+        [TestCase("", 1, Description = "Empty string")]
+        public void TestAddWithStringNotifiesBoundLists(string key, byte value)
+        {
+            var listA = new BindableDictionary<string, byte>();
+            var listB = new BindableDictionary<string, byte>();
+            var listC = new BindableDictionary<string, byte>();
+            listA.BindTo(bindableStringByteDictionary);
+            listB.BindTo(bindableStringByteDictionary);
+            listC.BindTo(bindableStringByteDictionary);
+
+            bindableStringByteDictionary.Add(key, value);
+
+            Assert.That(listA, Contains.Key(key));
+            Assert.That(listB, Contains.Key(key));
+            Assert.That(listC, Contains.Key(key));
+        }
+
+        [TestCase("a random string", 0)]
+        [TestCase("", 1, Description = "Empty string")]
+        public void TestAddWithDisabledListThrowsInvalidOperationException(string key, byte value)
+        {
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.Throws<InvalidOperationException>(() => { bindableStringByteDictionary.Add(key, value); });
+        }
+
+        [TestCase("a random string", 0)]
+        [TestCase("", 1, Description = "Empty string")]
+        public void TestAddWithListContainingItemsDoesNotOverrideItems(string key, byte value)
+        {
+            const string item = "existing string";
+            bindableStringByteDictionary.Add(item, 0);
+
+            bindableStringByteDictionary.Add(key, value);
+
+            Assert.That(bindableStringByteDictionary, Contains.Key(item));
+            Assert.That(bindableStringByteDictionary[item], Is.EqualTo(0));
+        }
+
+        #endregion
+
+        #region .Remove(key)
+
+        [Test]
+        public void TestRemoveWithDisabledListThrowsInvalidOperationException()
+        {
+            const string item = "hi";
+            bindableStringByteDictionary.Add(item, 0);
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.Throws(typeof(InvalidOperationException), () => bindableStringByteDictionary.Remove(item));
+        }
+
+        [Test]
+        public void TestRemoveWithAnItemThatIsNotInTheListReturnsFalse()
+        {
+            bool gotRemoved = bindableStringByteDictionary.Remove("hm");
+
+            Assert.IsFalse(gotRemoved);
+        }
+
+        [Test]
+        public void TestRemoveWhenListIsDisabledThrowsInvalidOperationException()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.Throws<InvalidOperationException>(() => { bindableStringByteDictionary.Remove(item); });
+        }
+
+        [Test]
+        public void TestRemoveWithAnItemThatIsInTheListReturnsTrue()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+
+            bool gotRemoved = bindableStringByteDictionary.Remove(item);
+
+            Assert.IsTrue(gotRemoved);
+        }
+
+        [Test]
+        public void TestRemoveNotifiesSubscriber()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary.Remove(item);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("item", 0).Yield()));
+        }
+
+        [Test]
+        public void TestRemoveDoesntNotifySubscribersOnNoOp()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+
+            bindableStringByteDictionary.Remove(item);
+
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary.Remove(item);
+
+            Assert.That(triggeredArgs, Is.Null);
+        }
+
+        [Test]
+        public void TestRemoveNotifiesSubscribers()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+
+            NotifyCollectionChangedEventArgs triggeredArgsA = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB = null;
+            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsA = args;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsB = args;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsC = args;
+
+            bindableStringByteDictionary.Remove(item);
+
+            Assert.That(triggeredArgsA, Is.Not.Null);
+            Assert.That(triggeredArgsB, Is.Not.Null);
+            Assert.That(triggeredArgsC, Is.Not.Null);
+        }
+
+        [Test]
+        public void TestRemoveNotifiesBoundList()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+            var list = new BindableDictionary<string, byte>();
+            list.BindTo(bindableStringByteDictionary);
+
+            bindableStringByteDictionary.Remove(item);
+
+            Assert.IsEmpty(list);
+        }
+
+        [Test]
+        public void TestRemoveNotifiesBoundLists()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+            var listA = new BindableDictionary<string, byte>();
+            listA.BindTo(bindableStringByteDictionary);
+            var listB = new BindableDictionary<string, byte>();
+            listB.BindTo(bindableStringByteDictionary);
+            var listC = new BindableDictionary<string, byte>();
+            listC.BindTo(bindableStringByteDictionary);
+
+            bindableStringByteDictionary.Remove(item);
+
+            Assert.Multiple(() =>
+            {
+                Assert.False(listA.ContainsKey(item));
+                Assert.False(listB.ContainsKey(item));
+                Assert.False(listC.ContainsKey(item));
+            });
+        }
+
+        [Test]
+        public void TestRemoveNotifiesBoundListSubscription()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+            var list = new BindableDictionary<string, byte>();
+            list.BindTo(bindableStringByteDictionary);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            list.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary.Remove(item);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>(item, 0).Yield()));
+        }
+
+        [Test]
+        public void TestRemoveNotifiesBoundListSubscriptions()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+            var listA = new BindableDictionary<string, byte>();
+            listA.BindTo(bindableStringByteDictionary);
+
+            NotifyCollectionChangedEventArgs triggeredArgsA1 = null;
+            NotifyCollectionChangedEventArgs triggeredArgsA2 = null;
+            listA.CollectionChanged += (_, args) => triggeredArgsA1 = args;
+            listA.CollectionChanged += (_, args) => triggeredArgsA2 = args;
+
+            var listB = new BindableDictionary<string, byte>();
+            listB.BindTo(bindableStringByteDictionary);
+
+            NotifyCollectionChangedEventArgs triggeredArgsB1 = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB2 = null;
+            listB.CollectionChanged += (_, args) => triggeredArgsB1 = args;
+            listB.CollectionChanged += (_, args) => triggeredArgsB2 = args;
+
+            bindableStringByteDictionary.Remove(item);
+
+            Assert.That(triggeredArgsA1, Is.Not.Null);
+            Assert.That(triggeredArgsA2, Is.Not.Null);
+            Assert.That(triggeredArgsB1, Is.Not.Null);
+            Assert.That(triggeredArgsB2, Is.Not.Null);
+        }
+
+        [Test]
+        public void TestRemoveDoesNotNotifySubscribersBeforeItemIsRemoved()
+        {
+            const string item = "item";
+            bindableStringByteDictionary.Add(item, 0);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            Assert.That(triggeredArgs, Is.Null);
+        }
+
+        #endregion
+
+        #region .Clear()
+
+        [Test]
+        public void TestClear()
+        {
+            for (byte i = 0; i < 5; i++)
+                bindableStringByteDictionary.Add($"test{i}", i);
+
+            bindableStringByteDictionary.Clear();
+
+            Assert.IsEmpty(bindableStringByteDictionary);
+        }
+
+        [Test]
+        public void TestClearWithDisabledListThrowsInvalidOperationException()
+        {
+            for (byte i = 0; i < 5; i++)
+                bindableStringByteDictionary.Add($"test{i}", i);
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.Throws(typeof(InvalidOperationException), () => bindableStringByteDictionary.Clear());
+        }
+
+        [Test]
+        public void TestClearWithEmptyDisabledListThrowsInvalidOperationException()
+        {
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.Throws(typeof(InvalidOperationException), () => bindableStringByteDictionary.Clear());
+        }
+
+        [Test]
+        public void TestClearUpdatesCountProperty()
+        {
+            for (byte i = 0; i < 5; i++)
+                bindableStringByteDictionary.Add($"test{i}", i);
+
+            bindableStringByteDictionary.Clear();
+
+            Assert.AreEqual(0, bindableStringByteDictionary.Count);
+        }
+
+        [Test]
+        public void TestClearNotifiesSubscriber()
+        {
+            var items = new[]
+            {
+                new KeyValuePair<string, byte>("test0", 0),
+                new KeyValuePair<string, byte>("test1", 1),
+                new KeyValuePair<string, byte>("test2", 2),
+                new KeyValuePair<string, byte>("test3", 3),
+                new KeyValuePair<string, byte>("test4", 4)
+            };
+
+            foreach (var (key, value) in items)
+                bindableStringByteDictionary.Add(key, value);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary.Clear();
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.OldItems, Is.EquivalentTo(items));
+        }
+
+        [Test]
+        public void TestClearDoesNotNotifySubscriberBeforeClear()
+        {
+            for (byte i = 0; i < 5; i++)
+                bindableStringByteDictionary.Add($"test{i}", i);
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            Assert.That(triggeredArgs, Is.Null);
+
+            bindableStringByteDictionary.Clear();
+        }
+
+        [Test]
+        public void TestClearNotifiesSubscribers()
+        {
+            for (byte i = 0; i < 5; i++)
+                bindableStringByteDictionary.Add($"test{i}", i);
+
+            NotifyCollectionChangedEventArgs triggeredArgsA = null;
+            NotifyCollectionChangedEventArgs triggeredArgsB = null;
+            NotifyCollectionChangedEventArgs triggeredArgsC = null;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsA = args;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsB = args;
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgsC = args;
+
+            bindableStringByteDictionary.Clear();
+
+            Assert.That(triggeredArgsA, Is.Not.Null);
+            Assert.That(triggeredArgsB, Is.Not.Null);
+            Assert.That(triggeredArgsC, Is.Not.Null);
+        }
+
+        [Test]
+        public void TestClearNotifiesBoundBindable()
+        {
+            var bindableList = new BindableDictionary<string, byte>();
+            bindableList.BindTo(bindableStringByteDictionary);
+            for (byte i = 0; i < 5; i++)
+                bindableStringByteDictionary.Add($"testA{i}", i);
+            for (byte i = 0; i < 5; i++)
+                bindableList.Add($"testB{i}", i);
+
+            bindableStringByteDictionary.Clear();
+
+            Assert.IsEmpty(bindableList);
+        }
+
+        [Test]
+        public void TestClearNotifiesBoundBindables()
+        {
+            var bindableListA = new BindableDictionary<string, byte>();
+            bindableListA.BindTo(bindableStringByteDictionary);
+            var bindableListB = new BindableDictionary<string, byte>();
+            bindableListB.BindTo(bindableStringByteDictionary);
+            var bindableListC = new BindableDictionary<string, byte>();
+            bindableListC.BindTo(bindableStringByteDictionary);
+            for (byte i = 0; i < 5; i++)
+                bindableStringByteDictionary.Add($"testA{i}", i);
+            for (byte i = 0; i < 5; i++)
+                bindableListA.Add($"testB{i}", i);
+            for (byte i = 0; i < 5; i++)
+                bindableListB.Add($"testC{i}", i);
+            for (byte i = 0; i < 5; i++)
+                bindableListC.Add($"testD{i}", i);
+
+            bindableStringByteDictionary.Clear();
+
+            Assert.Multiple(() =>
+            {
+                Assert.IsEmpty(bindableListA);
+                Assert.IsEmpty(bindableListB);
+                Assert.IsEmpty(bindableListC);
+            });
+        }
+
+        [Test]
+        public void TestClearDoesNotNotifyBoundBindablesBeforeClear()
+        {
+            var bindableListA = new BindableDictionary<string, byte>();
+            bindableListA.BindTo(bindableStringByteDictionary);
+            var bindableListB = new BindableDictionary<string, byte>();
+            bindableListB.BindTo(bindableStringByteDictionary);
+            var bindableListC = new BindableDictionary<string, byte>();
+            bindableListC.BindTo(bindableStringByteDictionary);
+            for (byte i = 0; i < 5; i++)
+                bindableStringByteDictionary.Add($"testA{i}", i);
+            for (byte i = 0; i < 5; i++)
+                bindableListA.Add($"testB{i}", i);
+            for (byte i = 0; i < 5; i++)
+                bindableListB.Add($"testC{i}", i);
+            for (byte i = 0; i < 5; i++)
+                bindableListC.Add($"testD{i}", i);
+
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotEmpty(bindableListA);
+                Assert.IsNotEmpty(bindableListB);
+                Assert.IsNotEmpty(bindableListC);
+            });
+
+            bindableStringByteDictionary.Clear();
+        }
+
+        #endregion
+
+        #region .Disabled
+
+        [Test]
+        public void TestDisabledWhenSetToTrueNotifiesSubscriber()
+        {
+            bool? isDisabled = null;
+            bindableStringByteDictionary.DisabledChanged += b => isDisabled = b;
+
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(isDisabled);
+                Assert.IsTrue(isDisabled.Value);
+            });
+        }
+
+        [Test]
+        public void TestDisabledWhenSetToTrueNotifiesSubscribers()
+        {
+            bool? isDisabledA = null;
+            bool? isDisabledB = null;
+            bool? isDisabledC = null;
+            bindableStringByteDictionary.DisabledChanged += b => isDisabledA = b;
+            bindableStringByteDictionary.DisabledChanged += b => isDisabledB = b;
+            bindableStringByteDictionary.DisabledChanged += b => isDisabledC = b;
+
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.Multiple(() =>
+            {
+                Assert.IsNotNull(isDisabledA);
+                Assert.IsTrue(isDisabledA.Value);
+                Assert.IsNotNull(isDisabledB);
+                Assert.IsTrue(isDisabledB.Value);
+                Assert.IsNotNull(isDisabledC);
+                Assert.IsTrue(isDisabledC.Value);
+            });
+        }
+
+        [Test]
+        public void TestDisabledWhenSetToCurrentValueDoesNotNotifySubscriber()
+        {
+            bindableStringByteDictionary.DisabledChanged += b => Assert.Fail();
+
+            bindableStringByteDictionary.Disabled = bindableStringByteDictionary.Disabled;
+        }
+
+        [Test]
+        public void TestDisabledWhenSetToCurrentValueDoesNotNotifySubscribers()
+        {
+            bindableStringByteDictionary.DisabledChanged += b => Assert.Fail();
+            bindableStringByteDictionary.DisabledChanged += b => Assert.Fail();
+            bindableStringByteDictionary.DisabledChanged += b => Assert.Fail();
+
+            bindableStringByteDictionary.Disabled = bindableStringByteDictionary.Disabled;
+        }
+
+        [Test]
+        public void TestDisabledNotifiesBoundLists()
+        {
+            var list = new BindableDictionary<string, byte>();
+            list.BindTo(bindableStringByteDictionary);
+
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.IsTrue(list.Disabled);
+        }
+
+        #endregion
+
+        #region .GetEnumberator()
+
+        [Test]
+        public void TestGetEnumeratorDoesNotReturnNull()
+        {
+            Assert.NotNull(bindableStringByteDictionary.GetEnumerator());
+        }
+
+        [Test]
+        public void TestGetEnumeratorWhenCopyConstructorIsUsedDoesNotReturnTheEnumeratorOfTheInputtedEnumerator()
+        {
+            var array = new[] { new KeyValuePair<string, byte>("", 0) };
+
+            var list = new BindableDictionary<string, byte>(array);
+
+            var enumerator = list.GetEnumerator();
+
+            Assert.AreNotEqual(array.GetEnumerator(), enumerator);
+        }
+
+        #endregion
+
+        #region .Description
+
+        [Test]
+        public void TestDescriptionWhenSetReturnsSetValue()
+        {
+            const string description = "The list used for testing.";
+
+            bindableStringByteDictionary.Description = description;
+
+            Assert.AreEqual(description, bindableStringByteDictionary.Description);
+        }
+
+        #endregion
+
+        #region .Parse(obj)
+
+        [Test]
+        public void TestParseWithNullClearsList()
+        {
+            bindableStringByteDictionary.Add("a item", 0);
+
+            bindableStringByteDictionary.Parse(null);
+
+            Assert.IsEmpty(bindableStringByteDictionary);
+        }
+
+        [Test]
+        public void TestParseWithArray()
+        {
+            var array = new[]
+            {
+                new KeyValuePair<string, byte>("testA", 0),
+                new KeyValuePair<string, byte>("testB", 1),
+            };
+
+            bindableStringByteDictionary.Parse(array);
+
+            CollectionAssert.AreEquivalent(array, bindableStringByteDictionary);
+        }
+
+        [Test]
+        public void TestParseWithDisabledListThrowsInvalidOperationException()
+        {
+            bindableStringByteDictionary.Disabled = true;
+
+            Assert.Multiple(() =>
+            {
+                Assert.Throws(typeof(InvalidOperationException), () => bindableStringByteDictionary.Parse(null));
+                Assert.Throws(typeof(InvalidOperationException), () => bindableStringByteDictionary.Parse(new[]
+                {
+                    new KeyValuePair<string, byte>("test", 0),
+                    new KeyValuePair<string, byte>("testabc", 1),
+                    new KeyValuePair<string, byte>("asdasdasdasd", 1),
+                }));
+            });
+        }
+
+        [Test]
+        public void TestParseWithInvalidArgumentTypesThrowsArgumentException()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.Throws(typeof(ArgumentException), () => bindableStringByteDictionary.Parse(1));
+                Assert.Throws(typeof(ArgumentException), () => bindableStringByteDictionary.Parse(""));
+                Assert.Throws(typeof(ArgumentException), () => bindableStringByteDictionary.Parse(new object()));
+                Assert.Throws(typeof(ArgumentException), () => bindableStringByteDictionary.Parse(1.1));
+                Assert.Throws(typeof(ArgumentException), () => bindableStringByteDictionary.Parse(1.1f));
+                Assert.Throws(typeof(ArgumentException), () => bindableStringByteDictionary.Parse("test123"));
+                Assert.Throws(typeof(ArgumentException), () => bindableStringByteDictionary.Parse(29387L));
+            });
+        }
+
+        [Test]
+        public void TestParseWithNullNotifiesClearSubscribers()
+        {
+            var array = new[]
+            {
+                new KeyValuePair<string, byte>("testA", 0),
+                new KeyValuePair<string, byte>("testB", 1),
+                new KeyValuePair<string, byte>("testC", 2),
+            };
+
+            foreach (var (key, value) in array)
+                bindableStringByteDictionary.Add(key, value);
+
+            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs.Add(args);
+
+            bindableStringByteDictionary.Parse(null);
+
+            Assert.That(triggeredArgs, Has.Count.EqualTo(1));
+            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.First().OldItems, Is.EquivalentTo(array));
+        }
+
+        [Test]
+        public void TestParseWithItemsNotifiesAddRangeAndClearSubscribers()
+        {
+            bindableStringByteDictionary.Add("test123", 0);
+
+            var array = new[]
+            {
+                new KeyValuePair<string, byte>("testA", 0),
+                new KeyValuePair<string, byte>("testB", 1),
+            };
+
+            var triggeredArgs = new List<NotifyCollectionChangedEventArgs>();
+            bindableStringByteDictionary.CollectionChanged += (_, args) => triggeredArgs.Add(args);
+
+            bindableStringByteDictionary.Parse(array);
+
+            Assert.That(triggeredArgs, Has.Count.EqualTo(2));
+            Assert.That(triggeredArgs.First().Action, Is.EqualTo(NotifyCollectionChangedAction.Remove));
+            Assert.That(triggeredArgs.First().OldItems, Is.EquivalentTo(new KeyValuePair<string, byte>("test123", 0).Yield()));
+            Assert.That(triggeredArgs.ElementAt(1).Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.ElementAt(1).NewItems, Is.EquivalentTo(array));
+        }
+
+        #endregion
+
+        #region GetBoundCopy()
+
+        [Test]
+        public void TestBoundCopyWithAdd()
+        {
+            var boundCopy = bindableStringByteDictionary.GetBoundCopy();
+
+            NotifyCollectionChangedEventArgs triggeredArgs = null;
+            boundCopy.CollectionChanged += (_, args) => triggeredArgs = args;
+
+            bindableStringByteDictionary.Add("test", 0);
+
+            Assert.That(triggeredArgs.Action, Is.EqualTo(NotifyCollectionChangedAction.Add));
+            Assert.That(triggeredArgs.NewItems, Is.EquivalentTo(new KeyValuePair<string, byte>("test", 0).Yield()));
+        }
+
+        #endregion
+    }
+}

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -176,6 +176,7 @@ namespace osu.Framework.Bindables
         {
             ensureMutationAllowed();
 
+#nullable disable // Todo: Remove after upgrading Resharper version on CI.
             bool hasPreviousValue = TryGetValue(key, out TValue lastValue);
 
             collection[key] = value;
@@ -184,14 +185,13 @@ namespace osu.Framework.Bindables
             {
                 foreach (var b in bindings)
                 {
-                    Debug.Assert(b != null);
-
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
                     if (b != caller)
                         b.setKey(key, value, this);
                 }
             }
+#nullable enable
 
             notifyDictionaryChanged(hasPreviousValue
                 ? new NotifyDictionaryChangedEventArgs<TKey, TValue>(new KeyValuePair<TKey, TValue>(key, value), new KeyValuePair<TKey, TValue>(key, lastValue!))
@@ -278,11 +278,13 @@ namespace osu.Framework.Bindables
 
         bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
         {
+#nullable disable // Todo: Remove after upgrading Resharper version on CI.
             if (TryGetValue(item.Key, out TValue value) && EqualityComparer<TValue>.Default.Equals(value, item.Value))
             {
                 Remove(item.Key);
                 return true;
             }
+#nullable enable
 
             return false;
         }

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -1,0 +1,536 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using osu.Framework.Caching;
+using osu.Framework.Lists;
+
+namespace osu.Framework.Bindables
+{
+    public class BindableDictionary<TKey, TValue> : IBindableDictionary<TKey, TValue>, IBindable, IParseable, IDictionary<TKey, TValue>, IDictionary
+        where TKey : notnull
+    {
+        /// <summary>
+        /// An event which is raised when this <see cref="BindableDictionary{TKey, TValue}"/> changes.
+        /// </summary>
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
+
+        /// <summary>
+        /// An event which is raised when <see cref="Disabled"/>'s state has changed (or manually via <see cref="triggerDisabledChange(bool)"/>).
+        /// </summary>
+        public event Action<bool>? DisabledChanged;
+
+        private readonly Dictionary<TKey, TValue> collection;
+
+        private readonly Cached<WeakReference<BindableDictionary<TKey, TValue>>> weakReferenceCache = new Cached<WeakReference<BindableDictionary<TKey, TValue>>>();
+
+        private WeakReference<BindableDictionary<TKey, TValue>> weakReference
+            => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<BindableDictionary<TKey, TValue>>(this);
+
+        private LockedWeakList<BindableDictionary<TKey, TValue>>? bindings;
+
+        public BindableDictionary(IEqualityComparer<TKey>? comparer = null)
+            : this(0, comparer)
+        {
+        }
+
+        public BindableDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer = null)
+            : this((IEnumerable<KeyValuePair<TKey, TValue>>)dictionary, comparer)
+        {
+        }
+
+        public BindableDictionary(int capacity, IEqualityComparer<TKey>? comparer = null)
+        {
+            collection = new Dictionary<TKey, TValue>(capacity, comparer);
+        }
+
+        public BindableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer = null)
+        {
+            this.collection = new Dictionary<TKey, TValue>(collection, comparer);
+        }
+
+        #region IDictionary<TKey, Value>
+
+        /// <summary>
+        /// Adds a single item to this <see cref="BindableDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="key">The item key.</param>
+        /// <param name="value">The item value.</param>
+        /// <exception cref="InvalidOperationException">Thrown when this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
+        public void Add(TKey key, TValue value)
+            => add(key, value, null);
+
+        private void add(TKey key, TValue value, BindableDictionary<TKey, TValue>? caller)
+        {
+            ensureMutationAllowed();
+
+            collection.Add(key, value);
+
+            if (bindings != null)
+            {
+                foreach (var b in bindings)
+                {
+                    Debug.Assert(b != null);
+
+                    // prevent re-adding the item back to the callee.
+                    // That would result in a <see cref="StackOverflowException"/>.
+                    if (b != caller)
+                        b.add(key, value, this);
+                }
+            }
+
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new KeyValuePair<TKey, TValue>(key, value), collection.Count - 1));
+        }
+
+        public bool ContainsKey(TKey key) => collection.ContainsKey(key);
+
+        /// <summary>
+        /// Removes an item from this <see cref="BindableDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="key">The item key.</param>
+        /// <returns><code>true</code> if the removal was successful.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
+        public bool Remove(TKey key)
+            => remove(key, null);
+
+        private bool remove(TKey key, BindableDictionary<TKey, TValue>? caller)
+        {
+            ensureMutationAllowed();
+
+            if (!TryGetValue(key, out TValue value))
+                return false;
+
+            if (bindings != null)
+            {
+                foreach (var b in bindings)
+                {
+                    Debug.Assert(b != null);
+
+                    // prevent re-adding the item back to the callee.
+                    // That would result in a <see cref="StackOverflowException"/>.
+                    if (b != caller)
+                        b.remove(key, this);
+                }
+            }
+
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, new KeyValuePair<TKey, TValue>(key, value)));
+
+            return true;
+        }
+
+        public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => collection.TryGetValue(key, out value);
+
+        /// <summary>
+        /// Gets or sets an item with a specified key in this <see cref="BindableDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="key">The item key.</param>
+        /// <exception cref="InvalidOperationException">Thrown when setting an item while this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
+        public TValue this[TKey key]
+        {
+            get => collection[key];
+            set => setKey(key, value, null);
+        }
+
+        private void setKey(TKey key, TValue value, BindableDictionary<TKey, TValue>? caller)
+        {
+            ensureMutationAllowed();
+
+            bool hasPreviousValue = TryGetValue(key, out TValue lastValue);
+
+            collection[key] = value;
+
+            if (bindings != null)
+            {
+                foreach (var b in bindings)
+                {
+                    Debug.Assert(b != null);
+
+                    // prevent re-adding the item back to the callee.
+                    // That would result in a <see cref="StackOverflowException"/>.
+                    if (b != caller)
+                        b.setKey(key, value, this);
+                }
+            }
+
+            if (hasPreviousValue)
+            {
+                notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace,
+                    new KeyValuePair<TKey, TValue>(key, value),
+                    new KeyValuePair<TKey, TValue>(key, lastValue!)));
+            }
+            else
+                notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new KeyValuePair<TKey, TValue>(key, value)));
+        }
+
+        public ICollection<TKey> Keys => collection.Keys;
+
+        public ICollection<TValue> Values => collection.Values;
+
+        #endregion
+
+        #region IDictionary
+
+        void IDictionary.Add(object key, object? value) => Add((TKey)key, (TValue)(value ?? throw new ArgumentNullException(nameof(value))));
+
+        /// <summary>
+        /// Clears the contents of this <see cref="BindableDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown when this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
+        public void Clear()
+            => clear(null);
+
+        private void clear(BindableDictionary<TKey, TValue>? caller)
+        {
+            ensureMutationAllowed();
+
+            if (collection.Count <= 0)
+                return;
+
+            // Preserve items for subscribers
+            var clearedItems = collection.ToList();
+
+            collection.Clear();
+
+            if (bindings != null)
+            {
+                foreach (var b in bindings)
+                {
+                    Debug.Assert(b != null);
+
+                    // prevent re-adding the item back to the callee.
+                    // That would result in a <see cref="StackOverflowException"/>.
+                    if (b != caller)
+                        b.clear(this);
+                }
+            }
+
+            notifyCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, clearedItems, 0));
+        }
+
+        bool IDictionary.Contains(object key)
+        {
+            return ((IDictionary)collection).Contains(key);
+        }
+
+        void IDictionary.Remove(object key) => Remove((TKey)key);
+
+        bool IDictionary.IsFixedSize => ((IDictionary)collection).IsFixedSize;
+
+        public bool IsReadOnly => Disabled;
+
+        object? IDictionary.this[object key]
+        {
+            get => this[(TKey)key];
+            set => this[(TKey)key] = (TValue)(value ?? throw new ArgumentNullException(nameof(value)));
+        }
+
+        ICollection IDictionary.Values => (ICollection)Values;
+
+        ICollection IDictionary.Keys => (ICollection)Keys;
+
+        #endregion
+
+        #region IReadOnlyDictionary<TKey, TValue>
+
+        IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => Keys;
+
+        IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => Values;
+
+        #endregion
+
+        #region ICollection<KeyValuePair<TKey, TValue>>
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+        {
+            if (TryGetValue(item.Key, out TValue value) && EqualityComparer<TValue>.Default.Equals(value, item.Value))
+            {
+                Remove(item.Key);
+                return true;
+            }
+
+            return false;
+        }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+            => Add(item.Key, item.Value);
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
+            => ((ICollection<KeyValuePair<TKey, TValue>>)collection).Contains(item);
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+            => ((ICollection<KeyValuePair<TKey, TValue>>)collection).CopyTo(array, arrayIndex);
+
+        #endregion
+
+        #region ICollection
+
+        void ICollection.CopyTo(Array array, int index)
+            => ((ICollection)collection).CopyTo(array, index);
+
+        bool ICollection.IsSynchronized => ((ICollection)collection).IsSynchronized;
+
+        object ICollection.SyncRoot => ((ICollection)collection).SyncRoot;
+
+        #endregion
+
+        #region IReadOnlyCollection<TKey, TValue>
+
+        public int Count => collection.Count;
+
+        #endregion
+
+        #region IParseable
+
+        /// <summary>
+        /// Parse an object into this instance.
+        /// A collection holding items of type <see cref="KeyValuePair{TKey,TValue}"/> can be parsed. Null results in an empty <see cref="BindableDictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="input">The input which is to be parsed.</param>
+        /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
+        public void Parse(object input)
+        {
+            ensureMutationAllowed();
+
+            switch (input)
+            {
+                case null:
+                    Clear();
+                    break;
+
+                case IEnumerable<KeyValuePair<TKey, TValue>> enumerable:
+                    // enumerate once locally before proceeding.
+                    var newItems = enumerable.ToList();
+
+                    if (this.SequenceEqual(newItems))
+                        return;
+
+                    Clear();
+
+                    foreach (var (key, value) in enumerable)
+                        Add(key, value);
+                    break;
+
+                default:
+                    throw new ArgumentException($@"Could not parse provided {input.GetType()} ({input}) to {typeof(KeyValuePair<TKey, TValue>)}.");
+            }
+        }
+
+        #endregion
+
+        #region ICanBeDisabled
+
+        private bool disabled;
+
+        /// <summary>
+        /// Whether this <see cref="BindableDictionary{TKey, TValue}"/> has been disabled. When disabled, attempting to change the contents of this <see cref="BindableDictionary{TKey, TValue}"/> will result in an <see cref="InvalidOperationException"/>.
+        /// </summary>
+        public bool Disabled
+        {
+            get => disabled;
+            set
+            {
+                if (value == disabled)
+                    return;
+
+                disabled = value;
+
+                triggerDisabledChange();
+            }
+        }
+
+        public void BindDisabledChanged(Action<bool> onChange, bool runOnceImmediately = false)
+        {
+            DisabledChanged += onChange;
+            if (runOnceImmediately)
+                onChange(Disabled);
+        }
+
+        private void triggerDisabledChange(bool propagateToBindings = true)
+        {
+            // check a bound bindable hasn't changed the value again (it will fire its own event)
+            bool beforePropagation = disabled;
+
+            if (propagateToBindings && bindings != null)
+            {
+                foreach (var b in bindings)
+                {
+                    Debug.Assert(b != null);
+                    b.Disabled = disabled;
+                }
+            }
+
+            if (beforePropagation == disabled)
+                DisabledChanged?.Invoke(disabled);
+        }
+
+        #endregion ICanBeDisabled
+
+        #region IUnbindable
+
+        public void UnbindEvents()
+        {
+            CollectionChanged = null;
+            DisabledChanged = null;
+        }
+
+        public void UnbindBindings()
+        {
+            if (bindings == null)
+                return;
+
+            foreach (var b in bindings)
+            {
+                Debug.Assert(b != null);
+                b.unbind(this);
+            }
+
+            bindings?.Clear();
+        }
+
+        public void UnbindAll()
+        {
+            UnbindEvents();
+            UnbindBindings();
+        }
+
+        public void UnbindFrom(IUnbindable them)
+        {
+            if (!(them is BindableDictionary<TKey, TValue> tThem))
+                throw new InvalidCastException($"Can't unbind a bindable of type {them.GetType()} from a bindable of type {GetType()}.");
+
+            removeWeakReference(tThem.weakReference);
+            tThem.removeWeakReference(weakReference);
+        }
+
+        private void unbind(BindableDictionary<TKey, TValue> binding)
+        {
+            Debug.Assert(bindings != null);
+            bindings.Remove(binding.weakReference);
+        }
+
+        #endregion IUnbindable
+
+        #region IHasDescription
+
+        public string? Description { get; set; }
+
+        #endregion IHasDescription
+
+        #region IBindableCollection
+
+        void IBindable.BindTo(IBindable them)
+        {
+            if (!(them is BindableDictionary<TKey, TValue> tThem))
+                throw new InvalidCastException($"Can't bind to a bindable of type {them.GetType()} from a bindable of type {GetType()}.");
+
+            BindTo(tThem);
+        }
+
+        void IBindableDictionary<TKey, TValue>.BindTo(IBindableDictionary<TKey, TValue> them)
+        {
+            if (!(them is BindableDictionary<TKey, TValue> tThem))
+                throw new InvalidCastException($"Can't bind to a bindable of type {them.GetType()} from a bindable of type {GetType()}.");
+
+            BindTo(tThem);
+        }
+
+        /// <summary>
+        /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
+        /// Passes the provided value as the foreign (more permanent) bindable.
+        /// </summary>
+        public BindableDictionary<TKey, TValue> BindTarget
+        {
+            set => ((IBindableDictionary<TKey, TValue>)this).BindTo(value);
+        }
+
+        /// <summary>
+        /// Binds this <see cref="BindableDictionary{TKey, TValue}"/> to another.
+        /// </summary>
+        /// <param name="them">The <see cref="BindableDictionary{TKey, TValue}"/> to be bound to.</param>
+        public void BindTo(BindableDictionary<TKey, TValue> them)
+        {
+            if (them == null)
+                throw new ArgumentNullException(nameof(them));
+            if (bindings?.Contains(weakReference) ?? false)
+                throw new ArgumentException("An already bound collection can not be bound again.");
+            if (them == this)
+                throw new ArgumentException("A collection can not be bound to itself");
+
+            // copy state and content over
+            Parse(them);
+            Disabled = them.Disabled;
+
+            addWeakReference(them.weakReference);
+            them.addWeakReference(weakReference);
+        }
+
+        /// <summary>
+        /// Bind an action to <see cref="CollectionChanged"/> with the option of running the bound action once immediately
+        /// with an <see cref="NotifyCollectionChangedAction.Add"/> event for the entire contents of this <see cref="BindableDictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="onChange">The action to perform when this <see cref="BindableDictionary{TKey, TValue}"/> changes.</param>
+        /// <param name="runOnceImmediately">Whether the action provided in <paramref name="onChange"/> should be run once immediately.</param>
+        public void BindCollectionChanged(NotifyCollectionChangedEventHandler onChange, bool runOnceImmediately = false)
+        {
+            CollectionChanged += onChange;
+            if (runOnceImmediately)
+                onChange(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, collection));
+        }
+
+        private void addWeakReference(WeakReference<BindableDictionary<TKey, TValue>> weakReference)
+        {
+            bindings ??= new LockedWeakList<BindableDictionary<TKey, TValue>>();
+            bindings.Add(weakReference);
+        }
+
+        private void removeWeakReference(WeakReference<BindableDictionary<TKey, TValue>> weakReference) => bindings?.Remove(weakReference);
+
+        IBindable IBindable.GetBoundCopy() => GetBoundCopy();
+
+        IBindableDictionary<TKey, TValue> IBindableDictionary<TKey, TValue>.GetBoundCopy()
+            => GetBoundCopy();
+
+        /// <summary>
+        /// Create a new instance of <see cref="BindableDictionary{TKey, TValue}"/> and binds it to this instance.
+        /// </summary>
+        /// <returns>The created instance.</returns>
+        public BindableDictionary<TKey, TValue> GetBoundCopy()
+        {
+            var copy = new BindableDictionary<TKey, TValue>();
+            copy.BindTo(this);
+            return copy;
+        }
+
+        #endregion IBindableCollection
+
+        #region IEnumerable
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() => collection.GetEnumerator();
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() => GetEnumerator();
+
+        IDictionaryEnumerator IDictionary.GetEnumerator() => GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        #endregion IEnumerable
+
+        private void notifyCollectionChanged(NotifyCollectionChangedEventArgs args) => CollectionChanged?.Invoke(this, args);
+
+        private void ensureMutationAllowed()
+        {
+            if (Disabled)
+                throw new InvalidOperationException($"Cannot mutate the {nameof(BindableDictionary<TKey, TValue>)} while it is disabled.");
+        }
+
+        public bool IsDefault => Count == 0;
+    }
+}

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -37,21 +37,40 @@ namespace osu.Framework.Bindables
 
         private LockedWeakList<BindableDictionary<TKey, TValue>>? bindings;
 
+        /// <summary>
+        /// Creates a new <see cref="BindableDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="comparer">An optional key-comparer.</param>
         public BindableDictionary(IEqualityComparer<TKey>? comparer = null)
             : this(0, comparer)
         {
         }
 
+        /// <summary>
+        /// Creates a new <see cref="BindableDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="dictionary">A source dictionary to populate this dictionary from.</param>
+        /// <param name="comparer">An optional key-comparer.</param>
         public BindableDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer = null)
             : this((IEnumerable<KeyValuePair<TKey, TValue>>)dictionary, comparer)
         {
         }
 
+        /// <summary>
+        /// Creates a new <see cref="BindableDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="capacity">The initial capacity.</param>
+        /// <param name="comparer">An optional key-comparer.</param>
         public BindableDictionary(int capacity, IEqualityComparer<TKey>? comparer = null)
         {
             collection = new Dictionary<TKey, TValue>(capacity, comparer);
         }
 
+        /// <summary>
+        /// Creates a new <see cref="BindableDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="collection">A source enumerable to populate this dictionary from.</param>
+        /// <param name="comparer">An optional key-comparer.</param>
         public BindableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer = null)
         {
             this.collection = new Dictionary<TKey, TValue>(collection, comparer);
@@ -97,7 +116,7 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="key">The item key.</param>
         /// <returns><code>true</code> if the removal was successful.</returns>
-        /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
         public bool Remove(TKey key)
             => remove(key, out _, null);
 
@@ -107,7 +126,7 @@ namespace osu.Framework.Bindables
         /// <param name="key">The item key.</param>
         /// <param name="value">The removed item value.</param>
         /// <returns><code>true</code> if the removal was successful.</returns>
-        /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
         public bool Remove(TKey key, [MaybeNullWhen(false)] out TValue value)
             => remove(key, out value, null);
 

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -305,7 +305,7 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="input">The input which is to be parsed.</param>
         /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
-        public void Parse(object input)
+        public void Parse(object? input)
         {
             ensureMutationAllowed();
 

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -155,7 +155,11 @@ namespace osu.Framework.Bindables
             return true;
         }
 
+#if NETSTANDARD
+        public bool TryGetValue(TKey key, out TValue value) => collection.TryGetValue(key, out value);
+#else
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => collection.TryGetValue(key, out value);
+#endif
 
         /// <summary>
         /// Gets or sets an item with a specified key in this <see cref="BindableDictionary{TKey,TValue}"/>.

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -18,9 +18,6 @@ namespace osu.Framework.Bindables
     public class BindableDictionary<TKey, TValue> : IBindableDictionary<TKey, TValue>, IBindable, IParseable, IDictionary<TKey, TValue>, IDictionary
         where TKey : notnull
     {
-        /// <summary>
-        /// An event which is raised when this <see cref="BindableDictionary{TKey, TValue}"/> changes.
-        /// </summary>
         public event NotifyDictionaryChangedEventHandler<TKey, TValue>? CollectionChanged;
 
         /// <summary>
@@ -78,11 +75,7 @@ namespace osu.Framework.Bindables
 
         #region IDictionary<TKey, Value>
 
-        /// <summary>
-        /// Adds a single item to this <see cref="BindableDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <param name="key">The item key.</param>
-        /// <param name="value">The item value.</param>
+        /// <inheritdoc />
         /// <exception cref="InvalidOperationException">Thrown when this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
         public void Add(TKey key, TValue value)
             => add(key, value, null);
@@ -143,7 +136,7 @@ namespace osu.Framework.Bindables
                 {
                     Debug.Assert(b != null);
 
-                    // prevent re-adding the item back to the callee.
+                    // prevent re-removing from the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
                     if (b != caller)
                         b.remove(key, out _, this);
@@ -219,7 +212,7 @@ namespace osu.Framework.Bindables
         {
             ensureMutationAllowed();
 
-            if (collection.Count <= 0)
+            if (collection.Count == 0)
                 return;
 
             // Preserve items for subscribers
@@ -257,7 +250,7 @@ namespace osu.Framework.Bindables
         object? IDictionary.this[object key]
         {
             get => this[(TKey)key];
-            set => this[(TKey)key] = (TValue)(value ?? throw new ArgumentNullException(nameof(value)));
+            set => this[(TKey)key] = (TValue)value!;
         }
 
         ICollection IDictionary.Values => (ICollection)Values;
@@ -512,7 +505,7 @@ namespace osu.Framework.Bindables
         {
             if (them == null)
                 throw new ArgumentNullException(nameof(them));
-            if (bindings?.Contains(weakReference) ?? false)
+            if (bindings?.Contains(weakReference) == true)
                 throw new ArgumentException("An already bound collection can not be bound again.");
             if (them == this)
                 throw new ArgumentException("A collection can not be bound to itself");

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -34,40 +34,25 @@ namespace osu.Framework.Bindables
 
         private LockedWeakList<BindableDictionary<TKey, TValue>>? bindings;
 
-        /// <summary>
-        /// Creates a new <see cref="BindableDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <param name="comparer">An optional key-comparer.</param>
+        /// <inheritdoc cref="Dictionary{TKey,TValue}(IEqualityComparer{TKey})" />
         public BindableDictionary(IEqualityComparer<TKey>? comparer = null)
             : this(0, comparer)
         {
         }
 
-        /// <summary>
-        /// Creates a new <see cref="BindableDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <param name="dictionary">A source dictionary to populate this dictionary from.</param>
-        /// <param name="comparer">An optional key-comparer.</param>
+        /// <inheritdoc cref="Dictionary{TKey,TValue}(IDictionary{TKey,TValue},IEqualityComparer{TKey})" />
         public BindableDictionary(IDictionary<TKey, TValue> dictionary, IEqualityComparer<TKey>? comparer = null)
             : this((IEnumerable<KeyValuePair<TKey, TValue>>)dictionary, comparer)
         {
         }
 
-        /// <summary>
-        /// Creates a new <see cref="BindableDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <param name="capacity">The initial capacity.</param>
-        /// <param name="comparer">An optional key-comparer.</param>
+        /// <inheritdoc cref="Dictionary{TKey,TValue}(int,IEqualityComparer{TKey})" />
         public BindableDictionary(int capacity, IEqualityComparer<TKey>? comparer = null)
         {
             collection = new Dictionary<TKey, TValue>(capacity, comparer);
         }
 
-        /// <summary>
-        /// Creates a new <see cref="BindableDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <param name="collection">A source enumerable to populate this dictionary from.</param>
-        /// <param name="comparer">An optional key-comparer.</param>
+        /// <inheritdoc cref="Dictionary{TKey,TValue}(IEnumerable{KeyValuePair{TKey,TValue}},IEqualityComparer{TKey})" />
         public BindableDictionary(IEnumerable<KeyValuePair<TKey, TValue>> collection, IEqualityComparer<TKey>? comparer = null)
         {
             this.collection = new Dictionary<TKey, TValue>(collection, comparer);
@@ -104,21 +89,12 @@ namespace osu.Framework.Bindables
 
         public bool ContainsKey(TKey key) => collection.ContainsKey(key);
 
-        /// <summary>
-        /// Removes an item from this <see cref="BindableDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <param name="key">The item key.</param>
-        /// <returns><code>true</code> if the removal was successful.</returns>
+        /// <inheritdoc />
         /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
         public bool Remove(TKey key)
             => remove(key, out _, null);
 
-        /// <summary>
-        /// Removes an item from this <see cref="BindableDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <param name="key">The item key.</param>
-        /// <param name="value">The removed item value.</param>
-        /// <returns><code>true</code> if the removal was successful.</returns>
+        /// <inheritdoc cref="IDictionary.Remove" />
         /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
         public bool Remove(TKey key, [MaybeNullWhen(false)] out TValue value)
             => remove(key, out value, null);
@@ -154,10 +130,7 @@ namespace osu.Framework.Bindables
         public bool TryGetValue(TKey key, [MaybeNullWhen(false)] out TValue value) => collection.TryGetValue(key, out value);
 #endif
 
-        /// <summary>
-        /// Gets or sets an item with a specified key in this <see cref="BindableDictionary{TKey,TValue}"/>.
-        /// </summary>
-        /// <param name="key">The item key.</param>
+        /// <inheritdoc cref="IDictionary{TKey,TValue}.this" />
         /// <exception cref="InvalidOperationException">Thrown when setting an item while this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
         public TValue this[TKey key]
         {
@@ -201,9 +174,7 @@ namespace osu.Framework.Bindables
 
         void IDictionary.Add(object key, object? value) => Add((TKey)key, (TValue)(value ?? throw new ArgumentNullException(nameof(value))));
 
-        /// <summary>
-        /// Clears the contents of this <see cref="BindableDictionary{TKey,TValue}"/>.
-        /// </summary>
+        /// <inheritdoc cref="IDictionary.Clear" />
         /// <exception cref="InvalidOperationException">Thrown when this <see cref="BindableDictionary{TKey, TValue}"/> is <see cref="Disabled"/>.</exception>
         public void Clear()
             => clear(null);
@@ -376,7 +347,8 @@ namespace osu.Framework.Bindables
         private bool disabled;
 
         /// <summary>
-        /// Whether this <see cref="BindableDictionary{TKey, TValue}"/> has been disabled. When disabled, attempting to change the contents of this <see cref="BindableDictionary{TKey, TValue}"/> will result in an <see cref="InvalidOperationException"/>.
+        /// Whether this <see cref="BindableDictionary{TKey, TValue}"/> has been disabled.
+        /// When disabled, attempting to change the contents of this <see cref="BindableDictionary{TKey, TValue}"/> will result in an <see cref="InvalidOperationException"/>.
         /// </summary>
         public bool Disabled
         {

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -189,10 +189,9 @@ namespace osu.Framework.Bindables
                 }
             }
 
-            if (hasPreviousValue)
-                notifyDictionaryChanged(new NotifyDictionaryChangedEventArgs<TKey, TValue>(new KeyValuePair<TKey, TValue>(key, value), new KeyValuePair<TKey, TValue>(key, lastValue!)));
-            else
-                notifyDictionaryChanged(new NotifyDictionaryChangedEventArgs<TKey, TValue>(NotifyDictionaryChangedAction.Add, new KeyValuePair<TKey, TValue>(key, value)));
+            notifyDictionaryChanged(hasPreviousValue
+                ? new NotifyDictionaryChangedEventArgs<TKey, TValue>(new KeyValuePair<TKey, TValue>(key, value), new KeyValuePair<TKey, TValue>(key, lastValue!))
+                : new NotifyDictionaryChangedEventArgs<TKey, TValue>(NotifyDictionaryChangedAction.Add, new KeyValuePair<TKey, TValue>(key, value)));
         }
 
         public ICollection<TKey> Keys => collection.Keys;

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -99,13 +99,23 @@ namespace osu.Framework.Bindables
         /// <returns><code>true</code> if the removal was successful.</returns>
         /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
         public bool Remove(TKey key)
-            => remove(key, null);
+            => remove(key, out _, null);
 
-        private bool remove(TKey key, BindableDictionary<TKey, TValue>? caller)
+        /// <summary>
+        /// Removes an item from this <see cref="BindableDictionary{TKey,TValue}"/>.
+        /// </summary>
+        /// <param name="key">The item key.</param>
+        /// <param name="value">The removed item value.</param>
+        /// <returns><code>true</code> if the removal was successful.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if this <see cref="BindableList{T}"/> is <see cref="Disabled"/>.</exception>
+        public bool Remove(TKey key, [MaybeNullWhen(false)] out TValue value)
+            => remove(key, out value, null);
+
+        private bool remove(TKey key, [MaybeNullWhen(false)] out TValue value, BindableDictionary<TKey, TValue>? caller)
         {
             ensureMutationAllowed();
 
-            if (!TryGetValue(key, out TValue value))
+            if (!collection.Remove(key, out value))
                 return false;
 
             if (bindings != null)
@@ -117,7 +127,7 @@ namespace osu.Framework.Bindables
                     // prevent re-adding the item back to the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
                     if (b != caller)
-                        b.remove(key, this);
+                        b.remove(key, out _, this);
                 }
             }
 

--- a/osu.Framework/Bindables/BindableDictionary.cs
+++ b/osu.Framework/Bindables/BindableDictionary.cs
@@ -482,7 +482,7 @@ namespace osu.Framework.Bindables
         {
             CollectionChanged += onChange;
             if (runOnceImmediately)
-                onChange(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, collection));
+                onChange(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, collection.ToArray()));
         }
 
         private void addWeakReference(WeakReference<BindableDictionary<TKey, TValue>> weakReference)

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -209,7 +209,7 @@ namespace osu.Framework.Bindables
             {
                 foreach (var b in bindings)
                 {
-                    // prevent re-adding the item back to the callee.
+                    // prevent re-removing from the callee.
                     // That would result in a <see cref="StackOverflowException"/>.
                     if (b != caller)
                         b.remove(listItem, this);
@@ -591,7 +591,7 @@ namespace osu.Framework.Bindables
         {
             if (them == null)
                 throw new ArgumentNullException(nameof(them));
-            if (bindings?.Contains(weakReference) ?? false)
+            if (bindings?.Contains(weakReference) == true)
                 throw new ArgumentException("An already bound collection can not be bound again.");
             if (them == this)
                 throw new ArgumentException("A collection can not be bound to itself");

--- a/osu.Framework/Bindables/IBindableDictionary.cs
+++ b/osu.Framework/Bindables/IBindableDictionary.cs
@@ -1,12 +1,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.Collections.Specialized;
 
 namespace osu.Framework.Bindables
 {
     public interface IBindableDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
+        where TKey : notnull
     {
         /// <summary>
         /// Binds self to another bindable such that we receive any values and value limitations of the bindable we bind width.

--- a/osu.Framework/Bindables/IBindableDictionary.cs
+++ b/osu.Framework/Bindables/IBindableDictionary.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Bindables
         /// Bind an action to <see cref="INotifyCollectionChanged.CollectionChanged"/> with the option of running the bound action once immediately
         /// with an <see cref="NotifyCollectionChangedAction.Add"/> event for the entire contents of this <see cref="BindableDictionary{TKey, TValue}"/>.
         /// </summary>
-        /// <param name="onChange">The action to perform when this <see cref="BindableList{T}"/> changes.</param>
+        /// <param name="onChange">The action to perform when this <see cref="BindableDictionary{TKey, TValue}"/> changes.</param>
         /// <param name="runOnceImmediately">Whether the action provided in <paramref name="onChange"/> should be run once immediately.</param>
         void BindCollectionChanged(NotifyCollectionChangedEventHandler onChange, bool runOnceImmediately = false);
 

--- a/osu.Framework/Bindables/IBindableDictionary.cs
+++ b/osu.Framework/Bindables/IBindableDictionary.cs
@@ -20,7 +20,7 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="onChange">The action to perform when this <see cref="BindableDictionary{TKey, TValue}"/> changes.</param>
         /// <param name="runOnceImmediately">Whether the action provided in <paramref name="onChange"/> should be run once immediately.</param>
-        void BindCollectionChanged(NotifyCollectionChangedEventHandler onChange, bool runOnceImmediately = false);
+        void BindCollectionChanged(NotifyDictionaryChangedEventHandler<TKey, TValue> onChange, bool runOnceImmediately = false);
 
         /// <summary>
         /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.

--- a/osu.Framework/Bindables/IBindableDictionary.cs
+++ b/osu.Framework/Bindables/IBindableDictionary.cs
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Collections.Specialized;
+
+namespace osu.Framework.Bindables
+{
+    public interface IBindableDictionary<TKey, TValue> : IReadOnlyDictionary<TKey, TValue>, ICanBeDisabled, IHasDefaultValue, IUnbindable, IHasDescription
+    {
+        /// <summary>
+        /// Binds self to another bindable such that we receive any values and value limitations of the bindable we bind width.
+        /// </summary>
+        /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
+        void BindTo(IBindableDictionary<TKey, TValue> them);
+
+        /// <summary>
+        /// Bind an action to <see cref="INotifyCollectionChanged.CollectionChanged"/> with the option of running the bound action once immediately
+        /// with an <see cref="NotifyCollectionChangedAction.Add"/> event for the entire contents of this <see cref="BindableDictionary{TKey, TValue}"/>.
+        /// </summary>
+        /// <param name="onChange">The action to perform when this <see cref="BindableList{T}"/> changes.</param>
+        /// <param name="runOnceImmediately">Whether the action provided in <paramref name="onChange"/> should be run once immediately.</param>
+        void BindCollectionChanged(NotifyCollectionChangedEventHandler onChange, bool runOnceImmediately = false);
+
+        /// <summary>
+        /// An alias of <see cref="BindTo"/> provided for use in object initializer scenarios.
+        /// Passes the provided value as the foreign (more permanent) bindable.
+        /// </summary>
+        sealed IBindableDictionary<TKey, TValue> BindTarget
+        {
+            set => BindTo(value);
+        }
+
+        /// <summary>
+        /// Retrieve a new bindable instance weakly bound to the configuration backing.
+        /// If you are further binding to events of a bindable retrieved using this method, ensure to hold
+        /// a local reference.
+        /// </summary>
+        /// <returns>A weakly bound copy of the specified bindable.</returns>
+        IBindableDictionary<TKey, TValue> GetBoundCopy();
+    }
+}

--- a/osu.Framework/Bindables/IBindableDictionary.cs
+++ b/osu.Framework/Bindables/IBindableDictionary.cs
@@ -4,7 +4,6 @@
 #nullable enable
 
 using System.Collections.Generic;
-using System.Collections.Specialized;
 
 namespace osu.Framework.Bindables
 {
@@ -12,14 +11,19 @@ namespace osu.Framework.Bindables
         where TKey : notnull
     {
         /// <summary>
+        /// An event which is raised when this <see cref="IBindableDictionary{TKey, TValue}"/> changes.
+        /// </summary>
+        event NotifyDictionaryChangedEventHandler<TKey, TValue>? CollectionChanged;
+
+        /// <summary>
         /// Binds self to another bindable such that we receive any values and value limitations of the bindable we bind width.
         /// </summary>
         /// <param name="them">The foreign bindable. This should always be the most permanent end of the bind (ie. a ConfigManager)</param>
         void BindTo(IBindableDictionary<TKey, TValue> them);
 
         /// <summary>
-        /// Bind an action to <see cref="INotifyCollectionChanged.CollectionChanged"/> with the option of running the bound action once immediately
-        /// with an <see cref="NotifyCollectionChangedAction.Add"/> event for the entire contents of this <see cref="BindableDictionary{TKey, TValue}"/>.
+        /// Bind an action to <see cref="CollectionChanged"/> with the option of running the bound action once immediately
+        /// with an <see cref="NotifyDictionaryChangedAction.Add"/> event for the entire contents of this <see cref="BindableDictionary{TKey, TValue}"/>.
         /// </summary>
         /// <param name="onChange">The action to perform when this <see cref="BindableDictionary{TKey, TValue}"/> changes.</param>
         /// <param name="runOnceImmediately">Whether the action provided in <paramref name="onChange"/> should be run once immediately.</param>

--- a/osu.Framework/Bindables/NotifyDictionaryChangedEventArgs.cs
+++ b/osu.Framework/Bindables/NotifyDictionaryChangedEventArgs.cs
@@ -48,15 +48,21 @@ namespace osu.Framework.Bindables
         /// <param name="items">The items affected.</param>
         public NotifyDictionaryChangedEventArgs(NotifyDictionaryChangedAction action, ICollection<KeyValuePair<TKey, TValue>> items)
         {
-            if (action != NotifyDictionaryChangedAction.Add && action != NotifyDictionaryChangedAction.Remove)
-                throw new ArgumentException($"Action must be {nameof(NotifyDictionaryChangedAction.Add)} or {nameof(NotifyDictionaryChangedAction.Remove)}.", nameof(action));
-
             Action = action;
 
-            if (action == NotifyDictionaryChangedAction.Add)
-                NewItems = items;
-            else
-                OldItems = items;
+            switch (action)
+            {
+                case NotifyDictionaryChangedAction.Add:
+                    NewItems = items;
+                    break;
+
+                case NotifyDictionaryChangedAction.Remove:
+                    OldItems = items;
+                    break;
+
+                default:
+                    throw new ArgumentException($"Action must be {nameof(NotifyDictionaryChangedAction.Add)} or {nameof(NotifyDictionaryChangedAction.Remove)}.", nameof(action));
+            }
         }
 
         /// <summary>

--- a/osu.Framework/Bindables/NotifyDictionaryChangedEventArgs.cs
+++ b/osu.Framework/Bindables/NotifyDictionaryChangedEventArgs.cs
@@ -1,0 +1,98 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Framework.Bindables
+{
+    /// <summary>
+    /// Arguments for a dictionary's CollectionChanged event.
+    /// </summary>
+    /// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
+    public class NotifyDictionaryChangedEventArgs<TKey, TValue> : EventArgs
+        where TKey : notnull
+    {
+        /// <summary>
+        /// The action that caused the event.
+        /// </summary>
+        public readonly NotifyDictionaryChangedAction Action;
+
+        /// <summary>
+        /// All newly-added items.
+        /// </summary>
+        public readonly ICollection<KeyValuePair<TKey, TValue>>? NewItems;
+
+        /// <summary>
+        /// All removed items.
+        /// </summary>
+        public readonly ICollection<KeyValuePair<TKey, TValue>>? OldItems;
+
+        /// <summary>
+        /// Creates a new <see cref="NotifyDictionaryChangedEventArgs{TKey,TValue}"/> that describes an add or remove event.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        /// <param name="item">The item affected.</param>
+        public NotifyDictionaryChangedEventArgs(NotifyDictionaryChangedAction action, KeyValuePair<TKey, TValue> item)
+            : this(action, new[] { item })
+        {
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="NotifyDictionaryChangedEventArgs{TKey,TValue}"/> that describes an add or remove event.
+        /// </summary>
+        /// <param name="action">The action.</param>
+        /// <param name="items">The items affected.</param>
+        public NotifyDictionaryChangedEventArgs(NotifyDictionaryChangedAction action, ICollection<KeyValuePair<TKey, TValue>> items)
+        {
+            if (action != NotifyDictionaryChangedAction.Add && action != NotifyDictionaryChangedAction.Remove)
+                throw new ArgumentException($"Action must be {nameof(NotifyDictionaryChangedAction.Add)} or {nameof(NotifyDictionaryChangedAction.Remove)}.", nameof(action));
+
+            Action = action;
+
+            if (action == NotifyDictionaryChangedAction.Add)
+                NewItems = items;
+            else
+                OldItems = items;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="NotifyDictionaryChangedEventArgs{TKey,TValue}"/> that describes a replacement event.
+        /// </summary>
+        /// <param name="newItem">The new (added) item.</param>
+        /// <param name="oldItem">The old (removed) item.</param>
+        public NotifyDictionaryChangedEventArgs(KeyValuePair<TKey, TValue> newItem, KeyValuePair<TKey, TValue> oldItem)
+        {
+            Action = NotifyDictionaryChangedAction.Replace;
+            NewItems = new[] { newItem };
+            OldItems = new[] { oldItem };
+        }
+    }
+
+    /// <summary>
+    /// The delegate to use for handlers that receive the CollectionChanged event.
+    /// </summary>
+    public delegate void NotifyDictionaryChangedEventHandler<TKey, TValue>(object? sender, NotifyDictionaryChangedEventArgs<TKey, TValue> e)
+        where TKey : notnull;
+
+    public enum NotifyDictionaryChangedAction
+    {
+        /// <summary>
+        /// One or more items were added to the dictionary.
+        /// </summary>
+        Add,
+
+        /// <summary>
+        /// One or more items were removed from the dictionary.
+        /// </summary>
+        Remove,
+
+        /// <summary>
+        /// One or more items were replaced in the dictionary.
+        /// </summary>
+        Replace,
+    }
+}


### PR DESCRIPTION
Most of the implementation is similar to that of `BindableList`, including the tests which were mostly copied across.

One core difference between this and `BindableList` is that I've implemented `NotifyDictionaryChangedEventArgs` instead of using `NotifyCollectionChangedEventArgs`, because the latter didn't work well in real-world use.

Perhaps we could consider implementing a custom event for `BindableList` too though for greater type safety...

