### PR TITLE
Add support for `TestCaseSourceAttribute` in test scenes

### DIFF
--- a/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedSource.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneDerivedTestWithDerivedSource.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+
+namespace osu.Framework.Tests.Visual.Testing
+{
+    public class TestSceneDerivedTestWithDerivedSource : TestSceneTestWithSource
+    {
+        [TestCaseSource(nameof(SourceField))]
+        public void TestDerivedSourceField(int a, int b)
+        {
+        }
+
+        [TestCaseSource(nameof(SourceProperty))]
+        public void TestDerivedSourceProperty(int a, int b)
+        {
+        }
+
+        [TestCaseSource(nameof(SourceMethod))]
+        public void TestDerivedSourceMethod(int a, int b)
+        {
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTestWithExternalSource.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTestWithExternalSource.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+
+namespace osu.Framework.Tests.Visual.Testing
+{
+    public class TestSceneTestWithExternalSource : FrameworkTestScene
+    {
+        [TestCaseSource(typeof(TestSceneTestWithSource), nameof(TestSceneTestWithSource.ExposedSourceField))]
+        public void TestExposedSourceField(int a, int b)
+        {
+        }
+
+        [TestCaseSource(typeof(TestSceneTestWithSource), nameof(TestSceneTestWithSource.ExposedSourceProperty))]
+        public void TestExposedSourceProperty(int a, int b)
+        {
+        }
+
+        [TestCaseSource(typeof(TestSceneTestWithSource), nameof(TestSceneTestWithSource.ExposedSourceMethod))]
+        public void TestExposedSourceMethod(int a, int b)
+        {
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
@@ -1,0 +1,113 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections;
+using NUnit.Framework;
+using osu.Framework.Graphics.Containers;
+
+namespace osu.Framework.Tests.Visual.Testing
+{
+    public class TestSceneTestWithSource : FrameworkTestScene
+    {
+        protected static object[][] SourceField =
+        {
+            new object[] { 1, 2 },
+            new object[] { 3, 4 },
+            new object[] { 5, 6 },
+            new object[] { 7, 8 },
+        };
+
+        protected static object[][] SourceProperty => new[]
+        {
+            new object[] { 1, 2 },
+            new object[] { 3, 4 },
+            new object[] { 5, 6 },
+            new object[] { 7, 8 },
+        };
+
+        protected static object[][] SourceMethod() => new[]
+        {
+            new object[] { 1, 2 },
+            new object[] { 3, 4 },
+            new object[] { 5, 6 },
+            new object[] { 7, 8 },
+        };
+
+        protected static object[][] SourceMethodWithParameters(int x, int y) => new[]
+        {
+            new object[] { x + 1, y + 2 },
+            new object[] { x + 3, y + 4 },
+            new object[] { x + 5, y + 6 },
+            new object[] { x + 7, y + 8 },
+        };
+
+        protected static object[] SingleParameterSource = { 1, 2, 3, 4 };
+
+        protected static object[][] DifferentTypesSource =
+        {
+            new object[] { Visibility.Visible, FillDirection.Horizontal, false },
+            new object[] { Visibility.Hidden, FillDirection.Vertical, true },
+            new object[] { Visibility.Hidden, FillDirection.Full, false },
+        };
+
+        public static object[][] ExposedSourceField = SourceField;
+
+        public static object[][] ExposedSourceProperty => SourceProperty;
+
+        public static object[][] ExposedSourceMethod => SourceMethod();
+
+        [TestCaseSource(nameof(SourceField))]
+        public void TestSourceField(int a, int b)
+        {
+        }
+
+        [TestCaseSource(nameof(SourceProperty))]
+        public void TestSourceProperty(int a, int b)
+        {
+        }
+
+        [TestCaseSource(nameof(SourceMethod))]
+        public void TestSourceMethod(int a, int b)
+        {
+        }
+
+        [TestCaseSource(nameof(SourceMethodWithParameters), new object[] { 10, 20 })]
+        public void TestSourceParamsMethod(int a, int b)
+        {
+        }
+
+        [TestCaseSource(nameof(SourceField))]
+        [TestCaseSource(nameof(SourceProperty))]
+        [TestCaseSource(nameof(SourceMethod))]
+        [TestCaseSource(nameof(SourceMethodWithParameters), new object[] { 10, 20 })]
+        public void TestMultipleSources(int a, int b)
+        {
+        }
+
+        [TestCaseSource(nameof(SingleParameterSource))]
+        public void TestSingleParameterSource(int x)
+        {
+        }
+
+        [TestCaseSource(nameof(DifferentTypesSource))]
+        public void TestDifferentTypesSource(Visibility a, FillDirection b, bool c)
+        {
+        }
+
+        [TestCaseSource(typeof(TestEnumerable))]
+        public void TestCustomEnumerableSource(int a, int b)
+        {
+        }
+
+        private class TestEnumerable : IEnumerable
+        {
+            public IEnumerator GetEnumerator()
+            {
+                yield return new[] { 1, 2 };
+                yield return new[] { 3, 4 };
+                yield return new[] { 5, 6 };
+                yield return new[] { 7, 8 };
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
@@ -17,21 +17,9 @@ namespace osu.Framework.Tests.Visual.Testing
             new object[] { 7, 8 },
         };
 
-        protected static object[][] SourceProperty => new[]
-        {
-            new object[] { 1, 2 },
-            new object[] { 3, 4 },
-            new object[] { 5, 6 },
-            new object[] { 7, 8 },
-        };
+        protected static object[][] SourceProperty => SourceField;
 
-        protected static object[][] SourceMethod() => new[]
-        {
-            new object[] { 1, 2 },
-            new object[] { 3, 4 },
-            new object[] { 5, 6 },
-            new object[] { 7, 8 },
-        };
+        protected static object[][] SourceMethod() => SourceField;
 
         protected static object[][] SourceMethodWithParameters(int x, int y) => new[]
         {

--- a/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneTestWithSource.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.Tests.Visual.Testing
 
         public static object[][] ExposedSourceProperty => SourceProperty;
 
-        public static object[][] ExposedSourceMethod => SourceMethod();
+        public static object[][] ExposedSourceMethod() => SourceMethod();
 
         [TestCaseSource(nameof(SourceField))]
         public void TestSourceField(int a, int b)

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -666,7 +666,7 @@ namespace osu.Framework.Testing
                     return (IEnumerable)sm.Invoke(null, tcs.MethodParams);
 
                 default:
-                    throw new ArgumentOutOfRangeException(nameof(sourceMember));
+                    throw new NotSupportedException($"{sourceMember.MemberType} is not a supported member type for {nameof(TestCaseSourceAttribute)} (must be static field, property or method)");
             }
         }
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -15,6 +16,8 @@ using osu.Framework.Configuration;
 using osu.Framework.Development;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.IEnumerableExtensions;
+using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -561,6 +564,35 @@ namespace osu.Framework.Testing
 
                         handleTestMethod(m, tc.Arguments);
                     }
+
+                    foreach (var tcs in m.GetCustomAttributes(typeof(TestCaseSourceAttribute), false).OfType<TestCaseSourceAttribute>())
+                    {
+                        IEnumerable sourceValue = getTestCaseSourceValue(m, tcs);
+
+                        if (sourceValue == null)
+                        {
+                            Debug.Assert(tcs.SourceName != null);
+                            throw new InvalidOperationException($"The value of the source member {tcs.SourceName} must be non-null.");
+                        }
+
+                        foreach (var argument in sourceValue)
+                        {
+                            hadTestAttributeTest = true;
+
+                            if (argument is IEnumerable argumentsEnumerable)
+                            {
+                                var arguments = argumentsEnumerable.Cast<object>().ToArray();
+
+                                CurrentTest.AddLabel($"{name}({string.Join(", ", arguments)}){repeatSuffix}");
+                                handleTestMethod(m, arguments);
+                            }
+                            else
+                            {
+                                CurrentTest.AddLabel($"{name}({argument}){repeatSuffix}");
+                                handleTestMethod(m, argument);
+                            }
+                        }
+                    }
                 }
             }
 
@@ -590,11 +622,60 @@ namespace osu.Framework.Testing
                 CurrentTest.RunSetUpSteps();
             }
 
-            void handleTestMethod(MethodInfo methodInfo, object[] arguments = null)
+            void handleTestMethod(MethodInfo methodInfo, params object[] arguments)
             {
                 addSetUpSteps();
                 methodInfo.Invoke(CurrentTest, arguments);
                 CurrentTest.RunTearDownSteps();
+            }
+        }
+
+        private static IEnumerable getTestCaseSourceValue(MethodInfo testMethod, TestCaseSourceAttribute tcs)
+        {
+            var sourceDeclaringType = tcs.SourceType ?? testMethod.DeclaringType;
+            Debug.Assert(sourceDeclaringType != null);
+
+            if (tcs.SourceName == null)
+                return (IEnumerable)Activator.CreateInstance(sourceDeclaringType);
+
+            var sourceMembers = sourceDeclaringType.AsNonNull().GetMember(tcs.SourceName, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy);
+            if (sourceMembers.Length == 0)
+                throw new InvalidOperationException($"No such source member exists with the name {tcs.SourceName} in {sourceDeclaringType} or its base types.");
+
+            if (sourceMembers.Length > 1)
+                throw new NotSupportedException($"There are multiple members with the same source name ({tcs.SourceName}) (e.g. method overloads).");
+
+            var sourceMember = sourceMembers.Single();
+
+            switch (sourceMember)
+            {
+                case FieldInfo sf:
+                    if (!sf.IsStatic)
+                        throw new InvalidOperationException($"The source field {sf.Name} in {sf.DeclaringType.ReadableName()} must be static.");
+
+                    return (IEnumerable)sf.GetValue(null);
+
+                case PropertyInfo sp:
+                    if (!sp.CanRead)
+                        throw new InvalidOperationException($"The source property {sp.Name} in {sp.DeclaringType.ReadableName()} must have a getter.");
+
+                    if (sp.GetGetMethod(true)?.IsStatic == false)
+                        throw new InvalidOperationException($"The source property {sp.Name} in {sp.DeclaringType.ReadableName()} must be static.");
+
+                    return (IEnumerable)sp.GetValue(null);
+
+                case MethodInfo sm:
+                    if (!sm.IsStatic)
+                        throw new InvalidOperationException($"The source method {sm.Name} in {sm.DeclaringType.ReadableName()} must be static.");
+
+                    var methodParamsLength = sm.GetParameters().Length;
+                    if (methodParamsLength != (tcs.MethodParams?.Length ?? 0))
+                        throw new InvalidOperationException($"The given source method parameters count doesn't match the method. ({tcs.MethodParams?.Length ?? 0} != {methodParamsLength})");
+
+                    return (IEnumerable)sm.Invoke(null, tcs.MethodParams);
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(sourceMember));
             }
         }
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -640,7 +640,7 @@ namespace osu.Framework.Testing
 
             var sourceMembers = sourceDeclaringType.AsNonNull().GetMember(tcs.SourceName, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy);
             if (sourceMembers.Length == 0)
-                throw new InvalidOperationException($"No such source member exists with the name {tcs.SourceName} in {sourceDeclaringType} or its base types.");
+                throw new InvalidOperationException($"No static member with the name of {tcs.SourceName} exists in {sourceDeclaringType} or its base types.");
 
             if (sourceMembers.Length > 1)
                 throw new NotSupportedException($"There are multiple members with the same source name ({tcs.SourceName}) (e.g. method overloads).");
@@ -661,7 +661,7 @@ namespace osu.Framework.Testing
                 case MethodInfo sm:
                     var methodParamsLength = sm.GetParameters().Length;
                     if (methodParamsLength != (tcs.MethodParams?.Length ?? 0))
-                        throw new InvalidOperationException($"The given source method parameters count doesn't match the method. ({tcs.MethodParams?.Length ?? 0} != {methodParamsLength})");
+                        throw new InvalidOperationException($"The given source method parameters count doesn't match the method. (attribute has {tcs.MethodParams?.Length ?? 0}, method has {methodParamsLength})");
 
                     return (IEnumerable)sm.Invoke(null, tcs.MethodParams);
 

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -650,24 +650,15 @@ namespace osu.Framework.Testing
             switch (sourceMember)
             {
                 case FieldInfo sf:
-                    if (!sf.IsStatic)
-                        throw new InvalidOperationException($"The source field {sf.Name} in {sf.DeclaringType.ReadableName()} must be static.");
-
                     return (IEnumerable)sf.GetValue(null);
 
                 case PropertyInfo sp:
                     if (!sp.CanRead)
                         throw new InvalidOperationException($"The source property {sp.Name} in {sp.DeclaringType.ReadableName()} must have a getter.");
 
-                    if (sp.GetGetMethod(true)?.IsStatic == false)
-                        throw new InvalidOperationException($"The source property {sp.Name} in {sp.DeclaringType.ReadableName()} must be static.");
-
                     return (IEnumerable)sp.GetValue(null);
 
                 case MethodInfo sm:
-                    if (!sm.IsStatic)
-                        throw new InvalidOperationException($"The source method {sm.Name} in {sm.DeclaringType.ReadableName()} must be static.");
-
                     var methodParamsLength = sm.GetParameters().Length;
                     if (methodParamsLength != (tcs.MethodParams?.Length ?? 0))
                         throw new InvalidOperationException($"The given source method parameters count doesn't match the method. ({tcs.MethodParams?.Length ?? 0} != {methodParamsLength})");

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -635,8 +635,8 @@ namespace osu.Framework.Testing
             var sourceDeclaringType = tcs.SourceType ?? testMethod.DeclaringType;
             Debug.Assert(sourceDeclaringType != null);
 
-            if (tcs.SourceName == null)
-                return (IEnumerable)Activator.CreateInstance(sourceDeclaringType);
+            if (tcs.SourceType != null && tcs.SourceName == null)
+                return (IEnumerable)Activator.CreateInstance(tcs.SourceType);
 
             var sourceMembers = sourceDeclaringType.AsNonNull().GetMember(tcs.SourceName, BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.FlattenHierarchy);
             if (sourceMembers.Length == 0)


### PR DESCRIPTION
Done mostly as in the [documentation](https://docs.nunit.org/articles/nunit/writing-tests/attributes/testcasesource.html), might have a small difference between but don't want to stuff more things into this any further.