### PR TITLE
Fix test scene restoring volume at an unsafe point in execution

### DIFF
--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -107,12 +107,14 @@ namespace osu.Framework.Graphics.UserInterface
         {
             base.LoadComplete();
 
-            currentNumberInstantaneous.ValueChanged += _ => UpdateValue(NormalizedValue);
-            currentNumberInstantaneous.MinValueChanged += _ => UpdateValue(NormalizedValue);
-            currentNumberInstantaneous.MaxValueChanged += _ => UpdateValue(NormalizedValue);
+            currentNumberInstantaneous.ValueChanged += _ => Scheduler.AddOnce(updateValue);
+            currentNumberInstantaneous.MinValueChanged += _ => Scheduler.AddOnce(updateValue);
+            currentNumberInstantaneous.MaxValueChanged += _ => Scheduler.AddOnce(updateValue);
 
-            UpdateValue(NormalizedValue);
+            Scheduler.AddOnce(updateValue);
         }
+
+        private void updateValue() => UpdateValue(NormalizedValue);
 
         private bool handleClick;
 

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -52,10 +52,10 @@ namespace osu.Framework.Testing
                 volume.Value = 0;
             }
 
-            protected override void Dispose(bool isDisposing)
+            internal override void UnbindAllBindables()
             {
+                base.UnbindAllBindables();
                 if (volume != null) volume.Value = volumeAtStartup;
-                base.Dispose(isDisposing);
             }
 
             protected override void LoadComplete()


### PR DESCRIPTION
Ran into the following case osu-side:

```csharp

osu.Framework.Graphics.Drawable+InvalidThreadForMutationException: Cannot mutate the Transforms of a Loaded Drawable while not on the update thread. Consider using Schedule to schedule the mutation operation.
   at osu.Framework.Graphics.Drawable.EnsureMutationAllowed(String member) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 2612
   at osu.Framework.Graphics.Drawable.EnsureTransformMutationAllowed() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 2583
   at osu.Framework.Graphics.Transforms.Transformable.AddTransform(Transform transform, Nullable`1 customTransformID) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Transforms/Transformable.cs:line 336
   at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis](TThis t, Transform transform) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 66
   at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis,TValue,TEasing](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 53
   at osu.Framework.Graphics.TransformableExtensions.MoveToX[T,TEasing](T drawable, Single destination, Double duration, TEasing& easing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 652
   at osu.Framework.Graphics.TransformableExtensions.MoveToX[T](T drawable, Single destination, Double duration, Easing easing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 401
   at osu.Game.Graphics.UserInterface.OsuSliderBar`1.UpdateValue(Single value) in /Users/dean/Projects/osu/osu.Game/Graphics/UserInterface/OsuSliderBar.cs:line 204
   at osu.Framework.Graphics.UserInterface.SliderBar`1.<LoadComplete>b__18_0(ValueChangedEvent`1 _) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/SliderBar.cs:line 110
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 291
   at osu.Framework.Bindables.Bindable`1.SetValue(T previousValue, T value, Boolean bypassChecks, Bindable`1 source) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 104
   at osu.Framework.Bindables.Bindable`1.set_Value(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 97
   at osu.Framework.Bindables.RangeConstrainedBindable`1.setValue(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/RangeConstrainedBindable.cs:line 193
   at osu.Framework.Bindables.RangeConstrainedBindable`1.set_Value(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/RangeConstrainedBindable.cs:line 46
   at osu.Framework.Bindables.BindableNumber`1.setValue(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/BindableNumber.cs:line 82
   at osu.Framework.Bindables.BindableNumber`1.set_Value(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/BindableNumber.cs:line 72
   at osu.Framework.Graphics.UserInterface.SliderBar`1.<.ctor>b__14_0(ValueChangedEvent`1 e) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/SliderBar.cs:line 66
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 291
   at osu.Framework.Bindables.Bindable`1.SetValue(T previousValue, T value, Boolean bypassChecks, Bindable`1 source) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 104
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 286
   at osu.Framework.Bindables.Bindable`1.SetValue(T previousValue, T value, Boolean bypassChecks, Bindable`1 source) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 104
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 286
   at osu.Framework.Bindables.Bindable`1.SetValue(T previousValue, T value, Boolean bypassChecks, Bindable`1 source) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 104
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 286
   at osu.Framework.Bindables.Bindable`1.SetValue(T previousValue, T value, Boolean bypassChecks, Bindable`1 source) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 104
   at osu.Framework.Bindables.Bindable`1.set_Value(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 97
   at osu.Framework.Bindables.RangeConstrainedBindable`1.setValue(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/RangeConstrainedBindable.cs:line 193
   at osu.Framework.Bindables.RangeConstrainedBindable`1.set_Value(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/RangeConstrainedBindable.cs:line 46
   at osu.Framework.Bindables.BindableNumber`1.setValue(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/BindableNumber.cs:line 82
   at osu.Framework.Bindables.BindableNumber`1.set_Value(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/BindableNumber.cs:line 72
   at osu.Framework.Testing.TestSceneTestRunner.TestRunner.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Testing/TestSceneTestRunner.cs:line 57
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Game.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Game.cs:line 373
   at osu.Game.OsuGameBase.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu/osu.Game/OsuGameBase.cs:line 472
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Graphics.Containers.CompositeDrawable.<>c.<Dispose>b__23_0(Drawable c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.Containers.CompositeDrawable.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Containers/CompositeDrawable.cs:line 299
   at osu.Framework.Input.CustomInputManager.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Input/CustomInputManager.cs:line 36
   at osu.Framework.Graphics.Drawable.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 81
   at osu.Framework.Platform.GameHost.Dispose(Boolean disposing) in /Users/dean/Projects/osu-framework/osu.Framework/Platform/GameHost.cs:line 946
   at osu.Framework.Platform.DesktopGameHost.Dispose(Boolean isDisposing) in /Users/dean/Projects/osu-framework/osu.Framework/Platform/DesktopGameHost.cs:line 106
   at osu.Framework.Platform.GameHost.Dispose() in /Users/dean/Projects/osu-framework/osu.Framework/Platform/GameHost.cs:line 962
   at osu.Framework.Testing.TestScene.DestroyGameHost() in /Users/dean/Projects/osu-framework/osu.Framework/Testing/TestScene.cs:line 80
```

This happens due to the restoration of volume running before children are disposed, making the bindable events fire (and do so on the disposal thread).

I've moved the code to `UnbindAllBindables` because that feels better, but the real fix is the reordering of the `base` call.

The changes to `SliderBar` are also not necessary, but I think they feel safer.