### PR TITLE
Fix `TranslatableString.Format` null ref when no languages are added to `LocalisationManager`

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -28,6 +28,16 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
+        public void TestNoLanguagesAdded()
+        {
+            // reinitialise without the default language
+            manager = new LocalisationManager(config);
+
+            var localisedText = manager.GetLocalisedString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
+            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
+        }
+
+        [Test]
         public void TestNotLocalised()
         {
             manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -7,6 +7,8 @@ using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 
+#nullable enable
+
 namespace osu.Framework.Localisation
 {
     public partial class LocalisationManager
@@ -15,7 +17,7 @@ namespace osu.Framework.Localisation
 
         private readonly Bindable<bool> preferUnicode;
         private readonly Bindable<string> configLocale;
-        private readonly Bindable<ILocalisationStore> currentStorage = new Bindable<ILocalisationStore>();
+        private readonly Bindable<ILocalisationStore?> currentStorage = new Bindable<ILocalisationStore?>();
 
         public LocalisationManager(FrameworkConfigManager config)
         {
@@ -27,7 +29,7 @@ namespace osu.Framework.Localisation
 
         public void AddLanguage(string language, ILocalisationStore storage)
         {
-            locales.Add(new LocaleMapping { Name = language, Storage = storage });
+            locales.Add(new LocaleMapping(language, storage));
             configLocale.TriggerChange();
         }
 
@@ -67,8 +69,14 @@ namespace osu.Framework.Localisation
 
         private class LocaleMapping
         {
-            public string Name;
-            public ILocalisationStore Storage;
+            public readonly string Name;
+            public readonly ILocalisationStore Storage;
+
+            public LocaleMapping(string name, ILocalisationStore storage)
+            {
+                Name = name;
+                Storage = storage;
+            }
         }
     }
 }

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using osu.Framework.Bindables;
 
 namespace osu.Framework.Localisation
@@ -9,12 +11,12 @@ namespace osu.Framework.Localisation
     {
         private class LocalisedBindableString : Bindable<string>, ILocalisedBindableString
         {
-            private readonly IBindable<ILocalisationStore> storage = new Bindable<ILocalisationStore>();
+            private readonly IBindable<ILocalisationStore?> storage = new Bindable<ILocalisationStore?>();
             private readonly IBindable<bool> preferUnicode = new Bindable<bool>();
 
             private LocalisableString text;
 
-            public LocalisedBindableString(LocalisableString text, IBindable<ILocalisationStore> storage, IBindable<bool> preferUnicode)
+            public LocalisedBindableString(LocalisableString text, Bindable<ILocalisationStore?> storage, IBindable<bool> preferUnicode)
             {
                 this.text = text;
 

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable enable
-
 using osu.Framework.Bindables;
 
 namespace osu.Framework.Localisation

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#pragma warning disable 8632 // TODO: can be #nullable enable when Bindables are updated to also be.
+
 using osu.Framework.Bindables;
 
 namespace osu.Framework.Localisation

--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -8,6 +8,8 @@ using System.Globalization;
 using System.Linq;
 using osu.Framework.Logging;
 
+#nullable enable
+
 namespace osu.Framework.Localisation
 {
     /// <summary>
@@ -48,8 +50,10 @@ namespace osu.Framework.Localisation
             Args = interpolation.GetArguments();
         }
 
-        public string Format(ILocalisationStore store)
+        public string Format(ILocalisationStore? store)
         {
+            if (store == null) return ToString();
+
             var localisedFormat = store.Get(Key);
 
             if (localisedFormat == null) return ToString();


### PR DESCRIPTION
I've chosen to make the storage nullable as it's a bit of a pain to provide an empty default. That said, if that's the preferred direction it can be done.