### PR TITLE
Fix incorrect GetParentScreen()/GetChildScreen() values for screens not in stack

### DIFF
--- a/osu.Framework.Tests/Lists/TestEnumerableExtensions.cs
+++ b/osu.Framework.Tests/Lists/TestEnumerableExtensions.cs
@@ -28,5 +28,25 @@ namespace osu.Framework.Tests.Lists
         {
             Assert.AreEqual(string.Empty, Enumerable.Empty<string>().GetCommonPrefix());
         }
+
+        [TestCase("a", null)]
+        [TestCase("b", "a")]
+        [TestCase("c", "b")]
+        [TestCase("d", null)]
+        public void TestGetPrevious(string item, string expected)
+        {
+            string[] arr = { "a", "b", "c" };
+            Assert.That(arr.GetPrevious(item), Is.EqualTo(expected));
+        }
+
+        [TestCase("a", "b")]
+        [TestCase("b", "c")]
+        [TestCase("c", null)]
+        [TestCase("d", null)]
+        public void TestGetNext(string item, string expected)
+        {
+            string[] arr = { "a", "b", "c" };
+            Assert.That(arr.GetNext(item), Is.EqualTo(expected));
+        }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneScreenStack.cs
@@ -871,6 +871,22 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("screen2 resumed from screen3", () => screen2.ResumedFrom == screen3);
         }
 
+        [Test]
+        public void TestGetChildScreenAndGetParentScreenReturnNullWhenNotInStack()
+        {
+            TestScreen screen1 = null;
+            TestScreen screen2 = null;
+            TestScreen screen3 = null;
+
+            pushAndEnsureCurrent(() => screen1 = new TestScreen(id: 1));
+            pushAndEnsureCurrent(() => screen2 = new TestScreen(id: 2), () => screen1);
+            pushAndEnsureCurrent(() => screen3 = new TestScreen(id: 3), () => screen2);
+
+            AddStep("exit from screen 3", () => screen3.Exit());
+            AddAssert("screen 3 parent is null", () => screen3.GetParentScreen() == null);
+            AddAssert("screen 3 child is null", () => screen3.GetChildScreen() == null);
+        }
+
         private void clickScreen(ManualInputManager inputManager, TestScreen screen)
         {
             inputManager.MoveMouseTo(screen);

--- a/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs
+++ b/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs
@@ -52,9 +52,7 @@ namespace osu.Framework.Extensions.IEnumerableExtensions
         /// <param name="pivot">The pivot value.</param>
         /// <returns>The item in <paramref name="collection"/> appearing before <paramref name="pivot"/>, or null if no such item exists.</returns>
         public static T GetPrevious<T>(this IEnumerable<T> collection, T pivot)
-        {
-            return collection.TakeWhile(i => !EqualityComparer<T>.Default.Equals(i, pivot)).LastOrDefault();
-        }
+            => collection.Reverse().GetNext(pivot);
 
         /// <summary>
         /// Returns the most common prefix of every string in this <see cref="IEnumerable{T}"/>

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -252,10 +253,10 @@ namespace osu.Framework.Screens
         internal bool IsCurrentScreen(IScreen source) => source == CurrentScreen;
 
         internal IScreen GetParentScreen(IScreen source)
-            => stack.Reverse().TakeWhile(s => s != source).LastOrDefault();
+            => stack.GetPrevious(source);
 
         internal IScreen GetChildScreen(IScreen source)
-            => stack.TakeWhile(s => s != source).LastOrDefault();
+            => stack.GetNext(source);
 
         /// <summary>
         /// Exits the current <see cref="IScreen"/>.

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -253,10 +253,10 @@ namespace osu.Framework.Screens
         internal bool IsCurrentScreen(IScreen source) => source == CurrentScreen;
 
         internal IScreen GetParentScreen(IScreen source)
-            => stack.GetPrevious(source);
+            => stack.GetNext(source);
 
         internal IScreen GetChildScreen(IScreen source)
-            => stack.GetNext(source);
+            => stack.GetPrevious(source);
 
         /// <summary>
         /// Exits the current <see cref="IScreen"/>.


### PR DESCRIPTION
Also found that the implementation of `Enumerable.GetPrevious()` has always been incorrect in the same fashion.