### PR TITLE
Flush framebuffer after FBO bind on macOS

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -62,9 +62,6 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
             GLWrapper.BindFrameBuffer(frameBuffer);
 
-            if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
-                GL.Flush();
-
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget2d.Texture2D, Texture.TextureId, 0);
             GLWrapper.BindTexture(null);
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -62,6 +62,9 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
             GLWrapper.BindFrameBuffer(frameBuffer);
 
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
+                GL.Flush();
+
             GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget2d.Texture2D, Texture.TextureId, 0);
             GLWrapper.BindTexture(null);
 

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -835,6 +835,7 @@ namespace osu.Framework.Graphics.OpenGL
                 GL.BindFramebuffer(FramebufferTarget.Framebuffer, frameBuffer);
                 GlobalPropertyManager.Set(GlobalProperty.BackbufferDraw, UsingBackbuffer);
 
+                // Speculative fix for macOS crashes (see: http://crbug.com/1181068, http://crbug.com/783979, https://github.com/google/angle/commit/ce89d99fdeda61d9bc88fc7abd2aa3b4666d770e).
                 if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
                     GL.Flush();
             }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -833,11 +833,12 @@ namespace osu.Framework.Graphics.OpenGL
             {
                 FlushCurrentBatch();
                 GL.BindFramebuffer(FramebufferTarget.Framebuffer, frameBuffer);
-                GlobalPropertyManager.Set(GlobalProperty.BackbufferDraw, UsingBackbuffer);
 
                 // Speculative fix for macOS crashes (see: http://crbug.com/1181068, http://crbug.com/783979, https://github.com/google/angle/commit/ce89d99fdeda61d9bc88fc7abd2aa3b4666d770e).
                 if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
                     GL.Flush();
+
+                GlobalPropertyManager.Set(GlobalProperty.BackbufferDraw, UsingBackbuffer);
             }
 
             GlobalPropertyManager.Set(GlobalProperty.GammaCorrection, UsingBackbuffer);

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -834,6 +834,9 @@ namespace osu.Framework.Graphics.OpenGL
                 FlushCurrentBatch();
                 GL.BindFramebuffer(FramebufferTarget.Framebuffer, frameBuffer);
                 GlobalPropertyManager.Set(GlobalProperty.BackbufferDraw, UsingBackbuffer);
+
+                if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
+                    GL.Flush();
             }
 
             GlobalPropertyManager.Set(GlobalProperty.GammaCorrection, UsingBackbuffer);


### PR DESCRIPTION
Maybe it's fine to get this in for further testing? Seems like Chromium has experienced similar crashes/full system lockups as a result of FBOs and integrated this fix themselves:
http://crbug.com/1181068
http://crbug.com/783979
https://github.com/google/angle/commit/ce89d99fdeda61d9bc88fc7abd2aa3b4666d770e




    
    
      
