### PR TITLE
Fix default audio device re-initting when devices change

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -353,7 +353,7 @@ namespace osu.Framework.Audio
         protected virtual bool IsCurrentDeviceValid()
         {
             var device = audioDevices.ElementAtOrDefault(Bass.CurrentDevice);
-            bool isFallback = AudioDevice.Value == null ? !device.IsDefault : device.Name != AudioDevice.Value;
+            bool isFallback = string.IsNullOrEmpty(AudioDevice.Value) ? !device.IsDefault : device.Name != AudioDevice.Value;
             return device.IsEnabled && device.IsInitialized && !isFallback;
         }
 


### PR DESCRIPTION
This probably _fixes_ https://github.com/ppy/osu/issues/12638 and https://github.com/ppy/osu/issues/12482

The default value here is `string.Empty`, so this check would always pass whenever the audio devices changed.