### PR TITLE
Remove invalid keybinding assertion causing crashes

### DIFF
--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -297,8 +296,6 @@ namespace osu.Framework.Input.Bindings
 
             // we don't want to consider exact matching here as we are dealing with bindings, not actions.
             var newlyReleased = pressedBindings.Where(b => !b.KeyCombination.IsPressed(pressedCombination, KeyCombinationMatchingMode.Any)).ToList();
-
-            Trace.Assert(newlyReleased.All(b => KeyCombination.ContainsKey(b.KeyCombination.Keys, releasedKey)));
 
             foreach (var binding in newlyReleased)
             {


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/11511

Here's a sample log I constructed showing what's going on:
```
[runtime] 2021-05-26 09:01:40 [debug]: KeyDownEvent(Enter, False) handled by FocusedTextBox.

[runtime] 2021-05-26 09:01:41 [verbose]: (GlobalActionContainer) Pressed (key: MouseLeft, combination: 49,132)
[runtime] 2021-05-26 09:01:41 [debug]: Pressed (Select) handled by ChatOverlay.
[runtime] 2021-05-26 09:01:41 [debug]: MouseDownEvent(Left) handled by GlobalActionContainer.

[runtime] 2021-05-26 09:01:41 [debug]: KeyUpEvent(Enter) propagated

[runtime] 2021-05-26 09:01:41 [verbose]: (GlobalActionContainer) Released: MouseLeft
[runtime] 2021-05-26 09:01:41 [error]: An unhandled error has occurred.
[runtime] 2021-05-26 09:01:41 [error]: NUnit.Framework.AssertionException
```

To explain...
* The `GlobalActionContainer` is non-exact matching.
* `MouseLeft` gets pressed, which is handled by the KeyBindingContainer. The KeyBindingContainer then aggregates the pressed combination directly from the `InputState`.
    * This results in the aggregate combination `{ 49 (Enter), 132 (MouseLeft) }`.
* A pressed binding is found with key combination `{ 49 (Enter) }`
* On release of `MouseLeft`, the assertion is triggered because the binding's key combination does not include `MouseLeft`.

Seems like this assert is just wrong.