### PR TITLE
Fix DelayedLoadUnloadWrapper asserting incorrectly

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -457,6 +457,34 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddStep("scroll to start", () => scrollContainer.ScrollToStart(false));
             AddWaitStep("wait some frames", 2);
             AddAssert("child not loaded", () => lastChild.LoadState != LoadState.Loaded);
+
+        [Test]
+        public void TestWrapperStopReceivingUpdatesAfterDelayedLoadCompleted()
+        {
+            DelayedLoadTestDrawable child = null;
+
+            AddStep("add panel", () =>
+            {
+                DelayedLoadUnloadWrapper wrapper;
+
+                Child = wrapper = new DelayedLoadUnloadWrapper(() => child = new DelayedLoadTestDrawable { RelativeSizeAxes = Axes.Both }, 0, 1000)
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 128,
+                };
+
+                // Prevent the wrapper from receiving updates as soon as load completes, and start making it unload its contents by repositioning it offscreen.
+                wrapper.DelayedLoadComplete += _ =>
+                {
+                    wrapper.Alpha = 0;
+                    wrapper.Position = new Vector2(-1000);
+                };
+            });
+
+            // Check that the child is disposed when its async-load completes while the wrapper is masked away.
+            AddAssert("wait for load to begin", () => child?.LoadState == LoadState.Loading);
+            AddStep("allow load", () => child.AllowLoad.Set());
+            AddUntilStep("drawable disposed", () => child.IsDisposed);
         }
 
         public class TestScrollContainer : BasicScrollContainer

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -451,12 +451,15 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddStep("allow load", () => child.AllowLoad.Set());
             AddUntilStep("drawable disposed", () => child.IsDisposed);
 
-            // Check that reuse of the child is not attempted.
             Drawable lastChild = null;
             AddStep("store child", () => lastChild = child);
+
+            // Check that reuse of the child is not attempted.
             AddStep("scroll to start", () => scrollContainer.ScrollToStart(false));
-            AddWaitStep("wait some frames", 2);
-            AddAssert("child not loaded", () => lastChild.LoadState != LoadState.Loaded);
+            AddStep("allow load of new child", () => child.AllowLoad.Set());
+            AddUntilStep("new child loaded", () => child.IsLoaded);
+            AddAssert("last child not loaded", () => !lastChild.IsLoaded);
+        }
 
         [Test]
         public void TestWrapperStopReceivingUpdatesAfterDelayedLoadCompleted()

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -111,16 +111,20 @@ namespace osu.Framework.Graphics.Containers
                 if (!ShouldUnloadContent)
                     return;
 
-                Debug.Assert(Content.LoadState >= LoadState.Ready);
-
                 // We need to dispose the content, taking into account what we know at this point in time:
                 // 1: The wrapper has not been disposed. Consequently, neither has the content.
                 // 2: The content has finished loading.
                 // 3: The content may not have been added to the hierarchy (e.g. if this wrapper is hidden). This is dependent upon the value of DelayedLoadCompleted.
                 if (DelayedLoadCompleted)
+                {
+                    Debug.Assert(Content.LoadState >= LoadState.Ready);
                     ClearInternal(); // Content added, remove AND dispose.
+                }
                 else
+                {
+                    Debug.Assert(Content.LoadState == LoadState.Ready);
                     DisposeChildAsync(Content); // Content not added, only need to dispose.
+                }
 
                 Content = null;
                 timeHidden = 0;

--- a/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadUnloadWrapper.cs
@@ -111,20 +111,16 @@ namespace osu.Framework.Graphics.Containers
                 if (!ShouldUnloadContent)
                     return;
 
+                Debug.Assert(Content.LoadState >= LoadState.Ready);
+
                 // We need to dispose the content, taking into account what we know at this point in time:
                 // 1: The wrapper has not been disposed. Consequently, neither has the content.
                 // 2: The content has finished loading.
                 // 3: The content may not have been added to the hierarchy (e.g. if this wrapper is hidden). This is dependent upon the value of DelayedLoadCompleted.
                 if (DelayedLoadCompleted)
-                {
-                    Debug.Assert(Content.LoadState == LoadState.Loaded);
                     ClearInternal(); // Content added, remove AND dispose.
-                }
                 else
-                {
-                    Debug.Assert(Content.LoadState == LoadState.Ready);
                     DisposeChildAsync(Content); // Content not added, only need to dispose.
-                }
 
                 Content = null;
                 timeHidden = 0;


### PR DESCRIPTION
If the content is added to the DLUW but the DLUW stops receiving updates, the content won't finish its load and will remain in `LoadState.Ready`.