### PR TITLE
Disable dotnet-format from running on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,9 @@ jobs:
              fi
           done
 
-      - name: .NET Format (Dry Run)
-        run: dotnet format --dry-run --check
+      # Temporarily disabled due to test failures, but it won't work anyway until the tool is upgraded.
+      # - name: .NET Format (Dry Run)
+      #   run: dotnet format --dry-run --check
 
       - name: InspectCode
         run: dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=$(pwd)/inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN


### PR DESCRIPTION
As seen in https://github.com/ppy/osu-framework/pull/4467/checks?check_run_id=2674918731 There was likely some changing in tooling in the GH Actions image that is now causing this.

`dotnet-format` is currently a no-op because it won't support .NET 5 until the tool version is upgraded:
https://github.com/ppy/osu-framework/blob/870e5d2dd7a535157dbc5fb46b2a4b8a165825b9/.config/dotnet-tools.json#L10-L16

Upgrading the tool is not simple because there's inspection conflicts with Resharper - in particular with ordering of `using`s which are not simple to resolve because Rider doesn't automatically sort usings. I thought it did but @peppy apparently experienced different.

Easiest solution is to just disable for now.