### PR TITLE
Fix audio devices not working after being disconnected then reconnected

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -268,7 +268,7 @@ namespace osu.Framework.Audio
         /// <summary>
         /// Lock globally across all usages ensure no funny-business occurs during device free/init.
         /// </summary>
-        private static object bass_init_lock = new object();
+        private static readonly object bass_init_lock = new object();
 
         /// <summary>
         /// This method calls <see cref="Bass.Init(int, int, DeviceInitFlags, IntPtr, IntPtr)"/>.
@@ -298,7 +298,7 @@ namespace osu.Framework.Audio
             // ensure there are no brief delays on audio operations (causing stream STALLs etc.) after periods of silence.
             Bass.Configure(ManagedBass.Configuration.DevNonStop, true);
 
-            bool didInit = false;
+            bool didInit;
 
             lock (bass_init_lock)
             {
@@ -316,8 +316,6 @@ namespace osu.Framework.Audio
                     didInit = Bass.Init(device);
                 }
             }
-
-            var error2 = Bass.LastError;
 
             if (didInit)
                 thread.RegisterInitialisedDevice(device);

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -5,6 +5,7 @@ using osu.Framework.Statistics;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using ManagedBass;
 using osu.Framework.Audio;
 using osu.Framework.Development;
@@ -112,7 +113,7 @@ namespace osu.Framework.Threading
             // Safety net to ensure we have freed all devices before exiting.
             // This is mainly required for device-lost scenarios.
             // See https://github.com/ppy/osu-framework/pull/3378 for further discussion.
-            foreach (var d in initialised_devices)
+            foreach (var d in initialised_devices.ToArray())
                 FreeDevice(d);
         }
 


### PR DESCRIPTION
This is a speculative fix that should be mergeable if we want to get things back on track. Needs further investigation into whether this is expected behaviour on bass's end or not.

This fixes the case where:
- The user disconnects a device, causing the windows default to change to another existing device. They then reconnect their preferred device and windows switches back.
- The user disconnects a device, and it is the last available device (causing bass to enter virtual device mode). They then reconnect the device and it becomes available for use again.

Closes ppy/osu#12638.