### PR TITLE
Fix KeyBindingContainer using InputState to build combinations

### DIFF
--- a/osu.Framework.Tests/Input/KeyBindingInputTest.cs
+++ b/osu.Framework.Tests/Input/KeyBindingInputTest.cs
@@ -15,7 +15,7 @@ using osuTK.Input;
 namespace osu.Framework.Tests.Input
 {
     [HeadlessTest]
-    public class KeybindingInputTest : ManualInputManagerTestScene
+    public class KeyBindingInputTest : ManualInputManagerTestScene
     {
         /// <summary>
         /// Tests that if the current input queue is changed, drawables that originally handled <see cref="IKeyBindingHandler{T}.OnPressed"/>

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -5,13 +5,16 @@ using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Testing;
+using osuTK;
+using osuTK.Input;
 
 namespace osu.Framework.Tests.Visual.Input
 {
     [HeadlessTest]
-    public class TestSceneKeyBindingContainer : FrameworkTestScene
+    public class TestSceneKeyBindingContainer : ManualInputManagerTestScene
     {
         [Test]
         public void TestTriggerWithNoKeyBindings()
@@ -26,23 +29,104 @@ namespace osu.Framework.Tests.Visual.Input
                 pressedReceived = false;
                 releasedReceived = false;
 
-                Clear();
-
-                Add(keyBindingContainer = new TestKeyBindingContainer
+                Child = keyBindingContainer = new TestKeyBindingContainer
                 {
                     Child = new TestKeyBindingReceptor
                     {
                         Pressed = _ => pressedReceived = true,
                         Released = _ => releasedReceived = true
                     }
-                });
+                };
             });
 
-            AddStep("trigger press", () => keyBindingContainer.TriggerPressed(TestAction.Action1));
+            AddStep("trigger press", () => keyBindingContainer.TriggerPressed(TestAction.ActionA));
             AddAssert("press received", () => pressedReceived);
 
-            AddStep("trigger release", () => keyBindingContainer.TriggerReleased(TestAction.Action1));
+            AddStep("trigger release", () => keyBindingContainer.TriggerReleased(TestAction.ActionA));
             AddAssert("release received", () => releasedReceived);
+        }
+
+        [Test]
+        public void TestPressKeyBeforeKeyBindingContainerAdded()
+        {
+            List<TestAction> pressedActions = new List<TestAction>();
+            List<TestAction> releasedActions = new List<TestAction>();
+
+            AddStep("press key B", () => InputManager.PressKey(Key.B));
+
+            AddStep("add container", () =>
+            {
+                pressedActions.Clear();
+                releasedActions.Clear();
+
+                Child = new TestKeyBindingContainer
+                {
+                    Child = new TestKeyBindingReceptor
+                    {
+                        Pressed = a => pressedActions.Add(a),
+                        Released = a => releasedActions.Add(a)
+                    }
+                };
+            });
+
+            AddStep("press key A", () => InputManager.PressKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions.Count == 1);
+            AddAssert("ActionA triggered", () => pressedActions[0] == TestAction.ActionA);
+            AddAssert("no actions released", () => releasedActions.Count == 0);
+
+            AddStep("release key A", () => InputManager.ReleaseKey(Key.A));
+            AddAssert("only one action triggered", () => pressedActions.Count == 1);
+            AddAssert("only one action released", () => releasedActions.Count == 1);
+            AddAssert("ActionA released", () => releasedActions[0] == TestAction.ActionA);
+        }
+
+        [Test]
+        public void TestKeyHandledByOtherDrawableDoesNotTrigger()
+        {
+            List<TestAction> pressedActions = new List<TestAction>();
+            List<TestAction> releasedActions = new List<TestAction>();
+
+            TextBox textBox = null;
+
+            AddStep("add children", () =>
+            {
+                pressedActions.Clear();
+                releasedActions.Clear();
+
+                Child = new TestKeyBindingContainer
+                {
+                    Children = new Drawable[]
+                    {
+                        textBox = new BasicTextBox
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(200, 30)
+                        },
+                        new TestKeyBindingReceptor
+                        {
+                            Pressed = a => pressedActions.Add(a),
+                            Released = a => releasedActions.Add(a)
+                        }
+                    }
+                };
+            });
+
+            AddStep("focus textbox and move mouse away", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+                InputManager.MoveMouseTo(textBox, new Vector2(0, 100));
+            });
+
+            AddStep("press enter", () => InputManager.PressKey(Key.Enter));
+            AddStep("press mouse button", () => InputManager.PressButton(MouseButton.Left));
+
+            AddStep("release enter", () => InputManager.ReleaseKey(Key.Enter));
+            AddStep("release mouse button", () => InputManager.ReleaseButton(MouseButton.Left));
+
+            AddAssert("no pressed actions", () => pressedActions.Count == 0);
+            AddAssert("no released actions", () => releasedActions.Count == 0);
         }
 
         private class TestKeyBindingReceptor : Drawable, IKeyBindingHandler<TestAction>
@@ -69,12 +153,19 @@ namespace osu.Framework.Tests.Visual.Input
 
         private class TestKeyBindingContainer : KeyBindingContainer<TestAction>
         {
-            public override IEnumerable<IKeyBinding> DefaultKeyBindings => null;
+            public override IEnumerable<IKeyBinding> DefaultKeyBindings => new IKeyBinding[]
+            {
+                new KeyBinding(InputKey.A, TestAction.ActionA),
+                new KeyBinding(new KeyCombination(InputKey.A, InputKey.B), TestAction.ActionAB),
+                new KeyBinding(InputKey.Enter, TestAction.ActionEnter),
+            };
         }
 
         private enum TestAction
         {
-            Action1
+            ActionA,
+            ActionAB,
+            ActionEnter
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -150,12 +150,7 @@ namespace osu.Framework.Tests.Visual.Input
                 };
             });
 
-            AddStep("press lctrl+a", () =>
-            {
-                InputManager.PressKey(Key.LControl);
-                InputManager.PressKey(Key.A);
-            });
-
+            AddStep("press lctrl", () => InputManager.PressKey(Key.LControl));
             AddAssert("press received", () => pressedReceived);
 
             AddStep("reset variables", () =>

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -2,14 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
-using osu.Framework.Input.States;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osuTK;
@@ -100,17 +98,20 @@ namespace osu.Framework.Input.Bindings
             return true;
         }
 
+        /// <summary>
+        /// All input keys which are currently pressed and have reached this <see cref="KeyBindingContainer"/>.
+        /// </summary>
+        private readonly HashSet<InputKey> pressedInputKeys = new HashSet<InputKey>();
+
         protected override bool Handle(UIEvent e)
         {
-            var state = e.CurrentState;
-
             switch (e)
             {
                 case MouseDownEvent mouseDown:
-                    return handleNewPressed(state, KeyCombination.FromMouseButton(mouseDown.Button), false);
+                    return handleNewPressed(KeyCombination.FromMouseButton(mouseDown.Button), false);
 
                 case MouseUpEvent mouseUp:
-                    handleNewReleased(state, KeyCombination.FromMouseButton(mouseUp.Button));
+                    handleNewReleased(KeyCombination.FromMouseButton(mouseUp.Button));
                     return false;
 
                 case KeyDownEvent keyDown:
@@ -119,7 +120,7 @@ namespace osu.Framework.Input.Bindings
 
                     foreach (var key in KeyCombination.FromKey(keyDown.Key))
                     {
-                        if (handleNewPressed(state, key, keyDown.Repeat))
+                        if (handleNewPressed(key, keyDown.Repeat))
                             return true;
                     }
 
@@ -129,36 +130,36 @@ namespace osu.Framework.Input.Bindings
                     // this is releasing the common shift when a remaining shift is still held.
                     // ie. press LShift, press RShift, release RShift will result in InputKey.Shift being incorrectly released.
                     foreach (var key in KeyCombination.FromKey(keyUp.Key))
-                        handleNewReleased(state, key);
+                        handleNewReleased(key);
 
                     return false;
 
                 case JoystickPressEvent joystickPress:
-                    return handleNewPressed(state, KeyCombination.FromJoystickButton(joystickPress.Button), false);
+                    return handleNewPressed(KeyCombination.FromJoystickButton(joystickPress.Button), false);
 
                 case JoystickReleaseEvent joystickRelease:
-                    handleNewReleased(state, KeyCombination.FromJoystickButton(joystickRelease.Button));
+                    handleNewReleased(KeyCombination.FromJoystickButton(joystickRelease.Button));
                     return false;
 
                 case MidiDownEvent midiDown:
-                    return handleNewPressed(state, KeyCombination.FromMidiKey(midiDown.Key), false);
+                    return handleNewPressed(KeyCombination.FromMidiKey(midiDown.Key), false);
 
                 case MidiUpEvent midiUp:
-                    handleNewReleased(state, KeyCombination.FromMidiKey(midiUp.Key));
+                    handleNewReleased(KeyCombination.FromMidiKey(midiUp.Key));
                     return false;
 
                 case TabletPenButtonPressEvent tabletPenButtonPress:
-                    return handleNewPressed(state, KeyCombination.FromTabletPenButton(tabletPenButtonPress.Button), false);
+                    return handleNewPressed(KeyCombination.FromTabletPenButton(tabletPenButtonPress.Button), false);
 
                 case TabletPenButtonReleaseEvent tabletPenButtonRelease:
-                    handleNewReleased(state, KeyCombination.FromTabletPenButton(tabletPenButtonRelease.Button));
+                    handleNewReleased(KeyCombination.FromTabletPenButton(tabletPenButtonRelease.Button));
                     return false;
 
                 case TabletAuxiliaryButtonPressEvent tabletAuxiliaryButtonPress:
-                    return handleNewPressed(state, KeyCombination.FromTabletAuxiliaryButton(tabletAuxiliaryButtonPress.Button), false);
+                    return handleNewPressed(KeyCombination.FromTabletAuxiliaryButton(tabletAuxiliaryButtonPress.Button), false);
 
                 case TabletAuxiliaryButtonReleaseEvent tabletAuxiliaryButtonRelease:
-                    handleNewReleased(state, KeyCombination.FromTabletAuxiliaryButton(tabletAuxiliaryButtonRelease.Button));
+                    handleNewReleased(KeyCombination.FromTabletAuxiliaryButton(tabletAuxiliaryButtonRelease.Button));
                     return false;
 
                 case ScrollEvent scroll:
@@ -168,8 +169,8 @@ namespace osu.Framework.Input.Bindings
 
                     foreach (var key in keys)
                     {
-                        handled |= handleNewPressed(state, key, false, scroll.ScrollDelta, scroll.IsPrecise);
-                        handleNewReleased(state, key);
+                        handled |= handleNewPressed(key, false, scroll.ScrollDelta, scroll.IsPrecise);
+                        handleNewReleased(key);
                     }
 
                     return handled;
@@ -179,10 +180,12 @@ namespace osu.Framework.Input.Bindings
             return false;
         }
 
-        private bool handleNewPressed(InputState state, InputKey newKey, bool repeat, Vector2? scrollDelta = null, bool isPrecise = false)
+        private bool handleNewPressed(InputKey newKey, bool repeat, Vector2? scrollDelta = null, bool isPrecise = false)
         {
+            pressedInputKeys.Add(newKey);
+
             var scrollAmount = getScrollAmount(newKey, scrollDelta);
-            var pressedCombination = KeyCombination.FromInputState(state, scrollDelta);
+            var pressedCombination = new KeyCombination(pressedInputKeys);
 
             bool handled = false;
             var bindings = (repeat ? KeyBindings : KeyBindings?.Except(pressedBindings)) ?? Enumerable.Empty<IKeyBinding>();
@@ -291,14 +294,19 @@ namespace osu.Framework.Input.Bindings
             pressedActions.Clear();
         }
 
-        private void handleNewReleased(InputState state, InputKey releasedKey)
+        private void handleNewReleased(InputKey releasedKey)
         {
-            var pressedCombination = KeyCombination.FromInputState(state);
+            pressedInputKeys.Remove(releasedKey);
+
+            if (pressedBindings.Count == 0)
+                return;
 
             // we don't want to consider exact matching here as we are dealing with bindings, not actions.
-            var newlyReleased = pressedBindings.Where(b => !b.KeyCombination.IsPressed(pressedCombination, KeyCombinationMatchingMode.Any)).ToList();
+            var pressedCombination = new KeyCombination(pressedInputKeys);
 
-            Trace.Assert(newlyReleased.All(b => KeyCombination.ContainsKey(b.KeyCombination.Keys, releasedKey)));
+            var newlyReleased = pressedInputKeys.Count == 0
+                ? pressedBindings.ToList()
+                : pressedBindings.Where(b => !b.KeyCombination.IsPressed(pressedCombination, KeyCombinationMatchingMode.Any)).ToList();
 
             foreach (var binding in newlyReleased)
             {

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -124,10 +124,7 @@ namespace osu.Framework.Input.Bindings
                     return false;
 
                 case KeyUpEvent keyUp:
-                    // this is releasing the common shift when a remaining shift is still held.
-                    // ie. press LShift, press RShift, release RShift will result in InputKey.Shift being incorrectly released.
                     handleNewReleased(KeyCombination.FromKey(keyUp.Key));
-
                     return false;
 
                 case JoystickPressEvent joystickPress:

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -118,19 +118,15 @@ namespace osu.Framework.Input.Bindings
                     if (keyDown.Repeat && !SendRepeats)
                         return pressedBindings.Count > 0;
 
-                    foreach (var key in KeyCombination.FromKey(keyDown.Key))
-                    {
-                        if (handleNewPressed(key, keyDown.Repeat))
-                            return true;
-                    }
+                    if (handleNewPressed(KeyCombination.FromKey(keyDown.Key), keyDown.Repeat))
+                        return true;
 
                     return false;
 
                 case KeyUpEvent keyUp:
                     // this is releasing the common shift when a remaining shift is still held.
                     // ie. press LShift, press RShift, release RShift will result in InputKey.Shift being incorrectly released.
-                    foreach (var key in KeyCombination.FromKey(keyUp.Key))
-                        handleNewReleased(key);
+                    handleNewReleased(KeyCombination.FromKey(keyUp.Key));
 
                     return false;
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -549,21 +549,21 @@ namespace osu.Framework.Input.Bindings
         {
             switch (key)
             {
-                case Key.LShift: return new[] { InputKey.Shift, InputKey.LShift };
+                case Key.LShift: return new[] { InputKey.LShift, InputKey.Shift };
 
-                case Key.RShift: return new[] { InputKey.Shift, InputKey.RShift };
+                case Key.RShift: return new[] { InputKey.RShift, InputKey.Shift };
 
-                case Key.LControl: return new[] { InputKey.Control, InputKey.LControl };
+                case Key.LControl: return new[] { InputKey.LControl, InputKey.Control };
 
-                case Key.RControl: return new[] { InputKey.Control, InputKey.RControl };
+                case Key.RControl: return new[] { InputKey.RControl, InputKey.Control };
 
-                case Key.LAlt: return new[] { InputKey.Alt, InputKey.LAlt };
+                case Key.LAlt: return new[] { InputKey.LAlt, InputKey.Alt };
 
-                case Key.RAlt: return new[] { InputKey.Alt, InputKey.RAlt };
+                case Key.RAlt: return new[] { InputKey.RAlt, InputKey.Alt };
 
-                case Key.LWin: return new[] { InputKey.Super, InputKey.LSuper };
+                case Key.LWin: return new[] { InputKey.LSuper, InputKey.Super };
 
-                case Key.RWin: return new[] { InputKey.Super, InputKey.RSuper };
+                case Key.RWin: return new[] { InputKey.RSuper, InputKey.Super };
             }
 
             return new[] { (InputKey)key };

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -545,28 +545,28 @@ namespace osu.Framework.Input.Bindings
             }
         }
 
-        public static InputKey[] FromKey(Key key)
+        public static InputKey FromKey(Key key)
         {
             switch (key)
             {
-                case Key.LShift: return new[] { InputKey.LShift, InputKey.Shift };
+                case Key.LShift: return InputKey.LShift;
 
-                case Key.RShift: return new[] { InputKey.RShift, InputKey.Shift };
+                case Key.RShift: return InputKey.RShift;
 
-                case Key.LControl: return new[] { InputKey.LControl, InputKey.Control };
+                case Key.LControl: return InputKey.LControl;
 
-                case Key.RControl: return new[] { InputKey.RControl, InputKey.Control };
+                case Key.RControl: return InputKey.RControl;
 
-                case Key.LAlt: return new[] { InputKey.LAlt, InputKey.Alt };
+                case Key.LAlt: return InputKey.LAlt;
 
-                case Key.RAlt: return new[] { InputKey.RAlt, InputKey.Alt };
+                case Key.RAlt: return InputKey.RAlt;
 
-                case Key.LWin: return new[] { InputKey.LSuper, InputKey.Super };
+                case Key.LWin: return InputKey.LSuper;
 
-                case Key.RWin: return new[] { InputKey.RSuper, InputKey.Super };
+                case Key.RWin: return InputKey.RSuper;
             }
 
-            return new[] { (InputKey)key };
+            return (InputKey)key;
         }
 
         public static InputKey FromMouseButton(MouseButton button) => (InputKey)((int)InputKey.FirstMouseButton + button);
@@ -634,11 +634,10 @@ namespace osu.Framework.Input.Bindings
             {
                 foreach (var key in state.Keyboard.Keys)
                 {
-                    foreach (var iKey in FromKey(key))
-                    {
-                        if (!keys.Contains(iKey))
-                            keys.Add(iKey);
-                    }
+                    var iKey = FromKey(key);
+
+                    if (!keys.Contains(iKey))
+                        keys.Add(iKey);
                 }
             }
 

--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -91,9 +91,9 @@ namespace osu.Framework.Input.Bindings
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static bool ContainsAll(ImmutableArray<InputKey> candidateKey, ImmutableArray<InputKey> pressedKey, KeyCombinationMatchingMode matchingMode)
         {
-            // can be local function once attribute on local functions are implemented
-            // optimized to avoid allocation
-            // Usually Keys.Count <= 3. Does not worth special logic for Contains().
+            // first, check that all the candidate keys are contained in the provided pressed keys.
+            // regardless of the matching mode, every key needs to at least be present (matching modes only change
+            // the behaviour of excess keys).
             foreach (var key in candidateKey)
             {
                 if (!ContainsKey(pressedKey, key))
@@ -105,6 +105,7 @@ namespace osu.Framework.Input.Bindings
                 case KeyCombinationMatchingMode.Exact:
                     foreach (var key in pressedKey)
                     {
+                        // in exact matching mode, every pressed key needs to be in the candidate.
                         if (!ContainsKeyPermissive(candidateKey, key))
                             return false;
                     }
@@ -114,10 +115,15 @@ namespace osu.Framework.Input.Bindings
                 case KeyCombinationMatchingMode.Modifiers:
                     foreach (var key in pressedKey)
                     {
+                        // in modifiers match mode, the same check applies as exact but only for modifier keys.
                         if (IsModifierKey(key) && !ContainsKeyPermissive(candidateKey, key))
                             return false;
                     }
 
+                    break;
+
+                case KeyCombinationMatchingMode.Any:
+                    // any match mode needs no further checks.
                     break;
             }
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/12936

`KeyBindingContainer` previously built the key combination directly from the `InputState`, not caring whether the event which changed the state ever reached the KBC. I identified two issues as a result of this:
1. Triggers the wrong binding when the KBC becomes alive.
    1. The KBC has bindings `{ A, B }, { B }`.
    1. `A` is held down.
    2. The KBC becomes alive.
    3. The user presses `B`.
    4. The binding for combination `{ A, B }` is triggered when only the one for `{ B }` is expected.
2. Triggers when other `Drawable`s handled input.
    1. The KBC has a binding for `{ A }`.
    2. `A` is held down.
    3. Another `Drawable` in the hierarchy handling input before the KBC handles `A` (never reaches the KBC).
    4. The user presses `B`, which reaches the KBC.
    5. The KBC triggers the binding for `{ A }`.

Also, in (2) above, the trace assertion from `handleNewReleased` would trigger if `B` is released as `B` is not a part of the combination forming the binding. I believe the assertion is just incorrect as I previously mentioned in https://github.com/ppy/osu-framework/pull/4465, so just removed it.