### PR TITLE
Fix samples not reloading if loaded too early

### DIFF
--- a/osu.Framework.Tests/Audio/SampleBassInitTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassInitTest.cs
@@ -1,0 +1,93 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using ManagedBass;
+using NUnit.Framework;
+using osu.Framework.Audio.Sample;
+using osu.Framework.Development;
+using osu.Framework.IO.Stores;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Audio
+{
+    [TestFixture]
+    public class SampleBassInitTest
+    {
+        private DllResourceStore resources;
+        private SampleBassFactory sampleFactory;
+        private Sample sample;
+
+        [SetUp]
+        public void Setup()
+        {
+            try
+            {
+                // Make sure that the audio device is not initialised.
+                if (RuntimeInfo.OS != RuntimeInfo.Platform.Linux)
+                {
+                    Bass.CurrentDevice = 0;
+                    Bass.Free();
+                }
+            }
+            catch
+            {
+            }
+
+            resources = new DllResourceStore(typeof(TrackBassTest).Assembly);
+            sampleFactory = new SampleBassFactory(resources.Get("Resources.Tracks.sample-track.mp3"));
+            sample = sampleFactory.CreateSample();
+
+            updateSample();
+
+            Bass.Init(0);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            // See AudioThread.FreeDevice().
+            if (RuntimeInfo.OS != RuntimeInfo.Platform.Linux)
+                Bass.Free();
+        }
+
+        [Test]
+        public void TestSampleInitialisesOnUpdateDevice()
+        {
+            if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux)
+                Assert.Ignore("Test may be intermittent on linux (see AudioThread.FreeDevice()).");
+
+            Assert.That(sample.IsLoaded, Is.False);
+            runOnAudioThread(() => sampleFactory.UpdateDevice(0));
+            Assert.That(sample.IsLoaded, Is.True);
+        }
+
+        private void updateSample() => runOnAudioThread(() => sampleFactory.Update());
+
+        /// <summary>
+        /// Certain actions are invoked on the audio thread.
+        /// Here we simulate this process on a correctly named thread to avoid endless blocking.
+        /// </summary>
+        /// <param name="action">The action to perform.</param>
+        private void runOnAudioThread(Action action)
+        {
+            var resetEvent = new ManualResetEvent(false);
+
+            new Thread(() =>
+            {
+                ThreadSafety.IsAudioThread = true;
+
+                action();
+
+                resetEvent.Set();
+            })
+            {
+                Name = GameThread.PrefixedThreadNameFor("Audio")
+            }.Start();
+
+            if (!resetEvent.WaitOne(TimeSpan.FromSeconds(10)))
+                throw new TimeoutException();
+        }
+    }
+}

--- a/osu.Framework/Audio/Sample/SampleBassFactory.cs
+++ b/osu.Framework/Audio/Sample/SampleBassFactory.cs
@@ -1,10 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using ManagedBass;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.Platform;
 
 namespace osu.Framework.Audio.Sample
@@ -25,18 +29,14 @@ namespace osu.Framework.Audio.Sample
         /// </summary>
         internal readonly Bindable<int> PlaybackConcurrency = new Bindable<int>(Sample.DEFAULT_CONCURRENCY);
 
-        private NativeMemoryTracker.NativeMemoryLease memoryLease;
+        private NativeMemoryTracker.NativeMemoryLease? memoryLease;
+        private byte[]? data;
 
         public SampleBassFactory(byte[] data)
         {
-            if (data.Length > 0)
-            {
-                EnqueueAction(() =>
-                {
-                    SampleId = loadSample(data);
-                    memoryLease = NativeMemoryTracker.AddMemory(this, data.Length);
-                });
-            }
+            this.data = data;
+
+            EnqueueAction(loadSample);
 
             PlaybackConcurrency.BindValueChanged(updatePlaybackConcurrency);
         }
@@ -57,6 +57,10 @@ namespace osu.Framework.Audio.Sample
 
         internal override void UpdateDevice(int deviceIndex)
         {
+            // The sample may not have already loaded if a device wasn't present in a previous load attempt.
+            if (!IsLoaded)
+                loadSample();
+
             if (!IsLoaded)
                 return;
 
@@ -65,19 +69,31 @@ namespace osu.Framework.Audio.Sample
             BassUtils.CheckFaulted(true);
         }
 
-        private int loadSample(byte[] data)
+        private void loadSample()
         {
-            int handle = getSampleHandle(data);
-            Length = Bass.ChannelBytes2Seconds(handle, data.Length) * 1000;
-            return handle;
-        }
+            Debug.Assert(ThreadSafety.IsAudioThread);
+            Debug.Assert(!IsLoaded);
 
-        private int getSampleHandle(byte[] data)
-        {
+            if (data == null)
+                return;
+
+            int dataLength = data.Length;
+
             const BassFlags flags = BassFlags.Default | BassFlags.SampleOverrideLongestPlaying;
-
             using (var handle = new ObjectHandle<byte[]>(data, GCHandleType.Pinned))
-                return Bass.SampleLoad(handle.Address, 0, data.Length, PlaybackConcurrency.Value, flags);
+                SampleId = Bass.SampleLoad(handle.Address, 0, dataLength, PlaybackConcurrency.Value, flags);
+
+            if (Bass.LastError == Errors.Init)
+                return;
+
+            // We've done as best as we could to init the sample. It may still have failed by some other cause (such as malformed data), but allow the GC to now clean up the locally-stored data.
+            data = null;
+
+            if (!IsLoaded)
+                return;
+
+            Length = Bass.ChannelBytes2Seconds(SampleId, dataLength) * 1000;
+            memoryLease = NativeMemoryTracker.AddMemory(this, dataLength);
         }
 
         public Sample CreateSample() => new SampleBass(this) { OnPlay = onPlay };

--- a/osu.Framework/Audio/Sample/SampleBassFactory.cs
+++ b/osu.Framework/Audio/Sample/SampleBassFactory.cs
@@ -8,7 +8,6 @@ using System.Runtime.InteropServices;
 using ManagedBass;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Development;
 using osu.Framework.Platform;
 
 namespace osu.Framework.Audio.Sample

--- a/osu.Framework/Audio/Sample/SampleBassFactory.cs
+++ b/osu.Framework/Audio/Sample/SampleBassFactory.cs
@@ -71,7 +71,7 @@ namespace osu.Framework.Audio.Sample
 
         private void loadSample()
         {
-            Debug.Assert(ThreadSafety.IsAudioThread);
+            Debug.Assert(CanPerformInline);
             Debug.Assert(!IsLoaded);
 
             if (data == null)


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/13266

If samples are loaded before `Bass.Init()`, `SampleLoad` fails with `Errors.Init`. In this case, and only this case, I want to reload the sample when a device is received afterwards.

I've added some safeguards in the hopes that it won't, but if the test fails intermittently then I can't see a good way to test this other than to ignore the test.