### PR TITLE
Fix `MarkdownContainer` not translating relative URLs correctly on android/iOS

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -3,3 +3,4 @@ M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Us
 M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
 M:System.Enum.HasFlag(System.Enum);Use osu.Framework.Extensions.EnumExtensions.HasFlagFast<T>() instead.
+F:System.UriKind.RelativeOrAbsolute;Incompatible results when run on mono, see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -178,14 +178,14 @@ namespace osu.Framework.Graphics.Containers.Markdown
                         continue;
 
                     // Can't use Uri.TryCreate with RelativeOrAbsolute, see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/.
-                    bool isRelative = url.StartsWith('/');
+                    bool isAbsolute = url.Contains("://");
 
-                    if (!isRelative)
+                    if (isAbsolute)
                         continue;
 
                     if (documentUri != null)
                     {
-                        link.Url = rootUri != null
+                        link.Url = rootUri != null && url.StartsWith('/')
                             // Ensure the URI is document-relative by removing all trailing slashes
                             ? new Uri(rootUri, new Uri(url.TrimStart('/'), UriKind.Relative)).AbsoluteUri
                             : new Uri(documentUri, new Uri(url, UriKind.Relative)).AbsoluteUri;

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -172,21 +172,23 @@ namespace osu.Framework.Graphics.Containers.Markdown
                 // Turn all relative URIs in the document into absolute URIs
                 foreach (var link in parsed.Descendants().OfType<LinkInline>())
                 {
-                    if (!Uri.TryCreate(link.Url, UriKind.RelativeOrAbsolute, out Uri linkUri))
+                    string url = link.Url;
+
+                    if (string.IsNullOrEmpty(url))
                         continue;
 
-                    if (linkUri.IsAbsoluteUri)
+                    // Can't use Uri.TryCreate with RelativeOrAbsolute, see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/.
+                    bool isRelative = url.StartsWith('/');
+
+                    if (!isRelative)
                         continue;
 
                     if (documentUri != null)
                     {
-                        if (rootUri != null && link.Url?.StartsWith('/') == true)
-                        {
+                        link.Url = rootUri != null
                             // Ensure the URI is document-relative by removing all trailing slashes
-                            link.Url = new Uri(rootUri, new Uri(link.Url.TrimStart('/'), UriKind.Relative)).AbsoluteUri;
-                        }
-                        else
-                            link.Url = new Uri(documentUri, linkUri).AbsoluteUri;
+                            ? new Uri(rootUri, new Uri(url.TrimStart('/'), UriKind.Relative)).AbsoluteUri
+                            : new Uri(documentUri, new Uri(url, UriKind.Relative)).AbsoluteUri;
                     }
                 }
 


### PR DESCRIPTION
Closes ppy/osu#13309.