### PR TITLE
Fix inability to backspace text after typing shifted characters

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -258,6 +258,49 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestBackspaceWhileShifted()
+        {
+            InsertableTextBox textBox = null;
+
+            AddStep("add textbox", () =>
+            {
+                textBoxes.Add(textBox = new InsertableTextBox
+                {
+                    Size = new Vector2(200, 40),
+                });
+            });
+
+            AddStep("click on textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("type character", () =>
+            {
+                // tests don't actually send consumable text, but this important part is that we fire the key event to begin consuming.
+                InputManager.Key(Key.A);
+                textBox.Text += "a";
+            });
+
+            AddStep("backspace character", () => InputManager.Key(Key.BackSpace));
+            AddAssert("character removed", () => textBox.Text == string.Empty);
+
+            AddStep("shift down", () => InputManager.PressKey(Key.ShiftLeft));
+
+            AddStep("type character", () =>
+            {
+                InputManager.Key(Key.A);
+                textBox.Text += "A";
+            });
+
+            AddStep("backspace character", () => InputManager.Key(Key.BackSpace));
+            AddAssert("character removed", () => textBox.Text == string.Empty);
+
+            AddStep("shift up", () => InputManager.ReleaseKey(Key.ShiftLeft));
+        }
+
+        [Test]
         public void TestPreviousWordDeletion()
         {
             InsertableTextBox textBox = null;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -721,6 +721,11 @@ namespace osu.Framework.Graphics.UserInterface
                 case Key.Enter:
                     Commit();
                     return true;
+
+                // avoid blocking certain keys which may be used during typing but don't produce characters.
+                case Key.BackSpace:
+                case Key.Delete:
+                    return false;
             }
 
             return base.OnKeyDown(e) || consumingText;


### PR DESCRIPTION
I've implemented this in a way which is least likely to break anything.

- [x] Depends on https://github.com/ppy/osu-framework/pull/4484.

Closes https://github.com/ppy/osu/issues/12964.