### PR TITLE
Avoid changing windows time period when focus changes

### DIFF
--- a/osu.Framework/Platform/Windows/TimePeriod.cs
+++ b/osu.Framework/Platform/Windows/TimePeriod.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Platform.Windows
 
             try
             {
-                didAdjust = 0 == timeBeginPeriod(Math.Clamp(period, MinimumPeriod, MaximumPeriod));
+                didAdjust = timeBeginPeriod(Math.Clamp(period, MinimumPeriod, MaximumPeriod)) == 0;
             }
             catch { }
         }

--- a/osu.Framework/Platform/Windows/TimePeriod.cs
+++ b/osu.Framework/Platform/Windows/TimePeriod.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Platform.Windows
         internal static int MinimumPeriod => time_capabilities.wPeriodMin;
         internal static int MaximumPeriod => time_capabilities.wPeriodMax;
 
-        private bool canAdjust = MaximumPeriod > 0;
+        private readonly bool didAdjust;
 
         static TimePeriod()
         {
@@ -37,34 +37,15 @@ namespace osu.Framework.Platform.Windows
         internal TimePeriod(int period)
         {
             this.period = period;
-        }
 
-        private bool active;
+            if (MaximumPeriod <= 0)
+                return;
 
-        internal bool Active
-        {
-            get => active;
-            set
+            try
             {
-                if (value == active || !canAdjust) return;
-
-                active = value;
-
-                try
-                {
-                    if (active)
-                    {
-                        canAdjust &= 0 == timeBeginPeriod(Math.Clamp(period, MinimumPeriod, MaximumPeriod));
-                    }
-                    else
-                    {
-                        timeEndPeriod(period);
-                    }
-                }
-                catch
-                {
-                }
+                didAdjust = 0 == timeBeginPeriod(Math.Clamp(period, MinimumPeriod, MaximumPeriod));
             }
+            catch { }
         }
 
         #region IDisposable Support
@@ -75,8 +56,16 @@ namespace osu.Framework.Platform.Windows
         {
             if (!disposedValue)
             {
-                Active = false;
                 disposedValue = true;
+
+                if (!didAdjust)
+                    return;
+
+                try
+                {
+                    timeEndPeriod(period);
+                }
+                catch { }
             }
         }
 

--- a/osu.Framework/Platform/Windows/TimePeriod.cs
+++ b/osu.Framework/Platform/Windows/TimePeriod.cs
@@ -39,34 +39,6 @@ namespace osu.Framework.Platform.Windows
             this.period = period;
         }
 
-        private bool active;
-
-        internal bool Active
-        {
-            get => active;
-            set
-            {
-                if (value == active || !canAdjust) return;
-
-                active = value;
-
-                try
-                {
-                    if (active)
-                    {
-                        canAdjust &= 0 == timeBeginPeriod(Math.Clamp(period, MinimumPeriod, MaximumPeriod));
-                    }
-                    else
-                    {
-                        timeEndPeriod(period);
-                    }
-                }
-                catch
-                {
-                }
-            }
-        }
-
         #region IDisposable Support
 
         private bool disposedValue; // To detect redundant calls
@@ -75,7 +47,6 @@ namespace osu.Framework.Platform.Windows
         {
             if (!disposedValue)
             {
-                Active = false;
                 disposedValue = true;
             }
         }

--- a/osu.Framework/Platform/Windows/TimePeriod.cs
+++ b/osu.Framework/Platform/Windows/TimePeriod.cs
@@ -39,6 +39,34 @@ namespace osu.Framework.Platform.Windows
             this.period = period;
         }
 
+        private bool active;
+
+        internal bool Active
+        {
+            get => active;
+            set
+            {
+                if (value == active || !canAdjust) return;
+
+                active = value;
+
+                try
+                {
+                    if (active)
+                    {
+                        canAdjust &= 0 == timeBeginPeriod(Math.Clamp(period, MinimumPeriod, MaximumPeriod));
+                    }
+                    else
+                    {
+                        timeEndPeriod(period);
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+
         #region IDisposable Support
 
         private bool disposedValue; // To detect redundant calls
@@ -47,6 +75,7 @@ namespace osu.Framework.Platform.Windows
         {
             if (!disposedValue)
             {
+                Active = false;
                 disposedValue = true;
             }
         }

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Platform.Windows
             // OnActivate / OnDeactivate may not fire, so the initial activity state may be unknown here.
             // In order to be certain we have the correct activity state we are querying the Windows API here.
 
-            timePeriod = new TimePeriod(1) { Active = true };
+            timePeriod = new TimePeriod(1);
         }
 
         protected override IWindow CreateWindow() => new WindowsWindow();
@@ -77,16 +77,12 @@ namespace osu.Framework.Platform.Windows
 
         protected override void OnActivated()
         {
-            timePeriod.Active = true;
-
             Execution.SetThreadExecutionState(Execution.ExecutionState.Continuous | Execution.ExecutionState.SystemRequired | Execution.ExecutionState.DisplayRequired);
             base.OnActivated();
         }
 
         protected override void OnDeactivated()
         {
-            timePeriod.Active = false;
-
             Execution.SetThreadExecutionState(Execution.ExecutionState.Continuous);
             base.OnDeactivated();
         }

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Platform.Windows
             // OnActivate / OnDeactivate may not fire, so the initial activity state may be unknown here.
             // In order to be certain we have the correct activity state we are querying the Windows API here.
 
-            timePeriod = new TimePeriod(1);
+            timePeriod = new TimePeriod(1) { Active = true };
         }
 
         protected override IWindow CreateWindow() => new WindowsWindow();
@@ -77,12 +77,16 @@ namespace osu.Framework.Platform.Windows
 
         protected override void OnActivated()
         {
+            timePeriod.Active = true;
+
             Execution.SetThreadExecutionState(Execution.ExecutionState.Continuous | Execution.ExecutionState.SystemRequired | Execution.ExecutionState.DisplayRequired);
             base.OnActivated();
         }
 
         protected override void OnDeactivated()
         {
+            timePeriod.Active = false;
+
             Execution.SetThreadExecutionState(Execution.ExecutionState.Continuous);
             base.OnDeactivated();
         }


### PR DESCRIPTION
In an attempt to figure out what is causing https://github.com/ppy/osu/issues/12702 we looked at all the operations we are performing on window active state change. This is the one that stood out the most.

Since this is a hard one to reproduce (does not affect all users), just going to get this out for user testing. Thinking about it, this could only be affecting users that have no other applications system-wide requesting a time period elevation. In general this is pretty rare as even Chrome will request it.

For reference, we don't do this in stable, and there is little reason to reset it on active state change (although it may be something we would consider if the game is ever minimising to system tray and expected to use zero resources).