### PR TITLE
Fix Markdown container crashing on absolute URIs with no authority part

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -3,4 +3,4 @@ M:System.Object.Equals(System.Object)~System.Boolean;Don't use object.Equals. Us
 M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(Fallbacks to ValueType). Use IEquatable<T> or EqualityComparer<T>.Default instead.
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
 M:System.Enum.HasFlag(System.Enum);Use osu.Framework.Extensions.EnumExtensions.HasFlagFast<T>() instead.
-F:System.UriKind.RelativeOrAbsolute;Incompatible results when run on mono, see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/
+F:System.UriKind.RelativeOrAbsolute;Incompatible results when run on mono (see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/). Use Validation.TryParseUri(string, out Uri?) instead.

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
@@ -277,6 +277,19 @@ soft break with '\'";
             AddAssert("has correct link", () => markdownContainer.Links[0].Url == "https://some.test.url/file");
         }
 
+        [Test]
+        public void TestAbsoluteLinkWithDifferentScheme()
+        {
+            AddStep("set content", () =>
+            {
+                markdownContainer.DocumentUrl = "https://some.test.url/some/path/2";
+                markdownContainer.RootUrl = "https://some.test.url/some/";
+                markdownContainer.Text = "[link](mailto:contact@ppy.sh)";
+            });
+
+            AddAssert("has correct link", () => markdownContainer.Links[0].Url == "mailto:contact@ppy.sh");
+        }
+
         private class TestMarkdownContainer : MarkdownContainer
         {
             public new string DocumentUrl

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -12,6 +12,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Caching;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Utils;
 using osuTK;
 
 namespace osu.Framework.Graphics.Containers.Markdown
@@ -177,10 +178,10 @@ namespace osu.Framework.Graphics.Containers.Markdown
                     if (string.IsNullOrEmpty(url))
                         continue;
 
-                    // Can't use Uri.TryCreate with RelativeOrAbsolute, see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/.
-                    bool isAbsolute = url.Contains("://");
+                    if (!Validation.TryParseUri(url, out Uri linkUri))
+                        continue;
 
-                    if (isAbsolute)
+                    if (linkUri.IsAbsoluteUri)
                         continue;
 
                     if (documentUri != null)

--- a/osu.Framework/Utils/Validation.cs
+++ b/osu.Framework/Utils/Validation.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Utils
         public static bool TryParseUri(string uriString, [NotNullWhen(true)] out Uri? result)
         {
 #pragma warning disable RS0030 // Bypassing banned API check, as it'll actually be used properly here
-            UriKind kind = uriString.StartsWith("/", StringComparison.Ordinal) ? UriKind.Relative : UriKind.RelativeOrAbsolute;
+            UriKind kind = uriString.StartsWith('/') ? UriKind.Relative : UriKind.RelativeOrAbsolute;
 #pragma warning restore RS0030
             return Uri.TryCreate(uriString, kind, out result);
         }

--- a/osu.Framework/Utils/Validation.cs
+++ b/osu.Framework/Utils/Validation.cs
@@ -1,8 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Diagnostics.CodeAnalysis;
 using osuTK;
 using osu.Framework.Graphics;
+
+#nullable enable
 
 namespace osu.Framework.Utils
 {
@@ -23,5 +27,26 @@ namespace osu.Framework.Utils
         /// <param name="toCheck">The <see cref="MarginPadding"/> to check.</param>
         /// <returns>False if either component of <paramref name="toCheck"/> are Infinity or NaN, true otherwise. </returns>
         public static bool IsFinite(MarginPadding toCheck) => float.IsFinite(toCheck.Top) && float.IsFinite(toCheck.Bottom) && float.IsFinite(toCheck.Left) && float.IsFinite(toCheck.Right);
+
+        /// <summary>
+        /// Attempts to parse <paramref name="uriString"/> as an absolute or relative <see cref="Uri"/> in a platform-agnostic manner.
+        /// </summary>
+        /// <remarks>
+        /// This method is a workaround for inconsistencies across .NET and mono runtimes;
+        /// on mono runtimes paths starting with <c>/</c> are considered absolute as per POSIX,
+        /// and on .NET such paths are considered to be relative.
+        /// This method uses the .NET behaviour.
+        /// For more info, see <a href="https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/">Mono documentation</a>.
+        /// </remarks>
+        /// <param name="uriString">The string representation of the URI to parse.</param>
+        /// <param name="result">The resultant parsed URI, if parsing succeeded.</param>
+        /// <returns><see langword="true"/> if parsing succeeded; <see langword="false"/> otherwise.</returns>
+        public static bool TryParseUri(string uriString, [NotNullWhen(true)] out Uri? result)
+        {
+#pragma warning disable RS0030 // Bypassing banned API check, as it'll actually be used properly here
+            UriKind kind = uriString.StartsWith("/", StringComparison.Ordinal) ? UriKind.Relative : UriKind.RelativeOrAbsolute;
+#pragma warning restore RS0030
+            return Uri.TryCreate(uriString, kind, out result);
+        }
     }
 }


### PR DESCRIPTION
...Which means URIs with a colon after the scheme name but no following double-slashes, and is basically an euphemism for `mailto:` URIs. I can't really imagine ever hitting a case of this with another URL scheme.

Fixed by applying [the first workaround listed in mono docs](https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/) more directly. I have tested on Android to confirm that doing so does not regress #4483, and it seems that it doesn't, but may be safer to double-check iOS, too.

Unsure of the placement of the new method, but `Validation` as an existing static class seemed fitting enough.

Closes https://github.com/ppy/osu/issues/13386.