### PR TITLE
Avoid overwriting user configuration locale when falling back to a default locale

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -38,6 +38,23 @@ namespace osu.Framework.Tests.Localisation
         }
 
         [Test]
+        public void TestConfigSettingRetainedWhenAddingNewLanguage()
+        {
+            config.SetValue(FrameworkSetting.Locale, "ja-JP");
+
+            // ensure that adding a new language which doesn't match the user's choice doesn't cause the configuration value to get reset.
+            manager.AddLanguage("po", new FakeStorage("po-OP"));
+            Assert.AreEqual("ja-JP", config.Get<string>(FrameworkSetting.Locale));
+
+            var localisedText = manager.GetLocalisedString(new TranslatableString(FakeStorage.LOCALISABLE_STRING_EN, FakeStorage.LOCALISABLE_STRING_EN));
+            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_EN, localisedText.Value);
+
+            // ensure that if the user's selection is added in a further AddLanguage call, the manager correctly translates strings.
+            manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
+            Assert.AreEqual(FakeStorage.LOCALISABLE_STRING_JA_JP, localisedText.Value);
+        }
+
+        [Test]
         public void TestNotLocalised()
         {
             manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -40,16 +40,16 @@ namespace osu.Framework.Localisation
         [NotNull]
         public ILocalisedBindableString GetLocalisedString(LocalisableString original) => new LocalisedBindableString(original, currentStorage, preferUnicode);
 
-        private void updateLocale(ValueChangedEvent<string> args)
+        private void updateLocale(ValueChangedEvent<string> locale)
         {
             if (locales.Count == 0)
                 return;
 
-            var validLocale = locales.Find(l => l.Name == args.NewValue);
+            var validLocale = locales.Find(l => l.Name == locale.NewValue);
 
             if (validLocale == null)
             {
-                var culture = string.IsNullOrEmpty(args.NewValue) ? CultureInfo.CurrentCulture : new CultureInfo(args.NewValue);
+                var culture = string.IsNullOrEmpty(locale.NewValue) ? CultureInfo.CurrentCulture : new CultureInfo(locale.NewValue);
 
                 for (var c = culture; !EqualityComparer<CultureInfo>.Default.Equals(c, CultureInfo.InvariantCulture); c = c.Parent)
                 {
@@ -61,10 +61,7 @@ namespace osu.Framework.Localisation
                 validLocale ??= locales[0];
             }
 
-            if (validLocale.Name != args.NewValue)
-                configLocale.Value = validLocale.Name;
-            else
-                currentStorage.Value = validLocale.Storage;
+            currentStorage.Value = validLocale.Storage;
         }
 
         private class LocaleMapping


### PR DESCRIPTION
During initialisation, it may be that locales are added in an order which means the user's selected locale is not immediately present. This ensures that the configuration setting is never modified by `LocalisationManager`, so even if we are still firing many `TriggerChange` events, they will eventually end in the correct state.

Not sure if there's a better way to avoid firing so many events, but I don't think it's of immediate concern as this is generally early in startup, before many strings would be consuming the manager. We may want to consider exposing an `AddLanguages` method or something, though.

Closes https://github.com/ppy/osu/issues/13383.