### PR TITLE
Improve safety of `GameThread.Running` (and make `GameThread.Start` blocking)

### DIFF
--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -111,8 +111,6 @@ namespace osu.Framework.Threading
             Debug.Assert(Thread == null);
             Debug.Assert(!Running);
 
-            Running = true;
-
             Thread = new Thread(runWork)
             {
                 Name = PrefixedThreadNameFor(Name),
@@ -131,6 +129,8 @@ namespace osu.Framework.Threading
 
         private void runWork()
         {
+            Running = true;
+
             try
             {
                 Initialize(true);
@@ -254,6 +254,9 @@ namespace osu.Framework.Threading
             }
 
             Thread.Start();
+
+            while (!Running)
+                Thread.Sleep(1);
         }
 
         protected virtual void PerformExit()

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.Threading
 
         public static string PrefixedThreadNameFor(string name) => $"{nameof(GameThread)}.{name}";
 
-        public bool Running => Thread?.IsAlive == true;
+        public bool Running { get; private set; }
 
         public virtual bool IsCurrent => true;
 
@@ -109,6 +109,9 @@ namespace osu.Framework.Threading
         private void createThread()
         {
             Debug.Assert(Thread == null);
+            Debug.Assert(!Running);
+
+            Running = true;
 
             Thread = new Thread(runWork)
             {
@@ -234,6 +237,7 @@ namespace osu.Framework.Threading
 
         protected virtual void Cleanup()
         {
+            Running = false;
             Thread = null;
         }
 


### PR DESCRIPTION
Noticed in passing that there's a potential for failure with the way this flag is handled: the thread could be `!IsAlive` for a brief moment before it is nulled. Calls to `Start` are checking for null, which may result in an invalid operation if the previous thread had not been nulled out yet.

https://github.com/ppy/osu-framework/blob/7d10a151ae4230e595fa912f64bb16761e9b48f1/osu.Framework/Threading/GameThread.cs#L250-L254

I have not reproduced this one, nor was it reproduced anywhere. Just seemed a bit dodgy..

This also makes `GameThread.Start` blocking, to give it symmetry with `GameThread.Pause` (which blocks in a similar fashion).