### PR TITLE
Rename CI run-annotating workflow to explain its purpose better

### DIFF
--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -2,14 +2,15 @@
 # See:
 #   * https://github.com/dorny/test-reporter#recommended-setup-for-public-repositories
 #   * https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token
-name: "Test Report"
+name: Annotate CI run with test results
 on:
   workflow_run:
     workflows: ["Continuous Integration"]
     types:
       - completed
 jobs:
-  report:
+  annotate:
+    name: Annotate CI run with test results
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     strategy:
@@ -21,7 +22,7 @@ jobs:
             - { prettyname: Linux }
           threadingMode: ['SingleThread', 'MultiThreaded']
     steps:
-      - name: Continuous Integration Test Report
+      - name: Annotate CI run with test results
         uses: dorny/test-reporter@v1.4.2
         with:
           artifact: osu-framework-test-results-${{matrix.os.prettyname}}-${{matrix.threadingMode}}


### PR DESCRIPTION
Just a simple rename of the run-annotating workflow to reduce the WTF factor when browsing the [actions view](https://github.com/ppy/osu-framework/actions). The "Test Report" items look like they should contain test results by their name, but they have no such thing and the main CI check run is actually the one to look at.

In general there is a filter view there too that also helps some:

![2021-06-10-110415_402x355_scrot](https://user-images.githubusercontent.com/20418176/121497336-9f25af80-c9db-11eb-9609-bfe36a046d91.png)

but I don't believe it is possible to filter these annotation runs out to not show on the list by default.