### PR TITLE
Add extra safety over thread start/pause logic

### DIFF
--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -225,16 +225,12 @@ namespace osu.Framework.Threading
 
         public void Pause()
         {
-            if (Thread != null)
-            {
-                paused = true;
-                while (Running)
-                    Thread.Sleep(1);
-            }
-            else
-            {
-                Cleanup();
-            }
+            if (Thread == null)
+                return;
+
+            paused = true;
+            while (Running)
+                Thread.Sleep(1);
         }
 
         protected virtual void Cleanup()
@@ -253,13 +249,10 @@ namespace osu.Framework.Threading
             lock (startStopLock)
             {
                 paused = false;
-                Debug.Assert(Thread == null);
 
-                if (Thread == null)
-                {
-                    createThread();
-                    Debug.Assert(Thread != null);
-                }
+                Debug.Assert(Thread == null);
+                createThread();
+                Debug.Assert(Thread != null);
 
                 Thread.Start();
 

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -242,8 +242,11 @@ namespace osu.Framework.Threading
 
         protected virtual void Cleanup()
         {
-            Thread = null;
-            Running = false;
+            lock (startStopLock)
+            {
+                Thread = null;
+                Running = false;
+            }
         }
 
         public void Exit() => exitRequested = true;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -237,8 +237,8 @@ namespace osu.Framework.Threading
 
         protected virtual void Cleanup()
         {
-            Running = false;
             Thread = null;
+            Running = false;
         }
 
         public void Exit() => exitRequested = true;

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -225,18 +225,15 @@ namespace osu.Framework.Threading
 
         public void Pause()
         {
-            lock (startStopLock)
+            if (Thread != null)
             {
-                if (Thread != null)
-                {
-                    paused = true;
-                    while (Running)
-                        Thread.Sleep(1);
-                }
-                else
-                {
-                    Cleanup();
-                }
+                paused = true;
+                while (Running)
+                    Thread.Sleep(1);
+            }
+            else
+            {
+                Cleanup();
             }
         }
 


### PR DESCRIPTION
Hopefully covers remaining test failure issues. The main resolution here is ensuring that `Thread` is `null` before `Running` is updated, but the lock has been added for extra safety, as we should never be starting/pausing a `GameThread` from different threads concurrently.