### PR TITLE
Add hex colour picker

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneHexColourPicker.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneHexColourPicker.cs
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Linq;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual.UserInterface
+{
+    public class TestSceneHexColourPicker : FrameworkTestScene
+    {
+        private TestHexColourPicker hexColourPicker;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("create picker", () => Child = hexColourPicker = new TestHexColourPicker());
+        }
+
+        private class TestHexColourPicker : BasicHexColourPicker
+        {
+            public TextBox HexCodeTextBox => this.ChildrenOfType<TextBox>().Single();
+            public ColourPreview Preview => this.ChildrenOfType<ColourPreview>().Single();
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneHexColourPicker.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneHexColourPicker.cs
@@ -2,20 +2,106 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Testing;
+using osuTK;
+using osuTK.Input;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
-    public class TestSceneHexColourPicker : FrameworkTestScene
+    public class TestSceneHexColourPicker : ManualInputManagerTestScene
     {
         private TestHexColourPicker hexColourPicker;
+        private SpriteText currentText;
+        private Box currentPreview;
 
         [SetUpSteps]
         public void SetUpSteps()
         {
-            AddStep("create picker", () => Child = hexColourPicker = new TestHexColourPicker());
+            AddStep("create content", () =>
+            {
+                Child = new FillFlowContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Spacing = new Vector2(0, 10),
+                    Children = new Drawable[]
+                    {
+                        hexColourPicker = new TestHexColourPicker(),
+                        new FillFlowContainer
+                        {
+                            RelativeSizeAxes = Axes.X,
+                            AutoSizeAxes = Axes.Y,
+                            Direction = FillDirection.Horizontal,
+                            Spacing = new Vector2(10, 0),
+                            Children = new Drawable[]
+                            {
+                                currentText = new SpriteText(),
+                                new Container
+                                {
+                                    Width = 50,
+                                    RelativeSizeAxes = Axes.Y,
+                                    Child = currentPreview = new Box
+                                    {
+                                        RelativeSizeAxes = Axes.Both
+                                    }
+                                }
+                            }
+                        }
+                    }
+                };
+
+                hexColourPicker.Current.BindValueChanged(colour =>
+                {
+                    currentText.Text = $"Current.Value = {colour.NewValue.ToHex()}";
+                    currentPreview.Colour = colour.NewValue;
+                }, true);
+            });
         }
+
+        [Test]
+        public void TestExternalChange()
+        {
+            Colour4 colour = Colour4.Yellow;
+
+            AddStep("set current colour", () => hexColourPicker.Current.Value = colour);
+
+            AddAssert("hex code updated", () => hexColourPicker.HexCodeTextBox.Text == colour.ToHex());
+            assertPreviewUpdated(colour);
+        }
+
+        [Test]
+        public void TestTextBoxBehaviour()
+        {
+            clickTextBox();
+            AddStep("insert valid colour", () => hexColourPicker.HexCodeTextBox.Text = "#ff00ff");
+            assertPreviewUpdated(Colour4.Magenta);
+            AddAssert("current not changed yet", () => hexColourPicker.Current.Value == Colour4.White);
+
+            AddStep("commit text", () => InputManager.Key(Key.Enter));
+            AddAssert("current updated", () => hexColourPicker.Current.Value == Colour4.Magenta);
+
+            clickTextBox();
+            AddStep("insert invalid colour", () => hexColourPicker.HexCodeTextBox.Text = "c0d0");
+            AddStep("commit text", () => InputManager.Key(Key.Enter));
+            AddAssert("current not changed", () => hexColourPicker.Current.Value == Colour4.Magenta);
+            AddAssert("old hex code restored", () => hexColourPicker.HexCodeTextBox.Text == "#FF00FF");
+        }
+
+        private void clickTextBox()
+            => AddStep("click text box", () =>
+            {
+                InputManager.MoveMouseTo(hexColourPicker.HexCodeTextBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+        private void assertPreviewUpdated(Colour4 expected)
+            => AddAssert("preview colour updated", () => hexColourPicker.Preview.Current.Value == expected);
 
         private class TestHexColourPicker : BasicHexColourPicker
         {

--- a/osu.Framework/Graphics/UserInterface/BasicHexColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicHexColourPicker.cs
@@ -1,0 +1,50 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Framework.Graphics.UserInterface
+{
+    public class BasicHexColourPicker : HexColourPicker
+    {
+        public BasicHexColourPicker()
+        {
+            Background.Colour = FrameworkColour.GreenDarker;
+
+            Padding = new MarginPadding(20);
+            Spacing = 10;
+        }
+
+        protected override TextBox CreateHexCodeTextBox() => new BasicTextBox
+        {
+            Height = 40
+        };
+
+        protected override ColourPreview CreateColourPreview() => new BasicColourPreview();
+
+        private class BasicColourPreview : ColourPreview
+        {
+            private readonly Box previewBox;
+
+            public BasicColourPreview()
+            {
+                InternalChild = previewBox = new Box
+                {
+                    RelativeSizeAxes = Axes.Both
+                };
+            }
+
+            protected override void LoadComplete()
+            {
+                base.LoadComplete();
+
+                Current.BindValueChanged(_ => updatePreview());
+            }
+
+            private void updatePreview()
+            {
+                previewBox.Colour = Current.Value;
+            }
+        }
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/BasicHexColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicHexColourPicker.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 base.LoadComplete();
 
-                Current.BindValueChanged(_ => updatePreview());
+                Current.BindValueChanged(_ => updatePreview(), true);
             }
 
             private void updatePreview()

--- a/osu.Framework/Graphics/UserInterface/HexColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/HexColourPicker.cs
@@ -1,0 +1,76 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Bindables;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Framework.Graphics.UserInterface
+{
+    public abstract class HexColourPicker : CompositeDrawable, IHasCurrentValue<Colour4>
+    {
+        private readonly BindableWithCurrent<Colour4> current = new BindableWithCurrent<Colour4>();
+
+        public Bindable<Colour4> Current
+        {
+            get => current.Current;
+            set => current.Current = value;
+        }
+
+        private readonly Box background;
+        private readonly TextBox hexCodeTextBox;
+        private readonly Drawable spacer;
+        private readonly ColourPreview colourPreview;
+
+        protected HexColourPicker()
+        {
+            InternalChildren = new Drawable[]
+            {
+                background = new Box
+                {
+                    RelativeSizeAxes = Axes.Both
+                },
+                new GridContainer
+                {
+                    ColumnDimensions = new[]
+                    {
+                        new Dimension(),
+                        new Dimension(GridSizeMode.AutoSize),
+                        new Dimension()
+                    },
+                    Content = new[]
+                    {
+                        new[]
+                        {
+                            hexCodeTextBox = CreateHexCodeTextBox(),
+                            spacer = Empty(),
+                            colourPreview = CreateColourPreview()
+                        }
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Creates the text box to be used for specifying the hex code of the target colour.
+        /// </summary>
+        protected abstract TextBox CreateHexCodeTextBox();
+
+        /// <summary>
+        /// Creates the control that will be used for displaying the preview of the target colour.
+        /// </summary>
+        protected abstract ColourPreview CreateColourPreview();
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            colourPreview.Current.BindTo(Current);
+        }
+
+        public abstract class ColourPreview : CompositeDrawable
+        {
+            public Bindable<Colour4> Current = new Bindable<Colour4>();
+        }
+    }
+}

--- a/osu.Framework/Graphics/UserInterface/HexColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/HexColourPicker.cs
@@ -17,34 +17,71 @@ namespace osu.Framework.Graphics.UserInterface
             set => current.Current = value;
         }
 
-        private readonly Box background;
+        public new MarginPadding Padding
+        {
+            get => content.Padding;
+            set => content.Padding = value;
+        }
+
+        /// <summary>
+        /// Sets the spacing between the hex input text box and the colour preview.
+        /// </summary>
+        public float Spacing
+        {
+            get => spacer.Width;
+            set => spacer.Width = value;
+        }
+
+        /// <summary>
+        /// The background of the control.
+        /// </summary>
+        protected readonly Box Background;
+
+        private readonly Container content;
+
         private readonly TextBox hexCodeTextBox;
         private readonly Drawable spacer;
         private readonly ColourPreview colourPreview;
 
         protected HexColourPicker()
         {
+            Current.Value = Colour4.White;
+
+            Width = 300;
+            AutoSizeAxes = Axes.Y;
+
             InternalChildren = new Drawable[]
             {
-                background = new Box
+                Background = new Box
                 {
                     RelativeSizeAxes = Axes.Both
                 },
-                new GridContainer
+                content = new Container
                 {
-                    ColumnDimensions = new[]
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Child = new GridContainer
                     {
-                        new Dimension(),
-                        new Dimension(GridSizeMode.AutoSize),
-                        new Dimension()
-                    },
-                    Content = new[]
-                    {
-                        new[]
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        ColumnDimensions = new[]
                         {
-                            hexCodeTextBox = CreateHexCodeTextBox(),
-                            spacer = Empty(),
-                            colourPreview = CreateColourPreview()
+                            new Dimension(),
+                            new Dimension(GridSizeMode.AutoSize),
+                            new Dimension()
+                        },
+                        RowDimensions = new[]
+                        {
+                            new Dimension(GridSizeMode.AutoSize)
+                        },
+                        Content = new[]
+                        {
+                            new[]
+                            {
+                                hexCodeTextBox = CreateHexCodeTextBox().With(d => d.RelativeSizeAxes = Axes.X),
+                                spacer = Empty(),
+                                colourPreview = CreateColourPreview().With(d => d.RelativeSizeAxes = Axes.Both)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Another part of #3134. The last part will be combining the two, which is basically a glorified way of saying "two `.BindTo()` calls with extra steps".

https://user-images.githubusercontent.com/20418176/121752419-60454600-cb10-11eb-9b87-dfba104a5b07.mp4

A note on the UX of this: Signaling input errors better than just discarding the value input by the user - by flashing the text box or otherwise - would definitely make this feel better, but the issue is that the structure of `TextBox` does not support that very well. What I mean by that is that both the things that control the appearance of it, and the things that control its behaviour wrt input validity (`NotifyInputError()`, `CanAddCharacter(char)`) are driven by virtual members.

So I cannot really define just the latter without the former, because that would require either multiple inheritance (impossible in this language, at least right now), or reimplementation of either the appearance or the validation logic by consumers.

If it is deemed necessary, I'll take the detour and try to fix the state of `TextBox` to decouple inherited validation logic from inherited appearance, but it'll end up being a fair few breaking changes I imagine.

However, if it's some consolation, from my experience image editing software (photoshop, GIMP) hex colour entry controls seem to work in an extremely similar manner to this.