### PR TITLE
Fix platform actions activating twice in `ManualTestScene`s

### DIFF
--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Input
         /// <summary>
         /// If there's an InputManager above us, decide whether we should use their available state.
         /// </summary>
-        public bool UseParentInput
+        public virtual bool UseParentInput
         {
             get => useParentInput;
             set

--- a/osu.Framework/Testing/ManualInputManagerTestScene.cs
+++ b/osu.Framework/Testing/ManualInputManagerTestScene.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Testing
                 InputManager = new ManualInputManager
                 {
                     UseParentInput = true,
-                    Child = new PlatformActionContainer().WithChild(Content)
+                    Child = Content,
                 },
                 new Container
                 {


### PR DESCRIPTION
Noticed while reviewing another pull request. This regressed in https://github.com/ppy/osu-framework/pull/4484 and will also require a similar osu!-side fix.

`PlatformActionContainer` does block actions it handles, but due to the `ManualInputManager`'s presence the blocking stops at that point (and is handled a second time in the parent handling context). This PR allows the nested platform action container to only be used when automated actions are involved (as that is what it was added for).

Can be tested by backspacing in `TestSceneTextBox`.