### PR TITLE
Fix switching to borderless window incorrectly overwriting window size configuration

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -482,7 +482,7 @@ namespace osu.Framework.Platform
 
             // This function may be invoked before the SDL internal states are all changed. (as documented here: https://wiki.libsdl.org/SDL_SetEventFilter)
             // Scheduling the store to config until after the event poll has run will ensure the window is in the correct state.
-            ScheduleEvent(storeWindowSizeToConfig);
+            eventScheduler.Add(storeWindowSizeToConfig, true);
         }
 
         /// <summary>


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu-framework/pull/4499 because the schedule call was not forced (and thus running incorrectly inline).

Closes https://github.com/ppy/osu-framework/issues/4507.