### PR TITLE
Disable `dotnet format` from running on appveyor too

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -123,8 +123,10 @@ Task("CodeFileSanity")
         });
     });
 
-Task("DotnetFormat")
-    .Does(() => DotNetCoreTool(sln.FullPath, "format", "--dry-run --check"));
+// Temporarily disabled until the tool is upgraded to 5.0.
+// The version specified in .config/dotnet-tools.json (3.1.37601) won't run on .NET hosts >=5.0.7.
+// Task("DotnetFormat")
+//    .Does(() => DotNetCoreTool(sln.FullPath, "format", "--dry-run --check"));
 
 Task("PackFramework")
     .Does(() => {
@@ -222,7 +224,7 @@ Task("Build")
     .IsDependentOn("Clean")
     .IsDependentOn("DetermineAppveyorBuildProperties")
     .IsDependentOn("CodeFileSanity")
-    .IsDependentOn("DotnetFormat")
+    //.IsDependentOn("DotnetFormat") <- To be uncommented after fixing the task.
     .IsDependentOn("InspectCode")
     .IsDependentOn("Test")
     .IsDependentOn("DetermineAppveyorDeployProperties")


### PR DESCRIPTION
#4468, but for appveyor as well. Also see https://github.com/ppy/osu/pull/13496.

PRing for visibility/ease of merge if this is deemed the way to go for now. An alternative would be to revisit #4410 (the reason why that one was abandoned is not entirely clear to me).