### PR TITLE
Make Resharper inspections fail the CI job

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -20,8 +20,8 @@
         "jb"
       ]
     },
-    "nvika": {
-      "version": "2.0.0",
+    "smoogipoo.nvika": {
+      "version": "1.0.0",
       "commands": [
         "nvika"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -21,7 +21,7 @@
       ]
     },
     "smoogipoo.nvika": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "commands": [
         "nvika"
       ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,5 @@ jobs:
       - name: InspectCode
         run: dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --output=$(pwd)/inspectcodereport.xml --cachesDir=$(pwd)/inspectcode --verbosity=WARN
 
-      - name: ReSharper
-        uses: glassechidna/resharper-action@master
-        with:
-          report: ${{github.workspace}}/inspectcodereport.xml
+      - name: NVika
+        run: dotnet nvika parsereport "${{github.workspace}}/inspectcodereport.xml" --treatwarningsaserrors

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Bindables;


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/4502

For the time being, I've published my own nuget package (smoogipoo.nvika) which has a GitHub build server built in. I've PR'd the change (https://github.com/laedit/vika/pull/290) and intend to use the official package once that's merged in. And if it isn't merged, I'll adopt it into the ppy org.

It can be seen working here: https://github.com/smoogipoo/osu-framework/pull/28/checks
- CI job fails
- Annotations in the `Files changed` view.