### PR TITLE
Add inspectcode scripts

### DIFF
--- a/InspectCode.ps1
+++ b/InspectCode.ps1
@@ -1,0 +1,11 @@
+dotnet tool restore
+
+# Temporarily disabled until the tool is upgraded to 5.0.
+  # The version specified in .config/dotnet-tools.json (3.1.37601) won't run on .NET hosts >=5.0.7.
+  # - cmd: dotnet format --dry-run --check
+
+dotnet CodeFileSanity
+dotnet jb inspectcode "osu-framework.Desktop.slnf" --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN
+dotnet nvika parsereport "inspectcodereport.xml" --treatwarningsaserrors
+
+exit $LASTEXITCODE

--- a/InspectCode.sh
+++ b/InspectCode.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+dotnet tool restore
+dotnet CodeFileSanity
+dotnet jb inspectcode "osu-framework.Desktop.slnf" --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN
+dotnet nvika parsereport "inspectcodereport.xml" --treatwarningsaserrors

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Build configurations for the recommended IDEs (listed above) are included. You s
 
 ### Code analysis
 
-Code analysis can be run with `powershell ./build.ps1` or `build.sh`. This is currently only supported under windows due to [resharper cli shortcomings](https://youtrack.jetbrains.com/issue/RSRP-410004). Alternatively, you can install resharper or use rider to get inline support in your IDE of choice.
+Code analysis can be run with `powershell ./InspectCode.ps1` or `InspectCode.sh`.
 
 ## Contributing
 


### PR DESCRIPTION
`build.sh`/`build.ps1` scripts also exist but they're a bit more all-encompassing, including running tests. The new scripts are sufficient for only running code inspections.