### PR TITLE
Lock before unbinding subtree in DisposeChildAsync

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -821,7 +821,9 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="drawable">The child to dispose.</param>
         internal void DisposeChildAsync(Drawable drawable)
         {
-            drawable.UnbindAllBindablesSubTree();
+            lock (LoadLock)
+                drawable.UnbindAllBindablesSubTree();
+
             AsyncDisposalQueue.Enqueue(drawable);
         }
 

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -821,7 +821,7 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="drawable">The child to dispose.</param>
         internal void DisposeChildAsync(Drawable drawable)
         {
-            lock (LoadLock)
+            lock (drawable.LoadLock)
                 drawable.UnbindAllBindablesSubTree();
 
             AsyncDisposalQueue.Enqueue(drawable);


### PR DESCRIPTION
This may be a simple and safe solution to the `UnbindAllBindablesSubTree()` issue that's been causing test failures.

I've been able to run both osu! + osu!framework tests without failures, and have done brief testing in-game with scenarios like entering player and exiting immediately.