### PR TITLE
Apply few changes to the `ShaderManager` structure

### DIFF
--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -48,7 +48,7 @@ namespace osu.Framework.Graphics.Shaders
             return name + ending;
         }
 
-        internal byte[] LoadRaw(string name) => store.Get(name);
+        public virtual byte[] LoadRaw(string name) => store.Get(name);
 
         private ShaderPart createShaderPart(string name, ShaderType type, bool bypassCache = false)
         {

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -29,14 +29,6 @@ namespace osu.Framework.Graphics.Shaders
         }
 
         /// <summary>
-        /// Constructs a new <see cref="ShaderManager"/> with no backing store.
-        /// </summary>
-        protected ShaderManager()
-        {
-            store = new ResourceStore<byte[]>();
-        }
-
-        /// <summary>
         /// Retrieves raw shader data from the store.
         /// Use <see cref="Load"/> to retrieve a usable <see cref="IShader"/> instead.
         /// </summary>

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -9,7 +9,7 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class ShaderManager
+    public class ShaderManager : IDisposable
     {
         private const string shader_prefix = @"sh_";
 
@@ -81,6 +81,27 @@ namespace osu.Framework.Graphics.Shaders
 
             return shaderCache[tuple] = new Shader($"{vertex}/{fragment}", parts);
         }
+
+        #region IDisposable Support
+
+        private bool isDisposed;
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                isDisposed = true;
+                store?.Dispose();
+            }
+        }
+
+        #endregion
     }
 
     public static class VertexShaderDescriptor

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 using osu.Framework.IO.Stores;
 using osuTK.Graphics.ES30;
 
@@ -16,9 +17,10 @@ namespace osu.Framework.Graphics.Shaders
         private readonly ConcurrentDictionary<string, ShaderPart> partCache = new ConcurrentDictionary<string, ShaderPart>();
         private readonly ConcurrentDictionary<(string, string), Shader> shaderCache = new ConcurrentDictionary<(string, string), Shader>();
 
-        private readonly ResourceStore<byte[]> store;
+        [CanBeNull]
+        private readonly IResourceStore<byte[]> store;
 
-        public ShaderManager(ResourceStore<byte[]> store)
+        public ShaderManager(IResourceStore<byte[]> store = null)
         {
             this.store = store;
         }
@@ -48,7 +50,7 @@ namespace osu.Framework.Graphics.Shaders
             return name + ending;
         }
 
-        public virtual byte[] LoadRaw(string name) => store.Get(name);
+        public virtual byte[] LoadRaw(string name) => store?.Get(name);
 
         private ShaderPart createShaderPart(string name, ShaderType type, bool bypassCache = false)
         {

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -1,10 +1,11 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using JetBrains.Annotations;
 using osu.Framework.IO.Stores;
 using osuTK.Graphics.ES30;
 
@@ -17,12 +18,22 @@ namespace osu.Framework.Graphics.Shaders
         private readonly ConcurrentDictionary<string, ShaderPart> partCache = new ConcurrentDictionary<string, ShaderPart>();
         private readonly ConcurrentDictionary<(string, string), Shader> shaderCache = new ConcurrentDictionary<(string, string), Shader>();
 
-        [CanBeNull]
         private readonly IResourceStore<byte[]> store;
 
-        public ShaderManager(IResourceStore<byte[]> store = null)
+        /// <summary>
+        /// Constructs a new <see cref="ShaderManager"/>.
+        /// </summary>
+        public ShaderManager(IResourceStore<byte[]> store)
         {
             this.store = store;
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="ShaderManager"/> with no backing store.
+        /// </summary>
+        protected ShaderManager()
+        {
+            store = new ResourceStore<byte[]>();
         }
 
         /// <summary>
@@ -30,7 +41,7 @@ namespace osu.Framework.Graphics.Shaders
         /// Use <see cref="Load"/> to retrieve a usable <see cref="IShader"/> instead.
         /// </summary>
         /// <param name="name">The shader name.</param>
-        public virtual byte[] LoadRaw(string name) => store?.Get(name);
+        public virtual byte[] LoadRaw(string name) => store.Get(name);
 
         /// <summary>
         /// Retrieves a usable <see cref="IShader"/> given the vertex and fragment shaders.
@@ -42,7 +53,7 @@ namespace osu.Framework.Graphics.Shaders
         {
             var tuple = (vertex, fragment);
 
-            if (shaderCache.TryGetValue(tuple, out Shader shader))
+            if (shaderCache.TryGetValue(tuple, out Shader? shader))
                 return shader;
 
             List<ShaderPart> parts = new List<ShaderPart>
@@ -58,7 +69,7 @@ namespace osu.Framework.Graphics.Shaders
         {
             name = ensureValidName(name, type);
 
-            if (!bypassCache && partCache.TryGetValue(name, out ShaderPart part))
+            if (!bypassCache && partCache.TryGetValue(name, out ShaderPart? part))
                 return part;
 
             byte[] rawData = LoadRaw(name);
@@ -111,7 +122,7 @@ namespace osu.Framework.Graphics.Shaders
             if (!isDisposed)
             {
                 isDisposed = true;
-                store?.Dispose();
+                store.Dispose();
             }
         }
 


### PR DESCRIPTION
Few simple changes to `ShaderManager` to become similar to other resource stores. Required for supporting https://github.com/ppy/osu/issues/13586.

- Make `LoadRaw` public and virtual, for the ability of overriding it and making a `FallbackShaderManager` osu!-side in `DrawableRulesetDependencies`.
- Add disposal logic that disposes of the underlying store, matches others like `TextureStore` which inherits `ResourceStore` that disposes of underlying stores.
- Make `ShaderManager` accept null underlying stores and make it an optional parameter, similar to `TextureStore` as well.

Also reorganizes the methods and xmldocs `Load` methods.

As a side note, I was also thinking about making `ShaderManager` inherit from `ResourceStore<byte[]>` and remove `LoadRaw` in favour of `ResourceStore.Get` instead (or even make it inherit `ResourceStore<ShaderPart>` and make a `ShaderLoaderStore`), but I realized that's changing too much than what's needed currently, so I left that part as-is for now. Can look into doing that in a separate PR if it sounds good, but it's out-of-scope here.