### PR TITLE
Change markdown heading text size to use actual font size

### DIFF
--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownHeading.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownHeading.cs
@@ -3,7 +3,7 @@
 
 using Markdig.Syntax;
 using osu.Framework.Allocation;
-using osuTK;
+using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Graphics.Containers.Markdown
 {
@@ -36,11 +36,13 @@ namespace osu.Framework.Graphics.Containers.Markdown
             MarkdownTextFlowContainer textFlow;
             InternalChild = textFlow = CreateTextFlow();
 
-            textFlow.Scale = new Vector2(GetFontSizeByLevel(headingBlock.Level));
             textFlow.AddInlineText(headingBlock.Inline);
         }
 
-        public virtual MarkdownTextFlowContainer CreateTextFlow() => parentFlowComponent.CreateTextFlow();
+        public virtual MarkdownTextFlowContainer CreateTextFlow() => new MarkdownHeadingTextFlowContainer
+        {
+            FontSize = GetFontSizeByLevel(headingBlock.Level),
+        };
 
         protected virtual float GetFontSizeByLevel(int level)
         {

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownHeading.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownHeading.cs
@@ -62,5 +62,13 @@ namespace osu.Framework.Graphics.Containers.Markdown
                     return 20;
             }
         }
+
+        private class MarkdownHeadingTextFlowContainer : MarkdownTextFlowContainer
+        {
+            public float FontSize;
+
+            protected override SpriteText CreateSpriteText()
+                => base.CreateSpriteText().With(t => t.Font = t.Font.With(size: FontSize));
+        }
     }
 }

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownHeading.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownHeading.cs
@@ -47,19 +47,19 @@ namespace osu.Framework.Graphics.Containers.Markdown
             switch (level)
             {
                 case 1:
-                    return 2.7f;
+                    return 54;
 
                 case 2:
-                    return 2;
+                    return 40;
 
                 case 3:
-                    return 1.5f;
+                    return 30;
 
                 case 4:
-                    return 1.3f;
+                    return 26;
 
                 default:
-                    return 1;
+                    return 20;
             }
         }
     }


### PR DESCRIPTION
Closes #4525

As I mentioned in https://github.com/ppy/osu-framework/issues/4525#issuecomment-864344644

Currently, `GetFontSizeByLevel` returns scale number value instead of actual font size value. Then that value is used to change heading size using scale.

This changes is make `GetFontSizeByLevel` to return actual font size value and then change the font size directly instead of using scale.

This is a bit breaking changes, so I need more advise for this PR.