### PR TITLE
Expose an event from `GameHost` before update thread changes native threads

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -587,11 +587,11 @@ namespace osu.Framework.Platform
 
                 Window = CreateWindow();
 
-                ExecutionState = ExecutionState.Running;
-
                 populateInputHandlers();
 
                 SetupConfig(game.GetFrameworkConfigDefaults() ?? new Dictionary<FrameworkSetting, object>());
+
+                ExecutionState = ExecutionState.Running;
 
                 initialiseInputHandlers();
 
@@ -810,8 +810,11 @@ namespace osu.Framework.Platform
             executionMode = Config.GetBindable<ExecutionMode>(FrameworkSetting.ExecutionMode);
             executionMode.BindValueChanged(e =>
             {
-                ThreadSafety.EnsureUpdateThread();
-                UpdateThreadChanging?.Invoke();
+                if (ExecutionState >= ExecutionState.Running)
+                {
+                    ThreadSafety.EnsureUpdateThread();
+                    UpdateThreadChanging?.Invoke();
+                }
 
                 threadRunner.ExecutionMode = e.NewValue;
             }, true);

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -46,7 +46,11 @@ namespace osu.Framework.Threading
             host.Window?.MakeCurrent();
         }
 
-        protected sealed override void OnPause() => host.Window?.ClearCurrent();
+        protected sealed override void OnPause()
+        {
+            base.OnPause();
+            host.Window?.ClearCurrent();
+        }
 
         internal override IEnumerable<StatisticsCounterType> StatisticsCounters => new[]
         {

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -40,6 +40,11 @@ namespace osu.Framework.Threading
         /// </summary>
         public EventHandler<UnhandledExceptionEventArgs> UnhandledException;
 
+        /// <summary>
+        /// Event fired when this thread is pausing.
+        /// </summary>
+        public event Action ThreadPausing;
+
         protected Action OnNewFrame;
 
         /// <summary>
@@ -259,6 +264,7 @@ namespace osu.Framework.Threading
         /// </summary>
         protected virtual void OnPause()
         {
+            ThreadPausing?.Invoke();
         }
 
         protected void Cleanup()


### PR DESCRIPTION
PRing for comment. Intended to be used as a way for realm to clean up after itself.

Not sure if we want to instead expose somewhere in `GameThread` itself.