### PR TITLE
Move pause event to only exist at `GameThread`

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -93,12 +93,6 @@ namespace osu.Framework.Platform
         public event Action<IpcMessage> MessageReceived;
 
         /// <summary>
-        /// Called from the current update thread before it is potentially moved to a different native thread.
-        /// This could occur from a change in <see cref="ExecutionMode"/> or end of host execution.
-        /// </summary>
-        public event Action UpdateThreadPausing;
-
-        /// <summary>
         /// Whether the on screen keyboard covers a portion of the game window when presented to the user.
         /// </summary>
         public virtual bool OnScreenKeyboardOverlapsGameWindow => false;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -186,10 +186,10 @@ namespace osu.Framework.Platform
             thread.UnhandledException = null;
         }
 
-        public DrawThread DrawThread;
-        public GameThread UpdateThread;
-        public InputThread InputThread;
-        public AudioThread AudioThread;
+        public DrawThread DrawThread { get; private set; }
+        public GameThread UpdateThread { get; private set; }
+        public InputThread InputThread { get; private set; }
+        public AudioThread AudioThread { get; private set; }
 
         private double maximumUpdateHz;
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -561,8 +561,6 @@ namespace osu.Framework.Platform
                     Monitor = { HandleGC = true },
                 });
 
-                UpdateThread.ThreadPausing += () => UpdateThreadPausing?.Invoke();
-
                 RegisterThread(DrawThread = new DrawThread(DrawFrame, this));
 
                 Trace.Listeners.Clear();

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -41,8 +41,11 @@ namespace osu.Framework.Threading
         public EventHandler<UnhandledExceptionEventArgs> UnhandledException;
 
         /// <summary>
-        /// Event fired when this thread is pausing.
+        /// Fired from this thread before it is paused for permanent termination, or potentially moved to a different native thread.
         /// </summary>
+        /// <remarks>
+        /// This could occur from a change in <see cref="ExecutionMode"/> or end of host execution.
+        /// </remarks>
         public event Action ThreadPausing;
 
         protected Action OnNewFrame;


### PR DESCRIPTION
As discussed, this seems to feel better.

Also made a `GameHost`'s threads read-only. Oops.