### PR TITLE
Add shader disposal support

### DIFF
--- a/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
+++ b/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
@@ -68,18 +68,18 @@ namespace osu.Framework.Tests.Shaders
                 {
                 }
 
-                protected override int CreateProgram() => 1337;
+                private protected override int CreateProgram() => 1337;
 
-                protected override bool CompileInternal() => true;
+                private protected override bool CompileInternal() => true;
 
-                protected override void SetupUniforms()
+                private protected override void SetupUniforms()
                 {
                     Uniforms.Add("test", new Uniform<int>(this, "test", 1));
                 }
 
-                protected override string GetProgramLog() => string.Empty;
+                private protected override string GetProgramLog() => string.Empty;
 
-                protected override void DeleteProgram(int id)
+                private protected override void DeleteProgram(int id)
                 {
                 }
             }

--- a/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
+++ b/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
@@ -1,0 +1,88 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Graphics.Shaders;
+using osu.Framework.IO.Stores;
+using osu.Framework.Testing;
+using osu.Framework.Tests.Visual;
+
+namespace osu.Framework.Tests.Shaders
+{
+    public class TestSceneShaderDisposal : FrameworkTestScene
+    {
+        private ShaderManager manager;
+        private Shader shader;
+
+        private WeakReference<IShader> shaderRef;
+
+        [SetUpSteps]
+        public void SetUpSteps()
+        {
+            AddStep("setup manager", () =>
+            {
+                manager = new TestShaderManager(new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(Game).Assembly), @"Resources/Shaders"));
+                shader = (Shader)manager.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
+                shaderRef = new WeakReference<IShader>(shader);
+
+                shader.Compile();
+            });
+
+            AddUntilStep("wait for load", () => shader.IsLoaded);
+        }
+
+        [Test]
+        public void TestShadersLoseReferencesOnManagerDisposal()
+        {
+            AddStep("remove local reference", () => shader = null);
+
+            AddStep("dispose manager", () =>
+            {
+                manager.Dispose();
+                manager = null;
+            });
+
+            AddUntilStep("reference lost", () =>
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                return !shaderRef.TryGetTarget(out _);
+            });
+        }
+
+        private class TestShaderManager : ShaderManager
+        {
+            public TestShaderManager(IResourceStore<byte[]> store)
+                : base(store)
+            {
+            }
+
+            internal override Shader CreateShader(string name, List<ShaderPart> parts) => new TestShader(name, parts);
+
+            private class TestShader : Shader
+            {
+                internal TestShader(string name, List<ShaderPart> parts)
+                    : base(name, parts)
+                {
+                }
+
+                protected override int CreateProgram() => 1337;
+
+                protected override bool CompileInternal() => true;
+
+                protected override void SetupUniforms()
+                {
+                    Uniforms.Add("test", new Uniform<int>(this, "test", 1));
+                }
+
+                protected override string GetProgramLog() => string.Empty;
+
+                protected override void DeleteProgram(int id)
+                {
+                }
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
+++ b/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Tests.Shaders
                 shader = (Shader)manager.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.TEXTURE);
                 shaderRef = new WeakReference<IShader>(shader);
 
-                shader.Compile();
+                shader.EnsureShaderCompiled();
             });
 
             AddUntilStep("wait for load", () => shader.IsLoaded);

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -147,8 +147,14 @@ namespace osu.Framework.Graphics.OpenGL
 
             stat_expensive_operations_queued.Value = expensive_operation_queue.Count;
 
-            if (expensive_operation_queue.TryDequeue(out ScheduledDelegate operation) && operation.State == RunState.Waiting)
-                operation.RunTask();
+            while (expensive_operation_queue.TryDequeue(out ScheduledDelegate operation))
+            {
+                if (operation.State == RunState.Waiting)
+                {
+                    operation.RunTask();
+                    break;
+                }
+            }
 
             lastActiveBatch = null;
             lastBlendingParameters = new BlendingParameters();

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -19,6 +19,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osu.Framework.Platform;
 using osu.Framework.Timing;
+using static osu.Framework.Threading.ScheduledDelegate;
 
 namespace osu.Framework.Graphics.OpenGL
 {
@@ -84,7 +85,7 @@ namespace osu.Framework.Graphics.OpenGL
         /// <summary>
         /// A queue from which a maximum of one operation is invoked per draw frame.
         /// </summary>
-        private static readonly ConcurrentQueue<Action> expensive_operation_queue = new ConcurrentQueue<Action>();
+        private static readonly ConcurrentQueue<ScheduledDelegate> expensive_operation_queue = new ConcurrentQueue<ScheduledDelegate>();
 
         private static readonly ConcurrentQueue<TextureGL> texture_upload_queue = new ConcurrentQueue<TextureGL>();
 
@@ -145,8 +146,9 @@ namespace osu.Framework.Graphics.OpenGL
             reset_scheduler.Update();
 
             stat_expensive_operations_queued.Value = expensive_operation_queue.Count;
-            if (expensive_operation_queue.TryDequeue(out Action action))
-                action.Invoke();
+
+            if (expensive_operation_queue.TryDequeue(out ScheduledDelegate operation) && operation.State == RunState.Waiting)
+                operation.RunTask();
 
             lastActiveBatch = null;
             lastBlendingParameters = new BlendingParameters();
@@ -309,13 +311,13 @@ namespace osu.Framework.Graphics.OpenGL
         }
 
         /// <summary>
-        /// Enqueues the compile of a shader.
+        /// Schedules an expensive operation to a queue from which a maximum of one operation is performed per frame.
         /// </summary>
-        /// <param name="shader">The shader to compile.</param>
-        public static void EnqueueShaderCompile(Shader shader)
+        /// <param name="operation">The operation to schedule.</param>
+        public static void ScheduleExpensiveOperation(ScheduledDelegate operation)
         {
             if (host != null)
-                expensive_operation_queue.Enqueue(shader.EnsureLoaded);
+                expensive_operation_queue.Enqueue(operation);
         }
 
         private static readonly int[] last_bound_buffers = new int[2];

--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Graphics.Shaders
 {
     internal static class GlobalPropertyManager
     {
-        private static readonly List<Shader> all_shaders = new List<Shader>();
+        private static readonly HashSet<Shader> all_shaders = new HashSet<Shader>();
         private static readonly IUniformMapping[] global_properties;
 
         static GlobalPropertyManager()
@@ -53,6 +53,8 @@ namespace osu.Framework.Graphics.Shaders
 
         public static void Register(Shader shader)
         {
+            if (!all_shaders.Add(shader)) return;
+
             // transfer all existing global properties across.
             foreach (var global in global_properties)
             {
@@ -61,8 +63,6 @@ namespace osu.Framework.Graphics.Shaders
 
                 global.LinkShaderUniform(uniform);
             }
-
-            all_shaders.Add(shader);
         }
 
         public static void Unregister(Shader shader)

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -44,7 +44,7 @@ namespace osu.Framework.Graphics.Shaders
                 throw new ObjectDisposedException(ToString(), "Can not compile a disposed shader.");
 
             if (IsLoaded)
-                throw new InvalidOperationException("Attempting to compile already compiled shader.");
+                throw new InvalidOperationException("Attempting to compile an already-compiled shader.");
 
             parts.RemoveAll(p => p == null);
             if (parts.Count == 0)

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Threading;
 using osuTK;
 using osuTK.Graphics.ES30;
+using static osu.Framework.Threading.ScheduledDelegate;
 
 namespace osu.Framework.Graphics.Shaders
 {
@@ -67,7 +68,7 @@ namespace osu.Framework.Graphics.Shaders
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not compile a disposed shader.");
 
-            if (!shaderCompileDelegate.Completed)
+            if (shaderCompileDelegate.State == RunState.Waiting)
                 shaderCompileDelegate.RunTask();
         }
 

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -31,6 +31,9 @@ namespace osu.Framework.Graphics.Shaders
 
         internal void Compile()
         {
+            if (IsDisposed)
+                return;
+
             parts.RemoveAll(p => p == null);
             Uniforms.Clear();
 
@@ -57,6 +60,9 @@ namespace osu.Framework.Graphics.Shaders
 
         public void Bind()
         {
+            if (IsDisposed)
+                throw new ObjectDisposedException(ToString(), "Can not bind a disposed shader.");
+
             if (IsBound)
                 return;
 

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -43,9 +43,10 @@ namespace osu.Framework.Graphics.Shaders
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not compile a disposed shader.");
 
-            parts.RemoveAll(p => p == null);
-            Uniforms.Clear();
+            if (IsLoaded)
+                throw new InvalidOperationException("Attempting to compile already compiled shader.");
 
+            parts.RemoveAll(p => p == null);
             if (parts.Count == 0)
                 return;
 
@@ -61,7 +62,7 @@ namespace osu.Framework.Graphics.Shaders
             GlobalPropertyManager.Register(this);
         }
 
-        private void ensureShaderLoaded()
+        internal void EnsureShaderCompiled()
         {
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not compile a disposed shader.");
@@ -78,7 +79,7 @@ namespace osu.Framework.Graphics.Shaders
             if (IsBound)
                 return;
 
-            ensureShaderLoaded();
+            EnsureShaderCompiled();
 
             GLWrapper.UseProgram(this);
 
@@ -109,7 +110,7 @@ namespace osu.Framework.Graphics.Shaders
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not retrieve uniforms from a disposed shader.");
 
-            ensureShaderLoaded();
+            EnsureShaderCompiled();
 
             return (Uniform<T>)Uniforms[name];
         }

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -99,7 +99,7 @@ namespace osu.Framework.Graphics.Shaders
             return (Uniform<T>)Uniforms[name];
         }
 
-        protected virtual bool CompileInternal()
+        private protected virtual bool CompileInternal()
         {
             foreach (ShaderPart p in parts)
             {
@@ -119,7 +119,7 @@ namespace osu.Framework.Graphics.Shaders
             return linkResult == 1;
         }
 
-        protected virtual void SetupUniforms()
+        private protected virtual void SetupUniforms()
         {
             GL.GetProgram(this, GetProgramParameterName.ActiveUniforms, out int uniformCount);
 
@@ -178,11 +178,11 @@ namespace osu.Framework.Graphics.Shaders
             }
         }
 
-        protected virtual string GetProgramLog() => GL.GetProgramInfoLog(this);
+        private protected virtual string GetProgramLog() => GL.GetProgramInfoLog(this);
 
-        protected virtual int CreateProgram() => GL.CreateProgram();
+        private protected virtual int CreateProgram() => GL.CreateProgram();
 
-        protected virtual void DeleteProgram(int id)
+        private protected virtual void DeleteProgram(int id)
         {
             if (id != -1)
                 GL.DeleteProgram(id);

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -182,11 +182,7 @@ namespace osu.Framework.Graphics.Shaders
 
         private protected virtual int CreateProgram() => GL.CreateProgram();
 
-        private protected virtual void DeleteProgram(int id)
-        {
-            if (id != -1)
-                GL.DeleteProgram(id);
-        }
+        private protected virtual void DeleteProgram(int id) => GL.DeleteProgram(id);
 
         public override string ToString() => $@"{name} Shader (Compiled: {programID != -1})";
 
@@ -215,7 +211,8 @@ namespace osu.Framework.Graphics.Shaders
 
                 GlobalPropertyManager.Unregister(this);
 
-                DeleteProgram(this);
+                if (programID != -1)
+                    DeleteProgram(this);
             }
         }
 

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -9,7 +9,7 @@ using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    public class Shader : IShader
+    public class Shader : IShader, IDisposable
     {
         public bool IsLoaded { get; private set; }
 
@@ -177,6 +177,32 @@ namespace osu.Framework.Graphics.Shaders
         }
 
         public static implicit operator int(Shader shader) => shader.programID;
+
+        protected internal bool IsDisposed { get; private set; }
+
+        ~Shader()
+        {
+            GLWrapper.ScheduleDisposal(() => Dispose(false));
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                IsDisposed = true;
+
+                GlobalPropertyManager.Unregister(this);
+
+                if (programID != -1)
+                    GL.DeleteProgram(this);
+            }
+        }
 
         public class PartCompilationFailedException : Exception
         {

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -35,10 +35,10 @@ namespace osu.Framework.Graphics.Shaders
             this.name = name;
             this.parts = parts;
 
-            GLWrapper.ScheduleExpensiveOperation(shaderCompileDelegate = new ScheduledDelegate(Compile));
+            GLWrapper.ScheduleExpensiveOperation(shaderCompileDelegate = new ScheduledDelegate(compile));
         }
 
-        internal void Compile()
+        private void compile()
         {
             if (IsDisposed)
                 throw new ObjectDisposedException(ToString(), "Can not compile a disposed shader.");

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using osu.Framework.Graphics.OpenGL;
 using osu.Framework.IO.Stores;
 using osuTK.Graphics.ES30;
 
@@ -114,7 +115,17 @@ namespace osu.Framework.Graphics.Shaders
             if (!isDisposed)
             {
                 isDisposed = true;
+
                 store.Dispose();
+
+                GLWrapper.ScheduleDisposal(() =>
+                {
+                    foreach (var shader in shaderCache.Values)
+                        shader.Dispose();
+
+                    foreach (var part in partCache.Values)
+                        part.Dispose();
+                });
             }
         }
 

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -55,8 +55,10 @@ namespace osu.Framework.Graphics.Shaders
                 createShaderPart(fragment, ShaderType.FragmentShader)
             };
 
-            return shaderCache[tuple] = new Shader($"{vertex}/{fragment}", parts);
+            return shaderCache[tuple] = CreateShader($"{vertex}/{fragment}", parts);
         }
+
+        internal virtual Shader CreateShader(string name, List<ShaderPart> parts) => new Shader(name, parts);
 
         private ShaderPart createShaderPart(string name, ShaderType type, bool bypassCache = false)
         {

--- a/osu.Framework/Graphics/Shaders/ShaderPart.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderPart.cs
@@ -5,11 +5,12 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.RegularExpressions;
+using osu.Framework.Graphics.OpenGL;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Shaders
 {
-    internal class ShaderPart
+    internal class ShaderPart : IDisposable
     {
         internal const string SHADER_ATTRIBUTE_PATTERN = "^\\s*(?>attribute|in)\\s+(?:(?:lowp|mediump|highp)\\s+)?\\w+\\s+(\\w+)";
 
@@ -149,13 +150,32 @@ namespace osu.Framework.Graphics.Shaders
 
         public static implicit operator int(ShaderPart program) => program.partID;
 
-        private void delete()
-        {
-            if (partID == -1) return;
+        #region IDisposable Support
 
-            GL.DeleteShader(this);
-            Compiled = false;
-            partID = -1;
+        protected internal bool IsDisposed { get; private set; }
+
+        ~ShaderPart()
+        {
+            GLWrapper.ScheduleDisposal(() => Dispose(false));
         }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+            {
+                IsDisposed = true;
+
+                if (partID != -1)
+                    GL.DeleteShader(this);
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Closes #4534 

Follows the existing pattern for GL disposal, if a `Shader`/`ShaderPart` gets finalised, the 3-frame delay will be applied, but if it's explicitly disposed, then there won't be any delay from the class itself, it would come from whatever's disposing of it internally (the `ShaderManager` in this case).

Double-checked with osu!lazer master and ppy/osu#13594. Looks to be working as intended. 

Also added a simple test case ensuring `Shader` references aren't leaked after disposing of `ShaderManager` (which heavily depended on doing https://github.com/ppy/osu-framework/commit/cd36ea3b8608aaa305603c0763c142a2ffd063f9 for testing without GL context, kinda ugly but needed).