### PR TITLE
Make tooltips text localisable

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osuTK;
 using osuTK.Graphics;
 
@@ -75,7 +76,7 @@ namespace osu.Framework.Tests.Visual.Sprites
 
         private class Icon : Container, IHasTooltip
         {
-            public string TooltipText { get; }
+            public LocalisableString TooltipText { get; }
 
             public SpriteIcon SpriteIcon { get; }
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTooltip.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTooltip.cs
@@ -167,7 +167,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             private class CustomContent
             {
-                public readonly string Text;
+                public readonly LocalisableString Text;
 
                 public CustomContent(string text)
                 {

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTooltip.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTooltip.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Localisation;
 using osuTK;
 using osuTK.Graphics;
 
@@ -212,7 +213,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class TooltipSpriteText : Container, IHasTooltip
         {
-            public string TooltipText { get; }
+            public LocalisableString TooltipText { get; }
 
             public TooltipSpriteText(string displayedContent)
                 : this(displayedContent, displayedContent)
@@ -246,7 +247,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class TooltipTooltipContainer : TooltipContainer, IHasTooltip
         {
-            public string TooltipText { get; set; }
+            public LocalisableString TooltipText { get; set; }
 
             public TooltipTooltipContainer(string tooltipText)
             {
@@ -256,12 +257,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class TooltipTextbox : BasicTextBox, IHasTooltip
         {
-            public string TooltipText => Text;
+            public LocalisableString TooltipText => Text;
         }
 
         private class TooltipBox : Box, IHasTooltip
         {
-            public string TooltipText { get; set; }
+            public LocalisableString TooltipText { get; set; }
         }
 
         private class RectangleCursorContainer : CursorContainer

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownLinkText.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownLinkText.cs
@@ -5,6 +5,7 @@ using Markdig.Syntax.Inlines;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Cursor;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Framework.Platform;
 using osuTK.Graphics;
 
@@ -18,7 +19,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
     /// </code>
     public class MarkdownLinkText : CompositeDrawable, IHasTooltip, IMarkdownTextComponent
     {
-        public string TooltipText => Url;
+        public LocalisableString TooltipText => Url;
 
         [Resolved]
         private IMarkdownTextComponent parentTextComponent { get; set; }

--- a/osu.Framework/Graphics/Cursor/IHasTooltip.cs
+++ b/osu.Framework/Graphics/Cursor/IHasTooltip.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using osu.Framework.Localisation;
+
 namespace osu.Framework.Graphics.Cursor
 {
     /// <summary>
@@ -12,6 +14,6 @@ namespace osu.Framework.Graphics.Cursor
         /// <summary>
         /// Tooltip text that shows when hovering the drawable.
         /// </summary>
-        string TooltipText { get; }
+        LocalisableString TooltipText { get; }
     }
 }

--- a/osu.Framework/Graphics/Cursor/TooltipContainer.cs
+++ b/osu.Framework/Graphics/Cursor/TooltipContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
+using osu.Framework.Localisation;
 using osuTK;
 using osuTK.Graphics;
 
@@ -178,8 +179,8 @@ namespace osu.Framework.Graphics.Cursor
         {
             var targetContent = getTargetContent(target);
 
-            if (targetContent is string strContent)
-                return !string.IsNullOrEmpty(strContent);
+            if (targetContent is LocalisableString localisableString)
+                return !string.IsNullOrEmpty(localisableString.Data?.ToString());
 
             return targetContent != null;
         }
@@ -318,7 +319,7 @@ namespace osu.Framework.Graphics.Cursor
 
             public virtual bool SetContent(object content)
             {
-                if (!(content is string contentString))
+                if (!(content is LocalisableString contentString))
                     return false;
 
                 text.Text = contentString;

--- a/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/TextureVisualiser.cs
@@ -10,6 +10,7 @@ using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
 using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
@@ -264,7 +265,7 @@ namespace osu.Framework.Graphics.Visualisation
                 protected internal override bool CanDrawOpaqueInterior => false;
             }
 
-            public string TooltipText
+            public LocalisableString TooltipText
             {
                 get
                 {


### PR DESCRIPTION
Pushing this to make localisation of the tooltips text possible in osu! by changing the `IHasTooltip.TooltipText` property to a `LocalisableString`. 

I guess I could have kept the string version of this property around to prevent breakage for other framework users and have a defaut implementation in the interface point to the string one, but I'm not sure default interface methods are being used in framework.

## Breaking change

`IHasTooltip.Text` now takes a `LocalisableString` instead of  regular string. Users of custom tooltip containers may also have to change checks in the `SetContent()` method of their tooltip type to check if content is a `LocalisableString` instead of a regular string.