### PR TITLE
Rewrite `GameThread` and expose state as `IBindable<GameThreadState>`

### DIFF
--- a/osu.Framework.Tests/Platform/GameHostSuspendTest.cs
+++ b/osu.Framework.Tests/Platform/GameHostSuspendTest.cs
@@ -49,7 +49,8 @@ namespace osu.Framework.Tests.Platform
                 updateThreadState = host.UpdateThread.State.GetBoundCopy();
                 updateThreadState.BindValueChanged(state =>
                 {
-                    Assert.IsTrue(ThreadSafety.IsUpdateThread);
+                    if (state.NewValue != GameThreadState.Starting)
+                        Assert.IsTrue(ThreadSafety.IsUpdateThread);
                 });
                 completed.Set();
             });

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -667,8 +667,8 @@ namespace osu.Framework.Platform
         /// </summary>
         public void Suspend()
         {
-            threadRunner.Suspend();
             suspended = true;
+            threadRunner.Suspend();
         }
 
         /// <summary>

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -129,8 +129,6 @@ namespace osu.Framework.Platform
             lock (startStopLock)
             {
                 pauseAllThreads();
-
-                // set the active execution mode back to null to set the state checking back to when it can be resumed.
                 activeExecutionMode = null;
             }
         }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -175,7 +175,6 @@ namespace osu.Framework.Platform
                     foreach (var t in Threads)
                     {
                         t.Start();
-                        t.Clock.Throttling = true;
                     }
 
                     break;

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -155,8 +155,7 @@ namespace osu.Framework.Platform
             });
 
             // as the input thread isn't actually handled by a thread, the above join does not necessarily mean it has been completed to an exiting state.
-            while (!mainThread.Exited)
-                mainThread.ProcessFrame();
+            mainThread.WaitForState(GameThreadState.Exited);
 
             ThreadSafety.ResetAllForCurrentThread();
         }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -168,8 +168,7 @@ namespace osu.Framework.Platform
                 if (ExecutionMode == activeExecutionMode)
                     return;
 
-                // if null, we have not yet got an execution mode, so set this early to allow usage in GameThread.Initialize overrides.
-                activeExecutionMode ??= ThreadSafety.ExecutionMode = ExecutionMode;
+                activeExecutionMode = ThreadSafety.ExecutionMode = ExecutionMode;
                 Logger.Log($"Execution mode changed to {activeExecutionMode}");
             }
 
@@ -201,8 +200,6 @@ namespace osu.Framework.Platform
                     break;
                 }
             }
-
-            activeExecutionMode = ThreadSafety.ExecutionMode = ExecutionMode;
 
             updateMainThreadRates();
         }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -182,9 +182,7 @@ namespace osu.Framework.Platform
                 {
                     // switch to multi-threaded
                     foreach (var t in Threads)
-                    {
                         t.Start();
-                    }
 
                     break;
                 }

--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -109,7 +109,7 @@ namespace osu.Framework.Platform
                     lock (threads)
                     {
                         foreach (var t in threads)
-                            t.ProcessFrame();
+                            t.RunSingleFrame();
                     }
 
                     break;
@@ -117,7 +117,7 @@ namespace osu.Framework.Platform
 
                 case ExecutionMode.MultiThreaded:
                     // still need to run the main/input thread on the window loop
-                    mainThread.ProcessFrame();
+                    mainThread.RunSingleFrame();
                     break;
             }
         }

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Threading
         public AudioThread()
             : base(name: "Audio")
         {
-            OnNewFrame = onNewFrame;
+            OnNewFrame += onNewFrame;
 
             if (RuntimeInfo.OS == RuntimeInfo.Platform.Linux)
             {
@@ -89,9 +89,9 @@ namespace osu.Framework.Threading
             initialised_devices.Add(deviceId);
         }
 
-        protected override void PerformExit()
+        protected override void OnExit()
         {
-            base.PerformExit();
+            base.OnExit();
 
             lock (managers)
             {

--- a/osu.Framework/Threading/DrawThread.cs
+++ b/osu.Framework/Threading/DrawThread.cs
@@ -46,9 +46,9 @@ namespace osu.Framework.Threading
             host.Window?.MakeCurrent();
         }
 
-        protected sealed override void OnPause()
+        protected sealed override void OnSuspended()
         {
-            base.OnPause();
+            base.OnSuspended();
             host.Window?.ClearCurrent();
         }
 

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -192,7 +192,8 @@ namespace osu.Framework.Threading
         internal bool ProcessFrame()
         {
             if (state.Value != GameThreadState.Running)
-                throw new InvalidOperationException("Cannot process frames when thread is not running");
+                // host could be in a suspended state. the input thread will still make calls to ProcessFrame so we can't throw.
+                return false;
 
             try
             {

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -110,7 +110,6 @@ namespace osu.Framework.Threading
                 MakeCurrent();
 
                 state.Value = GameThreadState.Running;
-                pauseRequested = false;
             }
 
             OnInitialize();
@@ -203,15 +202,20 @@ namespace osu.Framework.Threading
                 {
                     lock (startStopLock)
                     {
-                        Debug.Assert(state.Value == GameThreadState.Running);
+                        if (state.Value != GameThreadState.Running)
+                            throw new InvalidOperationException($"Attempted to process frame when state is {state.Value}");
 
                         if (exitRequested)
                         {
                             state.Value = GameThreadState.Exited;
+                            exitRequested = false;
                             PerformExit();
                         }
                         else
+                        {
                             state.Value = GameThreadState.Paused;
+                            pauseRequested = false;
+                        }
                     }
 
                     OnSuspended();

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -317,9 +317,9 @@ namespace osu.Framework.Threading
             {
                 Debug.Assert(state.Value != GameThreadState.Exited);
                 Debug.Assert(state.Value != GameThreadState.Running);
-
-                PrepareForWork();
             }
+
+            PrepareForWork();
         }
 
         /// <summary>

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -198,10 +198,10 @@ namespace osu.Framework.Threading
                 }
 
                 state.Value = GameThreadState.Starting;
+                PrepareForWork();
             }
 
-            PrepareForWork();
-
+            WaitForState(GameThreadState.Running);
             Debug.Assert(state.Value == GameThreadState.Running);
         }
 
@@ -339,8 +339,6 @@ namespace osu.Framework.Threading
             Debug.Assert(Thread != null);
 
             Thread.Start();
-
-            WaitForState(GameThreadState.Running);
         }
 
         /// <summary>

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -386,8 +386,6 @@ namespace osu.Framework.Threading
                 IsBackground = true,
             };
 
-            updateCulture();
-
             void runWork()
             {
                 Initialize(true);

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Threading
         public ThrottledFrameClock Clock { get; }
 
         /// <summary>
-        /// The dedicated OS thread for this <see cref="GameThread"/>.
+        /// The current dedicated OS thread for this <see cref="GameThread"/>.
         /// A value of <see langword="null"/> does not necessarily mean that this thread is not running;
         /// in <see cref="ExecutionMode.SingleThread"/> execution mode <see cref="ThreadRunner"/> drives its <see cref="GameThread"/>s
         /// manually and sequentially on the main OS thread of the game process.
@@ -104,6 +104,11 @@ namespace osu.Framework.Threading
         /// </summary>
         private volatile bool exitRequested;
 
+        /// <summary>
+        /// Prepare this thread for performing work.
+        /// Must be called when entering a running state.
+        /// </summary>
+        /// <param name="withThrottling">Whether this thread's clock should be throttling via thread sleeps.</param>
         internal void Initialize(bool withThrottling)
         {
             lock (startStopLock)

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -2,23 +2,36 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Threading;
-using osu.Framework.Statistics;
-using osu.Framework.Timing;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
+using System.Threading;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Development;
 using osu.Framework.Platform;
+using osu.Framework.Statistics;
+using osu.Framework.Timing;
 
 namespace osu.Framework.Threading
 {
+    /// <summary>
+    /// A conceptual thread used for running game work. May or may not be backed by a native thread.
+    /// </summary>
     public class GameThread
     {
         internal const double DEFAULT_ACTIVE_HZ = 1000;
         internal const double DEFAULT_INACTIVE_HZ = 60;
+
+        /// <summary>
+        /// The name of this thread.
+        /// </summary>
+        public readonly string Name;
+
+        /// <summary>
+        /// Whether the game is active (in the foreground).
+        /// </summary>
+        public readonly IBindable<bool> IsActive = new Bindable<bool>(true);
 
         /// <summary>
         /// The current state of this thread.
@@ -27,8 +40,24 @@ namespace osu.Framework.Threading
 
         private readonly Bindable<GameThreadState> state = new Bindable<GameThreadState>();
 
-        internal PerformanceMonitor Monitor { get; }
+        /// <summary>
+        /// Whether this thread is currently running.
+        /// </summary>
+        public bool Running => state.Value == GameThreadState.Running;
 
+        /// <summary>
+        /// Whether this thread is exited.
+        /// </summary>
+        public bool Exited => state.Value == GameThreadState.Exited;
+
+        /// <summary>
+        /// Whether currently executing on this thread (from the point of invocation).
+        /// </summary>
+        public virtual bool IsCurrent => true;
+
+        /// <summary>
+        /// The thread's clock. Responsible for timekeeping and throttling.
+        /// </summary>
         public ThrottledFrameClock Clock { get; }
 
         /// <summary>
@@ -40,6 +69,9 @@ namespace osu.Framework.Threading
         [CanBeNull]
         public Thread Thread { get; private set; }
 
+        /// <summary>
+        /// The thread's scheduler.
+        /// </summary>
         public Scheduler Scheduler { get; }
 
         /// <summary>
@@ -48,15 +80,25 @@ namespace osu.Framework.Threading
         /// </summary>
         public EventHandler<UnhandledExceptionEventArgs> UnhandledException;
 
-        protected Action OnNewFrame;
+        /// <summary>
+        /// The culture of this thread.
+        /// </summary>
+        public CultureInfo CurrentCulture
+        {
+            get => culture;
+            set
+            {
+                culture = value;
+
+                updateCulture();
+            }
+        }
+
+        private CultureInfo culture;
 
         /// <summary>
-        /// Whether the game is active (in the foreground).
+        /// The refresh rate this thread should run at when active. Only applies when the underlying clock is throttling.
         /// </summary>
-        public readonly IBindable<bool> IsActive = new Bindable<bool>(true);
-
-        private double activeHz = DEFAULT_ACTIVE_HZ;
-
         public double ActiveHz
         {
             get => activeHz;
@@ -67,8 +109,11 @@ namespace osu.Framework.Threading
             }
         }
 
-        private double inactiveHz = DEFAULT_INACTIVE_HZ;
+        private double activeHz = DEFAULT_ACTIVE_HZ;
 
+        /// <summary>
+        /// The refresh rate this thread should run at when inactive. Only applies when the underlying clock is throttling.
+        /// </summary>
         public double InactiveHz
         {
             get => inactiveHz;
@@ -79,16 +124,16 @@ namespace osu.Framework.Threading
             }
         }
 
-        public static string PrefixedThreadNameFor(string name) => $"{nameof(GameThread)}.{name}";
+        private double inactiveHz = DEFAULT_INACTIVE_HZ;
 
-        public bool Running => state.Value == GameThreadState.Running;
+        internal PerformanceMonitor Monitor { get; }
 
-        public bool Exited => state.Value == GameThreadState.Exited;
+        internal virtual IEnumerable<StatisticsCounterType> StatisticsCounters => Array.Empty<StatisticsCounterType>();
 
         /// <summary>
-        /// Whether currently executing on this thread (from the point of invocation).
+        /// The main work which is fired on each frame.
         /// </summary>
-        public virtual bool IsCurrent => true;
+        protected event Action OnNewFrame;
 
         private readonly ManualResetEvent initializedEvent = new ManualResetEvent(false);
 
@@ -104,40 +149,6 @@ namespace osu.Framework.Threading
         /// </summary>
         private volatile bool exitRequested;
 
-        /// <summary>
-        /// Prepare this thread for performing work.
-        /// Must be called when entering a running state.
-        /// </summary>
-        /// <param name="withThrottling">Whether this thread's clock should be throttling via thread sleeps.</param>
-        internal void Initialize(bool withThrottling)
-        {
-            lock (startStopLock)
-            {
-                Debug.Assert(state.Value != GameThreadState.Running);
-                Debug.Assert(state.Value != GameThreadState.Exited);
-
-                MakeCurrent();
-
-                state.Value = GameThreadState.Running;
-
-                OnInitialize();
-
-                Clock.Throttling = withThrottling;
-
-                Monitor.MakeCurrent();
-
-                updateCulture();
-
-                initializedEvent.Set();
-            }
-        }
-
-        protected virtual void OnInitialize() { }
-
-        internal virtual IEnumerable<StatisticsCounterType> StatisticsCounters => Array.Empty<StatisticsCounterType>();
-
-        public readonly string Name;
-
         internal GameThread(Action onNewFrame = null, string name = "unknown", bool monitorPerformance = true)
         {
             OnNewFrame = onNewFrame;
@@ -151,6 +162,206 @@ namespace osu.Framework.Threading
             IsActive.BindValueChanged(_ => updateMaximumHz(), true);
         }
 
+        /// <summary>
+        /// Block until this thread has entered an initialised state.
+        /// </summary>
+        public void WaitUntilInitialized()
+        {
+            initializedEvent.WaitOne();
+        }
+
+        /// <summary>
+        /// Returns a string representation that is prefixed with this thread's identifier.
+        /// </summary>
+        /// <param name="name">The content to prefix.</param>
+        /// <returns>A prefixed string.</returns>
+        public static string PrefixedThreadNameFor(string name) => $"{nameof(GameThread)}.{name}";
+
+        /// <summary>
+        /// Start this thread.
+        /// </summary>
+        /// <remarks>
+        /// This method blocks until in a running state.
+        /// </remarks>
+        public void Start()
+        {
+            lock (startStopLock)
+            {
+                Debug.Assert(state.Value != GameThreadState.Exited);
+                Debug.Assert(state.Value != GameThreadState.Running);
+            }
+
+            PrepareForWork();
+        }
+
+        /// <summary>
+        /// Request that this thread is exited.
+        /// </summary>
+        /// <remarks>
+        /// This does not block and will only queue an exit request, which is processed in the main frame loop.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">Thrown when attempting to exit from an invalid state.</exception>
+        public void Exit()
+        {
+            lock (startStopLock)
+            {
+                switch (state.Value)
+                {
+                    // technically we could support this, but we don't use this yet and it will add more complexity.
+                    case GameThreadState.Paused:
+                    case GameThreadState.NotStarted:
+                        throw new InvalidOperationException($"Cannot exit when thread is {state.Value}.");
+
+                    case GameThreadState.Exited:
+                        return;
+
+                    default:
+                        // actual exit will be done in ProcessFrame.
+                        exitRequested = true;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Prepare this thread for performing work. Must be called when entering a running state.
+        /// </summary>
+        /// <param name="withThrottling">Whether this thread's clock should be throttling via thread sleeps.</param>
+        internal void Initialize(bool withThrottling)
+        {
+            lock (startStopLock)
+            {
+                Debug.Assert(state.Value != GameThreadState.Running);
+                Debug.Assert(state.Value != GameThreadState.Exited);
+
+                MakeCurrent();
+
+                OnInitialize();
+
+                Clock.Throttling = withThrottling;
+
+                Monitor.MakeCurrent();
+
+                updateCulture();
+
+                initializedEvent.Set();
+                state.Value = GameThreadState.Running;
+            }
+        }
+
+        /// <summary>
+        /// Run when thread transitions into an active/processing state, at the beginning of each frame.
+        /// </summary>
+        internal virtual void MakeCurrent()
+        {
+            ThreadSafety.ResetAllForCurrentThread();
+        }
+
+        /// <summary>
+        /// Runs a single frame, updating the execution state if required.
+        /// </summary>
+        internal void RunSingleFrame()
+        {
+            var newState = processFrame();
+
+            if (newState.HasValue)
+                setExitState(newState.Value);
+        }
+
+        /// <summary>
+        /// Pause this thread. Must be run from <see cref="ThreadRunner"/> in a safe manner.
+        /// </summary>
+        /// <remarks>
+        /// This method blocks until in a paused state.
+        /// </remarks>
+        internal void Pause()
+        {
+            lock (startStopLock)
+            {
+                if (state.Value != GameThreadState.Running)
+                    return;
+
+                // actual pause will be done in ProcessFrame.
+                pauseRequested = true;
+            }
+
+            WaitForState(GameThreadState.Paused);
+        }
+
+        /// <summary>
+        /// Spin indefinitely until this thread enters a required state.
+        /// For cases where no native thread is present, this will run <see cref="processFrame"/> until the required state is reached.
+        /// </summary>
+        /// <param name="targetState">The state to wait for.</param>
+        internal void WaitForState(GameThreadState targetState)
+        {
+            if (state.Value == targetState)
+                return;
+
+            if (Thread == null)
+            {
+                // if the thread is null at this point, presume the call was made from the thread context.
+                // run frames until the required state is reached.
+                GameThreadState? newState = null;
+
+                while (newState != targetState)
+                    newState = processFrame();
+
+                // note that the only state transition here can be an exiting one. entering a running state can only occur in Initialize().
+                setExitState(newState.Value);
+            }
+            else
+            {
+                while (state.Value != targetState)
+                    Thread.Sleep(1);
+            }
+        }
+
+        /// <summary>
+        /// Prepares this game thread for work. Should block until <see cref="Initialize"/> has been run.
+        /// </summary>
+        protected virtual void PrepareForWork()
+        {
+            Debug.Assert(Thread == null);
+            createThread();
+            Debug.Assert(Thread != null);
+
+            Thread.Start();
+
+            WaitForState(GameThreadState.Running);
+        }
+
+        /// <summary>
+        /// Called whenever the thread is initialised. Should prepare the thread for performing work.
+        /// </summary>
+        protected virtual void OnInitialize()
+        {
+        }
+
+        /// <summary>
+        /// Called when a <see cref="Pause"/> or <see cref="Exit"/> is requested on this <see cref="GameThread"/>.
+        /// Use this method to release exclusive resources that the thread could have been holding in its current execution mode,
+        /// like GL contexts or similar.
+        /// </summary>
+        protected virtual void OnSuspended()
+        {
+        }
+
+        /// <summary>
+        /// Called when the thread is exited. Should clean up any thread-specific resources.
+        /// </summary>
+        protected virtual void OnExit()
+        {
+        }
+
+        private void updateMaximumHz()
+        {
+            Scheduler.Add(() => Clock.MaximumUpdateHz = IsActive.Value ? activeHz : inactiveHz);
+        }
+
+        /// <summary>
+        /// Create the native backing thread to run work.
+        /// </summary>
         private void createThread()
         {
             Debug.Assert(Thread == null);
@@ -163,37 +374,14 @@ namespace osu.Framework.Threading
             };
 
             updateCulture();
-        }
 
-        public void WaitUntilInitialized() => initializedEvent.WaitOne();
+            void runWork()
+            {
+                Initialize(true);
 
-        private void updateMaximumHz() => Scheduler.Add(() => Clock.MaximumUpdateHz = IsActive.Value ? activeHz : inactiveHz);
-
-        private void runWork()
-        {
-            Initialize(true);
-
-            while (Running)
-                RunSingleFrame();
-        }
-
-        /// <summary>
-        /// Run when thread transitions into an active/processing state.
-        /// </summary>
-        internal virtual void MakeCurrent()
-        {
-            ThreadSafety.ResetAllForCurrentThread();
-        }
-
-        /// <summary>
-        /// Runs a single frame updating the execution status if required.
-        /// </summary>
-        internal void RunSingleFrame()
-        {
-            var newState = processFrame();
-
-            if (newState.HasValue)
-                setExitState(newState.Value);
+                while (Running)
+                    RunSingleFrame();
+            }
         }
 
         /// <summary>
@@ -211,7 +399,6 @@ namespace osu.Framework.Threading
             if (exitRequested)
             {
                 exitRequested = false;
-                PerformExit();
                 return GameThreadState.Exited;
             }
 
@@ -248,127 +435,12 @@ namespace osu.Framework.Threading
             return null;
         }
 
-        private CultureInfo culture;
-
-        public CultureInfo CurrentCulture
-        {
-            get => culture;
-            set
-            {
-                culture = value;
-
-                updateCulture();
-            }
-        }
-
         private void updateCulture()
         {
             if (Thread == null || culture == null) return;
 
             Thread.CurrentCulture = culture;
             Thread.CurrentUICulture = culture;
-        }
-
-        /// <summary>
-        /// Pause this thread. Must be run from <see cref="ThreadRunner"/> in a safe manner.
-        /// </summary>
-        internal void Pause()
-        {
-            lock (startStopLock)
-            {
-                if (state.Value != GameThreadState.Running)
-                    return;
-
-                // actual pause will be done in ProcessFrame.
-                pauseRequested = true;
-            }
-
-            WaitForState(GameThreadState.Paused);
-        }
-
-        /// <summary>
-        /// Called when a <see cref="Pause"/> or <see cref="Exit"/> is requested on this <see cref="GameThread"/>.
-        /// Use this method to release exclusive resources that the thread could have been holding in its current execution mode,
-        /// like GL contexts or similar.
-        /// </summary>
-        protected virtual void OnSuspended()
-        {
-        }
-
-        public void Exit()
-        {
-            lock (startStopLock)
-            {
-                if (state.Value == GameThreadState.Paused)
-                    // technically we could support this, but we don't use this yet and it will add more complexity.
-                    throw new InvalidOperationException("Cannot exit when thread is paused");
-
-                // actual exit will be done in ProcessFrame.
-                exitRequested = true;
-            }
-        }
-
-        /// <summary>
-        /// Start this thread.
-        /// </summary>
-        public void Start()
-        {
-            lock (startStopLock)
-            {
-                Debug.Assert(state.Value != GameThreadState.Exited);
-                Debug.Assert(state.Value != GameThreadState.Running);
-            }
-
-            PrepareForWork();
-        }
-
-        /// <summary>
-        /// Prepares this game thread for work. Should block until <see cref="Initialize"/> has been run.
-        /// </summary>
-        protected virtual void PrepareForWork()
-        {
-            Debug.Assert(Thread == null);
-            createThread();
-            Debug.Assert(Thread != null);
-
-            Thread.Start();
-
-            WaitForState(GameThreadState.Running);
-        }
-
-        protected virtual void PerformExit()
-        {
-            Monitor?.Dispose();
-            initializedEvent?.Dispose();
-        }
-
-        /// <summary>
-        /// Spin indefinitely until this thread enters a required state.
-        /// For cases where no native thread is present, this will run <see cref="processFrame"/> until the required state is reached.
-        /// </summary>
-        /// <param name="targetState">The state to wait for.</param>
-        internal void WaitForState(GameThreadState targetState)
-        {
-            if (state.Value == targetState)
-                return;
-
-            if (Thread == null)
-            {
-                // if the thread is null at this point, presume the call was made from the thread context.
-                // run frames until the required state is reached.
-                GameThreadState? newState = null;
-
-                while (newState != targetState)
-                    newState = processFrame();
-
-                // note that the only state transition here can be an exiting one. entering a running state can only occur in Initialize().
-                setExitState(newState.Value);
-            }
-            else
-            {
-                while (state.Value != targetState)
-                    Thread.Sleep(1);
-            }
         }
 
         private void setExitState(GameThreadState exitState)
@@ -380,11 +452,22 @@ namespace osu.Framework.Threading
 
                 Thread = null;
                 OnSuspended();
+
+                switch (exitState)
+                {
+                    case GameThreadState.Exited:
+                        Monitor?.Dispose();
+                        initializedEvent?.Dispose();
+
+                        OnExit();
+                        break;
+                }
+
                 state.Value = exitState;
             }
         }
 
-        public class GameThreadScheduler : Scheduler
+        private class GameThreadScheduler : Scheduler
         {
             public GameThreadScheduler(GameThread thread)
                 : base(() => thread.IsCurrent, thread.Clock)

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -291,7 +291,7 @@ namespace osu.Framework.Threading
                 pauseRequested = true;
             }
 
-            waitForState(GameThreadState.Paused);
+            WaitForState(GameThreadState.Paused);
         }
 
         /// <summary>
@@ -341,7 +341,7 @@ namespace osu.Framework.Threading
 
             Thread.Start();
 
-            waitForState(GameThreadState.Running);
+            WaitForState(GameThreadState.Running);
         }
 
         protected virtual void PerformExit()
@@ -355,7 +355,7 @@ namespace osu.Framework.Threading
         /// For cases where no native thread is present, this will run <see cref="ProcessFrame"/> until the required state is reached.
         /// </summary>
         /// <param name="targetState">The state to wait for.</param>
-        private void waitForState(GameThreadState targetState)
+        internal void WaitForState(GameThreadState targetState)
         {
             if (Thread == null)
             {

--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -312,10 +312,10 @@ namespace osu.Framework.Threading
 
             if (Thread == null)
             {
-                // if the thread is null at this point, presume the call was made from the thread context.
-                // run frames until the required state is reached.
                 GameThreadState? newState = null;
 
+                // if the thread is null at this point, we need to assume that this WaitForState call is running on the same native thread as this GameThread has/will be running.
+                // run frames until the required state is reached.
                 while (newState != targetState)
                     newState = processFrame();
 

--- a/osu.Framework/Threading/GameThreadState.cs
+++ b/osu.Framework/Threading/GameThreadState.cs
@@ -13,6 +13,11 @@ namespace osu.Framework.Threading
         NotStarted,
 
         /// <summary>
+        /// This thread is preparing to run.
+        /// </summary>
+        Starting,
+
+        /// <summary>
         /// This thread is running.
         /// </summary>
         Running,

--- a/osu.Framework/Threading/GameThreadState.cs
+++ b/osu.Framework/Threading/GameThreadState.cs
@@ -1,0 +1,30 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Platform;
+
+namespace osu.Framework.Threading
+{
+    public enum GameThreadState
+    {
+        /// <summary>
+        /// This thread has not yet been started.
+        /// </summary>
+        NotStarted,
+
+        /// <summary>
+        /// This thread is running.
+        /// </summary>
+        Running,
+
+        /// <summary>
+        /// This thread is paused to be moved to a different native thread. This occurs when <see cref="ExecutionMode"/> changes.
+        /// </summary>
+        Paused,
+
+        /// <summary>
+        /// This thread has permanently exited.
+        /// </summary>
+        Exited
+    }
+}

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -23,7 +23,12 @@ namespace osu.Framework.Threading
             StatisticsCounterType.TabletEvents,
         };
 
-        protected override bool UsesNativeThread => false;
+        protected override void PrepareForWork()
+        {
+            // Intentionally inhibiting the base implementation which spawns a native thread.
+            // Therefore, we need to run Initialize inline.
+            Initialize(true);
+        }
 
         public override bool IsCurrent => ThreadSafety.IsInputThread;
 

--- a/osu.Framework/Threading/InputThread.cs
+++ b/osu.Framework/Threading/InputThread.cs
@@ -23,6 +23,8 @@ namespace osu.Framework.Threading
             StatisticsCounterType.TabletEvents,
         };
 
+        protected override bool UsesNativeThread => false;
+
         public override bool IsCurrent => ThreadSafety.IsInputThread;
 
         internal sealed override void MakeCurrent()
@@ -30,11 +32,6 @@ namespace osu.Framework.Threading
             base.MakeCurrent();
 
             ThreadSafety.IsInputThread = true;
-        }
-
-        public override void Start()
-        {
-            // InputThread does not get started. it is run manually by GameHost.
         }
     }
 }


### PR DESCRIPTION
Not sure where to start or end on this one. Found many issues along the way. I'm sure there's more but this is running in a stable state and seems to be safer than what we had.

Would recommend taking the diff with a grain of salt and just parsing the whole classes involved. I guarantee we will find more areas of improvement during review (although try and keep scope in check).

Fixes issues listed in https://github.com/ppy/osu-framework/issues/4541 except for exposure of methods to consumers. Not addressing that yet because it's kind of their fault if they try to mess with threads directly.

I have not yet tested this with realm requirements, so blocking until I get to doing that.