### PR TITLE
Restore window before maximising to ensure the correct size is used

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1021,6 +1021,7 @@ namespace osu.Framework.Platform
                     break;
 
                 case WindowState.Maximised:
+                    SDL.SDL_RestoreWindow(SDLWindowHandle);
                     SDL.SDL_MaximizeWindow(SDLWindowHandle);
 
                     SDL.SDL_GL_GetDrawableSize(SDLWindowHandle, out int w, out int h);


### PR DESCRIPTION
Resolves https://github.com/ppy/osu/issues/13638.

https://github.com/ppy/osu-framework/issues/4543 may touch more on the underlying issues, which is likely that the maximised state we are managing internally is flimsy during non-windowed display modes.

I'm just looking to fix this in the most resilient way possible, and this change does that. Appreciate testing on linux to make sure it doesn't regress anything (if there's even a concept of "maximised" conveyed there..)