### PR TITLE
Differentiate between maximised and fullscreen borderless state in macOS

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -24,6 +24,7 @@ namespace osu.Framework.Tests.Visual.Platform
         private readonly SpriteText currentActualSize = new SpriteText();
         private readonly SpriteText currentDisplayMode = new SpriteText();
         private readonly SpriteText currentWindowMode = new SpriteText();
+        private readonly SpriteText currentWindowState = new SpriteText();
         private readonly SpriteText supportedWindowModes = new SpriteText();
         private readonly Dropdown<Display> displaysDropdown;
 
@@ -45,6 +46,7 @@ namespace osu.Framework.Tests.Visual.Platform
                     currentActualSize,
                     currentDisplayMode,
                     currentWindowMode,
+                    currentWindowState,
                     supportedWindowModes,
                     displaysDropdown = new BasicDropdown<Display> { Width = 600 }
                 },
@@ -143,6 +145,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             currentActualSize.Text = $"Window size: {window?.ClientSize}";
             currentDisplayMode.Text = $"Display mode: {window?.CurrentDisplayMode}";
+            currentWindowState.Text = $"Window state: {window?.WindowState}";
         }
 
         private void testResolution(int w, int h)

--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -145,7 +145,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             currentActualSize.Text = $"Window size: {window?.ClientSize}";
             currentDisplayMode.Text = $"Display mode: {window?.CurrentDisplayMode}";
-            currentWindowState.Text = $"Window state: {window?.WindowState}";
+            currentWindowState.Text = $"Window State: {window?.WindowState}";
         }
 
         private void testResolution(int w, int h)

--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -448,8 +448,7 @@ namespace osu.Framework.Platform.SDL2
         {
             // NOTE: on macOS, SDL2 does not differentiate between "maximised" and "fullscreen desktop"
             if (windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP) ||
-                windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_BORDERLESS) ||
-                windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED) && RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
+                windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_BORDERLESS))
                 return WindowState.FullscreenBorderless;
 
             if (windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_MINIMIZED))
@@ -475,9 +474,7 @@ namespace osu.Framework.Platform.SDL2
                     return SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN;
 
                 case WindowState.Maximised:
-                    return RuntimeInfo.OS == RuntimeInfo.Platform.macOS
-                        ? SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP
-                        : SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED;
+                    return SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED;
 
                 case WindowState.Minimised:
                     return SDL.SDL_WindowFlags.SDL_WINDOW_MINIMIZED;

--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -446,7 +446,6 @@ namespace osu.Framework.Platform.SDL2
 
         public static WindowState ToWindowState(this SDL.SDL_WindowFlags windowFlags)
         {
-            // NOTE: on macOS, SDL2 does not differentiate between "maximised" and "fullscreen desktop"
             if (windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_FULLSCREEN_DESKTOP) ||
                 windowFlags.HasFlagFast(SDL.SDL_WindowFlags.SDL_WINDOW_BORDERLESS))
                 return WindowState.FullscreenBorderless;


### PR DESCRIPTION
Considering them the same looks to be wrong and have been causing state management problems (e.g. switching to borderless in a maximised window applies no effect).

For confirmation, I've added a "current window state" to `TestSceneFullscreen`, and started playing with the window states while checking what the `WindowState` value is, after applying this change. Looks to be correct in all scenarios.

https://user-images.githubusercontent.com/22781491/123504990-3427da00-d665-11eb-84b6-93dcd1807508.mp4
