### PR TITLE
Fix deadlock if disposing a `GameHost` which was never `Run()`

### DIFF
--- a/osu.Framework.Tests/IO/BackgroundGameHeadlessGameHost.cs
+++ b/osu.Framework.Tests/IO/BackgroundGameHeadlessGameHost.cs
@@ -8,7 +8,7 @@ using osu.Framework.Platform;
 namespace osu.Framework.Tests.IO
 {
     /// <summary>
-    /// Ad headless host for testing purposes. Contains an arbitrary game that is running after construction.
+    /// A headless host for testing purposes. Contains an arbitrary game that is running after construction.
     /// </summary>
     public class BackgroundGameHeadlessGameHost : HeadlessGameHost
     {

--- a/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
@@ -13,6 +13,15 @@ namespace osu.Framework.Tests.Platform
     public class HeadlessGameHostTest
     {
         [Test]
+        public void TestGameHostDisposalWhenNeverRun()
+        {
+            using (var host = new HeadlessGameHost(nameof(TestGameHostDisposalWhenNeverRun), true))
+            {
+                // never call host.Run()
+            }
+        }
+
+        [Test]
         public void TestIpc()
         {
             using (var server = new BackgroundGameHeadlessGameHost(@"server", true))

--- a/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Tests.Platform
         [Test]
         public void TestGameHostDisposalWhenNeverRun()
         {
-            using (var host = new HeadlessGameHost(nameof(TestGameHostDisposalWhenNeverRun), true))
+            using (new HeadlessGameHost(nameof(TestGameHostDisposalWhenNeverRun), true))
             {
                 // never call host.Run()
             }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -585,8 +585,6 @@ namespace osu.Framework.Platform
 
                 SetupConfig(game.GetFrameworkConfigDefaults() ?? new Dictionary<FrameworkSetting, object>());
 
-                ExecutionState = ExecutionState.Running;
-
                 initialiseInputHandlers();
 
                 if (Window != null)
@@ -599,6 +597,7 @@ namespace osu.Framework.Platform
                     IsActive.BindTo(Window.IsActive);
                 }
 
+                ExecutionState = ExecutionState.Running;
                 threadRunner.Start();
 
                 DrawThread.WaitUntilInitialized();

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -392,7 +392,7 @@ namespace osu.Framework.Platform
             if (Root == null)
                 return;
 
-            while (ExecutionState > ExecutionState.Stopping)
+            while (ExecutionState == ExecutionState.Running)
             {
                 using (var buffer = DrawRoots.Get(UsageType.Read))
                 {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -933,11 +933,17 @@ namespace osu.Framework.Platform
 
             isDisposed = true;
 
-            if (ExecutionState > ExecutionState.Stopping)
-                throw new InvalidOperationException($"{nameof(Exit)} must be called before the {nameof(GameHost)} is disposed.");
+            switch (ExecutionState)
+            {
+                case ExecutionState.Running:
+                    throw new InvalidOperationException($"{nameof(Exit)} must be called before the {nameof(GameHost)} is disposed.");
 
-            // Delay disposal until the game has exited
-            stoppedEvent.Wait();
+                case ExecutionState.Stopping:
+                case ExecutionState.Stopped:
+                    // Delay disposal until the game has exited
+                    stoppedEvent.Wait();
+                    break;
+            }
 
             AppDomain.CurrentDomain.UnhandledException -= unhandledExceptionHandler;
             TaskScheduler.UnobservedTaskException -= unobservedExceptionHandler;


### PR DESCRIPTION
This is not a new regression, and can be reproduced on previous framework releases before the `GameThread` changes.

Most of these changes are not actually related to the fix (see individual commit messages). Only the final two really matter.