### PR TITLE
Avoid running exit sequence when it has already been run once

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -497,7 +497,15 @@ namespace osu.Framework.Platform
             }
         }
 
-        public ExecutionState ExecutionState { get; private set; }
+        public ExecutionState ExecutionState
+        {
+            get => executionState;
+            private set
+            {
+                executionState = value;
+                Logger.Log($"Host execution state changed to {value}");
+            }
+        }
 
         /// <summary>
         /// Schedules the game to exit in the next frame.
@@ -935,6 +943,7 @@ namespace osu.Framework.Platform
         private bool isDisposed;
 
         private readonly ManualResetEventSlim stoppedEvent = new ManualResetEventSlim(false);
+        private ExecutionState executionState;
 
         protected virtual void Dispose(bool disposing)
         {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -518,7 +518,7 @@ namespace osu.Framework.Platform
         /// Schedules the game to exit in the next frame (or immediately if <paramref name="immediately"/> is true).
         /// </summary>
         /// <param name="immediately">If true, exits the game immediately.  If false (default), schedules the game to exit in the next frame.</param>
-        protected void PerformExit(bool immediately)
+        protected virtual void PerformExit(bool immediately)
         {
             switch (ExecutionState)
             {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -504,10 +504,15 @@ namespace osu.Framework.Platform
             get => executionState;
             private set
             {
+                if (executionState == value)
+                    return;
+
                 executionState = value;
                 Logger.Log($"Host execution state changed to {value}");
             }
         }
+
+        private ExecutionState executionState;
 
         /// <summary>
         /// Schedules the game to exit in the next frame.
@@ -520,21 +525,15 @@ namespace osu.Framework.Platform
         /// <param name="immediately">If true, exits the game immediately.  If false (default), schedules the game to exit in the next frame.</param>
         protected virtual void PerformExit(bool immediately)
         {
-            switch (ExecutionState)
-            {
-                case ExecutionState.Stopping:
-                case ExecutionState.Stopped:
-                    return;
-            }
+            if (executionState == ExecutionState.Stopped)
+                return;
 
             ExecutionState = ExecutionState.Stopping;
 
             if (immediately)
                 exit();
             else
-            {
                 InputThread.Scheduler.Add(exit, false);
-            }
         }
 
         /// <summary>
@@ -944,7 +943,6 @@ namespace osu.Framework.Platform
         private bool isDisposed;
 
         private readonly ManualResetEventSlim stoppedEvent = new ManualResetEventSlim(false);
-        private ExecutionState executionState;
 
         protected virtual void Dispose(bool disposing)
         {


### PR DESCRIPTION
I'm not sure if this had any adverse side effects (seems like it *should* have), but should make things saner in general regardless. Logging can be removed if preferred, but it seems like something good to have around.

Previously:

```csharp
[runtime] 2021-06-29 10:07:10 [verbose]: Host execution state changed to Running
[runtime] 2021-06-29 10:07:10 [verbose]: Execution mode changed to MultiThreaded
[runtime] 2021-06-29 10:07:10 [verbose]: BASS Initialized
[runtime] 2021-06-29 10:07:10 [verbose]: BASS Version:               2.4.15.26
[runtime] 2021-06-29 10:07:10 [verbose]: BASS FX Version:            2.4.12.3
[runtime] 2021-06-29 10:07:10 [verbose]: Device:                     No sound
[runtime] 2021-06-29 10:07:10 [verbose]: Drive:
[runtime] 2021-06-29 10:07:10 [verbose]: Host execution state changed to Stopping
[runtime] 2021-06-29 10:07:10 [verbose]: Host execution state changed to Stopping
[runtime] 2021-06-29 10:07:10 [verbose]: Host execution state changed to Stopped
[runtime] 2021-06-29 10:07:10 [verbose]: Host execution state changed to Stopping
[runtime] 2021-06-29 10:07:10 [verbose]: Host execution state changed to Stopped
```

Now:

```csharp
[runtime] 2021-06-29 10:08:18 [verbose]: Host execution state changed to Running
[runtime] 2021-06-29 10:08:18 [verbose]: Execution mode changed to MultiThreaded
[runtime] 2021-06-29 10:08:18 [verbose]: BASS Initialized
[runtime] 2021-06-29 10:08:18 [verbose]: BASS Version:               2.4.15.26
[runtime] 2021-06-29 10:08:18 [verbose]: BASS FX Version:            2.4.12.3
[runtime] 2021-06-29 10:08:18 [verbose]: Device:                     No sound
[runtime] 2021-06-29 10:08:18 [verbose]: Drive:
[runtime] 2021-06-29 10:08:18 [verbose]: Host execution state changed to Stopping
[runtime] 2021-06-29 10:08:18 [verbose]: Host execution state changed to Stopped
```