### PR TITLE
Add support for localising `IFormattable` objects

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
@@ -32,8 +32,8 @@ namespace osu.Framework.Benchmarks
             romanisableString2 = new RomanisableString("c", "d");
             translatableString1 = new TranslatableString("e", "f");
             translatableString2 = new TranslatableString("g", "h");
-            formattableString1 = new LocalisableFormattable(1.23, "N0");
-            formattableString2 = new LocalisableFormattable(4.56, "N1");
+            formattableString1 = new LocalisableFormattableString(1.23, "N0");
+            formattableString2 = new LocalisableFormattableString(4.56, "N1");
         }
 
         [Benchmark]

--- a/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using BenchmarkDotNet.Attributes;
 using osu.Framework.Localisation;
 
@@ -9,6 +10,10 @@ namespace osu.Framework.Benchmarks
     [MemoryDiagnoser]
     public class BenchmarkLocalisableString
     {
+        private string string1;
+        private string string2;
+        private LocalisableString localisableString1;
+        private LocalisableString localisableString2;
         private LocalisableString romanisableString1;
         private LocalisableString romanisableString2;
         private LocalisableString translatableString1;
@@ -19,6 +24,10 @@ namespace osu.Framework.Benchmarks
         [GlobalSetup]
         public void GlobalSetup()
         {
+            string1 = "a";
+            string2 = "b";
+            localisableString1 = "a";
+            localisableString2 = "b";
             romanisableString1 = new RomanisableString("a", "b");
             romanisableString2 = new RomanisableString("c", "d");
             translatableString1 = new TranslatableString("e", "f");
@@ -28,6 +37,12 @@ namespace osu.Framework.Benchmarks
         }
 
         [Benchmark]
+        public bool BenchmarkStringEquals() => string1.Equals(string2, StringComparison.Ordinal);
+
+        [Benchmark]
+        public bool BenchmarkLocalisableStringEquals() => localisableString1.Equals(localisableString2);
+
+        [Benchmark]
         public bool BenchmarkRomanisableEquals() => romanisableString1.Equals(romanisableString2);
 
         [Benchmark]
@@ -35,6 +50,12 @@ namespace osu.Framework.Benchmarks
 
         [Benchmark]
         public bool BenchmarkFormattableEquals() => formattableString1.Equals(formattableString2);
+
+        [Benchmark]
+        public int BenchmarkStringGetHashCode() => string1.GetHashCode();
+
+        [Benchmark]
+        public int BenchmarkLocalisableStringGetHashCode() => localisableString1.GetHashCode();
 
         [Benchmark]
         public int BenchmarkRomanisableGetHashCode() => romanisableString1.GetHashCode();

--- a/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLocalisableString.cs
@@ -9,20 +9,40 @@ namespace osu.Framework.Benchmarks
     [MemoryDiagnoser]
     public class BenchmarkLocalisableString
     {
-        private LocalisableString str1;
-        private LocalisableString str2;
+        private LocalisableString romanisableString1;
+        private LocalisableString romanisableString2;
+        private LocalisableString translatableString1;
+        private LocalisableString translatableString2;
+        private LocalisableString formattableString1;
+        private LocalisableString formattableString2;
 
         [GlobalSetup]
         public void GlobalSetup()
         {
-            str1 = new RomanisableString("a", "b");
-            str2 = new RomanisableString("c", "d");
+            romanisableString1 = new RomanisableString("a", "b");
+            romanisableString2 = new RomanisableString("c", "d");
+            translatableString1 = new TranslatableString("e", "f");
+            translatableString2 = new TranslatableString("g", "h");
+            formattableString1 = new LocalisableFormattable(1.23, "N0");
+            formattableString2 = new LocalisableFormattable(4.56, "N1");
         }
 
         [Benchmark]
-        public bool BenchmarkEquals() => str1.Equals(str2);
+        public bool BenchmarkRomanisableEquals() => romanisableString1.Equals(romanisableString2);
 
         [Benchmark]
-        public int BenchmarkGetHashCode() => str1.GetHashCode();
+        public bool BenchmarkTranslatableEquals() => translatableString1.Equals(translatableString2);
+
+        [Benchmark]
+        public bool BenchmarkFormattableEquals() => formattableString1.Equals(formattableString2);
+
+        [Benchmark]
+        public int BenchmarkRomanisableGetHashCode() => romanisableString1.GetHashCode();
+
+        [Benchmark]
+        public int BenchmarkTranslatableGetHashCode() => translatableString1.GetHashCode();
+
+        [Benchmark]
+        public int BenchmarkFormattableGetHashCode() => formattableString1.GetHashCode();
     }
 }

--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using osu.Framework.Localisation;
@@ -12,6 +13,9 @@ namespace osu.Framework.Tests.Localisation
     {
         private string makeStringA => makeString('a');
         private string makeStringB => makeString('b');
+
+        private IFormattable makeFormattableA => new DateTime(1);
+        private IFormattable makeFormattableB => new DateTime(2);
 
         [Test]
         public void TestTranslatableStringEqualsTranslatableString()
@@ -32,6 +36,17 @@ namespace osu.Framework.Tests.Localisation
 
             testEquals(true, str1, str1);
             testEquals(true, str1, new RomanisableString(makeStringA, makeStringB)); // Structural equality.
+            testEquals(false, str1, str2);
+        }
+
+        [Test]
+        public void TestLocalisableFormattableEqualsLocalisableFormattable()
+        {
+            var str1 = new LocalisableFormattable(makeFormattableA, makeStringB);
+            var str2 = new LocalisableFormattable(makeFormattableB, makeStringA);
+
+            testEquals(true, str1, str1);
+            testEquals(true, str1, new LocalisableFormattable(makeFormattableA, makeStringB));
             testEquals(false, str1, str2);
         }
 
@@ -64,6 +79,15 @@ namespace osu.Framework.Tests.Localisation
             testEquals(false, localisable, new RomanisableString(makeStringB, makeStringA));
             testEquals(false, localisable, makeStringA);
             testEquals(false, localisable, new TranslatableString(makeStringA, makeStringB));
+        }
+
+        [Test]
+        public void TestLocalisableStringEqualsLocalisableFormattable()
+        {
+            LocalisableString localisable = new LocalisableFormattable(makeFormattableA, makeStringB);
+
+            testEquals(true, localisable, new LocalisableFormattable(makeFormattableA, makeStringB));
+            testEquals(false, localisable, new LocalisableFormattable(makeFormattableB, makeStringA));
         }
 
         [Test]

--- a/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisableStringTest.cs
@@ -42,11 +42,11 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestLocalisableFormattableEqualsLocalisableFormattable()
         {
-            var str1 = new LocalisableFormattable(makeFormattableA, makeStringB);
-            var str2 = new LocalisableFormattable(makeFormattableB, makeStringA);
+            var str1 = new LocalisableFormattableString(makeFormattableA, makeStringB);
+            var str2 = new LocalisableFormattableString(makeFormattableB, makeStringA);
 
             testEquals(true, str1, str1);
-            testEquals(true, str1, new LocalisableFormattable(makeFormattableA, makeStringB));
+            testEquals(true, str1, new LocalisableFormattableString(makeFormattableA, makeStringB));
             testEquals(false, str1, str2);
         }
 
@@ -84,10 +84,10 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestLocalisableStringEqualsLocalisableFormattable()
         {
-            LocalisableString localisable = new LocalisableFormattable(makeFormattableA, makeStringB);
+            LocalisableString localisable = new LocalisableFormattableString(makeFormattableA, makeStringB);
 
-            testEquals(true, localisable, new LocalisableFormattable(makeFormattableA, makeStringB));
-            testEquals(false, localisable, new LocalisableFormattable(makeFormattableB, makeStringA));
+            testEquals(true, localisable, new LocalisableFormattableString(makeFormattableA, makeStringB));
+            testEquals(false, localisable, new LocalisableFormattableString(makeFormattableB, makeStringA));
         }
 
         [Test]

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -222,6 +222,26 @@ namespace osu.Framework.Tests.Localisation
             Assert.AreEqual(non_unicode_fallback, text.Value);
         }
 
+        /// <summary>
+        /// This tests the <see cref="LocalisableFormattable"/> string, which allows for formatting <see cref="IFormattable"/>s,
+        /// without necessarily being in a <see cref="TranslatableString"/> which requires keys mapping to strings from localistaion stores.
+        /// </summary>
+        [Test]
+        public void TestLocalisableFormattableString()
+        {
+            manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
+
+            var dateTime = new DateTime(1);
+            var format = "MMM yyyy";
+
+            var text = manager.GetLocalisedString(new LocalisableFormattable(dateTime, format));
+
+            Assert.AreEqual("Jan 0001", text.Value);
+
+            config.SetValue(FrameworkSetting.Locale, "ja-JP");
+            Assert.AreEqual("1月 0001", text.Value);
+        }
+
         private class FakeFrameworkConfigManager : FrameworkConfigManager
         {
             protected override string Filename => null;

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -229,7 +229,7 @@ namespace osu.Framework.Tests.Localisation
         [Test]
         public void TestLocalisableFormattableString()
         {
-            manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
+            manager.AddLanguage("fr", new FakeStorage("fr"));
 
             var dateTime = new DateTime(1);
             const string format = "MMM yyyy";
@@ -238,8 +238,8 @@ namespace osu.Framework.Tests.Localisation
 
             Assert.AreEqual("Jan 0001", text.Value);
 
-            config.SetValue(FrameworkSetting.Locale, "ja-JP");
-            Assert.AreEqual("1月 0001", text.Value);
+            config.SetValue(FrameworkSetting.Locale, "fr");
+            Assert.AreEqual("janv. 0001", text.Value);
         }
 
         private class FakeFrameworkConfigManager : FrameworkConfigManager

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -232,7 +232,7 @@ namespace osu.Framework.Tests.Localisation
             manager.AddLanguage("ja-JP", new FakeStorage("ja-JP"));
 
             var dateTime = new DateTime(1);
-            var format = "MMM yyyy";
+            const string format = "MMM yyyy";
 
             var text = manager.GetLocalisedString(new LocalisableFormattable(dateTime, format));
 

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -223,7 +223,7 @@ namespace osu.Framework.Tests.Localisation
         }
 
         /// <summary>
-        /// This tests the <see cref="LocalisableFormattableString"/> string, which allows for formatting <see cref="IFormattable"/>s,
+        /// This tests the <see cref="LocalisableFormattableString"/>, which allows for formatting <see cref="IFormattable"/>s,
         /// without necessarily being in a <see cref="TranslatableString"/> which requires keys mapping to strings from localistaion stores.
         /// </summary>
         [Test]

--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -223,7 +223,7 @@ namespace osu.Framework.Tests.Localisation
         }
 
         /// <summary>
-        /// This tests the <see cref="LocalisableFormattable"/> string, which allows for formatting <see cref="IFormattable"/>s,
+        /// This tests the <see cref="LocalisableFormattableString"/> string, which allows for formatting <see cref="IFormattable"/>s,
         /// without necessarily being in a <see cref="TranslatableString"/> which requires keys mapping to strings from localistaion stores.
         /// </summary>
         [Test]
@@ -234,7 +234,7 @@ namespace osu.Framework.Tests.Localisation
             var dateTime = new DateTime(1);
             const string format = "MMM yyyy";
 
-            var text = manager.GetLocalisedString(new LocalisableFormattable(dateTime, format));
+            var text = manager.GetLocalisedString(new LocalisableFormattableString(dateTime, format));
 
             Assert.AreEqual("Jan 0001", text.Value);
 

--- a/osu.Framework/Localisation/ILocalisableStringData.cs
+++ b/osu.Framework/Localisation/ILocalisableStringData.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Configuration;
 
 #nullable enable
 
@@ -16,7 +17,7 @@ namespace osu.Framework.Localisation
         /// Gets a localised <see cref="string"/> using the given localisation store and other required data.
         /// </summary>
         /// <param name="store">The localisation store.</param>
-        /// <param name="preferUnicode">Whether unicode is preferred if available.</param>
-        string GetLocalised(ILocalisationStore? store, bool preferUnicode);
+        /// <param name="config">The config manager, used for retrieving current value of certain settings (i.e. <see cref="FrameworkSetting.ShowUnicode"/>.</param>
+        string GetLocalised(ILocalisationStore? store, FrameworkConfigManager config);
     }
 }

--- a/osu.Framework/Localisation/ILocalisableStringData.cs
+++ b/osu.Framework/Localisation/ILocalisableStringData.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+#nullable enable
+
+namespace osu.Framework.Localisation
+{
+    /// <summary>
+    /// An interface for <see cref="LocalisableString"/>'s data.
+    /// </summary>
+    public interface ILocalisableStringData : IEquatable<ILocalisableStringData>
+    {
+        /// <summary>
+        /// Gets a localised <see cref="string"/> using the given localisation store and other required data.
+        /// </summary>
+        /// <param name="store">The localisation store.</param>
+        /// <param name="preferUnicode">Whether unicode is preferred if available.</param>
+        string GetLocalised(ILocalisationStore? store, bool preferUnicode);
+    }
+}

--- a/osu.Framework/Localisation/ILocalisableStringData.cs
+++ b/osu.Framework/Localisation/ILocalisableStringData.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Configuration;
 
 #nullable enable
 
@@ -16,8 +15,7 @@ namespace osu.Framework.Localisation
         /// <summary>
         /// Gets a localised <see cref="string"/> using the given localisation store and other required data.
         /// </summary>
-        /// <param name="store">The localisation store.</param>
-        /// <param name="config">The config manager, used for retrieving current value of certain settings (i.e. <see cref="FrameworkSetting.ShowUnicode"/>.</param>
-        string GetLocalised(ILocalisationStore? store, FrameworkConfigManager config);
+        /// <param name="parameters">Any parameters that control the localisation method.</param>
+        string GetLocalised(LocalisationParameters parameters);
     }
 }

--- a/osu.Framework/Localisation/LocalisableFormattable.cs
+++ b/osu.Framework/Localisation/LocalisableFormattable.cs
@@ -47,22 +47,8 @@ namespace osu.Framework.Localisation
                    Format == other.Format;
         }
 
-        public bool Equals(ILocalisableStringData? other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (other.GetType() != GetType()) return false;
-
-            return Equals((LocalisableFormattable)other);
-        }
-
-        public override bool Equals(object? obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-
-            return Equals((LocalisableFormattable)obj);
-        }
+        public bool Equals(ILocalisableStringData? other) => other is LocalisableFormattable formattable && Equals(formattable);
+        public override bool Equals(object? obj) => obj is LocalisableFormattable formattable && Equals(formattable);
 
         public override int GetHashCode() => HashCode.Combine(Value, Format);
     }

--- a/osu.Framework/Localisation/LocalisableFormattable.cs
+++ b/osu.Framework/Localisation/LocalisableFormattable.cs
@@ -49,7 +49,7 @@ namespace osu.Framework.Localisation
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != this.GetType()) return false;
+            if (obj.GetType() != GetType()) return false;
 
             return Equals((LocalisableFormattable)obj);
         }

--- a/osu.Framework/Localisation/LocalisableFormattable.cs
+++ b/osu.Framework/Localisation/LocalisableFormattable.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace osu.Framework.Localisation
+{
+    /// <summary>
+    /// A string allowing for formatting <see cref="IFormattable"/>s using the current locale.
+    /// </summary>
+    public class LocalisableFormattable : IEquatable<LocalisableFormattable>
+    {
+        public readonly IFormattable Value;
+        public readonly string Format;
+
+        /// <summary>
+        /// Creates a <see cref="LocalisableFormattable"/> with an <see cref="IFormattable"/> value and a format string.
+        /// </summary>
+        /// <param name="value">The <see cref="IFormattable"/> value.</param>
+        /// <param name="format">The format string.</param>
+        public LocalisableFormattable(IFormattable value, string format)
+        {
+            Value = value;
+            Format = format;
+        }
+
+        public string ToString(IFormatProvider formatProvider)
+        {
+            if (formatProvider == null)
+                return ToString();
+
+            return Value.ToString(Format, formatProvider);
+        }
+
+        public override string ToString() => Value.ToString(Format, CultureInfo.InvariantCulture);
+
+        public bool Equals(LocalisableFormattable other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+
+            return EqualityComparer<object>.Default.Equals(Value, other.Value) &&
+                   Format == other.Format;
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+
+            return Equals((LocalisableFormattable)obj);
+        }
+
+        public override int GetHashCode() => HashCode.Combine(Value, Format);
+    }
+}

--- a/osu.Framework/Localisation/LocalisableFormattable.cs
+++ b/osu.Framework/Localisation/LocalisableFormattable.cs
@@ -38,8 +38,6 @@ namespace osu.Framework.Localisation
 
         public override string ToString() => Value.ToString(Format, CultureInfo.InvariantCulture);
 
-        public static implicit operator LocalisableString(LocalisableFormattable formattable) => new LocalisableString(formattable);
-
         public bool Equals(LocalisableFormattable? other)
         {
             if (ReferenceEquals(null, other)) return false;

--- a/osu.Framework/Localisation/LocalisableFormattable.cs
+++ b/osu.Framework/Localisation/LocalisableFormattable.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using osu.Framework.Configuration;
 
 namespace osu.Framework.Localisation
 {
@@ -28,7 +29,7 @@ namespace osu.Framework.Localisation
             Format = format;
         }
 
-        public string GetLocalised(ILocalisationStore? store, bool preferUnicode)
+        public string GetLocalised(ILocalisationStore? store, FrameworkConfigManager config)
         {
             if (store == null)
                 return ToString();

--- a/osu.Framework/Localisation/LocalisableFormattable.cs
+++ b/osu.Framework/Localisation/LocalisableFormattable.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -10,7 +12,7 @@ namespace osu.Framework.Localisation
     /// <summary>
     /// A string allowing for formatting <see cref="IFormattable"/>s using the current locale.
     /// </summary>
-    public class LocalisableFormattable : IEquatable<LocalisableFormattable>
+    public class LocalisableFormattable : IEquatable<LocalisableFormattable>, ILocalisableStringData
     {
         public readonly IFormattable Value;
         public readonly string Format;
@@ -26,17 +28,19 @@ namespace osu.Framework.Localisation
             Format = format;
         }
 
-        public string ToString(IFormatProvider formatProvider)
+        public string GetLocalised(ILocalisationStore? store, bool preferUnicode)
         {
-            if (formatProvider == null)
+            if (store == null)
                 return ToString();
 
-            return Value.ToString(Format, formatProvider);
+            return Value.ToString(Format, store.EffectiveCulture);
         }
 
         public override string ToString() => Value.ToString(Format, CultureInfo.InvariantCulture);
 
-        public bool Equals(LocalisableFormattable other)
+        public static implicit operator LocalisableString(LocalisableFormattable formattable) => new LocalisableString(formattable);
+
+        public bool Equals(LocalisableFormattable? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -45,7 +49,15 @@ namespace osu.Framework.Localisation
                    Format == other.Format;
         }
 
-        public override bool Equals(object obj)
+        public bool Equals(ILocalisableStringData? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (other.GetType() != GetType()) return false;
+
+            return Equals((LocalisableFormattable)other);
+        }
+
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj)) return false;
             if (ReferenceEquals(this, obj)) return true;

--- a/osu.Framework/Localisation/LocalisableFormattable.cs
+++ b/osu.Framework/Localisation/LocalisableFormattable.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using osu.Framework.Configuration;
 
 namespace osu.Framework.Localisation
 {
@@ -29,12 +28,12 @@ namespace osu.Framework.Localisation
             Format = format;
         }
 
-        public string GetLocalised(ILocalisationStore? store, FrameworkConfigManager config)
+        public string GetLocalised(LocalisationParameters parameters)
         {
-            if (store == null)
+            if (parameters.Store == null)
                 return ToString();
 
-            return Value.ToString(Format, store.EffectiveCulture);
+            return Value.ToString(Format, parameters.Store.EffectiveCulture);
         }
 
         public override string ToString() => Value.ToString(Format, CultureInfo.InvariantCulture);

--- a/osu.Framework/Localisation/LocalisableFormattableString.cs
+++ b/osu.Framework/Localisation/LocalisableFormattableString.cs
@@ -10,7 +10,7 @@ using System.Globalization;
 namespace osu.Framework.Localisation
 {
     /// <summary>
-    /// A string allowing for formatting <see cref="IFormattable"/>s using the current locale.
+    /// A string which formats an <see cref="IFormattable"/>s using the current locale.
     /// </summary>
     public class LocalisableFormattableString : IEquatable<LocalisableFormattableString>, ILocalisableStringData
     {

--- a/osu.Framework/Localisation/LocalisableFormattableString.cs
+++ b/osu.Framework/Localisation/LocalisableFormattableString.cs
@@ -12,17 +12,17 @@ namespace osu.Framework.Localisation
     /// <summary>
     /// A string allowing for formatting <see cref="IFormattable"/>s using the current locale.
     /// </summary>
-    public class LocalisableFormattable : IEquatable<LocalisableFormattable>, ILocalisableStringData
+    public class LocalisableFormattableString : IEquatable<LocalisableFormattableString>, ILocalisableStringData
     {
         public readonly IFormattable Value;
         public readonly string Format;
 
         /// <summary>
-        /// Creates a <see cref="LocalisableFormattable"/> with an <see cref="IFormattable"/> value and a format string.
+        /// Creates a <see cref="LocalisableFormattableString"/> with an <see cref="IFormattable"/> value and a format string.
         /// </summary>
         /// <param name="value">The <see cref="IFormattable"/> value.</param>
         /// <param name="format">The format string.</param>
-        public LocalisableFormattable(IFormattable value, string format)
+        public LocalisableFormattableString(IFormattable value, string format)
         {
             Value = value;
             Format = format;
@@ -38,7 +38,7 @@ namespace osu.Framework.Localisation
 
         public override string ToString() => Value.ToString(Format, CultureInfo.InvariantCulture);
 
-        public bool Equals(LocalisableFormattable? other)
+        public bool Equals(LocalisableFormattableString? other)
         {
             if (ReferenceEquals(null, other)) return false;
             if (ReferenceEquals(this, other)) return true;
@@ -47,8 +47,8 @@ namespace osu.Framework.Localisation
                    Format == other.Format;
         }
 
-        public bool Equals(ILocalisableStringData? other) => other is LocalisableFormattable formattable && Equals(formattable);
-        public override bool Equals(object? obj) => obj is LocalisableFormattable formattable && Equals(formattable);
+        public bool Equals(ILocalisableStringData? other) => other is LocalisableFormattableString formattable && Equals(formattable);
+        public override bool Equals(object? obj) => obj is LocalisableFormattableString formattable && Equals(formattable);
 
         public override int GetHashCode() => HashCode.Combine(Value, Format);
     }

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Localisation
         internal readonly object? Data;
 
         /// <summary>
-        /// Creates a new <see cref="LocalisableString"/> with underlying string.
+        /// Creates a new <see cref="LocalisableString"/> with underlying string data.
         /// </summary>
         public LocalisableString(string data)
         {

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Localisation
     public readonly struct LocalisableString : IEquatable<LocalisableString>
     {
         /// <summary>
-        /// The underlying data, can be <see cref="string"/>, <see cref="TranslatableString"/>, or <see cref="RomanisableString"/>.
+        /// The underlying data, can be <see cref="string"/>, <see cref="TranslatableString"/>, <see cref="RomanisableString"/>, or <see cref="LocalisableFormattable"/>.
         /// </summary>
         internal readonly object? Data;
 
@@ -29,6 +29,7 @@ namespace osu.Framework.Localisation
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
         public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
         public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
+        public static implicit operator LocalisableString(LocalisableFormattable formattable) => new LocalisableString(formattable);
 
         public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
         public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -13,11 +13,25 @@ namespace osu.Framework.Localisation
     public readonly struct LocalisableString : IEquatable<LocalisableString>
     {
         /// <summary>
-        /// The underlying data, can be <see cref="string"/>, <see cref="TranslatableString"/>, <see cref="RomanisableString"/>, or <see cref="LocalisableFormattable"/>.
+        /// The underlying data.
         /// </summary>
         internal readonly object? Data;
 
-        private LocalisableString(object data) => Data = data;
+        /// <summary>
+        /// Creates a new <see cref="LocalisableString"/> with underlying string.
+        /// </summary>
+        public LocalisableString(string data)
+        {
+            Data = data;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="LocalisableString"/> with underlying localisable string data.
+        /// </summary>
+        public LocalisableString(ILocalisableStringData data)
+        {
+            Data = data;
+        }
 
         // it's somehow common to call default(LocalisableString), and we should return empty string then.
         public override string ToString() => Data?.ToString() ?? string.Empty;
@@ -27,9 +41,6 @@ namespace osu.Framework.Localisation
         public override int GetHashCode() => LocalisableStringEqualityComparer.Default.GetHashCode(this);
 
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
-        public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
-        public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
-        public static implicit operator LocalisableString(LocalisableFormattable formattable) => new LocalisableString(formattable);
 
         public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
         public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Localisation
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
         public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
         public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
-        public static implicit operator LocalisableString(LocalisableFormattable formattable) => new LocalisableString(formattable);
+        public static implicit operator LocalisableString(LocalisableFormattableString formattable) => new LocalisableString(formattable);
 
         public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
         public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);

--- a/osu.Framework/Localisation/LocalisableString.cs
+++ b/osu.Framework/Localisation/LocalisableString.cs
@@ -41,6 +41,9 @@ namespace osu.Framework.Localisation
         public override int GetHashCode() => LocalisableStringEqualityComparer.Default.GetHashCode(this);
 
         public static implicit operator LocalisableString(string text) => new LocalisableString(text);
+        public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
+        public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
+        public static implicit operator LocalisableString(LocalisableFormattable formattable) => new LocalisableString(formattable);
 
         public static bool operator ==(LocalisableString left, LocalisableString right) => left.Equals(right);
         public static bool operator !=(LocalisableString left, LocalisableString right) => !left.Equals(right);

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -33,14 +33,8 @@ namespace osu.Framework.Localisation
                 case string strX:
                     return strX.Equals((string)yData, StringComparison.Ordinal);
 
-                case TranslatableString translatableX:
-                    return translatableX.Equals((TranslatableString)yData);
-
-                case RomanisableString romanisableX:
-                    return romanisableX.Equals((RomanisableString)yData);
-
-                case LocalisableFormattable formattableX:
-                    return formattableX.Equals((LocalisableFormattable)yData);
+                case ILocalisableStringData dataX:
+                    return dataX.Equals((ILocalisableStringData)yData);
             }
 
             return false;
@@ -52,27 +46,8 @@ namespace osu.Framework.Localisation
                 return 0;
 
             var hashCode = new HashCode();
-            hashCode.Add(obj.Data.GetType().GetHashCode());
-
-            switch (obj.Data)
-            {
-                case string str:
-                    hashCode.Add(str.GetHashCode());
-                    break;
-
-                case TranslatableString translatable:
-                    hashCode.Add(translatable.GetHashCode());
-                    break;
-
-                case RomanisableString romanisable:
-                    hashCode.Add(romanisable.GetHashCode());
-                    break;
-
-                case LocalisableFormattable formattable:
-                    hashCode.Add(formattable.GetHashCode());
-                    break;
-            }
-
+            hashCode.Add(obj.Data.GetType());
+            hashCode.Add(obj.Data);
             return hashCode.ToHashCode();
         }
     }

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -38,6 +38,9 @@ namespace osu.Framework.Localisation
 
                 case RomanisableString romanisableX:
                     return romanisableX.Equals((RomanisableString)yData);
+
+                case LocalisableFormattable formattableX:
+                    return formattableX.Equals((LocalisableFormattable)yData);
             }
 
             return false;
@@ -63,6 +66,10 @@ namespace osu.Framework.Localisation
 
                 case RomanisableString romanisable:
                     hashCode.Add(romanisable.GetHashCode());
+                    break;
+
+                case LocalisableFormattable formattable:
+                    hashCode.Add(formattable.GetHashCode());
                     break;
             }
 

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -40,15 +40,6 @@ namespace osu.Framework.Localisation
             return false;
         }
 
-        public int GetHashCode(LocalisableString obj)
-        {
-            if (ReferenceEquals(null, obj.Data))
-                return 0;
-
-            var hashCode = new HashCode();
-            hashCode.Add(obj.Data.GetType());
-            hashCode.Add(obj.Data);
-            return hashCode.ToHashCode();
-        }
+        public int GetHashCode(LocalisableString obj) => HashCode.Combine(obj.Data?.GetType(), obj.Data);
     }
 }

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -14,19 +14,17 @@ namespace osu.Framework.Localisation
     {
         private readonly List<LocaleMapping> locales = new List<LocaleMapping>();
 
-        private readonly Bindable<string> configLocale;
-
-        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable Bidnable reference needs to be held.
-        private readonly Bindable<bool> configPreferUnicode;
+        private readonly Bindable<string> configLocale = new Bindable<string>();
+        private readonly Bindable<bool> configPreferUnicode = new BindableBool();
 
         private readonly Bindable<LocalisationParameters> currentSettings = new Bindable<LocalisationParameters>(new LocalisationParameters(null, false));
 
         public LocalisationManager(FrameworkConfigManager config)
         {
-            configLocale = config.GetBindable<string>(FrameworkSetting.Locale);
+            config.BindWith(FrameworkSetting.Locale, configLocale);
             configLocale.BindValueChanged(updateLocale);
 
-            configPreferUnicode = config.GetBindable<bool>(FrameworkSetting.ShowUnicode);
+            config.BindWith(FrameworkSetting.ShowUnicode, configPreferUnicode);
             configPreferUnicode.BindValueChanged(updateUnicodePreference, true);
         }
 

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Localisation
         private readonly Bindable<string> configLocale = new Bindable<string>();
         private readonly Bindable<bool> configPreferUnicode = new BindableBool();
 
-        private readonly Bindable<LocalisationParameters> currentSettings = new Bindable<LocalisationParameters>(new LocalisationParameters(null, false));
+        private readonly Bindable<LocalisationParameters> currentParameters = new Bindable<LocalisationParameters>(new LocalisationParameters(null, false));
 
         public LocalisationManager(FrameworkConfigManager config)
         {
@@ -38,7 +38,7 @@ namespace osu.Framework.Localisation
         /// Creates an <see cref="ILocalisedBindableString"/> which automatically updates its text according to information provided in <see cref="ILocalisedBindableString.Text"/>.
         /// </summary>
         /// <returns>The <see cref="ILocalisedBindableString"/>.</returns>
-        public ILocalisedBindableString GetLocalisedString(LocalisableString original) => new LocalisedBindableString(original, currentSettings);
+        public ILocalisedBindableString GetLocalisedString(LocalisableString original) => new LocalisedBindableString(original, currentParameters);
 
         private void updateLocale(ValueChangedEvent<string> locale)
         {
@@ -61,17 +61,17 @@ namespace osu.Framework.Localisation
                 validLocale ??= locales[0];
             }
 
-            ChangeSettings(CreateNewLocalisationParameters(validLocale.Storage, currentSettings.Value.PreferOriginalScript));
+            ChangeSettings(CreateNewLocalisationParameters(validLocale.Storage, currentParameters.Value.PreferOriginalScript));
         }
 
         private void updateUnicodePreference(ValueChangedEvent<bool> preferUnicode)
-            => ChangeSettings(CreateNewLocalisationParameters(currentSettings.Value.Store, preferUnicode.NewValue));
+            => ChangeSettings(CreateNewLocalisationParameters(currentParameters.Value.Store, preferUnicode.NewValue));
 
         /// <summary>
         /// Changes the localisation parameters.
         /// </summary>
         /// <param name="parameters">The new localisation parameters.</param>
-        protected void ChangeSettings(LocalisationParameters parameters) => currentSettings.Value = parameters;
+        protected void ChangeSettings(LocalisationParameters parameters) => currentParameters.Value = parameters;
 
         /// <summary>
         /// Creates new <see cref="LocalisationParameters"/>.

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -14,13 +14,14 @@ namespace osu.Framework.Localisation
     {
         private readonly List<LocaleMapping> locales = new List<LocaleMapping>();
 
-        private readonly Bindable<bool> preferUnicode;
         private readonly Bindable<string> configLocale;
         private readonly Bindable<ILocalisationStore?> currentStorage = new Bindable<ILocalisationStore?>();
 
+        private readonly FrameworkConfigManager config;
+
         public LocalisationManager(FrameworkConfigManager config)
         {
-            preferUnicode = config.GetBindable<bool>(FrameworkSetting.ShowUnicode);
+            this.config = config;
 
             configLocale = config.GetBindable<string>(FrameworkSetting.Locale);
             configLocale.BindValueChanged(updateLocale);
@@ -36,7 +37,7 @@ namespace osu.Framework.Localisation
         /// Creates an <see cref="ILocalisedBindableString"/> which automatically updates its text according to information provided in <see cref="ILocalisedBindableString.Text"/>.
         /// </summary>
         /// <returns>The <see cref="ILocalisedBindableString"/>.</returns>
-        public ILocalisedBindableString GetLocalisedString(LocalisableString original) => new LocalisedBindableString(original, currentStorage, preferUnicode);
+        public ILocalisedBindableString GetLocalisedString(LocalisableString original) => new LocalisedBindableString(original, currentStorage, config);
 
         private void updateLocale(ValueChangedEvent<string> locale)
         {

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -4,7 +4,6 @@
 #pragma warning disable 8632 // TODO: can be #nullable enable when Bindables are updated to also be.
 
 using osu.Framework.Bindables;
-using osu.Framework.Configuration;
 
 namespace osu.Framework.Localisation
 {
@@ -12,25 +11,16 @@ namespace osu.Framework.Localisation
     {
         private class LocalisedBindableString : Bindable<string>, ILocalisedBindableString
         {
-            private readonly IBindable<ILocalisationStore?> storage = new Bindable<ILocalisationStore?>();
-
-            // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable (reference must be kept for bindable to not get GC'd)
-            private readonly IBindable<bool> preferUnicode;
+            private readonly IBindable<LocalisationParameters> parameters = new Bindable<LocalisationParameters>();
 
             private LocalisableString text;
-            private readonly FrameworkConfigManager config;
 
-            public LocalisedBindableString(LocalisableString text, Bindable<ILocalisationStore?> storage, FrameworkConfigManager config)
+            public LocalisedBindableString(LocalisableString text, IBindable<LocalisationParameters> parameters)
             {
                 this.text = text;
 
-                this.storage.BindTo(storage);
-                this.storage.BindValueChanged(_ => updateValue());
-
-                this.config = config;
-
-                preferUnicode = config.GetBindable<bool>(FrameworkSetting.ShowUnicode);
-                preferUnicode.BindValueChanged(_ => updateValue());
+                this.parameters.BindTo(parameters);
+                this.parameters.BindValueChanged(_ => updateValue());
 
                 updateValue();
             }
@@ -44,7 +34,7 @@ namespace osu.Framework.Localisation
                         break;
 
                     case ILocalisableStringData data:
-                        Value = data.GetLocalised(storage.Value, config);
+                        Value = data.GetLocalised(parameters.Value);
                         break;
 
                     default:

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -43,6 +43,10 @@ namespace osu.Framework.Localisation
                         Value = translatable.Format(storage.Value);
                         break;
 
+                    case LocalisableFormattable formattable:
+                        Value = formattable.ToString(storage.Value?.EffectiveCulture);
+                        break;
+
                     default:
                         Value = string.Empty;
                         break;

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -35,16 +35,8 @@ namespace osu.Framework.Localisation
                         Value = plain;
                         break;
 
-                    case RomanisableString romanisable:
-                        Value = romanisable.GetPreferred(preferUnicode.Value);
-                        break;
-
-                    case TranslatableString translatable:
-                        Value = translatable.Format(storage.Value);
-                        break;
-
-                    case LocalisableFormattable formattable:
-                        Value = formattable.ToString(storage.Value?.EffectiveCulture);
+                    case ILocalisableStringData data:
+                        Value = data.GetLocalised(storage.Value, preferUnicode.Value);
                         break;
 
                     default:

--- a/osu.Framework/Localisation/LocalisationParameters.cs
+++ b/osu.Framework/Localisation/LocalisationParameters.cs
@@ -1,0 +1,34 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+namespace osu.Framework.Localisation
+{
+    /// <summary>
+    /// A set of parameters that control the way strings are localised.
+    /// </summary>
+    public class LocalisationParameters
+    {
+        /// <summary>
+        /// The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.
+        /// </summary>
+        public readonly ILocalisationStore? Store;
+
+        /// <summary>
+        /// Whether to prefer the "original" script of <see cref="RomanisableString"/>s.
+        /// </summary>
+        public readonly bool PreferOriginalScript;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="LocalisationParameters"/>.
+        /// </summary>
+        /// <param name="store">The <see cref="ILocalisationStore"/> to be used for string lookups and culture-specific formatting.</param>
+        /// <param name="preferOriginalScript">Whether to prefer the "original" script of <see cref="RomanisableString"/>s.</param>
+        public LocalisationParameters(ILocalisationStore? store, bool preferOriginalScript)
+        {
+            Store = store;
+            PreferOriginalScript = preferOriginalScript;
+        }
+    }
+}

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -38,15 +38,15 @@ namespace osu.Framework.Localisation
             Romanised = romanised;
         }
 
-        public string GetLocalised(ILocalisationStore? store, bool preferUnicode)
+        public string GetLocalised(ILocalisationStore? store, FrameworkConfigManager? config)
         {
             if (string.IsNullOrEmpty(Romanised)) return Original ?? string.Empty;
             if (string.IsNullOrEmpty(Original)) return Romanised ?? string.Empty;
 
-            return preferUnicode ? Original : Romanised;
+            return config?.Get<bool>(FrameworkSetting.ShowUnicode) == true ? Original : Romanised;
         }
 
-        public override string ToString() => GetLocalised(null, false);
+        public override string ToString() => GetLocalised(null, null);
 
         public bool Equals(RomanisableString? other)
         {

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -48,8 +48,6 @@ namespace osu.Framework.Localisation
 
         public override string ToString() => GetLocalised(null, false);
 
-        public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
-
         public bool Equals(RomanisableString? other)
         {
             if (ReferenceEquals(null, other)) return false;

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -57,22 +57,8 @@ namespace osu.Framework.Localisation
                    && Romanised == other.Romanised;
         }
 
-        public bool Equals(ILocalisableStringData? other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (other.GetType() != GetType()) return false;
-
-            return Equals((RomanisableString)other);
-        }
-
-        public override bool Equals(object? obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-
-            return Equals((RomanisableString)obj);
-        }
+        public bool Equals(ILocalisableStringData? other) => other is RomanisableString romanisable && Equals(romanisable);
+        public override bool Equals(object? obj) => obj is RomanisableString romanisable && Equals(romanisable);
 
         public override int GetHashCode()
         {

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -38,12 +38,19 @@ namespace osu.Framework.Localisation
             Romanised = romanised;
         }
 
-        public string GetLocalised(LocalisationParameters parameters)
+        public string GetLocalised(LocalisationParameters parameters) => GetPreferred(parameters.PreferOriginalScript);
+
+        /// <summary>
+        /// Get the best match for this string based on a user preference for which should be displayed.
+        /// </summary>
+        /// <param name="preferUnicode">Whether to prefer the unicode (aka original) version where available.</param>
+        /// <returns>The best match for the provided criteria.</returns>
+        public string GetPreferred(bool preferUnicode)
         {
             if (string.IsNullOrEmpty(Romanised)) return Original ?? string.Empty;
             if (string.IsNullOrEmpty(Original)) return Romanised ?? string.Empty;
 
-            return parameters.PreferOriginalScript ? Original : Romanised;
+            return preferUnicode ? Original : Romanised;
         }
 
         public override string ToString() => GetLocalised(new LocalisationParameters(null, false));

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Localisation
     /// A string that has a romanised fallback to allow a better experience for users that potentially can't read the original script.
     /// See <see cref="FrameworkSetting.ShowUnicode"/>, which can toggle the display of romanised variants.
     /// </summary>
-    public class RomanisableString : IEquatable<RomanisableString>
+    public class RomanisableString : IEquatable<RomanisableString>, ILocalisableStringData
     {
         /// <summary>
         /// The string in its original script. May be null.
@@ -28,7 +28,7 @@ namespace osu.Framework.Localisation
         /// Construct a new romanisable string.
         /// </summary>
         /// <remarks>
-        /// For flexibility, both of the provided strings are allowed to be null. If both are null, the returned string value from <see cref="GetPreferred"/> will be <see cref="string.Empty"/>.
+        /// For flexibility, both of the provided strings are allowed to be null. If both are null, the returned string value from <see cref="GetLocalised"/> will be <see cref="string.Empty"/>.
         /// </remarks>
         /// <param name="original">The string in its original script. If null, the <paramref name="romanised"/> version will always be used.</param>
         /// <param name="romanised">The romanised version of the string. If null, the <paramref name="original"/> version will always be used.</param>
@@ -38,12 +38,7 @@ namespace osu.Framework.Localisation
             Romanised = romanised;
         }
 
-        /// <summary>
-        /// Get the best match for this string based on a user preference for which should be displayed.
-        /// </summary>
-        /// <param name="preferUnicode">Whether to prefer the unicode (aka original) version where available.</param>
-        /// <returns>The best match for the provided criteria.</returns>
-        public string GetPreferred(bool preferUnicode)
+        public string GetLocalised(ILocalisationStore? store, bool preferUnicode)
         {
             if (string.IsNullOrEmpty(Romanised)) return Original ?? string.Empty;
             if (string.IsNullOrEmpty(Original)) return Romanised ?? string.Empty;
@@ -51,7 +46,9 @@ namespace osu.Framework.Localisation
             return preferUnicode ? Original : Romanised;
         }
 
-        public override string ToString() => GetPreferred(false);
+        public override string ToString() => GetLocalised(null, false);
+
+        public static implicit operator LocalisableString(RomanisableString romanisable) => new LocalisableString(romanisable);
 
         public bool Equals(RomanisableString? other)
         {
@@ -60,6 +57,14 @@ namespace osu.Framework.Localisation
 
             return Original == other.Original
                    && Romanised == other.Romanised;
+        }
+
+        public bool Equals(ILocalisableStringData? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (other.GetType() != GetType()) return false;
+
+            return Equals((RomanisableString)other);
         }
 
         public override bool Equals(object? obj)

--- a/osu.Framework/Localisation/RomanisableString.cs
+++ b/osu.Framework/Localisation/RomanisableString.cs
@@ -38,15 +38,15 @@ namespace osu.Framework.Localisation
             Romanised = romanised;
         }
 
-        public string GetLocalised(ILocalisationStore? store, FrameworkConfigManager? config)
+        public string GetLocalised(LocalisationParameters parameters)
         {
             if (string.IsNullOrEmpty(Romanised)) return Original ?? string.Empty;
             if (string.IsNullOrEmpty(Original)) return Romanised ?? string.Empty;
 
-            return config?.Get<bool>(FrameworkSetting.ShowUnicode) == true ? Original : Romanised;
+            return parameters.PreferOriginalScript ? Original : Romanised;
         }
 
-        public override string ToString() => GetLocalised(null, null);
+        public override string ToString() => GetLocalised(new LocalisationParameters(null, false));
 
         public bool Equals(RomanisableString? other)
         {

--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -8,14 +8,12 @@ using System.Globalization;
 using System.Linq;
 using osu.Framework.Logging;
 
-#nullable enable
-
 namespace osu.Framework.Localisation
 {
     /// <summary>
     /// A string that can be translated with optional formattable arguments.
     /// </summary>
-    public class TranslatableString : IEquatable<TranslatableString>
+    public class TranslatableString : IEquatable<TranslatableString>, ILocalisableStringData
     {
         public readonly string Key;
         public readonly string Fallback;
@@ -50,13 +48,14 @@ namespace osu.Framework.Localisation
             Args = interpolation.GetArguments();
         }
 
-        public string Format(ILocalisationStore? store)
+        public string GetLocalised(ILocalisationStore? store, bool preferUnicode)
         {
-            if (store == null) return ToString();
+            if (store == null)
+                return ToString();
 
             var localisedFormat = store.Get(Key);
-
-            if (localisedFormat == null) return ToString();
+            if (localisedFormat == null)
+                return ToString();
 
             try
             {
@@ -74,6 +73,8 @@ namespace osu.Framework.Localisation
 
         public override string ToString() => string.Format(CultureInfo.InvariantCulture, Fallback, Args);
 
+        public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
+
         public bool Equals(TranslatableString? other)
         {
             if (ReferenceEquals(null, other)) return false;
@@ -82,6 +83,14 @@ namespace osu.Framework.Localisation
             return Key == other.Key
                    && Fallback == other.Fallback
                    && Args.SequenceEqual(other.Args);
+        }
+
+        public bool Equals(ILocalisableStringData? other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (other.GetType() != GetType()) return false;
+
+            return Equals((TranslatableString)other);
         }
 
         public override bool Equals(object? obj)

--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Globalization;
 using System.Linq;
-using osu.Framework.Configuration;
 using osu.Framework.Logging;
 
 namespace osu.Framework.Localisation
@@ -49,23 +48,23 @@ namespace osu.Framework.Localisation
             Args = interpolation.GetArguments();
         }
 
-        public string GetLocalised(ILocalisationStore? store, FrameworkConfigManager config)
+        public string GetLocalised(LocalisationParameters parameters)
         {
-            if (store == null)
+            if (parameters.Store == null)
                 return ToString();
 
-            var localisedFormat = store.Get(Key);
+            var localisedFormat = parameters.Store.Get(Key);
             if (localisedFormat == null)
                 return ToString();
 
             try
             {
-                return string.Format(store.EffectiveCulture, localisedFormat, Args);
+                return string.Format(parameters.Store.EffectiveCulture, localisedFormat, Args);
             }
             catch (FormatException e)
             {
                 // The formatting has failed
-                Logger.Log($"Localised format failed. Key: {Key}, culture: {store.EffectiveCulture.Name}, fallback format string: \"{Fallback}\", localised format string: \"{localisedFormat}\". Exception: {e}",
+                Logger.Log($"Localised format failed. Key: {Key}, culture: {parameters.Store.EffectiveCulture}, fallback format string: \"{Fallback}\", localised format string: \"{localisedFormat}\". Exception: {e}",
                     LoggingTarget.Runtime, LogLevel.Verbose);
             }
 

--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -73,8 +73,6 @@ namespace osu.Framework.Localisation
 
         public override string ToString() => string.Format(CultureInfo.InvariantCulture, Fallback, Args);
 
-        public static implicit operator LocalisableString(TranslatableString translatable) => new LocalisableString(translatable);
-
         public bool Equals(TranslatableString? other)
         {
             if (ReferenceEquals(null, other)) return false;

--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Globalization;
 using System.Linq;
+using osu.Framework.Configuration;
 using osu.Framework.Logging;
 
 namespace osu.Framework.Localisation
@@ -48,7 +49,7 @@ namespace osu.Framework.Localisation
             Args = interpolation.GetArguments();
         }
 
-        public string GetLocalised(ILocalisationStore? store, bool preferUnicode)
+        public string GetLocalised(ILocalisationStore? store, FrameworkConfigManager config)
         {
             if (store == null)
                 return ToString();

--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -83,22 +83,8 @@ namespace osu.Framework.Localisation
                    && Args.SequenceEqual(other.Args);
         }
 
-        public bool Equals(ILocalisableStringData? other)
-        {
-            if (ReferenceEquals(null, other)) return false;
-            if (other.GetType() != GetType()) return false;
-
-            return Equals((TranslatableString)other);
-        }
-
-        public override bool Equals(object? obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (ReferenceEquals(this, obj)) return true;
-            if (obj.GetType() != GetType()) return false;
-
-            return Equals((TranslatableString)obj);
-        }
+        public bool Equals(ILocalisableStringData? other) => other is TranslatableString translatable && Equals(translatable);
+        public override bool Equals(object? obj) => obj is TranslatableString translatable && Equals(translatable);
 
         public override int GetHashCode()
         {


### PR DESCRIPTION
Introduces a `LocalisableFormattable` class, containing the `IFormattable` object and the format string, and a method for formatting the `IFormattable` with the provided format provider.

Allowing for localising any `IFormattable` object (integers, floats, `DateTime`s, etc...) with the currently selected locale, like in [here](https://github.com/ppy/osu/commit/feb67bee58f071c0cfddba75dccdaf648275a0e5) for example.

---

I've initially written this for resolving https://github.com/ppy/osu/issues/13559, but I think it's worth actually using this for localising all `IFormattable`-formatted strings osu!-side (i.e. `double.ToString("N0")` and otherwise) while at it, will look into that now.