### PR TITLE
Fix TrackVirtual seeks failing in unexpected ways

### DIFF
--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -263,6 +263,38 @@ namespace osu.Framework.Tests.Audio
             Assert.That(track.CurrentTime, Is.EqualTo(20000).Within(100));
         }
 
+        [Test]
+        public void TestSeekToCurrentTime()
+        {
+            track.Seek(5000);
+
+            bool seekSucceeded = false;
+            RunOnAudioThread(() => seekSucceeded = track.Seek(track.CurrentTime));
+
+            Assert.That(seekSucceeded, Is.True);
+            Assert.That(track.CurrentTime, Is.EqualTo(5000));
+        }
+
+        [Test]
+        public void TestSeekBeyondStartTime()
+        {
+            bool seekSucceeded = false;
+            RunOnAudioThread(() => seekSucceeded = track.Seek(-1000));
+
+            Assert.That(seekSucceeded, Is.False);
+            Assert.That(track.CurrentTime, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void TestSeekBeyondEndTime()
+        {
+            bool seekSucceeded = false;
+            RunOnAudioThread(() => seekSucceeded = track.Seek(track.Length + 1000));
+
+            Assert.That(seekSucceeded, Is.False);
+            Assert.That(track.CurrentTime, Is.EqualTo(track.Length));
+        }
+
         private void testPlaybackRate(double expectedRate)
         {
             const double play_time = 1000;

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -19,9 +19,7 @@ namespace osu.Framework.Audio.Track
 
         public override bool Seek(double seek)
         {
-            double current = CurrentTime;
-
-            seekOffset = seek;
+            seekOffset = Math.Clamp(seek, 0, Length);
 
             lock (clock)
             {
@@ -31,9 +29,7 @@ namespace osu.Framework.Audio.Track
                     clock.Reset();
             }
 
-            seekOffset = Math.Clamp(seekOffset, 0, Length);
-
-            return current != seekOffset;
+            return seekOffset == seek;
         }
 
         public override void Start()


### PR DESCRIPTION
- `Seek(CurrentTime)` failed even though the time is a valid value.
- `Seek(EndTime+1000)` succeeded even though the time is an invalid value.
  - Following `TrackBass`, this should fail but seek to the end.