### PR TITLE
Set more appropriate time limits for GH Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
             - { prettyname: macOS, fullname: macos-latest }
             - { prettyname: Linux, fullname: ubuntu-latest }
           threadingMode: ['SingleThread', 'MultiThreaded']
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/report-nunit.yml
+++ b/.github/workflows/report-nunit.yml
@@ -21,6 +21,7 @@ jobs:
             - { prettyname: macOS }
             - { prettyname: Linux }
           threadingMode: ['SingleThread', 'MultiThreaded']
+    timeout-minutes: 5
     steps:
       - name: Annotate CI run with test results
         uses: dorny/test-reporter@v1.4.2


### PR DESCRIPTION
https://github.com/ppy/osu/pull/13639 but for framework.

Time limit for the main job matches appveyor. Briefly thought about going lower but /shrug. Not touching old deploy workflows either because those don't really run yet.