### PR TITLE
Add factory method creating `BindableWithCurrent`s depending on the value type

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
@@ -75,5 +75,13 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(new BasicTextBox().Current, Is.TypeOf<BindableWithCurrent<string>>());
             Assert.That(new BasicDropdown<object>().Current, Is.TypeOf<BindableWithCurrent<object>>());
         }
+
+        [Test]
+        public void TestCreateBindableWithCurrentViaFactory()
+        {
+            Assert.That(IBindableWithCurrent<string>.Create(), Is.TypeOf<BindableWithCurrent<string>>());
+            Assert.That(IBindableWithCurrent<bool>.Create(), Is.TypeOf<BindableWithCurrent<bool>>());
+            Assert.That(IBindableWithCurrent<int>.Create(), Is.TypeOf<BindableNumberWithCurrent<int>>());
+        }
     }
 }

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -16,9 +16,6 @@ namespace osu.Framework.Bindables
         public BindableNumber(T defaultValue = default)
             : base(defaultValue)
         {
-            // Directly comparing typeof(T) to type literal is recognized pattern of JIT and very fast.
-            // Just a pointer comparison for reference types, or constant for value types.
-            // The check will become NOP after optimization.
             if (!Validation.IsSupportedBindableNumberType<T>())
             {
                 throw new NotSupportedException(

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -4,7 +4,7 @@
 using System;
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.CompilerServices;
+using osu.Framework.Utils;
 
 namespace osu.Framework.Bindables
 {
@@ -19,7 +19,7 @@ namespace osu.Framework.Bindables
             // Directly comparing typeof(T) to type literal is recognized pattern of JIT and very fast.
             // Just a pointer comparison for reference types, or constant for value types.
             // The check will become NOP after optimization.
-            if (!isSupportedType())
+            if (!Validation.IsSupportedBindableNumberType<T>())
             {
                 throw new NotSupportedException(
                     $"{nameof(BindableNumber<T>)} only accepts the primitive numeric types (except for {typeof(decimal).FullName}) as type arguments. You provided {typeof(T).FullName}.");
@@ -89,7 +89,7 @@ namespace osu.Framework.Bindables
         {
             get
             {
-                Debug.Assert(isSupportedType());
+                Debug.Assert(Validation.IsSupportedBindableNumberType<T>());
 
                 if (typeof(T) == typeof(sbyte))
                     return (T)(object)sbyte.MinValue;
@@ -118,7 +118,7 @@ namespace osu.Framework.Bindables
         {
             get
             {
-                Debug.Assert(isSupportedType());
+                Debug.Assert(Validation.IsSupportedBindableNumberType<T>());
 
                 if (typeof(T) == typeof(sbyte))
                     return (T)(object)sbyte.MaxValue;
@@ -215,7 +215,7 @@ namespace osu.Framework.Bindables
         public void Set<TNewValue>(TNewValue val) where TNewValue : struct,
             IFormattable, IConvertible, IComparable<TNewValue>, IEquatable<TNewValue>
         {
-            Debug.Assert(isSupportedType());
+            Debug.Assert(Validation.IsSupportedBindableNumberType<T>());
 
             // Comparison between typeof(T) and type literals are treated as **constant** on value types.
             // Code paths for other types will be eliminated.
@@ -244,7 +244,7 @@ namespace osu.Framework.Bindables
         public void Add<TNewValue>(TNewValue val) where TNewValue : struct,
             IFormattable, IConvertible, IComparable<TNewValue>, IEquatable<TNewValue>
         {
-            Debug.Assert(isSupportedType());
+            Debug.Assert(Validation.IsSupportedBindableNumberType<T>());
 
             // Comparison between typeof(T) and type literals are treated as **constant** on value types.
             // Code pathes for other types will be eliminated.
@@ -328,18 +328,5 @@ namespace osu.Framework.Bindables
             var comparison = value1.CompareTo(value2);
             return comparison > 0 ? value2 : value1;
         }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static bool isSupportedType() =>
-            typeof(T) == typeof(sbyte)
-            || typeof(T) == typeof(byte)
-            || typeof(T) == typeof(short)
-            || typeof(T) == typeof(ushort)
-            || typeof(T) == typeof(int)
-            || typeof(T) == typeof(uint)
-            || typeof(T) == typeof(long)
-            || typeof(T) == typeof(ulong)
-            || typeof(T) == typeof(float)
-            || typeof(T) == typeof(double);
     }
 }

--- a/osu.Framework/Bindables/BindableNumberWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableNumberWithCurrent.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Graphics.UserInterface;
 
 namespace osu.Framework.Bindables
 {
@@ -10,7 +9,7 @@ namespace osu.Framework.Bindables
     /// A bindable which holds a reference to a bound target, allowing switching between targets and handling unbind/rebind.
     /// </summary>
     /// <typeparam name="T">The type of our stored <see cref="Bindable{T}.Value"/>.</typeparam>
-    public class BindableNumberWithCurrent<T> : BindableNumber<T>, IHasCurrentValue<T>
+    public class BindableNumberWithCurrent<T> : BindableNumber<T>, IBindableWithCurrent<T>
         where T : struct, IComparable<T>, IConvertible, IEquatable<T>
     {
         private BindableNumber<T> currentBound;

--- a/osu.Framework/Bindables/BindableWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableWithCurrent.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Graphics.UserInterface;
 
 namespace osu.Framework.Bindables
 {
@@ -10,7 +9,7 @@ namespace osu.Framework.Bindables
     /// A bindable which holds a reference to a bound target, allowing switching between targets and handling unbind/rebind.
     /// </summary>
     /// <typeparam name="T">The type of our stored <see cref="Bindable{T}.Value"/>.</typeparam>
-    public class BindableWithCurrent<T> : Bindable<T>, IHasCurrentValue<T>
+    public class BindableWithCurrent<T> : Bindable<T>, IBindableWithCurrent<T>
     {
         private Bindable<T> currentBound;
 

--- a/osu.Framework/Bindables/IBindableWithCurrent.cs
+++ b/osu.Framework/Bindables/IBindableWithCurrent.cs
@@ -1,0 +1,32 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Utils;
+
+namespace osu.Framework.Bindables
+{
+    public interface IBindableWithCurrent<T> : IBindable<T>
+    {
+        /// <summary>
+        /// Gets or sets the <see cref="Bindable{T}"/> that provides the current value.
+        /// </summary>
+        /// <remarks>
+        /// A provided <see cref="Bindable{T}"/> will be bound to, rather than be stored internally.
+        /// </remarks>
+        Bindable<T> Current { get; set; }
+
+        /// <summary>
+        /// Creates a new <see cref="IBindableWithCurrent{T}"/> according to the specified value type.
+        /// If the value type is one supported by the <see cref="BindableNumber{T}"/>, an instance of <see cref="BindableNumberWithCurrent{T}"/> will be returned.
+        /// Otherwise an instance of <see cref="BindableWithCurrent{T}"/> will be returned instead.
+        /// </summary>
+        public static IBindableWithCurrent<T> Create()
+        {
+            if (Validation.IsSupportedBindableNumberType<T>())
+                return (IBindableWithCurrent<T>)Activator.CreateInstance(typeof(BindableNumberWithCurrent<>).MakeGenericType(typeof(T)));
+
+            return new BindableWithCurrent<T>();
+        }
+    }
+}

--- a/osu.Framework/Bindables/IBindableWithCurrent.cs
+++ b/osu.Framework/Bindables/IBindableWithCurrent.cs
@@ -2,20 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Utils;
 
 namespace osu.Framework.Bindables
 {
-    public interface IBindableWithCurrent<T> : IBindable<T>
+    public interface IBindableWithCurrent<T> : IBindable<T>, IHasCurrentValue<T>
     {
-        /// <summary>
-        /// Gets or sets the <see cref="Bindable{T}"/> that provides the current value.
-        /// </summary>
-        /// <remarks>
-        /// A provided <see cref="Bindable{T}"/> will be bound to, rather than be stored internally.
-        /// </remarks>
-        Bindable<T> Current { get; set; }
-
         /// <summary>
         /// Creates a new <see cref="IBindableWithCurrent{T}"/> according to the specified value type.
         /// If the value type is one supported by the <see cref="BindableNumber{T}"/>, an instance of <see cref="BindableNumberWithCurrent{T}"/> will be returned.

--- a/osu.Framework/Utils/Validation.cs
+++ b/osu.Framework/Utils/Validation.cs
@@ -57,7 +57,7 @@ namespace osu.Framework.Utils
         /// <typeparam name="T">The type to check for.</typeparam>
         /// <returns><see langword="true"/> if the type is supported; <see langword="false"/> otherwise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool IsSupportedBindableNumberType<T>() =>
+        public static bool IsSupportedBindableNumberType<T>() =>
             typeof(T) == typeof(sbyte)
             || typeof(T) == typeof(byte)
             || typeof(T) == typeof(short)

--- a/osu.Framework/Utils/Validation.cs
+++ b/osu.Framework/Utils/Validation.cs
@@ -3,6 +3,8 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+using osu.Framework.Bindables;
 using osuTK;
 using osu.Framework.Graphics;
 
@@ -48,5 +50,23 @@ namespace osu.Framework.Utils
 #pragma warning restore RS0030
             return Uri.TryCreate(uriString, kind, out result);
         }
+
+        /// <summary>
+        /// Whether the specified type <typeparamref name="T"/> is a number type supported by <see cref="BindableNumber{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">The type to check for.</typeparam>
+        /// <returns><see langword="true"/> if the type is supported; <see langword="false"/> otherwise.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool IsSupportedBindableNumberType<T>() =>
+            typeof(T) == typeof(sbyte)
+            || typeof(T) == typeof(byte)
+            || typeof(T) == typeof(short)
+            || typeof(T) == typeof(ushort)
+            || typeof(T) == typeof(int)
+            || typeof(T) == typeof(uint)
+            || typeof(T) == typeof(long)
+            || typeof(T) == typeof(ulong)
+            || typeof(T) == typeof(float)
+            || typeof(T) == typeof(double);
     }
 }

--- a/osu.Framework/Utils/Validation.cs
+++ b/osu.Framework/Utils/Validation.cs
@@ -54,6 +54,11 @@ namespace osu.Framework.Utils
         /// <summary>
         /// Whether the specified type <typeparamref name="T"/> is a number type supported by <see cref="BindableNumber{T}"/>.
         /// </summary>
+        /// <remarks>
+        /// Directly comparing typeof(T) to type literal is recognized pattern of JIT and very fast.
+        /// Just a pointer comparison for reference types, or constant for value types.
+        /// The check will become NOP in usages after optimization.
+        /// </remarks>
         /// <typeparam name="T">The type to check for.</typeparam>
         /// <returns><see langword="true"/> if the type is supported; <see langword="false"/> otherwise.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]


### PR DESCRIPTION
Allows for having a `BindableWithCurrent` or `BindableNumberWithCurrent` instance depending on the value type itself, [as proposed here](https://github.com/ppy/osu/issues/13649#issuecomment-870006577).

Initially, I was going to privatize the classes' constructors and force all usages to call `IBindableWithCurrent<T>.Create()` to avoid potentially constructing `BindableWithCurrent<float>` instead of the correct `BindableNumberWithCurrent<float>`, but since that results in severe breaking changes, I've let that as-is for now.