### PR TITLE
Fix HSV colour picker spuriously changing some externally-set colour values

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneColourPicker.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneColourPicker.cs
@@ -15,7 +15,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
             ColourPicker colourPicker = null;
 
             AddStep("create picker", () => Child = colourPicker = new BasicColourPicker());
-            AddStep("set colour externally", () => colourPicker.Current.Value = Colour4.CornflowerBlue);
+            AddStep("set colour externally", () => colourPicker.Current.Value = Colour4.Goldenrod);
+            AddAssert("colour is correct", () => colourPicker.Current.Value == Colour4.Goldenrod);
         }
     }
 }


### PR DESCRIPTION
This regressed in 3035d06 without me noticing. While improving the performance, those `AddOnce` calls broke my impromptu mechanism of detecting value change callback cycles using the `changeInProgress` flag, because after adding the schedule directly like in that commit, the `Current -> Hue/Saturation/Value` changes were happening in frame N, while the `Hue/Saturation/Value -> Current` changes, closing the undesired feedback loop, were happening in frame N+1, at which point the flag was already unset.

The proposed solution (which I don't entirely like but I don't see anything better) is to use that same flag for deciding whether to schedule the second part. I added inline comments to explain what is going there - hopefully they suffice.

In general colour storage is a nightmare. Going back and forth from/to: RGB colours expressed on bytes, RGB colours expressed in [0,1] floats, and HSV colours expressed in [0,1] floats is potentially lossy/inaccurate in *all* directions. (The byte -> float route is potentially lossy because 1/255 is not a fraction that has a finite base-2 decimal expansion.) So I won't necessarily be surprised if something of this sort pops up again in a different manner in the future.

