### PR TITLE
Fix deadlock state if an exception is thrown during `GameHost.Run()`

### DIFF
--- a/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -12,6 +13,15 @@ namespace osu.Framework.Tests.Platform
     [TestFixture]
     public class HeadlessGameHostTest
     {
+        [Test]
+        public void TestGameHostExceptionDuringSetupHost()
+        {
+            using (var host = new ExceptionDuringSetupGameHost(nameof(TestGameHostExceptionDuringSetupHost)))
+            {
+                Assert.Throws<InvalidOperationException>(() => host.Run(new TestGame()));
+            }
+        }
+
         [Test]
         public void TestGameHostDisposalWhenNeverRun()
         {
@@ -57,6 +67,20 @@ namespace osu.Framework.Tests.Platform
         private class Foobar
         {
             public string Bar;
+        }
+
+        public class ExceptionDuringSetupGameHost : HeadlessGameHost
+        {
+            public ExceptionDuringSetupGameHost(string gameName)
+                : base(gameName)
+            {
+            }
+
+            protected override void SetupForRun()
+            {
+                base.SetupForRun();
+                throw new InvalidOperationException();
+            }
         }
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -525,7 +525,7 @@ namespace osu.Framework.Platform
         /// <param name="immediately">If true, exits the game immediately.  If false (default), schedules the game to exit in the next frame.</param>
         protected virtual void PerformExit(bool immediately)
         {
-            if (executionState == ExecutionState.Stopped)
+            if (executionState == ExecutionState.Stopped || executionState == ExecutionState.Idle)
                 return;
 
             ExecutionState = ExecutionState.Stopping;


### PR DESCRIPTION
Without the check for `Idle` state, the `threadRunner` would attempt to stop threads which are not in a running state, causing a subsequent exception in the exit process, leaving the game in a `Stopping` state and waiting on the `stoppedEvent` in disposal logic.