### PR TITLE
Fix `GetBoundCopy()` not working on "bindable with current" classes

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableWithCurrentTest.cs
@@ -83,5 +83,12 @@ namespace osu.Framework.Tests.Bindables
             Assert.That(IBindableWithCurrent<bool>.Create(), Is.TypeOf<BindableWithCurrent<bool>>());
             Assert.That(IBindableWithCurrent<int>.Create(), Is.TypeOf<BindableNumberWithCurrent<int>>());
         }
+
+        [Test]
+        public void TestGetBoundCopy()
+        {
+            Assert.That(new BindableWithCurrent<string>().GetBoundCopy(), Is.TypeOf<BindableWithCurrent<string>>());
+            Assert.That(new BindableNumberWithCurrent<int>().GetBoundCopy(), Is.TypeOf<BindableNumberWithCurrent<int>>());
+        }
     }
 }

--- a/osu.Framework/Bindables/BindableNumberWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableNumberWithCurrent.cs
@@ -26,5 +26,10 @@ namespace osu.Framework.Bindables
                 BindTo(currentBound = (BindableNumber<T>)value);
             }
         }
+
+        public BindableNumberWithCurrent(T defaultValue = default)
+            : base(defaultValue)
+        {
+        }
     }
 }

--- a/osu.Framework/Bindables/BindableWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableWithCurrent.cs
@@ -25,5 +25,10 @@ namespace osu.Framework.Bindables
                 BindTo(currentBound = value);
             }
         }
+
+        public BindableWithCurrent(T defaultValue = default)
+            : base(defaultValue)
+        {
+        }
     }
 }

--- a/osu.Framework/Bindables/IBindableWithCurrent.cs
+++ b/osu.Framework/Bindables/IBindableWithCurrent.cs
@@ -17,7 +17,7 @@ namespace osu.Framework.Bindables
         public static IBindableWithCurrent<T> Create()
         {
             if (Validation.IsSupportedBindableNumberType<T>())
-                return (IBindableWithCurrent<T>)Activator.CreateInstance(typeof(BindableNumberWithCurrent<>).MakeGenericType(typeof(T)));
+                return (IBindableWithCurrent<T>)Activator.CreateInstance(typeof(BindableNumberWithCurrent<>).MakeGenericType(typeof(T)), default(T));
 
             return new BindableWithCurrent<T>();
         }


### PR DESCRIPTION
Both missing constructors with `T defaultValue` parameter for `GetBoundCopy()` to successfully create an instance of the bindable type. Not sure if that can be enforced in some way.

Attached test case before change:
![CleanShot 2021-07-02 at 23 54 50](https://user-images.githubusercontent.com/22781491/124330240-a765aa80-db95-11eb-8274-768b5e5e3f37.png)
