### PR TITLE
Make `VertexUtils<T>` public

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Vertices/VertexUtils.cs
+++ b/osu.Framework/Graphics/OpenGL/Vertices/VertexUtils.cs
@@ -15,7 +15,7 @@ namespace osu.Framework.Graphics.OpenGL.Vertices
     /// <summary>
     /// Helper method that provides functionality to enable and bind vertex attributes.
     /// </summary>
-    internal static class VertexUtils<T>
+    public static class VertexUtils<T>
         where T : struct, IVertex
     {
         /// <summary>


### PR DESCRIPTION
`VertexUtils<T>` is already documented but to reiterate, it is a helper class that keeps track of how many vertex attributes are enabled and enables and/or disables them as needed.

It will be needed for our project [vignette-project/vignette-live2d](https://github.com/vignette-project/vignette-application-live2d) which allows the framework to render Live2D models as the framework's current way, specifically making use of `VertexBatch<T>` is not suitable for our needs as we directly provide vertex and indices data to OpenGL.

![image](https://user-images.githubusercontent.com/20495991/124353547-bef66f00-dc39-11eb-8c6f-ed0ef7c7c807.png)

One can argue that we can directly use `GL.EnableVertexAttribArray` directly but doing so will cause the class, or specifically `VertexUtils<T>.amountEnabledAttributes` to be in an invalid state.

Example code of how we use the class is this:
```csharp
public void Draw()
{
    if (vaoID == -1 && iboID == -1)
        Initialise();

    if (GLWrapper.BindBuffer(BufferTarget.ArrayBuffer, vaoID))
        VertexUtils<MeshVertex>.Bind();

    var vertices = new MeshVertex[Positions.Length];
    for (int i = 0; i < Positions.Length; i++)
    {
        vertices[i] = new MeshVertex
        {
            Position = Positions[i],
            TexturePosition = TexturePositions[i],
        };
    }

    GL.BufferData(BufferTarget.ArrayBuffer, (IntPtr)(Positions.Length * VertexUtils<MeshVertex>.STRIDE), vertices, BufferUsageHint.DynamicDraw);

    GLWrapper.BindBuffer(BufferTarget.ElementArrayBuffer, iboID);
    GL.DrawElements(PrimitiveType.Triangles, Indices.Length, DrawElementsType.UnsignedShort, IntPtr.Zero);
}
```