### PR TITLE
Fix colour picker mutating current colour set before load complete

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneColourPicker.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneColourPicker.cs
@@ -1,21 +1,33 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestSceneColourPicker : FrameworkTestScene
     {
-        [SetUpSteps]
-        public void SetUpSteps()
+        [Test]
+        public void TestExternalColourSetAfterCreation()
         {
             ColourPicker colourPicker = null;
 
             AddStep("create picker", () => Child = colourPicker = new BasicColourPicker());
             AddStep("set colour externally", () => colourPicker.Current.Value = Colour4.Goldenrod);
+            AddAssert("colour is correct", () => colourPicker.Current.Value == Colour4.Goldenrod);
+        }
+
+        [Test]
+        public void TestExternalColourSetAtCreation()
+        {
+            ColourPicker colourPicker = null;
+
+            AddStep("create picker", () => Child = colourPicker = new BasicColourPicker
+            {
+                Current = { Value = Colour4.Goldenrod }
+            });
             AddAssert("colour is correct", () => colourPicker.Current.Value == Colour4.Goldenrod);
         }
     }

--- a/osu.Framework/Graphics/UserInterface/HSVColourPicker_SaturationValueSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/HSVColourPicker_SaturationValueSelector.cs
@@ -93,11 +93,14 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 base.LoadComplete();
 
-                Current.BindValueChanged(_ => currentChanged(), true);
+                // the following handlers aren't fired immediately to avoid mutating Current by accident when ran prematurely.
+                // if necessary, they will run when the Current value change callback fires at the end of this method.
+                Hue.BindValueChanged(_ => debounce(hueChanged));
+                Saturation.BindValueChanged(_ => debounce(saturationChanged));
+                Value.BindValueChanged(_ => debounce(valueChanged));
 
-                Hue.BindValueChanged(_ => debounce(hueChanged), true);
-                Saturation.BindValueChanged(_ => debounce(saturationChanged), true);
-                Value.BindValueChanged(_ => debounce(valueChanged), true);
+                // Current takes precedence over HSV controls, and as such it must run last after HSV handlers have been set up for correct operation.
+                Current.BindValueChanged(_ => currentChanged(), true);
             }
 
             // As Current and {Hue,Saturation,Value} are mutually bound together,

--- a/osu.Framework/Graphics/UserInterface/HSVColourPicker_SaturationValueSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/HSVColourPicker_SaturationValueSelector.cs
@@ -58,7 +58,8 @@ namespace osu.Framework.Graphics.UserInterface
                             hueBox = new Box
                             {
                                 Name = "Hue",
-                                RelativeSizeAxes = Axes.Both
+                                RelativeSizeAxes = Axes.Both,
+                                Colour = new Colour4(255, 0, 0, 255)
                             },
                             new Box
                             {


### PR DESCRIPTION
I had thought I had fixed an issue I was seeing when trying to push forwards with integration game-side, but it turns out I actually had two separate issues, depending on when `Current` was set...

Unfortunately the fix proposed is subtle and brittle, like the entire bindable flow in there is increasingly starting to be. I could maybe afford be a bit more haphazard and not have to worry about these small details, if the colour conversions weren't so lossy and imprecise. Better ideas very welcome.