### PR TITLE
Remove bindable `State` and `Scheduler` requirements of `VideoDecoder`

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -78,8 +78,8 @@ namespace osu.Framework.Android
         public override IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore)
             => new AndroidTextureLoaderStore(underlyingStore);
 
-        public override VideoDecoder CreateVideoDecoder(Stream stream, Scheduler scheduler)
-            => new AndroidVideoDecoder(stream, scheduler);
+        public override VideoDecoder CreateVideoDecoder(Stream stream)
+            => new AndroidVideoDecoder(stream);
 
         protected override void PerformExit(bool immediately)
         {

--- a/osu.Framework.Android/Graphics/Video/AndroidVideoDecoder.cs
+++ b/osu.Framework.Android/Graphics/Video/AndroidVideoDecoder.cs
@@ -87,13 +87,13 @@ namespace osu.Framework.Android.Graphics.Video
         [DllImport(lib_swscale)]
         private static extern int sws_scale(SwsContext* c, byte*[] srcSlice, int[] srcStride, int srcSliceY, int srcSliceH, byte*[] dst, int[] dstStride);
 
-        public AndroidVideoDecoder(string filename, Scheduler scheduler)
-            : base(filename, scheduler)
+        public AndroidVideoDecoder(string filename)
+            : base(filename)
         {
         }
 
-        public AndroidVideoDecoder(Stream videoStream, Scheduler scheduler)
-            : base(videoStream, scheduler)
+        public AndroidVideoDecoder(Stream videoStream)
+            : base(videoStream)
         {
         }
 

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -7,7 +7,6 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
-using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.Video;
 using osu.Framework.Testing;
 using osu.Framework.Timing;
@@ -17,7 +16,7 @@ namespace osu.Framework.Tests.Visual.Sprites
     public class TestSceneVideo : FrameworkTestScene
     {
         private Container videoContainer;
-        private SpriteText timeText;
+        private TextFlowContainer timeText;
         private readonly IBindable<VideoDecoder.DecoderState> decoderState = new Bindable<VideoDecoder.DecoderState>();
 
         private ManualClock clock;
@@ -34,10 +33,10 @@ namespace osu.Framework.Tests.Visual.Sprites
                     RelativeSizeAxes = Axes.Both,
                     Clock = new FramedClock(clock = new ManualClock()),
                 },
-                timeText = new SpriteText
+                timeText = new TextFlowContainer(f => f.Font = FrameworkFont.Condensed)
                 {
+                    RelativeSizeAxes = Axes.Both,
                     Text = "Video is loading...",
-                    Font = FrameworkFont.Condensed.With()
                 }
             };
         }
@@ -164,11 +163,11 @@ namespace osu.Framework.Tests.Visual.Sprites
 
                 if (timeText != null)
                 {
-                    timeText.Text = $"aim time: {video.PlaybackPosition:N2} | "
-                                    + $"video time: {video.CurrentFrameTime:N2} | "
-                                    + $"duration: {video.Duration:N2} | "
-                                    + $"buffered {video.AvailableFrames} | "
-                                    + $"FPS: {fps} | "
+                    timeText.Text = $"aim time: {video.PlaybackPosition:N2}\n"
+                                    + $"video time: {video.CurrentFrameTime:N2}\n"
+                                    + $"duration: {video.Duration:N2}\n"
+                                    + $"buffered {video.AvailableFrames}\n"
+                                    + $"FPS: {fps}\n"
                                     + $"State: {decoderState.Value}";
                 }
             }

--- a/osu.Framework.iOS/Graphics/Video/IOSVideoDecoder.cs
+++ b/osu.Framework.iOS/Graphics/Video/IOSVideoDecoder.cs
@@ -83,13 +83,13 @@ namespace osu.Framework.iOS.Graphics.Video
         [DllImport(dll_name)]
         private static extern int sws_scale(SwsContext* c, byte*[] srcSlice, int[] srcStride, int srcSliceY, int srcSliceH, byte*[] dst, int[] dstStride);
 
-        public IOSVideoDecoder(string filename, Scheduler scheduler)
-            : base(filename, scheduler)
+        public IOSVideoDecoder(string filename)
+            : base(filename)
         {
         }
 
-        public IOSVideoDecoder(Stream videoStream, Scheduler scheduler)
-            : base(videoStream, scheduler)
+        public IOSVideoDecoder(Stream videoStream)
+            : base(videoStream)
         {
         }
 

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -126,7 +126,7 @@ namespace osu.Framework.iOS
         public override IResourceStore<TextureUpload> CreateTextureLoaderStore(IResourceStore<byte[]> underlyingStore)
             => new IOSTextureLoaderStore(underlyingStore);
 
-        public override VideoDecoder CreateVideoDecoder(Stream stream, Scheduler scheduler) => new IOSVideoDecoder(stream, scheduler);
+        public override VideoDecoder CreateVideoDecoder(Stream stream) => new IOSVideoDecoder(stream);
 
         public override IEnumerable<KeyBinding> PlatformKeyBindings => new[]
         {

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using JetBrains.Annotations;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -46,9 +45,9 @@ namespace osu.Framework.Graphics.Video
         public bool IsFaulted => decoder?.IsFaulted ?? false;
 
         /// <summary>
-        /// The current state of the <see cref="VideoDecoder"/>, as a bindable.
+        /// The current state of the decoding process.
         /// </summary>
-        public readonly IBindable<VideoDecoder.DecoderState> State = new Bindable<VideoDecoder.DecoderState>();
+        public VideoDecoder.DecoderState State => decoder?.State ?? VideoDecoder.DecoderState.Ready;
 
         internal double CurrentFrameTime => lastFrame?.Time ?? 0;
 
@@ -107,9 +106,8 @@ namespace osu.Framework.Graphics.Video
         [BackgroundDependencyLoader]
         private void load(GameHost gameHost, ShaderManager shaders)
         {
-            decoder = gameHost.CreateVideoDecoder(stream, Scheduler);
+            decoder = gameHost.CreateVideoDecoder(stream);
             decoder.Looping = Loop;
-            State.BindTo(decoder.State);
             decoder.StartDecoding();
 
             Duration = decoder.Duration;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1043,9 +1043,8 @@ namespace osu.Framework.Platform
         /// decoder implementation.
         /// </summary>
         /// <param name="stream">The <see cref="Stream"/> to decode.</param>
-        /// <param name="scheduler">The <see cref="Scheduler"/> to use when scheduling tasks from the decoder thread.</param>
         /// <returns>An instance of <see cref="VideoDecoder"/> initialised with the given stream.</returns>
-        public virtual VideoDecoder CreateVideoDecoder(Stream stream, Scheduler scheduler) => new VideoDecoder(stream, scheduler);
+        public virtual VideoDecoder CreateVideoDecoder(Stream stream) => new VideoDecoder(stream);
 
         /// <summary>
         /// Creates the <see cref="ThreadRunner"/> to run the threads of this <see cref="GameHost"/>.


### PR DESCRIPTION
This was suppsoed to just be adding a test to confirm that the decoding loop is not running while a `Video` is non-present, but turned out to be a bit of a refactor. Initially I tried to write the test using the `State` bindable, but it would never change from `Running` state when the video becomes hidden, because the scheduler was not being run. Our usual workaround of overriding `IsPresent` and adding a `Scheduler.HasPendingTasks` check would just cause the decoding to start again.

It was weird that `VideoDecoder` - a non-drawable component - was requiring a scheduler at construction time just to run a bindable update on the update thread. As the `State` bindable was not being used anywhere, I have removed it, along with the scheduler requirement.