### PR TITLE
Mark shader disposal test scene headless

### DIFF
--- a/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
+++ b/osu.Framework.Tests/Shaders/TestSceneShaderDisposal.cs
@@ -11,6 +11,7 @@ using osu.Framework.Tests.Visual;
 
 namespace osu.Framework.Tests.Shaders
 {
+    [HeadlessTest]
     public class TestSceneShaderDisposal : FrameworkTestScene
     {
         private ShaderManager manager;


### PR DESCRIPTION
The test scene in question was adding `Visual` prefixes to all other test scenes in typical fashion without the headless attribute.

While the test mentions "shaders" it's only really testing reference retention (or rather, lack thereof), so I believe it should be fine as a headless test. If it was hitting actual GL parts it should have been `[Ignore]`d anyway, because headless hosts don't get a GL context.