### PR TITLE
Expose extension points for replacing game-side file/directory selector 

### DIFF
--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorBreadcrumbDisplay.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorBreadcrumbDisplay.cs
@@ -10,6 +10,14 @@ namespace osu.Framework.Graphics.UserInterface
 {
     public class BasicDirectorySelectorBreadcrumbDisplay : DirectorySelectorBreadcrumbDisplay
     {
+        protected override Drawable CreateCaption() => new SpriteText
+        {
+            Text = "Current Directory:",
+            Font = FrameworkFont.Condensed.With(size: 20),
+            Anchor = Anchor.CentreLeft,
+            Origin = Anchor.CentreLeft
+        };
+
         protected override DirectorySelectorDirectory CreateRootDirectoryItem() => new BreadcrumbDisplayComputer();
 
         protected override DirectorySelectorDirectory CreateDirectoryItem(DirectoryInfo directory, string displayName = null) => new BreadcrumbDisplayDirectory(directory, displayName);

--- a/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorDirectory.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicDirectorySelectorDirectory.cs
@@ -12,6 +12,11 @@ namespace osu.Framework.Graphics.UserInterface
             ? FontAwesome.Solid.Database
             : FontAwesome.Regular.Folder;
 
+        protected override SpriteText CreateSpriteText() => new SpriteText
+        {
+            Font = FrameworkFont.Regular.With(size: FONT_SIZE)
+        };
+
         public BasicDirectorySelectorDirectory(DirectoryInfo directory, string displayName = null)
             : base(directory, displayName)
         {

--- a/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicFileSelector.cs
@@ -58,6 +58,11 @@ namespace osu.Framework.Graphics.UserInterface
                     }
                 }
             }
+
+            protected override SpriteText CreateSpriteText() => new SpriteText
+            {
+                Font = FrameworkFont.Regular.With(size: FONT_SIZE)
+            };
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorBreadcrumbDisplay.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorBreadcrumbDisplay.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
@@ -13,6 +14,12 @@ namespace osu.Framework.Graphics.UserInterface
 {
     public abstract class DirectorySelectorBreadcrumbDisplay : CompositeDrawable
     {
+        /// <summary>
+        /// Creates a caption to be displayed in front of the breadcrumb items.
+        /// </summary>
+        [CanBeNull]
+        protected virtual Drawable CreateCaption() => null;
+
         /// <summary>
         /// Create a directory item in the breadcrumb trail.
         /// </summary>
@@ -58,10 +65,11 @@ namespace osu.Framework.Graphics.UserInterface
                 ptr = ptr.Parent;
             }
 
-            flow.ChildrenEnumerable = new Drawable[]
-            {
-                CreateRootDirectoryItem(),
-            }.Concat(pathPieces);
+            var caption = CreateCaption();
+            if (caption != null)
+                flow.Add(caption);
+
+            flow.AddRange(pathPieces.Prepend(CreateRootDirectoryItem()));
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/DirectorySelectorItem.cs
+++ b/osu.Framework/Graphics/UserInterface/DirectorySelectorItem.cs
@@ -34,6 +34,11 @@ namespace osu.Framework.Graphics.UserInterface
             this.displayName = displayName;
         }
 
+        /// <summary>
+        /// Creates the sprite text to be used for the item text.
+        /// </summary>
+        protected virtual SpriteText CreateSpriteText() => new SpriteText();
+
         [BackgroundDependencyLoader]
         private void load()
         {
@@ -58,13 +63,12 @@ namespace osu.Framework.Graphics.UserInterface
                 });
             }
 
-            Flow.Add(new SpriteText
+            Flow.Add(CreateSpriteText().With(text =>
             {
-                Anchor = Anchor.CentreLeft,
-                Origin = Anchor.CentreLeft,
-                Text = displayName ?? FallbackName,
-                Font = FrameworkFont.Regular.With(size: FONT_SIZE)
-            });
+                text.Anchor = Anchor.CentreLeft;
+                text.Origin = Anchor.CentreLeft;
+                text.Text = displayName ?? FallbackName;
+            }));
         }
     }
 }


### PR DESCRIPTION
There were two areas where the customisation structure was lacking in order to migrate the game-side components to use the framework ones: sprite text construction (so that game can use `OsuSpriteText`), and a  "caption" on the breadcrumb display, by which I mean the "Current Directory" text below:

![2021-07-06-222654_270x88_scrot](https://user-images.githubusercontent.com/20418176/124662806-8c52ad80-dea9-11eb-9f77-6691801c3cbb.png)

I couldn't just expose the flow for the breadcrumb thing since all breadcrumb items get reconstructed on directory change. Maybe a bit wasteful but I'm not super sure it's worth having nested flows instead... Game was reconstructing every time too already, for what that's worth.

This PR should not incur any breaking changes.