### PR TITLE
Avoid collection-modified exceptions during unbind process

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -811,8 +811,14 @@ namespace osu.Framework.Graphics.Containers
         {
             base.UnbindAllBindablesSubTree();
 
-            foreach (Drawable child in internalChildren)
+            // TODO: this code can potentially be run from an update thread while a drawable is still loading (see ScreenStack as an example).
+            // while this is quite a bad issue, it is rare and generally happens in tests which have frame perfect behaviours.
+            // as such, for loop is used here intentionally to avoid collection modified exceptions for this (usually) non-critical failure.
+            for (var i = 0; i < internalChildren.Count; i++)
+            {
+                Drawable child = internalChildren[i];
                 child.UnbindAllBindablesSubTree();
+            }
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -814,6 +814,7 @@ namespace osu.Framework.Graphics.Containers
             // TODO: this code can potentially be run from an update thread while a drawable is still loading (see ScreenStack as an example).
             // while this is quite a bad issue, it is rare and generally happens in tests which have frame perfect behaviours.
             // as such, for loop is used here intentionally to avoid collection modified exceptions for this (usually) non-critical failure.
+            // see https://github.com/ppy/osu-framework/issues/4054.
             for (var i = 0; i < internalChildren.Count; i++)
             {
                 Drawable child = internalChildren[i];


### PR DESCRIPTION
This has been a point of contention for quite some months now, causing test failures at a rate of 50% (or maybe higher). The actual fix for this issue likely involves locking or changing the asynchronousity of the whole disposal/unbind/load process, which is quite involved.

This is intended to be a temporary fix until we get around to addressing the underlying issue. The case where a drawable is potentially missed due to `for` loop is generally not critical (just means they will be bound to other bindables for slightly longer than expected, but they will not be in a loaded state so in most cases this doesn't mean much).