### PR TITLE
Obsolete ability for slider bar to handle keyboard input when not hovered

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
@@ -220,6 +221,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             public bool KeyboardInput;
 
+            [Obsolete("Implement this kind of behaviour separately instead.")]
             protected override bool AllowKeyboardInputWhenNotHovered => KeyboardInput;
         }
     }

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -166,7 +166,9 @@ namespace osu.Framework.Graphics.UserInterface
             if (currentNumberInstantaneous.Disabled)
                 return false;
 
+#pragma warning disable 618
             bool shouldHandle = IsHovered || AllowKeyboardInputWhenNotHovered;
+#pragma warning restore 618
             if (!shouldHandle)
                 return false;
 

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -24,6 +24,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Whether keyboard control should be allowed even when the bar is not hovered.
         /// </summary>
+        [Obsolete("Implement this kind of behaviour separately instead.")] // Can be removed 20220107
         protected virtual bool AllowKeyboardInputWhenNotHovered => false;
 
         public float UsableWidth => DrawWidth - 2 * RangePadding;


### PR DESCRIPTION
This was a weird overload added for a very specific use case in osu!, which has since been deemed to add very hidden input handling functionality that we'd rather avoid.

It doesn't make sense for a slider bar to handle input when it's not hovered under any circumstances.