### PR TITLE
Unbind remaining events during `UnbindEvents` call

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -445,7 +445,15 @@ namespace osu.Framework.Tests.Bindables
         [Test]
         public void TestUnbindEvents()
         {
-            var bindable = new BindableInt();
+            var bindable = new BindableInt
+            {
+                Value = 0,
+                Default = 0,
+                MinValue = -5,
+                MaxValue = 5,
+                Precision = 1,
+                Disabled = false
+            };
 
             bool valueChanged = false;
             bool defaultChanged = false;

--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -443,6 +443,38 @@ namespace osu.Framework.Tests.Bindables
         }
 
         [Test]
+        public void TestUnbindEvents()
+        {
+            var bindable = new BindableInt();
+
+            bool valueChanged = false;
+            bool defaultChanged = false;
+            bool disabledChanged = false;
+            bool minValueChanged = false;
+            bool maxValueChanged = false;
+            bool precisionChanged = false;
+
+            bindable.ValueChanged += _ => valueChanged = true;
+            bindable.DefaultChanged += _ => defaultChanged = true;
+            bindable.DisabledChanged += _ => disabledChanged = true;
+            bindable.MinValueChanged += _ => minValueChanged = true;
+            bindable.MaxValueChanged += _ => maxValueChanged = true;
+            bindable.PrecisionChanged += _ => precisionChanged = true;
+
+            bindable.UnbindEvents();
+
+            bindable.Value = 5;
+            bindable.Default = 5;
+            bindable.MinValue = 0;
+            bindable.MaxValue = 10;
+            bindable.Precision = 5;
+            bindable.Disabled = true;
+
+            Assert.That(!valueChanged && !defaultChanged && !disabledChanged &&
+                        !minValueChanged && !maxValueChanged && !precisionChanged);
+        }
+
+        [Test]
         public void TestEventArgs()
         {
             var bindable1 = new Bindable<int>();

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -330,11 +330,12 @@ namespace osu.Framework.Bindables
         }
 
         /// <summary>
-        /// Unbind any events bound to <see cref="ValueChanged"/> and <see cref="DisabledChanged"/>.
+        /// Unbinds any actions bound to the value changed events.
         /// </summary>
-        public void UnbindEvents()
+        public virtual void UnbindEvents()
         {
             ValueChanged = null;
+            DefaultChanged = null;
             DisabledChanged = null;
         }
 

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -205,6 +205,13 @@ namespace osu.Framework.Bindables
             base.BindTo(them);
         }
 
+        public override void UnbindEvents()
+        {
+            base.UnbindEvents();
+
+            PrecisionChanged = null;
+        }
+
         public bool IsInteger =>
             typeof(T) != typeof(float) &&
             typeof(T) != typeof(double); // Will be **constant** after JIT.

--- a/osu.Framework/Bindables/RangeConstrainedBindable.cs
+++ b/osu.Framework/Bindables/RangeConstrainedBindable.cs
@@ -173,6 +173,14 @@ namespace osu.Framework.Bindables
             base.BindTo(them);
         }
 
+        public override void UnbindEvents()
+        {
+            base.UnbindEvents();
+
+            MinValueChanged = null;
+            MaxValueChanged = null;
+        }
+
         public new RangeConstrainedBindable<T> GetBoundCopy() => (RangeConstrainedBindable<T>)base.GetBoundCopy();
 
         public new RangeConstrainedBindable<T> GetUnboundCopy() => (RangeConstrainedBindable<T>)base.GetUnboundCopy();


### PR DESCRIPTION
Spotted during [osu!-side PR review](https://github.com/ppy/osu/pull/13701#discussion_r666529763), quite bad this wasn't noticed at all.

Open to suggestions how this can be properly tested, the test case I wrote feels almost pointless, but can't think of anything better.