### PR TITLE
Throw when attempting to set container to `Children` and similar cases

### DIFF
--- a/osu.Framework.Tests/Containers/ContainerEnumerableTest.cs
+++ b/osu.Framework.Tests/Containers/ContainerEnumerableTest.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+
+namespace osu.Framework.Tests.Containers
+{
+    [TestFixture]
+    public class ContainerEnumerableTest
+    {
+        /// <summary>
+        /// Ensures that adding container as an enumerable of drawables to another container results in an exception.
+        /// Tests with a regular <see cref="Container{T}"/>, and an <see cref="AudioContainer{T}"/> which doesn't directly inherit from <see cref="Container{T}"/>.
+        /// </summary>
+        [TestCase(typeof(Container))]
+        [TestCase(typeof(Container<Drawable>))]
+        [TestCase(typeof(Container<Box>))]
+        [TestCase(typeof(AudioContainer))]
+        [TestCase(typeof(AudioContainer<Drawable>))]
+        [TestCase(typeof(AudioContainer<Box>))]
+        public void TestAddingContainerAsEnumerableRangeThrows(Type containerType)
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var unused = new Container
+                {
+                    Children = (IReadOnlyList<Drawable>)Activator.CreateInstance(containerType)
+                };
+            });
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var unused = new Container();
+
+                unused.AddRange((IEnumerable<Drawable>)Activator.CreateInstance(containerType));
+            });
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var unused = new AudioContainer
+                {
+                    Children = (IReadOnlyList<Drawable>)Activator.CreateInstance(containerType)
+                };
+            });
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                var unused = new AudioContainer();
+
+                unused.AddRange((IEnumerable<Drawable>)Activator.CreateInstance(containerType));
+            });
+        }
+    }
+}

--- a/osu.Framework.Tests/Containers/TestSceneContainerState.cs
+++ b/osu.Framework.Tests/Containers/TestSceneContainerState.cs
@@ -43,8 +43,7 @@ namespace osu.Framework.Tests.Containers
         }
 
         /// <summary>
-        /// Tests whether adding a child to multiple containers by abusing <see cref="Container{T}.Children"/>
-        /// results in a <see cref="InvalidOperationException"/>.
+        /// Tests whether adding a child to multiple containers results in a <see cref="InvalidOperationException"/>.
         /// </summary>
         [Test]
         public void TestPreLoadMultipleAdds()
@@ -52,13 +51,12 @@ namespace osu.Framework.Tests.Containers
             // Non-async
             Assert.Throws<InvalidOperationException>(() =>
             {
-                var unused = new Container
+                var unused1 = new Container
                 {
-                    // Container is an IReadOnlyList<T>, so Children can accept a Container.
-                    // This further means that CompositeDrawable.AddInternal will try to add all of
-                    // the children of the Container that was set to Children, which should throw an exception
-                    Children = new Container { Child = new Container() }
+                    Child = new Container(),
                 };
+
+                var unused2 = new Container { Child = unused1.Child };
             });
         }
 
@@ -75,14 +73,12 @@ namespace osu.Framework.Tests.Containers
 
                 try
                 {
-                    loadedContainer.Add(new Container
+                    var unused = new Container
                     {
-                        // Container is an IReadOnlyList<T>, so Children can accept a Container.
-                        // This further means that CompositeDrawable.AddInternal will try to add all of
-                        // the children of the Container that was set to Children, which should throw an exception
-                        Children = new Container { Child = new Container() }
-                    });
+                        Child = new Container(),
+                    };
 
+                    loadedContainer.Add(new Container { Child = unused.Child });
                     return false;
                 }
                 catch (InvalidOperationException)

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -567,6 +567,12 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected internal void AddRangeInternal(IEnumerable<Drawable> range)
         {
+            if (range is IContainerEnumerable<Drawable> container)
+            {
+                throw new InvalidOperationException($"Attempting to add a {container} as a range of children to {this}."
+                                                    + $"If intentional, consider using the {nameof(container.Children)} property instead.");
+            }
+
             foreach (Drawable d in range)
                 AddInternal(d);
         }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -567,10 +567,10 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected internal void AddRangeInternal(IEnumerable<Drawable> range)
         {
-            if (range is IContainerEnumerable<Drawable> container)
+            if (range is IContainerEnumerable<Drawable>)
             {
-                throw new InvalidOperationException($"Attempting to add a {container} as a range of children to {this}."
-                                                    + $"If intentional, consider using the {nameof(container.Children)} property instead.");
+                throw new InvalidOperationException($"Attempting to add a {nameof(IContainer)} as a range of children to {this}."
+                                                    + $"If intentional, consider using the {nameof(IContainerEnumerable<Drawable>.Children)} property instead.");
             }
 
             foreach (Drawable d in range)

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -209,10 +209,10 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public void AddRange(IEnumerable<T> range)
         {
-            if (range is IContainerEnumerable<Drawable> container)
+            if (range is IContainerEnumerable<Drawable>)
             {
-                throw new InvalidOperationException($"Attempting to add a {container} as a range of children to {this}."
-                                                    + $"If intentional, consider using the {nameof(container.Children)} property instead.");
+                throw new InvalidOperationException($"Attempting to add a {nameof(IContainer)} as a range of children to {this}."
+                                                    + $"If intentional, consider using the {nameof(IContainerEnumerable<Drawable>.Children)} property instead.");
             }
 
             foreach (T d in range)

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -209,6 +209,12 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public void AddRange(IEnumerable<T> range)
         {
+            if (range is IContainerEnumerable<Drawable> container)
+            {
+                throw new InvalidOperationException($"Attempting to add a {container} as a range of children to {this}."
+                                                    + $"If intentional, consider using the {nameof(container.Children)} property instead.");
+            }
+
             foreach (T d in range)
                 Add(d);
         }

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Gets the item representations contained by this <see cref="Menu"/>.
         /// </summary>
-        protected internal IReadOnlyList<DrawableMenuItem> Children => ItemsContainer;
+        protected internal IReadOnlyList<DrawableMenuItem> Children => ItemsContainer.Children;
 
         protected readonly Direction Direction;
 

--- a/osu.Framework/Testing/MenuTestScene.cs
+++ b/osu.Framework/Testing/MenuTestScene.cs
@@ -59,7 +59,7 @@ namespace osu.Framework.Testing
             /// <summary>
             /// Retrieves the <see cref="Menu.DrawableMenuItem"/>s of the <see cref="Menu"/> represented by this <see cref="MenuStructure"/>.
             /// </summary>
-            public IReadOnlyList<Drawable> GetMenuItems() => menu.ChildrenOfType<FillFlowContainer<Menu.DrawableMenuItem>>().First();
+            public IReadOnlyList<Drawable> GetMenuItems() => menu.ChildrenOfType<FillFlowContainer<Menu.DrawableMenuItem>>().First().Children;
 
             /// <summary>
             /// Finds the <see cref="Menu.DrawableMenuItem"/> index in the <see cref="Menu"/> represented by this <see cref="MenuStructure"/> that


### PR DESCRIPTION
Gets rid of the usual mistake of setting a `Container` to `Children`, or passing a `Container` to `AddRange`, which causes weird behaviour such as "May not add a drawable to multiple containers" without any trace of being related to this.

Tests seem to pass, double-checked and removed any usages to this quirk.