### PR TITLE
Add support for parsing autolinks in Markdown container

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
@@ -291,14 +291,14 @@ soft break with '\'";
         }
 
         [Test]
-        public void TestAutolinkInline()
+        public void TestAutoLinkInline()
         {
             AddStep("set content", () =>
             {
                 markdownContainer.Text = "<https://discord.gg/ppy>";
             });
 
-            AddAssert("has correct autolink", () => markdownContainer.Autolinks[0].Url == "https://discord.gg/ppy");
+            AddAssert("has correct autolink", () => markdownContainer.AutoLinks[0].Url == "https://discord.gg/ppy");
         }
 
         private class TestMarkdownContainer : MarkdownContainer
@@ -317,12 +317,12 @@ soft break with '\'";
 
             public readonly List<LinkInline> Links = new List<LinkInline>();
 
-            public readonly List<AutolinkInline> Autolinks = new List<AutolinkInline>();
+            public readonly List<AutolinkInline> AutoLinks = new List<AutolinkInline>();
 
             public override MarkdownTextFlowContainer CreateTextFlow() => new TestMarkdownTextFlowContainer
             {
                 UrlAdded = url => Links.Add(url),
-                AutolinkAdded = autolink => Autolinks.Add(autolink),
+                AutoLinkAdded = autolink => AutoLinks.Add(autolink),
             };
 
             public override SpriteText CreateSpriteText() => base.CreateSpriteText().With(t => t.Font = t.Font.With("Roboto", weight: "Regular"));
@@ -331,7 +331,7 @@ soft break with '\'";
             {
                 public Action<LinkInline> UrlAdded;
 
-                public Action<AutolinkInline> AutolinkAdded;
+                public Action<AutolinkInline> AutoLinkAdded;
 
                 protected override void AddLinkText(string text, LinkInline linkInline)
                 {
@@ -344,7 +344,7 @@ soft break with '\'";
                 {
                     base.AddAutoLink(autolinkInline);
 
-                    AutolinkAdded?.Invoke(autolinkInline);
+                    AutoLinkAdded?.Invoke(autolinkInline);
                 }
             }
         }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
@@ -297,6 +297,8 @@ soft break with '\'";
             {
                 markdownContainer.Text = "<https://discord.gg/ppy>";
             });
+
+            AddAssert("has correct autolink", () => markdownContainer.Autolinks[0].Url == "https://discord.gg/ppy");
         }
 
         private class TestMarkdownContainer : MarkdownContainer
@@ -315,9 +317,12 @@ soft break with '\'";
 
             public readonly List<LinkInline> Links = new List<LinkInline>();
 
+            public readonly List<AutolinkInline> Autolinks = new List<AutolinkInline>();
+
             public override MarkdownTextFlowContainer CreateTextFlow() => new TestMarkdownTextFlowContainer
             {
-                UrlAdded = url => Links.Add(url)
+                UrlAdded = url => Links.Add(url),
+                AutolinkAdded = autolink => Autolinks.Add(autolink),
             };
 
             public override SpriteText CreateSpriteText() => base.CreateSpriteText().With(t => t.Font = t.Font.With("Roboto", weight: "Regular"));
@@ -326,11 +331,20 @@ soft break with '\'";
             {
                 public Action<LinkInline> UrlAdded;
 
+                public Action<AutolinkInline> AutolinkAdded;
+
                 protected override void AddLinkText(string text, LinkInline linkInline)
                 {
                     base.AddLinkText(text, linkInline);
 
                     UrlAdded?.Invoke(linkInline);
+                }
+
+                protected override void AddAutoLink(AutolinkInline autolinkInline)
+                {
+                    base.AddAutoLink(autolinkInline);
+
+                    AutolinkAdded?.Invoke(autolinkInline);
                 }
             }
         }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
@@ -290,6 +290,15 @@ soft break with '\'";
             AddAssert("has correct link", () => markdownContainer.Links[0].Url == "mailto:contact@ppy.sh");
         }
 
+        [Test]
+        public void TestAutolinkInline()
+        {
+            AddStep("set content", () =>
+            {
+                markdownContainer.Text = "<https://discord.gg/ppy>";
+            });
+        }
+
         private class TestMarkdownContainer : MarkdownContainer
         {
             public new string DocumentUrl

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownLinkText.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownLinkText.cs
@@ -31,12 +31,22 @@ namespace osu.Framework.Graphics.Containers.Markdown
 
         protected readonly string Url;
 
-        public MarkdownLinkText(string text, LinkInline linkInline)
+        public MarkdownLinkText(string text, string url)
         {
             this.text = text;
-            Url = linkInline.Url ?? string.Empty;
+            Url = url;
 
             AutoSizeAxes = Axes.Both;
+        }
+
+        public MarkdownLinkText(string text, LinkInline linkInline)
+            : this(text, linkInline.Url ?? string.Empty)
+        {
+        }
+
+        public MarkdownLinkText(AutolinkInline autolinkInline)
+            : this(autolinkInline.Url, autolinkInline.Url)
+        {
         }
 
         [BackgroundDependencyLoader]

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
@@ -108,6 +108,10 @@ namespace osu.Framework.Graphics.Containers.Markdown
                         AddInlineText(innerContainer);
                         break;
 
+                    case AutolinkInline autoLink:
+                        AddAutoLink(autoLink);
+                        break;
+
                     default:
                         AddNotImplementedInlineText(single);
                         break;
@@ -123,6 +127,9 @@ namespace osu.Framework.Graphics.Containers.Markdown
 
         protected virtual void AddLinkText(string text, LinkInline linkInline)
             => AddDrawable(new MarkdownLinkText(text, linkInline));
+
+        protected virtual void AddAutoLink(AutolinkInline autolinkInline)
+            => AddDrawable(new MarkdownLinkText(autolinkInline));
 
         protected virtual void AddCodeInLine(CodeInline codeInline)
             => AddText(codeInline.Content, t => { t.Colour = Color4.Orange; });


### PR DESCRIPTION
As seen in https://github.com/ppy/osu/issues/13848, currently markdown container does not support autolink.

Example of autolink syntax:

```markdown
<https://discord.gg/ppy>
```

This PR add overloading constructor in `MarkdownLinkText` to handle autolink and also add `AddAutoLink` virtual method in `MarkdownTextFlowContainer`.