### PR TITLE
Improve usability of popover & popover container

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
@@ -29,6 +29,17 @@ namespace osu.Framework.Tests.Visual.UserInterface
         });
 
         [Test]
+        public void TestSizingDirectly() => createContent((anchor, popover) =>
+        {
+            popover.Size = new Vector2(200, 100);
+
+            popover.Child = new SpriteText
+            {
+                Text = "I have a custom size!"
+            };
+        });
+
+        [Test]
         public void TestInteractiveContent() => createContent((anchor, popover) =>
         {
             TextBox textBox;

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -140,7 +140,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             TextBox textBox;
 
-            return new BasicPopover
+            return new AnimatedPopover
             {
                 Child = new FillFlowContainer
                 {
@@ -272,6 +272,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     }
                 }
             });
+
+        private class AnimatedPopover : BasicPopover
+        {
+            protected override void PopIn() => this.FadeIn(300, Easing.OutQuint);
+            protected override void PopOut() => this.FadeOut(300, Easing.OutQuint);
+        }
 
         private class DrawableWithPopover : CircularContainer, IHasPopover
         {

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -214,6 +214,41 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
         }
 
+        [Test]
+        public void TestAutoSize()
+        {
+            AddStep("create content", () =>
+            {
+                popoverWrapper.RelativeSizeAxes = popoverContainer.RelativeSizeAxes = Axes.X;
+                popoverWrapper.AutoSizeAxes = popoverContainer.AutoSizeAxes = Axes.Y;
+
+                popoverContainer.Child = new Container
+                {
+                    RelativeSizeAxes = Axes.X,
+                    Height = 200,
+                    Child = new DrawableWithPopover
+                    {
+                        Width = 200,
+                        Height = 30,
+                        Text = "open",
+                        CreateContent = _ => new BasicPopover
+                        {
+                            Child = new SpriteText
+                            {
+                                Text = "I'm in an auto-sized container!"
+                            }
+                        }
+                    }
+                };
+            });
+
+            AddSliderStep("change content height", 100, 500, 200, height =>
+            {
+                if (popoverContainer?.Children.Count == 1)
+                    popoverContainer.Child.Height = height;
+            });
+        }
+
         private void createContent(Func<DrawableWithPopover, Popover> creationFunc)
             => AddStep("create content", () =>
             {

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -85,7 +85,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.MoveMouseTo(this.ChildrenOfType<DrawableWithPopover>().First());
                 InputManager.Click(MouseButton.Left);
             });
-            AddAssert("popover created", () => this.ChildrenOfType<Popover>().Any());
+            AddAssert("popover shown", () => this.ChildrenOfType<Popover>().Any(popover => popover.State.Value == Visibility.Visible));
 
             AddStep("click popover", () =>
             {
@@ -99,7 +99,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.MoveMouseTo(this.ChildrenOfType<DrawableWithPopover>().Last());
                 InputManager.Click(MouseButton.Left);
             });
-            AddAssert("popover removed", () => !this.ChildrenOfType<Popover>().Any());
+            AddAssert("popover hidden", () => this.ChildrenOfType<Popover>().All(popover => popover.State.Value != Visibility.Visible));
         }
 
         [Test]
@@ -119,7 +119,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("popover created", () => this.ChildrenOfType<Popover>().Any());
+            AddAssert("popover shown", () => this.ChildrenOfType<Popover>().Any(popover => popover.State.Value == Visibility.Visible));
 
             AddStep("mousedown popover", () =>
             {
@@ -132,7 +132,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep("release button", () => InputManager.ReleaseButton(MouseButton.Left));
 
-            AddAssert("popover remains", () => this.ChildrenOfType<Popover>().Any());
+            AddAssert("popover remains", () => this.ChildrenOfType<Popover>().Any(popover => popover.State.Value == Visibility.Visible));
         }
 
         [Test]

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -11,7 +11,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osuTK;
-using osuTK.Input;
 
 #nullable enable
 
@@ -44,9 +43,6 @@ namespace osu.Framework.Graphics.Cursor
 
         protected override bool OnClick(ClickEvent e)
         {
-            if (e.Button != MouseButton.Left)
-                return false;
-
             target = FindTargets().FirstOrDefault();
             if (target == null)
                 return false;

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -42,34 +42,25 @@ namespace osu.Framework.Graphics.Cursor
             };
         }
 
-        protected override bool OnMouseDown(MouseDownEvent e)
+        protected override bool OnClick(ClickEvent e)
         {
-            switch (e.Button)
-            {
-                case MouseButton.Left:
-                    target = FindTargets().FirstOrDefault();
-                    break;
-            }
+            if (e.Button != MouseButton.Left)
+                return false;
 
-            return false;
-        }
-
-        protected override void OnMouseUp(MouseUpEvent e)
-        {
-            base.OnMouseUp(e);
-
+            target = FindTargets().FirstOrDefault();
             if (target == null)
-                return;
+                return false;
 
             currentPopover?.Hide();
 
             var newPopover = target.GetPopover();
             if (newPopover == null)
-                return;
+                return false;
 
             popoverContainer.Add(currentPopover = newPopover);
             currentPopover.Show();
             currentPopover.State.BindValueChanged(_ => cleanUpPopover(currentPopover));
+            return true;
         }
 
         private void cleanUpPopover(Popover popover)

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -80,6 +80,19 @@ namespace osu.Framework.Graphics.Cursor
             updatePopoverPositioning();
         }
 
+        protected override void OnSizingChanged()
+        {
+            base.OnSizingChanged();
+
+            // reset to none to prevent exceptions
+            content.RelativeSizeAxes = Axes.None;
+            content.AutoSizeAxes = Axes.None;
+
+            // in addition to using this.RelativeSizeAxes, sets RelativeSizeAxes on every axis that is neither relative size nor auto size
+            content.RelativeSizeAxes = Axes.Both & ~AutoSizeAxes;
+            content.AutoSizeAxes = AutoSizeAxes;
+        }
+
         /// <summary>
         /// The <see cref="Anchor"/>s to consider when auto-layouting the popover.
         /// <see cref="Anchor.Centre"/> is not included, as it is used as a fallback if any other anchor fails.

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -48,6 +48,7 @@ namespace osu.Framework.Graphics.Cursor
                 return false;
 
             currentPopover?.Hide();
+            currentPopover?.Expire();
 
             var newPopover = target.GetPopover();
             if (newPopover == null)
@@ -55,18 +56,7 @@ namespace osu.Framework.Graphics.Cursor
 
             popoverContainer.Add(currentPopover = newPopover);
             currentPopover.Show();
-            currentPopover.State.BindValueChanged(_ => cleanUpPopover(currentPopover));
             return true;
-        }
-
-        private void cleanUpPopover(Popover popover)
-        {
-            if (popover.State.Value != Visibility.Hidden)
-                return;
-
-            popover.Expire();
-            if (currentPopover == popover)
-                currentPopover = null;
         }
 
         protected override void UpdateAfterChildren()

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -60,7 +61,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected Popover()
         {
-            InternalChild = BoundingBoxContainer = new Container
+            base.AddInternal(BoundingBoxContainer = new Container
             {
                 AutoSizeAxes = Axes.Both,
                 Children = new[]
@@ -83,7 +84,7 @@ namespace osu.Framework.Graphics.UserInterface
                         };
                     })
                 }
-            };
+            });
         }
 
         /// <summary>
@@ -137,6 +138,8 @@ namespace osu.Framework.Graphics.UserInterface
                     return 135;
             }
         }
+
+        protected internal sealed override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(Content)} instead.");
 
         protected class PopoverFocusedOverlayContainer : FocusedOverlayContainer
         {

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -3,6 +3,7 @@
 
 using System;
 using osu.Framework.Extensions;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
@@ -140,6 +141,48 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         protected internal sealed override void AddInternal(Drawable drawable) => throw new InvalidOperationException($"Use {nameof(Content)} instead.");
+
+        #region Sizing delegation
+
+        // Popovers rely on being 0x0 sized and placed exactly at the attachment point to their drawable for layouting logic.
+        // This can cause undesirable results if somebody tries to directly set the Width/Height of a popover, expecting the body to be resized.
+        // This is done via shadowing rather than overrides, because we still want framework to read the base 0x0 size.
+
+        public new float Width
+        {
+            get => Body.DrawWidth;
+            set
+            {
+                if (Body.AutoSizeAxes.HasFlagFast(Axes.X))
+                    Body.AutoSizeAxes &= ~Axes.X;
+
+                Body.Width = value;
+            }
+        }
+
+        public new float Height
+        {
+            get => Body.DrawHeight;
+            set
+            {
+                if (Body.AutoSizeAxes.HasFlagFast(Axes.Y))
+                    Body.AutoSizeAxes &= ~Axes.Y;
+
+                Body.Height = value;
+            }
+        }
+
+        public new Vector2 Size
+        {
+            get => Body.DrawSize;
+            set
+            {
+                Width = value.X;
+                Height = value.Y;
+            }
+        }
+
+        #endregion
 
         protected class PopoverFocusedOverlayContainer : FocusedOverlayContainer
         {

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -150,7 +150,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public new float Width
         {
-            get => Body.DrawWidth;
+            get => Body.Width;
             set
             {
                 if (Body.AutoSizeAxes.HasFlagFast(Axes.X))
@@ -162,7 +162,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public new float Height
         {
-            get => Body.DrawHeight;
+            get => Body.Height;
             set
             {
                 if (Body.AutoSizeAxes.HasFlagFast(Axes.Y))
@@ -174,7 +174,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         public new Vector2 Size
         {
-            get => Body.DrawSize;
+            get => Body.Size;
             set
             {
                 Width = value.X;

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -57,8 +57,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         protected internal FocusedOverlayContainer Body { get; }
 
-        private Container content;
-        protected override Container<Drawable> Content => content;
+        protected override Container<Drawable> Content { get; } = new Container { AutoSizeAxes = Axes.Both };
 
         protected Popover()
         {
@@ -78,10 +77,7 @@ namespace osu.Framework.Graphics.UserInterface
                             {
                                 RelativeSizeAxes = Axes.Both,
                             },
-                            content = new Container
-                            {
-                                AutoSizeAxes = Axes.Both,
-                            }
+                            Content
                         };
                     })
                 }


### PR DESCRIPTION
Some assorted fixes and improvements which resulted from @peppy attempting to use the control for multiplayer room password input. I recommend reading commit-by-commit; I didn't want to split this into 3 or 4 pulls because noise.

* 58863c6 removes the weird `OnMouse{Down,Up}` handling that seemed to be unnecessary in the end. Shaves a fair bit of complexity off as well.
* 7fed4ba fixes not being able to use the popover container in hierarchies that had auto-size axes on them. Fix mirrors what `ContextMenuContainer` and `TooltipContainer` already do.
* 26cde79 is intended to guide towards the proper usage of popovers (which is putting what should go inside the popover into `Children` rather than `InternalChildren`).
* f32bebb adds support for sizing the popovers directly rather than them breaking when sizes are set on the popover itself, which leads to having to set the desired size on their contents instead.