### PR TITLE
Allow drawables to manually show and hide popovers

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
@@ -104,7 +104,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class TestBasicPopover : BasicPopover
         {
-            protected override FocusedOverlayContainer CreateBody() => new TestPopoverFocusedOverlayContainer();
+            protected override VisibilityContainer CreateBody() => new TestPopoverFocusedOverlayContainer();
 
             private class TestPopoverFocusedOverlayContainer : PopoverFocusedOverlayContainer
             {

--- a/osu.Framework/Extensions/PopoverExtensions.cs
+++ b/osu.Framework/Extensions/PopoverExtensions.cs
@@ -1,0 +1,39 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Cursor;
+
+#nullable enable
+
+namespace osu.Framework.Extensions
+{
+    public static class PopoverExtensions
+    {
+        /// <summary>
+        /// Shows the popover for <paramref name="hasPopover"/> on its nearest <see cref="PopoverContainer"/> ancestor.
+        /// </summary>
+        public static void ShowPopover(this IHasPopover hasPopover) => setTargetOnNearestPopover((Drawable)hasPopover, hasPopover);
+
+        /// <summary>
+        /// Hides the popover shown on <paramref name="drawable"/>'s nearest <see cref="PopoverContainer"/> ancestor.
+        /// </summary>
+        public static void HidePopover(this Drawable drawable) => setTargetOnNearestPopover(drawable, null);
+
+        private static void setTargetOnNearestPopover(Drawable origin, IHasPopover? target)
+        {
+            var node = origin.Parent;
+
+            while (node != null)
+            {
+                if (node is PopoverContainer popoverContainer)
+                {
+                    popoverContainer.SetTarget(target);
+                    return;
+                }
+
+                node = node.Parent;
+            }
+        }
+    }
+}

--- a/osu.Framework/Extensions/PopoverExtensions.cs
+++ b/osu.Framework/Extensions/PopoverExtensions.cs
@@ -21,19 +21,6 @@ namespace osu.Framework.Extensions
         public static void HidePopover(this Drawable drawable) => setTargetOnNearestPopover(drawable, null);
 
         private static void setTargetOnNearestPopover(Drawable origin, IHasPopover? target)
-        {
-            var node = origin.Parent;
-
-            while (node != null)
-            {
-                if (node is PopoverContainer popoverContainer)
-                {
-                    popoverContainer.SetTarget(target);
-                    return;
-                }
-
-                node = node.Parent;
-            }
-        }
+            => origin.FindClosestParent<PopoverContainer>()?.SetTarget(target);
     }
 }

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -47,13 +47,28 @@ namespace osu.Framework.Graphics.Cursor
             if (e.Button != MouseButton.Left)
                 return false;
 
-            target = FindTargets().FirstOrDefault();
-            if (target == null)
+            var newTarget = FindTargets().FirstOrDefault();
+            if (newTarget == null)
                 return false;
+
+            return SetTarget(newTarget);
+        }
+
+        /// <summary>
+        /// Sets the target drawable for this <see cref="PopoverContainer"/> to <paramref name="newTarget"/>.
+        /// </summary>
+        /// <remarks>
+        /// After calling this method, the previous popover shown in this <see cref="PopoverContainer"/> will be hidden.
+        /// This method can be called with a <see langword="null"/> argument to hide the currently-visible popover.
+        /// </remarks>
+        /// <returns><see langword="true"/> if a new popover was shown, <see langword="false"/> otherwise.</returns>
+        internal bool SetTarget(IHasPopover? newTarget)
+        {
+            target = newTarget;
 
             currentPopover?.Hide();
 
-            var newPopover = target.GetPopover();
+            var newPopover = target?.GetPopover();
             if (newPopover == null)
                 return false;
 

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// The body of this <see cref="Popover"/>, containing the actual contents.
         /// </summary>
-        protected internal FocusedOverlayContainer Body { get; }
+        protected internal VisibilityContainer Body { get; }
 
         private Container content;
         protected override Container<Drawable> Content => content;
@@ -96,7 +96,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Creates the body of this <see cref="Popover"/>.
         /// </summary>
-        protected virtual FocusedOverlayContainer CreateBody() => new PopoverFocusedOverlayContainer();
+        protected virtual VisibilityContainer CreateBody() => new PopoverFocusedOverlayContainer();
 
         protected override void PopIn() => this.FadeIn();
         protected override void PopOut() => this.FadeOut();


### PR DESCRIPTION
- [x] Depends on #4590 (for mergeability).

Another thing that fell out of @peppy's attempt of integrating the popover into the multi screen is that sometimes the "automagic" way of showing the popover, via handling the mouse events and target finding, doesn't work for various reasons in some scenarios (for instance, if a click never reaches the popover, like when the popover target is inside a scroll, or it might be desired to show a popover as a result of another user interaction, such as focusing a text box).

This pull adds a method to manually drive the nearest `PopoverContainer` via extension methods that traverse the drawable hierarchy. The test scene shows what can be done with this (showing a popover when a textbox is focused).

A side thing that also happens in this pull to allow the above test scene to happen, is relaxing the constraint on the body of the popover (it no longer needs to be a `FocusedOverlayContainer` and take keyboard focus). This opens the popover to yet more use cases that it might not have been applicable to without it.