### PR TITLE
Reset a StepSlider to its default value when right-clicked

### DIFF
--- a/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.UserInterface;
 using System;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
-using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.Events;
 using osuTK.Input;
 
@@ -68,7 +67,7 @@ namespace osu.Framework.Testing.Drawables.Steps
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (e.Button.HasFlagFast(MouseButton.Right))
+            if (e.Button == MouseButton.Right)
             {
                 Current.SetDefault();
                 Flash();

--- a/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
@@ -67,6 +67,7 @@ namespace osu.Framework.Testing.Drawables.Steps
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
+            // Reset value via right click. This shouldn't happen if a drag (via left button) is in progress.
             if (!IsDragged && e.Button == MouseButton.Right)
             {
                 Current.SetDefault();

--- a/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
@@ -9,7 +9,9 @@ using osu.Framework.Graphics.UserInterface;
 using System;
 using osu.Framework.Bindables;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Input.Events;
+using osuTK.Input;
 
 namespace osu.Framework.Testing.Drawables.Steps
 {
@@ -64,19 +66,21 @@ namespace osu.Framework.Testing.Drawables.Steps
             currentNumber.SetDefault();
         }
 
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (e.Button.HasFlagFast(MouseButton.Right))
+            {
+                Current.SetDefault();
+                Flash();
+                Reset();
+            }
+
+            return base.OnMouseDown(e);
+        }
+
         protected override void OnDragEnd(DragEndEvent e)
         {
-            var flash = new Box
-            {
-                RelativeSizeAxes = Axes.Both,
-                Colour = Color4.RoyalBlue,
-                Blending = BlendingParameters.Additive,
-                Alpha = 0.6f,
-            };
-
-            Add(flash);
-            flash.FadeOut(200).Expire();
-
+            Flash();
             Success();
             base.OnDragEnd(e);
         }
@@ -88,6 +92,27 @@ namespace osu.Framework.Testing.Drawables.Steps
             ValueChanged?.Invoke(value);
             spriteText.Text = $"{text}: {Convert.ToDouble(value):G3}";
             selection.ResizeWidthTo(normalizedValue);
+        }
+
+        protected void Flash()
+        {
+            var flash = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Color4.RoyalBlue,
+                Blending = BlendingParameters.Additive,
+                Alpha = 0.6f,
+            };
+
+            Add(flash);
+            flash.FadeOut(200).Expire();
+        }
+
+        protected void Reset()
+        {
+            background.Alpha = 1f;
+            selection.Alpha = 1f;
+            spriteText.Alpha = 1f;
         }
 
         protected void Success()

--- a/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepSlider.cs
@@ -67,7 +67,7 @@ namespace osu.Framework.Testing.Drawables.Steps
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (e.Button == MouseButton.Right)
+            if (!IsDragged && e.Button == MouseButton.Right)
             {
                 Current.SetDefault();
                 Flash();


### PR DESCRIPTION
Allows the user to right-click a SliderStep in the test browser to reset it to its default value.

[Streamable](https://streamable.com/xihrgd)