### PR TITLE
Refactor `PopoverContainer` to simplify dismissal process

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
@@ -81,7 +81,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         popoverAnchor |= (Anchor)((int)Anchor.x0 << i);
                         popoverAnchor |= (Anchor)((int)Anchor.y0 << j);
 
-                        var popover = new TestBasicPopover
+                        var popover = new BasicPopover
                         {
                             PopoverAnchor = popoverAnchor,
                             State = { Value = Visibility.Visible }
@@ -101,15 +101,5 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     }
                 }
             });
-
-        private class TestBasicPopover : BasicPopover
-        {
-            protected override BodyContainer CreateBody() => new TestBody();
-
-            private class TestBody : BodyContainer
-            {
-                public override bool HandlePositionalInput => false;
-            }
-        }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopover.cs
@@ -104,9 +104,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class TestBasicPopover : BasicPopover
         {
-            protected override VisibilityContainer CreateBody() => new TestPopoverFocusedOverlayContainer();
+            protected override BodyContainer CreateBody() => new TestBody();
 
-            private class TestPopoverFocusedOverlayContainer : PopoverFocusedOverlayContainer
+            private class TestBody : BodyContainer
             {
                 public override bool HandlePositionalInput => false;
             }

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -108,6 +108,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             createContent(button => new BasicPopover
             {
+                Name = button.Anchor.ToString(),
                 Child = new SpriteText
                 {
                     Text = $"{button.Anchor} popover"
@@ -120,7 +121,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("first shown", () => this.ChildrenOfType<Popover>().First().State.Value == Visibility.Visible);
+            AddAssert("first shown", () => this.ChildrenOfType<Popover>().Single().Name == Anchor.TopLeft.ToString());
 
             AddStep("click last button", () =>
             {
@@ -128,8 +129,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("first hidden", () => this.ChildrenOfType<Popover>().First().State.Value == Visibility.Visible);
-            AddAssert("last shown", () => this.ChildrenOfType<Popover>().Last().State.Value == Visibility.Visible);
+            AddAssert("last shown", () => this.ChildrenOfType<Popover>().Single().Name == Anchor.BottomRight.ToString());
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -14,6 +14,7 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input.Events;
 using osu.Framework.Testing;
 using osuTK;
+using osuTK.Graphics;
 using osuTK.Input;
 
 namespace osu.Framework.Tests.Visual.UserInterface
@@ -50,9 +51,33 @@ namespace osu.Framework.Tests.Visual.UserInterface
                         {
                             RelativeSizeAxes = Axes.Both,
                             Padding = new MarginPadding(5),
-                            Child = gridContainer = new GridContainer
+                            Children = new Drawable[]
                             {
-                                RelativeSizeAxes = Axes.Both
+                                new ClickableContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Size = new Vector2(0.5f),
+                                    Children = new Drawable[]
+                                    {
+                                        new Box
+                                        {
+                                            Colour = Color4.Blue,
+                                            RelativeSizeAxes = Axes.Both,
+                                        },
+                                        new TextFlowContainer
+                                        {
+                                            AutoSizeAxes = Axes.X,
+                                            TextAnchor = Anchor.TopCentre,
+                                            Anchor = Anchor.Centre,
+                                            Origin = Anchor.Centre,
+                                            Text = "click blocking container between\nPopover creator and PopoverContainer"
+                                        }
+                                    }
+                                },
+                                gridContainer = new GridContainer
+                                {
+                                    RelativeSizeAxes = Axes.Both
+                                }
                             }
                         }
                     }

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -369,6 +369,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
             }
 
             public Popover GetPopover() => CreateContent.Invoke(this);
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                this.ShowPopover();
+                return true;
+            }
         }
 
         private class TextBoxWithPopover : BasicTextBox, IHasPopover

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -356,24 +356,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 this.HidePopover();
             }
 
-            public Popover GetPopover() => new NonFocusGrabbingPopover
+            public Popover GetPopover() => new BasicPopover
             {
                 Child = new SpriteText
                 {
                     Text = "the text box has focus now!"
                 }
             };
-        }
-
-        private class NonFocusGrabbingPopover : BasicPopover
-        {
-            protected override VisibilityContainer CreateBody() => new TestNonFocusGrabbingPopoverBody();
-
-            private class TestNonFocusGrabbingPopoverBody : VisibilityContainer
-            {
-                protected override void PopIn() => Show();
-                protected override void PopOut() => Hide();
-            }
         }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -71,7 +71,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestSimpleText()
+        public void TestShowHide()
         {
             createContent(button => new BasicPopover
             {
@@ -97,10 +97,39 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep("click away", () =>
             {
+                InputManager.MoveMouseTo(this.ChildrenOfType<DrawableWithPopover>().First().ScreenSpaceDrawQuad.BottomRight + new Vector2(10));
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("all hidden", () => this.ChildrenOfType<Popover>().All(popover => popover.State.Value != Visibility.Visible));
+        }
+
+        [Test]
+        public void TestClickBetweenMultiple()
+        {
+            createContent(button => new BasicPopover
+            {
+                Child = new SpriteText
+                {
+                    Text = $"{button.Anchor} popover"
+                }
+            });
+
+            AddStep("click button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<DrawableWithPopover>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("first shown", () => this.ChildrenOfType<Popover>().First().State.Value == Visibility.Visible);
+
+            AddStep("click last button", () =>
+            {
                 InputManager.MoveMouseTo(this.ChildrenOfType<DrawableWithPopover>().Last());
                 InputManager.Click(MouseButton.Left);
             });
-            AddAssert("popover hidden", () => this.ChildrenOfType<Popover>().All(popover => popover.State.Value != Visibility.Visible));
+
+            AddAssert("first hidden", () => this.ChildrenOfType<Popover>().First().State.Value == Visibility.Visible);
+            AddAssert("last shown", () => this.ChildrenOfType<Popover>().Last().State.Value == Visibility.Visible);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -247,7 +247,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddAssert("textbox is not focused", () => InputManager.FocusedDrawable == null);
+            AddAssert("popover is focused", () => InputManager.FocusedDrawable is Popover);
             AddAssert("popover still shown", () => this.ChildrenOfType<Popover>().Any(popover => popover.State.Value == Visibility.Visible));
         }
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -191,37 +191,65 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestInteractiveContent() => createContent(button =>
+        public void TestInteractiveContent()
         {
-            TextBox textBox;
-
-            return new AnimatedPopover
+            createContent(button =>
             {
-                Child = new FillFlowContainer
+                TextBox textBox;
+
+                return new AnimatedPopover
                 {
-                    Direction = FillDirection.Vertical,
-                    Width = 200,
-                    AutoSizeAxes = Axes.Y,
-                    Spacing = new Vector2(5),
-                    Children = new Drawable[]
+                    Child = new FillFlowContainer
                     {
-                        textBox = new BasicTextBox
+                        Direction = FillDirection.Vertical,
+                        Width = 200,
+                        AutoSizeAxes = Axes.Y,
+                        Spacing = new Vector2(5),
+                        Children = new Drawable[]
                         {
-                            PlaceholderText = $"{button.Anchor} text box",
-                            Height = 30,
-                            RelativeSizeAxes = Axes.X
-                        },
-                        new BasicButton
-                        {
-                            RelativeSizeAxes = Axes.X,
-                            Height = 30,
-                            Text = "Clear",
-                            Action = () => textBox.Text = string.Empty
+                            textBox = new BasicTextBox
+                            {
+                                PlaceholderText = $"{button.Anchor} text box",
+                                Height = 30,
+                                RelativeSizeAxes = Axes.X
+                            },
+                            new BasicButton
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                Height = 30,
+                                Text = "Clear",
+                                Action = () => textBox.Text = string.Empty
+                            }
                         }
                     }
-                }
-            };
-        });
+                };
+            });
+
+            AddStep("click button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<DrawableWithPopover>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("popover shown", () => this.ChildrenOfType<Popover>().Any(popover => popover.State.Value == Visibility.Visible));
+
+            AddStep("click textbox", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<TextBox>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("textbox is focused", () => InputManager.FocusedDrawable is TextBox);
+            AddAssert("popover still shown", () => this.ChildrenOfType<Popover>().Any(popover => popover.State.Value == Visibility.Visible));
+            AddStep("click in popover", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<Popover>().First().Body.ScreenSpaceDrawQuad.TopLeft + Vector2.One);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("textbox is not focused", () => InputManager.FocusedDrawable == null);
+            AddAssert("popover still shown", () => this.ChildrenOfType<Popover>().Any(popover => popover.State.Value == Visibility.Visible));
+        }
 
         [Test]
         public void TestAutomaticLayouting()

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -14,7 +14,7 @@ using osuTK;
 
 namespace osu.Framework.Graphics.Cursor
 {
-    public class PopoverContainer : CursorEffectContainer<PopoverContainer, IHasPopover>
+    public class PopoverContainer : Container
     {
         private readonly Container content;
         private readonly Container<Popover> popoverContainer;

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -2,13 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Linq;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osuTK;
 
@@ -39,11 +37,6 @@ namespace osu.Framework.Graphics.Cursor
                     AutoSizeAxes = Axes.Both
                 },
             };
-        }
-
-        protected override bool OnClick(ClickEvent e)
-        {
-            return SetTarget(FindTargets().FirstOrDefault());
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -43,11 +43,7 @@ namespace osu.Framework.Graphics.Cursor
 
         protected override bool OnClick(ClickEvent e)
         {
-            var newTarget = FindTargets().FirstOrDefault();
-            if (newTarget == null)
-                return false;
-
-            return SetTarget(newTarget);
+            return SetTarget(FindTargets().FirstOrDefault());
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -16,19 +16,22 @@ namespace osu.Framework.Graphics.UserInterface
     /// It typically is activated by another control and includes an arrow pointing to the location from which it emerged.
     /// (loosely paraphrasing: https://developer.apple.com/design/human-interface-guidelines/ios/views/popovers/)
     /// </summary>
-    public abstract class Popover : VisibilityContainer
+    public abstract class Popover : FocusedOverlayContainer
     {
+        protected override bool BlockPositionalInput => false; // not required as we only care about intercepting mouse down in certain cases.
+
         public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => State.Value == Visibility.Visible;
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (!Body.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
-            {
-                this.HidePopover();
-            }
+            if (Body.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
+                return true;
 
+            this.HidePopover();
             return base.OnMouseDown(e);
         }
+
+        protected override bool OnClick(ClickEvent e) => Body.ReceivePositionalInputAt(e.ScreenSpaceMousePosition);
 
         /// <summary>
         /// The <see cref="Anchor"/> that this <see cref="Popover"/> is to be attached to the triggering UI control by.
@@ -57,7 +60,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// The background box of the popover.
         /// </summary>
-        protected Box Background { get; private set; }
+        protected Box Background { get; }
 
         /// <summary>
         /// The arrow of this <see cref="Popover"/>, pointing at the component which triggered it.
@@ -79,7 +82,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Children = new[]
                 {
                     Arrow = CreateArrow(),
-                    Body = new BodyContainer
+                    Body = new Container
                     {
                         AutoSizeAxes = Axes.Both,
                         Children = new Drawable[]
@@ -185,10 +188,5 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         #endregion
-
-        protected class BodyContainer : Container
-        {
-            protected override bool Handle(UIEvent e) => true;
-        }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -92,7 +92,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// Creates the body of this <see cref="Popover"/>.
         /// </summary>
-        protected virtual VisibilityContainer CreateBody() => new PopoverFocusedOverlayContainer();
+        protected virtual BodyContainer CreateBody() => new BodyContainer();
 
         protected override void PopIn() => this.FadeIn();
         protected override void PopOut() => this.FadeOut();
@@ -180,33 +180,14 @@ namespace osu.Framework.Graphics.UserInterface
 
         #endregion
 
-        protected class PopoverFocusedOverlayContainer : FocusedOverlayContainer
+        protected class BodyContainer : VisibilityContainer
         {
-            protected override bool BlockPositionalInput => true;
+            protected override bool OnMouseDown(MouseDownEvent e) => true;
 
-            public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => State.Value == Visibility.Visible;
+            protected override bool OnClick(ClickEvent e) => true;
 
-            protected override void OnMouseUp(MouseUpEvent e)
-            {
-                base.OnMouseUp(e);
-                handleMouseEvent(e.ScreenSpaceMouseDownPosition);
-            }
-
-            protected override bool OnClick(ClickEvent e)
-            {
-                return handleMouseEvent(e.ScreenSpaceMouseDownPosition);
-            }
-
-            private bool handleMouseEvent(Vector2 position)
-            {
-                // if the mouse event can be handled by this container, prevent it from propagating further.
-                if (base.ReceivePositionalInputAt(position))
-                    return true;
-
-                // anything else means that the user is clicking away from the popover, and so that should hide the popover and trigger focus loss.
-                Hide();
-                return false;
-            }
+            protected override void PopIn() => Show();
+            protected override void PopOut() => Hide();
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -18,6 +18,18 @@ namespace osu.Framework.Graphics.UserInterface
     /// </summary>
     public abstract class Popover : VisibilityContainer
     {
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => State.Value == Visibility.Visible;
+
+        protected override bool OnMouseDown(MouseDownEvent e)
+        {
+            if (!Body.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
+            {
+                this.HidePopover();
+            }
+
+            return base.OnMouseDown(e);
+        }
+
         /// <summary>
         /// The <see cref="Anchor"/> that this <see cref="Popover"/> is to be attached to the triggering UI control by.
         /// </summary>
@@ -176,8 +188,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected class BodyContainer : Container
         {
-            protected override bool OnMouseDown(MouseDownEvent e) => true;
-            protected override bool OnClick(ClickEvent e) => true;
+            protected override bool Handle(UIEvent e) => true;
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -55,7 +55,7 @@ namespace osu.Framework.Graphics.UserInterface
         /// <summary>
         /// The body of this <see cref="Popover"/>, containing the actual contents.
         /// </summary>
-        protected internal VisibilityContainer Body { get; }
+        protected internal Container Body { get; }
 
         protected override Container<Drawable> Content { get; } = new Container { AutoSizeAxes = Axes.Both };
 
@@ -67,19 +67,18 @@ namespace osu.Framework.Graphics.UserInterface
                 Children = new[]
                 {
                     Arrow = CreateArrow(),
-                    Body = CreateBody().With(body =>
+                    Body = new BodyContainer
                     {
-                        body.AutoSizeAxes = Axes.Both;
-                        body.State.BindTarget = State;
-                        body.Children = new Drawable[]
+                        AutoSizeAxes = Axes.Both,
+                        Children = new Drawable[]
                         {
                             Background = new Box
                             {
                                 RelativeSizeAxes = Axes.Both,
                             },
                             Content
-                        };
-                    })
+                        },
+                    }
                 }
             });
         }
@@ -88,11 +87,6 @@ namespace osu.Framework.Graphics.UserInterface
         /// Creates an arrow drawable that points away from the given <see cref="Anchor"/>.
         /// </summary>
         protected abstract Drawable CreateArrow();
-
-        /// <summary>
-        /// Creates the body of this <see cref="Popover"/>.
-        /// </summary>
-        protected virtual BodyContainer CreateBody() => new BodyContainer();
 
         protected override void PopIn() => this.FadeIn();
         protected override void PopOut() => this.FadeOut();
@@ -180,14 +174,10 @@ namespace osu.Framework.Graphics.UserInterface
 
         #endregion
 
-        protected class BodyContainer : VisibilityContainer
+        protected class BodyContainer : Container
         {
             protected override bool OnMouseDown(MouseDownEvent e) => true;
-
             protected override bool OnClick(ClickEvent e) => true;
-
-            protected override void PopIn() => Show();
-            protected override void PopOut() => Hide();
         }
     }
 }


### PR DESCRIPTION
This is intended to simplify how the dismissal of popovers works, removing the required logic inside `CreateBody()`'s resultant container. Passes all tests but probably needs some manual testing to ensure nothing weird has regressed.

- Refactor dismissal handling to avoid popover-level focus logic
- Remove exposed `CreateBody` (doesn't seem to be required)
- Update tests to cover new click-between behaviour (clicking a second popover provider will open immediately)
