### PR TITLE
Avoid creating a second popover when one is already displayed for the current target

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -104,6 +104,34 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestUseExistingWhenSameProviderClicked()
+        {
+            Popover first = null;
+
+            createContent(button => new BasicPopover
+            {
+                Child = new SpriteText
+                {
+                    Text = $"{button.Anchor} popover"
+                }
+            });
+
+            AddStep("click button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<DrawableWithPopover>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("popover shown", () => (first = this.ChildrenOfType<Popover>().FirstOrDefault(popover => popover.State.Value == Visibility.Visible)) != null);
+
+            AddStep("click button again", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<DrawableWithPopover>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("same popover shown", () => first == this.ChildrenOfType<Popover>().FirstOrDefault(popover => popover.State.Value == Visibility.Visible));
+        }
+
+        [Test]
         public void TestClickBetweenMultiple()
         {
             createContent(button => new BasicPopover

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
     {
         private Container[,] cells;
         private Container popoverWrapper;
-        private PopoverContainer popoverContainer;
+        private TestPopoverContainer popoverContainer;
         private GridContainer gridContainer;
 
         [SetUpSteps]
@@ -46,7 +46,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                             AlwaysPresent = true,
                             Colour = Colour4.Transparent
                         },
-                        popoverContainer = new PopoverContainer
+                        popoverContainer = new TestPopoverContainer
                         {
                             RelativeSizeAxes = Axes.Both,
                             Padding = new MarginPadding(5),
@@ -101,6 +101,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
             AddAssert("all hidden", () => this.ChildrenOfType<Popover>().All(popover => popover.State.Value != Visibility.Visible));
+
+            AddStep("click background", () =>
+            {
+                popoverContainer.ClickHandled = false;
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("popover didn't handle click", () => !popoverContainer.ClickHandled);
         }
 
         [Test]
@@ -356,6 +363,16 @@ namespace osu.Framework.Tests.Visual.UserInterface
                     }
                 }
             });
+
+        private class TestPopoverContainer : PopoverContainer
+        {
+            public bool ClickHandled { get; set; }
+
+            protected override bool OnClick(ClickEvent e)
+            {
+                return ClickHandled = base.OnClick(e);
+            }
+        }
 
         private class AnimatedPopover : BasicPopover
         {

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -56,6 +56,9 @@ namespace osu.Framework.Graphics.Cursor
         /// <returns><see langword="true"/> if a new popover was shown, <see langword="false"/> otherwise.</returns>
         internal bool SetTarget(IHasPopover? newTarget)
         {
+            if (newTarget == target)
+                return true;
+
             target = newTarget;
 
             currentPopover?.Hide();

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -53,11 +53,11 @@ namespace osu.Framework.Graphics.Cursor
         /// After calling this method, the previous popover shown in this <see cref="PopoverContainer"/> will be hidden.
         /// This method can be called with a <see langword="null"/> argument to hide the currently-visible popover.
         /// </remarks>
-        /// <returns><see langword="true"/> if a new popover was shown, <see langword="false"/> otherwise.</returns>
+        /// <returns><see langword="true"/> if a popover is being shown after the call to this method, <see langword="false"/> otherwise.</returns>
         internal bool SetTarget(IHasPopover? newTarget)
         {
             if (newTarget == target)
-                return true;
+                return target != null;
 
             target = newTarget;
 


### PR DESCRIPTION
As dicussed.

- [x] Depends on #4595 to avoid merge conflicts in tests
