### PR TITLE
Make Bindable.UnbindFrom() virtual and called in all cases

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableBindingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableBindingTest.cs
@@ -511,6 +511,19 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(2, event2.NewValue);
         }
 
+        [Test]
+        public void TestCustomUnbindFromCalledFromUnbindAll()
+        {
+            var bindable1 = new Bindable<int>();
+            var bindable2 = new TestCustomBindable();
+
+            bindable2.BindTo(bindable1);
+            Assert.That(bindable2.IsBound, Is.True);
+
+            bindable2.UnbindAll();
+            Assert.That(bindable2.IsBound, Is.False);
+        }
+
         private class TestDrawable : Drawable
         {
             public bool ValueChanged;
@@ -568,6 +581,23 @@ namespace osu.Framework.Tests.Bindables
             {
                 // because we are run outside of a game instance but need the cached disposal methods.
                 Load(new FramedClock(), new DependencyContainer());
+            }
+        }
+
+        private class TestCustomBindable : Bindable<int>
+        {
+            public bool IsBound { get; private set; }
+
+            public override void BindTo(Bindable<int> them)
+            {
+                base.BindTo(them);
+                IsBound = true;
+            }
+
+            public override void UnbindFrom(IUnbindable them)
+            {
+                base.UnbindFrom(them);
+                IsBound = false;
             }
         }
     }

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -359,7 +359,9 @@ namespace osu.Framework.Bindables
         /// Calls <see cref="UnbindEvents"/> and <see cref="UnbindBindings"/>.
         /// Also returns any active lease.
         /// </summary>
-        public virtual void UnbindAll()
+        public void UnbindAll() => UnbindAllInternal();
+
+        internal virtual void UnbindAllInternal()
         {
             if (isLeased)
                 leasedBindable.Return();

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -350,9 +350,7 @@ namespace osu.Framework.Bindables
             // ToArray required as this may be called from an async disposal thread.
             // This can lead to deadlocks since each child is also enumerating its Bindings.
             foreach (var b in Bindings.ToArray())
-                b.Bindings.Remove(weakReference);
-
-            Bindings.Clear();
+                UnbindFrom(b);
         }
 
         /// <summary>
@@ -370,7 +368,7 @@ namespace osu.Framework.Bindables
             UnbindBindings();
         }
 
-        public void UnbindFrom(IUnbindable them)
+        public virtual void UnbindFrom(IUnbindable them)
         {
             if (!(them is Bindable<T> tThem))
                 throw new InvalidCastException($"Can't unbind a bindable of type {them.GetType()} from a bindable of type {GetType()}.");

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -454,7 +454,7 @@ namespace osu.Framework.Bindables
 
         #region IUnbindable
 
-        public void UnbindEvents()
+        public virtual void UnbindEvents()
         {
             CollectionChanged = null;
             DisabledChanged = null;
@@ -466,9 +466,7 @@ namespace osu.Framework.Bindables
                 return;
 
             foreach (var b in bindings)
-                b.unbind(this);
-
-            bindings?.Clear();
+                UnbindFrom(b);
         }
 
         public void UnbindAll()
@@ -477,7 +475,7 @@ namespace osu.Framework.Bindables
             UnbindBindings();
         }
 
-        public void UnbindFrom(IUnbindable them)
+        public virtual void UnbindFrom(IUnbindable them)
         {
             if (!(them is BindableList<T> tThem))
                 throw new InvalidCastException($"Can't unbind a bindable of type {them.GetType()} from a bindable of type {GetType()}.");
@@ -485,9 +483,6 @@ namespace osu.Framework.Bindables
             removeWeakReference(tThem.weakReference);
             tThem.removeWeakReference(weakReference);
         }
-
-        private void unbind(BindableList<T> binding)
-            => bindings.Remove(binding.weakReference);
 
         #endregion IUnbindable
 

--- a/osu.Framework/Bindables/LeasedBindable.cs
+++ b/osu.Framework/Bindables/LeasedBindable.cs
@@ -101,7 +101,7 @@ namespace osu.Framework.Bindables
             }
         }
 
-        public override void UnbindAll()
+        internal override void UnbindAllInternal()
         {
             if (source != null && !hasBeenReturned)
             {
@@ -114,7 +114,7 @@ namespace osu.Framework.Bindables
                 hasBeenReturned = true;
             }
 
-            base.UnbindAll();
+            base.UnbindAllInternal();
         }
 
         private void checkValid()


### PR DESCRIPTION
Prereqs:
- [x] https://github.com/ppy/osu-framework/pull/4594

For bindables that override `BindTo()`, they should also override `UnbindFrom()` to revert changes. I don't know the deep implications (e.g. re: performance) of `UnbindAll()` calling `UnbindFrom()`, but it seems to be alright.