### PR TITLE
Add ability to `SpriteText` to change displayed text case

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTextTransforms.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTextTransforms.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Visual.Sprites
+{
+    public class TestSceneSpriteTextTextTransforms : TestScene
+    {
+        private readonly BasicDropdown<TextTransform> textTransformDropdown;
+
+        private SpriteText sprite;
+
+        public TestSceneSpriteTextTextTransforms()
+        {
+            Child = new FillFlowContainer()
+            {
+                Direction = FillDirection.Vertical,
+                Spacing = new osuTK.Vector2(0, 25),
+                Children = new Drawable[]
+                {
+                    new SpriteText
+                    {
+                        Text = "text is displayed without any case transforms (lowercase)",
+                        TextTransform = TextTransform.None,
+                    },
+                    new SpriteText
+                    {
+                        Text = "text is displayed in uppercase",
+                        TextTransform = TextTransform.Uppercase,
+                    },
+                    new SpriteText
+                    {
+                        Text = "text is displayed in capitalized case aka title case",
+                        TextTransform = TextTransform.Capitalize,
+                    },
+                    new SpriteText
+                    {
+                        Text = "text is displayed in lowercase",
+                        TextTransform = TextTransform.Lowercase,
+                    },
+                    new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new osuTK.Vector2(15, 0),
+                        Children = new Drawable[]
+                        {
+                            textTransformDropdown = new BasicDropdown<TextTransform>
+                            {
+                                Width = 200,
+                                Items = (TextTransform[])Enum.GetValues(typeof(TextTransform))
+                            },
+                            sprite = new SpriteText
+                            {
+                                Text = "you can change text transform on the fly"
+                            }
+                        }
+                    }
+                }
+            };
+        }
+
+        protected override void LoadComplete()
+        {
+            textTransformDropdown.Current.BindValueChanged(e => sprite.TextTransform = e.NewValue);
+            base.LoadComplete();
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTextTransforms.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextTextTransforms.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                             },
                             sprite = new SpriteText
                             {
-                                Text = "you can change text transform on the fly"
+                                Text = "The quick brown fox jumps over the lazy dog"
                             }
                         }
                     }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -158,7 +158,6 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
-        //todo: support culture localisation when applying transforms.
         private string transformedText
         {
             get

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -18,6 +18,7 @@ using osu.Framework.Utils;
 using osu.Framework.Text;
 using osuTK;
 using osuTK.Graphics;
+using System.Globalization;
 
 namespace osu.Framework.Graphics.Sprites
 {
@@ -139,6 +140,46 @@ namespace osu.Framework.Graphics.Sprites
 
                 invalidate(true, true);
                 shadowOffsetCache.Invalidate();
+            }
+        }
+
+        private TextTransform textTransform = TextTransform.None;
+
+        /// <summary>
+        /// The <see cref="Sprites.TextTransform"/> to apply to the displayed text.
+        /// </summary>
+        public TextTransform TextTransform
+        {
+            get => textTransform;
+            set
+            {
+                textTransform = value;
+                invalidate(true);
+            }
+        }
+
+        //todo: support culture localisation when applying transforms.
+        private string transformedText
+        {
+            get
+            {
+                switch (textTransform)
+                {
+
+                    case TextTransform.Uppercase:
+                        return displayedText.ToUpperInvariant();
+
+                    case TextTransform.Capitalize:
+                        return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(displayedText);
+
+                    case TextTransform.Lowercase:
+                        return displayedText.ToLowerInvariant();
+
+                    case TextTransform.None:
+                    default:
+                        return displayedText;
+                        
+                }
             }
         }
 
@@ -473,7 +514,7 @@ namespace osu.Framework.Graphics.Sprites
                 TextBuilder textBuilder = getTextBuilder();
 
                 textBuilder.Reset();
-                textBuilder.AddText(displayedText);
+                textBuilder.AddText(transformedText);
                 textBounds = textBuilder.Bounds;
             }
             finally
@@ -641,7 +682,7 @@ namespace osu.Framework.Graphics.Sprites
                 if (string.IsNullOrEmpty(displayedText))
                     return 0;
 
-                return store.GetBaseHeight(displayedText[0]).GetValueOrDefault() * Font.Size;
+                return store.GetBaseHeight(transformedText[0]).GetValueOrDefault() * Font.Size;
             }
         }
 

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -163,17 +163,19 @@ namespace osu.Framework.Graphics.Sprites
         {
             get
             {
+                var culture = localisation.LocalisationParameters.Store?.EffectiveCulture ?? CultureInfo.InvariantCulture;
+
                 switch (textTransform)
                 {
 
                     case TextTransform.Uppercase:
-                        return displayedText.ToUpperInvariant();
+                        return displayedText.ToUpper(culture);
 
                     case TextTransform.Capitalize:
-                        return CultureInfo.InvariantCulture.TextInfo.ToTitleCase(displayedText);
+                        return culture.TextInfo.ToTitleCase(displayedText);
 
                     case TextTransform.Lowercase:
-                        return displayedText.ToLowerInvariant();
+                        return displayedText.ToLower(culture);
 
                     case TextTransform.None:
                     default:

--- a/osu.Framework/Graphics/Sprites/TextTransform.cs
+++ b/osu.Framework/Graphics/Sprites/TextTransform.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.Graphics.Sprites
+{
+    /// <summary>
+    /// Types of text transforms that can be applied to a <see cref="SpriteText"/> displayed text.
+    /// </summary>
+    public enum TextTransform
+    {
+        /// <summary>
+        /// Text is displayed as is.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// Text is displayed in uppercase.
+        /// </summary>
+        Uppercase,
+
+        /// <summary>
+        /// Text is displayed in capitalized case aka title case.
+        /// </summary>
+        Capitalize,
+
+        /// <summary>
+        /// Text is displayed in lowercase.
+        /// </summary>
+        Lowercase
+    }
+}

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -19,6 +19,8 @@ namespace osu.Framework.Localisation
 
         private readonly Bindable<LocalisationParameters> currentParameters = new Bindable<LocalisationParameters>(new LocalisationParameters(null, false));
 
+        public LocalisationParameters LocalisationParameters => currentParameters.Value;
+
         public LocalisationManager(FrameworkConfigManager config)
         {
             config.BindWith(FrameworkSetting.Locale, configLocale);


### PR DESCRIPTION
osu-web uses in a few places the [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform) CSS property which allows overriding the case in which text is displayed. This is replicated osu!-side by calling `.ToUpper()` / `.ToLower()` on strings. However, with localisation, this becomes a bit more difficult to do so and I don't think adding yet another type of localisable string is the way to go hence this PR.

# Introducing the `TextTransform` property
This adds the ability to `SpriteText` to change the case in which the text is displayed through the `TextTransform` property. The used text transform will use the effective culture of the localisation manager for applying case transforms. I'm actually hesistant about the property name since it may create confusion with the `Transforms` property (maybe `Casing` fits better ?) so I'm open to suggestions for naming.