### PR TITLE
Throw an exception if a popover is attempted to be shown without a parent `PopoverContainer`

### DIFF
--- a/osu.Framework/Extensions/PopoverExtensions.cs
+++ b/osu.Framework/Extensions/PopoverExtensions.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Cursor;
 
@@ -21,6 +22,11 @@ namespace osu.Framework.Extensions
         public static void HidePopover(this Drawable drawable) => setTargetOnNearestPopover(drawable, null);
 
         private static void setTargetOnNearestPopover(Drawable origin, IHasPopover? target)
-            => origin.FindClosestParent<PopoverContainer>()?.SetTarget(target);
+        {
+            var popoverContainer = origin.FindClosestParent<PopoverContainer>()
+                                   ?? throw new InvalidOperationException($"Cannot show or hide a popover without a parent {nameof(PopoverContainer)} in the hierarchy");
+
+            popoverContainer.SetTarget(target);
+        }
     }
 }


### PR DESCRIPTION
The intention is to help framework consumers to understand how this component should be used, if they happen to be attempting to misuse it (rather than silently failing).
