### PR TITLE
Fix popovers fading out in wrong location

### DIFF
--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -17,7 +17,6 @@ namespace osu.Framework.Graphics.Cursor
     public class PopoverContainer : Container
     {
         private readonly Container content;
-        private readonly Container<Popover> popoverContainer;
 
         private IHasPopover? target;
         private Popover? currentPopover;
@@ -31,10 +30,6 @@ namespace osu.Framework.Graphics.Cursor
                 content = new Container
                 {
                     RelativeSizeAxes = Axes.Both,
-                },
-                popoverContainer = new Container<Popover>
-                {
-                    AutoSizeAxes = Axes.Both
                 },
             };
         }
@@ -58,7 +53,7 @@ namespace osu.Framework.Graphics.Cursor
             if (newPopover == null)
                 return false;
 
-            popoverContainer.Add(currentPopover = newPopover);
+            AddInternal(currentPopover = newPopover);
             currentPopover.Show();
             return true;
         }
@@ -109,9 +104,6 @@ namespace osu.Framework.Graphics.Cursor
             Anchor bestAnchor = Anchor.Centre;
             float biggestArea = 0;
 
-            // Reset the body position before proceeding, as it potentially affects the popover's BoundingBoxContainer size.
-            currentPopover.Position = new Vector2(0);
-
             float totalSize = Math.Max(DrawSize.X * DrawSize.Y, 1);
 
             foreach (var anchor in candidate_anchors)
@@ -136,27 +128,30 @@ namespace osu.Framework.Graphics.Cursor
             currentPopover.PopoverAnchor = bestAnchor.Opposite();
 
             var positionOnQuad = bestAnchor.PositionOnQuad(targetLocalQuad);
-            popoverContainer.Position = new Vector2(positionOnQuad.X - Padding.Left, positionOnQuad.Y - Padding.Top);
+            currentPopover.Position = new Vector2(positionOnQuad.X - Padding.Left, positionOnQuad.Y - Padding.Top);
 
             // While the side has been chosen to maximise the area of free space available, that doesn't mean that the popover's body
             // will still fit in its entirety in the default configuration.
-            // To avoid this, keep the arrow where it was, but offset the body so that it fits in the bounds of this container.
+            // To avoid this, offset the popover so that it fits in the bounds of this container.
+            var adjustment = new Vector2();
+
             var popoverContentLocalQuad = ToLocalSpace(currentPopover.Body.ScreenSpaceDrawQuad);
             if (popoverContentLocalQuad.TopLeft.X < 0)
-                currentPopover.X = -popoverContentLocalQuad.TopLeft.X;
+                adjustment.X = -popoverContentLocalQuad.TopLeft.X;
             else if (popoverContentLocalQuad.BottomRight.X > DrawWidth)
-                currentPopover.X = DrawWidth - popoverContentLocalQuad.BottomRight.X;
+                adjustment.X = DrawWidth - popoverContentLocalQuad.BottomRight.X;
             if (popoverContentLocalQuad.TopLeft.Y < 0)
-                currentPopover.Y = -popoverContentLocalQuad.TopLeft.Y;
+                adjustment.Y = -popoverContentLocalQuad.TopLeft.Y;
             else if (popoverContentLocalQuad.BottomRight.Y > DrawHeight)
-                currentPopover.Y = DrawHeight - popoverContentLocalQuad.BottomRight.Y;
+                adjustment.Y = DrawHeight - popoverContentLocalQuad.BottomRight.Y;
+
+            currentPopover.Position += adjustment;
 
             // Even if the popover was moved, the arrow should stay fixed in place and point at the target's centre.
             // In such a case, apply a counter-adjustment to the arrow position.
             // The reason why just the body isn't moved is that the popover's autosize does not play well with that
             // (setting X/Y on the body can lead BoundingBox to be larger than it actually needs to be, causing 1-frame-errors)
-            currentPopover.Arrow.X = -currentPopover.X;
-            currentPopover.Arrow.Y = -currentPopover.Y;
+            currentPopover.Arrow.Position = -adjustment;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #4597.

Popovers that have been dismissed by the user could be displayed in the wrong location, due to sharing the `popoverContainer` with the currently displayed popover, which is attached to the current (new) target.

To resolve, use the popover itself as a replacement for the popover container. This works because both the removed container and the popover were/are 0x0 absolute-sized drawables, so the removed container's position can be combined with the move-back-in-bounds adjustment.

This isn't the general positioning refactor which was asked for, I'm more trying to just make things mostly work for now and move forward with other things.