### PR TITLE
Dismiss popovers on pressing Escape

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -129,6 +129,28 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestHideViaKeyboard()
+        {
+            createContent(button => new BasicPopover
+            {
+                Child = new SpriteText
+                {
+                    Text = $"{button.Anchor} popover"
+                }
+            });
+
+            AddStep("click button", () =>
+            {
+                InputManager.MoveMouseTo(this.ChildrenOfType<DrawableWithPopover>().First());
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("popover shown", () => this.ChildrenOfType<Popover>().Any(popover => popover.State.Value == Visibility.Visible));
+
+            AddStep("press Escape", () => InputManager.Key(Key.Escape));
+            AddAssert("all hidden", () => this.ChildrenOfType<Popover>().All(popover => popover.State.Value != Visibility.Visible));
+        }
+
+        [Test]
         public void TestClickBetweenMultiple()
         {
             createContent(button => new BasicPopover

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -8,6 +8,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Input.Events;
 using osuTK;
+using osuTK.Input;
 
 namespace osu.Framework.Graphics.UserInterface
 {
@@ -32,6 +33,19 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         protected override bool OnClick(ClickEvent e) => Body.ReceivePositionalInputAt(e.ScreenSpaceMousePosition);
+
+        public override bool HandleNonPositionalInput => State.Value == Visibility.Visible;
+
+        protected override bool OnKeyDown(KeyDownEvent e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                this.HidePopover();
+                return true;
+            }
+
+            return base.OnKeyDown(e);
+        }
 
         /// <summary>
         /// The <see cref="Anchor"/> that this <see cref="Popover"/> is to be attached to the triggering UI control by.


### PR DESCRIPTION
Closes #4600.

Aside from the automated testing here, I tested with the game-side room password PR. It half-works, because currently two escape presses are needed (the first one is handled by the password textbox to yield focus, and only the second one is seen by the popover itself). I *think* that's something to fix at the usage site...?