### PR TITLE
Remove speculative macOS crash fix

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -842,10 +842,6 @@ namespace osu.Framework.Graphics.OpenGL
                 FlushCurrentBatch();
                 GL.BindFramebuffer(FramebufferTarget.Framebuffer, frameBuffer);
 
-                // Speculative fix for macOS crashes (see: http://crbug.com/1181068, http://crbug.com/783979, https://github.com/google/angle/commit/ce89d99fdeda61d9bc88fc7abd2aa3b4666d770e).
-                if (RuntimeInfo.OS == RuntimeInfo.Platform.macOS)
-                    GL.Flush();
-
                 GlobalPropertyManager.Set(GlobalProperty.BackbufferDraw, UsingBackbuffer);
             }
 


### PR DESCRIPTION
This neither fixed https://github.com/ppy/osu/issues/12944 nor peppy's crashes, so pretty safe to disable. I don't want to be causing too many unnecessary flushes.