### PR TITLE
Fix refresh rate potentially being incorrect on startup

### DIFF
--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -113,9 +113,9 @@ namespace osu.Framework.Platform
         Bindable<Display> CurrentDisplayBindable { get; }
 
         /// <summary>
-        /// Gets the <see cref="DisplayMode"/> for the display that this window is currently on.
+        /// The <see cref="DisplayMode"/> for the display that this window is currently on.
         /// </summary>
-        DisplayMode CurrentDisplayMode { get; }
+        IBindable<DisplayMode> CurrentDisplayMode { get; }
 
         /// <summary>
         /// Makes this window the current graphics context, if appropriate for the driver.

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -90,12 +90,12 @@ namespace osu.Framework.Platform
         /// as it defers to the current resolution. Note that we round the refresh rate, as osuTK can sometimes
         /// report refresh rates such as 59.992863 where SDL2 will report 60.
         /// </summary>
-        public virtual DisplayMode CurrentDisplayMode
+        public virtual IBindable<DisplayMode> CurrentDisplayMode
         {
             get
             {
                 var display = CurrentDisplayDevice;
-                return new DisplayMode(null, new Size(display.Width, display.Height), display.BitsPerPixel, (int)Math.Round(display.RefreshRate), 0, 0);
+                return new Bindable<DisplayMode>(new DisplayMode(null, new Size(display.Width, display.Height), display.BitsPerPixel, (int)Math.Round(display.RefreshRate), 0, 0));
             }
         }
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -283,22 +283,12 @@ namespace osu.Framework.Platform
 
         public readonly Bindable<ConfineMouseMode> ConfineMouseMode = new Bindable<ConfineMouseMode>();
 
-        private DisplayMode currentDisplayMode;
+        private Bindable<DisplayMode> currentDisplayMode = new Bindable<DisplayMode>();
 
         /// <summary>
-        /// Gets or sets the <see cref="DisplayMode"/> for the display that this window is currently on.
+        /// The <see cref="DisplayMode"/> for the display that this window is currently on.
         /// </summary>
-        public DisplayMode CurrentDisplayMode
-        {
-            get => currentDisplayMode;
-            set
-            {
-                currentDisplayMode = value;
-
-                // todo: proper handling of this, if we decide we want it.
-                pendingWindowState = windowState;
-            }
-        }
+        public IBindable<DisplayMode> CurrentDisplayMode => currentDisplayMode;
 
         /// <summary>
         /// Gets the native window handle as provided by the operating system.
@@ -1008,7 +998,7 @@ namespace osu.Framework.Platform
                     break;
 
                 case WindowState.Fullscreen:
-                    var closestMode = getClosestDisplayMode(sizeFullscreen.Value, currentDisplayMode.RefreshRate, currentDisplay.Index);
+                    var closestMode = getClosestDisplayMode(sizeFullscreen.Value, currentDisplayMode.Value.RefreshRate, currentDisplay.Index);
 
                     Size = new Size(closestMode.w, closestMode.h);
 
@@ -1036,7 +1026,7 @@ namespace osu.Framework.Platform
             updateMaximisedState();
 
             if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
-                currentDisplayMode = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);
+                currentDisplayMode.Value = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);
         }
 
         private void updateMaximisedState()

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -283,7 +283,7 @@ namespace osu.Framework.Platform
 
         public readonly Bindable<ConfineMouseMode> ConfineMouseMode = new Bindable<ConfineMouseMode>();
 
-        private Bindable<DisplayMode> currentDisplayMode = new Bindable<DisplayMode>();
+        private readonly Bindable<DisplayMode> currentDisplayMode = new Bindable<DisplayMode>();
 
         /// <summary>
         /// The <see cref="DisplayMode"/> for the display that this window is currently on.


### PR DESCRIPTION
Due to initialisation order of the window, there's no guarantee that the `DisplayMode` will be in a good state when the `frameLimiter.TriggerChange()` call is performed.

This converts that property to a bindable to allow for late initialisation.

Closes https://github.com/ppy/osu/issues/13888.

Has been tested by @PandaDriver156 to fix the issue (one of those that reported it). I can't test locally because parallels decided to gimp their shit even more.