### PR TITLE
Fix textbox readonly flag not working in all cases

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -459,19 +459,19 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestReadOnly()
         {
-            BasicTextBox readOnlyTextBox = null;
-            BasicTextBox nonReadOnlyTextBox = null;
+            BasicTextBox firstTextBox = null;
+            BasicTextBox secondTextBox = null;
 
             AddStep("add textboxes", () => textBoxes.AddRange(new[]
             {
-                readOnlyTextBox = new BasicTextBox
+                firstTextBox = new BasicTextBox
                 {
                     Text = "Readonly textbox",
                     Size = new Vector2(500, 30),
                     ReadOnly = true,
                     TabbableContentContainer = textBoxes
                 },
-                nonReadOnlyTextBox = new BasicTextBox
+                secondTextBox = new BasicTextBox
                 {
                     Text = "Standard textbox",
                     Size = new Vector2(500, 30),
@@ -479,16 +479,16 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 }
             }));
 
-            AddStep("click readonly textbox", () =>
+            AddStep("click first (readonly) textbox", () =>
             {
-                InputManager.MoveMouseTo(readOnlyTextBox);
+                InputManager.MoveMouseTo(firstTextBox);
                 InputManager.Click(MouseButton.Left);
             });
-            AddAssert("readonly textbox has no focus", () => !readOnlyTextBox.HasFocus);
+            AddAssert("first textbox has no focus", () => !firstTextBox.HasFocus);
 
-            AddStep("click non-readonly textbox", () =>
+            AddStep("click second (editable) textbox", () =>
             {
-                InputManager.MoveMouseTo(nonReadOnlyTextBox);
+                InputManager.MoveMouseTo(secondTextBox);
                 InputManager.Click(MouseButton.Left);
             });
             AddStep("try to tab backwards", () =>
@@ -497,16 +497,27 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.Key(Key.Tab);
                 InputManager.ReleaseKey(Key.ShiftLeft);
             });
-            AddAssert("readonly textbox has no focus", () => !readOnlyTextBox.HasFocus);
+            AddAssert("first (readonly) has no focus", () => !firstTextBox.HasFocus);
 
-            AddStep("drag on readonly textbox", () =>
+            AddStep("drag on first (readonly) textbox", () =>
             {
-                InputManager.MoveMouseTo(readOnlyTextBox.ScreenSpaceDrawQuad.Centre);
+                InputManager.MoveMouseTo(firstTextBox.ScreenSpaceDrawQuad.Centre);
                 InputManager.PressButton(MouseButton.Left);
-                InputManager.MoveMouseTo(readOnlyTextBox.ScreenSpaceDrawQuad.TopLeft);
+                InputManager.MoveMouseTo(firstTextBox.ScreenSpaceDrawQuad.TopLeft);
                 InputManager.ReleaseButton(MouseButton.Left);
             });
-            AddAssert("readonly textbox has no focus", () => !readOnlyTextBox.HasFocus);
+            AddAssert("first textbox has no focus", () => !firstTextBox.HasFocus);
+
+            AddStep("make first textbox non-readonly", () => firstTextBox.ReadOnly = false);
+            AddStep("click first textbox", () =>
+            {
+                InputManager.MoveMouseTo(firstTextBox);
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("make first textbox readonly again", () => firstTextBox.ReadOnly = true);
+            AddAssert("first textbox yielded focus", () => !firstTextBox.HasFocus);
+            AddStep("delete last character", () => firstTextBox.OnPressed(new PlatformAction(PlatformActionType.CharPrevious, PlatformActionMethod.Delete)));
+            AddAssert("no text removed", () => firstTextBox.Text == "Readonly textbox");
         }
 
         public class InsertableTextBox : BasicTextBox

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -456,6 +456,59 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("text replaced", () => textBox.FlowingText == "another" && textBox.FlowingText == textBox.Text);
         }
 
+        [Test]
+        public void TestReadOnly()
+        {
+            BasicTextBox readOnlyTextBox = null;
+            BasicTextBox nonReadOnlyTextBox = null;
+
+            AddStep("add textboxes", () => textBoxes.AddRange(new[]
+            {
+                readOnlyTextBox = new BasicTextBox
+                {
+                    Text = "Readonly textbox",
+                    Size = new Vector2(500, 30),
+                    ReadOnly = true,
+                    TabbableContentContainer = textBoxes
+                },
+                nonReadOnlyTextBox = new BasicTextBox
+                {
+                    Text = "Standard textbox",
+                    Size = new Vector2(500, 30),
+                    TabbableContentContainer = textBoxes
+                }
+            }));
+
+            AddStep("click readonly textbox", () =>
+            {
+                InputManager.MoveMouseTo(readOnlyTextBox);
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("readonly textbox has no focus", () => !readOnlyTextBox.HasFocus);
+
+            AddStep("click non-readonly textbox", () =>
+            {
+                InputManager.MoveMouseTo(nonReadOnlyTextBox);
+                InputManager.Click(MouseButton.Left);
+            });
+            AddStep("try to tab backwards", () =>
+            {
+                InputManager.PressKey(Key.ShiftLeft);
+                InputManager.Key(Key.Tab);
+                InputManager.ReleaseKey(Key.ShiftLeft);
+            });
+            AddAssert("readonly textbox has no focus", () => !readOnlyTextBox.HasFocus);
+
+            AddStep("drag on readonly textbox", () =>
+            {
+                InputManager.MoveMouseTo(readOnlyTextBox.ScreenSpaceDrawQuad.Centre);
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.MoveMouseTo(readOnlyTextBox.ScreenSpaceDrawQuad.TopLeft);
+                InputManager.ReleaseButton(MouseButton.Left);
+            });
+            AddAssert("readonly textbox has no focus", () => !readOnlyTextBox.HasFocus);
+        }
+
         public class InsertableTextBox : BasicTextBox
         {
             /// <summary>

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -63,7 +63,19 @@ namespace osu.Framework.Graphics.UserInterface
         /// <returns>Whether the character is allowed to be added.</returns>
         protected virtual bool CanAddCharacter(char character) => true;
 
-        public bool ReadOnly;
+        private bool readOnly;
+
+        public bool ReadOnly
+        {
+            get => readOnly;
+            set
+            {
+                readOnly = value;
+
+                if (readOnly)
+                    KillFocus();
+            }
+        }
 
         /// <summary>
         /// Whether the textbox should rescind focus on commit.
@@ -743,7 +755,7 @@ namespace osu.Framework.Graphics.UserInterface
         private void killFocus()
         {
             var manager = GetContainingInputManager();
-            if (manager.FocusedDrawable == this)
+            if (manager?.FocusedDrawable == this)
                 manager.ChangeFocus(null);
         }
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -779,6 +779,9 @@ namespace osu.Framework.Graphics.UserInterface
         {
             //if (textInput?.ImeActive == true) return true;
 
+            if (ReadOnly)
+                return;
+
             if (doubleClickWord != null)
             {
                 //select words at a time

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -883,7 +883,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (textInput?.ImeActive == true) return true;
+            if (textInput?.ImeActive == true || ReadOnly) return true;
 
             selectionStart = selectionEnd = getCharacterClosestTo(e.MousePosition);
 


### PR DESCRIPTION
Closes #4611.

Found at least two cases in which focus was incorrectly grabbed or not yielded by a readonly textbox:

* When dragging - as reported in the aforementioned issue; fixed by 9ee8c9a.
* When setting flag to `false` after construction and addition to hierarchy; fixed by d440c50.

The thing that is tested most is the reception of focus by the textbox. I skimped on doing paste/delete thoroughly except for one step + assert for brevity, but those should be handled correctly as long as this guard is there:

https://github.com/ppy/osu-framework/blob/08ffacbb0733efeb8973842321aed7dab7f1d61e/osu.Framework/Graphics/UserInterface/TextBox.cs#L150-L155

and there is one deletion step in there so if that is ever removed then the test will fail anyhow (alongside many others, I would hope?)

The extra condition in the `OnMouseDown` guard has no visible/easily testable effect, it's just an optimisation.