### PR TITLE
Show soft keyboard on Android on click of an already focused TextBox

### DIFF
--- a/osu.Framework.Android/Input/AndroidTextInput.cs
+++ b/osu.Framework.Android/Input/AndroidTextInput.cs
@@ -74,7 +74,7 @@ namespace osu.Framework.Android.Input
             });
         }
 
-        public void ShowSoftKeyboard()
+        public void EnsureActivated()
         {
             activity.RunOnUiThread(() =>
             {

--- a/osu.Framework.Android/Input/AndroidTextInput.cs
+++ b/osu.Framework.Android/Input/AndroidTextInput.cs
@@ -68,9 +68,17 @@ namespace osu.Framework.Android.Input
             activity.RunOnUiThread(() =>
             {
                 view.RequestFocus();
-                inputMethodManager.ToggleSoftInputFromWindow(view.WindowToken, ShowSoftInputFlags.Forced, HideSoftInputFlags.None);
+                inputMethodManager.ShowSoftInput(view, 0);
                 view.KeyDown += keyDown;
                 view.CommitText += commitText;
+            });
+        }
+
+        public void ShowSoftKeyboard()
+        {
+            activity.RunOnUiThread(() =>
+            {
+                inputMethodManager.ShowSoftInput(view, 0);
             });
         }
     }

--- a/osu.Framework.iOS/Input/IOSTextInput.cs
+++ b/osu.Framework.iOS/Input/IOSTextInput.cs
@@ -50,7 +50,7 @@ namespace osu.Framework.iOS.Input
             view.KeyboardTextField.UpdateFirstResponder(true);
         }
 
-        public void ShowSoftKeyboard()
+        public void EnsureActivated()
         {
             /// If the user has manually closed the keyboard, it will not be shown until another <see cref="Framework.Graphics.UserInterface.TextBox"/>
             /// is focused. Calling <see cref="IOSGameView.HiddenTextField.UpdateFirstResponder"/> over and over again won't work, due to how

--- a/osu.Framework.iOS/Input/IOSTextInput.cs
+++ b/osu.Framework.iOS/Input/IOSTextInput.cs
@@ -52,6 +52,11 @@ namespace osu.Framework.iOS.Input
 
         public void ShowSoftKeyboard()
         {
+            /// If the user has manually closed the keyboard, it will not be shown until another <see cref="Framework.Graphics.UserInterface.TextBox"/>
+            /// is focused. Calling <see cref="IOSGameView.HiddenTextField.UpdateFirstResponder"/> over and over again won't work, due to how
+            /// `responderSemaphore` currently works.
+
+            // TODO: add iOS implementation
         }
 
         public event Action<string> OnNewImeComposition

--- a/osu.Framework.iOS/Input/IOSTextInput.cs
+++ b/osu.Framework.iOS/Input/IOSTextInput.cs
@@ -50,6 +50,10 @@ namespace osu.Framework.iOS.Input
             view.KeyboardTextField.UpdateFirstResponder(true);
         }
 
+        public void ShowSoftKeyboard()
+        {
+        }
+
         public event Action<string> OnNewImeComposition
         {
             add { }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -898,7 +898,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected override bool OnClick(ClickEvent e)
         {
             if (!ReadOnly && HasFocus)
-                textInput?.ShowSoftKeyboard();
+                textInput?.EnsureActivated();
 
             return !ReadOnly;
         }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -897,7 +897,7 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnClick(ClickEvent e)
         {
-            if (!ReadOnly)
+            if (!ReadOnly && HasFocus)
                 textInput?.ShowSoftKeyboard();
 
             return !ReadOnly;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -895,7 +895,13 @@ namespace osu.Framework.Graphics.UserInterface
 
         public override bool AcceptsFocus => true;
 
-        protected override bool OnClick(ClickEvent e) => !ReadOnly;
+        protected override bool OnClick(ClickEvent e)
+        {
+            if (!ReadOnly)
+                textInput?.ShowSoftKeyboard();
+
+            return !ReadOnly;
+        }
 
         protected override void OnFocus(FocusEvent e)
         {

--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -63,6 +63,10 @@ namespace osu.Framework.Input
             }
         }
 
+        public void ShowSoftKeyboard()
+        {
+        }
+
         private void imeCompose()
         {
             //todo: implement

--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Input
             }
         }
 
-        public void ShowSoftKeyboard()
+        public void EnsureActivated()
         {
         }
 

--- a/osu.Framework/Input/ITextInputSource.cs
+++ b/osu.Framework/Input/ITextInputSource.cs
@@ -20,13 +20,10 @@ namespace osu.Framework.Input
         void Activate(object sender);
 
         /// <summary>
-        /// Requests the OS to show the on-screen/software keyboard.
+        /// Ensures that the native implementation that retrieves user text input is activated
+        /// and that the user can start entering text.
         /// </summary>
-        /// <remarks>
-        /// The OS is hopefully smart enough not to show the software keyboard if a hardware one is present.
-        /// Should be reguraly called when doing text editing operations, as the user might have manually closed the software keyboard.
-        /// </remarks>
-        void ShowSoftKeyboard();
+        void EnsureActivated();
 
         event Action<string> OnNewImeComposition;
         event Action<string> OnNewImeResult;

--- a/osu.Framework/Input/ITextInputSource.cs
+++ b/osu.Framework/Input/ITextInputSource.cs
@@ -19,6 +19,8 @@ namespace osu.Framework.Input
 
         void Activate(object sender);
 
+        void ShowSoftKeyboard();
+
         event Action<string> OnNewImeComposition;
         event Action<string> OnNewImeResult;
     }

--- a/osu.Framework/Input/ITextInputSource.cs
+++ b/osu.Framework/Input/ITextInputSource.cs
@@ -19,6 +19,13 @@ namespace osu.Framework.Input
 
         void Activate(object sender);
 
+        /// <summary>
+        /// Requests the OS to show the on-screen/software keyboard.
+        /// </summary>
+        /// <remarks>
+        /// The OS is hopefully smart enough not to show the software keyboard if a hardware one is present.
+        /// Should be reguraly called when doing text editing operations, as the user might have manually closed the software keyboard.
+        /// </remarks>
         void ShowSoftKeyboard();
 
         event Action<string> OnNewImeComposition;


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/5284

Right now, if you manually close the keyboard by pressing the system back button, the keyboard will not open again if you tap on the currently focused TextBox. This PR fixes that.

`ToggleSoftInputFromWindow` is depricated in Android API level 31 (see [here](https://developer.android.com/reference/android/view/inputmethod/InputMethodManager#toggleSoftInputFromWindow(android.os.IBinder,%20int,%20int))) so `ShowSoftInput` is used instead.

**For iOS:**
The way `UpdateFirstResponder` works means that just calling `view.KeyboardTextField.UpdateFirstResponder(true)` in `ShowSoftKeyboard()` won't work as expected, as the keyboard might not close when the textbox is unfocused.

I don't have an iOS device to test with, so it's on somebody else to implement this at a later time. (And to test if hiding the keyboard manually even causes problems in the first place.)