### PR TITLE
Remove unused `object sender` in ITextInputSource

### DIFF
--- a/osu.Framework.Android/Input/AndroidTextInput.cs
+++ b/osu.Framework.Android/Input/AndroidTextInput.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Android.Input
             inputMethodManager = view.Context.GetSystemService(Context.InputMethodService) as InputMethodManager;
         }
 
-        public void Deactivate(object sender)
+        public void Deactivate()
         {
             activity.RunOnUiThread(() =>
             {
@@ -63,7 +63,7 @@ namespace osu.Framework.Android.Input
         public event Action<string> OnNewImeComposition;
         public event Action<string> OnNewImeResult;
 
-        public void Activate(object sender)
+        public void Activate()
         {
             activity.RunOnUiThread(() =>
             {

--- a/osu.Framework.iOS/Input/IOSTextInput.cs
+++ b/osu.Framework.iOS/Input/IOSTextInput.cs
@@ -38,13 +38,13 @@ namespace osu.Framework.iOS.Input
                 pending += text;
         }
 
-        public void Deactivate(object sender)
+        public void Deactivate()
         {
             view.KeyboardTextField.HandleShouldChangeCharacters -= handleShouldChangeCharacters;
             view.KeyboardTextField.UpdateFirstResponder(false);
         }
 
-        public void Activate(object sender)
+        public void Activate()
         {
             view.KeyboardTextField.HandleShouldChangeCharacters += handleShouldChangeCharacters;
             view.KeyboardTextField.UpdateFirstResponder(true);

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -911,12 +911,12 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void unbindInput()
         {
-            textInput?.Deactivate(this);
+            textInput?.Deactivate();
         }
 
         private void bindInput()
         {
-            textInput?.Activate(this);
+            textInput?.Activate();
         }
 
         private void onImeResult()

--- a/osu.Framework/Input/GameWindowTextInput.cs
+++ b/osu.Framework/Input/GameWindowTextInput.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.Input
             }
         }
 
-        public void Deactivate(object sender)
+        public void Deactivate()
         {
             switch (window)
             {
@@ -49,7 +49,7 @@ namespace osu.Framework.Input
             }
         }
 
-        public void Activate(object sender)
+        public void Activate()
         {
             switch (window)
             {

--- a/osu.Framework/Input/ITextInputSource.cs
+++ b/osu.Framework/Input/ITextInputSource.cs
@@ -15,9 +15,9 @@ namespace osu.Framework.Input
 
         string GetPendingText();
 
-        void Deactivate(object sender);
+        void Deactivate();
 
-        void Activate(object sender);
+        void Activate();
 
         event Action<string> OnNewImeComposition;
         event Action<string> OnNewImeResult;


### PR DESCRIPTION
As discussed in https://github.com/ppy/osu-framework/pull/4613#discussion_r671718379.