### PR TITLE
Add extension for localisable formattable strings

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -234,7 +234,7 @@ namespace osu.Framework.Tests.Localisation
             var dateTime = new DateTime(1);
             const string format = "MMM yyyy";
 
-            var text = manager.GetLocalisedString(new LocalisableFormattableString(dateTime, format));
+            var text = manager.GetLocalisedString(dateTime.ToLocalisableString(format));
 
             Assert.AreEqual("Jan 0001", text.Value);
 

--- a/osu.Framework/Localisation/LocalisableStringExtensions.cs
+++ b/osu.Framework/Localisation/LocalisableStringExtensions.cs
@@ -1,0 +1,17 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+
+namespace osu.Framework.Localisation
+{
+    public static class LocalisableStringExtensions
+    {
+        /// <summary>
+        /// Returns a <see cref="LocalisableFormattableString"/> formatting the given <paramref name="value"/> with the specified <see cref="format"/>.
+        /// </summary>
+        /// <param name="value">The value to format.</param>
+        /// <param name="format">The format string.</param>
+        public static LocalisableFormattableString ToLocalisableString(this IFormattable value, string format) => new LocalisableFormattableString(value, format);
+    }
+}

--- a/osu.Framework/Localisation/LocalisableStringExtensions.cs
+++ b/osu.Framework/Localisation/LocalisableStringExtensions.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Localisation
     public static class LocalisableStringExtensions
     {
         /// <summary>
-        /// Returns a <see cref="LocalisableFormattableString"/> formatting the given <paramref name="value"/> with the specified <see cref="format"/>.
+        /// Returns a <see cref="LocalisableFormattableString"/> formatting the given <paramref name="value"/> with the specified <paramref name="format"/>.
         /// </summary>
         /// <param name="value">The value to format.</param>
         /// <param name="format">The format string.</param>


### PR DESCRIPTION
Similar to the C# built-in `ToString`, this adds a `ToLocalisableString` extension creating a `LocalisableFormattableString` for the `IFormattable` with the specified format string.

Simplifies usages from:
```csharp
Text = new LocalisableFormattableString(value, "#,##0");
```
to
```csharp
Text = value.ToLocalisableString("#,##0");
```