### PR TITLE
Handle localisable strings during `TranslatableString` formatting

### DIFF
--- a/osu.Framework/Localisation/TranslatableString.cs
+++ b/osu.Framework/Localisation/TranslatableString.cs
@@ -59,7 +59,16 @@ namespace osu.Framework.Localisation
 
             try
             {
-                return string.Format(parameters.Store.EffectiveCulture, localisedFormat, Args);
+                return string.Format(parameters.Store.EffectiveCulture, localisedFormat, Args.Select(argument =>
+                {
+                    if (argument is LocalisableString localisableString)
+                        argument = localisableString.Data;
+
+                    if (argument is ILocalisableStringData localisableData)
+                        return localisableData.GetLocalised(parameters);
+
+                    return argument;
+                }).ToArray());
             }
             catch (FormatException e)
             {


### PR DESCRIPTION
Closes #4530

Also allows for cases like the one mentioned in https://github.com/ppy/osu/pull/13921#pullrequestreview-709051043 (`TranslatableString` accepting a `LocalisableFormattableString` argument) to be possible.