### PR TITLE
Fix colour picker current not updating on HSV changes when not present

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneColourPicker.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneColourPicker.cs
@@ -1,9 +1,11 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Testing;
 
 namespace osu.Framework.Tests.Visual.UserInterface
 {
@@ -29,6 +31,32 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 Current = { Value = Colour4.Goldenrod }
             });
             AddAssert("colour is correct", () => colourPicker.Current.Value == Colour4.Goldenrod);
+        }
+
+        [Test]
+        public void TestExternalHSVChange()
+        {
+            const float hue = 0.34f;
+            const float saturation = 0.46f;
+            const float value = 0.84f;
+
+            ColourPicker colourPicker = null;
+
+            AddStep("create picker", () => Child = colourPicker = new BasicColourPicker
+            {
+                Current = { Value = Colour4.Goldenrod }
+            });
+            AddStep("hide picker", () => colourPicker.Hide());
+            AddStep("set HSV manually", () =>
+            {
+                var saturationValueControl = this.ChildrenOfType<HSVColourPicker.SaturationValueSelector>().Single();
+
+                saturationValueControl.Hue.Value = hue;
+                saturationValueControl.Saturation.Value = saturation;
+                saturationValueControl.Value.Value = value;
+            });
+
+            AddUntilStep("colour is correct", () => colourPicker.Current.Value == Colour4.FromHSV(hue, saturation, value));
         }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneHSVColourPicker.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneHSVColourPicker.cs
@@ -109,6 +109,24 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestExternalChangeWhileNotPresent()
+        {
+            const float hue = 0.34f;
+            const float saturation = 0.46f;
+            const float value = 0.84f;
+
+            AddStep("hide picker", () => colourPicker.Hide());
+            AddStep("set HSV manually", () =>
+            {
+                colourPicker.SaturationValueControl.Hue.Value = hue;
+                colourPicker.SaturationValueControl.Saturation.Value = saturation;
+                colourPicker.SaturationValueControl.Value.Value = value;
+            });
+
+            AddUntilStep("colour is correct", () => colourPicker.Current.Value == Colour4.FromHSV(hue, saturation, value));
+        }
+
+        [Test]
         public void TestHueUnchangedIfSaturationAlmostZero()
         {
             AddStep("change colour", () => colourPicker.Current.Value = Colour4.FromHSV(0.5f, 0.5f, 0.5f));

--- a/osu.Framework/Graphics/UserInterface/ColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/ColourPicker.cs
@@ -63,6 +63,8 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         protected abstract HexColourPicker CreateHexColourPicker();
 
+        public override bool IsPresent => base.IsPresent || hsvColourPicker.IsPresent;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();

--- a/osu.Framework/Graphics/UserInterface/HSVColourPicker.cs
+++ b/osu.Framework/Graphics/UserInterface/HSVColourPicker.cs
@@ -69,6 +69,10 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         protected abstract SaturationValueSelector CreateSaturationValueSelector();
 
+        public override bool IsPresent => base.IsPresent
+                                          || saturationValueSelector.Scheduler.HasPendingTasks
+                                          || hueSelector.Scheduler.HasPendingTasks;
+
         protected override void LoadComplete()
         {
             base.LoadComplete();


### PR DESCRIPTION
Closes #4620.

This is incidentally the perfect counterexample for why blanket-including `this.Scheduler.HasPendingTasks` in the base `Drawable.IsPresent` is not a be-all and end-all of these types of issues.

Doing "the obvious" does not work with this component's structure. The child components are not the ones accessible outwardly, the picker itself is. And if someone is messing with the inner components, they are creating a problem entirely by themselves by misusing them.