### PR TITLE
Clarify to use `ScreenStack.Push` on null stack exception from extension

### DIFF
--- a/osu.Framework/Screens/IScreen.cs
+++ b/osu.Framework/Screens/IScreen.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Screens
             var stack = getStack(screen);
 
             if (stack == null)
-                throw new InvalidOperationException($"Cannot {nameof(Push)} to a non-loaded {nameof(IScreen)} directly. Consider using {nameof(ScreenStack.Push)} instead.");
+                throw new InvalidOperationException($"Cannot {nameof(Push)} to a non-loaded {nameof(IScreen)} directly. Consider using {nameof(ScreenStack)}.{nameof(ScreenStack.Push)} instead.");
 
             stack.Push(screen, newScreen);
         }


### PR DESCRIPTION
Using `nameof(ScreenStack.Push)` alone will only output `Push`, this should clarify to call the one in `ScreenStack` specifically.