### PR TITLE
Fix DrawableTrack/DrawableSample not receiving new parent adjustments when parent changes

### DIFF
--- a/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
+++ b/osu.Framework.Tests/Audio/TestSceneDrawableTrack.cs
@@ -6,7 +6,9 @@ using osu.Framework.Allocation;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
+using osu.Framework.Graphics;
 using osu.Framework.Graphics.Audio;
+using osu.Framework.Graphics.Containers;
 using osu.Framework.Testing;
 using osu.Framework.Tests.Visual;
 using osu.Framework.Utils;
@@ -49,6 +51,25 @@ namespace osu.Framework.Tests.Audio
 
             AddStep("reset", () => track.Reset());
             AddAssert("track volume is 1", () => Precision.AlmostEquals(1, track.Volume.Value));
+        }
+
+        [Test]
+        public void TestTrackingParentAdjustmentChangedWhenMovedParents()
+        {
+            AddStep("set volume 1", () => track.Volume.Value = 1);
+
+            AddStep("move track a container with 0 volume", () =>
+            {
+                Remove(track);
+                Child = new AudioContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Volume = { Value = 0 },
+                    Child = track
+                };
+            });
+
+            AddAssert("track has 0 volume", () => track.AggregateVolume.Value == 0);
         }
     }
 }

--- a/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioWrapper.cs
@@ -51,15 +51,20 @@ namespace osu.Framework.Graphics.Audio
 
         private readonly LayoutValue parentAdjustmentLayout = new LayoutValue(Invalidation.Parent);
 
+        private DrawableAudioWrapper()
+        {
+            AddLayout(parentAdjustmentLayout);
+        }
+
         /// <summary>
         /// Creates a <see cref="DrawableAudioWrapper"/> that will contain a drawable child.
         /// Generally used to add adjustments to a hierarchy without adding an audio component.
         /// </summary>
         /// <param name="content">The <see cref="Drawable"/> to be wrapped.</param>
         protected DrawableAudioWrapper(Drawable content)
+            : this()
         {
             AddInternal(content);
-            AddLayout(parentAdjustmentLayout);
         }
 
         /// <summary>
@@ -68,6 +73,7 @@ namespace osu.Framework.Graphics.Audio
         /// <param name="component">The audio component to wrap.</param>
         /// <param name="disposeUnderlyingComponentOnDispose">Whether the component should be automatically disposed on drawable disposal/expiry.</param>
         protected DrawableAudioWrapper([NotNull] IAdjustableAudioComponent component, bool disposeUnderlyingComponentOnDispose = true)
+            : this()
         {
             this.component = component ?? throw new ArgumentNullException(nameof(component));
             this.disposeUnderlyingComponentOnDispose = disposeUnderlyingComponentOnDispose;


### PR DESCRIPTION
I don't know if this breaks anything (quick check says no) - hopefully we've built around the assumption that this is working correctly, but it's now working as it was initially intended.