### PR TITLE
Fix GET request params not being percent-encoded

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -523,6 +523,40 @@ namespace osu.Framework.Tests.IO
         }
 
         [Test, Retry(5)]
+        public void TestGetWithQueryStringParameters()
+        {
+            const string test_key_1 = "testkey1";
+            const string test_val_1 = "testval1 that ends with a #";
+
+            const string test_key_2 = "testkey2";
+            const string test_val_2 = "testval2 that ends with a space ";
+
+            var request = new JsonWebRequest<HttpBinGetResponse>($@"{default_protocol}://{host}/get")
+            {
+                Method = HttpMethod.Get,
+                AllowInsecureRequests = true
+            };
+
+            request.AddParameter(test_key_1, test_val_1);
+            request.AddParameter(test_key_2, test_val_2);
+
+            Assert.DoesNotThrow(request.Perform);
+
+            var responseObject = request.ResponseObject;
+
+            Assert.IsTrue(request.Completed);
+            Assert.IsFalse(request.Aborted);
+
+            Assert.NotNull(responseObject.Arguments);
+
+            Assert.True(responseObject.Arguments.ContainsKey(test_key_1));
+            Assert.AreEqual(test_val_1, responseObject.Arguments[test_key_1]);
+
+            Assert.True(responseObject.Arguments.ContainsKey(test_key_2));
+            Assert.AreEqual(test_val_2, responseObject.Arguments[test_key_2]);
+        }
+
+        [Test, Retry(5)]
         public void TestPostWithJsonResponse([Values(true, false)] bool async)
         {
             var request = new JsonWebRequest<HttpBinPostResponse>($"{default_protocol}://{host}/post")
@@ -638,6 +672,9 @@ namespace osu.Framework.Tests.IO
         [Serializable]
         private class HttpBinGetResponse
         {
+            [JsonProperty("args")]
+            public Dictionary<string, string> Arguments { get; set; }
+
             [JsonProperty("headers")]
             public HttpBinHeaders Headers { get; set; }
 

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -647,9 +647,12 @@ namespace osu.Framework.IO.Network
         }
 
         /// <summary>
-        /// Add a new POST parameter to this request. Replaces any existing parameter with the same name.
+        /// Add a new parameter to this request. Replaces any existing parameter with the same name.
         /// This may not be used in conjunction with <see cref="AddRaw(Stream)"/>.
         /// </summary>
+        /// <remarks>
+        /// Values added to the request URL query string are automatically percent-encoded before sending the request.
+        /// </remarks>
         /// <param name="name">The name of the parameter.</param>
         /// <param name="value">The parameter value.</param>
         public void AddParameter(string name, string value)

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -275,7 +275,7 @@ namespace osu.Framework.IO.Network
 
                         StringBuilder requestParameters = new StringBuilder();
                         foreach (var p in parameters)
-                            requestParameters.Append($@"{p.Key}={p.Value}&");
+                            requestParameters.Append($@"{p.Key}={Uri.EscapeDataString(p.Value)}&");
                         string requestString = requestParameters.ToString().TrimEnd('&');
 
                         request = new HttpRequestMessage(HttpMethod.Get, string.IsNullOrEmpty(requestString) ? url : $"{url}?{requestString}");


### PR DESCRIPTION
This does not really do anything towards https://github.com/ppy/osu/issues/13966 yet, but it fixes a possible analogue of it that could occur for plain GET requests.