### PR TITLE
Allow adding query string params to non-GET `WebRequest`s

### DIFF
--- a/osu.Framework/IO/Network/RequestParameterType.cs
+++ b/osu.Framework/IO/Network/RequestParameterType.cs
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace osu.Framework.IO.Network
+{
+    /// <summary>
+    /// Determines the type of a key-value parameter supplied to a <see cref="WebRequest"/>.
+    /// </summary>
+    public enum RequestParameterType
+    {
+        /// <summary>
+        /// This parameter should be contained in the query string of the request URL.
+        /// </summary>
+        Query,
+
+        /// <summary>
+        /// This parameter should be placed in the body of the request, using the <c>multipart/form-data</c> MIME type.
+        /// </summary>
+        Form
+    }
+}

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -626,7 +626,8 @@ namespace osu.Framework.IO.Network
 
         /// <summary>
         /// Adds a raw POST body to this request.
-        /// This may not be used in conjunction with <see cref="AddFile"/> and <see cref="AddParameter(string,string,RequestParameterType)"/>.
+        /// This may not be used in conjunction with <see cref="AddFile"/>
+        /// and <see cref="AddParameter(string,string,RequestParameterType)"/> with the request type of <see cref="RequestParameterType.Form"/>.
         /// </summary>
         /// <param name="stream">The stream containing the raw data. This stream will _not_ be finalized by this request.</param>
         public void AddRaw(Stream stream)

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -295,7 +295,7 @@ namespace osu.Framework.IO.Network
                         if (rawContent != null)
                         {
                             if (formParameters.Count > 0)
-                                throw new InvalidOperationException($"Cannot use {nameof(AddRaw)} in conjunction with {nameof(AddParameter)}");
+                                throw new InvalidOperationException($"Cannot use {nameof(AddRaw)} in conjunction with form parameters");
                             if (files.Count > 0)
                                 throw new InvalidOperationException($"Cannot use {nameof(AddRaw)} in conjunction with {nameof(AddFile)}");
 
@@ -657,12 +657,12 @@ namespace osu.Framework.IO.Network
         /// Add a new parameter to this request. Replaces any existing parameter with the same name.
         /// </para>
         /// <para>
-        /// If this request's <see cref="Method"/> supports a request body (<c>POST, PUT, DELETE, PATCH</c>), a form parameter will be added;
-        /// otherwise, a query parameter will be added.
+        /// If this request's <see cref="Method"/> supports a request body (<c>POST, PUT, DELETE, PATCH</c>), a <see cref="RequestParameterType.Form"/> parameter will be added;
+        /// otherwise, a <see cref="RequestParameterType.Query"/> parameter will be added.
         /// For more fine-grained control over the parameter type, use the <see cref="AddParameter(string,string,RequestParameterType)"/> overload.
         /// </para>
         /// <para>
-        /// This may not be used in conjunction with <see cref="AddRaw(Stream)"/>.
+        /// <see cref="RequestParameterType.Form"/> parameters may not be used in conjunction with <see cref="AddRaw(Stream)"/>.
         /// </para>
         /// </summary>
         /// <remarks>
@@ -675,7 +675,7 @@ namespace osu.Framework.IO.Network
 
         /// <summary>
         /// Add a new parameter to this request. Replaces any existing parameter with the same name.
-        /// This may not be used in conjunction with <see cref="AddRaw(Stream)"/>.
+        /// <see cref="RequestParameterType.Form"/> parameters may not be used in conjunction with <see cref="AddRaw(Stream)"/>.
         /// </summary>
         /// <remarks>
         /// Values added to the request URL query string are automatically percent-encoded before sending the request.

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -89,9 +89,14 @@ namespace osu.Framework.IO.Network
         public string Url;
 
         /// <summary>
-        /// POST parameters.
+        /// Query string parameters.
         /// </summary>
-        private readonly Dictionary<string, string> parameters = new Dictionary<string, string>();
+        private readonly Dictionary<string, string> queryParameters = new Dictionary<string, string>();
+
+        /// <summary>
+        /// Form parameters.
+        /// </summary>
+        private readonly Dictionary<string, string> formParameters = new Dictionary<string, string>();
 
         /// <summary>
         /// FILE parameters.
@@ -268,17 +273,18 @@ namespace osu.Framework.IO.Network
 
                     HttpRequestMessage request;
 
+                    StringBuilder requestParameters = new StringBuilder();
+                    foreach (var p in queryParameters)
+                        requestParameters.Append($@"{p.Key}={Uri.EscapeDataString(p.Value)}&");
+                    string requestString = requestParameters.ToString().TrimEnd('&');
+                    url = string.IsNullOrEmpty(requestString) ? url : $"{url}?{requestString}";
+
                     if (Method == HttpMethod.Get)
                     {
                         if (files.Count > 0)
                             throw new InvalidOperationException($"Cannot use {nameof(AddFile)} in a GET request. Please set the {nameof(Method)} to POST.");
 
-                        StringBuilder requestParameters = new StringBuilder();
-                        foreach (var p in parameters)
-                            requestParameters.Append($@"{p.Key}={Uri.EscapeDataString(p.Value)}&");
-                        string requestString = requestParameters.ToString().TrimEnd('&');
-
-                        request = new HttpRequestMessage(HttpMethod.Get, string.IsNullOrEmpty(requestString) ? url : $"{url}?{requestString}");
+                        request = new HttpRequestMessage(HttpMethod.Get, url);
                     }
                     else
                     {
@@ -288,7 +294,7 @@ namespace osu.Framework.IO.Network
 
                         if (rawContent != null)
                         {
-                            if (parameters.Count > 0)
+                            if (formParameters.Count > 0)
                                 throw new InvalidOperationException($"Cannot use {nameof(AddRaw)} in conjunction with {nameof(AddParameter)}");
                             if (files.Count > 0)
                                 throw new InvalidOperationException($"Cannot use {nameof(AddRaw)} in conjunction with {nameof(AddFile)}");
@@ -300,16 +306,16 @@ namespace osu.Framework.IO.Network
 
                             postContent.Position = 0;
                         }
-                        else if (parameters.Count > 0 || files.Count > 0)
+                        else if (formParameters.Count > 0 || files.Count > 0)
                         {
                             if (!string.IsNullOrEmpty(ContentType) && ContentType != form_content_type)
-                                throw new InvalidOperationException($"Cannot use custom {nameof(ContentType)} in a POST request.");
+                                throw new InvalidOperationException($"Cannot use custom {nameof(ContentType)} in a POST request with form/file parameters.");
 
                             ContentType = form_content_type;
 
                             var formData = new MultipartFormDataContent(form_boundary);
 
-                            foreach (var p in parameters)
+                            foreach (var p in formParameters)
                                 formData.Add(new StringContent(p.Value), p.Key);
 
                             foreach (var p in files)
@@ -600,7 +606,7 @@ namespace osu.Framework.IO.Network
 
         /// <summary>
         /// Adds a raw POST body to this request.
-        /// This may not be used in conjunction with <see cref="AddFile"/> and <see cref="AddParameter"/>.
+        /// This may not be used in conjunction with <see cref="AddFile"/> and <see cref="AddParameter(string,string,RequestParameterType)"/>.
         /// </summary>
         /// <param name="text">The text.</param>
         public void AddRaw(string text)
@@ -610,7 +616,7 @@ namespace osu.Framework.IO.Network
 
         /// <summary>
         /// Adds a raw POST body to this request.
-        /// This may not be used in conjunction with <see cref="AddFile"/> and <see cref="AddParameter"/>.
+        /// This may not be used in conjunction with <see cref="AddFile"/> and <see cref="AddParameter(string,string,RequestParameterType)"/>.
         /// </summary>
         /// <param name="bytes">The raw data.</param>
         public void AddRaw(byte[] bytes)
@@ -620,7 +626,7 @@ namespace osu.Framework.IO.Network
 
         /// <summary>
         /// Adds a raw POST body to this request.
-        /// This may not be used in conjunction with <see cref="AddFile"/> and <see cref="AddParameter"/>.
+        /// This may not be used in conjunction with <see cref="AddFile"/> and <see cref="AddParameter(string,string,RequestParameterType)"/>.
         /// </summary>
         /// <param name="stream">The stream containing the raw data. This stream will _not_ be finalized by this request.</param>
         public void AddRaw(Stream stream)
@@ -647,6 +653,27 @@ namespace osu.Framework.IO.Network
         }
 
         /// <summary>
+        /// <para>
+        /// Add a new parameter to this request. Replaces any existing parameter with the same name.
+        /// </para>
+        /// <para>
+        /// If this request's <see cref="Method"/> supports a request body (<c>POST, PUT, DELETE, PATCH</c>), a form parameter will be added;
+        /// otherwise, a query parameter will be added.
+        /// For more fine-grained control over the parameter type, use the <see cref="AddParameter(string,string,RequestParameterType)"/> overload.
+        /// </para>
+        /// <para>
+        /// This may not be used in conjunction with <see cref="AddRaw(Stream)"/>.
+        /// </para>
+        /// </summary>
+        /// <remarks>
+        /// Values added to the request URL query string are automatically percent-encoded before sending the request.
+        /// </remarks>
+        /// <param name="name">The name of the parameter.</param>
+        /// <param name="value">The parameter value.</param>
+        public void AddParameter(string name, string value)
+            => AddParameter(name, value, supportsRequestBody(Method) ? RequestParameterType.Form : RequestParameterType.Query);
+
+        /// <summary>
         /// Add a new parameter to this request. Replaces any existing parameter with the same name.
         /// This may not be used in conjunction with <see cref="AddRaw(Stream)"/>.
         /// </summary>
@@ -655,13 +682,32 @@ namespace osu.Framework.IO.Network
         /// </remarks>
         /// <param name="name">The name of the parameter.</param>
         /// <param name="value">The parameter value.</param>
-        public void AddParameter(string name, string value)
+        /// <param name="type">The type of the request parameter.</param>
+        public void AddParameter(string name, string value, RequestParameterType type)
         {
             if (name == null) throw new ArgumentNullException(nameof(name));
             if (value == null) throw new ArgumentNullException(nameof(value));
 
-            parameters[name] = value;
+            switch (type)
+            {
+                case RequestParameterType.Query:
+                    queryParameters[name] = value;
+                    break;
+
+                case RequestParameterType.Form:
+                    if (!supportsRequestBody(Method))
+                        throw new ArgumentException("Cannot add form parameter to a request type which has no body.", nameof(type));
+
+                    formParameters[name] = value;
+                    break;
+            }
         }
+
+        private static bool supportsRequestBody(HttpMethod method)
+            => method == HttpMethod.Post
+               || method == HttpMethod.Put
+               || method == HttpMethod.Delete
+               || method == HttpMethod.Patch;
 
         /// <summary>
         /// Adds a new header to this request. Replaces any existing header with the same name.


### PR DESCRIPTION
- [x] Depends on #4628 for mergeability

PRing for discussion. The end goal is to use this change for https://github.com/ppy/osu/issues/13966 and fixing a TODO item therein in one fell swoop, by applying the following diff game-side:

```diff
diff --git a/osu.Game/Online/Rooms/JoinRoomRequest.cs b/osu.Game/Online/Rooms/JoinRoomRequest.cs
index b2d772cac7..d9d4f2eb5c 100644
--- a/osu.Game/Online/Rooms/JoinRoomRequest.cs
+++ b/osu.Game/Online/Rooms/JoinRoomRequest.cs
@@ -22,10 +22,10 @@ protected override WebRequest CreateWebRequest()
         {
             var req = base.CreateWebRequest();
             req.Method = HttpMethod.Put;
+            req.AddParameter(@"password", Password, RequestParameterType.Query);
             return req;
         }
 
-        // Todo: Password needs to be specified here rather than via AddParameter() because this is a PUT request. May be a framework bug.
-        protected override string Target => $"rooms/{Room.RoomID.Value}/users/{User.Id}?password={Password}";
+        protected override string Target => $@"rooms/{Room.RoomID.Value}/users/{User.Id}";
     }
 }
```

The reason why I am proposing to allow adding both query and form params simultaneously is that many existing tools and frameworks already support it. cURL, postman, ASP.NET Core all will happily support both query string and form parameters on any request that has a body. So from a framework perspective I feel it's better to be less "opinionated"/rigid than more.

The change was designed to be non-breaking in any reasonable scenario (if anyone is expecting things like `OPTIONS` requests to work with form params, they have another thing coming).