### PR TITLE
Hide popovers on target disposal

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -380,6 +380,38 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("popover hidden", () => !this.ChildrenOfType<Popover>().Any());
         }
 
+        [Test]
+        public void TestPopoverCleanupOnTargetDisposal()
+        {
+            DrawableWithPopover target = null;
+
+            AddStep("add button", () => popoverContainer.Child = target = new DrawableWithPopover
+            {
+                Width = 200,
+                Height = 30,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Text = "open",
+                CreateContent = _ => new BasicPopover
+                {
+                    Child = new SpriteText
+                    {
+                        Text = "This popover should be cleaned up when its button is removed",
+                    }
+                }
+            });
+
+            AddStep("click button", () =>
+            {
+                InputManager.MoveMouseTo(target);
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("popover created", () => this.ChildrenOfType<Popover>().Any());
+
+            AddStep("dispose of button", () => popoverContainer.Clear());
+            AddUntilStep("no popover present", () => !this.ChildrenOfType<Popover>().Any());
+        }
+
         private void createContent(Func<DrawableWithPopover, Popover> creationFunc)
             => AddStep("create content", () =>
             {

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -412,6 +412,38 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddUntilStep("no popover present", () => !this.ChildrenOfType<Popover>().Any());
         }
 
+        [Test]
+        public void TestPopoverCleanupOnTargetHide()
+        {
+            DrawableWithPopover target = null;
+
+            AddStep("add button", () => popoverContainer.Child = target = new DrawableWithPopover
+            {
+                Width = 200,
+                Height = 30,
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Text = "open",
+                CreateContent = _ => new BasicPopover
+                {
+                    Child = new SpriteText
+                    {
+                        Text = "This popover should be cleaned up when its button is hidden",
+                    }
+                }
+            });
+
+            AddStep("click button", () =>
+            {
+                InputManager.MoveMouseTo(target);
+                InputManager.Click(MouseButton.Left);
+            });
+            AddAssert("popover created", () => this.ChildrenOfType<Popover>().Any());
+
+            AddStep("hide button", () => target.Hide());
+            AddUntilStep("no popover present", () => !this.ChildrenOfType<Popover>().Any());
+        }
+
         private void createContent(Func<DrawableWithPopover, Popover> creationFunc)
             => AddStep("create content", () =>
             {

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -47,28 +47,26 @@ namespace osu.Framework.Graphics.Cursor
             currentPopover?.Hide();
             currentPopover?.Expire();
 
-            if (target is Drawable oldDrawableTarget)
-                oldDrawableTarget.OnDispose -= onTargetDisposed;
-
             target = newTarget;
 
             var newPopover = target?.GetPopover();
             if (newPopover == null)
                 return false;
 
-            if (target is Drawable newDrawableTarget)
-                newDrawableTarget.OnDispose += onTargetDisposed;
-
             AddInternal(currentPopover = newPopover);
             currentPopover.Show();
             return true;
         }
 
-        private void onTargetDisposed() => Schedule(() => SetTarget(null));
-
         protected override void UpdateAfterChildren()
         {
             base.UpdateAfterChildren();
+
+            if ((target as Drawable)?.FindClosestParent<PopoverContainer>() != this || target?.IsPresent != true)
+            {
+                SetTarget(null);
+                return;
+            }
 
             updatePopoverPositioning();
         }
@@ -189,14 +187,6 @@ namespace osu.Framework.Graphics.Cursor
 
             // the final size is the intersection of the X/Y areas.
             return availableSize;
-        }
-
-        protected override void Dispose(bool isDisposing)
-        {
-            base.Dispose(isDisposing);
-
-            if (target is Drawable drawableTarget)
-                drawableTarget.OnDispose -= onTargetDisposed;
         }
     }
 }


### PR DESCRIPTION
Aims to ensure that popovers are cleaned up properly when their target gets disposed.

The schedule of `SetTarget(null)` is required as disposal can happen on non-update thread - omitting it was causing invalid transform mutation exceptions due to indirectly invoking `PopOut` otherwise. The scheduled `SetTarget(null)` call intends to ensure that both the reference to the disposed drawable is released and that the `OnDispose` subscription is removed.