### PR TITLE
Ensure that popover handles all mouse events within the bounds of its body

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -599,24 +599,54 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class EventHandlingContainer : Container
         {
+            private readonly Box colourBox;
+
             public bool ClickReceived { get; private set; }
             public bool HoverReceived { get; private set; }
+
+            protected override Container<Drawable> Content { get; }
+
+            public EventHandlingContainer()
+            {
+                AddInternal(new Container
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Children = new Drawable[]
+                    {
+                        colourBox = new Box
+                        {
+                            Colour = Color4.Black,
+                            RelativeSizeAxes = Axes.Both,
+                        },
+                        Content = new Container { RelativeSizeAxes = Axes.Both },
+                    }
+                });
+            }
 
             public void Reset()
             {
                 ClickReceived = HoverReceived = false;
+                colourBox.FadeColour(Color4.Black);
             }
 
             protected override bool OnClick(ClickEvent e)
             {
                 ClickReceived = true;
+                colourBox.FlashColour(Color4.White, 200);
                 return true;
             }
 
             protected override bool OnHover(HoverEvent e)
             {
                 HoverReceived = true;
+                colourBox.FadeColour(Color4.DarkSlateBlue, 200);
                 return true;
+            }
+
+            protected override void OnHoverLost(HoverLostEvent e)
+            {
+                colourBox.FadeColour(Color4.Black, 200);
+                base.OnHoverLost(e);
             }
         }
     }

--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -475,6 +475,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.MoveMouseTo(target);
                 InputManager.Click(MouseButton.Left);
             });
+
+            AddAssert("container received hover", () => eventHandlingContainer.HoverReceived);
+
             AddAssert("popover created", () => this.ChildrenOfType<Popover>().Any());
 
             AddStep("mouse over popover", () =>
@@ -482,10 +485,21 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 eventHandlingContainer.Reset();
                 InputManager.MoveMouseTo(this.ChildrenOfType<Popover>().Single().Body);
             });
+
             AddAssert("container did not receive hover", () => !eventHandlingContainer.HoverReceived);
 
             AddStep("click on popover", () => InputManager.Click(MouseButton.Left));
             AddAssert("container did not receive click", () => !eventHandlingContainer.ClickReceived);
+
+            AddStep("dismiss popover", () =>
+            {
+                InputManager.MoveMouseTo(eventHandlingContainer.ScreenSpaceDrawQuad.TopLeft + new Vector2(10));
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddAssert("container received hover", () => eventHandlingContainer.HoverReceived);
+            AddStep("click again", () => InputManager.Click(MouseButton.Left));
+            AddAssert("container received click", () => eventHandlingContainer.ClickReceived);
         }
 
         private void createContent(Func<DrawableWithPopover, Popover> creationFunc)

--- a/osu.Framework/Graphics/Cursor/PopoverContainer.cs
+++ b/osu.Framework/Graphics/Cursor/PopoverContainer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.UserInterface;
+using osu.Framework.Input.Events;
 using osu.Framework.Utils;
 using osuTK;
 
@@ -17,6 +18,7 @@ namespace osu.Framework.Graphics.Cursor
     public class PopoverContainer : Container
     {
         private readonly Container content;
+        private readonly Container dismissOnMouseDownContainer;
 
         private IHasPopover? target;
         private Popover? currentPopover;
@@ -31,6 +33,10 @@ namespace osu.Framework.Graphics.Cursor
                 {
                     RelativeSizeAxes = Axes.Both,
                 },
+                dismissOnMouseDownContainer = new DismissOnMouseDownContainer
+                {
+                    RelativeSizeAxes = Axes.Both
+                }
             };
         }
 
@@ -59,7 +65,7 @@ namespace osu.Framework.Graphics.Cursor
             if (target is Drawable newDrawableTarget)
                 newDrawableTarget.OnDispose += onTargetDisposed;
 
-            AddInternal(currentPopover = newPopover);
+            dismissOnMouseDownContainer.Add(currentPopover = newPopover);
             currentPopover.Show();
             return true;
         }
@@ -197,6 +203,15 @@ namespace osu.Framework.Graphics.Cursor
 
             if (target is Drawable drawableTarget)
                 drawableTarget.OnDispose -= onTargetDisposed;
+        }
+
+        private class DismissOnMouseDownContainer : Container
+        {
+            protected override bool OnMouseDown(MouseDownEvent e)
+            {
+                this.HidePopover();
+                return false;
+            }
         }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -19,18 +19,9 @@ namespace osu.Framework.Graphics.UserInterface
     /// </summary>
     public abstract class Popover : FocusedOverlayContainer
     {
-        protected override bool BlockPositionalInput => false; // not required as we only care about intercepting mouse down in certain cases.
+        protected override bool BlockPositionalInput => true;
 
-        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => State.Value == Visibility.Visible;
-
-        protected override bool OnMouseDown(MouseDownEvent e)
-        {
-            this.HidePopover();
-            return base.OnMouseDown(e);
-        }
-
-        // click is handled here instead of in MouseBlockingContainer so that the popover can be focused.
-        protected override bool OnClick(ClickEvent e) => Body.ReceivePositionalInputAt(e.ScreenSpaceMousePosition);
+        public override bool ReceivePositionalInputAt(Vector2 screenSpacePos) => Body.ReceivePositionalInputAt(screenSpacePos) || Arrow.ReceivePositionalInputAt(screenSpacePos);
 
         public override bool HandleNonPositionalInput => State.Value == Visibility.Visible;
 
@@ -94,7 +85,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Children = new[]
                 {
                     Arrow = CreateArrow(),
-                    Body = new MouseBlockingContainer
+                    Body = new Container
                     {
                         AutoSizeAxes = Axes.Both,
                         Children = new Drawable[]
@@ -200,24 +191,5 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         #endregion
-
-        private class MouseBlockingContainer : Container
-        {
-            protected override bool Handle(UIEvent e)
-            {
-                switch (e)
-                {
-                    case ClickEvent _:
-                        // let clicks be handled by the popover itself, since it can receive focus.
-                        return false;
-
-                    case MouseEvent _:
-                        return true;
-
-                    default:
-                        return false;
-                }
-            }
-        }
     }
 }

--- a/osu.Framework/Graphics/UserInterface/Popover.cs
+++ b/osu.Framework/Graphics/UserInterface/Popover.cs
@@ -25,13 +25,11 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (Body.ReceivePositionalInputAt(e.ScreenSpaceMousePosition))
-                return true;
-
             this.HidePopover();
             return base.OnMouseDown(e);
         }
 
+        // click is handled here instead of in MouseBlockingContainer so that the popover can be focused.
         protected override bool OnClick(ClickEvent e) => Body.ReceivePositionalInputAt(e.ScreenSpaceMousePosition);
 
         public override bool HandleNonPositionalInput => State.Value == Visibility.Visible;
@@ -96,7 +94,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Children = new[]
                 {
                     Arrow = CreateArrow(),
-                    Body = new Container
+                    Body = new MouseBlockingContainer
                     {
                         AutoSizeAxes = Axes.Both,
                         Children = new Drawable[]
@@ -202,5 +200,24 @@ namespace osu.Framework.Graphics.UserInterface
         }
 
         #endregion
+
+        private class MouseBlockingContainer : Container
+        {
+            protected override bool Handle(UIEvent e)
+            {
+                switch (e)
+                {
+                    case ClickEvent _:
+                        // let clicks be handled by the popover itself, since it can receive focus.
+                        return false;
+
+                    case MouseEvent _:
+                        return true;
+
+                    default:
+                        return false;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
- [x] Depends on #4631 for mergeability

PRing for discussion. The reason that this is written so awkwardly (and the primary issue I was intending to resolve) was that with the current implementation, hover events were leaking to background drawables.

Unfortunately, doing

```csharp
protected override bool OnHover(HoverEvent e) => Body.ReceivePositionalInputAt(e.ScreenSpaceMousePosition);
```

is not viable. The reason why is that as you may recall, popovers have `ReceivePositionalInputEvent()` overridden to return `true` for any screen-space point. This in turn makes it so that the popover is *always* hovered, so long as the mouse is in bounds of the screen.

The thing about hover events is that a drawable will (correctly) *not* have its `OnHover()` called again if it is hovered, until it is finally unhovered. And the popover will _never_ become unhovered, again, as long as the mouse is within the screen. This makes it so that unless the mouse is *inside* the popover when it returns to the window, it will never be able to handle a hover again. That's the reason for the container hack - it will only handle input within its bounds, and *not* be hovered when mouse is anywhere else on the screen.

The biggest hang-up about this diff is the click handling. Unfortunately as the parent popover is the focus-controlling drawable, the mouse-blocking container has to let clicks through so that the popover can handle them itself and receive and yield focus correctly.

I can think of a few ways of resolving this differently, but they would be reverting to some of the previous behaviour (either blocking mouse events over the entire screen, or moving the focused container lower down and doing a `State` bind from the `Popover` to it, etc.) Willing to listen to alternatives.