### PR TITLE
Split `TextChunk` from `TextFlowContainer`

### DIFF
--- a/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
@@ -79,14 +79,14 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="factory">The factory method creating drawables.</param>
         protected void AddIconFactory(string name, Func<int, int, Drawable> factory) => iconFactories.Add(name, factory);
 
-        internal override IEnumerable<Drawable> AddLine(TextLine line, bool newLineIsParagraph)
+        internal override IEnumerable<Drawable> AddLine(TextChunk chunk, bool newLineIsParagraph)
         {
             if (!newLineIsParagraph)
                 AddInternal(new NewLineContainer(true));
 
             var sprites = new List<Drawable>();
             int index = 0;
-            string str = line.Text;
+            string str = chunk.Text;
 
             while (index < str.Length)
             {
@@ -172,7 +172,7 @@ namespace osu.Framework.Graphics.Containers
 
                 // unescape stuff
                 strPiece = Unescape(strPiece);
-                sprites.AddRange(AddString(new TextLine(strPiece, line.CreationParameters), newLineIsParagraph));
+                sprites.AddRange(AddString(new TextChunk(strPiece, chunk.CreationParameters), newLineIsParagraph));
 
                 if (placeholderDrawable != null)
                 {

--- a/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
@@ -79,9 +79,9 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="factory">The factory method creating drawables.</param>
         protected void AddIconFactory(string name, Func<int, int, Drawable> factory) => iconFactories.Add(name, factory);
 
-        internal override IEnumerable<Drawable> AddLine(TextChunk chunk, bool newLineIsParagraph)
+        internal override IEnumerable<Drawable> AddLine(TextChunk chunk)
         {
-            if (!newLineIsParagraph)
+            if (!chunk.NewLineIsParagraph)
                 AddInternal(new NewLineContainer(true));
 
             var sprites = new List<Drawable>();
@@ -172,7 +172,7 @@ namespace osu.Framework.Graphics.Containers
 
                 // unescape stuff
                 strPiece = Unescape(strPiece);
-                sprites.AddRange(AddString(new TextChunk(strPiece, chunk.CreationParameters), newLineIsParagraph));
+                sprites.AddRange(AddString(new TextChunk(strPiece, chunk.NewLineIsParagraph, chunk.CreationParameters)));
 
                 if (placeholderDrawable != null)
                 {

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -9,11 +9,13 @@ namespace osu.Framework.Graphics.Containers
     internal class TextChunk
     {
         public readonly string Text;
+        public readonly bool NewLineIsParagraph;
         internal readonly Action<SpriteText> CreationParameters;
 
-        public TextChunk(string text, Action<SpriteText> creationParameters = null)
+        public TextChunk(string text, bool newLineIsParagraph, Action<SpriteText> creationParameters = null)
         {
             Text = text;
+            NewLineIsParagraph = newLineIsParagraph;
             CreationParameters = creationParameters;
         }
 

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -1,0 +1,25 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Graphics.Containers
+{
+    internal class TextChunk
+    {
+        public readonly string Text;
+        internal readonly Action<SpriteText> CreationParameters;
+
+        public TextChunk(string text, Action<SpriteText> creationParameters = null)
+        {
+            Text = text;
+            CreationParameters = creationParameters;
+        }
+
+        public void ApplyParameters(SpriteText spriteText)
+        {
+            CreationParameters?.Invoke(spriteText);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -205,7 +205,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>A collection of <see cref="Drawable" /> objects for each <see cref="SpriteText"/> word and <see cref="NewLineContainer"/> created from the given text.</returns>
         /// <param name="text">The text to add.</param>
         /// <param name="creationParameters">A callback providing any <see cref="SpriteText" /> instances created for this new text.</param>
-        public IEnumerable<Drawable> AddText(string text, Action<SpriteText> creationParameters = null) => AddLine(new TextLine(text, creationParameters), true);
+        public IEnumerable<Drawable> AddText(string text, Action<SpriteText> creationParameters = null) => AddLine(new TextChunk(text, creationParameters), true);
 
         /// <summary>
         /// Add an arbitrary <see cref="SpriteText"/> to this <see cref="TextFlowContainer"/>.
@@ -227,7 +227,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>A collection of <see cref="Drawable" /> objects for each <see cref="SpriteText"/> word and <see cref="NewLineContainer"/> created from the given text.</returns>
         /// <param name="paragraph">The paragraph to add.</param>
         /// <param name="creationParameters">A callback providing any <see cref="SpriteText" /> instances created for this new paragraph.</param>
-        public IEnumerable<Drawable> AddParagraph(string paragraph, Action<SpriteText> creationParameters = null) => AddLine(new TextLine(paragraph, creationParameters), false);
+        public IEnumerable<Drawable> AddParagraph(string paragraph, Action<SpriteText> creationParameters = null) => AddLine(new TextChunk(paragraph, creationParameters), false);
 
         /// <summary>
         /// End current line and start a new one.
@@ -241,11 +241,11 @@ namespace osu.Framework.Graphics.Containers
 
         protected virtual SpriteText CreateSpriteText() => new SpriteText();
 
-        internal SpriteText CreateSpriteTextWithLine(TextLine line)
+        internal SpriteText CreateSpriteTextWithChunk(TextChunk chunk)
         {
             var spriteText = CreateSpriteText();
             defaultCreationParameters?.Invoke(spriteText);
-            line.ApplyParameters(spriteText);
+            chunk.ApplyParameters(spriteText);
             return spriteText;
         }
 
@@ -254,7 +254,7 @@ namespace osu.Framework.Graphics.Containers
             throw new InvalidOperationException($"Use {nameof(AddText)} to add text to a {nameof(TextFlowContainer)}.");
         }
 
-        internal virtual IEnumerable<Drawable> AddLine(TextLine line, bool newLineIsParagraph)
+        internal virtual IEnumerable<Drawable> AddLine(TextChunk chunk, bool newLineIsParagraph)
         {
             var sprites = new List<Drawable>();
 
@@ -267,17 +267,17 @@ namespace osu.Framework.Graphics.Containers
                 base.Add(newLine);
             }
 
-            sprites.AddRange(AddString(line, newLineIsParagraph));
+            sprites.AddRange(AddString(chunk, newLineIsParagraph));
 
             return sprites;
         }
 
-        internal IEnumerable<Drawable> AddString(TextLine line, bool newLineIsParagraph)
+        internal IEnumerable<Drawable> AddString(TextChunk chunk, bool newLineIsParagraph)
         {
             bool first = true;
             var sprites = new List<Drawable>();
 
-            foreach (string l in line.Text.Split('\n'))
+            foreach (string l in chunk.Text.Split('\n'))
             {
                 if (!first)
                 {
@@ -295,7 +295,7 @@ namespace osu.Framework.Graphics.Containers
                 {
                     if (string.IsNullOrEmpty(word)) continue;
 
-                    var textSprite = CreateSpriteTextWithLine(line);
+                    var textSprite = CreateSpriteTextWithChunk(chunk);
                     textSprite.Text = word;
                     sprites.Add(textSprite);
                     base.Add(textSprite);
@@ -416,12 +416,12 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        internal class TextLine
+        internal class TextChunk
         {
             public readonly string Text;
             internal readonly Action<SpriteText> CreationParameters;
 
-            public TextLine(string text, Action<SpriteText> creationParameters = null)
+            public TextChunk(string text, Action<SpriteText> creationParameters = null)
             {
                 Text = text;
                 CreationParameters = creationParameters;

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -205,7 +205,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>A collection of <see cref="Drawable" /> objects for each <see cref="SpriteText"/> word and <see cref="NewLineContainer"/> created from the given text.</returns>
         /// <param name="text">The text to add.</param>
         /// <param name="creationParameters">A callback providing any <see cref="SpriteText" /> instances created for this new text.</param>
-        public IEnumerable<Drawable> AddText(string text, Action<SpriteText> creationParameters = null) => AddLine(new TextChunk(text, creationParameters), true);
+        public IEnumerable<Drawable> AddText(string text, Action<SpriteText> creationParameters = null) => AddLine(new TextChunk(text, true, creationParameters));
 
         /// <summary>
         /// Add an arbitrary <see cref="SpriteText"/> to this <see cref="TextFlowContainer"/>.
@@ -227,7 +227,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>A collection of <see cref="Drawable" /> objects for each <see cref="SpriteText"/> word and <see cref="NewLineContainer"/> created from the given text.</returns>
         /// <param name="paragraph">The paragraph to add.</param>
         /// <param name="creationParameters">A callback providing any <see cref="SpriteText" /> instances created for this new paragraph.</param>
-        public IEnumerable<Drawable> AddParagraph(string paragraph, Action<SpriteText> creationParameters = null) => AddLine(new TextChunk(paragraph, creationParameters), false);
+        public IEnumerable<Drawable> AddParagraph(string paragraph, Action<SpriteText> creationParameters = null) => AddLine(new TextChunk(paragraph, false, creationParameters));
 
         /// <summary>
         /// End current line and start a new one.
@@ -254,25 +254,25 @@ namespace osu.Framework.Graphics.Containers
             throw new InvalidOperationException($"Use {nameof(AddText)} to add text to a {nameof(TextFlowContainer)}.");
         }
 
-        internal virtual IEnumerable<Drawable> AddLine(TextChunk chunk, bool newLineIsParagraph)
+        internal virtual IEnumerable<Drawable> AddLine(TextChunk chunk)
         {
             var sprites = new List<Drawable>();
 
             // !newLineIsParagraph effectively means that we want to add just *one* paragraph, which means we need to make sure that any previous paragraphs
             // are terminated. Thus, we add a NewLineContainer that indicates the end of the paragraph before adding our current paragraph.
-            if (!newLineIsParagraph)
+            if (!chunk.NewLineIsParagraph)
             {
                 var newLine = new NewLineContainer(true);
                 sprites.Add(newLine);
                 base.Add(newLine);
             }
 
-            sprites.AddRange(AddString(chunk, newLineIsParagraph));
+            sprites.AddRange(AddString(chunk));
 
             return sprites;
         }
 
-        internal IEnumerable<Drawable> AddString(TextChunk chunk, bool newLineIsParagraph)
+        internal IEnumerable<Drawable> AddString(TextChunk chunk)
         {
             bool first = true;
             var sprites = new List<Drawable>();
@@ -285,7 +285,7 @@ namespace osu.Framework.Graphics.Containers
 
                     if (lastChild != null)
                     {
-                        var newLine = new NewLineContainer(newLineIsParagraph);
+                        var newLine = new NewLineContainer(chunk.NewLineIsParagraph);
                         sprites.Add(newLine);
                         base.Add(newLine);
                     }

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -415,22 +415,5 @@ namespace osu.Framework.Graphics.Containers
                 IndicatesNewParagraph = newParagraph;
             }
         }
-
-        internal class TextChunk
-        {
-            public readonly string Text;
-            internal readonly Action<SpriteText> CreationParameters;
-
-            public TextChunk(string text, Action<SpriteText> creationParameters = null)
-            {
-                Text = text;
-                CreationParameters = creationParameters;
-            }
-
-            public void ApplyParameters(SpriteText spriteText)
-            {
-                CreationParameters?.Invoke(spriteText);
-            }
-        }
     }
 }


### PR DESCRIPTION
This is a mostly "code quality" sort of change, but one that is pretty conducive to adding localisation to `TextFlowContainer` on the path that I have explored on my WIP/MVP branch. The commits are mostly simple source transformations:

* 578d6d3 renames `TextLine` to `TextChunk`. It was never really a "line" of text anyways; adding consecutive "lines" via repeated `AddText()` calls would make the text flow as normal and *not* add lines. The actual "new line" logic is in `AddLine()`.
* dfd39a8 splits the class to a new file - I intend it to grow, and contain all of the drawable-constructing logic that currently resides in the text flow itself.
* ede05f7 folds the `newLineIsParagraph` flag into the chunk - aside from simplifying data flow, it ensures that all information required to construct the drawable representation of a chunk resides *in* the chunk.