### PR TITLE
Propagate button events in a certain order

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -25,6 +25,7 @@ using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Graphics.Effects;
 using osu.Framework.Graphics.Primitives;
+using osu.Framework.Input;
 using osu.Framework.Layout;
 using osu.Framework.Testing;
 using osu.Framework.Utils;
@@ -1321,7 +1322,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>Whether or not the specified drawable should be considered when building input queues.</returns>
         protected virtual bool ShouldBeConsideredForInput(Drawable child) => child.LoadState == LoadState.Loaded;
 
-        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal override bool BuildNonPositionalInputQueue(InputQueue queue, bool allowBlocking = true)
         {
             if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))
                 return false;
@@ -1346,7 +1347,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>True if the subtree should receive input at the given screen-space position.</returns>
         protected virtual bool ReceivePositionalInputAtSubTree(Vector2 screenSpacePos) => !Masking || ReceivePositionalInputAt(screenSpacePos);
 
-        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, InputQueue queue)
         {
             if (!base.BuildPositionalInputQueue(screenSpacePos, queue))
                 return false;

--- a/osu.Framework/Graphics/Containers/OverlayContainer.cs
+++ b/osu.Framework/Graphics/Containers/OverlayContainer.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Generic;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 
@@ -29,7 +28,7 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         protected virtual bool BlockNonPositionalInput => false;
 
-        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal override bool BuildNonPositionalInputQueue(InputQueue queue, bool allowBlocking = true)
         {
             if (PropagateNonPositionalInputSubTree && HandleNonPositionalInput && BlockNonPositionalInput)
             {

--- a/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
+++ b/osu.Framework/Graphics/Cursor/CursorEffectContainer.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Graphics.Cursor
             Debug.Assert(targetChildren.Count == 0, $"{nameof(targetChildren)} should be empty but has {targetChildren.Count} elements.");
 
             // Skip all drawables in the hierarchy prior to (and including) ourself.
-            var targetCandidates = inputManager.PositionalInputQueue;
+            var targetCandidates = inputManager.PositionalInputQueue.All;
 
             int selfIndex = targetCandidates.IndexOf(this);
 

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2553,7 +2553,7 @@ namespace osu.Framework.Graphics
         /// <param name="queue">The input queue to be built.</param>
         /// <param name="allowBlocking">Whether blocking at <see cref="PassThroughInputManager"/>s should be allowed.</param>
         /// <returns>Returns false if we should skip this sub-tree.</returns>
-        internal virtual bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal virtual bool BuildNonPositionalInputQueue(InputQueue queue, bool allowBlocking = true)
         {
             if (!PropagateNonPositionalInputSubTree)
                 return false;
@@ -2570,7 +2570,7 @@ namespace osu.Framework.Graphics
         /// <param name="screenSpacePos">The screen space position of the positional input.</param>
         /// <param name="queue">The input queue to be built.</param>
         /// <returns>Returns false if we should skip this sub-tree.</returns>
-        internal virtual bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        internal virtual bool BuildPositionalInputQueue(Vector2 screenSpacePos, InputQueue queue)
         {
             if (!PropagatePositionalInputSubTree)
                 return false;

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Input.Bindings
         public IEnumerable<T> PressedActions => pressedActions;
 
         private readonly Dictionary<IKeyBinding, List<Drawable>> keyBindingQueues = new Dictionary<IKeyBinding, List<Drawable>>();
-        private readonly List<Drawable> queue = new List<Drawable>();
+        private readonly InputQueue queue = new InputQueue();
 
         /// <summary>
         /// The input queue to be used for processing key bindings. Based on the non-positional <see cref="InputManager.NonPositionalInputQueue"/>.
@@ -58,10 +58,10 @@ namespace osu.Framework.Input.Bindings
             get
             {
                 queue.Clear();
-                //BuildNonPositionalInputQueue(queue, false);
+                BuildNonPositionalInputQueue(queue, false);
                 queue.Reverse();
 
-                return queue;
+                return queue.Regular;
             }
         }
 
@@ -78,25 +78,6 @@ namespace osu.Framework.Input.Bindings
         /// Each repeated action will have its own pressed/released event pair.
         /// </summary>
         protected virtual bool SendRepeats => false;
-
-        /// <summary>
-        /// Whether this <see cref="KeyBindingContainer"/> should attempt to handle input before any of its children.
-        /// </summary>
-        protected virtual bool Prioritised => false;
-
-        internal override bool BuildNonPositionalInputQueue(InputQueue queue, bool allowBlocking = true)
-        {
-            if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))
-                return false;
-
-            if (Prioritised)
-            {
-                queue.AllList.Remove(this);
-                queue.AllList.Add(this);
-            }
-
-            return true;
-        }
 
         /// <summary>
         /// All input keys which are currently pressed and have reached this <see cref="KeyBindingContainer"/>.

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -58,7 +58,7 @@ namespace osu.Framework.Input.Bindings
             get
             {
                 queue.Clear();
-                BuildNonPositionalInputQueue(queue, false);
+                //BuildNonPositionalInputQueue(queue, false);
                 queue.Reverse();
 
                 return queue;
@@ -84,15 +84,15 @@ namespace osu.Framework.Input.Bindings
         /// </summary>
         protected virtual bool Prioritised => false;
 
-        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal override bool BuildNonPositionalInputQueue(InputQueue queue, bool allowBlocking = true)
         {
             if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))
                 return false;
 
             if (Prioritised)
             {
-                queue.Remove(this);
-                queue.Add(this);
+                queue.AllList.Remove(this);
+                queue.AllList.Add(this);
             }
 
             return true;

--- a/osu.Framework/Input/FrameworkActionContainer.cs
+++ b/osu.Framework/Input/FrameworkActionContainer.cs
@@ -25,8 +25,6 @@ namespace osu.Framework.Input
             : base(matchingMode: KeyCombinationMatchingMode.Exact)
         {
         }
-
-        protected override bool Prioritised => true;
     }
 
     public enum FrameworkAction

--- a/osu.Framework/Input/InputQueue.cs
+++ b/osu.Framework/Input/InputQueue.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+
+namespace osu.Framework.Input
+{
+    public class InputQueue : ReadOnlyInputQueue
+    {
+        public List<Drawable> AllList => AllInner;
+        public List<Drawable> RegularList => RegularInner;
+        public List<KeyBindingContainer> KeyBingingContainersList => KeyBingingContainersInner;
+
+        public InputQueue(Func<Drawable> getFocusedDrawable = null)
+            : base(getFocusedDrawable)
+        {
+        }
+
+        public void Add(Drawable drawable)
+        {
+            if (drawable is KeyBindingContainer kbc)
+                KeyBingingContainersList.Add(kbc);
+            else
+                RegularList.Add(drawable);
+
+            AllList.Add(drawable);
+        }
+
+        /// <summary>
+        /// Clears underlying input queues.
+        /// </summary>
+        public void Clear()
+        {
+            AllList.Clear();
+            RegularList.Clear();
+            KeyBingingContainersList.Clear();
+        }
+
+        /// <summary>
+        /// Reverses underlying input queues.
+        /// </summary>
+        public void Reverse()
+        {
+            AllList.Reverse();
+            RegularList.Reverse();
+            KeyBingingContainersList.Reverse();
+        }
+
+        public void RemoveAll(Predicate<Drawable> func)
+        {
+            RegularList.RemoveAll(func);
+        }
+    }
+}

--- a/osu.Framework/Input/JoystickButtonEventManager.cs
+++ b/osu.Framework/Input/JoystickButtonEventManager.cs
@@ -15,7 +15,12 @@ namespace osu.Framework.Input
         {
         }
 
-        protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new JoystickPressEvent(state, Button));
+        protected override Drawable HandleButtonDown(InputState state, ReadOnlyInputQueue targets)
+        {
+            var joystickPressEvent = new JoystickPressEvent(state, Button);
+
+            return PropagateButtonEvent(targets, joystickPressEvent);
+        }
 
         protected override void HandleButtonUp(InputState state, List<Drawable> targets)
         {

--- a/osu.Framework/Input/KeyEventManager.cs
+++ b/osu.Framework/Input/KeyEventManager.cs
@@ -23,12 +23,17 @@ namespace osu.Framework.Input
         public void HandleRepeat(InputState state)
         {
             // Only drawables that can still handle input should handle the repeat
-            var drawables = ButtonDownInputQueue.Intersect(InputQueue).Where(t => t.IsAlive && t.IsPresent);
+            var drawables = ButtonDownInputQueue.Intersect(InputQueue.Regular).Where(t => t.IsAlive && t.IsPresent);
 
             PropagateButtonEvent(drawables, new KeyDownEvent(state, Button, true));
         }
 
-        protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new KeyDownEvent(state, Button));
+        protected override Drawable HandleButtonDown(InputState state, ReadOnlyInputQueue targets)
+        {
+            var keyDownEvent = new KeyDownEvent(state, Button);
+
+            return PropagateButtonEvent(targets, keyDownEvent);
+        }
 
         protected override void HandleButtonUp(InputState state, List<Drawable> targets)
         {

--- a/osu.Framework/Input/MidiKeyEventManager.cs
+++ b/osu.Framework/Input/MidiKeyEventManager.cs
@@ -15,7 +15,12 @@ namespace osu.Framework.Input
         {
         }
 
-        protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new MidiDownEvent(state, Button, state.Midi.Velocities[Button]));
+        protected override Drawable HandleButtonDown(InputState state, ReadOnlyInputQueue targets)
+        {
+            var midiDownEvent = new MidiDownEvent(state, Button, state.Midi.Velocities[Button]);
+
+            return PropagateButtonEvent(targets, midiDownEvent);
+        }
 
         protected override void HandleButtonUp(InputState state, List<Drawable> targets)
         {

--- a/osu.Framework/Input/PassThroughInputManager.cs
+++ b/osu.Framework/Input/PassThroughInputManager.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Graphics;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.States;
@@ -46,7 +45,7 @@ namespace osu.Framework.Input
 
         public override bool HandleHoverEvents => UseParentInput ? parentInputManager.HandleHoverEvents : base.HandleHoverEvents;
 
-        internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
+        internal override bool BuildNonPositionalInputQueue(InputQueue queue, bool allowBlocking = true)
         {
             if (!PropagateNonPositionalInputSubTree) return false;
 
@@ -58,7 +57,7 @@ namespace osu.Framework.Input
             return false;
         }
 
-        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, List<Drawable> queue)
+        internal override bool BuildPositionalInputQueue(Vector2 screenSpacePos, InputQueue queue)
         {
             if (!PropagatePositionalInputSubTree) return false;
 

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -21,8 +21,6 @@ namespace osu.Framework.Input
 
         public override IEnumerable<IKeyBinding> DefaultKeyBindings => Host.PlatformKeyBindings;
 
-        protected override bool Prioritised => true;
-
         protected override bool SendRepeats => true;
     }
 }

--- a/osu.Framework/Input/ReadOnlyInputQueue.cs
+++ b/osu.Framework/Input/ReadOnlyInputQueue.cs
@@ -1,0 +1,55 @@
+﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Extensions.ListExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Input.Bindings;
+using osu.Framework.Lists;
+
+namespace osu.Framework.Input
+{
+    /// <summary>
+    /// Holds grouped drawables for input event propagation.
+    /// </summary>
+    public class ReadOnlyInputQueue
+    {
+        protected readonly List<Drawable> AllInner;
+        protected readonly List<Drawable> RegularInner;
+        protected readonly List<KeyBindingContainer> KeyBingingContainersInner;
+
+        protected ReadOnlyInputQueue(Func<Drawable> getFocusedDrawable = null)
+        {
+            GetFocusedDrawable = getFocusedDrawable;
+
+            AllInner = new List<Drawable>();
+            RegularInner = new List<Drawable>();
+            KeyBingingContainersInner = new List<KeyBindingContainer>();
+
+            All = AllInner.AsSlimReadOnly();
+            Regular = RegularInner.AsSlimReadOnly();
+            KeyBingingContainers = KeyBingingContainersInner.AsSlimReadOnly();
+        }
+
+        /// <summary>
+        /// The currently focused <see cref="Drawable"/>. Null if there is no current focus.
+        /// </summary>
+        public readonly Func<Drawable> GetFocusedDrawable;
+
+        /// <summary>
+        /// Holds drawables that handles regular input.
+        /// </summary>
+        public readonly SlimReadOnlyListWrapper<Drawable> Regular;
+
+        /// <summary>
+        /// Holds drawables that handles key binding input.
+        /// </summary>
+        public readonly SlimReadOnlyListWrapper<KeyBindingContainer> KeyBingingContainers;
+
+        /// <summary>
+        /// Holds all drawables that handles any input
+        /// </summary>
+        public readonly SlimReadOnlyListWrapper<Drawable> All;
+    }
+}

--- a/osu.Framework/Input/TabletAuxiliaryButtonEventManager.cs
+++ b/osu.Framework/Input/TabletAuxiliaryButtonEventManager.cs
@@ -15,7 +15,12 @@ namespace osu.Framework.Input
         {
         }
 
-        protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new TabletAuxiliaryButtonPressEvent(state, Button));
+        protected override Drawable HandleButtonDown(InputState state, ReadOnlyInputQueue targets)
+        {
+            var tabletAuxiliaryButtonPressEvent = new TabletAuxiliaryButtonPressEvent(state, Button);
+
+            return PropagateButtonEvent(targets, tabletAuxiliaryButtonPressEvent);
+        }
 
         protected override void HandleButtonUp(InputState state, List<Drawable> targets)
         {

--- a/osu.Framework/Input/TabletPenButtonEventManager.cs
+++ b/osu.Framework/Input/TabletPenButtonEventManager.cs
@@ -15,7 +15,12 @@ namespace osu.Framework.Input
         {
         }
 
-        protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets) => PropagateButtonEvent(targets, new TabletPenButtonPressEvent(state, Button));
+        protected override Drawable HandleButtonDown(InputState state, ReadOnlyInputQueue targets)
+        {
+            var tabletPenButtonPressEvent = new TabletPenButtonPressEvent(state, Button);
+
+            return PropagateButtonEvent(targets, tabletPenButtonPressEvent);
+        }
 
         protected override void HandleButtonUp(InputState state, List<Drawable> targets)
         {

--- a/osu.Framework/Input/TouchEventManager.cs
+++ b/osu.Framework/Input/TouchEventManager.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Input
             PropagateButtonEvent(ButtonDownInputQueue, new TouchMoveEvent(state, new Touch(Button, position), TouchDownPosition, lastPosition));
         }
 
-        protected override Drawable HandleButtonDown(InputState state, List<Drawable> targets)
+        protected override Drawable HandleButtonDown(InputState state, ReadOnlyInputQueue targets)
         {
             Debug.Assert(HeldDrawable == null);
 
@@ -45,7 +45,9 @@ namespace osu.Framework.Input
             TouchDownPosition = state.Touch.GetTouchPosition(Button);
             Debug.Assert(TouchDownPosition != null);
 
-            return HeldDrawable = PropagateButtonEvent(targets, new TouchDownEvent(state, new Touch(Button, (Vector2)TouchDownPosition)));
+            var touchDownEvent = new TouchDownEvent(state, new Touch(Button, (Vector2)TouchDownPosition));
+
+            return HeldDrawable = PropagateButtonEvent(targets, touchDownEvent);
         }
 
         protected override void HandleButtonUp(InputState state, List<Drawable> targets)


### PR DESCRIPTION
resolves #3992 

The idea is to categorise input queue content and propagate input events in the following order:
1. Focused drawable
2. Key binding containers
3. Other drawables

Also, there is an `All` group for edge cases like building `ButtonDownInputQueue` when the event was not handled.