### PR TITLE
Make `Drawable`'s `Scheduler` acquisition lock static

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -428,7 +428,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// A lock exclusively used for initial acquisition/construction of the <see cref="Scheduler"/>.
         /// </summary>
-        private readonly object schedulerAcquisitionLock = new object();
+        private static readonly object scheduler_acquisition_lock = new object();
 
         private Scheduler scheduler;
 
@@ -443,7 +443,7 @@ namespace osu.Framework.Graphics
                 if (scheduler != null)
                     return scheduler;
 
-                lock (schedulerAcquisitionLock)
+                lock (scheduler_acquisition_lock)
                     return scheduler ??= new Scheduler(() => ThreadSafety.IsUpdateThread, Clock);
             }
         }


### PR DESCRIPTION
In profiling we have seen these `lock` objects add up. There's no reason to have one of these per drawable as the contention is so low that multiple drawables locking over a single instance should never be a problem.
