### PR TITLE
Disable SpriteText assertion on cyclic computation

### DIFF
--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -441,8 +441,6 @@ namespace osu.Framework.Graphics.Sprites
             }
         }
 
-        private bool isComputingCharacters;
-
         /// <summary>
         /// Compute character textures and positions.
         /// </summary>
@@ -461,8 +459,6 @@ namespace osu.Framework.Graphics.Sprites
 
             // Todo: Re-enable this assert after autosize is split into two passes.
             // Debug.Assert(!isComputingCharacters, "Cyclic invocation of computeCharacters()!");
-
-            isComputingCharacters = true;
 
             Vector2 textBounds = Vector2.Zero;
 
@@ -486,7 +482,6 @@ namespace osu.Framework.Graphics.Sprites
 
                 base.Width = Math.Min(base.Width, MaxWidth);
 
-                isComputingCharacters = false;
                 charactersCache.Validate();
             }
         }

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Development;
@@ -460,7 +459,9 @@ namespace osu.Framework.Graphics.Sprites
 
             charactersBacking.Clear();
 
-            Debug.Assert(!isComputingCharacters, "Cyclic invocation of computeCharacters()!");
+            // Todo: Re-enable this assert after autosize is split into two passes.
+            // Debug.Assert(!isComputingCharacters, "Cyclic invocation of computeCharacters()!");
+
             isComputingCharacters = true;
 
             Vector2 textBounds = Vector2.Zero;


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-framework/issues/3349

Autosize disallows cyclic invocations itself, so we are safe to incur an extra computation until autosize is split into two passes.