### PR TITLE
mark public CanBeNull as deprecated

### DIFF
--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -295,12 +295,12 @@ namespace osu.Framework.Tests.Dependencies
         {
         }
 
-        [Cached(Type = typeof(object))]
+        [Cached(type: typeof(object))]
         private class Provider2
         {
         }
 
-        [Cached(Type = typeof(Provider1))]
+        [Cached(type: typeof(Provider1))]
         private class Provider3 : Provider1
         {
         }
@@ -331,19 +331,19 @@ namespace osu.Framework.Tests.Dependencies
         private class Provider7
         {
             [Cached]
-            [Cached(Type = typeof(object))]
+            [Cached(type: typeof(object))]
             private ProvidedType1 provided1 = new ProvidedType1();
         }
 
         [Cached]
-        [Cached(Type = typeof(object))]
+        [Cached(type: typeof(object))]
         private class Provider8
         {
         }
 
         private class Provider9
         {
-            [Cached(Type = typeof(ProvidedType1))]
+            [Cached(type: typeof(ProvidedType1))]
             private object provided1 = new object();
         }
 
@@ -356,13 +356,13 @@ namespace osu.Framework.Tests.Dependencies
         private class Provider11
         {
             [Cached]
-            [Cached(Type = typeof(IProvidedInterface1))]
+            [Cached(type: typeof(IProvidedInterface1))]
             private IProvidedInterface1 provided1 = new ProvidedType1();
         }
 
         private class Provider12
         {
-            [Cached(Type = typeof(IProvidedInterface1))]
+            [Cached(type: typeof(IProvidedInterface1))]
             private IProvidedInterface1 provided1 = new ProvidedType3();
         }
 

--- a/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/ResolvedAttributeTest.cs
@@ -220,7 +220,7 @@ namespace osu.Framework.Tests.Dependencies
 
         private class Receiver3
         {
-            [Resolved(CanBeNull = true)]
+            [Resolved(canBeNull: true)]
             private BaseObject obj { get; set; }
         }
 
@@ -234,37 +234,37 @@ namespace osu.Framework.Tests.Dependencies
 
         private class Receiver5
         {
-            [Resolved(CanBeNull = true)]
+            [Resolved(canBeNull: true)]
             public BaseObject Obj { get; set; }
         }
 
         private class Receiver6
         {
-            [Resolved(CanBeNull = true)]
+            [Resolved(canBeNull: true)]
             public BaseObject Obj { get; protected set; }
         }
 
         private class Receiver7
         {
-            [Resolved(CanBeNull = true)]
+            [Resolved(canBeNull: true)]
             public BaseObject Obj { get; internal set; }
         }
 
         private class Receiver8
         {
-            [Resolved(CanBeNull = true)]
+            [Resolved(canBeNull: true)]
             public BaseObject Obj { get; private set; }
         }
 
         private class Receiver9
         {
-            [Resolved(CanBeNull = true)]
+            [Resolved(canBeNull: true)]
             public BaseObject Obj { get; protected internal set; }
         }
 
         private class Receiver10
         {
-            [Resolved(CanBeNull = true)]
+            [Resolved(canBeNull: true)]
             public BaseObject Obj { get; }
         }
 
@@ -292,7 +292,7 @@ namespace osu.Framework.Tests.Dependencies
 
         private class Receiver15
         {
-            [Resolved(CanBeNull = true)]
+            [Resolved(canBeNull: true)]
             public int Obj { get; private set; } = 1;
         }
 

--- a/osu.Framework/Allocation/CachedAttribute.cs
+++ b/osu.Framework/Allocation/CachedAttribute.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Allocation
         ///
         /// Then the cached type will be "DerivedType".
         /// </example>
-        public Type Type;
+        public readonly Type Type;
 
         /// <summary>
         /// The name to identify this member with.
@@ -40,7 +40,7 @@ namespace osu.Framework.Allocation
         /// <remarks>
         /// If the member is cached with a custom <see cref="CacheInfo"/> that provides a parent, the name is automatically inferred from the field/property.
         /// </remarks>
-        public string Name;
+        public readonly string Name;
 
         /// <summary>
         /// Identifies a member to be cached to a <see cref="DependencyContainer"/>.

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -45,6 +45,7 @@ namespace osu.Framework.Allocation
         /// <summary>
         /// Whether a null value can be accepted if the member doesn't exist in the cache.
         /// </summary>
+        [Obsolete("Directly setting CanBeNull is deprecated, please refrain from doing that in the future.")]
         public bool CanBeNull;
 
         /// <summary>

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -45,7 +45,7 @@ namespace osu.Framework.Allocation
         /// <summary>
         /// Whether a null value can be accepted if the member doesn't exist in the cache.
         /// </summary>
-        [Obsolete("Directly setting CanBeNull is deprecated, please refrain from doing that in the future.")]
+        [Obsolete("Directly setting CanBeNull is deprecated, please refrain from doing that in the future.", false)]
         public bool CanBeNull;
 
         /// <summary>

--- a/osu.Framework/Allocation/ResolvedAttribute.cs
+++ b/osu.Framework/Allocation/ResolvedAttribute.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Allocation
         /// <remarks>
         /// This is only set if the member was cached with a custom <see cref="CacheInfo"/>.
         /// </remarks>
-        public Type Parent;
+        public readonly Type Parent;
 
         /// <summary>
         /// The name of the cached member in the <see cref="DependencyContainer"/>.
@@ -40,13 +40,12 @@ namespace osu.Framework.Allocation
         /// <remarks>
         /// This is only set if the member was cached with a custom <see cref="CacheInfo"/>.
         /// </remarks>
-        public string Name;
+        public readonly string Name;
 
         /// <summary>
         /// Whether a null value can be accepted if the member doesn't exist in the cache.
         /// </summary>
-        [Obsolete("Directly setting CanBeNull is deprecated, please refrain from doing that in the future.", false)]
-        public bool CanBeNull;
+        public readonly bool CanBeNull;
 
         /// <summary>
         /// Identifies a member to be resolved from a <see cref="DependencyContainer"/>.

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownContainer.cs
@@ -20,8 +20,8 @@ namespace osu.Framework.Graphics.Containers.Markdown
     /// <summary>
     /// Visualises a markdown text document.
     /// </summary>
-    [Cached(Type = typeof(IMarkdownTextComponent))]
-    [Cached(Type = typeof(IMarkdownTextFlowComponent))]
+    [Cached(type: typeof(IMarkdownTextComponent))]
+    [Cached(type: typeof(IMarkdownTextFlowComponent))]
     public class MarkdownContainer : CompositeDrawable, IMarkdownTextComponent, IMarkdownTextFlowComponent
     {
         private const int root_level = 0;

--- a/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
@@ -30,7 +30,7 @@ namespace osu.Framework.Graphics.Containers
             safeAreaPadding.BindTo(safeArea.SafeAreaPadding);
         }
 
-        [Resolved(CanBeNull = true)]
+        [Resolved(canBeNull: true)]
         private ISafeArea safeArea { get; set; }
 
         /// <summary>

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -40,7 +40,7 @@ namespace osu.Framework.Input
         /// </summary>
         private const int repeat_tick_rate = 70;
 
-        [Resolved(CanBeNull = true)]
+        [Resolved(canBeNull:true)]
         protected GameHost Host { get; private set; }
 
         /// <summary>


### PR DESCRIPTION
This will mark the currently public `CanBeNull` attribute of `ResolvedAttribute` as deprecated, as this should become private at some point in the future and this change is breaking.

closes #3849 