### PR TITLE
Fix glyph edge interpolation for non-transparent pixels

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
@@ -22,6 +22,7 @@ namespace osu.Framework.Tests.Visual.Sprites
     {
         public TestSceneSpriteIcon()
         {
+            Box background;
             FillFlowContainer flow;
 
             Add(new TooltipContainer
@@ -29,7 +30,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                 RelativeSizeAxes = Axes.Both,
                 Children = new Drawable[]
                 {
-                    new Box
+                    background = new Box
                     {
                         Colour = Color4.Teal,
                         RelativeSizeAxes = Axes.Both,
@@ -43,6 +44,7 @@ namespace osu.Framework.Tests.Visual.Sprites
                             Origin = Anchor.TopRight,
                             RelativeSizeAxes = Axes.X,
                             AutoSizeAxes = Axes.Y,
+                            Spacing = new Vector2(5),
                             Direction = FillDirection.Full,
                         },
                     }
@@ -72,6 +74,7 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             AddStep("toggle shadows", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.Shadow = !i.SpriteIcon.Shadow));
             AddStep("change icons", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.Icon = new IconUsage((char)(i.SpriteIcon.Icon.Icon + 1))));
+            AddStep("white background", () => background.FadeColour(Color4.White, 200));
         }
 
         private class Icon : Container, IHasTooltip

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
@@ -49,9 +49,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
             var data = upload.Data;
 
-            uploadCornerPadding(data, middleBounds, actualPadding);
-            uploadHorizontalPadding(data, middleBounds, actualPadding);
-            uploadVerticalPadding(data, middleBounds, actualPadding);
+            uploadCornerPadding(data, middleBounds, actualPadding, wrapModeS != WrapMode.None && wrapModeT != WrapMode.None);
+            uploadHorizontalPadding(data, middleBounds, actualPadding, wrapModeS != WrapMode.None);
+            uploadVerticalPadding(data, middleBounds, actualPadding, wrapModeT != WrapMode.None);
 
             // Upload the middle part of the texture
             // For a texture atlas, we don't care about opacity, so we avoid
@@ -59,7 +59,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             base.SetData(upload, wrapModeS, wrapModeT, Opacity.Mixed);
         }
 
-        private void uploadVerticalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding)
+        private void uploadVerticalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
         {
             RectangleI[] sideBoundsArray =
             {
@@ -92,7 +92,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                             Rgba32 pixel = upload[index + x];
                             allTransparent &= checkEdgeRGB(pixel);
 
-                            transferBorderPixel(ref data[y * sideBounds.Width + x], pixel);
+                            transferBorderPixel(ref data[y * sideBounds.Width + x], pixel, fillOpaque);
                         }
                     }
 
@@ -107,7 +107,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
-        private void uploadHorizontalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding)
+        private void uploadHorizontalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
         {
             RectangleI[] sideBoundsArray =
             {
@@ -143,7 +143,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
                             allTransparent &= checkEdgeRGB(pixel);
 
-                            transferBorderPixel(ref data[y * sideBounds.Width + x], pixel);
+                            transferBorderPixel(ref data[y * sideBounds.Width + x], pixel, fillOpaque);
                         }
                     }
 
@@ -158,7 +158,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
-        private void uploadCornerPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding)
+        private void uploadCornerPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
         {
             RectangleI[] cornerBoundsArray =
             {
@@ -189,7 +189,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                     var data = cornerUpload.RawData;
 
                     for (int j = 0; j < nCornerPixels; ++j)
-                        transferBorderPixel(ref data[j], pixel);
+                        transferBorderPixel(ref data[j], pixel, fillOpaque);
 
                     // For a texture atlas, we don't care about opacity, so we avoid
                     // any computations related to it by assuming it to be mixed.
@@ -199,14 +199,12 @@ namespace osu.Framework.Graphics.OpenGL.Textures
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void transferBorderPixel(ref Rgba32 dest, Rgba32 source)
+        private void transferBorderPixel(ref Rgba32 dest, Rgba32 source, bool fillOpaque)
         {
             dest.R = source.R;
             dest.G = source.G;
             dest.B = source.B;
-            // in the case the adjacent pixel is solid, we presume that it should interpolate to itself (creating a hard edge).
-            // in the case of pixels with transparency it makes more sense to interpolate to nothing.
-            dest.A = source.A < 255 ? (byte)0 : source.A;
+            dest.A = fillOpaque ? source.A : (byte)0;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
@@ -49,9 +49,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
             var data = upload.Data;
 
-            uploadCornerPadding(data, middleBounds, actualPadding);
-            uploadHorizontalPadding(data, middleBounds, actualPadding);
-            uploadVerticalPadding(data, middleBounds, actualPadding);
+            uploadCornerPadding(data, middleBounds, actualPadding, wrapModeS != WrapMode.None && wrapModeT != WrapMode.None);
+            uploadHorizontalPadding(data, middleBounds, actualPadding, wrapModeS != WrapMode.None);
+            uploadVerticalPadding(data, middleBounds, actualPadding, wrapModeT != WrapMode.None);
 
             // Upload the middle part of the texture
             // For a texture atlas, we don't care about opacity, so we avoid
@@ -59,7 +59,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             base.SetData(upload, wrapModeS, wrapModeT, Opacity.Mixed);
         }
 
-        private void uploadVerticalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding)
+        private void uploadVerticalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
         {
             RectangleI[] sideBoundsArray =
             {
@@ -92,8 +92,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                             Rgba32 pixel = upload[index + x];
                             allTransparent &= checkEdgeRGB(pixel);
 
-                            // fill the padding with a transparent version of the adjacent pixel.
-                            pixel.A = 0;
+                            if (!fillOpaque)
+                                pixel.A = 0;
+
                             data[y * sideBounds.Width + x] = pixel;
                         }
                     }
@@ -109,7 +110,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
-        private void uploadHorizontalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding)
+        private void uploadHorizontalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
         {
             RectangleI[] sideBoundsArray =
             {
@@ -144,8 +145,9 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                             Rgba32 pixel = upload[index + y * stride];
                             allTransparent &= checkEdgeRGB(pixel);
 
-                            // fill the padding with a transparent version of the adjacent pixel.
-                            pixel.A = 0;
+                            if (!fillOpaque)
+                                pixel.A = 0;
+
                             data[y * sideBounds.Width + x] = pixel;
                         }
                     }
@@ -161,7 +163,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
-        private void uploadCornerPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding)
+        private void uploadCornerPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding, bool fillOpaque)
         {
             RectangleI[] cornerBoundsArray =
             {
@@ -188,7 +190,8 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 // Only upload if we have a non-zero size and if the colour isn't already transparent white
                 if (nCornerPixels > 0 && !checkEdgeRGB(cornerPixel))
                 {
-                    cornerPixel.A = 0;
+                    if (!fillOpaque)
+                        cornerPixel.A = 0;
 
                     var cornerUpload = new MemoryAllocatorTextureUpload(cornerBounds.Width, cornerBounds.Height) { Bounds = cornerBounds };
                     var data = cornerUpload.RawData;

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLAtlas.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
+using System.Runtime.CompilerServices;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Textures;
 using osuTK.Graphics.ES30;
@@ -20,10 +22,10 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         private readonly RectangleI atlasBounds;
 
-        private static readonly Rgba32 transparent_black = new Rgba32(0, 0, 0, 0);
+        private static readonly Rgba32 initialisation_colour = default;
 
         public TextureGLAtlas(int width, int height, bool manualMipmaps, All filteringMode = All.Linear, int padding = 0)
-            : base(width, height, manualMipmaps, filteringMode)
+            : base(width, height, manualMipmaps, filteringMode, initialisationColour: initialisation_colour)
         {
             this.padding = padding;
 
@@ -45,14 +47,11 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
             int actualPadding = padding / (1 << upload.Level);
 
-            if (wrapModeS != WrapMode.None && wrapModeT != WrapMode.None)
-                uploadCornerPadding(upload, middleBounds, actualPadding);
+            var data = upload.Data;
 
-            if (wrapModeS != WrapMode.None)
-                uploadHorizontalPadding(upload, middleBounds, actualPadding);
-
-            if (wrapModeT != WrapMode.None)
-                uploadVerticalPadding(upload, middleBounds, actualPadding);
+            uploadCornerPadding(data, middleBounds, actualPadding);
+            uploadHorizontalPadding(data, middleBounds, actualPadding);
+            uploadVerticalPadding(data, middleBounds, actualPadding);
 
             // Upload the middle part of the texture
             // For a texture atlas, we don't care about opacity, so we avoid
@@ -60,7 +59,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             base.SetData(upload, wrapModeS, wrapModeT, Opacity.Mixed);
         }
 
-        private void uploadVerticalPadding(ITextureUpload upload, RectangleI middleBounds, int actualPadding)
+        private void uploadVerticalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding)
         {
             RectangleI[] sideBoundsArray =
             {
@@ -80,23 +79,27 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
                 if (!sideBounds.IsEmpty)
                 {
-                    bool allTransparentBlack = true;
+                    bool allTransparent = true;
                     int index = sideIndices[i];
 
                     var sideUpload = new MemoryAllocatorTextureUpload(sideBounds.Width, sideBounds.Height) { Bounds = sideBounds };
+                    var data = sideUpload.RawData;
 
                     for (int y = 0; y < sideBounds.Height; ++y)
                     {
                         for (int x = 0; x < sideBounds.Width; ++x)
                         {
-                            Rgba32 pixel = upload.Data[index + x];
-                            allTransparentBlack &= pixel == transparent_black;
-                            sideUpload.RawData[y * sideBounds.Width + x] = pixel;
+                            Rgba32 pixel = upload[index + x];
+                            allTransparent &= checkEdgeRGB(pixel);
+
+                            // fill the padding with a transparent version of the adjacent pixel.
+                            pixel.A = 0;
+                            data[y * sideBounds.Width + x] = pixel;
                         }
                     }
 
                     // Only upload padding if the border isn't completely transparent.
-                    if (!allTransparentBlack)
+                    if (!allTransparent)
                     {
                         // For a texture atlas, we don't care about opacity, so we avoid
                         // any computations related to it by assuming it to be mixed.
@@ -106,7 +109,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
-        private void uploadHorizontalPadding(ITextureUpload upload, RectangleI middleBounds, int actualPadding)
+        private void uploadHorizontalPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding)
         {
             RectangleI[] sideBoundsArray =
             {
@@ -126,10 +129,11 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
                 if (!sideBounds.IsEmpty)
                 {
-                    bool allTransparentBlack = true;
+                    bool allTransparent = true;
                     int index = sideIndices[i];
 
                     var sideUpload = new MemoryAllocatorTextureUpload(sideBounds.Width, sideBounds.Height) { Bounds = sideBounds };
+                    var data = sideUpload.RawData;
 
                     int stride = middleBounds.Width;
 
@@ -137,14 +141,17 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                     {
                         for (int x = 0; x < sideBounds.Width; ++x)
                         {
-                            Rgba32 pixel = upload.Data[index + y * stride];
-                            allTransparentBlack &= pixel == transparent_black;
-                            sideUpload.RawData[y * sideBounds.Width + x] = pixel;
+                            Rgba32 pixel = upload[index + y * stride];
+                            allTransparent &= checkEdgeRGB(pixel);
+
+                            // fill the padding with a transparent version of the adjacent pixel.
+                            pixel.A = 0;
+                            data[y * sideBounds.Width + x] = pixel;
                         }
                     }
 
                     // Only upload padding if the border isn't completely transparent.
-                    if (!allTransparentBlack)
+                    if (!allTransparent)
                     {
                         // For a texture atlas, we don't care about opacity, so we avoid
                         // any computations related to it by assuming it to be mixed.
@@ -154,7 +161,7 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             }
         }
 
-        private void uploadCornerPadding(ITextureUpload upload, RectangleI middleBounds, int actualPadding)
+        private void uploadCornerPadding(ReadOnlySpan<Rgba32> upload, RectangleI middleBounds, int actualPadding)
         {
             RectangleI[] cornerBoundsArray =
             {
@@ -176,14 +183,18 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             {
                 RectangleI cornerBounds = cornerBoundsArray[i];
                 int nCornerPixels = cornerBounds.Width * cornerBounds.Height;
-                Rgba32 cornerPixel = upload.Data[cornerIndices[i]];
+                Rgba32 cornerPixel = upload[cornerIndices[i]];
 
-                // Only upload if we have a non-zero size and if the colour isn't already transparent black
-                if (nCornerPixels > 0 && cornerPixel != transparent_black)
+                // Only upload if we have a non-zero size and if the colour isn't already transparent white
+                if (nCornerPixels > 0 && !checkEdgeRGB(cornerPixel))
                 {
+                    cornerPixel.A = 0;
+
                     var cornerUpload = new MemoryAllocatorTextureUpload(cornerBounds.Width, cornerBounds.Height) { Bounds = cornerBounds };
+                    var data = cornerUpload.RawData;
+
                     for (int j = 0; j < nCornerPixels; ++j)
-                        cornerUpload.RawData[j] = cornerPixel;
+                        data[j] = cornerPixel;
 
                     // For a texture atlas, we don't care about opacity, so we avoid
                     // any computations related to it by assuming it to be mixed.
@@ -191,5 +202,14 @@ namespace osu.Framework.Graphics.OpenGL.Textures
                 }
             }
         }
+
+        /// <summary>
+        /// Check whether the provided upload edge pixel's RGB components match the initialisation colour.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool checkEdgeRGB(Rgba32 cornerPixel)
+            => cornerPixel.R == initialisation_colour.R
+               && cornerPixel.G == initialisation_colour.G
+               && cornerPixel.B == initialisation_colour.B;
     }
 }


### PR DESCRIPTION
Uploading glyphs, which are usually `rgba(255,255,255,x)` to a texture atlas initialised with `rgba(0,0,0,0)` would cause incorrect interpolation of edge pixels in the case where a glyph has a non-zero alpha value.

I attempted to fix this in multiple different ways, but the solution here is the best combination of being performant and future-proof. A faster method would be to change the initialisation colour of the texture atlas in the case of glyph stores and call it a day, but this would break any potential usages where a user has fonts with colour data.

Note that the new `initialisationColour` flow is (in the end) unused in this PR, but I've left it in place for potential future usage and clarity as to what is going on. If you want to test the performance of the alternative method (initialising with transparent white) you can do so by changing only the `initialisation_colour` constant in `TextureGLAtlas` (and commenting out the padding upload methods if you want to avoid the performance incurrence they carry).

In some quick testing, the overhead of this is negligible now that the span retrieval is outside of the loops. This turned out to be a huge performance concern (as you might expect) and is probably also the reason for https://github.com/ppy/osu-framework/blob/58eea16f51b401f4138986a80c19467d7e0cca55/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs#L153, but that's for another day.

Cross-tested with `TestSceneWrapModes` to ensure the expectations there have not been altered.

Before:

![20210806 163431 (dotnet)](https://user-images.githubusercontent.com/191335/128474150-75f6a7f0-9044-4b8c-82fc-61ade1ebf03d.png)

After:

![20210806 163455 (dotnet)](https://user-images.githubusercontent.com/191335/128474200-81a3d877-5b9e-4301-9225-6ad9f8809c45.png)

Before:

![20210806 163725 (dotnet)](https://user-images.githubusercontent.com/191335/128474514-a52a87ef-5f57-4465-9958-3e46393ed31a.png)

After:

![20210806 163848 (dotnet)](https://user-images.githubusercontent.com/191335/128474666-807b8224-3a85-4cf8-9c94-ce4e81999df7.png)

---

If unsure about what is going on, here's some further details to hopefully ease review:

You can visualise the edges that are being drawn/interpolated to by altering the transfer function:

```csharp
        [MethodImpl(MethodImplOptions.AggressiveInlining)]
        private void transferBorderPixel(ref Rgba32 dest, Rgba32 source)
        {
            dest.R = 255;
            dest.G = 0;
            dest.B = 0;
            dest.A = 255;
        }
```

This branch:
![20210806 170403 (dotnet)](https://user-images.githubusercontent.com/191335/128477821-ea1aedd9-7c7a-4c66-904b-7a7970965826.png)
![20210806 170626 (dotnet)](https://user-images.githubusercontent.com/191335/128478153-3bd37611-4b7e-452b-a8c8-1fcc0666a941.png)

With the `initialisation_colour` change mentioned above:
![20210806 170456 (dotnet)](https://user-images.githubusercontent.com/191335/128477940-c60f9157-1517-42c9-8194-b374b2328ab1.png)
![20210806 170545 (dotnet)](https://user-images.githubusercontent.com/191335/128478062-b93e8dbb-48e2-4cb8-aa1d-3da196c55c57.png)

Notice that with the `initialisation_colour` change it causes less of the border/padding uploads, which may be something we should investigate in the future (potentially better performance due to the "normal" case of glyph uploads requiring less uploads? but it does also incur a small i# overhead to initialise the `Image`).