### PR TITLE
Migrate track BASS sync usages to mixer infrastructure

### DIFF
--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -202,23 +202,23 @@ namespace osu.Framework.Audio.Mixing.Bass
             => BassMix.ChannelGetData(channel.Handle, buffer, length);
 
         /// <summary>
-        /// Sets up a synchronizer on a mixer source channel.
+        /// Sets up a synchroniser on a mixer source channel.
         /// </summary>
         /// <remarks>See: <see cref="ManagedBass.Mix.BassMix.ChannelSetSync(int, SyncFlags, long, SyncProcedure, IntPtr)"/>.</remarks>
-        /// <param name="channel">The <see cref="IBassAudioChannel"/> to set up the synchronizer for.</param>
+        /// <param name="channel">The <see cref="IBassAudioChannel"/> to set up the synchroniser for.</param>
         /// <param name="type">The type of sync.</param>
         /// <param name="parameter">The sync parameters, depending on the sync type.</param>
         /// <param name="procedure">The callback function which should be invoked with the sync.</param>
         /// <param name="user">User instance data to pass to the callback function.</param>
-        /// <returns>If successful, then the new synchronizer's handle is returned, else 0 is returned. Use <see cref="P:ManagedBass.Bass.LastError" /> to get the error code.</returns>
+        /// <returns>If successful, then the new synchroniser's handle is returned, else 0 is returned. Use <see cref="P:ManagedBass.Bass.LastError" /> to get the error code.</returns>
         public int ChannelSetSync(IBassAudioChannel channel, SyncFlags type, long parameter, SyncProcedure procedure, IntPtr user = default)
             => BassMix.ChannelSetSync(channel.Handle, type, parameter, procedure, user);
 
         /// <summary>
-        /// Removes a synchronizer from a mixer source channel.
+        /// Removes a synchroniser from a mixer source channel.
         /// </summary>
-        /// <param name="channel">The <see cref="IBassAudioChannel"/> to remove the synchronizer for.</param>
-        /// <param name="sync">Handle of the synchronizer to remove (return value of a previous <see cref="M:ManagedBass.Mix.BassMix.ChannelSetSync(System.Int32,ManagedBass.SyncFlags,System.Int64,ManagedBass.SyncProcedure,System.IntPtr)" /> call).</param>
+        /// <param name="channel">The <see cref="IBassAudioChannel"/> to remove the synchroniser for.</param>
+        /// <param name="sync">Handle of the synchroniser to remove (return value of a previous <see cref="M:ManagedBass.Mix.BassMix.ChannelSetSync(System.Int32,ManagedBass.SyncFlags,System.Int64,ManagedBass.SyncProcedure,System.IntPtr)" /> call).</param>
         /// <returns>If successful, <see langword="true" /> is returned, else <see langword="false" /> is returned. Use <see cref="P:ManagedBass.Bass.LastError" /> to get the error code.</returns>
         public bool ChannelRemoveSync(IBassAudioChannel channel, int sync)
             => BassMix.ChannelRemoveSync(channel.Handle, sync);

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -202,6 +202,28 @@ namespace osu.Framework.Audio.Mixing.Bass
             => BassMix.ChannelGetData(channel.Handle, buffer, length);
 
         /// <summary>
+        /// Sets up a synchronizer on a mixer source channel.
+        /// </summary>
+        /// <remarks>See: <see cref="ManagedBass.Mix.BassMix.ChannelSetSync(int, SyncFlags, long, SyncProcedure, IntPtr)"/>.</remarks>
+        /// <param name="channel">The <see cref="IBassAudioChannel"/> to set up the synchronizer for.</param>
+        /// <param name="type">The type of sync.</param>
+        /// <param name="parameter">The sync parameters, depending on the sync type.</param>
+        /// <param name="procedure">The callback function which should be invoked with the sync.</param>
+        /// <param name="user">User instance data to pass to the callback function.</param>
+        /// <returns>If successful, then the new synchronizer's handle is returned, else 0 is returned. Use <see cref="P:ManagedBass.Bass.LastError" /> to get the error code.</returns>
+        public int ChannelSetSync(IBassAudioChannel channel, SyncFlags type, long parameter, SyncProcedure procedure, IntPtr user = default)
+            => BassMix.ChannelSetSync(channel.Handle, type, parameter, procedure, user);
+
+        /// <summary>
+        /// Removes a synchronizer from a mixer source channel.
+        /// </summary>
+        /// <param name="channel">The <see cref="IBassAudioChannel"/> to remove the synchronizer for.</param>
+        /// <param name="sync">Handle of the synchronizer to remove (return value of a previous <see cref="M:ManagedBass.Mix.BassMix.ChannelSetSync(System.Int32,ManagedBass.SyncFlags,System.Int64,ManagedBass.SyncProcedure,System.IntPtr)" /> call).</param>
+        /// <returns>If successful, <see langword="true" /> is returned, else <see langword="false" /> is returned. Use <see cref="P:ManagedBass.Bass.LastError" /> to get the error code.</returns>
+        public bool ChannelRemoveSync(IBassAudioChannel channel, int sync)
+            => BassMix.ChannelRemoveSync(channel.Handle, sync);
+
+        /// <summary>
         /// Frees a channel's resources.
         /// </summary>
         /// <param name="channel">The <see cref="IBassAudioChannel"/> to free.</param>

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -15,6 +15,7 @@ using osu.Framework.Audio.Callbacks;
 using osu.Framework.Audio.Mixing;
 using osu.Framework.Audio.Mixing.Bass;
 using osu.Framework.Extensions.ObjectExtensions;
+using osu.Framework.Utils;
 
 namespace osu.Framework.Audio.Track
 {
@@ -50,9 +51,12 @@ namespace osu.Framework.Audio.Track
         private double lastSeekablePosition;
 
         private FileCallbacks? fileCallbacks;
-        private SyncCallback? endMixtimeCallback;
+
         private SyncCallback? stopCallback;
         private SyncCallback? endCallback;
+
+        private int? stopSync;
+        private int? endSync;
 
         private volatile bool isLoaded;
 
@@ -110,26 +114,6 @@ namespace osu.Framework.Audio.Track
 
                     // Bass does not allow seeking to the end of the track, so the last available position is 1 sample before.
                     lastSeekablePosition = Bass.ChannelBytes2Seconds(activeStream, byteLength - BYTES_PER_SAMPLE) * 1000;
-
-                    stopCallback = new SyncCallback((a, b, c, d) => RaiseFailed());
-                    endCallback = new SyncCallback((a, b, c, d) =>
-                    {
-                        if (Looping) return;
-
-                        hasCompleted = true;
-                        RaiseCompleted();
-                    });
-                    endMixtimeCallback = new SyncCallback((a, b, c, d) =>
-                    {
-                        // this is separate from the above callback as this is required to be invoked on mixtime.
-                        // see "BASS_SYNC_MIXTIME" part of http://www.un4seen.com/doc/#bass/BASS_ChannelSetSync.html for reason why.
-                        if (Looping)
-                            seekInternal(RestartPoint);
-                    });
-
-                    Bass.ChannelSetSync(activeStream, SyncFlags.Stop, 0, stopCallback.Callback, stopCallback.Handle);
-                    Bass.ChannelSetSync(activeStream, SyncFlags.End, 0, endCallback.Callback, endCallback.Handle);
-                    Bass.ChannelSetSync(activeStream, SyncFlags.End | SyncFlags.Mixtime, 0, endMixtimeCallback.Callback, endMixtimeCallback.Handle);
 
                     isLoaded = true;
 
@@ -356,6 +340,56 @@ namespace osu.Framework.Audio.Track
 
         public override ChannelAmplitudes CurrentAmplitudes => (bassAmplitudeProcessor ??= new BassAmplitudeProcessor(this)).CurrentAmplitudes;
 
+        private void initializeSyncs()
+        {
+            Debug.Assert(stopCallback == null
+                         && stopSync == null
+                         && endCallback == null
+                         && endSync == null);
+
+            stopCallback = new SyncCallback((a, b, c, d) => RaiseFailed());
+            endCallback = new SyncCallback((a, b, c, d) =>
+            {
+                if (Looping)
+                {
+                    // because the sync callback doesn't necessarily fire in the right moment and the transition may not always be smooth,
+                    // do not attempt to seek back to restart point if it is 0, and defer to the channel loop flag instead.
+                    // a mixtime callback was used for this previously, but it is incompatible with mixers
+                    // (as they have a playback buffer, and so a skip forward would be audible).
+                    if (Precision.DefinitelyBigger(RestartPoint, 0, 1))
+                        seekInternal(RestartPoint);
+
+                    return;
+                }
+
+                hasCompleted = true;
+                RaiseCompleted();
+            });
+
+            stopSync = bassMixer.ChannelSetSync(this, SyncFlags.Stop, 0, stopCallback.Callback, stopCallback.Handle);
+            endSync = bassMixer.ChannelSetSync(this, SyncFlags.End, 0, endCallback.Callback, endCallback.Handle);
+        }
+
+        private void cleanUpSyncs()
+        {
+            Debug.Assert(stopCallback != null
+                         && stopSync != null
+                         && endCallback != null
+                         && endSync != null);
+
+            bassMixer.ChannelRemoveSync(this, stopSync.Value);
+            bassMixer.ChannelRemoveSync(this, endSync.Value);
+
+            stopSync = null;
+            endSync = null;
+
+            stopCallback.Dispose();
+            stopCallback = null;
+
+            endCallback.Dispose();
+            endCallback = null;
+        }
+
         #region Mixing
 
         protected override AudioMixer? Mixer
@@ -363,11 +397,21 @@ namespace osu.Framework.Audio.Track
             get => base.Mixer;
             set
             {
+                // While BASS cleans up syncs automatically on mixer change, ManagedBass internally tracks the sync procedures via ChannelReferences, so clean up eagerly for safety.
+                if (Mixer != null)
+                    cleanUpSyncs();
+
                 base.Mixer = value;
 
-                // Tracks are always active until they're disposed, so they need to be added to the mix prematurely for operations like Seek() to work immediately.
                 // The mixer can be null in this case, if set via Dispose() / bassMixer.StreamFree(this).
-                (Mixer as BassAudioMixer)?.AddChannelToBassMix(this);
+                if (Mixer != null)
+                {
+                    // Tracks are always active until they're disposed, so they need to be added to the mix prematurely for operations like Seek() to work immediately.
+                    bassMixer.AddChannelToBassMix(this);
+
+                    // Syncs are not automatically moved on mixer change, so restore them on the new mixer manually.
+                    initializeSyncs();
+                }
             }
         }
 
@@ -412,9 +456,6 @@ namespace osu.Framework.Audio.Track
 
             endCallback?.Dispose();
             endCallback = null;
-
-            endMixtimeCallback?.Dispose();
-            endMixtimeCallback = null;
 
             base.Dispose(disposing);
         }


### PR DESCRIPTION
* Fixes #4670 (mostly)
* Fixes #4671

PRing for comment / CI verification. Tests passed locally.

As stated in the issues above, there is a dedicated mixer function for syncs and the above two issues were caused by not using it. Caveats:

* The syncs are manually unregistered and re-registered on each mixer change. The first is not necessarily required, but I decided to do it for safety, as [ManagedBass internally tracks callbacks](https://github.com/ManagedBass/ManagedBass/blob/0d46c12a8a9bdf8ceffdf60950cbb905cd5719b7/src/AddOns/BassMix/BassMix.cs#L773-L784), so I wasn't entirely comfortable with reusing the callbacks or leaving their unregistration to BASS.
* The mixtime stop sync is replaced by a standard sync. This is intentional, because due to mixer playback buffering the mixtime sync was causing loops to audibly loop back to a later time instant than intended (causing #4670). Not using a mixtime sync means that now there may be a gap in the loop, but this is mostly a matter of choosing your own poison at this point, if you will.

This *may* also do something for https://github.com/ppy/osu/issues/14162 but it is unclear as that issue does not have many details.