### PR TITLE
Flush audio mixer on critical BASS operations (seek/stop)

### DIFF
--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -170,11 +170,11 @@ namespace osu.Framework.Tests.Audio
         public void TestRestart()
         {
             startPlaybackAt(1000);
-            takeEffectsAndUpdateAfter(50);
 
+            Thread.Sleep(50);
+
+            bass.Update();
             restartTrack();
-
-            takeEffectsAndUpdateAfter(50);
 
             Assert.IsTrue(track.IsRunning);
             Assert.Less(track.CurrentTime, 1000);
@@ -198,10 +198,9 @@ namespace osu.Framework.Tests.Audio
         public void TestRestartFromRestartPoint()
         {
             track.RestartPoint = 1000;
-            startPlaybackAt(3000);
 
+            startPlaybackAt(3000);
             restartTrack();
-            takeEffectsAndUpdateAfter(50);
 
             Assert.IsTrue(track.IsRunning);
             Assert.GreaterOrEqual(track.CurrentTime, 1000);
@@ -311,12 +310,13 @@ namespace osu.Framework.Tests.Audio
 
             // now set to zero frequency and update track to take effects.
             track.Frequency.Value = 0;
-            takeEffectsAndUpdateAfter(50);
+            bass.Update();
 
             var currentTime = track.CurrentTime;
 
             // assert time is frozen after 50ms sleep and didn't change with full precision, but "IsRunning" is still true.
-            takeEffectsAndUpdateAfter(50);
+            Thread.Sleep(50);
+            bass.Update();
 
             Assert.IsTrue(track.IsRunning);
             Assert.AreEqual(currentTime, track.CurrentTime);
@@ -374,8 +374,6 @@ namespace osu.Framework.Tests.Audio
             bass.Update();
 
             bass.RunOnAudioThread(() => track.Seek(20000));
-            takeEffectsAndUpdateAfter(50);
-
             Assert.That(track.CurrentTime, Is.EqualTo(20000).Within(100));
         }
 

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -374,7 +374,9 @@ namespace osu.Framework.Tests.Audio
             bass.Update();
 
             bass.RunOnAudioThread(() => track.Seek(20000));
-            Assert.That(track.CurrentTime, Is.EqualTo(20000).Within(500));
+            takeEffectsAndUpdateAfter(50);
+
+            Assert.That(track.CurrentTime, Is.EqualTo(20000).Within(100));
         }
 
         private void takeEffectsAndUpdateAfter(int after)

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -287,13 +287,13 @@ namespace osu.Framework.Tests.Audio
 
             // ensure seeking to end doesn't reset completed state.
             track.SeekAsync(track.Length);
-            takeEffectsAndUpdateAfter(50);
+            bass.Update();
 
             Assert.IsTrue(track.HasCompleted);
 
             // seeking back reset completed state.
-            track.SeekAsync(0);
-            takeEffectsAndUpdateAfter(50);
+            track.SeekAsync(track.Length - 1);
+            bass.Update();
 
             Assert.IsFalse(track.HasCompleted);
         }

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -374,8 +374,6 @@ namespace osu.Framework.Tests.Audio
             bass.Update();
 
             bass.RunOnAudioThread(() => track.Seek(20000));
-            takeEffectsAndUpdateAfter(50);
-
             Assert.That(track.CurrentTime, Is.EqualTo(20000).Within(500));
         }
 

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -112,7 +112,12 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// If successful, <see langword="true"/> is returned, else <see langword="false"/> is returned.
         /// Use <see cref="ManagedBass.Bass.LastError"/> to get the error code.
         /// </returns>
-        public bool ChannelPause(IBassAudioChannel channel) => BassMix.ChannelAddFlag(channel.Handle, BassFlags.MixerChanPause);
+        public bool ChannelPause(IBassAudioChannel channel)
+        {
+            bool result = BassMix.ChannelAddFlag(channel.Handle, BassFlags.MixerChanPause);
+            flush();
+            return result;
+        }
 
         /// <summary>
         /// Stops a channel.
@@ -125,8 +130,9 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// </returns>
         public bool ChannelStop(IBassAudioChannel channel)
         {
-            BassMix.ChannelAddFlag(channel.Handle, BassFlags.MixerChanPause);
-            return ManagedBass.Bass.ChannelSetPosition(channel.Handle, 0); // resets position and also flushes buffer
+            bool result = BassMix.ChannelAddFlag(channel.Handle, BassFlags.MixerChanPause);
+            flush();
+            return result;
         }
 
         /// <summary>
@@ -172,7 +178,11 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// Use <see cref="P:ManagedBass.Bass.LastError"/> to get the error code.
         /// </returns>
         public bool ChannelSetPosition(IBassAudioChannel channel, long position, PositionFlags mode = PositionFlags.Bytes)
-            => BassMix.ChannelSetPosition(channel.Handle, position, mode);
+        {
+            bool result = BassMix.ChannelSetPosition(channel.Handle, position, mode);
+            flush();
+            return result;
+        }
 
         /// <summary>
         /// Retrieves the level (peak amplitude) of a channel.
@@ -398,6 +408,15 @@ namespace osu.Framework.Audio.Mixing.Bass
                 }
             }
         });
+
+        /// <summary>
+        /// Flushes the mixer.
+        /// </summary>
+        private void flush()
+        {
+            if (Handle != 0)
+                ManagedBass.Bass.ChannelSetPosition(Handle, 0);
+        }
 
         protected override void Dispose(bool disposing)
         {


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/14184

This reverts all the changes to this test which were made in https://github.com/ppy/osu-framework/pull/4291.

It seems like the proper way is to flush the mixer, by setting its position to 0: http://www.un4seen.com/forum/?topic=6895.msg46426#msg46426
I've applied this to `ChannelSetPosition()` and to `ChannelStop()` (already had the flush) and `ChannelPause()`. The latter of which seems to be more required for stopping playback upon 0 frequency for `TestZeroFrequencyHandling`.

Tested over 100 times locally with no test failures, and can't repro the osu!-side issue after these changes.