### PR TITLE
Disable audio mixer channel ramping

### DIFF
--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -305,7 +305,7 @@ namespace osu.Framework.Audio.Mixing.Bass
             Debug.Assert(Handle != 0);
             Debug.Assert(channel.Handle != 0);
 
-            BassFlags flags = BassFlags.MixerChanBuffer;
+            BassFlags flags = BassFlags.MixerChanBuffer | BassFlags.MixerChanNoRampin;
             if (channel.MixerChannelPaused)
                 flags |= BassFlags.MixerChanPause;
 

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -191,7 +191,6 @@ namespace osu.Framework.Audio.Sample
             if (!hasChannel)
                 return;
 
-            Bass.ChannelSetAttribute(channel, ChannelAttribute.NoRamp, 1);
             setLoopFlag(Looping);
 
             relativeFrequencyHandler.SetChannel(channel);


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/14199

`NoRamp` flag was being applied to the (incorrect) decoding channel.