### PR TITLE
Pause channels on seek from a stopped state

### DIFF
--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -179,6 +179,9 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// </returns>
         public bool ChannelSetPosition(IBassAudioChannel channel, long position, PositionFlags mode = PositionFlags.Bytes)
         {
+            if (ChannelIsActive(channel) == PlaybackState.Stopped)
+                ChannelPause(channel);
+
             bool result = BassMix.ChannelSetPosition(channel.Handle, position, mode);
             flush();
             return result;

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -179,6 +179,9 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// </returns>
         public bool ChannelSetPosition(IBassAudioChannel channel, long position, PositionFlags mode = PositionFlags.Bytes)
         {
+            // All BASS channels enter a stopped state once they reach the end.
+            // Non-decoding channels remain in the stopped state when seeked afterwards, however decoding channels are put back into a playing state which causes audio to play.
+            // Thus, on seek, in order to reproduce the expectations set out by non-decoding channels, manually pause the mixer channel when the decoding channel is stopped.
             if (ChannelIsActive(channel) == PlaybackState.Stopped)
                 ChannelPause(channel);
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/14214

Decoding channels enter the `PlaybackState.Stopped` state when they reach the end, but are resumed into the `PlaybackState.Playing` state once seeked backwards. This is contrary to our expectation that the channel remains in a stopped state.

This change pauses the mixer channel on seeks while in the stopped state in order to match expectations.