### PR TITLE
Fix localisation overhead in `SpriteText` / `LocalisedBindableString`

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkLocalisedBindableString.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLocalisedBindableString.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Configuration;
+using osu.Framework.Localisation;
+using osu.Framework.Tests;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkLocalisedBindableString
+    {
+        private LocalisationManager manager;
+        private TemporaryNativeStorage storage;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            storage = new TemporaryNativeStorage(new Guid().ToString());
+            manager = new LocalisationManager(new FrameworkConfigManager(storage));
+        }
+
+        [GlobalCleanup]
+        public void GlobalCleanup()
+        {
+            storage.Dispose();
+        }
+
+        [Benchmark]
+        public void BenchmarkNonLocalised()
+        {
+            var bindable = manager.GetLocalisedString("test");
+            bindable.UnbindAll();
+        }
+
+        [Benchmark]
+        public void BenchmarkLocalised()
+        {
+            var bindable = manager.GetLocalisedString(new TranslatableString("test", "test"));
+            bindable.UnbindAll();
+        }
+    }
+}

--- a/osu.Framework/Localisation/LocalisationManager.cs
+++ b/osu.Framework/Localisation/LocalisationManager.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Localisation
         /// Creates an <see cref="ILocalisedBindableString"/> which automatically updates its text according to information provided in <see cref="ILocalisedBindableString.Text"/>.
         /// </summary>
         /// <returns>The <see cref="ILocalisedBindableString"/>.</returns>
-        public ILocalisedBindableString GetLocalisedString(LocalisableString original) => new LocalisedBindableString(original, currentParameters);
+        public ILocalisedBindableString GetLocalisedString(LocalisableString original) => new LocalisedBindableString(original, this);
 
         private void updateLocale(ValueChangedEvent<string> locale)
         {

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -11,16 +11,16 @@ namespace osu.Framework.Localisation
     {
         private class LocalisedBindableString : Bindable<string>, ILocalisedBindableString
         {
-            private readonly IBindable<LocalisationParameters> parameters = new Bindable<LocalisationParameters>();
+            private IBindable<LocalisationParameters> parameters;
 
             private LocalisableString text;
 
-            public LocalisedBindableString(LocalisableString text, IBindable<LocalisationParameters> parameters)
+            private readonly LocalisationManager manager;
+
+            public LocalisedBindableString(LocalisableString text, LocalisationManager manager)
             {
                 this.text = text;
-
-                this.parameters.BindTo(parameters);
-                this.parameters.BindValueChanged(_ => updateValue());
+                this.manager = manager;
 
                 updateValue();
             }
@@ -34,6 +34,13 @@ namespace osu.Framework.Localisation
                         break;
 
                     case ILocalisableStringData data:
+                        if (parameters == null)
+                        {
+                            parameters = new Bindable<LocalisationParameters>();
+                            parameters.BindTo(manager.currentParameters);
+                            parameters.BindValueChanged(_ => updateValue());
+                        }
+
                         Value = data.GetLocalised(parameters.Value);
                         break;
 

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -55,6 +55,16 @@ namespace osu.Framework.Localisation
                     updateValue();
                 }
             }
+
+            internal override void UnbindAllInternal()
+            {
+                base.UnbindAllInternal();
+
+                // optimisation to ensure cleanup happens aggressively.
+                // without this, the central parameters bindable's internal WeakList can balloon out of control due to the
+                // weak reference cleanup only occurring on Value retrieval (which rarely/never happens in this case).
+                parameters?.UnbindAll();
+            }
         }
     }
 }


### PR DESCRIPTION
master:

**benchmark will not complete** (performance consistently degrades enough from the `WeakList` overhead that benchmark.net will not allow it).

### with only `UnbindAll` commit (https://github.com/ppy/osu-framework/commit/a2ff29a183b4173de8229cd41521d2651a8f8fa2)

|                Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |---------:|---------:|---------:|-------:|------:|------:|----------:|
| BenchmarkNonLocalised | 827.4 ns |  9.59 ns |  8.01 ns | 0.0591 |     - |     - |     680 B |
|    BenchmarkLocalised | 939.9 ns | 14.54 ns | 11.35 ns | 0.0668 |     - |     - |     776 B |


### also with lazy binding commit (https://github.com/ppy/osu-framework/commit/59a4b8920359143a226a457849f4c3921e635959):

|                Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|---------------------- |----------:|----------:|----------:|-------:|------:|------:|----------:|
| BenchmarkNonLocalised |  68.50 ns |  1.397 ns |  1.307 ns | 0.0131 |     - |     - |     152 B |
|    BenchmarkLocalised | 919.32 ns | 18.094 ns | 16.925 ns | 0.0677 |     - |     - |     784 B |

the extra 8 bytes here is the reference to `LocalisationManager`.

Closes #4679.

I *think* the benchmark not completing on master is enough by way of testing, but we could add proper testing by exposing some internals of `WeakList` if thats required.