### PR TITLE
Reduce amount of audio mixer flushes

### DIFF
--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -120,22 +120,6 @@ namespace osu.Framework.Audio.Mixing.Bass
         }
 
         /// <summary>
-        /// Stops a channel.
-        /// </summary>
-        /// <remarks>See: <see cref="ManagedBass.Bass.ChannelStop"/>.</remarks>
-        /// <param name="channel">The channel to stop.</param>
-        /// <returns>
-        /// If successful, <see langword="true"/> is returned, else <see langword="false"/> is returned.
-        /// Use <see cref="ManagedBass.Bass.LastError"/> to get the error code.
-        /// </returns>
-        public bool ChannelStop(IBassAudioChannel channel)
-        {
-            bool result = BassMix.ChannelAddFlag(channel.Handle, BassFlags.MixerChanPause);
-            flush();
-            return result;
-        }
-
-        /// <summary>
         /// Checks if a channel is active (playing) or stalled.
         /// </summary>
         /// <remarks>See: <see cref="ManagedBass.Bass.ChannelIsActive"/>.</remarks>

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -108,14 +108,22 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// </summary>
         /// <remarks>See: <see cref="ManagedBass.Bass.ChannelPause"/>.</remarks>
         /// <param name="channel">The channel to pause.</param>
+        /// <param name="flushMixer">Set to <c>true</c> to make the pause take effect immediately.
+        /// <para>
+        /// This will change the timing of <see cref="ChannelGetPosition"/>, so should be used sparingly.
+        /// </para>
+        /// </param>
         /// <returns>
         /// If successful, <see langword="true"/> is returned, else <see langword="false"/> is returned.
         /// Use <see cref="ManagedBass.Bass.LastError"/> to get the error code.
         /// </returns>
-        public bool ChannelPause(IBassAudioChannel channel)
+        public bool ChannelPause(IBassAudioChannel channel, bool flushMixer = false)
         {
             bool result = BassMix.ChannelAddFlag(channel.Handle, BassFlags.MixerChanPause);
-            flush();
+
+            if (flushMixer)
+                flush();
+
             return result;
         }
 
@@ -167,10 +175,13 @@ namespace osu.Framework.Audio.Mixing.Bass
             // Non-decoding channels remain in the stopped state when seeked afterwards, however decoding channels are put back into a playing state which causes audio to play.
             // Thus, on seek, in order to reproduce the expectations set out by non-decoding channels, manually pause the mixer channel when the decoding channel is stopped.
             if (ChannelIsActive(channel) == PlaybackState.Stopped)
-                ChannelPause(channel);
+                ChannelPause(channel, true);
 
             bool result = BassMix.ChannelSetPosition(channel.Handle, position, mode);
+
+            // Perform a flush so that ChannelGetPosition() immediately returns the new value.
             flush();
+
             return result;
         }
 
@@ -400,8 +411,11 @@ namespace osu.Framework.Audio.Mixing.Bass
         });
 
         /// <summary>
-        /// Flushes the mixer.
+        /// Flushes the mixer, causing pause and seek events to take effect immediately.
         /// </summary>
+        /// <remarks>
+        /// This will change the timing of <see cref="ChannelGetPosition"/>, so should be used sparingly.
+        /// </remarks>
         private void flush()
         {
             if (Handle != 0)

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -215,7 +215,7 @@ namespace osu.Framework.Audio.Track
             isPlayed = false;
         });
 
-        private bool stopInternal() => isRunningState(bassMixer.ChannelIsActive(this)) && bassMixer.ChannelPause(this);
+        private bool stopInternal() => isRunningState(bassMixer.ChannelIsActive(this)) && bassMixer.ChannelPause(this, true);
 
         private int direction;
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/14262

Previously, stopping `SampleChannel`s would cause the mixer to get flushed. This would occur when slider sliding samples were stopped in particular: https://github.com/ppy/osu/blob/00ca066c39a66a31ade67b8ad33be8f57d377b7b/osu.Game.Rulesets.Osu/Objects/Drawables/DrawableSlider.cs#L136-L148  

Flushing messes with `ChannelGetPosition()`, as one would expect, causing it (and the `Track`'s current time) jump to a more up-to-date value. Unlike `Track`s, this is not useful for `SampleChannel`s due to the lack of a way to seek or retrieve their current time.

Gameplay comparison via `FrameStabilityContainer` logging:
Pre-bassmix: [runtime-old.log](https://github.com/ppy/osu/files/6979490/runtime-old.log)
Post-bassmix: [runtime-new.log](https://github.com/ppy/osu/files/6979491/runtime-new.log)
This PR: [fixed.log](https://github.com/ppy/osu-framework/files/6979601/fixed.log)