### PR TITLE
Introduce HandleModifier properties

### DIFF
--- a/osu.Framework.Tests/Visual/Audio/TestSceneTrackAdjustments.cs
+++ b/osu.Framework.Tests/Visual/Audio/TestSceneTrackAdjustments.cs
@@ -182,6 +182,8 @@ namespace osu.Framework.Tests.Visual.Audio
             private void updateLocal(ValueChangedEvent<double> obj) =>
                 textLocal.Text = $"local: vol {audio.Volume.Value:F1} freq {audio.Frequency.Value:F1} tempo {audio.Tempo.Value:F1} bal {audio.Balance.Value:F1}";
 
+            public override bool HandleControl => true;
+
             protected override void OnDrag(DragEvent e)
             {
                 Position += e.Delta;

--- a/osu.Framework/Graphics/Containers/TabbableContainer.cs
+++ b/osu.Framework/Graphics/Containers/TabbableContainer.cs
@@ -36,6 +36,8 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         public CompositeDrawable TabbableContentContainer { private get; set; }
 
+        public override bool HandleShift => true;
+
         protected override bool OnKeyDown(KeyDownEvent e)
         {
             if (TabbableContentContainer == null || e.Key != Key.Tab)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2362,6 +2362,26 @@ namespace osu.Framework.Graphics
         public virtual bool HandlePositionalInput => RequestsPositionalInput;
 
         /// <summary>
+        /// Whether this <see cref="Drawable"/> handles input when <see cref="Key.LControl"/> or <see cref="Key.RControl"/> is pressed
+        /// </summary>
+        public virtual bool HandleControl => false;
+
+        /// <summary>
+        /// Whether this <see cref="Drawable"/> handles input when <see cref="Key.LAlt"/> or <see cref="Key.RAlt"/> is pressed
+        /// </summary>
+        public virtual bool HandleAlt => false;
+
+        /// <summary>
+        /// Whether this <see cref="Drawable"/> handles input when <see cref="Key.LShift"/> or <see cref="Key.RShift"/> is pressed
+        /// </summary>
+        public virtual bool HandleShift => false;
+
+        /// <summary>
+        /// Whether this <see cref="Drawable"/> handles input when <see cref="Key.LWin"/> or <see cref="Key.RWin"/> is pressed
+        /// </summary>
+        public virtual bool HandleSuper => false;
+
+        /// <summary>
         /// Nested class which is used for caching <see cref="Drawable.HandleNonPositionalInput"/>, <see cref="Drawable.HandlePositionalInput"/> values obtained via reflection.
         /// </summary>
         private static class HandleInputCache

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -210,6 +210,8 @@ namespace osu.Framework.Graphics.UserInterface
             return true;
         }
 
+        public override bool HandleShift => true;
+
         private void handleMouseInput(UIEvent e)
         {
             var xPosition = ToLocalSpace(e.ScreenSpaceMousePosition).X - RangePadding;

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -774,9 +774,6 @@ namespace osu.Framework.Graphics.UserInterface
         {
             if (textInput?.ImeActive == true || ReadOnly) return true;
 
-            if (e.ControlPressed || e.SuperPressed || e.AltPressed)
-                return false;
-
             // we only care about keys which can result in text output.
             if (keyProducesCharacter(e.Key))
                 BeginConsumingText();

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -105,6 +105,8 @@ namespace osu.Framework.Graphics.Visualisation
             return base.OnKeyDown(e);
         }
 
+        public override bool HandleControl => true;
+
         protected override void OnKeyUp(KeyUpEvent e)
         {
             if (!e.ControlPressed)

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -84,6 +84,14 @@ namespace osu.Framework.Input.Bindings
         /// </summary>
         protected virtual bool Prioritised => false;
 
+        public override bool HandleControl => true;
+
+        public override bool HandleAlt => true;
+
+        public override bool HandleShift => true;
+
+        public override bool HandleSuper => true;
+
         internal override bool BuildNonPositionalInputQueue(List<Drawable> queue, bool allowBlocking = true)
         {
             if (!base.BuildNonPositionalInputQueue(queue, allowBlocking))

--- a/osu.Framework/Input/ButtonEventManager.cs
+++ b/osu.Framework/Input/ButtonEventManager.cs
@@ -114,7 +114,11 @@ namespace osu.Framework.Input
         /// <returns>The drawable which handled the event or null if none.</returns>
         protected Drawable PropagateButtonEvent(IEnumerable<Drawable> drawables, UIEvent e)
         {
-            var handledBy = drawables.FirstOrDefault(target => target.TriggerEvent(e));
+            var handledBy = drawables.FirstOrDefault(target => (!e.ControlPressed || target.HandleControl)
+                                                               && (!e.AltPressed || target.HandleAlt)
+                                                               && (!e.ShiftPressed || target.HandleShift)
+                                                               && (!e.SuperPressed || target.HandleSuper)
+                                                               && target.TriggerEvent(e));
 
             if (handledBy != null)
                 Logger.Log($"{e} handled by {handledBy}.", LoggingTarget.Runtime, LogLevel.Debug);


### PR DESCRIPTION
resolves #3992

Since the problem is mainly about modifier keys(Ctrl, Alt, Shift, Win), I have added `HandleCtrl`/`HandleAlt`/`HandleShift`/`HandleSuper` properties to the `Drawable` class. They are used to determine whether a button input event should be propagated to a drawable if the corresponding modifier is pressed.

Known issues:
1. `ScrollEvent`. It may [depend on a modifier state](https://github.com/ppy/osu/blob/7654df94f6f37b8382be7dfcb4f674e03bd35427/osu.Game/Graphics/Containers/OsuScrollContainer.cs#L105), but it is propagated by an `InputManager`. It probably should support new properties, but I haven't figured how to do it yet.