### PR TITLE
Drop float flag from audio mixer

### DIFF
--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -279,7 +279,7 @@ namespace osu.Framework.Audio.Mixing.Bass
             if (!ManagedBass.Bass.GetDeviceInfo(ManagedBass.Bass.CurrentDevice, out var deviceInfo) || !deviceInfo.IsInitialized)
                 return;
 
-            Handle = BassMix.CreateMixerStream(frequency, 2, BassFlags.MixerNonStop | BassFlags.Float);
+            Handle = BassMix.CreateMixerStream(frequency, 2, BassFlags.MixerNonStop);
             if (Handle == 0)
                 return;
 


### PR DESCRIPTION
In a similar way as https://github.com/ppy/osu-framework/pull/2128, hoping this re-fixes the issue for macOS users that have been experiencing it since https://github.com/ppy/osu-framework/pull/4291.

If it does, I'll add myself a todo to follow up with un4seen.