### PR TITLE
Disable timeout in until-steps when debugger attached

### DIFF
--- a/osu.Framework/Testing/Drawables/Steps/UntilStepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/UntilStepButton.cs
@@ -50,7 +50,7 @@ namespace osu.Framework.Testing.Drawables.Steps
                     success = true;
                     Success();
                 }
-                else if (elapsedTime.ElapsedMilliseconds >= max_attempt_milliseconds)
+                else if (!Debugger.IsAttached && elapsedTime.ElapsedMilliseconds >= max_attempt_milliseconds)
                     throw new TimeoutException($"\"{Text}\" timed out");
 
                 Action?.Invoke();


### PR DESCRIPTION
Helps me not lose my sanity. Closes #4464 