### PR TITLE
Add fallback path if AppContext.BaseDirectory is null

### DIFF
--- a/osu.Framework/RuntimeInfo.cs
+++ b/osu.Framework/RuntimeInfo.cs
@@ -13,7 +13,7 @@ namespace osu.Framework
         /// <summary>
         /// The absolute path to the startup directory of this game.
         /// </summary>
-        public static string StartupDirectory { get; } = AppContext.BaseDirectory;
+        public static string StartupDirectory => AppContext.BaseDirectory ?? Environment.GetFolderPath(Environment.SpecialFolder.Personal);
 
         /// <summary>
         /// Returns the absolute path of osu.Framework.dll.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/6507

### PR Description: 
This PR is a simple fix to the long standing "Could not load rulesets from directory" error that appears on some (if not all?) Android devices apon every boot of the game. This apparently was being caused by https://github.com/xamarin/xamarin-android/issues/3489: TL;DR `AppContext.BaseDirectory` currently returns null on Android, and as `LoadFromDisk()` in RulesetStore.cs was the only function I noticed that relied on that heavily, it was the only one mainly affected.

### Fix:
`RuntimeInfo.StartupDirectory` continues to return `AppContext.BaseDirectory` by default, meaning nothing current should change, while now returning `Environment.SpecialFolder.Personal` if BaseDirectory is null. This is equivalent to the path `/data/user/0/sh.ppy.osulazer/files` on Android.

### References:
Xamarin implementation of `Environment.SpecialFolder`:
https://docs.microsoft.com/en-us/xamarin/android/platform/files/

### Tested Platforms:

- [x] Windows - Win10 21H1
- [x] MacOS - No change, `AppContext.BaseDirectory` returns correct path
- [x] Linux - Linux Mint, fully updated
- [x] Android - Hardware: Android Oreo and Android 11 (S7 Active and S20 FE)
- [x] iOS - No change, `AppContext.BaseDirectory` returns correct path (tested on separate project because iOS is broken here)

### Additional Notes:
- Given the issue at hand, I believe https://github.com/ppy/osu/issues/6507 is a candidate for transfer to this repo
- I am open to suggestions, including "Why is this PR so long for a one line change?"