### PR TITLE
Mark scrollbar drag-sourced scrolls as user scrolls

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -374,7 +374,7 @@ namespace osu.Framework.Graphics.Containers
             return true;
         }
 
-        private void onScrollbarMovement(float value) => scrollTo(Clamp(fromScrollbarPosition(value)), false);
+        private void onScrollbarMovement(float value) => OnUserScroll(Clamp(fromScrollbarPosition(value)), false);
 
         /// <summary>
         /// Immediately offsets the current and target scroll position.


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/14413.

Scrollbar scrolls were not marked as "user" scrolls, therefore breaking the game-side `UserScrollTrackingContainer`'s logic.

No tests included because there's not much to test in framework without moving the container here, pretty much. Which I can do on request, just wasn't sure if it's worth it.