### PR TITLE
Fix HSV colour picker shaders not working on GL ES

### DIFF
--- a/osu.Framework/Resources/Shaders/sh_HueSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_HueSelectorBackground.fs
@@ -5,6 +5,6 @@ varying mediump vec4 v_TexRect;
 
 void main(void)
 {
-    float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
+    float hueValue = v_TexCoord.x / (v_TexRect.z - v_TexRect.x);
     gl_FragColor = hsv2rgb(vec4(hueValue, 1, 1, 1));
 }

--- a/osu.Framework/Resources/Shaders/sh_HueSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_HueSelectorBackground.fs
@@ -1,6 +1,6 @@
 #include "sh_Utils.h"
 
-varying mediump vec2 v_TexCoord;
+varying highp vec2 v_TexCoord;
 varying mediump vec4 v_TexRect;
 
 void main(void)

--- a/osu.Framework/Resources/Shaders/sh_HueSelectorBackgroundRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_HueSelectorBackgroundRounded.fs
@@ -5,6 +5,6 @@ varying highp vec2 v_TexCoord;
 
 void main(void)
 {
-    float hueValue = v_TexCoord.x / (v_TexRect[2] - v_TexRect[0]);
+    float hueValue = v_TexCoord.x / (v_TexRect.z - v_TexRect.x);
     gl_FragColor = getRoundedColor(hsv2rgb(vec4(hueValue, 1, 1, 1)), v_TexCoord);
 }

--- a/osu.Framework/Resources/Shaders/sh_HueSelectorBackgroundRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_HueSelectorBackgroundRounded.fs
@@ -1,7 +1,7 @@
 #include "sh_Utils.h"
 #include "sh_Masking.h"
 
-varying mediump vec2 v_TexCoord;
+varying highp vec2 v_TexCoord;
 
 void main(void)
 {

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
@@ -1,6 +1,6 @@
 #include "sh_Utils.h"
 
-varying mediump vec2 v_TexCoord;
+varying highp vec2 v_TexCoord;
 varying mediump vec4 v_TexRect;
 
 uniform mediump float hue;

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackground.fs
@@ -7,7 +7,7 @@ uniform mediump float hue;
 
 void main(void)
 {
-    vec2 resolution = vec2(v_TexRect[2] - v_TexRect[0], v_TexRect[3] - v_TexRect[1]);
+    vec2 resolution = v_TexRect.zw - v_TexRect.xy;
     vec2 pixelPos = v_TexCoord / resolution;
     gl_FragColor = hsv2rgb(vec4(hue, pixelPos.x, 1.0 - pixelPos.y, 1.0));
 }

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackgroundRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackgroundRounded.fs
@@ -1,7 +1,7 @@
 #include "sh_Utils.h"
 #include "sh_Masking.h"
 
-varying mediump vec2 v_TexCoord;
+varying highp vec2 v_TexCoord;
 
 uniform mediump float hue;
 

--- a/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackgroundRounded.fs
+++ b/osu.Framework/Resources/Shaders/sh_SaturationSelectorBackgroundRounded.fs
@@ -7,7 +7,7 @@ uniform mediump float hue;
 
 void main(void)
 {
-    vec2 resolution = vec2(v_TexRect[2] - v_TexRect[0], v_TexRect[3] - v_TexRect[1]);
+    vec2 resolution = v_TexRect.zw - v_TexRect.xy;
     vec2 pixelPos = v_TexCoord / resolution;
     gl_FragColor = getRoundedColor(hsv2rgb(vec4(hue, pixelPos.x, 1.0 - pixelPos.y, 1.0)), v_TexCoord);
 }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/14383.

Seemingly the cause was insufficient precision of `v_TexCoord` which is rectified by cc626cc.

11c755a is sort of unrelated but after reading the shader code after a while it felt weird/unidiomatic to use array indices so I opted to swizzle instead. Likely to end up being faster in the saturation selector case at least (although I don't claim to have benchmarked).