### PR TITLE
Restructure `TextFlowContainer` to be backed by collection of `ITextPart`s

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneTextFlowContainer.cs
@@ -4,10 +4,13 @@
 using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Extensions.Color4Extensions;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Testing;
+using osuTK;
 using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Containers
@@ -71,5 +74,55 @@ namespace osu.Framework.Tests.Visual.Containers
             AddStep("add text", () => textContainer.AddText("added text"));
             AddAssert("children have correct anchors", () => textContainer.Children.All(c => c.Anchor == Anchor.TopCentre && c.Origin == Anchor.TopCentre));
         }
+
+        [Test]
+        public void TestSetText()
+        {
+            AddStep("set text", () => textContainer.Text = "first text");
+            AddAssert("text flow has 2 sprite texts", () => textContainer.ChildrenOfType<SpriteText>().Count() == 2);
+
+            AddStep("set text", () => textContainer.Text = "second text");
+            AddAssert("text flow has 2 sprite texts", () => textContainer.ChildrenOfType<SpriteText>().Count() == 2);
+        }
+
+        [Test]
+        public void TestPartManagement()
+        {
+            ITextPart part = null;
+
+            AddStep("clear text", () => textContainer.Clear());
+            assertSpriteTextCount(0);
+
+            AddStep("add text", () => part = textContainer.AddText("this is some text"));
+            AddStep("set text colour to red manually", () => part.Drawables.ForEach(p => p.Colour = Colour4.Red));
+            assertSpriteTextCount(4);
+
+            AddStep("add more text", () => textContainer.AddText("and some more of it too"));
+            assertSpriteTextCount(10);
+
+            AddStep("add manual drawable", () => textContainer.AddPart(new TextPartManual(new[]
+            {
+                new SpriteIcon
+                {
+                    Icon = FontAwesome.Regular.Clipboard,
+                    Size = new Vector2(16)
+                }
+            })));
+            assertSpriteTextCount(10);
+            assertTotalChildCount(11);
+
+            AddStep("remove original text", () => textContainer.RemovePart(part));
+            assertSpriteTextCount(6);
+            assertTotalChildCount(7);
+
+            AddStep("clear text", () => textContainer.Clear());
+            assertSpriteTextCount(0);
+        }
+
+        private void assertSpriteTextCount(int count)
+            => AddAssert($"text flow has {count} sprite texts", () => textContainer.ChildrenOfType<SpriteText>().Count() == count);
+
+        private void assertTotalChildCount(int count)
+            => AddAssert($"text flow has {count} children", () => textContainer.Count == count);
     }
 }

--- a/osu.Framework/Graphics/Containers/CustomizableTextChunk.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextChunk.cs
@@ -1,0 +1,134 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using osu.Framework.Graphics.Sprites;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// Implementation of <see cref="TextChunk"/> that support substitution of text placeholders for arbitrary placeholders
+    /// as provided by <see cref="CustomizableTextContainer.TryGetIconFactory"/>.
+    /// </summary>
+    internal class CustomizableTextChunk : TextChunk
+    {
+        public CustomizableTextChunk(string text, bool newLineIsParagraph, Action<SpriteText> creationParameters = null)
+            : base(text, newLineIsParagraph, creationParameters)
+        {
+        }
+
+        protected override IEnumerable<Drawable> CreateDrawablesFor(TextFlowContainer textFlowContainer)
+        {
+            var customizableContainer = (CustomizableTextContainer)textFlowContainer;
+
+            if (!NewLineIsParagraph)
+            {
+                var newLine = new TextNewLine(true);
+                customizableContainer.AddPart(newLine);
+            }
+
+            var sprites = new List<Drawable>();
+            int index = 0;
+            string str = Text;
+
+            while (index < str.Length)
+            {
+                Drawable placeholderDrawable = null;
+                int nextPlaceholderIndex = str.IndexOf(CustomizableTextContainer.UNESCAPED_LEFT, index, StringComparison.Ordinal);
+                // make sure we skip ahead to the next [ as long as the current [ is escaped
+                while (nextPlaceholderIndex != -1 && str.IndexOf(CustomizableTextContainer.ESCAPED_LEFT, nextPlaceholderIndex, StringComparison.Ordinal) == nextPlaceholderIndex)
+                    nextPlaceholderIndex = str.IndexOf(CustomizableTextContainer.UNESCAPED_LEFT, nextPlaceholderIndex + 2, StringComparison.Ordinal);
+
+                string strPiece = null;
+
+                if (nextPlaceholderIndex != -1)
+                {
+                    int placeholderEnd = str.IndexOf(CustomizableTextContainer.UNESCAPED_RIGHT, nextPlaceholderIndex, StringComparison.Ordinal);
+                    // make sure we skip  ahead to the next ] as long as the current ] is escaped
+                    while (placeholderEnd != -1 && str.IndexOf(CustomizableTextContainer.ESCAPED_RIGHT, placeholderEnd, StringComparison.InvariantCulture) == placeholderEnd)
+                        placeholderEnd = str.IndexOf(CustomizableTextContainer.UNESCAPED_RIGHT, placeholderEnd + 2, StringComparison.Ordinal);
+
+                    if (placeholderEnd != -1)
+                    {
+                        strPiece = str[index..nextPlaceholderIndex];
+                        string placeholderStr = str.AsSpan(nextPlaceholderIndex + 1, placeholderEnd - nextPlaceholderIndex - 1).Trim().ToString();
+                        string placeholderName = placeholderStr;
+                        string paramStr = "";
+                        int parensOpen = placeholderStr.IndexOf('(');
+
+                        if (parensOpen != -1)
+                        {
+                            placeholderName = placeholderStr.AsSpan(0, parensOpen).Trim().ToString();
+                            int parensClose = placeholderStr.IndexOf(')', parensOpen);
+                            if (parensClose != -1)
+                                paramStr = placeholderStr.AsSpan(parensOpen + 1, parensClose - parensOpen - 1).Trim().ToString();
+                            else
+                                throw new ArgumentException($"Missing ) in placeholder {placeholderStr}.");
+                        }
+
+                        if (int.TryParse(placeholderStr, out int placeholderIndex))
+                        {
+                            if (placeholderIndex < 0)
+                                throw new ArgumentException($"Negative placeholder indices are invalid. Index {placeholderIndex} was used.");
+
+                            placeholderDrawable = customizableContainer.Placeholders.ElementAtOrDefault(placeholderIndex);
+                            if (placeholderDrawable == null)
+                                throw new ArgumentException($"Placeholder with index {placeholderIndex} is null, or {placeholderIndex} is outside the bounds of allowable placeholder indices.");
+                        }
+                        else
+                        {
+                            object[] args;
+
+                            if (string.IsNullOrWhiteSpace(paramStr))
+                            {
+                                args = Array.Empty<object>();
+                            }
+                            else
+                            {
+                                string[] argStrs = paramStr.Split(',');
+                                args = new object[argStrs.Length];
+
+                                for (int i = 0; i < argStrs.Length; ++i)
+                                {
+                                    if (!int.TryParse(argStrs[i], out int argVal))
+                                        throw new ArgumentException($"The argument \"{argStrs[i]}\" in placeholder {placeholderStr} is not an integer.");
+
+                                    args[i] = argVal;
+                                }
+                            }
+
+                            if (!customizableContainer.TryGetIconFactory(placeholderName, out Delegate cb))
+                                throw new ArgumentException($"There is no placeholder named {placeholderName}.");
+
+                            placeholderDrawable = (Drawable)cb.DynamicInvoke(args);
+                        }
+
+                        index = placeholderEnd + 1;
+                    }
+                }
+
+                if (strPiece == null)
+                {
+                    strPiece = str.Substring(index);
+                    index = str.Length;
+                }
+
+                // unescape stuff
+                strPiece = CustomizableTextContainer.Unescape(strPiece);
+                sprites.AddRange(base.CreateDrawablesFor(strPiece, textFlowContainer));
+
+                if (placeholderDrawable != null)
+                {
+                    if (placeholderDrawable.Parent != null)
+                        throw new ArgumentException("All icons used by a customizable text container must not have a parent. If you get this error message it means one of your icon factories created a drawable that was already added to another parent, or you used a drawable as a placeholder that already has another parent or you used an index-based placeholder (like [2]) more than once.");
+
+                    sprites.Add(placeholderDrawable);
+                }
+            }
+
+            return sprites;
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CustomizableTextChunk.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextChunk.cs
@@ -19,19 +19,13 @@ namespace osu.Framework.Graphics.Containers
         {
         }
 
-        protected override IEnumerable<Drawable> CreateDrawablesFor(TextFlowContainer textFlowContainer)
+        protected override IEnumerable<Drawable> CreateDrawablesFor(string text, TextFlowContainer textFlowContainer)
         {
             var customizableContainer = (CustomizableTextContainer)textFlowContainer;
 
-            if (!NewLineIsParagraph)
-            {
-                var newLine = new TextNewLine(true);
-                customizableContainer.AddPart(newLine);
-            }
-
             var sprites = new List<Drawable>();
             int index = 0;
-            string str = Text;
+            string str = text;
 
             while (index < str.Length)
             {

--- a/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -11,21 +12,22 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     public class CustomizableTextContainer : TextFlowContainer
     {
-        private const string unescaped_left = "[";
-        private const string escaped_left = "[[";
+        internal const string UNESCAPED_LEFT = "[";
+        internal const string ESCAPED_LEFT = "[[";
 
-        private const string unescaped_right = "]";
-        private const string escaped_right = "]]";
+        internal const string UNESCAPED_RIGHT = "]";
+        internal const string ESCAPED_RIGHT = "]]";
 
-        public static string Escape(string text) => text.Replace(unescaped_left, escaped_left).Replace(unescaped_right, escaped_right);
+        public static string Escape(string text) => text.Replace(UNESCAPED_LEFT, ESCAPED_LEFT).Replace(UNESCAPED_RIGHT, ESCAPED_RIGHT);
 
-        public static string Unescape(string text) => text.Replace(escaped_left, unescaped_left).Replace(escaped_right, unescaped_right);
+        public static string Unescape(string text) => text.Replace(ESCAPED_LEFT, UNESCAPED_LEFT).Replace(ESCAPED_RIGHT, UNESCAPED_RIGHT);
 
         /// <summary>
         /// Sets the placeholders that should be used to replace the numeric placeholders, in the order given.
         /// </summary>
         public IEnumerable<Drawable> Placeholders
         {
+            get => placeholders;
             set
             {
                 if (value == null)
@@ -79,111 +81,15 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="factory">The factory method creating drawables.</param>
         protected void AddIconFactory(string name, Func<int, int, Drawable> factory) => iconFactories.Add(name, factory);
 
-        internal override IEnumerable<Drawable> AddLine(TextChunk chunk)
-        {
-            if (!chunk.NewLineIsParagraph)
-                AddInternal(new NewLineContainer(true));
+        /// <summary>
+        /// Attempts to retrieve an icon factory matching the placeholder with the given <paramref name="name"/>.
+        /// </summary>
+        /// <param name="name">The name of the placeholder.</param>
+        /// <param name="iconFactory">The icon factory matching <paramref name="name"/>, if the method returned <see langword="true"/>.</param>
+        /// <returns>Whether an icon factory was found for the given <paramref name="name"/>.</returns>
+        internal bool TryGetIconFactory(string name, out Delegate iconFactory) => iconFactories.TryGetValue(name, out iconFactory);
 
-            var sprites = new List<Drawable>();
-            int index = 0;
-            string str = chunk.Text;
-
-            while (index < str.Length)
-            {
-                Drawable placeholderDrawable = null;
-                int nextPlaceholderIndex = str.IndexOf(unescaped_left, index, StringComparison.Ordinal);
-                // make sure we skip ahead to the next [ as long as the current [ is escaped
-                while (nextPlaceholderIndex != -1 && str.IndexOf(escaped_left, nextPlaceholderIndex, StringComparison.Ordinal) == nextPlaceholderIndex)
-                    nextPlaceholderIndex = str.IndexOf(unescaped_left, nextPlaceholderIndex + 2, StringComparison.Ordinal);
-
-                string strPiece = null;
-
-                if (nextPlaceholderIndex != -1)
-                {
-                    int placeholderEnd = str.IndexOf(unescaped_right, nextPlaceholderIndex, StringComparison.Ordinal);
-                    // make sure we skip  ahead to the next ] as long as the current ] is escaped
-                    while (placeholderEnd != -1 && str.IndexOf(escaped_right, placeholderEnd, StringComparison.InvariantCulture) == placeholderEnd)
-                        placeholderEnd = str.IndexOf(unescaped_right, placeholderEnd + 2, StringComparison.Ordinal);
-
-                    if (placeholderEnd != -1)
-                    {
-                        strPiece = str[index..nextPlaceholderIndex];
-                        string placeholderStr = str.AsSpan(nextPlaceholderIndex + 1, placeholderEnd - nextPlaceholderIndex - 1).Trim().ToString();
-                        string placeholderName = placeholderStr;
-                        string paramStr = "";
-                        int parensOpen = placeholderStr.IndexOf('(');
-
-                        if (parensOpen != -1)
-                        {
-                            placeholderName = placeholderStr.AsSpan(0, parensOpen).Trim().ToString();
-                            int parensClose = placeholderStr.IndexOf(')', parensOpen);
-                            if (parensClose != -1)
-                                paramStr = placeholderStr.AsSpan(parensOpen + 1, parensClose - parensOpen - 1).Trim().ToString();
-                            else
-                                throw new ArgumentException($"Missing ) in placeholder {placeholderStr}.");
-                        }
-
-                        if (int.TryParse(placeholderStr, out int placeholderIndex))
-                        {
-                            if (placeholderIndex >= placeholders.Count)
-                                throw new ArgumentException($"This text has {placeholders.Count} placeholders. But placeholder with index {placeholderIndex} was used.");
-                            if (placeholderIndex < 0)
-                                throw new ArgumentException($"Negative placeholder indices are invalid. Index {placeholderIndex} was used.");
-
-                            placeholderDrawable = placeholders[placeholderIndex];
-                        }
-                        else
-                        {
-                            object[] args;
-
-                            if (string.IsNullOrWhiteSpace(paramStr))
-                            {
-                                args = Array.Empty<object>();
-                            }
-                            else
-                            {
-                                string[] argStrs = paramStr.Split(',');
-                                args = new object[argStrs.Length];
-
-                                for (int i = 0; i < argStrs.Length; ++i)
-                                {
-                                    if (!int.TryParse(argStrs[i], out int argVal))
-                                        throw new ArgumentException($"The argument \"{argStrs[i]}\" in placeholder {placeholderStr} is not an integer.");
-
-                                    args[i] = argVal;
-                                }
-                            }
-
-                            if (!iconFactories.TryGetValue(placeholderName, out Delegate cb))
-                                throw new ArgumentException($"There is no placeholder named {placeholderName}.");
-
-                            placeholderDrawable = (Drawable)cb.DynamicInvoke(args);
-                        }
-
-                        index = placeholderEnd + 1;
-                    }
-                }
-
-                if (strPiece == null)
-                {
-                    strPiece = str.Substring(index);
-                    index = str.Length;
-                }
-
-                // unescape stuff
-                strPiece = Unescape(strPiece);
-                sprites.AddRange(AddString(new TextChunk(strPiece, chunk.NewLineIsParagraph, chunk.CreationParameters)));
-
-                if (placeholderDrawable != null)
-                {
-                    if (placeholderDrawable.Parent != null)
-                        throw new ArgumentException("All icons used by a customizable text container must not have a parent. If you get this error message it means one of your icon factories created a drawable that was already added to another parent, or you used a drawable as a placeholder that already has another parent or you used an index-based placeholder (like [2]) more than once.");
-
-                    AddInternal(placeholderDrawable);
-                }
-            }
-
-            return sprites;
-        }
+        internal override TextChunk CreateChunkFor(string text, bool newLineIsParagraph, Action<SpriteText> creationParameters = null)
+            => new CustomizableTextChunk(text, newLineIsParagraph, creationParameters);
     }
 }

--- a/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>Whether an icon factory was found for the given <paramref name="name"/>.</returns>
         internal bool TryGetIconFactory(string name, out Delegate iconFactory) => iconFactories.TryGetValue(name, out iconFactory);
 
-        internal override TextChunk CreateChunkFor(string text, bool newLineIsParagraph, Action<SpriteText> creationParameters = null)
+        protected internal override TextChunk CreateChunkFor(string text, bool newLineIsParagraph, Action<SpriteText> creationParameters = null)
             => new CustomizableTextChunk(text, newLineIsParagraph, creationParameters);
     }
 }

--- a/osu.Framework/Graphics/Containers/ITextPart.cs
+++ b/osu.Framework/Graphics/Containers/ITextPart.cs
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// Represents a part of text inside a <see cref="TextFlowContainer"/>.
+    /// This implementation allows for the contents of a text part to be swapped out,
+    /// in order to support things like text localisation, for instance.
+    /// </summary>
+    public interface ITextPart
+    {
+        /// <summary>
+        /// The drawables which currently correspond to this text part.
+        /// </summary>
+        IEnumerable<Drawable> Drawables { get; }
+
+        /// <summary>
+        /// Raised when <see cref="Drawables"/> is reconstructed (e.g. when the user language was changed).
+        /// </summary>
+        event Action<IEnumerable<Drawable>> DrawablePartsRecreated;
+
+        /// <summary>
+        /// Recreates the drawables for this text part, in order for them to be appended to the <paramref name="textFlowContainer"/>.
+        /// </summary>
+        void RecreateDrawablesFor(TextFlowContainer textFlowContainer);
+    }
+}

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownTextFlowContainer.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Graphics.Containers.Markdown
         public new void AddText(string text, Action<SpriteText> creationParameters = null)
             => base.AddText(Escape(text), creationParameters);
 
-        public new IEnumerable<Drawable> AddParagraph(string text, Action<SpriteText> creationParameters = null)
+        public new ITextPart AddParagraph(string text, Action<SpriteText> creationParameters = null)
             => base.AddParagraph(Escape(text), creationParameters);
 
         public void AddInlineText(ContainerInline container)

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -14,20 +14,22 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     internal class TextChunk : TextPart
     {
-        public readonly string Text;
-        public readonly bool NewLineIsParagraph;
-        internal readonly Action<SpriteText> CreationParameters;
+        protected readonly string Text;
+        protected readonly bool NewLineIsParagraph;
+
+        private readonly Action<SpriteText> creationParameters;
 
         public TextChunk(string text, bool newLineIsParagraph, Action<SpriteText> creationParameters = null)
         {
             Text = text;
             NewLineIsParagraph = newLineIsParagraph;
-            CreationParameters = creationParameters;
+
+            this.creationParameters = creationParameters;
         }
 
         public void ApplyParameters(SpriteText spriteText)
         {
-            CreationParameters?.Invoke(spriteText);
+            creationParameters?.Invoke(spriteText);
         }
 
         protected override IEnumerable<Drawable> CreateDrawablesFor(TextFlowContainer textFlowContainer)

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Graphics.Containers
     /// <summary>
     /// Represents a plain chunk of text to be displayed in a text flow.
     /// </summary>
-    internal class TextChunk : TextPart
+    public class TextChunk : TextPart
     {
         private readonly string text;
         private readonly bool newLineIsParagraph;

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -14,16 +14,14 @@ namespace osu.Framework.Graphics.Containers
     /// </summary>
     internal class TextChunk : TextPart
     {
-        protected readonly string Text;
-        protected readonly bool NewLineIsParagraph;
-
+        private readonly string text;
+        private readonly bool newLineIsParagraph;
         private readonly Action<SpriteText> creationParameters;
 
         public TextChunk(string text, bool newLineIsParagraph, Action<SpriteText> creationParameters = null)
         {
-            Text = text;
-            NewLineIsParagraph = newLineIsParagraph;
-
+            this.text = text;
+            this.newLineIsParagraph = newLineIsParagraph;
             this.creationParameters = creationParameters;
         }
 
@@ -36,16 +34,16 @@ namespace osu.Framework.Graphics.Containers
         {
             // !newLineIsParagraph effectively means that we want to add just *one* paragraph, which means we need to make sure that any previous paragraphs
             // are terminated. Thus, we add a NewLineContainer that indicates the end of the paragraph before adding our current paragraph.
-            if (!NewLineIsParagraph)
+            if (!newLineIsParagraph)
             {
                 var newLine = new TextNewLine(true);
                 textFlowContainer.AddPart(newLine);
             }
 
-            return CreateDrawablesFor(Text, textFlowContainer);
+            return CreateDrawablesFor(text, textFlowContainer);
         }
 
-        protected IEnumerable<Drawable> CreateDrawablesFor(string text, TextFlowContainer textFlowContainer)
+        protected virtual IEnumerable<Drawable> CreateDrawablesFor(string text, TextFlowContainer textFlowContainer)
         {
             bool first = true;
             var sprites = new List<Drawable>();
@@ -58,7 +56,7 @@ namespace osu.Framework.Graphics.Containers
 
                     if (lastChild != null)
                     {
-                        var newLine = new TextFlowContainer.NewLineContainer(NewLineIsParagraph);
+                        var newLine = new TextFlowContainer.NewLineContainer(newLineIsParagraph);
                         sprites.Add(newLine);
                     }
                 }

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -2,11 +2,17 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using osu.Framework.Graphics.Sprites;
 
 namespace osu.Framework.Graphics.Containers
 {
-    internal class TextChunk
+    /// <summary>
+    /// Represents a plain chunk of text to be displayed in a text flow.
+    /// </summary>
+    internal class TextChunk : TextPart
     {
         public readonly string Text;
         public readonly bool NewLineIsParagraph;
@@ -22,6 +28,64 @@ namespace osu.Framework.Graphics.Containers
         public void ApplyParameters(SpriteText spriteText)
         {
             CreationParameters?.Invoke(spriteText);
+        }
+
+        protected override IEnumerable<Drawable> CreateDrawablesFor(TextFlowContainer textFlowContainer)
+            => CreateDrawablesFor(Text, textFlowContainer);
+
+        protected IEnumerable<Drawable> CreateDrawablesFor(string text, TextFlowContainer textFlowContainer)
+        {
+            bool first = true;
+            var sprites = new List<Drawable>();
+
+            foreach (string l in text.Split('\n'))
+            {
+                if (!first)
+                {
+                    Drawable lastChild = sprites.LastOrDefault() ?? textFlowContainer.Children.LastOrDefault();
+
+                    if (lastChild != null)
+                    {
+                        var newLine = new TextFlowContainer.NewLineContainer(NewLineIsParagraph);
+                        sprites.Add(newLine);
+                    }
+                }
+
+                foreach (string word in SplitWords(l))
+                {
+                    if (string.IsNullOrEmpty(word)) continue;
+
+                    var textSprite = textFlowContainer.CreateSpriteTextWithChunk(this);
+                    textSprite.Text = word;
+                    sprites.Add(textSprite);
+                }
+
+                first = false;
+            }
+
+            return sprites;
+        }
+
+        protected string[] SplitWords(string text)
+        {
+            var words = new List<string>();
+            var builder = new StringBuilder();
+
+            for (var i = 0; i < text.Length; i++)
+            {
+                if (i == 0 || char.IsSeparator(text[i - 1]) || char.IsControl(text[i - 1]))
+                {
+                    words.Add(builder.ToString());
+                    builder.Clear();
+                }
+
+                builder.Append(text[i]);
+            }
+
+            if (builder.Length > 0)
+                words.Add(builder.ToString());
+
+            return words.ToArray();
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/TextChunk.cs
+++ b/osu.Framework/Graphics/Containers/TextChunk.cs
@@ -31,7 +31,17 @@ namespace osu.Framework.Graphics.Containers
         }
 
         protected override IEnumerable<Drawable> CreateDrawablesFor(TextFlowContainer textFlowContainer)
-            => CreateDrawablesFor(Text, textFlowContainer);
+        {
+            // !newLineIsParagraph effectively means that we want to add just *one* paragraph, which means we need to make sure that any previous paragraphs
+            // are terminated. Thus, we add a NewLineContainer that indicates the end of the paragraph before adding our current paragraph.
+            if (!NewLineIsParagraph)
+            {
+                var newLine = new TextNewLine(true);
+                textFlowContainer.AddPart(newLine);
+            }
+
+            return CreateDrawablesFor(Text, textFlowContainer);
+        }
 
         protected IEnumerable<Drawable> CreateDrawablesFor(string text, TextFlowContainer textFlowContainer)
         {

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -207,7 +207,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>A collection of <see cref="Drawable" /> objects for each <see cref="SpriteText"/> word and <see cref="NewLineContainer"/> created from the given text.</returns>
         /// <param name="text">The text to add.</param>
         /// <param name="creationParameters">A callback providing any <see cref="SpriteText" /> instances created for this new text.</param>
-        public ITextPart AddText(string text, Action<SpriteText> creationParameters = null) => AddLine(CreateChunkFor(text, true, creationParameters));
+        public ITextPart AddText(string text, Action<SpriteText> creationParameters = null) => AddPart(CreateChunkFor(text, true, creationParameters));
 
         /// <summary>
         /// Add an arbitrary <see cref="SpriteText"/> to this <see cref="TextFlowContainer"/>.
@@ -229,7 +229,7 @@ namespace osu.Framework.Graphics.Containers
         /// <returns>A collection of <see cref="Drawable" /> objects for each <see cref="SpriteText"/> word and <see cref="NewLineContainer"/> created from the given text.</returns>
         /// <param name="paragraph">The paragraph to add.</param>
         /// <param name="creationParameters">A callback providing any <see cref="SpriteText" /> instances created for this new paragraph.</param>
-        public ITextPart AddParagraph(string paragraph, Action<SpriteText> creationParameters = null) => AddLine(CreateChunkFor(paragraph, false, creationParameters));
+        public ITextPart AddParagraph(string paragraph, Action<SpriteText> creationParameters = null) => AddPart(CreateChunkFor(paragraph, false, creationParameters));
 
         /// <summary>
         /// Creates an appropriate implementation of <see cref="TextChunk"/> for this text flow container type.
@@ -266,20 +266,6 @@ namespace osu.Framework.Graphics.Containers
         {
             base.Clear(disposeChildren);
             parts.Clear();
-        }
-
-        internal ITextPart AddLine(TextChunk chunk)
-        {
-            // !newLineIsParagraph effectively means that we want to add just *one* paragraph, which means we need to make sure that any previous paragraphs
-            // are terminated. Thus, we add a NewLineContainer that indicates the end of the paragraph before adding our current paragraph.
-            if (!chunk.NewLineIsParagraph)
-            {
-                var newLine = new TextNewLine(true);
-                AddPart(newLine);
-            }
-
-            AddPart(chunk);
-            return chunk;
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -282,6 +282,29 @@ namespace osu.Framework.Graphics.Containers
             return part;
         }
 
+        /// <summary>
+        /// Removes an <see cref="ITextPart"/> from this text flow.
+        /// </summary>
+        /// <returns>Whether <see cref="ITextPart"/> was successfully removed from the flow.</returns>
+        public bool RemovePart(ITextPart partToRemove)
+        {
+            if (!parts.Remove(partToRemove))
+                return false;
+
+            // manual parts need to be manually removed before clearing contents,
+            // to avoid accidentally disposing of them in the process.
+            foreach (var manualPart in parts.OfType<TextPartManual>())
+                RemoveRange(manualPart.Drawables);
+
+            // make sure not to clear the list of parts on accident.
+            base.Clear(true);
+
+            foreach (var part in parts)
+                AddPart(part);
+
+            return true;
+        }
+
         private readonly Cached layout = new Cached();
 
         private void computeLayout()

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -234,7 +234,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// Creates an appropriate implementation of <see cref="TextChunk"/> for this text flow container type.
         /// </summary>
-        internal virtual TextChunk CreateChunkFor(string text, bool newLineIsParagraph, Action<SpriteText> creationParameters = null)
+        protected internal virtual TextChunk CreateChunkFor(string text, bool newLineIsParagraph, Action<SpriteText> creationParameters = null)
             => new TextChunk(text, newLineIsParagraph, creationParameters);
 
         /// <summary>
@@ -300,7 +300,11 @@ namespace osu.Framework.Graphics.Containers
             base.Clear(true);
 
             foreach (var part in parts)
-                AddPart(part);
+            {
+                part.RecreateDrawablesFor(this);
+                foreach (var drawable in part.Drawables)
+                    base.Add(drawable);
+            }
 
             return true;
         }

--- a/osu.Framework/Graphics/Containers/TextNewLine.cs
+++ b/osu.Framework/Graphics/Containers/TextNewLine.cs
@@ -1,0 +1,24 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using osu.Framework.Extensions.IEnumerableExtensions;
+
+namespace osu.Framework.Graphics.Containers
+{
+    public class TextNewLine : TextPart
+    {
+        private readonly bool indicatesNewParagraph;
+
+        public TextNewLine(bool indicatesNewParagraph)
+        {
+            this.indicatesNewParagraph = indicatesNewParagraph;
+        }
+
+        protected override IEnumerable<Drawable> CreateDrawablesFor(TextFlowContainer textFlowContainer)
+        {
+            var newLineContainer = new TextFlowContainer.NewLineContainer(indicatesNewParagraph);
+            return newLineContainer.Yield();
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/TextPart.cs
+++ b/osu.Framework/Graphics/Containers/TextPart.cs
@@ -1,0 +1,35 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using osu.Framework.Extensions.ListExtensions;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// A basic implementation of <see cref="ITextPart"/>,
+    /// which automatically handles returning correct <see cref="Drawables"/>
+    /// and raising <see cref="DrawablePartsRecreated"/>.
+    /// </summary>
+    public abstract class TextPart : ITextPart
+    {
+        public IEnumerable<Drawable> Drawables => drawables.AsSlimReadOnly();
+        private readonly List<Drawable> drawables = new List<Drawable>();
+
+        public event Action<IEnumerable<Drawable>> DrawablePartsRecreated;
+
+        public void RecreateDrawablesFor(TextFlowContainer textFlowContainer)
+        {
+            drawables.Clear();
+            drawables.AddRange(CreateDrawablesFor(textFlowContainer));
+            DrawablePartsRecreated?.Invoke(drawables);
+        }
+
+        /// <summary>
+        /// Creates drawables representing the contents of this <see cref="TextPart"/>,
+        /// to be appended to the <paramref name="textFlowContainer"/>.
+        /// </summary>
+        protected abstract IEnumerable<Drawable> CreateDrawablesFor(TextFlowContainer textFlowContainer);
+    }
+}

--- a/osu.Framework/Graphics/Containers/TextPartManual.cs
+++ b/osu.Framework/Graphics/Containers/TextPartManual.cs
@@ -1,0 +1,33 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace osu.Framework.Graphics.Containers
+{
+    /// <summary>
+    /// An <see cref="ITextPart"/> which utilises externally-provided drawables.
+    /// Will never recreate its contents or raise <see cref="DrawablePartsRecreated"/>.
+    /// </summary>
+    public class TextPartManual : ITextPart
+    {
+        public IEnumerable<Drawable> Drawables { get; }
+
+        public event Action<IEnumerable<Drawable>> DrawablePartsRecreated
+        {
+            add { }
+            remove { }
+        }
+
+        public TextPartManual(IEnumerable<Drawable> drawables)
+        {
+            Drawables = drawables.ToImmutableArray();
+        }
+
+        public void RecreateDrawablesFor(TextFlowContainer textFlowContainer)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This is the major change that is supposed to facilitate #4636.

# Breaking changes

## `TextFlowContainer` no longer returns raw `SpriteText`s

In preparation for adding localisation support to `TextFlowContainer`s, the various `AddText()`/`AddLine()` overloads will no longer return raw `SpriteText`s. Instead, an `ITextPart` structure will be returned.

Via `ITextPart`, the consumer can both access all `Drawables` associated with a given piece of text, as well as react to any future changes in representation of the text by subscribing to `DrawablePartsRecreated`. In the future, with more localisation changes, this event will be invoked once an `LocalisableString`'s displayable content changes, which will trigger a recreation of all parts' drawables, upon which any manual adjustments applied to `Drawables` can be re-applied again.

For consumers wanting to implement their own `ITextPart`s to extend the functionality of `TextFlowContainer`, an abstract `TextPart` is also provided which implements the typical flow of handling `Drawables` and `DrawablePartsRecreated`. The only thing that a consumer has to do when inheriting that class is to implement `CreateDrawablesFor(TextFlowContainer)`.

---

I have been sitting on this diff for a few reasons - other than the usual constant deficit of time, I have written this twice (the first attempt was swiftly defeated by existing game-side usage patterns), and feel like it could still use more testing (I have checked the weird usage patterns, as well as ran framework-side and game-side test suites against this change, but this is a change so far-reaching that that still feels too little). Therefore this pull is mostly intended as a request for comments as it comes to the structure.

Due to the size of this change, `LocalisableString`s are not yet stored or returned by the text flow. But I hope that the breaking change notice explains the central idea behind these changes and the way that they will fit into the localisation structure is self-evident. I have successfully managed to get `RomanisableString`s to work with the first iteration of this structure in a test scene.

An early draft of game-side changes to adapt to changes made in this PR can be previewed [here](https://github.com/bdach/osu/tree/text-flow-parts).