### PR TITLE
Update osuTK again (with android build corrected)

### DIFF
--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.Android" Version="1.0.173" />
+    <PackageReference Include="ppy.osuTK.Android" Version="1.0.178" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\**\*.so" />

--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -66,7 +66,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.177" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.178" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801"/>
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.173" />
+    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.178" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.3" />
   </ItemGroup>
   <ItemGroup>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="ManagedBass.Fx" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.2.0" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.177" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.178" />
     <PackageReference Include="StbiSharp" Version="1.0.13" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.452-alpha" />
   </ItemGroup>


### PR DESCRIPTION
See discussion in https://github.com/ppy/osu-framework/issues/2669.

Not sure why android has even been working in the mean time, as the specified package seems to have not been available on nuget...
