### PR TITLE
Call `SDL_StartTextInput` explicitly to receive `SDL_TEXTINPUT` events

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -367,6 +367,9 @@ namespace osu.Framework.Platform
         public SDL2DesktopWindow()
         {
             SDL.SDL_Init(SDL.SDL_INIT_VIDEO | SDL.SDL_INIT_GAMECONTROLLER);
+            // On most platforms SDL_Init already calls this function for us, but not on all.
+            // So call it explicitly, to make sure that we will receive SDL_TEXTINPUT events.
+            SDL.SDL_StartTextInput();
 
             graphicsBackend = CreateGraphicsBackend();
 


### PR DESCRIPTION
On most platforms `SDL_Init` [already calls `SDL_StartTextInput` for us](https://github.com/libsdl-org/SDL/blob/130b6bebaec4bc9f37c103a69595e8c261f2af49/src/video/SDL_video.c#L565-L574), but not on all.

For example the `wayland` backend of `SDL` does not do this and therefore this is required to get input in textboxes to work with `wayland`.  