### PR TITLE
Avoid `Enum.GetValues` overhead in `AudioAdjustments`

### DIFF
--- a/osu.Framework/Audio/AudioAdjustments.cs
+++ b/osu.Framework/Audio/AudioAdjustments.cs
@@ -12,6 +12,8 @@ namespace osu.Framework.Audio
     /// </summary>
     public class AudioAdjustments : IAdjustableAudioComponent
     {
+        private static readonly AdjustableProperty[] all_adjustments = (AdjustableProperty[])Enum.GetValues(typeof(AdjustableProperty));
+
         /// <summary>
         /// The volume of this component.
         /// </summary>
@@ -59,7 +61,7 @@ namespace osu.Framework.Audio
 
         public AudioAdjustments()
         {
-            foreach (AdjustableProperty type in Enum.GetValues(typeof(AdjustableProperty)))
+            foreach (AdjustableProperty type in all_adjustments)
             {
                 var aggregate = getAggregate(type) = new AggregateBindable<double>(getAggregateFunction(type), getProperty(type).GetUnboundCopy());
                 aggregate.AddSource(getProperty(type));
@@ -74,13 +76,13 @@ namespace osu.Framework.Audio
 
         public void BindAdjustments(IAggregateAudioAdjustment component)
         {
-            foreach (AdjustableProperty type in Enum.GetValues(typeof(AdjustableProperty)))
+            foreach (AdjustableProperty type in all_adjustments)
                 getAggregate(type).AddSource(component.GetAggregate(type));
         }
 
         public void UnbindAdjustments(IAggregateAudioAdjustment component)
         {
-            foreach (AdjustableProperty type in Enum.GetValues(typeof(AdjustableProperty)))
+            foreach (AdjustableProperty type in all_adjustments)
                 getAggregate(type).RemoveSource(component.GetAggregate(type));
         }
 


### PR DESCRIPTION
Benchmark probably unnecessary, but comparing using the one added in #4713

Before:

|                                    Method |     Mean |    Error |   StdDev |   Median |  Gen 0 |  Gen 1 | Allocated |
|------------------------------------------ |---------:|---------:|---------:|---------:|-------:|-------:|----------:|
| TransferBetweenParentAdjustmentContainers | 24.20 us | 0.294 us | 0.245 us | 24.23 us | 0.3662 | 0.0305 |   4,240 B |
|   TransferToSameParentAdjustmentContainer | 12.07 us | 0.239 us | 0.651 us | 11.79 us |      - |      - |         - |

After:

|                                    Method |     Mean |    Error |   StdDev |   Median |  Gen 0 | Allocated |
|------------------------------------------ |---------:|---------:|---------:|---------:|-------:|----------:|
| TransferBetweenParentAdjustmentContainers | 22.65 us | 0.456 us | 1.315 us | 22.21 us | 0.3052 |   3,712 B |
|   TransferToSameParentAdjustmentContainer | 13.01 us | 0.297 us | 0.868 us | 12.50 us |      - |         - |