### PR TITLE
Use a `ThreadLocal` shared list for absolute sequence propagation

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1245,21 +1245,21 @@ namespace osu.Framework.Graphics.Containers
             if (!recursive || internalChildren.Count == 0)
                 return base.BeginAbsoluteSequence(newTransformStartTime, false);
 
-            List<IDisposable> disposalActions = new List<IDisposable>(internalChildren.Count + 1);
+            List<AbsoluteSequenceSender> disposalActions = new List<AbsoluteSequenceSender>(internalChildren.Count + 1);
 
             base.CollectAbsoluteSequenceActionsFromSubTree(newTransformStartTime, disposalActions);
 
             foreach (var c in internalChildren)
                 c.CollectAbsoluteSequenceActionsFromSubTree(newTransformStartTime, disposalActions);
 
-            return new ValueInvokeOnDisposal<List<IDisposable>>(disposalActions, actions =>
+            return new ValueInvokeOnDisposal<List<AbsoluteSequenceSender>>(disposalActions, actions =>
             {
                 foreach (var a in actions)
                     a.Dispose();
             });
         }
 
-        internal override void CollectAbsoluteSequenceActionsFromSubTree(double newTransformStartTime, List<IDisposable> actions)
+        internal override void CollectAbsoluteSequenceActionsFromSubTree(double newTransformStartTime, List<AbsoluteSequenceSender> actions)
         {
             base.CollectAbsoluteSequenceActionsFromSubTree(newTransformStartTime, actions);
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osu-framework/pull/4723
 
Working under the following requirements:

- No changes to API
- Assumption that this is going to be a hot path in most projects (not just osu!) and should be expected to not allocate more than necessary
- Should work from load thread or update thread, as it currently does

This seems like about the best we can do. I can understand if this approach is a tad hard to swallow, but wanted to push this out for discussion. Using "static" lists with the paradigm I've used here is safe enough, but the lists do still have the ability to grow and reside in memory indefinitely. Maybe this is fine?

If we are not happy with `ThreadLocal`, it is also enough to cater to the most common usage (ie. only use a shared list on the `Update` thread, and construct a new one in all other cases).

Note that this is a similar issues to #4683 and we may want to decide on a path forward to use in cases like these as they come up. #4683 is more simple as it can only ever run on the update thread (and also know the length from the outset).


Before:

|                     Method |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|--------------------------- |-----------:|---------:|---------:|-------:|----------:|
|               NonRecursive | 1,008.6 us | 19.83 us | 17.58 us |      - |     187 B |
|                  Recursive |   970.0 us | 15.64 us | 14.63 us | 1.9531 |  24,259 B |
| SlightlyNestedNonRecursive | 1,003.6 us | 18.42 us | 16.33 us |      - |     191 B |
|    SlightlyNestedRecursive | 1,058.8 us | 20.21 us | 17.91 us | 5.8594 |  72,334 B |
|     VeryNestedNonRecursive | 1,031.8 us | 20.08 us | 23.91 us |      - |     187 B |
|        VeryNestedRecursive | 1,124.8 us | 21.70 us | 22.28 us | 3.9063 |  49,555 B |


After:

|                     Method |     Mean |     Error |    StdDev | Allocated |
|--------------------------- |---------:|----------:|----------:|----------:|
|               NonRecursive | 1.006 ms | 0.0200 ms | 0.0231 ms |     214 B |
|                  Recursive | 1.039 ms | 0.0205 ms | 0.0191 ms |     267 B |
| SlightlyNestedNonRecursive | 1.010 ms | 0.0161 ms | 0.0179 ms |     211 B |
|    SlightlyNestedRecursive | 1.135 ms | 0.0206 ms | 0.0192 ms |     267 B |
|     VeryNestedNonRecursive | 1.009 ms | 0.0173 ms | 0.0153 ms |     211 B |
|        VeryNestedRecursive | 1.105 ms | 0.0137 ms | 0.0121 ms |     267 B |

Note a slight allocation overhead due to the thread check. Feels best to have it in place at least initially?

Real world, this remove the array allocations associated with `BeginAbsoluteSequence` (blue line):

![image](https://user-images.githubusercontent.com/191335/131006122-01a07f36-b42d-44d6-8e65-fff2f7ced66b.png)
