### PR TITLE
Exclude non-breaking space from fixed width in sprite texts by default

### DIFF
--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -26,7 +26,11 @@ namespace osu.Framework.Graphics.Sprites
     public partial class SpriteText : Drawable, IHasLineBaseHeight, ITexturedShaderDrawable, IHasText, IHasFilterTerms, IFillFlowContainer, IHasCurrentValue<string>
     {
         private const float default_text_size = 20;
-        private static readonly char[] default_never_fixed_width_characters = { '.', ',', ':', ' ' };
+
+        /// <remarks>
+        /// <c>U+00A0</c> is the Unicode NON-BREAKING SPACE character (distinct from the standard ASCII space).
+        /// </remarks>
+        private static readonly char[] default_never_fixed_width_characters = { '.', ',', ':', ' ', '\u00A0' };
 
         [Resolved]
         private FontStore store { get; set; }


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/14523.

| before | after |
| :-: | :-: |
| ![2021-08-28-174949_749x171_scrot](https://user-images.githubusercontent.com/20418176/131223546-d0cfd1b1-364d-4a65-8d6d-ef4163e3469f.png) | ![2021-08-28-175118_746x168_scrot](https://user-images.githubusercontent.com/20418176/131223549-e3fbbfbb-8815-4d52-8414-03017553ebf5.png) |
| ![2021-08-28-175001_327x160_scrot](https://user-images.githubusercontent.com/20418176/131223551-c52a3288-cbff-428a-9ff0-83b6e0f90660.png) | ![2021-08-28-175128_289x154_scrot](https://user-images.githubusercontent.com/20418176/131223555-e193e0ce-b921-4ec1-81cb-e945685127f9.png) |

I would have included a test case for this but the roboto font actually does not have a glyph generated for `U+00A0` using bmfont it seems, so it shows up as `?` in text which looks broken. I can go and fix this but I'm not sure if worth.
