### PR TITLE
Allow `HidePopover()` to be called directly on popover containers 

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestScenePopoverContainer.cs
@@ -151,6 +151,24 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestShowHideViaExtensionMethod()
+        {
+            createContent(button => new BasicPopover
+            {
+                Child = new SpriteText
+                {
+                    Text = $"{button.Anchor} popover"
+                }
+            });
+
+            AddStep("show popover manually", () => this.ChildrenOfType<DrawableWithPopover>().First().ShowPopover());
+            AddAssert("popover shown", () => this.ChildrenOfType<Popover>().Any(popover => popover.State.Value == Visibility.Visible));
+
+            AddStep("hide popover manually", () => popoverContainer.HidePopover());
+            AddAssert("all hidden", () => this.ChildrenOfType<Popover>().All(popover => popover.State.Value != Visibility.Visible));
+        }
+
+        [Test]
         public void TestClickBetweenMultiple()
         {
             createContent(button => new BasicPopover

--- a/osu.Framework/Extensions/PopoverExtensions.cs
+++ b/osu.Framework/Extensions/PopoverExtensions.cs
@@ -23,7 +23,8 @@ namespace osu.Framework.Extensions
 
         private static void setTargetOnNearestPopover(Drawable origin, IHasPopover? target)
         {
-            var popoverContainer = origin.FindClosestParent<PopoverContainer>()
+            var popoverContainer = origin as PopoverContainer
+                                   ?? origin.FindClosestParent<PopoverContainer>()
                                    ?? throw new InvalidOperationException($"Cannot show or hide a popover without a parent {nameof(PopoverContainer)} in the hierarchy");
 
             popoverContainer.SetTarget(target);


### PR DESCRIPTION
This [came up previously as a usability issue](https://github.com/ppy/osu/pull/13861/commits/4dea2d97782151a1a8e383cd09cd225662b99d15). Due to the way `.FindClosestParent<T>()` works, you couldn't actually call `.HidePopover()` on a `PopoverContainer` and expect that same container to hide its popover, for no real reason at all. This change makes that possible.

Aside from being a usability improvement I need this for an upcoming game-side change.