### PR TITLE
Avoid running menu animation code on `Clear()` calls

### DIFF
--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -233,7 +233,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (!IsLoaded)
                 return;
 
-            submenu?.Close();
+            resetState();
 
             switch (State)
             {
@@ -258,7 +258,14 @@ namespace osu.Framework.Graphics.UserInterface
 
                     break;
             }
+        }
 
+        private void resetState()
+        {
+            if (!IsLoaded)
+                return;
+
+            submenu?.Close();
             sizeCache.Invalidate();
         }
 
@@ -307,7 +314,7 @@ namespace osu.Framework.Graphics.UserInterface
         public void Clear()
         {
             ItemsContainer.Clear();
-            updateState();
+            resetState();
         }
 
         /// <summary>


### PR DESCRIPTION
From blame history, it looks like this was only done to consolidate the invalidation logic call. I've split this out to ensure correct behaviour, while avoiding the actual state change operations being unnecessarily run.

Closes https://github.com/ppy/osu/issues/14553.
