### PR TITLE
Fix `GetBackwardWordAmount()` going back two words if the last word is only one character long

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -331,7 +331,68 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestPreviousWordDeletionWithShortWords()
+        {
+            InsertableTextBox textBox = null;
+
+            AddStep("add textbox", () =>
+            {
+                textBoxes.Add(textBox = new InsertableTextBox
+                {
+                    Size = new Vector2(200, 40),
+                });
+            });
+
+            AddStep("click on textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("insert three words", () => textBox.InsertString("a b c"));
+            AddStep("delete last word", () => InputManager.Keys(PlatformAction.DeleteBackwardWord));
+            AddAssert("two words remain", () => textBox.Text == "a b ");
+            AddStep("delete last word", () => InputManager.Keys(PlatformAction.DeleteBackwardWord));
+            AddAssert("one word remains", () => textBox.Text == "a ");
+            AddStep("delete last word", () => InputManager.Keys(PlatformAction.DeleteBackwardWord));
+            AddAssert("text is empty", () => textBox.Text.Length == 0);
+            AddStep("delete last word", () => InputManager.Keys(PlatformAction.DeleteBackwardWord));
+            AddAssert("text is empty", () => textBox.Text.Length == 0);
+        }
+
+        [Test]
         public void TestNextWordDeletion()
+        {
+            InsertableTextBox textBox = null;
+
+            AddStep("add textbox", () =>
+            {
+                textBoxes.Add(textBox = new InsertableTextBox
+                {
+                    Size = new Vector2(200, 40)
+                });
+            });
+
+            AddStep("click on textbox", () =>
+            {
+                InputManager.MoveMouseTo(textBox);
+                InputManager.Click(MouseButton.Left);
+            });
+
+            AddStep("insert three words", () => textBox.InsertString("a b c"));
+            AddStep("move caret to start", () => InputManager.Keys(PlatformAction.MoveBackwardLine));
+            AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
+            AddAssert("two words remain", () => textBox.Text == " b c");
+            AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
+            AddAssert("one word remains", () => textBox.Text == " c");
+            AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
+            AddAssert("text is empty", () => textBox.Text.Length == 0);
+            AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
+            AddAssert("text is empty", () => textBox.Text.Length == 0);
+        }
+
+        [Test]
+        public void TestNextWordDeletionWithShortWords()
         {
             InsertableTextBox textBox = null;
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -379,12 +379,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddStep("insert three words", () => textBox.InsertString("a b c"));
+            AddStep("insert three words", () => textBox.InsertString("some long text"));
             AddStep("move caret to start", () => InputManager.Keys(PlatformAction.MoveBackwardLine));
             AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
-            AddAssert("two words remain", () => textBox.Text == " b c");
+            AddAssert("two words remain", () => textBox.Text == " long text");
             AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
-            AddAssert("one word remains", () => textBox.Text == " c");
+            AddAssert("one word remains", () => textBox.Text == " text");
             AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
             AddAssert("text is empty", () => textBox.Text.Length == 0);
             AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
@@ -410,12 +410,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.Click(MouseButton.Left);
             });
 
-            AddStep("insert three words", () => textBox.InsertString("some long text"));
+            AddStep("insert three words", () => textBox.InsertString("a b c"));
             AddStep("move caret to start", () => InputManager.Keys(PlatformAction.MoveBackwardLine));
             AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
-            AddAssert("two words remain", () => textBox.Text == " long text");
+            AddAssert("two words remain", () => textBox.Text == " b c");
             AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
-            AddAssert("one word remains", () => textBox.Text == " text");
+            AddAssert("one word remains", () => textBox.Text == " c");
             AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));
             AddAssert("text is empty", () => textBox.Text.Length == 0);
             AddStep("delete first word", () => InputManager.Keys(PlatformAction.DeleteForwardWord));

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -288,7 +288,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (!AllowWordNavigation)
                 return -1;
 
-            int searchPrev = Math.Clamp(selectionEnd - 2, 0, Math.Max(0, Text.Length - 1));
+            int searchPrev = Math.Clamp(selectionEnd - 1, 0, Math.Max(0, Text.Length - 1));
             while (searchPrev > 0 && text[searchPrev] == ' ')
                 searchPrev--;
             int lastSpace = text.LastIndexOf(' ', searchPrev);


### PR DESCRIPTION
Fixes #4742 

I've tested this and it works fine.
Not sure if tests should be added for this. 