### PR TITLE
Fix video decode running before start time

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -96,6 +96,22 @@ namespace osu.Framework.Tests.Visual.Sprites
         }
 
         [Test]
+        public void TestDecodingStopsBeforeStartTime()
+        {
+            AddStep("Jump back to before start time", () => clock.CurrentTime = -30000);
+
+            AddUntilStep("decoding stopped", () => video.State == VideoDecoder.DecoderState.Ready);
+
+            AddStep("reset decode state", () => didDecode = false);
+
+            AddWaitStep("wait a bit", 10);
+            AddAssert("decoding didn't run", () => !didDecode);
+
+            AddStep("seek close to start", () => clock.CurrentTime = -500);
+            AddUntilStep("decoding ran", () => didDecode);
+        }
+
+        [Test]
         public void TestJumpForward()
         {
             AddStep("Jump ahead by 10 seconds", () => clock.CurrentTime += 10000);

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -96,6 +96,17 @@ namespace osu.Framework.Tests.Visual.Sprites
         }
 
         [Test]
+        public void TestDecodingContinuesBeforeStartTimeIfLooping()
+        {
+            AddStep("Set looping", () => video.Loop = true);
+
+            AddStep("Jump back to before start time", () => clock.CurrentTime = -30000);
+
+            AddStep("reset decode state", () => didDecode = false);
+            AddUntilStep("decoding ran", () => didDecode);
+        }
+
+        [Test]
         public void TestDecodingStopsBeforeStartTime()
         {
             AddStep("Jump back to before start time", () => clock.CurrentTime = -30000);

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -95,20 +95,12 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddUntilStep("decoding ran", () => didDecode);
         }
 
-        [Test]
-        public void TestDecodingContinuesBeforeStartTimeIfLooping()
+        [TestCase(false)]
+        [TestCase(true)]
+        public void TestDecodingStopsBeforeStartTime(bool looping)
         {
-            AddStep("Set looping", () => video.Loop = true);
+            AddStep("Set looping", () => video.Loop = looping);
 
-            AddStep("Jump back to before start time", () => clock.CurrentTime = -30000);
-
-            AddStep("reset decode state", () => didDecode = false);
-            AddUntilStep("decoding ran", () => didDecode);
-        }
-
-        [Test]
-        public void TestDecodingStopsBeforeStartTime()
-        {
             AddStep("Jump back to before start time", () => clock.CurrentTime = -30000);
 
             AddUntilStep("decoding stopped", () => video.State == VideoDecoder.DecoderState.Ready);

--- a/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
+++ b/osu.Framework/Graphics/Animations/AnimationClockComposite.cs
@@ -83,10 +83,11 @@ namespace osu.Framework.Graphics.Animations
         {
             get
             {
-                if (Loop)
-                    return manualClock.CurrentTime % Duration;
+                double current = manualClock.CurrentTime;
 
-                return Math.Min(manualClock.CurrentTime, Duration);
+                if (Loop) current %= Duration;
+
+                return Math.Clamp(current, 0, Duration);
             }
             set
             {

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -127,11 +127,6 @@ namespace osu.Framework.Graphics.Video
                 }
             }
 
-            // if not looping and not yet having reached the start of the video, don't attempt to consume frames yet.
-            // if we begin consuming frames the decoder will be performing unnecessary work.
-            if (!Loop && PlaybackPosition < 0)
-                return;
-
             var peekFrame = availableFrames.Count > 0 ? availableFrames.Peek() : null;
             bool outOfSync = false;
 


### PR DESCRIPTION
Noticed that we were continuously decoding frames before a video started due to no checks in place.

- [x] Depends on https://github.com/ppy/osu-framework/pull/4750 (for mergeability)

Note that I did some code quality improvements around the `outOfSync` logic but the only part which matters is the early return.