### PR TITLE
Let `TabControl` always sort initial selection if auto sort is on

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTabControl.cs
@@ -378,6 +378,30 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddAssert("initial selection is correct", () => tabControl.Current.Value == expectedInitialSelection);
         }
 
+        [TestCase(true, TestEnum.Test1, true)]
+        [TestCase(false, TestEnum.Test1, true)]
+        [TestCase(true, TestEnum.Test9, true)]
+        [TestCase(false, TestEnum.Test9, false)]
+        public void TestInitialSort(bool autoSort, TestEnum? initialItem, bool expected)
+        {
+            StyledTabControl tabControlWithBindable = null;
+            Bindable<TestEnum?> testBindable = new Bindable<TestEnum?> { Value = initialItem };
+
+            AddStep("create tab control", () =>
+            {
+                tabControlContainer.Add(tabControlWithBindable = new StyledTabControl
+                {
+                    Size = new Vector2(200, 20),
+                    Items = items.Cast<TestEnum?>().ToList(),
+                    AutoSort = autoSort,
+                    Current = { BindTarget = testBindable }
+                });
+            });
+
+            AddUntilStep("wait for loaded", () => tabControlWithBindable.IsLoaded);
+            AddAssert($"Current selection {(expected ? "visible" : "not visible")}", () => tabControlWithBindable.SelectedTab.IsPresent == expected);
+        }
+
         private class StyledTabControlWithoutDropdown : TabControl<TestEnum>
         {
             protected override Dropdown<TestEnum> CreateDropdown() => null;

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -204,6 +204,9 @@ namespace osu.Framework.Graphics.UserInterface
                 Current.Value = Items.First();
 
             Current.BindValueChanged(v => selectTab(v.NewValue != null ? tabMap[v.NewValue] : null), true);
+            // TabContainer doesn't have valid layout yet, so TabItems all have y=0 and selectTab() didn't call performTabSort() so we call it here instead
+            if (AutoSort && Current.Value != null)
+                performTabSort(tabMap[Current.Value]);
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/UserInterface/TabControl.cs
+++ b/osu.Framework/Graphics/UserInterface/TabControl.cs
@@ -204,6 +204,7 @@ namespace osu.Framework.Graphics.UserInterface
                 Current.Value = Items.First();
 
             Current.BindValueChanged(v => selectTab(v.NewValue != null ? tabMap[v.NewValue] : null), true);
+
             // TabContainer doesn't have valid layout yet, so TabItems all have y=0 and selectTab() didn't call performTabSort() so we call it here instead
             if (AutoSort && Current.Value != null)
                 performTabSort(tabMap[Current.Value]);


### PR DESCRIPTION
`TabControl` was relying on `TabContainer` to have correct layout for the initial autosort, but the layout isn't correct yet and all children in `TabContainer` have y=0. 

`y==0` is used by `TabItem` for its `IsPresent` which is checked by `selectTab()` when considering whether to sort the new selection or not.

If the tab is present then it isn't sorted, but the tab might not be present if the initial selected tab is changed when constructing the `TabControl`. The result was the initial selection being hidden in the dropdown.

This PR calls `performTabSort()` directly in `LoadComplete` so the initial selection is always auto-sorted.