### PR TITLE
Fix user storage potentially losing true existing install directory

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -59,7 +59,9 @@ namespace osu.Framework.Android
 
         public override Storage GetStorage(string path) => new AndroidStorage(path, this);
 
-        public override string UserStoragePath => Application.Context.GetExternalFilesDir(string.Empty).ToString();
+        public override IEnumerable<string> UserStoragePaths => new[] {
+            Application.Context.GetExternalFilesDir(string.Empty).ToString()
+        };
 
         public override void OpenFileExternally(string filename)
             => throw new NotImplementedException();

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -59,7 +59,8 @@ namespace osu.Framework.Android
 
         public override Storage GetStorage(string path) => new AndroidStorage(path, this);
 
-        public override IEnumerable<string> UserStoragePaths => new[] {
+        public override IEnumerable<string> UserStoragePaths => new[]
+        {
             Application.Context.GetExternalFilesDir(string.Empty).ToString()
         };
 

--- a/osu.Framework.Tests/Platform/UserStorageLookupTest.cs
+++ b/osu.Framework.Tests/Platform/UserStorageLookupTest.cs
@@ -1,0 +1,141 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using NUnit.Framework;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Platform
+{
+    [TestFixture]
+    public class UserStorageLookupTest
+    {
+        private static readonly string path1 = Path.Combine(TestRunHeadlessGameHost.TemporaryTestDirectory, "path1");
+        private static readonly string path2 = Path.Combine(TestRunHeadlessGameHost.TemporaryTestDirectory, "path2");
+
+        private const string game_name = "test_game";
+
+        [TearDown]
+        public void TearDown()
+        {
+            try
+            {
+                Directory.Delete(path1, true);
+                Directory.Delete(path2, true);
+            }
+            catch
+            {
+            }
+        }
+
+        [Test]
+        public void TestFirstBaseExisting()
+        {
+            Directory.CreateDirectory(path1);
+
+            using (var host = new StorageLookupHeadlessGameHost())
+            {
+                runHost(host);
+                Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path1, StringComparison.Ordinal));
+            }
+        }
+
+        [Test]
+        public void TestSecondBaseExisting()
+        {
+            Directory.CreateDirectory(path2);
+
+            using (var host = new StorageLookupHeadlessGameHost())
+            {
+                runHost(host);
+                Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path2, StringComparison.Ordinal));
+            }
+        }
+
+        [Test]
+        public void TestPrefersFirstBase()
+        {
+            Directory.CreateDirectory(path1);
+            Directory.CreateDirectory(path2);
+
+            using (var host = new StorageLookupHeadlessGameHost())
+            {
+                runHost(host);
+                Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path1, StringComparison.Ordinal));
+            }
+        }
+
+        [Test]
+        public void TestFirstDataExisting()
+        {
+            Directory.CreateDirectory(Path.Combine(path1, game_name));
+
+            using (var host = new StorageLookupHeadlessGameHost())
+            {
+                runHost(host);
+                Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path1, StringComparison.Ordinal));
+            }
+        }
+
+        [Test]
+        public void TestSecondDataExisting()
+        {
+            Directory.CreateDirectory(Path.Combine(path2, game_name));
+
+            using (var host = new StorageLookupHeadlessGameHost())
+            {
+                runHost(host);
+                Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path2, StringComparison.Ordinal));
+            }
+        }
+
+        [Test]
+        public void TestPrefersFirstData()
+        {
+            Directory.CreateDirectory(Path.Combine(path1, game_name));
+            Directory.CreateDirectory(Path.Combine(path2, game_name));
+
+            using (var host = new StorageLookupHeadlessGameHost())
+            {
+                runHost(host);
+                Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path1, StringComparison.Ordinal));
+            }
+        }
+
+        [Test]
+        public void TestPrefersSecondDataOverFirstBase()
+        {
+            Directory.CreateDirectory(path1);
+            Directory.CreateDirectory(Path.Combine(path2, game_name));
+
+            using (var host = new StorageLookupHeadlessGameHost())
+            {
+                runHost(host);
+                Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path2, StringComparison.Ordinal));
+            }
+        }
+
+        private static void runHost(StorageLookupHeadlessGameHost host)
+        {
+            TestGame game = new TestGame();
+            game.Schedule(() => game.Exit());
+            host.Run(game);
+        }
+
+        private class StorageLookupHeadlessGameHost : TestRunHeadlessGameHost
+        {
+            public StorageLookupHeadlessGameHost()
+                : base(game_name)
+            {
+            }
+
+            public override IEnumerable<string> UserStoragePaths => new[]
+            {
+                path1,
+                path2,
+            };
+        }
+    }
+}

--- a/osu.Framework.Tests/Platform/UserStorageLookupTest.cs
+++ b/osu.Framework.Tests/Platform/UserStorageLookupTest.cs
@@ -22,6 +22,15 @@ namespace osu.Framework.Tests.Platform
         {
             try
             {
+                File.Delete(path1);
+                File.Delete(path2);
+            }
+            catch
+            {
+            }
+
+            try
+            {
                 Directory.Delete(path1, true);
                 Directory.Delete(path2, true);
             }
@@ -43,27 +52,27 @@ namespace osu.Framework.Tests.Platform
         }
 
         [Test]
-        public void TestSecondBaseExisting()
+        public void TestSecondBaseExistingStillPrefersFirst()
         {
-            Directory.CreateDirectory(path2);
-
-            using (var host = new StorageLookupHeadlessGameHost())
-            {
-                runHost(host);
-                Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path2, StringComparison.Ordinal));
-            }
-        }
-
-        [Test]
-        public void TestPrefersFirstBase()
-        {
-            Directory.CreateDirectory(path1);
             Directory.CreateDirectory(path2);
 
             using (var host = new StorageLookupHeadlessGameHost())
             {
                 runHost(host);
                 Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path1, StringComparison.Ordinal));
+            }
+        }
+
+        [Test]
+        public void TestSecondBaseUsedIfFirstFails()
+        {
+            // write a file so directory creation fails.
+            File.WriteAllText(path1, "");
+
+            using (var host = new StorageLookupHeadlessGameHost())
+            {
+                runHost(host);
+                Assert.IsTrue(host.Storage.GetFullPath(string.Empty).StartsWith(path2, StringComparison.Ordinal));
             }
         }
 

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -107,8 +107,6 @@ namespace osu.Framework.iOS
 
         public override Storage GetStorage(string path) => new IOSStorage(path, this);
 
-        public override string UserStoragePath => Environment.GetFolderPath(Environment.SpecialFolder.Personal);
-
         public override void OpenFileExternally(string filename) => throw new NotImplementedException();
 
         public override void OpenUrlExternally(string url)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -695,13 +695,17 @@ namespace osu.Framework.Platform
                     return storage.GetStorageForDirectory(Name);
             }
 
-            // if an existing directory could not be found, use the first available valid path.
+            // if an existing directory could not be found, use the first path that can be created.
             foreach (var path in UserStoragePaths)
             {
-                var storage = GetStorage(path);
-
-                if (storage.ExistsDirectory(string.Empty))
-                    return storage.GetStorageForDirectory(Name);
+                try
+                {
+                    return GetStorage(path).GetStorageForDirectory(Name);
+                }
+                catch
+                {
+                    // may fail on directory creation.
+                }
             }
 
             throw new InvalidOperationException("No valid user storage path could be resolved.");

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -704,8 +704,7 @@ namespace osu.Framework.Platform
                     return storage.GetStorageForDirectory(Name);
             }
 
-            // should never actually get here.
-            return null;
+            throw new InvalidOperationException("No valid user storage path could be resolved.");
         }
 
         /// <summary>

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -136,7 +136,10 @@ namespace osu.Framework.Platform
         /// <param name="path">The absolute path to be used as a root for the storage.</param>
         public abstract Storage GetStorage(string path);
 
-        public abstract string UserStoragePath { get; }
+        /// <summary>
+        /// All valid user storage paths in order of usage priority.
+        /// </summary>
+        public virtual IEnumerable<string> UserStoragePaths => Environment.GetFolderPath(Environment.SpecialFolder.Personal).Yield();
 
         /// <summary>
         /// The main storage as proposed by the host game.
@@ -680,7 +683,30 @@ namespace osu.Framework.Platform
         /// Finds the default <see cref="Storage"/> for the game to be used if <see cref="Game.CreateStorage"/> is not overridden.
         /// </summary>
         /// <returns>The <see cref="Storage"/>.</returns>
-        protected virtual Storage GetDefaultGameStorage() => GetStorage(UserStoragePath).GetStorageForDirectory(Name);
+        protected virtual Storage GetDefaultGameStorage()
+        {
+            // first check all valid paths for any existing install.
+            foreach (var path in UserStoragePaths)
+            {
+                var storage = GetStorage(path);
+
+                // if an existing data directory exists for this application, prefer it immediately.
+                if (storage.ExistsDirectory(Name))
+                    return storage.GetStorageForDirectory(Name);
+            }
+
+            // if an existing directory could not be found, use the first available valid path.
+            foreach (var path in UserStoragePaths)
+            {
+                var storage = GetStorage(path);
+
+                if (storage.ExistsDirectory(string.Empty))
+                    return storage.GetStorageForDirectory(Name);
+            }
+
+            // should never actually get here.
+            return null;
+        }
 
         /// <summary>
         /// Pauses all active threads. Call <see cref="Resume"/> to resume execution.

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Platform
 
         public override void OpenUrlExternally(string url) => Logger.Log($"Application has requested URL \"{url}\" to be opened.");
 
-        public override string UserStoragePath => "./headless/";
+        public override IEnumerable<string> UserStoragePaths => new[] { "./headless/" };
 
         public HeadlessGameHost(string gameName = null, bool bindIPC = false, bool realtime = true, bool portableInstallation = false)
             : base(gameName ?? Guid.NewGuid().ToString(), bindIPC, portableInstallation: portableInstallation)

--- a/osu.Framework/Platform/Linux/LinuxGameHost.cs
+++ b/osu.Framework/Platform/Linux/LinuxGameHost.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using osu.Framework.Platform.Linux.SDL2;
 
@@ -16,25 +17,19 @@ namespace osu.Framework.Platform.Linux
 
         protected override IWindow CreateWindow() => new SDL2DesktopWindow();
 
-        public override string UserStoragePath
+        public override IEnumerable<string> UserStoragePaths
         {
             get
             {
-                string home = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
                 string xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
-                string[] paths =
-                {
-                    xdg ?? Path.Combine(home, ".local", "share"),
-                    Path.Combine(home)
-                };
 
-                foreach (string path in paths)
-                {
-                    if (Directory.Exists(path))
-                        return path;
-                }
+                if (!string.IsNullOrEmpty(xdg))
+                    yield return xdg;
 
-                return paths[0];
+                yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".local", "share");
+
+                foreach (var path in base.UserStoragePaths)
+                    yield return path;
             }
         }
 

--- a/osu.Framework/Platform/MacOS/MacOSGameHost.cs
+++ b/osu.Framework/Platform/MacOS/MacOSGameHost.cs
@@ -22,25 +22,19 @@ namespace osu.Framework.Platform.MacOS
 
         protected override IWindow CreateWindow() => new MacOSWindow();
 
-        public override string UserStoragePath
+        public override IEnumerable<string> UserStoragePaths
         {
             get
             {
-                string home = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
                 string xdg = Environment.GetEnvironmentVariable("XDG_DATA_HOME");
-                string[] paths =
-                {
-                    xdg ?? Path.Combine(home, ".local", "share"),
-                    Path.Combine(home)
-                };
 
-                foreach (string path in paths)
-                {
-                    if (Directory.Exists(path))
-                        return path;
-                }
+                if (!string.IsNullOrEmpty(xdg))
+                    yield return xdg;
 
-                return paths[0];
+                yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".local", "share");
+
+                foreach (var path in base.UserStoragePaths)
+                    yield return path;
             }
         }
 

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Handlers;
@@ -20,7 +21,9 @@ namespace osu.Framework.Platform.Windows
 
         public override Clipboard GetClipboard() => new WindowsClipboard();
 
-        public override string UserStoragePath => Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        public override IEnumerable<string> UserStoragePaths =>
+            // on windows this is guaranteed to exist (and be usable) so don't fallback to the base/default.
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData).Yield();
 
 #if NET5_0
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]

--- a/osu.Framework/Testing/TestRunHeadlessGameHost.cs
+++ b/osu.Framework/Testing/TestRunHeadlessGameHost.cs
@@ -1,7 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System.Collections.Generic;
 using System.IO;
+using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 
@@ -14,7 +16,7 @@ namespace osu.Framework.Testing
     {
         private readonly bool bypassCleanup;
 
-        public override string UserStoragePath { get; }
+        public override IEnumerable<string> UserStoragePaths { get; }
 
         public static string TemporaryTestDirectory = Path.Combine(Path.GetTempPath(), "of-test-headless");
 
@@ -22,7 +24,7 @@ namespace osu.Framework.Testing
             : base(name, bindIPC, realtime, portableInstallation)
         {
             this.bypassCleanup = bypassCleanup;
-            UserStoragePath = TemporaryTestDirectory;
+            UserStoragePaths = TemporaryTestDirectory.Yield();
         }
 
         protected override void Dispose(bool isDisposing)


### PR DESCRIPTION
It was pointed out recently by @p00ya (after encountering this precise scenario) that user data could be completely unlinked from an existing "install" of an osu!framework game via the following steps:

- Run via release and have data created (previously defaults on macOS to `~/osu`, which is super weird but ok)
- Decide to help develop the game, install `dotnet-sdk` which makes a `.local/share` folder
- Run via release again and have data create at `.local/share/osu`, losing existing install at less-preferred `~/osu`

This changes the resolution to be a two-part lookup, with the first half checking for existing data folders and the second deciding where to create a *new* data folder.

Still not sure about the macOS default paths, but that's for another PR. We probably want to use `ApplicationData` (which resolves to `.config`) if anything. Or figure out correct usage of `~/Library/Application Data`.

This change also (as of https://github.com/ppy/osu-framework/pull/4757/commits/96afb3c3e936f787f4bbb5df66044677f05901bc) also alters the order of precedence to be based on whether the full path can be *created*, rather than if it *exists*.