### PR TITLE
Improve headless test run efficiency

### DIFF
--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -51,10 +51,23 @@ namespace osu.Framework.Platform
         {
             base.SetupForRun();
 
+            // We want the draw thread to run, but it doesn't matter how fast it runs.
+            // This limiting is mostly to reduce CPU overhead.
             MaximumDrawHz = 60;
-            MaximumUpdateHz = MaximumInactiveHz = 1000;
 
-            if (!realtime) customClock = new FramedClock(new FastClock(CLOCK_RATE));
+            if (!realtime)
+            {
+                customClock = new FramedClock(new FastClock(CLOCK_RATE));
+
+                // time is incremented per frame, rather than based on the real-world time.
+                // therefore our goal is to run frames as fast as possible.
+                MaximumUpdateHz = MaximumInactiveHz = 0;
+            }
+            else
+            {
+                // in realtime runs, set a sane upper limit to avoid cpu overhead from spinning.
+                MaximumUpdateHz = MaximumInactiveHz = 1000;
+            }
         }
 
         protected override void DrawFrame()

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -51,9 +51,8 @@ namespace osu.Framework.Platform
         {
             base.SetupForRun();
 
-            MaximumDrawHz = double.MaxValue;
-            MaximumUpdateHz = double.MaxValue;
-            MaximumInactiveHz = double.MaxValue;
+            MaximumDrawHz = 60;
+            MaximumUpdateHz = MaximumInactiveHz = 1000;
 
             if (!realtime) customClock = new FramedClock(new FastClock(CLOCK_RATE));
         }

--- a/osu.Framework/Testing/TestBrowserTestRunner.cs
+++ b/osu.Framework/Testing/TestBrowserTestRunner.cs
@@ -41,10 +41,6 @@ namespace osu.Framework.Testing
         {
             base.LoadComplete();
 
-            host.MaximumDrawHz = int.MaxValue;
-            host.MaximumUpdateHz = int.MaxValue;
-            host.MaximumInactiveHz = int.MaxValue;
-
             AddInternal(browser);
 
             Console.WriteLine($@"{(int)Time.Current}: Running {browser.TestTypes.Count} visual test cases...");

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -58,15 +58,6 @@ namespace osu.Framework.Testing
                 if (volume != null) volume.Value = volumeAtStartup;
             }
 
-            protected override void LoadComplete()
-            {
-                base.LoadComplete();
-
-                host.MaximumDrawHz = int.MaxValue;
-                host.MaximumUpdateHz = int.MaxValue;
-                host.MaximumInactiveHz = int.MaxValue;
-            }
-
             /// <summary>
             /// Blocks execution until a provided <see cref="TestScene"/> runs to completion.
             /// </summary>


### PR DESCRIPTION
Turns out that by running at unlimited frame rates during tests we were probably impeding performance. The specific issue is the draw thread, which is both unnecessary for this kind of testing, and also uninhibited (in headless mode there's no `SwapBuffer` to limit it to some sane speed) meaning it was just spinning a core at all times.

This was only noticeable in multi-thread execution mode, but this is also the default for headless testing. I've only tested on a 16 physical core system, but on less powerful dev machines the real-time improvement is probably much more significant.

Real time measurements come from rider runs (time reported in rider).
CPU time measurements come from total sampled times.

## `TestAutoplay`

This is a test where a large number of frames are required to run to complete, so if the changes were going to regress this is where you would see it. This is comparing profiled runs of all four `TestAutoplay` executions in one batch.

Before:

Real time 43.6s
CPU time 87.4s

![20210907 133724 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132285071-7f86602f-9261-4790-b3f9-bd070b224f27.png)

![20210907 133747 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132285096-64b13d66-fb75-4889-b0dc-7912319a9fb3.png)

After:

Real time 42.5s
CPU time 49.2s

![20210907 133548 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132284945-87dcce9c-e958-4314-84b9-6ce798f0b3db.png)

![20210907 133613 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132284979-5272bbd8-7a1a-4d51-859e-bd1fa2c337a8.png)


## `UserInterface` namespace (framework)

These tests exit quickly, so is testing that in cases where few frames are run we aren't regressing the overall (real time) speed of tests. Note real time speed hasn't changed, but CPU time has been reduced greatly.

Before:

Real time 10.9s
CPU time 20.2s

![20210907 132757 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132284416-f7eb721c-c286-499d-8632-9f8ec830ea20.png)

After:

Real time 10.9s
CPU time 12.7s

![20210907 132951 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/132284502-b10d4a3e-66c4-47df-9cbe-682c84f3b158.png)
