### PR TITLE
Remove inherit lookups from `GetDescription` methods

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkDescription.cs
+++ b/osu.Framework.Benchmarks/BenchmarkDescription.cs
@@ -1,0 +1,38 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.ComponentModel;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Extensions;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkDescription
+    {
+        private string[] descriptions;
+
+        [Params(1, 10, 100, 1000)]
+        public int Times { get; set; }
+
+        [GlobalSetup]
+        public void SetUp()
+        {
+            descriptions = new string[Times];
+        }
+
+        [Benchmark]
+        public string[] GetDescription()
+        {
+            for (int i = 0; i < Times; i++)
+                descriptions[i] = TestLocalisableEnum.One.GetDescription();
+
+            return descriptions;
+        }
+
+        private enum TestLocalisableEnum
+        {
+            [Description("test")]
+            One,
+        }
+    }
+}

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -200,7 +200,7 @@ namespace osu.Framework.Extensions
             else
                 type = value.GetType();
 
-            var attribute = type.GetCustomAttribute<LocalisableDescriptionAttribute>();
+            var attribute = type.GetCustomAttribute<LocalisableDescriptionAttribute>(false);
             if (attribute == null)
                 return GetDescription(value);
 
@@ -233,7 +233,7 @@ namespace osu.Framework.Extensions
         public static string GetDescription(this object value)
             => value.GetType()
                     .GetField(value.ToString())?
-                    .GetCustomAttribute<DescriptionAttribute>()?.Description
+                    .GetCustomAttribute<DescriptionAttribute>(false)?.Description
                ?? value.ToString();
 
         private static string toLowercaseHex(this byte[] bytes)


### PR DESCRIPTION
Probably pointless change, can close or merge.

Before:

|                    Method | Times |         Mean |      Error |     StdDev |
|-------------------------- |------ |-------------:|-----------:|-----------:|
| GetDescription |     1 |     1.358 us |  0.0160 us |  0.0125 us |
| GetDescription |    10 |    12.394 us |  0.0632 us |  0.0493 us |
| GetDescription |   100 |   134.561 us |  1.0000 us |  0.8865 us |
| GetDescription |  1000 | 1,250.189 us | 13.2282 us | 11.0462 us |


|                    Method | Times |         Mean |      Error |     StdDev |
|-------------------------- |------ |-------------:|-----------:|-----------:|
| GetLocalisableDescription |     1 |     3.682 us |  0.0162 us |  0.0144 us |
| GetLocalisableDescription |    10 |    36.608 us |  0.3450 us |  0.3058 us |
| GetLocalisableDescription |   100 |   378.352 us |  3.3188 us |  3.1044 us |
| GetLocalisableDescription |  1000 | 3,684.076 us | 22.7740 us | 20.1886 us |


After:

|         Method | Times |         Mean |     Error |    StdDev |
|--------------- |------ |-------------:|----------:|----------:|
| GetDescription |     1 |     1.322 us | 0.0136 us | 0.0121 us |
| GetDescription |    10 |    12.736 us | 0.0947 us | 0.0886 us |
| GetDescription |   100 |   135.271 us | 1.6253 us | 1.3572 us |
| GetDescription |  1000 | 1,395.562 us | 8.9123 us | 7.4422 us |


|                    Method | Times |         Mean |      Error |     StdDev |
|-------------------------- |------ |-------------:|-----------:|-----------:|
| GetLocalisableDescription |     1 |     4.094 us |  0.0576 us |  0.0539 us |
| GetLocalisableDescription |    10 |    37.475 us |  0.2630 us |  0.2460 us |
| GetLocalisableDescription |   100 |   361.800 us |  2.9557 us |  2.7647 us |
| GetLocalisableDescription |  1000 | 3,761.765 us | 28.0766 us | 24.8892 us |
