### PR TITLE
Implement new audio mixer concurrency limits

### DIFF
--- a/osu.Framework/Audio/Mixing/AudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/AudioMixer.cs
@@ -28,6 +28,8 @@ namespace osu.Framework.Audio.Mixing
 
         public abstract BindableList<IEffectParameter> Effects { get; }
 
+        public abstract int Concurrency { get; set; }
+
         public void Add(IAudioChannel channel)
         {
             channel.EnqueueAction(() =>

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -73,8 +73,15 @@ namespace osu.Framework.Audio.Mixing.Bass
                 return;
 
             int countToRemove = activeChannels.Count - concurrency;
+
             for (int i = 0; i < countToRemove; i++)
+            {
                 removeChannelFromBassMix(activeChannels[i]);
+
+                // Notify the source channel that it's stopped.
+                ManagedBass.Bass.ChannelStop(activeChannels[i].Handle);
+            }
+
             activeChannels.RemoveRange(0, countToRemove);
         }
 

--- a/osu.Framework/Audio/Mixing/IAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/IAudioMixer.cs
@@ -24,6 +24,14 @@ namespace osu.Framework.Audio.Mixing
         BindableList<IEffectParameter> Effects { get; }
 
         /// <summary>
+        /// The number of audio channels allowed to be played concurrently by this <see cref="IAudioMixer"/>.
+        /// <para>
+        /// If the number of active channels exceeds this value, the earliest played channel is removed from the mix.
+        /// </para>
+        /// </summary>
+        int Concurrency { get; set; }
+
+        /// <summary>
         /// Adds a channel to the mix.
         /// </summary>
         /// <param name="channel">The channel to add.</param>

--- a/osu.Framework/Audio/Sample/ISample.cs
+++ b/osu.Framework/Audio/Sample/ISample.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using osu.Framework.Bindables;
-
 namespace osu.Framework.Audio.Sample
 {
     /// <summary>
@@ -16,28 +14,14 @@ namespace osu.Framework.Audio.Sample
         double Length { get; }
 
         /// <summary>
-        /// The number of times this sample (as identified by name) can be played back concurrently.
-        /// </summary>
-        /// <remarks>
-        /// This affects all <see cref="ISample"/> instances identified by the same sample name.
-        /// </remarks>
-        Bindable<int> PlaybackConcurrency { get; }
-
-        /// <summary>
         /// Creates a new unique playback channel for this <see cref="ISample"/> and immediately plays it.
         /// </summary>
-        /// <remarks>
-        /// Multiple channels can be played simultaneously, but can only be heard up to <see cref="PlaybackConcurrency"/> times.
-        /// </remarks>
         /// <returns>The unique <see cref="SampleChannel"/> for the playback.</returns>
         SampleChannel Play();
 
         /// <summary>
         /// Retrieves a unique playback channel for this <see cref="ISample"/>.
         /// </summary>
-        /// <remarks>
-        /// Multiple channels can be retrieved and played simultaneously, but can only be heard up to <see cref="PlaybackConcurrency"/> times.
-        /// </remarks>
         /// <returns>The unique <see cref="SampleChannel"/> for the playback.</returns>
         SampleChannel GetChannel();
     }

--- a/osu.Framework/Audio/Sample/ISampleStore.cs
+++ b/osu.Framework/Audio/Sample/ISampleStore.cs
@@ -5,9 +5,5 @@ namespace osu.Framework.Audio.Sample
 {
     public interface ISampleStore : IAdjustableResourceStore<Sample>
     {
-        /// <summary>
-        /// How many instances of a single sample should be allowed to playback concurrently before stopping the longest playing.
-        /// </summary>
-        int PlaybackConcurrency { get; set; }
     }
 }

--- a/osu.Framework/Audio/Sample/Sample.cs
+++ b/osu.Framework/Audio/Sample/Sample.cs
@@ -2,17 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using osu.Framework.Bindables;
 
 namespace osu.Framework.Audio.Sample
 {
     public abstract class Sample : AudioCollectionManager<SampleChannel>, ISample
     {
-        public const int DEFAULT_CONCURRENCY = 2;
-
         public double Length { get; protected set; }
-
-        public Bindable<int> PlaybackConcurrency { get; } = new Bindable<int>(DEFAULT_CONCURRENCY);
 
         internal Action<Sample> OnPlay;
 

--- a/osu.Framework/Audio/Sample/SampleBass.cs
+++ b/osu.Framework/Audio/Sample/SampleBass.cs
@@ -20,8 +20,6 @@ namespace osu.Framework.Audio.Sample
         {
             this.factory = factory;
             this.mixer = mixer;
-
-            PlaybackConcurrency.BindTo(factory.PlaybackConcurrency);
         }
 
         protected override SampleChannel CreateChannel()

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -21,8 +21,6 @@ namespace osu.Framework.Audio.Sample
 
         private readonly ConcurrentDictionary<string, SampleBassFactory> factories = new ConcurrentDictionary<string, SampleBassFactory>();
 
-        public int PlaybackConcurrency { get; set; } = Sample.DEFAULT_CONCURRENCY;
-
         internal SampleStore([NotNull] IResourceStore<byte[]> store, [NotNull] AudioMixer mixer)
         {
             this.store = store;
@@ -45,7 +43,7 @@ namespace osu.Framework.Audio.Sample
                     this.LogIfNonBackgroundThread(name);
 
                     byte[] data = store.Get(name);
-                    factory = factories[name] = data == null ? null : new SampleBassFactory(data, (BassAudioMixer)mixer) { PlaybackConcurrency = { Value = PlaybackConcurrency } };
+                    factory = factories[name] = data == null ? null : new SampleBassFactory(data, (BassAudioMixer)mixer);
 
                     if (factory != null)
                         AddItem(factory);

--- a/osu.Framework/Graphics/Audio/DrawableAudioMixer.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioMixer.cs
@@ -24,6 +24,12 @@ namespace osu.Framework.Graphics.Audio
 
         public BindableList<IEffectParameter> Effects { get; } = new BindableList<IEffectParameter>();
 
+        public int Concurrency
+        {
+            get => mixer.Concurrency;
+            set => mixer.Concurrency = value;
+        }
+
         public void Add(IAudioChannel channel)
         {
             if (LoadState < LoadState.Ready)

--- a/osu.Framework/Graphics/Audio/DrawableSample.cs
+++ b/osu.Framework/Graphics/Audio/DrawableSample.cs
@@ -28,8 +28,6 @@ namespace osu.Framework.Graphics.Audio
             : base(sample, disposeSampleOnDisposal)
         {
             this.sample = sample;
-
-            PlaybackConcurrency.BindTo(sample.PlaybackConcurrency);
         }
 
         public SampleChannel Play()
@@ -50,8 +48,6 @@ namespace osu.Framework.Graphics.Audio
         }
 
         public double Length => sample.Length;
-
-        public Bindable<int> PlaybackConcurrency { get; } = new Bindable<int>(Sample.DEFAULT_CONCURRENCY);
 
         private IAudioMixer? mixer;
 


### PR DESCRIPTION
I debated for quite a long time whether to keep playback concurrency as part of `Sample` or not. Here's a few observations I made:
1. One problem is that `Sample`s are inherently distinct objects - they don't know about each other and especially don't know about each others' channels, so they would have to be linked with the `AudioMixer` in some way anyway because that's the only component which knows about everything.
2. When considering the case of global (shared between all `Sample`s with the same data backing) vs per-`Sample` concurrency limitations, I didn't feel like keeping playback concurrency as part of `Sample` to be the most extensible and intuitive way to go about this if it would ever be required.
3. After looking at how we're currently doing concurrency, I noticed that we have to explicitly set `SampleStore.PlaybackConcurrency` when creating a custom `SampleStore` (e.g. the `DrawableRuleset` `SampleStore`). This feels very flaky to me, easy for a consumer to miss, and quite hard to document.

With all of that in mind, I came to the conclusion that concurrency should be part of `AudioMixer`. It works on audio channels, which means that there's no distinction between a track or a sample - the user should be able to use this without caring about there being special cases.

By default, I've set unlimited concurrency to both the global track mixer and sample mixer.

---

## Playback concurrency

By default, all `AudioMixer`s play as many channels as given to them concurrently. For cases where this may be undesirable, such as when playing back samples on user interactions, the `AudioMixer.Concurrency` property can be used to limit the number of concurrent playback channels.
```csharp
[BackgroundDependencyLoader]
private void load(ISampleStore samples, AudioManager audioManager)
{
    // Limit all global samples to two concurrent playbacks.
    audioManager.SampleMixer.Concurrency = 2;

    Sample globalSample = samples.Get(...);

    // The sample attached to the global audio mixer can only be played back two times.
    globalSample.Play(); // 1
    globalSample.Play();
    globalSample.Play(); // Upon calling this, playback #1 above will be stopped.


    DrawableAudioMixer localAudioMixer;
    DrawableSample localSample;

    // A local audio mixer allowing six concurrent playbacks.
    Add(localAudioMixer = new DrawableAudioMixer
    {
        Concurrency = 6,
        Child = localSample = new DrawableSample(samples.Get(...)),
        Effects =
        {
            ...
        }
    });

    // A sample within the local mixer can only be played back six times.
    localSample.Play(); // 1
    localSample.Play();
    localSample.Play();
    localSample.Play();
    localSample.Play();
    localSample.Play();
    localSample.Play(); // Upon calling this, playback #1 above will be stopped.
}
```