### PR TITLE
Mark `GetClipboard()` as possibly returning null

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -13,6 +13,7 @@ using System.Runtime.ExceptionServices;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 using osuTK;
 using osuTK.Graphics;
@@ -128,6 +129,7 @@ namespace osu.Framework.Platform
         /// </summary>
         protected virtual IWindow CreateWindow() => null;
 
+        [CanBeNull]
         public virtual Clipboard GetClipboard() => null;
 
         /// <summary>


### PR DESCRIPTION
Something I got bit by when working on support for transferring editor state between difficulties.

Game-side `ComposeScreen` uses `GetClipboard()` unprotected once for copying out object timestamps to the OS clipboard, which crashes headless. This never came up before likely because editor clipboard tests use `Editor.{Copy,Paste}()` directly, rather than firing platform actions, so that code path was never exercised.

In the ideal world this would also happen to `CreateWindow()` as well, but I don't want to detour to do that right now as that has a *lot* more usages.
