### PR TITLE
Align `TextBuilder` characters by their baselines during addition/removal

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkTextBuilder.cs
+++ b/osu.Framework.Benchmarks/BenchmarkTextBuilder.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
+using osu.Framework.Text;
+
+namespace osu.Framework.Benchmarks
+{
+    public class BenchmarkTextBuilder
+    {
+        private readonly ITexturedGlyphLookupStore store = new TestStore();
+
+        private TextBuilder textBuilder;
+
+        [Benchmark]
+        public void AddCharacters() => initialiseBuilder(false);
+
+        [Benchmark]
+        public void RemoveLastCharacter()
+        {
+            initialiseBuilder(false);
+            textBuilder.RemoveLastCharacter();
+        }
+
+        private void initialiseBuilder(bool allDifferentBaselines)
+        {
+            textBuilder = new TextBuilder(store, FontUsage.Default);
+
+            char different = 'B';
+
+            for (int i = 0; i < 100; i++)
+                textBuilder.AddCharacter(i % (allDifferentBaselines ? 1 : 10) == 0 ? different++ : 'A');
+        }
+
+        private class TestStore : ITexturedGlyphLookupStore
+        {
+            public ITexturedCharacterGlyph Get(string fontName, char character) => new TexturedCharacterGlyph(new CharacterGlyph(character, character, character, character, null), Texture.WhitePixel);
+
+            public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));
+        }
+    }
+}

--- a/osu.Framework.Benchmarks/BenchmarkTextBuilder.cs
+++ b/osu.Framework.Benchmarks/BenchmarkTextBuilder.cs
@@ -19,25 +19,35 @@ namespace osu.Framework.Benchmarks
         public void AddCharacters() => initialiseBuilder(false);
 
         [Benchmark]
+        public void AddCharactersWithDifferentBaselines() => initialiseBuilder(true);
+
+        [Benchmark]
         public void RemoveLastCharacter()
         {
             initialiseBuilder(false);
             textBuilder.RemoveLastCharacter();
         }
 
-        private void initialiseBuilder(bool allDifferentBaselines)
+        [Benchmark]
+        public void RemoveLastCharacterWithDifferentBaselines()
+        {
+            initialiseBuilder(true);
+            textBuilder.RemoveLastCharacter();
+        }
+
+        private void initialiseBuilder(bool withDifferentBaselines)
         {
             textBuilder = new TextBuilder(store, FontUsage.Default);
 
             char different = 'B';
 
             for (int i = 0; i < 100; i++)
-                textBuilder.AddCharacter(i % (allDifferentBaselines ? 1 : 10) == 0 ? different++ : 'A');
+                textBuilder.AddCharacter(withDifferentBaselines && (i % 10 == 0) ? different++ : 'A');
         }
 
         private class TestStore : ITexturedGlyphLookupStore
         {
-            public ITexturedCharacterGlyph Get(string fontName, char character) => new TexturedCharacterGlyph(new CharacterGlyph(character, character, character, character, null), Texture.WhitePixel);
+            public ITexturedCharacterGlyph Get(string fontName, char character) => new TexturedCharacterGlyph(new CharacterGlyph(character, character, character, character, character, null), Texture.WhitePixel);
 
             public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));
         }

--- a/osu.Framework.Tests/Text/TextBuilderTest.cs
+++ b/osu.Framework.Tests/Text/TextBuilderTest.cs
@@ -599,7 +599,7 @@ namespace osu.Framework.Tests.Text
                 return glyphs.FirstOrDefault(g => g.Font.FontName == fontName && g.Glyph.Character == character).Glyph;
             }
 
-            public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => throw new System.NotImplementedException();
+            public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => throw new NotImplementedException();
         }
 
         private readonly struct GlyphEntry

--- a/osu.Framework.Tests/Text/TextBuilderTest.cs
+++ b/osu.Framework.Tests/Text/TextBuilderTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -20,24 +21,27 @@ namespace osu.Framework.Tests.Text
         private const float y_offset = 2;
         private const float x_advance = 3;
         private const float width = 4;
-        private const float height = 5;
-        private const float kerning = -6;
+        private const float baseline = 5;
+        private const float height = 6;
+        private const float kerning = -7;
 
-        private const float b_x_offset = 7;
-        private const float b_y_offset = 8;
-        private const float b_x_advance = 9;
-        private const float b_width = 10;
-        private const float b_height = 11;
-        private const float b_kerning = -12;
+        private const float b_x_offset = 8;
+        private const float b_y_offset = 9;
+        private const float b_x_advance = 10;
+        private const float b_width = 11;
+        private const float b_baseline = 12;
+        private const float b_height = 13;
+        private const float b_kerning = -14;
 
-        private const float m_x_offset = 13;
-        private const float m_y_offset = 14;
-        private const float m_x_advance = 15;
-        private const float m_width = 16;
-        private const float m_height = 17;
-        private const float m_kerning = -18;
+        private const float m_x_offset = 15;
+        private const float m_y_offset = 16;
+        private const float m_x_advance = 17;
+        private const float m_width = 18;
+        private const float m_baseline = 19;
+        private const float m_height = 20;
+        private const float m_kerning = -21;
 
-        private static readonly Vector2 spacing = new Vector2(19, 20);
+        private static readonly Vector2 spacing = new Vector2(22, 23);
 
         private static readonly TestFontUsage normal_font = new TestFontUsage("test");
         private static readonly TestFontUsage fixed_width_font = new TestFontUsage("test-fixedwidth", fixedWidth: true);
@@ -47,12 +51,12 @@ namespace osu.Framework.Tests.Text
         public TextBuilderTest()
         {
             fontStore = new TestStore(
-                new GlyphEntry(normal_font, new TestGlyph('a', x_offset, y_offset, x_advance, width, height, kerning)),
-                new GlyphEntry(normal_font, new TestGlyph('b', b_x_offset, b_y_offset, b_x_advance, b_width, b_height, b_kerning)),
-                new GlyphEntry(normal_font, new TestGlyph('m', m_x_offset, m_y_offset, m_x_advance, m_width, m_height, m_kerning)),
-                new GlyphEntry(fixed_width_font, new TestGlyph('a', x_offset, y_offset, x_advance, width, height, kerning)),
-                new GlyphEntry(fixed_width_font, new TestGlyph('b', b_x_offset, b_y_offset, b_x_advance, b_width, b_height, b_kerning)),
-                new GlyphEntry(fixed_width_font, new TestGlyph('m', m_x_offset, m_y_offset, m_x_advance, m_width, m_height, m_kerning))
+                new GlyphEntry(normal_font, new TestGlyph('a', x_offset, y_offset, x_advance, width, baseline, height, kerning)),
+                new GlyphEntry(normal_font, new TestGlyph('b', b_x_offset, b_y_offset, b_x_advance, b_width, b_baseline, b_height, b_kerning)),
+                new GlyphEntry(normal_font, new TestGlyph('m', m_x_offset, m_y_offset, m_x_advance, m_width, m_baseline, m_height, m_kerning)),
+                new GlyphEntry(fixed_width_font, new TestGlyph('a', x_offset, y_offset, x_advance, width, baseline, height, kerning)),
+                new GlyphEntry(fixed_width_font, new TestGlyph('b', b_x_offset, b_y_offset, b_x_advance, b_width, b_baseline, b_height, b_kerning)),
+                new GlyphEntry(fixed_width_font, new TestGlyph('m', m_x_offset, m_y_offset, m_x_advance, m_width, m_baseline, m_height, m_kerning))
             );
         }
 
@@ -239,20 +243,119 @@ namespace osu.Framework.Tests.Text
         }
 
         /// <summary>
-        /// Tests that the current position is correctly reset when the first character is removed.
+        /// Tests that a character with a lower baseline moves the previous character down to align with the new character.
         /// </summary>
         [Test]
-        public void TestRemoveFirstCharacterResetsCurrentPosition()
+        public void TestCharacterWithLowerBaselineOffsetsPreviousCharacters()
+        {
+            var builder = new TextBuilder(fontStore, normal_font);
+
+            builder.AddText("a");
+
+            Assert.That(builder.LineBaseHeight, Is.EqualTo(baseline));
+
+            builder.AddText("b");
+
+            Assert.That(builder.LineBaseHeight, Is.EqualTo(b_baseline));
+            Assert.That(builder.Characters[0].DrawRectangle.Top, Is.EqualTo(y_offset + (b_baseline - baseline)));
+
+            builder.AddText("m");
+
+            Assert.That(builder.LineBaseHeight, Is.EqualTo(m_baseline));
+            Assert.That(builder.Characters[0].DrawRectangle.Top, Is.EqualTo(y_offset + (m_baseline - baseline)));
+            Assert.That(builder.Characters[1].DrawRectangle.Top, Is.EqualTo(b_y_offset + (m_baseline - b_baseline)));
+        }
+
+        /// <summary>
+        /// Tests that a character with a higher (lesser in value) baseline gets moved down to align with the previous characters.
+        /// </summary>
+        [Test]
+        public void TestCharacterWithHigherBaselineGetsOffset()
+        {
+            var builder = new TextBuilder(fontStore, normal_font);
+
+            builder.AddText("m");
+
+            Assert.That(builder.LineBaseHeight, Is.EqualTo(m_baseline));
+
+            builder.AddText("b");
+
+            Assert.That(builder.LineBaseHeight, Is.EqualTo(m_baseline));
+            Assert.That(builder.Characters[1].DrawRectangle.Top, Is.EqualTo(b_y_offset + (m_baseline - b_baseline)));
+
+            builder.AddText("a");
+
+            Assert.That(builder.LineBaseHeight, Is.EqualTo(m_baseline));
+            Assert.That(builder.Characters[1].DrawRectangle.Top, Is.EqualTo(b_y_offset + (m_baseline - b_baseline)));
+            Assert.That(builder.Characters[2].DrawRectangle.Top, Is.EqualTo(y_offset + (m_baseline - baseline)));
+        }
+
+        /// <summary>
+        /// Tests that baseline alignment adjustments only affect the line the new character was placed on.
+        /// </summary>
+        [Test]
+        public void TestBaselineAdjustmentAffectsRelevantLineOnly()
+        {
+            var builder = new TextBuilder(fontStore, normal_font);
+
+            builder.AddText("a");
+            builder.AddNewLine();
+            builder.AddText("ab");
+            builder.AddNewLine();
+
+            builder.AddText("ab");
+
+            assertOtherCharactersNotAffected();
+            Assert.That(builder.Characters[3].DrawRectangle.Top, Is.EqualTo(font_size * 2 + y_offset + (b_baseline - baseline)));
+            Assert.That(builder.Characters[4].DrawRectangle.Top, Is.EqualTo(font_size * 2 + b_y_offset));
+
+            builder.AddText("m");
+
+            assertOtherCharactersNotAffected();
+            Assert.That(builder.Characters[3].DrawRectangle.Top, Is.EqualTo(font_size * 2 + y_offset + (m_baseline - baseline)));
+            Assert.That(builder.Characters[4].DrawRectangle.Top, Is.EqualTo(font_size * 2 + b_y_offset + (b_baseline - baseline)));
+            Assert.That(builder.Characters[5].DrawRectangle.Top, Is.EqualTo(font_size * 2 + m_y_offset));
+
+            void assertOtherCharactersNotAffected()
+            {
+                Assert.That(builder.Characters[0].DrawRectangle.Top, Is.EqualTo(y_offset));
+                Assert.That(builder.Characters[1].DrawRectangle.Top, Is.EqualTo(font_size + y_offset + (b_baseline - baseline)));
+                Assert.That(builder.Characters[2].DrawRectangle.Top, Is.EqualTo(font_size + b_y_offset));
+            }
+        }
+
+        /// <summary>
+        /// Tests that accessing <see cref="TextBuilder.LineBaseHeight"/> while the builder has multiline text throws.
+        /// </summary>
+        [Test]
+        public void TestLineBaseHeightThrowsOnMultiline()
+        {
+            var builder = new TextBuilder(fontStore, normal_font);
+
+            builder.AddText("a");
+            builder.AddNewLine();
+            builder.AddText("b");
+
+            Assert.Throws<InvalidOperationException>(() => _ = builder.LineBaseHeight);
+        }
+
+        /// <summary>
+        /// Tests that the current position and "line base height" are correctly reset when the first character is removed.
+        /// </summary>
+        [Test]
+        public void TestRemoveFirstCharacterResetsCurrentPositionAndLineBaseHeight()
         {
             var builder = new TextBuilder(fontStore, normal_font, spacing: spacing);
 
             builder.AddText("a");
             builder.RemoveLastCharacter();
 
+            Assert.That(builder.LineBaseHeight, Is.EqualTo(0f));
             Assert.That(builder.Bounds, Is.EqualTo(Vector2.Zero));
 
             builder.AddText("a");
 
+            Assert.That(builder.LineBaseHeight, Is.EqualTo(baseline));
             Assert.That(builder.Characters[0].DrawRectangle.Top, Is.EqualTo(y_offset));
             Assert.That(builder.Characters[0].DrawRectangle.Left, Is.EqualTo(x_offset));
         }
@@ -299,6 +402,73 @@ namespace osu.Framework.Tests.Text
         }
 
         /// <summary>
+        /// Tests that removing a character adjusts the baseline of the relevant line.
+        /// </summary>
+        [Test]
+        public void TestRemoveCharacterAdjustsCharactersBaselineOfRelevantLine()
+        {
+            var builder = new TextBuilder(fontStore, normal_font);
+
+            builder.AddText("a");
+            builder.AddNewLine();
+            builder.AddText("ab");
+            builder.AddNewLine();
+            builder.AddText("abm");
+
+            builder.RemoveLastCharacter();
+
+            assertOtherCharactersNotAffected();
+            Assert.That(builder.Characters[3].DrawRectangle.Top, Is.EqualTo(font_size * 2 + y_offset + (b_baseline - baseline)));
+            Assert.That(builder.Characters[4].DrawRectangle.Top, Is.EqualTo(font_size * 2 + b_y_offset));
+
+            builder.RemoveLastCharacter();
+
+            assertOtherCharactersNotAffected();
+            Assert.That(builder.Characters[3].DrawRectangle.Top, Is.EqualTo(font_size * 2 + y_offset));
+
+            void assertOtherCharactersNotAffected()
+            {
+                Assert.That(builder.Characters[0].DrawRectangle.Top, Is.EqualTo(y_offset));
+                Assert.That(builder.Characters[1].DrawRectangle.Top, Is.EqualTo(font_size + y_offset + (b_baseline - baseline)));
+                Assert.That(builder.Characters[2].DrawRectangle.Top, Is.EqualTo(font_size + b_y_offset));
+            }
+        }
+
+        /// <summary>
+        /// Tests that removing a character from a text that still has another character with the same baseline doesn't affect the alignment.
+        /// </summary>
+        [Test]
+        public void TestRemoveSameBaselineCharacterDoesntAffectAlignment()
+        {
+            var builder = new TextBuilder(fontStore, normal_font);
+
+            builder.AddText("abb");
+
+            Assert.That(builder.Characters[0].DrawRectangle.Top, Is.EqualTo(y_offset + (b_baseline - baseline)));
+
+            builder.RemoveLastCharacter();
+
+            Assert.That(builder.Characters[0].DrawRectangle.Top, Is.EqualTo(y_offset + (b_baseline - baseline)));
+        }
+
+        /// <summary>
+        /// Tests that removing the first character of a line doesn't affect the baseline alignment of the line above it.
+        /// </summary>
+        [Test]
+        public void TestRemoveFirstCharacterOnNewlineDoesntAffectLastLineAlignment()
+        {
+            var builder = new TextBuilder(fontStore, normal_font);
+
+            builder.AddText("ab");
+            builder.AddNewLine();
+            builder.AddText("m");
+            builder.RemoveLastCharacter();
+
+            Assert.That(builder.Characters[0].DrawRectangle.Top, Is.EqualTo(y_offset + (b_baseline - baseline)));
+            Assert.That(builder.Characters[1].DrawRectangle.Top, Is.EqualTo(b_y_offset));
+        }
+
+        /// <summary>
         /// Tests that the custom user-provided spacing is added for a new character/line.
         /// </summary>
         [Test]
@@ -326,10 +496,10 @@ namespace osu.Framework.Tests.Text
             var font = new TestFontUsage("test");
             var nullFont = new TestFontUsage(null);
             var builder = new TextBuilder(new TestStore(
-                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                new GlyphEntry(nullFont, new TestGlyph('a', 0, 0, 0, 0, 0, 0)),
-                new GlyphEntry(font, new TestGlyph('?', 0, 0, 0, 0, 0, 0)),
-                new GlyphEntry(nullFont, new TestGlyph('?', 0, 0, 0, 0, 0, 0))
+                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('a', 0, 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(font, new TestGlyph('?', 0, 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('?', 0, 0, 0, 0, 0, 0, 0))
             ), font);
 
             builder.AddText("a");
@@ -346,10 +516,10 @@ namespace osu.Framework.Tests.Text
             var font = new TestFontUsage("test");
             var nullFont = new TestFontUsage(null);
             var builder = new TextBuilder(new TestStore(
-                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                new GlyphEntry(nullFont, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                new GlyphEntry(font, new TestGlyph('?', 0, 0, 0, 0, 0, 0)),
-                new GlyphEntry(nullFont, new TestGlyph('?', 1, 0, 0, 0, 0, 0))
+                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('b', 0, 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(font, new TestGlyph('?', 0, 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('?', 1, 0, 0, 0, 0, 0, 0))
             ), font);
 
             builder.AddText("a");
@@ -367,10 +537,10 @@ namespace osu.Framework.Tests.Text
             var font = new TestFontUsage("test");
             var nullFont = new TestFontUsage(null);
             var builder = new TextBuilder(new TestStore(
-                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                new GlyphEntry(nullFont, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0)),
-                new GlyphEntry(nullFont, new TestGlyph('?', 1, 0, 0, 0, 0, 0))
+                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('b', 0, 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(font, new TestGlyph('b', 0, 0, 0, 0, 0, 0, 0)),
+                new GlyphEntry(nullFont, new TestGlyph('?', 1, 0, 0, 0, 0, 0, 0))
             ), font);
 
             builder.AddText("a");
@@ -424,9 +594,7 @@ namespace osu.Framework.Tests.Text
             public ITexturedCharacterGlyph Get(string fontName, char character)
             {
                 if (string.IsNullOrEmpty(fontName))
-                {
                     return glyphs.FirstOrDefault(g => g.Glyph.Character == character).Glyph;
-                }
 
                 return glyphs.FirstOrDefault(g => g.Font.FontName == fontName && g.Glyph.Character == character).Glyph;
             }
@@ -453,12 +621,13 @@ namespace osu.Framework.Tests.Text
             public float YOffset { get; }
             public float XAdvance { get; }
             public float Width { get; }
+            public float Baseline { get; }
             public float Height { get; }
             public char Character { get; }
 
             private readonly float glyphKerning;
 
-            public TestGlyph(char character, float xOffset, float yOffset, float xAdvance, float width, float height, float kerning)
+            public TestGlyph(char character, float xOffset, float yOffset, float xAdvance, float width, float baseline, float height, float kerning)
             {
                 glyphKerning = kerning;
                 Character = character;
@@ -466,6 +635,7 @@ namespace osu.Framework.Tests.Text
                 YOffset = yOffset;
                 XAdvance = xAdvance;
                 Width = width;
+                Baseline = baseline;
                 Height = height;
             }
 

--- a/osu.Framework/Graphics/Sprites/SpriteText.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteText.cs
@@ -627,21 +627,12 @@ namespace osu.Framework.Graphics.Sprites
 
         public override string ToString() => $@"""{displayedText}"" " + base.ToString();
 
-        /// <summary>
-        /// Gets the base height of the font used by this text. If the font of this text is invalid, 0 is returned.
-        /// </summary>
         public float LineBaseHeight
         {
             get
             {
-                var baseHeight = store.GetBaseHeight(Font.FontName);
-                if (baseHeight.HasValue)
-                    return baseHeight.Value * Font.Size;
-
-                if (string.IsNullOrEmpty(displayedText))
-                    return 0;
-
-                return store.GetBaseHeight(displayedText[0]).GetValueOrDefault() * Font.Size;
+                computeCharacters();
+                return textBuilderCache.Value.LineBaseHeight;
             }
         }
 

--- a/osu.Framework/IO/Stores/FontStore.cs
+++ b/osu.Framework/IO/Stores/FontStore.cs
@@ -174,45 +174,6 @@ namespace osu.Framework.IO.Stores
 
         public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));
 
-        public float? GetBaseHeight(char c)
-        {
-            foreach (var store in glyphStores)
-            {
-                if (store.HasGlyph(c))
-                    return store.GetBaseHeight() / ScaleAdjust;
-            }
-
-            foreach (var store in nestedFontStores)
-            {
-                var height = store.GetBaseHeight(c);
-                if (height.HasValue)
-                    return height;
-            }
-
-            return null;
-        }
-
-        public float? GetBaseHeight(string fontName)
-        {
-            foreach (var store in glyphStores)
-            {
-                if (store.FontName != fontName)
-                    continue;
-
-                var bh = store.GetBaseHeight();
-                return bh / ScaleAdjust;
-            }
-
-            foreach (var store in nestedFontStores)
-            {
-                var height = store.GetBaseHeight(fontName);
-                if (height.HasValue)
-                    return height;
-            }
-
-            return null;
-        }
-
         protected override void Dispose(bool disposing)
         {
             base.Dispose(disposing);

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -78,8 +78,6 @@ namespace osu.Framework.IO.Stores
 
         public bool HasGlyph(char c) => Font?.Characters.ContainsKey(c) == true;
 
-        public int GetBaseHeight() => Font?.Common.Base ?? 0;
-
         protected virtual TextureUpload GetPageImage(int page)
         {
             if (TextureLoader != null)

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -28,6 +28,8 @@ namespace osu.Framework.IO.Stores
 
         public string FontName { get; }
 
+        public float? Baseline => Font?.Common.Base;
+
         protected readonly ResourceStore<byte[]> Store;
 
         [CanBeNull]
@@ -39,7 +41,7 @@ namespace osu.Framework.IO.Stores
         /// Create a new glyph store.
         /// </summary>
         /// <param name="store">The store to provide font resources.</param>
-        /// <param name="assetName">The base name of thße font.</param>
+        /// <param name="assetName">The base name of the font.</param>
         /// <param name="textureLoader">An optional platform-specific store for loading textures. Should load for the store provided in <param ref="param"/>.</param>
         public GlyphStore(ResourceStore<byte[]> store, string assetName = null, IResourceStore<TextureUpload> textureLoader = null)
         {
@@ -99,8 +101,10 @@ namespace osu.Framework.IO.Stores
             if (Font == null)
                 return null;
 
+            Debug.Assert(Baseline != null);
+
             var bmCharacter = Font.GetCharacter(character);
-            return new CharacterGlyph(character, bmCharacter.XOffset, bmCharacter.YOffset, bmCharacter.XAdvance, this);
+            return new CharacterGlyph(character, bmCharacter.XOffset, bmCharacter.YOffset, bmCharacter.XAdvance, Baseline.Value, this);
         }
 
         public int GetKerning(char left, char right) => Font?.GetKerningAmount(left, right) ?? 0;

--- a/osu.Framework/IO/Stores/IGlyphStore.cs
+++ b/osu.Framework/IO/Stores/IGlyphStore.cs
@@ -17,6 +17,11 @@ namespace osu.Framework.IO.Stores
         string FontName { get; }
 
         /// <summary>
+        /// The font's baseline position, or <see langword="null"/> if not available (i.e. font not loaded or failed to load).
+        /// </summary>
+        float? Baseline { get; }
+
+        /// <summary>
         /// Loads glyph information for consumption asynchronously.
         /// </summary>
         Task LoadFontAsync();

--- a/osu.Framework/IO/Stores/IGlyphStore.cs
+++ b/osu.Framework/IO/Stores/IGlyphStore.cs
@@ -32,11 +32,6 @@ namespace osu.Framework.IO.Stores
         bool HasGlyph(char c);
 
         /// <summary>
-        /// Retrieves the height from the top of the glyph cell to the baseline.
-        /// </summary>
-        int GetBaseHeight();
-
-        /// <summary>
         /// Retrieves a <see cref="CharacterGlyph"/> that contains associated spacing information for a character.
         /// </summary>
         /// <param name="character">The character to retrieve the <see cref="CharacterGlyph"/> for.</param>

--- a/osu.Framework/Text/CharacterGlyph.cs
+++ b/osu.Framework/Text/CharacterGlyph.cs
@@ -12,11 +12,12 @@ namespace osu.Framework.Text
         public float XOffset { get; }
         public float YOffset { get; }
         public float XAdvance { get; }
+        public float Baseline { get; }
         public char Character { get; }
 
         private readonly IGlyphStore containingStore;
 
-        public CharacterGlyph(char character, float xOffset, float yOffset, float xAdvance, [CanBeNull] IGlyphStore containingStore)
+        public CharacterGlyph(char character, float xOffset, float yOffset, float xAdvance, float baseline, [CanBeNull] IGlyphStore containingStore)
         {
             this.containingStore = containingStore;
 
@@ -24,6 +25,7 @@ namespace osu.Framework.Text
             XOffset = xOffset;
             YOffset = yOffset;
             XAdvance = xAdvance;
+            Baseline = baseline;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/osu.Framework/Text/ICharacterGlyph.cs
+++ b/osu.Framework/Text/ICharacterGlyph.cs
@@ -24,6 +24,11 @@ namespace osu.Framework.Text
         float XAdvance { get; }
 
         /// <summary>
+        /// The position of the baseline in this glyph.
+        /// </summary>
+        float Baseline { get; }
+
+        /// <summary>
         /// The character represented by this glyph.
         /// </summary>
         char Character { get; }

--- a/osu.Framework/Text/TextBuilder.cs
+++ b/osu.Framework/Text/TextBuilder.cs
@@ -13,7 +13,7 @@ namespace osu.Framework.Text
     /// <summary>
     /// A text builder for <see cref="SpriteText"/> and other text-based display components.
     /// </summary>
-    public class TextBuilder
+    public class TextBuilder : IHasLineBaseHeight
     {
         /// <summary>
         /// The bounding size of the composite text.
@@ -37,7 +37,25 @@ namespace osu.Framework.Text
 
         private Vector2 currentPos;
         private float currentLineHeight;
+        private float? currentLineBase;
         private bool currentNewLine = true;
+
+        /// <summary>
+        /// Gets the current base height of the text in this <see cref="TextBuilder"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when attempting to access this property on a <see cref="TextBuilder"/> with multiple lines added.
+        /// </exception>
+        public float LineBaseHeight
+        {
+            get
+            {
+                if (currentPos.Y > startOffset.Y)
+                    throw new InvalidOperationException($"Cannot return a {nameof(LineBaseHeight)} from a text builder with multiple lines.");
+
+                return currentLineBase ?? 0f;
+            }
+        }
 
         /// <summary>
         /// Creates a new <see cref="TextBuilder"/>.
@@ -79,6 +97,7 @@ namespace osu.Framework.Text
             Characters.Clear();
 
             currentPos = startOffset;
+            currentLineBase = null;
             currentLineHeight = 0;
             currentNewLine = true;
         }
@@ -118,7 +137,8 @@ namespace osu.Framework.Text
             // 1. Add the kerning to the current position if required.
             // 2. Draw the character at the current position offset by the glyph.
             //    The offset is not applied to the current position, it is only a value to be used at draw-time.
-            // 3. Advance the current position by glyph's XAdvance.
+            // 3. If this character has a different baseline from the previous, adjust either the previous characters or this character's to align on one baseline.
+            // 4. Advance the current position by glyph's XAdvance.
 
             float kerning = 0;
 
@@ -144,9 +164,26 @@ namespace osu.Framework.Text
 
             glyph.DrawRectangle = new RectangleF(new Vector2(currentPos.X + glyph.XOffset, currentPos.Y + glyph.YOffset), new Vector2(glyph.Width, glyph.Height));
             glyph.OnNewLine = currentNewLine;
+
+            if (glyph.Baseline > currentLineBase)
+            {
+                for (int i = Characters.Count - 1; i >= 0; --i)
+                {
+                    var previous = Characters[i];
+                    previous.DrawRectangle = previous.DrawRectangle.Offset(0, glyph.Baseline - currentLineBase.Value);
+                    Characters[i] = previous;
+
+                    if (previous.OnNewLine)
+                        break;
+                }
+            }
+            else if (glyph.Baseline < currentLineBase)
+                glyph.DrawRectangle = glyph.DrawRectangle.Offset(0, currentLineBase.Value - glyph.Baseline);
+
             Characters.Add(glyph);
 
             currentPos.X += glyph.XAdvance;
+            currentLineBase = currentLineBase == null ? glyph.Baseline : Math.Max(currentLineBase.Value, glyph.Baseline);
             currentLineHeight = Math.Max(currentLineHeight, getGlyphHeight(ref glyph));
             currentNewLine = false;
 
@@ -169,6 +206,7 @@ namespace osu.Framework.Text
             currentPos.X = startOffset.X;
             currentPos.Y += currentLineHeight + spacing.Y;
 
+            currentLineBase = null;
             currentLineHeight = 0;
             currentNewLine = true;
         }
@@ -188,12 +226,16 @@ namespace osu.Framework.Text
             Characters.RemoveAt(Characters.Count - 1);
 
             // For each character that is removed:
-            // 1. Calculate the line height of the last line.
+            // 1. Calculate the new baseline and line height of the last line.
             // 2. If the character is the first on a new line, move the current position upwards by the calculated line height and to the end of the previous line.
             //    The position at the end of the line is the post-XAdvanced position.
             // 3. If the character is not the first on a new line, move the current position backwards by the XAdvance and the kerning from the previous glyph.
             //    This brings the current position to the post-XAdvanced position of the previous glyph.
+            // 4. Also if the character is not the first on a new line and removing it changed the baseline, adjust the characters behind it to the new baseline.
 
+            var lastLineBase = currentLineBase;
+
+            currentLineBase = null;
             currentLineHeight = 0;
 
             // This is O(n^2) for removing all characters within a line, but is generally not used in such a case
@@ -201,6 +243,7 @@ namespace osu.Framework.Text
             {
                 var character = Characters[i];
 
+                currentLineBase = currentLineBase == null ? character.Baseline : Math.Max(currentLineBase.Value, character.Baseline);
                 currentLineHeight = Math.Max(currentLineHeight, getGlyphHeight(ref character));
 
                 if (character.OnNewLine)
@@ -233,6 +276,20 @@ namespace osu.Framework.Text
 
                 if (previousCharacter != null)
                     currentPos.X -= removedCharacter.GetKerning(previousCharacter.Value) + spacing.X;
+
+                // Adjust the alignment of the previous characters if the baseline position lowered after removing the character.
+                if (currentLineBase < lastLineBase)
+                {
+                    for (int i = Characters.Count - 1; i >= 0; i--)
+                    {
+                        var character = Characters[i];
+                        character.DrawRectangle = character.DrawRectangle.Offset(0, currentLineBase.Value - lastLineBase.Value);
+                        Characters[i] = character;
+
+                        if (character.OnNewLine)
+                            break;
+                    }
+                }
             }
 
             Bounds = Vector2.Zero;

--- a/osu.Framework/Text/TextBuilderGlyph.cs
+++ b/osu.Framework/Text/TextBuilderGlyph.cs
@@ -16,6 +16,7 @@ namespace osu.Framework.Text
         public readonly float XOffset => ((fixedWidth - Glyph.Width) / 2 ?? Glyph.XOffset) * textSize;
         public readonly float YOffset => Glyph.YOffset * textSize;
         public readonly float XAdvance => (fixedWidth ?? Glyph.XAdvance) * textSize;
+        public readonly float Baseline => Glyph.Baseline * textSize;
         public readonly float Width => Glyph.Width * textSize;
         public readonly float Height => Glyph.Height * textSize;
         public readonly char Character => Glyph.Character;

--- a/osu.Framework/Text/TexturedCharacterGlyph.cs
+++ b/osu.Framework/Text/TexturedCharacterGlyph.cs
@@ -13,6 +13,7 @@ namespace osu.Framework.Text
         public float XOffset => glyph.XOffset * Scale;
         public float YOffset => glyph.YOffset * Scale;
         public float XAdvance => glyph.XAdvance * Scale;
+        public float Baseline => glyph.Baseline * Scale;
         public char Character => glyph.Character;
         public float Width => Texture.Width * Scale;
         public float Height => Texture.Height * Scale;


### PR DESCRIPTION
Previously characters were *implicitly aligned* using their `YOffset`s, and that works when only one font is used, but not when more than one font gets used inside one `SpriteText`/`TextBuilder`.

This PR aims to resolve the "multiple fonts" case by offsetting their `DrawRectangle`s based on the difference between the `Baseline` of the new character and the previous characters.

I've worked on this initially so that font-mixed sprite texts with #3271 don't look badly misaligned (as I noticed after implementing #3271), but apparently, there are already alignment improvements osu!-side with this PR alone (although slightly unnoticable):

- Before:
![image](https://user-images.githubusercontent.com/22781491/133373547-b409f35c-27e6-455a-af43-cf990156951d.png)

- After:
![image](https://user-images.githubusercontent.com/22781491/133373555-8c905a4e-11b0-45fd-99c8-8e0d9217c55b.png)

(notice `(TV Size)` aligned correctly with the other glyphs)

I have added in-depth test coverage in `TextBuilderTest` which had the perfect setup for having so, with all possible scenarios I can think of.

Along with test coverage, I've also added a benchmark including the regular "no baseline adjustment" cases, and "one baseline adjustment every 10 characters" case, and the results seem reasonable.

|                                    Method |     Mean |    Error |   StdDev |
|------------------------------------------ |---------:|---------:|---------:|
|                             AddCharacters | 19.99 us | 0.280 us | 0.323 us |
|       AddCharactersWithDifferentBaselines | 31.02 us | 0.219 us | 0.183 us |
|                       RemoveLastCharacter | 24.90 us | 0.493 us | 0.506 us |
| RemoveLastCharacterWithDifferentBaselines | 38.14 us | 0.570 us | 0.505 us |

I can see this being further optimised by offseting new characters to negative `X/Y`s rather than offsetting all the other previous characters in the line, but that might be a bit complicated to deal with in the `SpriteText_DrawNode` (especially given that `TextBuilder` can have multiple lines), therefore I've went with the simplest way of for looping all characters in the line for now.