### PR TITLE
Avoid GL crash from vertex buffer index upload overflow

### DIFF
--- a/osu.Framework/Graphics/Batches/QuadBatch.cs
+++ b/osu.Framework/Graphics/Batches/QuadBatch.cs
@@ -3,9 +3,8 @@
 
 using System;
 using osu.Framework.Graphics.OpenGL.Buffers;
-using osuTK.Graphics.ES30;
 using osu.Framework.Graphics.OpenGL.Vertices;
-using osu.Framework.Graphics.Primitives;
+using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics.Batches
 {

--- a/osu.Framework/Graphics/Batches/QuadBatch.cs
+++ b/osu.Framework/Graphics/Batches/QuadBatch.cs
@@ -5,6 +5,7 @@ using System;
 using osu.Framework.Graphics.OpenGL.Buffers;
 using osuTK.Graphics.ES30;
 using osu.Framework.Graphics.OpenGL.Vertices;
+using osu.Framework.Graphics.Primitives;
 
 namespace osu.Framework.Graphics.Batches
 {
@@ -14,6 +15,8 @@ namespace osu.Framework.Graphics.Batches
         public QuadBatch(int size, int maxBuffers)
             : base(size, maxBuffers)
         {
+            if (size > QuadVertexBuffer<T>.MAX_QUADS)
+                throw new OverflowException($"Attempted to initialise a {nameof(QuadVertexBuffer<T>)} with more than {nameof(QuadVertexBuffer<T>)}.{nameof(QuadVertexBuffer<T>.MAX_QUADS)} quads ({QuadVertexBuffer<T>.MAX_QUADS}).");
         }
 
         protected override VertexBuffer<T> CreateVertexBuffer() => new QuadVertexBuffer<T>(Size, BufferUsageHint.DynamicDraw);

--- a/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
@@ -22,25 +22,28 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
     public class QuadVertexBuffer<T> : VertexBuffer<T>
         where T : struct, IEquatable<T>, IVertex
     {
-        private readonly int amountQuads;
+        private readonly int amountIndices;
+
+        private const int indices_per_quad = TextureGLSingle.VERTICES_PER_QUAD + 2;
 
         internal QuadVertexBuffer(int amountQuads, BufferUsageHint usage)
             : base(amountQuads * TextureGLSingle.VERTICES_PER_QUAD, usage)
         {
-            this.amountQuads = amountQuads;
+            amountIndices = amountQuads * indices_per_quad;
+
+            if (amountIndices > ushort.MaxValue)
+                throw new OverflowException($"Attempted to initialise a {nameof(QuadVertexBuffer<T>)} with more than {ushort.MaxValue} indices.");
         }
 
         protected override void Initialise()
         {
             base.Initialise();
 
-            int amountIndices = amountQuads * 6;
-
             if (amountIndices > QuadIndexData.MaxAmountIndices)
             {
                 ushort[] indices = new ushort[amountIndices];
 
-                for (ushort i = 0, j = 0; j < amountIndices; i += TextureGLSingle.VERTICES_PER_QUAD, j += 6)
+                for (ushort i = 0, j = 0; j < amountIndices; i += TextureGLSingle.VERTICES_PER_QUAD, j += indices_per_quad)
                 {
                     indices[j] = i;
                     indices[j + 1] = (ushort)(i + 1);

--- a/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/QuadVertexBuffer.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Diagnostics;
 using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.Graphics.OpenGL.Vertices;
 using osuTK.Graphics.ES30;
@@ -26,13 +27,16 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         private const int indices_per_quad = TextureGLSingle.VERTICES_PER_QUAD + 2;
 
+        /// <summary>
+        /// The maximum number of quads supported by this buffer.
+        /// </summary>
+        public const int MAX_QUADS = ushort.MaxValue / indices_per_quad;
+
         internal QuadVertexBuffer(int amountQuads, BufferUsageHint usage)
             : base(amountQuads * TextureGLSingle.VERTICES_PER_QUAD, usage)
         {
             amountIndices = amountQuads * indices_per_quad;
-
-            if (amountIndices > ushort.MaxValue)
-                throw new OverflowException($"Attempted to initialise a {nameof(QuadVertexBuffer<T>)} with more than {ushort.MaxValue} indices.");
+            Debug.Assert(amountIndices <= ushort.MaxValue);
         }
 
         protected override void Initialise()


### PR DESCRIPTION
Now throws instead. This should be a very edge case that can only be hit with custom usage of `QuadVertexBuffer`, and is intended to avoid a runaway scenario where the game becomes unresponsive.

sample exception:

```csharp
[runtime] 2021-09-15 09:30:10 [error]: An unhandled error has occurred.
[runtime] 2021-09-15 09:30:10 [error]: System.OverflowException: Attempted to initialise a QuadVertexBuffer with more than QuadVertexBuffer.MAX_QUADS quads (10922).
[runtime] 2021-09-15 09:30:10 [error]: at osu.Framework.Graphics.Batches.QuadBatch`1..ctor(Int32 size, Int32 maxBuffers) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Batches/QuadBatch.cs:line 19

```