### PR TITLE
Flush all stream writes on dispose to avoid potential disk write failures

### DIFF
--- a/osu.Framework/Platform/FlushingStream.cs
+++ b/osu.Framework/Platform/FlushingStream.cs
@@ -1,0 +1,29 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+
+namespace osu.Framework.Platform
+{
+    /// <summary>
+    /// A <see cref="FileStream"/> which always flushes to disk on disposal.
+    /// </summary>
+    /// <remarks>
+    /// This adds a considerable overhead, but is required to avoid files being potentially written to disk in a corrupt state.
+    /// See https://stackoverflow.com/questions/49260358/what-could-cause-an-xml-file-to-be-filled-with-null-characters/52751216#52751216.
+    /// </remarks>
+    public class FlushingStream : FileStream
+    {
+        public FlushingStream(string path, FileMode mode, FileAccess access)
+            : base(path, mode, access)
+        {
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            Flush(true);
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -86,7 +86,7 @@ namespace osu.Framework.Platform
                     return File.Open(path, FileMode.Open, access, FileShare.Read);
 
                 default:
-                    return File.Open(path, mode, access);
+                    return new FlushingStream(path, mode, access);
             }
         }
 


### PR DESCRIPTION
Following twitter advice (see https://github.com/EverestAPI/Everest/pull/301 / https://twitter.com/WEGFan/status/1438409484779491328?s=20).

Alternative to #4776 I guess? Probably fine to roll without that one and just tell any remaining users which hit this issue to delete their cache folder.