### PR TITLE
Add ability for `SearchContainer` to match even when letters are missing

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -91,6 +91,16 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkCount(count);
         }
 
+        [TestCase("tst", 2)]
+        [TestCase("ssn 1", 6)]
+        [TestCase("sns 1", 0)]
+        [TestCase("hdr", 8)]
+        public void TestEagerFiltering(string term, int count)
+        {
+            setTerm(term);
+            checkCount(count);
+        }
+
         [TestCase]
         public void TestRefilterAfterNewChild()
         {

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSearchContainer.cs
@@ -95,6 +95,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [TestCase("ssn 1", 6)]
         [TestCase("sns 1", 0)]
         [TestCase("hdr", 8)]
+        [TestCase("tt", 2)]
+        [TestCase("ttt", 0)]
         public void TestEagerFiltering(string term, int count)
         {
             setTerm(term);

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using osu.Framework.Caching;
 using osu.Framework.Extensions.IEnumerableExtensions;
@@ -64,12 +65,12 @@ namespace osu.Framework.Graphics.Containers
             Children.OfType<IFilterable>().ForEach(child => match(child, terms, terms.Length > 0));
         }
 
-        private static bool match(IFilterable filterable, IEnumerable<string> terms, bool searchActive)
+        private static bool match(IFilterable filterable, IEnumerable<string> searchTerms, bool searchActive)
         {
             //Words matched by parent is not needed to match children
-            var childTerms = terms.Where(term =>
+            var childTerms = searchTerms.Where(term =>
                 !filterable.FilterTerms.Any(filterTerm =>
-                    filterTerm.Contains(term, StringComparison.InvariantCultureIgnoreCase))).ToArray();
+                    forwardMatch(filterTerm, term))).ToArray();
 
             bool matching = childTerms.Length == 0;
 
@@ -82,6 +83,26 @@ namespace osu.Framework.Graphics.Containers
 
             filterable.FilteringActive = searchActive;
             return filterable.MatchingFilter = matching;
+        }
+
+        /// <summary>
+        /// Check whether a search term exists in a forward direction, allowing for potentially non-matching characters to exist between matches.
+        /// </summary>
+        private static bool forwardMatch(string haystack, string needle)
+        {
+            int index = 0;
+
+            for (int i = 0; i < needle.Length; i++)
+            {
+                // string.IndexOf doesn't have an overload which takes both a `startIndex` and `StringComparison` mode.
+                int found = CultureInfo.InvariantCulture.CompareInfo.IndexOf(haystack, needle[i], index, CompareOptions.OrdinalIgnoreCase);
+                if (found < 0)
+                    return false;
+
+                index = found;
+            }
+
+            return true;
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/SearchContainer.cs
+++ b/osu.Framework/Graphics/Containers/SearchContainer.cs
@@ -99,7 +99,7 @@ namespace osu.Framework.Graphics.Containers
                 if (found < 0)
                     return false;
 
-                index = found;
+                index = found + 1;
             }
 
             return true;


### PR DESCRIPTION
Allows matching `MultiplayerLoungeSubScreen` using `MLSScre` and the likes. Seems like behaviour we'd probably want in all search containers, but if that's a point of conflict it can be done via a property or derived class.