### PR TITLE
Update `IsPrimaryInstance` on first access rather than after `GameHost.Run`

### DIFF
--- a/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
@@ -36,7 +36,7 @@ namespace osu.Framework.Tests.Platform
         public void TestIpc()
         {
             using (var server = new BackgroundGameHeadlessGameHost(@"server", true))
-            using (var client = new BackgroundGameHeadlessGameHost(@"client", true))
+            using (var client = new HeadlessGameHost(@"client", true))
             {
                 Assert.IsTrue(server.IsPrimaryInstance, @"Server wasn't able to bind");
                 Assert.IsFalse(client.IsPrimaryInstance, @"Client was able to bind when it shouldn't have been able to");

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -70,7 +70,10 @@ namespace osu.Framework.Platform
         /// </remarks>
         public readonly AggregateBindable<bool> AllowScreenSuspension = new AggregateBindable<bool>((a, b) => a & b, new Bindable<bool>(true));
 
-        public bool IsPrimaryInstance { get; protected set; } = true;
+        /// <summary>
+        /// For IPC messaging purposes, whether this <see cref="GameHost"/> is the primary (bound) host.
+        /// </summary>
+        public virtual bool IsPrimaryInstance { get; protected set; } = true;
 
         /// <summary>
         /// Invoked when the game window is activated. Always invoked from the update thread.


### PR DESCRIPTION
This is mainly to fix the only framework-side test scene relying on two `GameHost`s running at the same time.