### PR TITLE
Fix test execution running indefinitely after exception thrown in asynchronous load thread

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -547,7 +547,9 @@ namespace osu.Framework.Platform
         /// Schedules the game to exit in the next frame (or immediately if <paramref name="immediately"/> is true).
         /// </summary>
         /// <param name="immediately">If true, exits the game immediately.  If false (default), schedules the game to exit in the next frame.</param>
-        protected virtual void PerformExit(bool immediately)
+        protected virtual void PerformExit(bool immediately) => performExit(immediately);
+
+        private void performExit(bool immediately)
         {
             if (executionState == ExecutionState.Stopped || executionState == ExecutionState.Idle)
                 return;
@@ -558,20 +560,17 @@ namespace osu.Framework.Platform
                 exit();
             else
                 InputThread.Scheduler.Add(exit, false);
-        }
 
-        /// <summary>
-        /// Exits the game. This must always be called from <see cref="InputThread"/>.
-        /// </summary>
-        private void exit()
-        {
-            Debug.Assert(ExecutionState == ExecutionState.Stopping);
+            void exit()
+            {
+                Debug.Assert(ExecutionState == ExecutionState.Stopping);
 
-            Window?.Close();
-            threadRunner.Stop();
+                Window?.Close();
+                threadRunner.Stop();
 
-            ExecutionState = ExecutionState.Stopped;
-            stoppedEvent.Set();
+                ExecutionState = ExecutionState.Stopped;
+                stoppedEvent.Set();
+            }
         }
 
         public void Run(Game game)
@@ -696,7 +695,7 @@ namespace osu.Framework.Platform
             finally
             {
                 // Close the window and stop all threads
-                PerformExit(true);
+                performExit(true);
             }
         }
 


### PR DESCRIPTION
Regressed with https://github.com/ppy/osu-framework/pull/4771.