### PR TITLE
Fix `windowPositionX/Y` being reset to `0.5` on startup

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1128,8 +1128,6 @@ namespace osu.Framework.Platform
             CurrentDisplayBindable.ValueChanged += evt =>
             {
                 windowDisplayIndexBindable.Value = (DisplayIndex)evt.NewValue.Index;
-                windowPositionX.Value = 0.5;
-                windowPositionY.Value = 0.5;
             };
 
             config.BindWith(FrameworkSetting.LastDisplayDevice, windowDisplayIndexBindable);


### PR DESCRIPTION
Closes #4608

This code seems to be doing nothing productive, the only thing it can do is reset the `windowPosition` in the config to unwanted values. Resulting in the windowed window appearing in the center if the screen when changing modes or opening the game.

Tested only on Windows.