### PR TITLE
Fix inconsistencies in `KeyCombination.getReadableKey()`

### DIFF
--- a/osu.Framework/Input/Bindings/KeyCombination.cs
+++ b/osu.Framework/Input/Bindings/KeyCombination.cs
@@ -375,73 +375,91 @@ namespace osu.Framework.Input.Bindings
                     return "Del";
 
                 case InputKey.PageUp:
-                    return "Pgup";
+                    return "PgUp";
 
                 case InputKey.PageDown:
-                    return "Pgdn";
+                    return "PgDn";
 
                 case InputKey.CapsLock:
                     return "Caps";
 
-                case InputKey.Number0:
-                    return "0";
-
                 case InputKey.Keypad0:
                     return "Numpad0";
-
-                case InputKey.Number1:
-                    return "1";
 
                 case InputKey.Keypad1:
                     return "Numpad1";
 
-                case InputKey.Number2:
-                    return "2";
-
                 case InputKey.Keypad2:
                     return "Numpad2";
-
-                case InputKey.Number3:
-                    return "3";
 
                 case InputKey.Keypad3:
                     return "Numpad3";
 
-                case InputKey.Number4:
-                    return "4";
-
                 case InputKey.Keypad4:
                     return "Numpad4";
-
-                case InputKey.Number5:
-                    return "5";
 
                 case InputKey.Keypad5:
                     return "Numpad5";
 
-                case InputKey.Number6:
-                    return "6";
-
                 case InputKey.Keypad6:
                     return "Numpad6";
-
-                case InputKey.Number7:
-                    return "7";
 
                 case InputKey.Keypad7:
                     return "Numpad7";
 
-                case InputKey.Number8:
-                    return "8";
-
                 case InputKey.Keypad8:
                     return "Numpad8";
 
-                case InputKey.Number9:
-                    return "9";
-
                 case InputKey.Keypad9:
                     return "Numpad9";
+
+                case InputKey.KeypadDivide:
+                    return "NumpadDivide";
+
+                case InputKey.KeypadMultiply:
+                    return "NumpadMultiply";
+
+                case InputKey.KeypadMinus:
+                    return "NumpadMinus";
+
+                case InputKey.KeypadPlus:
+                    return "NumpadPlus";
+
+                case InputKey.KeypadDecimal:
+                    return "NumpadDecimal";
+
+                case InputKey.KeypadEnter:
+                    return "NumpadEnter";
+
+                case InputKey.Number0:
+                    return "0";
+
+                case InputKey.Number1:
+                    return "1";
+
+                case InputKey.Number2:
+                    return "2";
+
+                case InputKey.Number3:
+                    return "3";
+
+                case InputKey.Number4:
+                    return "4";
+
+                case InputKey.Number5:
+                    return "5";
+
+                case InputKey.Number6:
+                    return "6";
+
+                case InputKey.Number7:
+                    return "7";
+
+                case InputKey.Number8:
+                    return "8";
+
+                case InputKey.Number9:
+                    return "9";
 
                 case InputKey.Tilde:
                     return "~";
@@ -453,10 +471,10 @@ namespace osu.Framework.Input.Bindings
                     return "Plus";
 
                 case InputKey.BracketLeft:
-                    return "(";
+                    return "[";
 
                 case InputKey.BracketRight:
-                    return ")";
+                    return "]";
 
                 case InputKey.Semicolon:
                     return ";";


### PR DESCRIPTION
Discussed in https://github.com/ppy/osu-framework/issues/4618#issuecomment-882590413.

Changes are:

- change capitalization of page up/down (to be in line with the new numpad keys)
- move the number keys to their place (separate from numpad keys)
- add missing numpad keys
- fix the bracket keys