### PR TITLE
Fix `ExecutionMode` potentially changing between equality and set calls

### DIFF
--- a/osu.Framework/Platform/ThreadRunner.cs
+++ b/osu.Framework/Platform/ThreadRunner.cs
@@ -163,10 +163,13 @@ namespace osu.Framework.Platform
             // locking is required as this method may be called from two different threads.
             lock (startStopLock)
             {
-                if (ExecutionMode == activeExecutionMode)
+                // pull into a local variable as the property is not locked during writes.
+                var executionMode = ExecutionMode;
+
+                if (executionMode == activeExecutionMode)
                     return;
 
-                activeExecutionMode = ThreadSafety.ExecutionMode = ExecutionMode;
+                activeExecutionMode = ThreadSafety.ExecutionMode = executionMode;
                 Logger.Log($"Execution mode changed to {activeExecutionMode}");
             }
 


### PR DESCRIPTION
Hard one to write a test for, but should be obvious why this is needed. An alternative is to make `ExecutionMode` a field-backed computed property and lock on `set`. Either works for me if that is preferred.