### PR TITLE
Remove SQLite specific methods from framework `Storage` classes

### DIFF
--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -90,10 +90,6 @@ namespace osu.Framework.Platform
             }
         }
 
-        public override string GetDatabaseConnectionString(string name) => string.Concat("Data Source=", GetFullPath($@"{name}.db", true));
-
-        public override void DeleteDatabase(string name) => Delete($@"{name}.db");
-
         public override Storage GetStorageForDirectory([NotNull] string path)
         {
             if (path == null) throw new ArgumentNullException(nameof(path));

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -108,19 +108,6 @@ namespace osu.Framework.Platform
         public abstract Stream GetStream(string path, FileAccess access = FileAccess.Read, FileMode mode = FileMode.OpenOrCreate);
 
         /// <summary>
-        /// Retrieve an SQLite database connection string from within this storage.
-        /// </summary>
-        /// <param name="name">The name of the database.</param>
-        /// <returns>An SQLite connection string.</returns>
-        public abstract string GetDatabaseConnectionString(string name);
-
-        /// <summary>
-        /// Delete an SQLite database from within this storage.
-        /// </summary>
-        /// <param name="name">The name of the database to delete.</param>
-        public abstract void DeleteDatabase(string name);
-
-        /// <summary>
         /// Opens a native file browser window to the root path of this storage.
         /// </summary>
         public void OpenInNativeExplorer() => OpenPathInNativeExplorer(string.Empty);


### PR DESCRIPTION
Not sure how these got here, but they shouldn't be in o!f, as it is considered database backend agnostic.