### PR TITLE
Fix CI failures due to file access denied to log files

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneResourceStores.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneResourceStores.cs
@@ -90,8 +90,6 @@ namespace osu.Framework.Tests.Visual.Platform
             });
 
             AddAssert("ensure some loaded", () => flow.Children.Any());
-
-            AddAssert("ensure all loaded", () => flow.Children.All(rd => rd.Resource != null));
         }
 
         private class ResourceDisplay : Container

--- a/osu.Framework.Tests/Visual/Platform/TestSceneResourceStores.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneResourceStores.cs
@@ -94,12 +94,8 @@ namespace osu.Framework.Tests.Visual.Platform
 
         private class ResourceDisplay : Container
         {
-            public readonly object Resource;
-
             public ResourceDisplay(string name, [CanBeNull] object resource)
             {
-                Resource = resource;
-
                 AutoSizeAxes = Axes.Y;
                 RelativeSizeAxes = Axes.X;
 

--- a/osu.Framework.Tests/Visual/Platform/TestSceneResourceStores.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneResourceStores.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -64,7 +65,19 @@ namespace osu.Framework.Tests.Visual.Platform
 
         private void showResources<T>(Func<IResourceStore<T>> store)
             where T : class
-            => showResources(() => store().GetAvailableResources(), l => store().Get(l));
+            => showResources(() => store().GetAvailableResources(), l =>
+            {
+                try
+                {
+                    return store().Get(l);
+                }
+                catch
+                {
+                    // This is iterating over all files in the game storage, which may include files that are actively being written to (ie. log files).
+                    // On windows, this can lead to file access errors, but we don't really care about that.
+                    return null;
+                }
+            });
 
         private void showResources<T>(Func<IEnumerable<string>> getResourceNames, Func<string, T> getResource)
         {
@@ -85,7 +98,7 @@ namespace osu.Framework.Tests.Visual.Platform
         {
             public readonly object Resource;
 
-            public ResourceDisplay(string name, object resource)
+            public ResourceDisplay(string name, [CanBeNull] object resource)
             {
                 Resource = resource;
 


### PR DESCRIPTION
Not really sure how useful this test scene is, but the fix is easy enough so may as well just make it work properly. 

Initially I was thinking there was some cross-talk from other tests, but it looks like the `performance.log` file that keeps causing this issue is generated (due to many atlas backings being created for the `SpriteText` tests in the same scene) so it's a very local issue.

Fixes CI failures as seen at https://github.com/ppy/osu-framework/pull/4784/checks?check_run_id=3712782332.