### PR TITLE
Fix TestSceneDelayedLoadUnloadWrapper test failures

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneDelayedLoadUnloadWrapper.cs
@@ -283,28 +283,24 @@ namespace osu.Framework.Tests.Visual.Drawables
                 }
             });
 
-            int childrenWithAvatarsLoaded() =>
-                flow.Children.Count(c => c.Children.OfType<DelayedLoadWrapper>().First().Content?.IsLoaded ?? false);
-
-            int loadCount1 = 0;
-            int loadCount2 = 0;
+            IEnumerable<Drawable> childrenWithAvatarsLoaded() => flow.Children.Where(c => c.Children.OfType<DelayedLoadWrapper>().First().Content?.IsLoaded ?? false);
 
             AddUntilStep("wait for load", () => loaded > 0);
 
+            int loadedCount1 = 0;
+            Drawable[] loadedChildren1 = null;
+
             AddStep("scroll down", () =>
             {
-                loadCount1 = loaded;
+                loadedCount1 = loaded;
+                loadedChildren1 = childrenWithAvatarsLoaded().ToArray();
                 scroll.ScrollToEnd();
             });
 
-            AddUntilStep("more loaded", () =>
-            {
-                loadCount2 = childrenWithAvatarsLoaded();
-                return loaded > loadCount1;
-            });
+            AddUntilStep("more loaded", () => loaded > loadedCount1);
 
-            AddAssert("not too many loaded", () => childrenWithAvatarsLoaded() < panel_count / 4);
-            AddUntilStep("wait some unloaded", () => childrenWithAvatarsLoaded() < loadCount2);
+            AddAssert("not too many loaded", () => loaded < panel_count / 4);
+            AddUntilStep("wait some unloaded", () => loadedChildren1.Any(c => !childrenWithAvatarsLoaded().Contains(c)));
         }
 
         [Test]
@@ -485,7 +481,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             });
 
             // Check that the child is disposed when its async-load completes while the wrapper is masked away.
-            AddAssert("wait for load to begin", () => child?.LoadState == LoadState.Loading);
+            AddUntilStep("wait for load to begin", () => child?.LoadState == LoadState.Loading);
             AddStep("allow load", () => child.AllowLoad.Set());
             AddUntilStep("drawable disposed", () => child.IsDisposed);
         }


### PR DESCRIPTION
Has been happening intermittently for a while now, only just now had an idea for why it could occur.

Can be tested by adding a `Thread.Sleep(1000)` in `TestBox.load()`.