### PR TITLE
Fix game hosts exiting immediately on mobile

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -83,10 +83,5 @@ namespace osu.Framework.Android
 
         public override VideoDecoder CreateVideoDecoder(Stream stream)
             => new AndroidVideoDecoder(stream);
-
-        protected override void PerformExit(bool immediately)
-        {
-            // Do not exit on Android, Window.Run() does not block
-        }
     }
 }

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -82,11 +82,6 @@ namespace osu.Framework.iOS
             DebugConfig.SetValue(DebugSetting.BypassFrontToBackPass, true);
         }
 
-        protected override void PerformExit(bool immediately)
-        {
-            // we shouldn't exit on iOS, as Window.Run does not block
-        }
-
         public override bool OnScreenKeyboardOverlapsGameWindow => true;
 
         protected override bool LimitedMemoryEnvironment => true;

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -544,11 +544,18 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Schedules the game to exit in the next frame.
         /// </summary>
-        public void Exit() => PerformExit(false);
+        public void Exit()
+        {
+            if (CanExit)
+                PerformExit(false);
+        }
 
         /// <summary>
         /// Schedules the game to exit in the next frame (or immediately if <paramref name="immediately"/> is true).
         /// </summary>
+        /// <remarks>
+        /// Will never be called if <see cref="CanExit"/> is <see langword="false"/>.
+        /// </remarks>
         /// <param name="immediately">If true, exits the game immediately.  If false (default), schedules the game to exit in the next frame.</param>
         protected virtual void PerformExit(bool immediately) => performExit(immediately);
 
@@ -702,10 +709,13 @@ namespace osu.Framework.Platform
             }
             finally
             {
-                // Close the window and stop all threads
-                performExit(true);
+                if (CanExit)
+                {
+                    // Close the window and stop all threads
+                    performExit(true);
 
-                host_running_mutex.Release();
+                    host_running_mutex.Release();
+                }
             }
         }
 

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -133,7 +133,8 @@ namespace osu.Framework.Platform
         void Close();
 
         /// <summary>
-        /// Start the window's run loop. Is a blocking call.
+        /// Start the window's run loop.
+        /// Is a blocking call on desktop platforms, and a non-blocking call on mobile platforms.
         /// </summary>
         void Run();
 


### PR DESCRIPTION
This is a proposal of a fix for framework apps booting to black screen on android, as reported on https://github.com/ppy/osu/discussions/14874 (also in changelog, and other places).

Regressed in #4786, as using the non-virtual private `performGameExit()` neutered this android-local override:

https://github.com/ppy/osu-framework/blob/4ba0b636d97bedb072079f987213900856b43696/osu.Framework.Android/AndroidGameHost.cs#L87-L90

To make matters worse, `IWindow`'s xmldoc straight up lies:

https://github.com/ppy/osu-framework/blob/4ba0b636d97bedb072079f987213900856b43696/osu.Framework/Platform/IWindow.cs#L135-L138

As evidenced by this regression, the above claim that `Run()` is blocking is false on mobile.

There's probably about a dozen ways you could fix this; I tried three of them and they all felt bad to me in different ways. The one I settled on here is using a pre-existing `CanExit` property and adding a soft invariant that `PerformExit()` should never be called if a game host implementation overrides `CanExit` to `false`. This has the added "benefit" (?) of being able to trim the android-local overrides.

The other things I've tried (and can work) is either putting that `CanExit` guard directly in `performExit()`, or removing the private `performExit()` and assuming that if the protected `PerformExit()` is called with `true`, then it should never be overridden to not exit unless a platform doesn't support exit at all. I don't know which is best at this point, further opinions more than welcome.