### PR TITLE
Set window to be per-monitor DPI aware on Windows

### DIFF
--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Platform.Windows
             try
             {
                 // SDL doesn't handle DPI correctly on windows, but this brings things mostly in-line with expectations. (https://bugzilla.libsdl.org/show_bug.cgi?id=3281)
-                SetProcessDpiAwareness(ProcessDpiAwareness.Process_System_DPI_Aware);
+                SetProcessDpiAwareness(ProcessDpiAwareness.Process_Per_Monitor_DPI_Aware);
             }
             catch
             {


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/12188

This makes it so that Windows will no longer scale our window when moving between monitors with different DPI.
All of the issues with Windows scaling interfering with mouse input are therefore fixed.

Previously, the Window would be scaled, as seen 20 seconds into this video: https://github.com/ppy/osu/issues/12188#issuecomment-815998081

With the same setup (left is secondary 100%, right is primary 150%) and this change:

https://user-images.githubusercontent.com/16479013/136251440-c4744a95-3141-44f4-991b-4e9843502b0b.mp4
