### PR TITLE
Fix synchronization context test failure

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneSynchronizationContext.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneSynchronizationContext.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Tests.Visual.Drawables
             AddStep("add box", () => Child = box = new AsyncPerformingBox(true));
             AddAssert("no tasks run", () => host.UpdateThread.Scheduler.TotalTasksRun == initialTasksRun);
             AddStep("trigger", () => box.ReleaseAsyncLoadCompleteLock());
-            AddAssert("one new task run", () => host.UpdateThread.Scheduler.TotalTasksRun == initialTasksRun + 1);
+            AddUntilStep("one new task run", () => host.UpdateThread.Scheduler.TotalTasksRun == initialTasksRun + 1);
         }
 
         [Test]


### PR DESCRIPTION
See: https://github.com/ppy/osu-framework/pull/4810/checks?check_run_id=3823214244

Repro'd by adding `await Task.Delay(1000)` in the async method.