### PR TITLE
Add test coverage showing that `async` usage via `SynchronizationContext` does throw correctly

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneSynchronizationContext.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneSynchronizationContext.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;


### PR DESCRIPTION
Attempting to use this for some realm isolated test case design (to avoid `IsUpdateThread` check failures) and wasn't sure this was working correctly, so wrote a test.