### PR TITLE
Fix `EnqueueAction` randomly throwing if called from (async) disposal thread

### DIFF
--- a/osu.Framework/Audio/AudioComponent.cs
+++ b/osu.Framework/Audio/AudioComponent.cs
@@ -45,15 +45,6 @@ namespace osu.Framework.Audio
                 // we don't want consumers to block on operations after we are disposed.
                 return Task.CompletedTask;
 
-            if (ThreadSafety.ExecutionMode == ExecutionMode.SingleThread)
-            {
-                if (ThreadSafety.IsDrawThread)
-                    throw new InvalidOperationException("Cannot perform audio operation from draw thread.");
-
-                if (ThreadSafety.IsInputThread)
-                    throw new InvalidOperationException("Cannot perform audio operation from input thread.");
-            }
-
             var task = new Task(action);
             PendingActions.Enqueue(task);
             return task;


### PR DESCRIPTION
This may not fix every incorrect case, but will fix the disposal path (as seen [here](https://github.com/ppy/osu/pull/15038/checks?check_run_id=3865955663)).

Probably "good enough" for the time being?