### PR TITLE
Don't immediately update relative mode when entering window

### DIFF
--- a/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
+++ b/osu.Framework/Input/Handlers/Mouse/MouseHandler.cs
@@ -65,7 +65,7 @@ namespace osu.Framework.Input.Handlers.Mouse
         /// <summary>
         /// Set to true to unconditionally update relative mode on the next <see cref="FeedbackMousePositionChange"/>
         /// </summary>
-        private bool updateNextTime;
+        private bool pendingUpdateRelativeMode;
 
         public override bool Initialize(GameHost host)
         {
@@ -85,7 +85,7 @@ namespace osu.Framework.Input.Handlers.Mouse
             {
                 if (e.NewValue)
                     // don't immediately update if the cursor has just entered the window
-                    updateNextTime = true;
+                    pendingUpdateRelativeMode = true;
                 else
                     updateRelativeMode();
             });
@@ -143,10 +143,10 @@ namespace osu.Framework.Input.Handlers.Mouse
                 // to mouse control at any point.
                 window.UpdateMousePosition(position);
 
-            if (updateNextTime)
+            if (pendingUpdateRelativeMode)
             {
                 updateRelativeMode();
-                updateNextTime = false;
+                pendingUpdateRelativeMode = false;
             }
 
             bool positionOutsideWindow = position.X < 0 || position.Y < 0 || position.X >= window.Size.Width || position.Y >= window.Size.Height;


### PR DESCRIPTION
If we update immediately, we'll lose one absolute mouse move (the mouse move that caused the cursor to enter the window).

This fixes two problems:
1. The framework cursor being in the wrong location if the window is moved onto the cursor. (eg. when maximizing, by snapping the window, or moving it from one monitor to another by keyboard shortcuts) -- those actions usually produce a `SDL_MOUSEMOTION`, but we had enabled relative mode too early, and that flushed those events (probably).
2. The framework cursor never making it into the window if quickly entering and leaving. This can result the cursor getting stuck outside the game bounds with relative mode enabled. (eg. https://discord.com/channels/188630481301012481/589331078574112768/898447367399964712)