### PR TITLE
Fix benchmark `ManualGameHost` running from TPL thread

### DIFF
--- a/osu.Framework.Benchmarks/GameBenchmark.cs
+++ b/osu.Framework.Benchmarks/GameBenchmark.cs
@@ -53,7 +53,7 @@ namespace osu.Framework.Benchmarks
             public ManualGameHost(Game runnableGame)
                 : base("manual")
             {
-                Task.Run(() =>
+                Task.Factory.StartNew(() =>
                 {
                     try
                     {
@@ -63,7 +63,7 @@ namespace osu.Framework.Benchmarks
                     {
                         // may throw an unobserved exception if we don't handle here.
                     }
-                });
+                }, TaskCreationOptions.LongRunning);
 
                 // wait for the game to initialise before continuing with the benchmark process.
                 while (threadRunner?.HasRunOnce != true)


### PR DESCRIPTION
Spotted this by running "Run All Tests from Solution" via Rider, which will also run the benchmarks as unit tests.

This wasn't caught by CI because the benchmark project doesn't fit the glob pattern in the workflow file:

https://github.com/ppy/osu-framework/blob/8cb4b3376b86f6c1b59126d6894855388185b435/.github/workflows/ci.yml#L41

Not sure if CI should be running benchmarks as tests too. I'll add that spec to the workflow definition on request.