### PR TITLE
Fix FlappyDon template game not building

### DIFF
--- a/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/ScoreSpriteText.cs
+++ b/osu.Framework.Templates/templates/template-flappy/FlappyDon.Game/Elements/ScoreSpriteText.cs
@@ -53,7 +53,7 @@ namespace FlappyDon.Game.Elements
                     return null;
 
                 return new TexturedCharacterGlyph(new CharacterGlyph(character, 0, 0,
-                    texture.Width, null), texture, 0.09f);
+                    texture.Width, 0, null), texture, 0.09f);
             }
 
             public Task<ITexturedCharacterGlyph> GetAsync(string fontName, char character) => Task.Run(() => Get(fontName, character));


### PR DESCRIPTION
Regressed in https://github.com/ppy/osu-framework/pull/4774.

Should probably get templates under CI too to ensure this doesn't happen in the future but I am leaving that for Later™.