### PR TITLE
Ensure text box's `Text` and `Current.Value` are synchronised

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -626,6 +626,30 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
+        public void TestInputOverride()
+        {
+            InsertableTextBox overrideInputBox = null;
+
+            AddStep("add override textbox", () =>
+            {
+                textBoxes.Add(overrideInputBox = new InsertableTextBox
+                {
+                    Text = @"Override input textbox",
+                    Size = new Vector2(500, 30),
+                    TabbableContentContainer = textBoxes
+                });
+                overrideInputBox.Current.BindValueChanged(vce =>
+                {
+                    if (vce.NewValue != @"Input overridden!")
+                        overrideInputBox.Current.Value = @"Input overridden!";
+                });
+            });
+
+            AddStep(@"set some text", () => overrideInputBox.Text = "smth");
+            AddAssert(@"verify display state", () => overrideInputBox.FlowingText == "Input overridden!");
+        }
+
+        [Test]
         public void TestDisableAndSetText()
         {
             InsertableTextBox textBox = null;

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -625,6 +625,35 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
         }
 
+        [Test]
+        public void TestDisableAndSetText()
+        {
+            InsertableTextBox textBox = null;
+
+            AddStep("add text box", () =>
+            {
+                textBoxes.Add(textBox = new InsertableTextBox
+                {
+                    Size = new Vector2(200, 40),
+                    Text = "hello"
+                });
+            });
+            AddAssert("text is hello", () => textBox.Text == "hello");
+
+            AddStep("set new text and disable", () =>
+            {
+                textBox.Text = "goodbye";
+                textBox.Current.Disabled = true;
+            });
+            AddAssert("text is goodbye", () => textBox.Text == "goodbye");
+
+            AddStep("attempt to set text", () => textBox.Text = "change!");
+            AddAssert("text is unchanged", () => textBox.Text == "goodbye");
+
+            AddStep("attempt to insert text", () => textBox.InsertString("maybe this way?"));
+            AddAssert("text is unchanged", () => textBox.Text == "goodbye");
+        }
+
         private void prependString(InsertableTextBox textBox, string text)
         {
             InputManager.Keys(PlatformAction.MoveBackwardLine);


### PR DESCRIPTION
- [x] Depends on #4522
- Closes #3919
- Supersedes / closes #3831

This is another issue that has long plagued `TextBox` - I could never fully grasp how the `Current.Value` propagation there worked, there were no comments, I have several times tried to tweak around it to no avail. This PR is a proposal of how that could be cleaned up.

All operations that mutate `text` (the field) will now transfer it out to `Current.Value` at the end of the operation. This is only possible sanely due to tearing out the scheduler logic as done in #4522.

The initial version of this was much simpler, but unfortunately is complicated by the fact that a text operation could be compound with regard to how `TextBox` methods are shaped. For example, a text insertion with a selection present is really just a removal of the selection and an insertion in the end, and a full text replacement is a clear and re-insert.

If `Current.Value` mutations have side-effects that change `Current.Value` again (like in the attached test cases), the only time to run those side effects that seemed reasonable is at the end of the operation chain. And this is not possible to achieve using `Current.Value` alone - which is why it is also not feasible to remove the `text` field and just have `Text` proxy to `Current.Value`.

The invariant that must hold here for this to work is that all `text` sets must be between a `beginTextChange()` and an `endTextChange()` call.

I have ran this past the game-side test suite and got no failures, for whatever that's worth.