### PR TITLE
Allow BufferedDrawNode's frame buffer to be clipped to the root node

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -38,6 +38,7 @@ namespace osu.Framework.Graphics
         private RectangleF screenSpaceDrawRectangle;
         private Vector2 frameBufferScale;
         private Vector2 frameBufferSize;
+        private IDrawable? rootNodeCached;
 
         public BufferedDrawNode(IBufferedDrawable source, DrawNode child, BufferedDrawNodeSharedData sharedData)
             : base(source)
@@ -54,6 +55,8 @@ namespace osu.Framework.Graphics
             screenSpaceDrawRectangle = Source.ScreenSpaceDrawQuad.AABBFloat;
             DrawColourInfo = Source.FrameBufferDrawColour ?? new DrawColourInfo(Color4.White, base.DrawColourInfo.Blending);
             frameBufferScale = Source.FrameBufferScale;
+
+            clipDrawRectangle();
 
             frameBufferSize = new Vector2(MathF.Ceiling(screenSpaceDrawRectangle.Width * frameBufferScale.X), MathF.Ceiling(screenSpaceDrawRectangle.Height * frameBufferScale.Y));
             DrawRectangle = SharedData.PixelSnapping
@@ -176,6 +179,26 @@ namespace osu.Framework.Graphics
             GLWrapper.PopViewport();
             GLWrapper.PopScissor();
             GLWrapper.PopMaskingInfo();
+        }
+
+        private void clipDrawRectangle()
+        {
+            if (!SharedData.ClipToRootNode || Source == null)
+                return;
+
+            // Get the root node
+            IDrawable rootNode = rootNodeCached;
+            if (rootNodeCached == null)
+            {
+                rootNode = Source;
+                while (rootNode.Parent != null)
+                    rootNode = rootNode.Parent;
+                rootNodeCached = rootNode;
+            }
+
+            // Clip the screen space draw rectangle to the bounds of the root node
+            RectangleF clipBounds = new RectangleF(rootNode.ScreenSpaceDrawQuad.TopLeft, rootNode.ScreenSpaceDrawQuad.Size);
+            screenSpaceDrawRectangle.Intersect(clipBounds);
         }
 
         protected override void Dispose(bool isDisposing)

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.OpenGL;
@@ -187,7 +189,8 @@ namespace osu.Framework.Graphics
                 return;
 
             // Get the root node
-            IDrawable rootNode = rootNodeCached;
+            IDrawable? rootNode = rootNodeCached;
+
             if (rootNodeCached == null)
             {
                 rootNode = Source;
@@ -195,6 +198,9 @@ namespace osu.Framework.Graphics
                     rootNode = rootNode.Parent;
                 rootNodeCached = rootNode;
             }
+
+            if (rootNode == null)
+                return;
 
             // Clip the screen space draw rectangle to the bounds of the root node
             RectangleF clipBounds = new RectangleF(rootNode.ScreenSpaceDrawQuad.TopLeft, rootNode.ScreenSpaceDrawQuad.Size);

--- a/osu.Framework/Graphics/BufferedDrawNode.cs
+++ b/osu.Framework/Graphics/BufferedDrawNode.cs
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#nullable enable
-
 using System;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.OpenGL;
@@ -40,7 +38,7 @@ namespace osu.Framework.Graphics
         private RectangleF screenSpaceDrawRectangle;
         private Vector2 frameBufferScale;
         private Vector2 frameBufferSize;
-        private IDrawable? rootNodeCached;
+        private IDrawable rootNodeCached;
 
         public BufferedDrawNode(IBufferedDrawable source, DrawNode child, BufferedDrawNodeSharedData sharedData)
             : base(source)
@@ -189,7 +187,7 @@ namespace osu.Framework.Graphics
                 return;
 
             // Get the root node
-            IDrawable? rootNode = rootNodeCached;
+            IDrawable rootNode = rootNodeCached;
 
             if (rootNodeCached == null)
             {

--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -4,6 +4,7 @@
 using System;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
+using osu.Framework.Graphics.Primitives;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics
@@ -34,6 +35,11 @@ namespace osu.Framework.Graphics
         public readonly bool PixelSnapping;
 
         /// <summary>
+        /// Whether the frame buffer should be clipped to be contained in the root node.
+        /// </summary>
+        public readonly bool ClipToRootNode;
+
+        /// <summary>
         /// A set of <see cref="FrameBuffer"/>s which are used in a ping-pong manner to render effects to.
         /// </summary>
         private readonly FrameBuffer[] effectBuffers;
@@ -41,8 +47,8 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// Creates a new <see cref="BufferedDrawNodeSharedData"/> with no effect buffers.
         /// </summary>
-        public BufferedDrawNodeSharedData(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
-            : this(0, formats, pixelSnapping)
+        public BufferedDrawNodeSharedData(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = false)
+            : this(0, formats, pixelSnapping, clipToRootNode)
         {
         }
 
@@ -53,14 +59,17 @@ namespace osu.Framework.Graphics
         /// <param name="formats">The render buffer formats to attach to each frame buffer.</param>
         /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
         /// This amounts to setting the texture filtering mode to "nearest".</param>
+        /// <param name="clipToRootNode">Whether the frame buffer should be clipped to be contained in the root node..</param>
         /// <exception cref="ArgumentOutOfRangeException">If <paramref name="effectBufferCount"/> is less than 0.</exception>
-        public BufferedDrawNodeSharedData(int effectBufferCount, RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
+        public BufferedDrawNodeSharedData(int effectBufferCount, RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = false)
         {
             if (effectBufferCount < 0)
                 throw new ArgumentOutOfRangeException(nameof(effectBufferCount), "Must be positive.");
 
             PixelSnapping = pixelSnapping;
             All filterMode = pixelSnapping ? All.Nearest : All.Linear;
+
+            ClipToRootNode = clipToRootNode;
 
             MainBuffer = new FrameBuffer(formats, filterMode);
             effectBuffers = new FrameBuffer[effectBufferCount];

--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -4,7 +4,6 @@
 using System;
 using osu.Framework.Graphics.OpenGL;
 using osu.Framework.Graphics.OpenGL.Buffers;
-using osu.Framework.Graphics.Primitives;
 using osuTK.Graphics.ES30;
 
 namespace osu.Framework.Graphics

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -26,7 +26,7 @@ namespace osu.Framework.Graphics.Containers
     public class BufferedContainer : BufferedContainer<Drawable>
     {
         /// <inheritdoc />
-        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = false)
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = true)
             : base(formats, pixelSnapping, clipToRootNode)
         {
         }
@@ -246,8 +246,8 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="formats">The render buffer formats attached to the frame buffers of this <see cref="BufferedContainer"/>.</param>
         /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
         /// This amounts to setting the texture filtering mode to "nearest".</param>
-        /// <param name="clipToRootNode">Whether the frame buffer should be clipped to be contained in the root node.</param>
-        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = false)
+        /// <param name="clipToRootNode">Whether the frame buffer should be clipped to be contained in the root node. Should only be disabled if you plan to draw to a region outside (or larger than) the screen.</param>
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = true)
         {
             sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping, clipToRootNode);
 

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -26,8 +26,8 @@ namespace osu.Framework.Graphics.Containers
     public class BufferedContainer : BufferedContainer<Drawable>
     {
         /// <inheritdoc />
-        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
-            : base(formats, pixelSnapping)
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = false)
+            : base(formats, pixelSnapping, clipToRootNode)
         {
         }
     }
@@ -246,9 +246,10 @@ namespace osu.Framework.Graphics.Containers
         /// <param name="formats">The render buffer formats attached to the frame buffers of this <see cref="BufferedContainer"/>.</param>
         /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
         /// This amounts to setting the texture filtering mode to "nearest".</param>
-        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false)
+        /// <param name="clipToRootNode">Whether the frame buffer should be clipped to be contained in the root node.</param>
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = false)
         {
-            sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping);
+            sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping, clipToRootNode);
 
             AddLayout(screenSpaceSizeBacking);
         }

--- a/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer_DrawNode.cs
@@ -128,8 +128,8 @@ namespace osu.Framework.Graphics.Containers
 
         private class BufferedContainerDrawNodeSharedData : BufferedDrawNodeSharedData
         {
-            public BufferedContainerDrawNodeSharedData(RenderbufferInternalFormat[] formats, bool pixelSnapping)
-                : base(2, formats, pixelSnapping)
+            public BufferedContainerDrawNodeSharedData(RenderbufferInternalFormat[] formats, bool pixelSnapping, bool clipToRootNode)
+                : base(2, formats, pixelSnapping, clipToRootNode)
             {
             }
         }

--- a/osu.Framework/Graphics/Lines/Path.cs
+++ b/osu.Framework/Graphics/Lines/Path.cs
@@ -279,7 +279,7 @@ namespace osu.Framework.Graphics.Lines
 
         public Color4 BackgroundColour => new Color4(0, 0, 0, 0);
 
-        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(new[] { RenderbufferInternalFormat.DepthComponent16 });
+        private readonly BufferedDrawNodeSharedData sharedData = new BufferedDrawNodeSharedData(new[] { RenderbufferInternalFormat.DepthComponent16 }, clipToRootNode: true);
 
         protected override DrawNode CreateDrawNode() => new BufferedDrawNode(this, new PathDrawNode(this), sharedData);
 


### PR DESCRIPTION
fixes ppy/osu#15434

caching the root node might cause problems in the future, but there doesn't seem to be any better way of getting the window resolution from here that i can think of