### PR TITLE
Fix video playback failing on invalid frame timestamps

### DIFF
--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -602,7 +602,10 @@ namespace osu.Framework.Graphics.Video
                     break;
                 }
 
-                double frameTime = (receiveFrame->pts - stream->start_time) * timeBaseInSeconds * 1000;
+                // some formats (e.g. AVI) don't contain "presentation timestamp" so fallback to the best effort one if it's missing.
+                long frameTimestamp = receiveFrame->pts != AGffmpeg.AV_NOPTS_VALUE ? receiveFrame->pts : receiveFrame->best_effort_timestamp;
+
+                double frameTime = (frameTimestamp - stream->start_time) * timeBaseInSeconds * 1000;
 
                 if (skipOutputUntilTime > frameTime)
                     continue;

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -412,6 +412,7 @@ namespace osu.Framework.Graphics.Video
                 }
 
                 codecContext = ffmpeg.avcodec_alloc_context3(decoder.Pointer);
+                codecContext->pkt_timebase = stream->time_base;
 
                 if (codecContext == null)
                 {


### PR DESCRIPTION
Temporary fix for #4858

This should resolve AVI videos not playing at all, except on Android with HW decoding enabled.
However there are still some pretty big problems with most HW decoders when used for AVI playback. I'm afraid these affect all of them except DXVA...

- seeking backwards breaks the video playback, it freezes at the current frame and starts spamming `Video too far out of sync`
- enabling it mid-playback can pin the GPU to 100% for a bit because it basically starts decoding from the start, it'll stop once it reaches the correct frame

Both of these are caused by the missing timestamps as the HW decoders only read `pts` and if it's missing they start counting the timestamps by themselves from 0.

I still plan to properly fix all of this but I couldn't find a solution that wasn't way too hacky today.