### PR TITLE
Move `CacheDrawnFrameBuffer` property to constructor, replacing `clipToRootNode`

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
@@ -120,7 +120,7 @@ namespace osu.Framework.Tests.Visual.Containers
             private readonly SpriteText count;
 
             public CountingBox(bool rotating = false, bool moving = false, bool cached = false)
-                : base(useCachedFrameBuffer: cached)
+                : base(cachedFrameBuffer: cached)
             {
                 this.rotating = rotating;
                 this.moving = moving;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCachedBufferedContainer.cs
@@ -50,9 +50,8 @@ namespace osu.Framework.Tests.Visual.Containers
                     },
                     box = new ContainingBox(i >= 6, i >= 8)
                     {
-                        Child = new CountingBox(i == 2 || i == 3, i == 4 || i == 5)
+                        Child = new CountingBox(i == 2 || i == 3, i == 4 || i == 5, cached: i % 2 == 1 || i == 10)
                         {
-                            CacheDrawnFrameBuffer = i % 2 == 1 || i == 10,
                             RedrawOnScale = i != 10
                         },
                     }
@@ -120,7 +119,8 @@ namespace osu.Framework.Tests.Visual.Containers
             private readonly bool moving;
             private readonly SpriteText count;
 
-            public CountingBox(bool rotating = false, bool moving = false)
+            public CountingBox(bool rotating = false, bool moving = false, bool cached = false)
+                : base(useCachedFrameBuffer: cached)
             {
                 this.rotating = rotating;
                 this.moving = moving;

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -26,8 +26,8 @@ namespace osu.Framework.Graphics.Containers
     public class BufferedContainer : BufferedContainer<Drawable>
     {
         /// <inheritdoc />
-        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = true)
-            : base(formats, pixelSnapping, clipToRootNode)
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool useCachedFrameBuffer = false)
+            : base(formats, pixelSnapping, useCachedFrameBuffer)
         {
         }
     }
@@ -192,12 +192,12 @@ namespace osu.Framework.Graphics.Containers
         }
 
         /// <summary>
-        /// Whether the rendered framebuffer shall be cached until <see cref="ForceRedraw"/> is called
+        /// Whether the rendered framebuffer is being cached until <see cref="ForceRedraw"/> is called
         /// or the size of the container (i.e. framebuffer) changes.
         /// If false, then the framebuffer is re-rendered before it is blitted to the screen; equivalent
         /// to calling <see cref="ForceRedraw"/> every frame.
         /// </summary>
-        public bool CacheDrawnFrameBuffer;
+        public readonly bool UsingCachedFrameBuffer;
 
         private bool redrawOnScale = true;
 
@@ -219,7 +219,7 @@ namespace osu.Framework.Graphics.Containers
 
         /// <summary>
         /// Forces a redraw of the framebuffer before it is blitted the next time.
-        /// Only relevant if <see cref="CacheDrawnFrameBuffer"/> is true.
+        /// Only relevant if <see cref="UsingCachedFrameBuffer"/> is true.
         /// </summary>
         public void ForceRedraw() => Invalidate(Invalidation.DrawNode);
 
@@ -244,12 +244,20 @@ namespace osu.Framework.Graphics.Containers
         /// Constructs an empty buffered container.
         /// </summary>
         /// <param name="formats">The render buffer formats attached to the frame buffers of this <see cref="BufferedContainer"/>.</param>
-        /// <param name="pixelSnapping">Whether the frame buffer position should be snapped to the nearest pixel when blitting.
-        /// This amounts to setting the texture filtering mode to "nearest".</param>
-        /// <param name="clipToRootNode">Whether the frame buffer should be clipped to be contained in the root node. Should only be disabled if you plan to draw to a region outside (or larger than) the screen.</param>
-        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool clipToRootNode = true)
+        /// <param name="pixelSnapping">
+        /// Whether the frame buffer position should be snapped to the nearest pixel when blitting.
+        /// This amounts to setting the texture filtering mode to "nearest".
+        /// </param>
+        /// <param name="useCachedFrameBuffer">
+        /// Whether the rendered framebuffer should be cached until <see cref="ForceRedraw"/> is called
+        /// or the size of the container (i.e. framebuffer) changes.
+        /// When disabled, drawing will be clipped to the game window bounds. Enabling can allow drawing larger than (or outside) the game window bounds.
+        /// </param>
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool useCachedFrameBuffer = false)
         {
-            sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping, clipToRootNode);
+            UsingCachedFrameBuffer = useCachedFrameBuffer;
+
+            sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping, !useCachedFrameBuffer);
 
             AddLayout(screenSpaceSizeBacking);
         }
@@ -301,7 +309,7 @@ namespace osu.Framework.Graphics.Containers
             base.Update();
 
             // Invalidate drawn frame buffer every frame.
-            if (!CacheDrawnFrameBuffer)
+            if (!UsingCachedFrameBuffer)
                 ForceRedraw();
             else if (!screenSpaceSizeBacking.IsValid)
             {

--- a/osu.Framework/Graphics/Containers/BufferedContainer.cs
+++ b/osu.Framework/Graphics/Containers/BufferedContainer.cs
@@ -26,8 +26,8 @@ namespace osu.Framework.Graphics.Containers
     public class BufferedContainer : BufferedContainer<Drawable>
     {
         /// <inheritdoc />
-        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool useCachedFrameBuffer = false)
-            : base(formats, pixelSnapping, useCachedFrameBuffer)
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool cachedFrameBuffer = false)
+            : base(formats, pixelSnapping, cachedFrameBuffer)
         {
         }
     }
@@ -248,16 +248,16 @@ namespace osu.Framework.Graphics.Containers
         /// Whether the frame buffer position should be snapped to the nearest pixel when blitting.
         /// This amounts to setting the texture filtering mode to "nearest".
         /// </param>
-        /// <param name="useCachedFrameBuffer">
+        /// <param name="cachedFrameBuffer">
         /// Whether the rendered framebuffer should be cached until <see cref="ForceRedraw"/> is called
         /// or the size of the container (i.e. framebuffer) changes.
         /// When disabled, drawing will be clipped to the game window bounds. Enabling can allow drawing larger than (or outside) the game window bounds.
         /// </param>
-        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool useCachedFrameBuffer = false)
+        public BufferedContainer(RenderbufferInternalFormat[] formats = null, bool pixelSnapping = false, bool cachedFrameBuffer = false)
         {
-            UsingCachedFrameBuffer = useCachedFrameBuffer;
+            UsingCachedFrameBuffer = cachedFrameBuffer;
 
-            sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping, !useCachedFrameBuffer);
+            sharedData = new BufferedContainerDrawNodeSharedData(formats, pixelSnapping, !cachedFrameBuffer);
 
             AddLayout(screenSpaceSizeBacking);
         }

--- a/osu.Framework/Graphics/Effects/BlurEffect.cs
+++ b/osu.Framework/Graphics/Effects/BlurEffect.cs
@@ -54,11 +54,6 @@ namespace osu.Framework.Graphics.Effects
         /// </summary>
         public bool PadExtent;
 
-        /// <summary>
-        /// Whether the resulting <see cref="BufferedContainer"/> should cache its drawn framebuffer.
-        /// </summary>
-        public bool CacheDrawnEffect;
-
         public BufferedContainer ApplyTo(Drawable drawable) =>
             new BufferedContainer
             {
@@ -69,8 +64,6 @@ namespace osu.Framework.Graphics.Effects
                 EffectPlacement = Placement,
 
                 DrawOriginal = DrawOriginal,
-
-                CacheDrawnFrameBuffer = CacheDrawnEffect,
 
                 Padding = !PadExtent
                     ? new MarginPadding()

--- a/osu.Framework/Graphics/Effects/GlowEffect.cs
+++ b/osu.Framework/Graphics/Effects/GlowEffect.cs
@@ -44,12 +44,6 @@ namespace osu.Framework.Graphics.Effects
         /// </summary>
         public bool PadExtent;
 
-        /// <summary>
-        /// True if the effect should be cached. This is an optimization, but can cause issues if the drawable changes the way it looks without changing its size.
-        /// Turned off by default.
-        /// </summary>
-        public bool CacheDrawnEffect;
-
         public BufferedContainer ApplyTo(Drawable drawable) => drawable.WithEffect(new BlurEffect
         {
             Strength = Strength,
@@ -58,7 +52,6 @@ namespace osu.Framework.Graphics.Effects
             Blending = Blending,
             Placement = Placement,
             PadExtent = PadExtent,
-            CacheDrawnEffect = CacheDrawnEffect,
 
             DrawOriginal = true,
         });

--- a/osu.Framework/Graphics/Effects/OutlineEffect.cs
+++ b/osu.Framework/Graphics/Effects/OutlineEffect.cs
@@ -35,19 +35,12 @@ namespace osu.Framework.Graphics.Effects
         /// </summary>
         public bool PadExtent;
 
-        /// <summary>
-        /// True if the effect should be cached. This is an optimization, but can cause issues if the drawable changes the way it looks without changing its size.
-        /// Turned off by default.
-        /// </summary>
-        public bool CacheDrawnEffect;
-
         public BufferedContainer ApplyTo(Drawable drawable) => drawable.WithEffect(new BlurEffect
         {
             Strength = Strength,
             Sigma = BlurSigma,
             Colour = Colour,
             PadExtent = PadExtent,
-            CacheDrawnEffect = CacheDrawnEffect,
 
             DrawOriginal = true,
         });


### PR DESCRIPTION
As seen by the [regressions](https://github.com/ppy/osu/issues/15475#issuecomment-961382253), with the current invalidation structure we have, clipping to the root node does not mix well with `BufferedContainer` in the case it is caching its framebuffer.

To minimise user error, this PR hard couples the state of caching with the state of clipping. The rationale is that when not buffering, you would never want to draw to an area larger than the screen, while when you *are* caching you are usually aware of the size of the container, and may be explicitly using caching to draw to a larger area than is currently being displayed.

We can iterate on this if other use cases come up which don't obide by these rules.

Closes #15475.

---

# Breaking Changes

## `BufferedContainer.CacheDrawnFrameBuffer` has been moved to a constructor argument

```csharp
// old code:
var bufferedContainer = new BufferedContainer() { CacheDrawnFrameBuffer = true };

// new code:
var bufferedContainer = new BufferedContainer(cachedFrameBuffer: true);
```

## `IEffect.CacheDrawnEffect` has been removed

We had no usages of this. If you were using it, nest the effected content in a `BufferedContainer` with `cachedFrameBuffer` set to `true`.