### PR TITLE
Fix .avi video seeking and Android playback when HW acceleration is enabled

### DIFF
--- a/osu.Framework.Android/Graphics/Video/AndroidVideoDecoder.cs
+++ b/osu.Framework.Android/Graphics/Video/AndroidVideoDecoder.cs
@@ -2,13 +2,16 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Android.Runtime;
 using FFmpeg.AutoGen;
+using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Video;
+using osu.Framework.Logging;
 
 namespace osu.Framework.Android.Graphics.Video
 {
@@ -150,6 +153,32 @@ namespace osu.Framework.Android.Graphics.Video
             int result = av_jni_set_java_vm((void*)(IntPtr)jvmPtrObj, null);
             if (result < 0)
                 throw new InvalidOperationException($"Couldn't pass Java VM handle to FFmpeg: ${result}");
+        }
+
+        protected override IEnumerable<(FFmpegCodec codec, AVHWDeviceType hwDeviceType)> GetAvailableDecoders(
+            AVInputFormat* inputFormat,
+            AVCodecID codecId,
+            HardwareVideoDecoder targetHwDecoders
+        )
+        {
+            if (targetHwDecoders.HasFlagFast(HardwareVideoDecoder.MediaCodec))
+            {
+                string formatName = Marshal.PtrToStringAnsi((IntPtr)inputFormat->name);
+
+                switch (formatName)
+                {
+                    // MediaCodec doesn't return correct timestamps when playing back AVI files
+                    // which results in the video running at ~30% less FPS than it's supposed to.
+                    case "avi":
+                    {
+                        Logger.Log($"Disabling HW decoding for this video because of unsupported input format: ${formatName}");
+                        targetHwDecoders &= ~HardwareVideoDecoder.MediaCodec;
+                        break;
+                    }
+                }
+            }
+
+            return base.GetAvailableDecoders(inputFormat, codecId, targetHwDecoders);
         }
 
         protected override FFmpegFuncs CreateFuncs() => new FFmpegFuncs

--- a/osu.Framework/Graphics/Video/FFmpegCodec.cs
+++ b/osu.Framework/Graphics/Video/FFmpegCodec.cs
@@ -8,7 +8,7 @@ using FFmpeg.AutoGen;
 
 namespace osu.Framework.Graphics.Video
 {
-    internal sealed unsafe class FFmpegCodec
+    public sealed unsafe class FFmpegCodec
     {
         public readonly AVCodec* Pointer;
         public readonly Lazy<IReadOnlyList<AVHWDeviceType>> SupportedHwDeviceTypes;

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -602,8 +602,9 @@ namespace osu.Framework.Graphics.Video
                     break;
                 }
 
-                // some formats (e.g. AVI) don't contain "presentation timestamp" so fallback to the best effort one if it's missing.
-                long frameTimestamp = receiveFrame->pts != AGffmpeg.AV_NOPTS_VALUE ? receiveFrame->pts : receiveFrame->best_effort_timestamp;
+                // use `best_effort_timestamp` as it can be more accurate if timestamps from the source file (pts) are broken.
+                // but some HW codecs don't set it in which case fallback to `pts`
+                long frameTimestamp = receiveFrame->best_effort_timestamp != AGffmpeg.AV_NOPTS_VALUE ? receiveFrame->best_effort_timestamp : receiveFrame->pts;
 
                 double frameTime = (frameTimestamp - stream->start_time) * timeBaseInSeconds * 1000;
 


### PR DESCRIPTION
Closes #4858 and fixes both problems that I mentioned in #4860

Android's MediaCodec unfortunately turned out to be a lost cause, I just couldn't get it to work properly no matter what I tried, so I added a check that disables HW decoding if the source is an AVI file...

As before, I only got to test this with the following HW devices, I highly recommend testing this on everything before merging.

- [x] NVDEC
- [x] QuickSync
- [x] DXVA
- [x] VDPAU
- [x] VA-API
- [x] MediaCodec
- [x] VideoToolbox - MacOS
- [x] VideoToolbox - iOS

Patch for testing:
```csharp
Index: osu.Framework.Tests/Visual/Sprites/TestVideo.cs
===================================================================
diff --git a/osu.Framework.Tests/Visual/Sprites/TestVideo.cs b/osu.Framework.Tests/Visual/Sprites/TestVideo.cs
--- a/osu.Framework.Tests/Visual/Sprites/TestVideo.cs	(revision bb82b3c57715f2f26532053ea1436b9102e5c34b)
+++ b/osu.Framework.Tests/Visual/Sprites/TestVideo.cs	(date 1636329661869)
@@ -14,7 +14,7 @@
     {
         private static MemoryStream consumeVideoStream()
         {
-            var wr = new WebRequest("https://assets.ppy.sh/media/landing.mp4");
+            var wr = new WebRequest("https://file-examples-com.github.io/uploads/2018/04/file_example_AVI_480_750kB.avi");
             Task.Run(() => wr.PerformAsync());
 
             while (!wr.Completed)
```
The `FPS` counter should show 30, if it's ~20 then I have to go back to the drawing board because it means that the returned timestamps are wrong.