### PR TITLE
Set window title after creation

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -680,9 +680,9 @@ namespace osu.Framework.Platform
                 if (Window != null)
                 {
                     Window.SetupWindow(Config);
-                    Window.Title = $@"osu!framework (running ""{Name}"")";
 
                     Window.Create();
+                    Window.Title = $@"osu!framework (running ""{Name}"")";
 
                     currentDisplayMode = Window.CurrentDisplayMode.GetBoundCopy();
                     currentDisplayMode.BindValueChanged(_ => updateFrameSyncMode());


### PR DESCRIPTION
Built SDL with debug, and got this warning when opening visual-tests:

![image](https://user-images.githubusercontent.com/16479013/140745452-19bfdce5-b4d4-404e-ac06-88cd3f8774f4.png)

The title does get set as expected, SDL probably has a good reason to complain.