### PR TITLE
Make `AudioMixer` non-adjustable

### DIFF
--- a/osu.Framework/Audio/AudioCollectionManager.cs
+++ b/osu.Framework/Audio/AudioCollectionManager.cs
@@ -10,7 +10,7 @@ namespace osu.Framework.Audio
     /// A collection of audio components which need central property control.
     /// </summary>
     public class AudioCollectionManager<T> : AdjustableAudioComponent, IBassAudio
-        where T : AdjustableAudioComponent
+        where T : AudioComponent
     {
         internal List<T> Items = new List<T>();
 
@@ -20,7 +20,8 @@ namespace osu.Framework.Audio
             {
                 if (Items.Contains(item)) return;
 
-                item.BindAdjustments(this);
+                if (item is IAdjustableAudioComponent adjustable)
+                    adjustable.BindAdjustments(this);
                 Items.Add(item);
             });
         }

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -20,7 +20,7 @@ using osu.Framework.Threading;
 
 namespace osu.Framework.Audio
 {
-    public class AudioManager : AudioCollectionManager<AdjustableAudioComponent>
+    public class AudioManager : AudioCollectionManager<AudioComponent>
     {
         /// <summary>
         /// The manager component responsible for audio tracks (e.g. songs).

--- a/osu.Framework/Audio/Mixing/AudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/AudioMixer.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Audio.Mixing
     /// <summary>
     /// Mixes together multiple <see cref="IAudioChannel"/>s into one output.
     /// </summary>
-    public abstract class AudioMixer : AdjustableAudioComponent, IAudioMixer
+    public abstract class AudioMixer : AudioComponent, IAudioMixer
     {
         private readonly AudioMixer? globalMixer;
 


### PR DESCRIPTION
It doesn't support adjustments and is not in the expected location in the hierarchy. This only leads to confusion.