### PR TITLE
Stop exposing `TrackBass`'s constructor

### DIFF
--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -69,7 +69,7 @@ namespace osu.Framework.Audio.Track
         /// </summary>
         /// <param name="data">The sample data stream.</param>
         /// <param name="quick">If true, the track will not be fully loaded, and should only be used for preview purposes.  Defaults to false.</param>
-        public TrackBass(Stream data, bool quick = false)
+        internal TrackBass(Stream data, bool quick = false)
         {
             if (data == null)
                 throw new ArgumentNullException(nameof(data));


### PR DESCRIPTION
Rationale is that it can no longer work without being in the audio hierarchy. A `TrackStore` should be used instead.

Note that I am still working on the osu!-side changes to support this. Will block until I'm 100%.

- [x] Depends on (acceptance of) https://github.com/ppy/osu/pull/15535
- Closes https://github.com/ppy/osu-framework/issues/4813