### PR TITLE
Fix audio mixers potentially not showing in `AudioMixer` visualiser

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -109,8 +109,8 @@ namespace osu.Framework.Audio
         /// </summary>
         public Scheduler EventScheduler;
 
-        internal IBindableList<int> ActiveMixerHandles => activeMixerHandles;
-        private readonly BindableList<int> activeMixerHandles = new BindableList<int>();
+        internal IBindableList<AudioMixer> ActiveMixers => activeMixers;
+        private readonly BindableList<AudioMixer> activeMixers = new BindableList<AudioMixer>();
 
         private readonly Lazy<TrackStore> globalTrackStore;
         private readonly Lazy<SampleStore> globalSampleStore;

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -170,6 +170,13 @@ namespace osu.Framework.Audio
             });
         }
 
+        protected override void UpdateChildren()
+        {
+            base.UpdateChildren();
+
+            activeMixers.RemoveAll(m => m.HasCompleted);
+        }
+
         protected override void Dispose(bool disposing)
         {
             cancelSource.Cancel();
@@ -210,8 +217,7 @@ namespace osu.Framework.Audio
         private AudioMixer createAudioMixer(AudioMixer globalMixer)
         {
             var mixer = new BassAudioMixer(globalMixer);
-            mixer.HandleCreated += i => activeMixerHandles.Add(i);
-            mixer.HandleDestroyed += i => activeMixerHandles.Remove(i);
+            activeMixers.Add(mixer);
             AddItem(mixer);
             return mixer;
         }

--- a/osu.Framework/Audio/Mixing/AudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/AudioMixer.cs
@@ -14,6 +14,11 @@ namespace osu.Framework.Audio.Mixing
     /// </summary>
     public abstract class AudioMixer : AdjustableAudioComponent, IAudioMixer
     {
+        /// <summary>
+        /// The handle for this mixer.
+        /// </summary>
+        public int Handle { get; protected set; }
+
         private readonly AudioMixer? globalMixer;
 
         /// <summary>

--- a/osu.Framework/Audio/Mixing/AudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/AudioMixer.cs
@@ -14,11 +14,6 @@ namespace osu.Framework.Audio.Mixing
     /// </summary>
     public abstract class AudioMixer : AdjustableAudioComponent, IAudioMixer
     {
-        /// <summary>
-        /// The handle for this mixer.
-        /// </summary>
-        public int Handle { get; protected set; }
-
         private readonly AudioMixer? globalMixer;
 
         /// <summary>

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -23,9 +23,8 @@ namespace osu.Framework.Audio.Mixing.Bass
     /// </summary>
     internal class BassAudioMixer : AudioMixer, IBassAudio
     {
-        public event Action<int>? HandleCreated;
-        public event Action<int>? HandleDestroyed;
-
+        public event Action<AudioMixer>? HandleCreated;
+        public event Action<AudioMixer>? HandleDestroyed;
 
         /// <summary>
         /// The list of effects which are currently active in the BASS mix.
@@ -292,7 +291,7 @@ namespace osu.Framework.Audio.Mixing.Bass
             Effects.BindCollectionChanged(onEffectsChanged, true);
 
             ManagedBass.Bass.ChannelPlay(Handle);
-            HandleCreated?.Invoke(Handle);
+            HandleCreated?.Invoke(this);
         }
 
         /// <summary>
@@ -434,7 +433,7 @@ namespace osu.Framework.Audio.Mixing.Bass
 
             if (Handle != 0)
             {
-                HandleDestroyed?.Invoke(Handle);
+                HandleDestroyed?.Invoke(this);
 
                 ManagedBass.Bass.StreamFree(Handle);
                 Handle = 0;

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -26,10 +26,6 @@ namespace osu.Framework.Audio.Mixing.Bass
         public event Action<int>? HandleCreated;
         public event Action<int>? HandleDestroyed;
 
-        /// <summary>
-        /// The handle for this mixer.
-        /// </summary>
-        public int Handle { get; private set; }
 
         /// <summary>
         /// The list of effects which are currently active in the BASS mix.

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -23,9 +23,6 @@ namespace osu.Framework.Audio.Mixing.Bass
     /// </summary>
     internal class BassAudioMixer : AudioMixer, IBassAudio
     {
-        public event Action<AudioMixer>? HandleCreated;
-        public event Action<AudioMixer>? HandleDestroyed;
-
         /// <summary>
         /// The list of effects which are currently active in the BASS mix.
         /// </summary>
@@ -291,7 +288,6 @@ namespace osu.Framework.Audio.Mixing.Bass
             Effects.BindCollectionChanged(onEffectsChanged, true);
 
             ManagedBass.Bass.ChannelPlay(Handle);
-            HandleCreated?.Invoke(this);
         }
 
         /// <summary>
@@ -433,14 +429,9 @@ namespace osu.Framework.Audio.Mixing.Bass
 
             if (Handle != 0)
             {
-                HandleDestroyed?.Invoke(this);
-
                 ManagedBass.Bass.StreamFree(Handle);
                 Handle = 0;
             }
-
-            HandleCreated = null;
-            HandleDestroyed = null;
         }
 
         internal class EffectWithHandle

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -24,6 +24,11 @@ namespace osu.Framework.Audio.Mixing.Bass
     internal class BassAudioMixer : AudioMixer, IBassAudio
     {
         /// <summary>
+        /// The handle for this mixer.
+        /// </summary>
+        public int Handle { get; private set; }
+
+        /// <summary>
         /// The list of effects which are currently active in the BASS mix.
         /// </summary>
         internal readonly List<EffectWithHandle> ActiveEffects = new List<EffectWithHandle>();

--- a/osu.Framework/Graphics/Visualisation/Audio/AudioMixerVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/AudioMixerVisualiser.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
+using osu.Framework.Audio.Mixing;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osuTK;
@@ -18,7 +19,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
         private AudioManager audioManager { get; set; }
 
         private readonly FillFlowContainer<MixerDisplay> mixerFlow;
-        private readonly IBindableList<int> activeMixerHandles = new BindableList<int>();
+        private readonly IBindableList<AudioMixer> activeMixers = new BindableList<AudioMixer>();
 
         public AudioMixerVisualiser()
             : base("AudioMixer", "(Ctrl+F9 to toggle)")
@@ -45,8 +46,8 @@ namespace osu.Framework.Graphics.Visualisation.Audio
         {
             base.LoadComplete();
 
-            activeMixerHandles.BindTo(audioManager.ActiveMixerHandles);
-            activeMixerHandles.BindCollectionChanged(onActiveMixerHandlesChanged, true);
+            activeMixers.BindTo(audioManager.ActiveMixers);
+            activeMixers.BindCollectionChanged(onActiveMixerHandlesChanged, true);
         }
 
         private void onActiveMixerHandlesChanged(object sender, NotifyCollectionChangedEventArgs e) => Schedule(() =>
@@ -55,13 +56,13 @@ namespace osu.Framework.Graphics.Visualisation.Audio
             {
                 case NotifyCollectionChangedAction.Add:
                     Debug.Assert(e.NewItems != null);
-                    foreach (int handle in e.NewItems.OfType<int>())
-                        mixerFlow.Add(new MixerDisplay(handle));
+                    foreach (var mixer in e.NewItems.OfType<AudioMixer>())
+                        mixerFlow.Add(new MixerDisplay(mixer));
                     break;
 
                 case NotifyCollectionChangedAction.Remove:
                     Debug.Assert(e.OldItems != null);
-                    mixerFlow.RemoveAll(m => e.OldItems.OfType<int>().Contains(m.MixerHandle));
+                    mixerFlow.RemoveAll(m => e.OldItems.OfType<AudioMixer>().Contains(m.Mixer));
                     break;
             }
         });

--- a/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using ManagedBass.Mix;
+using osu.Framework.Audio.Mixing;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -13,13 +14,13 @@ namespace osu.Framework.Graphics.Visualisation.Audio
 {
     public class MixerDisplay : CompositeDrawable
     {
-        public readonly int MixerHandle;
+        public readonly AudioMixer Mixer;
 
         private readonly FillFlowContainer<AudioChannelDisplay> channelsContainer;
 
-        public MixerDisplay(int mixerHandle)
+        public MixerDisplay(AudioMixer mixer)
         {
-            MixerHandle = mixerHandle;
+            Mixer = mixer;
 
             RelativeSizeAxes = Axes.Y;
             AutoSizeAxes = Axes.X;
@@ -51,7 +52,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
         {
             base.Update();
 
-            int[] channels = BassMix.MixerGetChannels(MixerHandle);
+            int[] channels = BassMix.MixerGetChannels(Mixer.Handle);
 
             if (channels == null)
                 return;

--- a/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
@@ -4,6 +4,7 @@
 using System.Linq;
 using ManagedBass.Mix;
 using osu.Framework.Audio.Mixing;
+using osu.Framework.Audio.Mixing.Bass;
 using osu.Framework.Extensions.Color4Extensions;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -52,7 +53,10 @@ namespace osu.Framework.Graphics.Visualisation.Audio
         {
             base.Update();
 
-            int[] channels = BassMix.MixerGetChannels(Mixer.Handle);
+            if (!(Mixer is BassAudioMixer bassMixer))
+                return;
+
+            int[] channels = BassMix.MixerGetChannels(bassMixer.Handle);
 
             if (channels == null)
                 return;


### PR DESCRIPTION
The underlying events would potentially be fired too early and never reach the hooking methods due to the fact the invocation call site is run on the audio thread, before the binding may have completed.

Also done some restructuring for a future PR which allows showing an identifying string on the visualiser.

Can be tested via the existing `TestSceneAudioMixerVisualiser` while running in multi-thread mode (previously the new mixers would usually not display).