### PR TITLE
Add Rider autogenerated .idea files

### DIFF
--- a/.idea/.idea.osu-framework.Android/.idea/indexLayout.xml
+++ b/.idea/.idea.osu-framework.Android/.idea/indexLayout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ContentModelUserStore">
+  <component name="UserContentModel">
     <attachedFolders />
     <explicitIncludes />
     <explicitExcludes />

--- a/.idea/.idea.osu-framework.Android/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.osu-framework.Android/.idea/projectSettingsUpdater.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RiderProjectSettingsUpdater">
+    <option name="vcsConfiguration" value="2" />
+  </component>
+</project>

--- a/.idea/.idea.osu-framework/.idea/indexLayout.xml
+++ b/.idea/.idea.osu-framework/.idea/indexLayout.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ContentModelUserStore">
+  <component name="UserContentModel">
     <attachedFolders />
     <explicitIncludes />
     <explicitExcludes />

--- a/.idea/.idea.osu-framework/.idea/misc.xml
+++ b/.idea/.idea.osu-framework/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.jetbrains.rider.android.RiderAndroidMiscFileCreationComponent">
+    <option name="ENSURE_MISC_FILE_EXISTS" value="true" />
+  </component>
+</project>

--- a/.idea/.idea.osu-framework/.idea/projectSettingsUpdater.xml
+++ b/.idea/.idea.osu-framework/.idea/projectSettingsUpdater.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RiderProjectSettingsUpdater">
+    <option name="vcsConfiguration" value="2" />
+  </component>
+</project>


### PR DESCRIPTION
Feels a bit weird having something called `com.jetbrains.rider.android.RiderAndroidMiscFileCreationComponent` be in the root `.sln`, but it does exist for desktop as well ¯\\\_(ツ)_/¯

https://github.com/ppy/osu-framework/blob/1035fb17fea1fe9e39a179164bae275a1746514c/.idea/.idea.osu-framework.Desktop/.idea/misc.xml#L3