### PR TITLE
Downgrade `Microsoft.Diagnostics.Runtime` back to avoid AOT issues with iOS

### DIFF
--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -68,7 +68,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.178" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801"/>
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401"/>
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="ppy.ManagedBass" Version="3.1.3-alpha"/>

--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -68,7 +68,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.178" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401"/>
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="ppy.ManagedBass" Version="3.1.3-alpha"/>
@@ -81,5 +80,9 @@
 
     <!-- Manually downgrade for 4.5.1-4.5.3. Should be removed when 4.6.0 released. -->
     <PackageReference Include="System.Memory" Version="4.5.4" NoWarn="NU1605" />
+
+    <!-- Any version ahead of this will cause AOT issues with iOS
+         See https://github.com/mono/mono/issues/21188 -->
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401"/>
   </ItemGroup>
 </Project>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -32,7 +32,7 @@
     <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801" />
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="ppy.ManagedBass" Version="3.1.3-alpha" />
     <PackageReference Include="ManagedBass.Fx" Version="3.0.0" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -32,7 +32,6 @@
     <!-- Preview version of ImageSharp causes NU5104. -->
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="ppy.ManagedBass" Version="3.1.3-alpha" />
     <PackageReference Include="ManagedBass.Fx" Version="3.0.0" />
@@ -41,6 +40,10 @@
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.178" />
     <PackageReference Include="StbiSharp" Version="1.0.13" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.468-alpha" />
+
+    <!-- Any version ahead of this will cause AOT issues with iOS
+         See https://github.com/mono/mono/issues/21188 -->
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401"/>
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp'">
     <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2021.805.0" />


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/issues/13302
- Resolves the first point mentioned in https://github.com/ppy/osu-framework/issues/4677
- Works around https://github.com/mono/mono/issues/21188.

This is the simplest solution for the time being. Ideally we wouldn't want this package to be included in Xamarin projects to begin with, but not really sure if there's a simple way to do that without using `#if` directives (not sure we want that).