### PR TITLE
Add more user-friendly variant of the exponential damp interpolation

### DIFF
--- a/osu.Framework.Tests/MathUtils/TestInterpolation.cs
+++ b/osu.Framework.Tests/MathUtils/TestInterpolation.cs
@@ -32,6 +32,32 @@ namespace osu.Framework.Tests.MathUtils
         }
 
         [Test]
+        public void TestContinuousDamp()
+        {
+            const double start = 1;
+            const double target = 2;
+            const double half_time = 1000;
+
+            Assert.AreEqual(start, damp(start, 0));
+            Assert.AreEqual(target, damp(start, double.PositiveInfinity));
+
+            double middle = Interpolation.Lerp(start, target, 0.5);
+            Assert.AreEqual(middle, damp(start, half_time));
+
+            // The final value shouldn't depend on the frame rate
+            Assert.AreEqual(
+                damp(start, 300 + 700),
+                damp(damp(start, 300), 700));
+
+            // The elapsed time can be negative.
+            Assert.AreEqual(
+                damp(start, 500 - 200),
+                damp(damp(start, 500), -200));
+
+            static double damp(double current, double elapsed) => Interpolation.DampContinuously(current, target, half_time, elapsed);
+        }
+
+        [Test]
         public void TestLagrange()
         {
             // lagrange of (0,0) (0.5,0.35) (1,1) is equal to 0.6x*x + 0.4x

--- a/osu.Framework/Utils/Interpolation.cs
+++ b/osu.Framework/Utils/Interpolation.cs
@@ -31,10 +31,27 @@ namespace osu.Framework.Utils
         {
             if (@base < 0 || @base > 1)
                 throw new ArgumentOutOfRangeException(nameof(@base), $"{nameof(@base)} has to lie in [0,1], but is {@base}.");
-            if (exponent < 0)
-                throw new ArgumentOutOfRangeException(nameof(exponent), $"{nameof(exponent)} has to be bigger than 0, but is {exponent}.");
 
             return Lerp(start, final, 1 - Math.Pow(@base, exponent));
+        }
+
+        /// <summary>
+        /// Interpolate the current value towards the target value based on the elapsed time.
+        /// If this function is applied to the current value at every frame,
+        /// the approximately same value is calculated at the same time regardless of the frame rate.
+        /// </summary>
+        /// <remarks>
+        /// Because floating-point errors can accumulate over a long time, this function shouldn't be
+        /// used for things requiring accurate values.
+        /// </remarks>
+        /// <param name="current">The current value.</param>
+        /// <param name="target">The target value.</param>
+        /// <param name="halfTime">The time it takes to reach the middle value of the current and the target value.</param>
+        /// <param name="elapsedTime">The elapsed time of the current frame.</param>
+        public static double DampContinuously(double current, double target, double halfTime, double elapsedTime)
+        {
+            double exponent = elapsedTime / halfTime;
+            return Damp(current, target, 0.5, exponent);
         }
 
         /// <summary>

--- a/osu.Framework/Utils/Interpolation.cs
+++ b/osu.Framework/Utils/Interpolation.cs
@@ -37,8 +37,7 @@ namespace osu.Framework.Utils
 
         /// <summary>
         /// Interpolate the current value towards the target value based on the elapsed time.
-        /// If this function is applied to the current value at every frame,
-        /// the approximately same value is calculated at the same time regardless of the frame rate.
+        /// If the current value is updated every frame using this function, the result is approximately frame-rate independent.
         /// </summary>
         /// <remarks>
         /// Because floating-point errors can accumulate over a long time, this function shouldn't be


### PR DESCRIPTION
This function can be used to to interpolate a value in a frame-rate independent manner without maintaining additional variables.
It should replace the current frame-rate dependent transition used in osu e.g. <https://github.com/ppy/osu/blob/f9d5abff8a8d3b6752343c185eb7767a3944a532/osu.Game/Screens/Play/SkipOverlay.cs#L132>.