### PR TITLE
Use upstream `ManagedBass` packages again and update to 3.1.0

### DIFF
--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -71,9 +71,9 @@
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801"/>
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="ppy.ManagedBass" Version="3.1.3-alpha"/>
-    <PackageReference Include="ManagedBass.Fx" Version="3.0.0"/>
-    <PackageReference Include="ManagedBass.Mix" Version="3.0.0"/>
+    <PackageReference Include="ManagedBass" Version="3.1.0"/>
+    <PackageReference Include="ManagedBass.Fx" Version="3.1.0"/>
+    <PackageReference Include="ManagedBass.Mix" Version="3.1.0"/>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="System.Reflection.Emit.ILGeneration" Version="4.7.0" />

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="managed-midi" Version="1.9.14" />
-    <PackageReference Include="ManagedBass.Mix" Version="3.0.0" />
     <PackageReference Include="Markdig" Version="0.26.0" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
@@ -34,8 +33,9 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.226801" />
     <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="ppy.ManagedBass" Version="3.1.3-alpha" />
-    <PackageReference Include="ManagedBass.Fx" Version="3.0.0" />
+    <PackageReference Include="ManagedBass" Version="3.1.0" />
+    <PackageReference Include="ManagedBass.Fx" Version="3.1.0" />
+    <PackageReference Include="ManagedBass.Mix" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.178" />


### PR DESCRIPTION
- Fulfills the second point in https://github.com/ppy/osu-framework/issues/4677 ("Testing of new bass library version")

Also resolves visible `ManagedBass` reference conflicts in iOS projects:

<img width="487" alt="CleanShot 2021-11-10 at 13 42 25@2x" src="https://user-images.githubusercontent.com/22781491/141099043-2ed7441c-c220-49e9-85f7-84eb0b4efa56.png">

Tested this update to work on macOS and iOS, would appreciate testing on other platforms just in case.