### PR TITLE
Fix crashes in `AudioManager` due to no threading guarantee on `CreateAudioMixer`

### DIFF
--- a/osu.Framework/Audio/AudioCollectionManager.cs
+++ b/osu.Framework/Audio/AudioCollectionManager.cs
@@ -22,7 +22,9 @@ namespace osu.Framework.Audio
 
                 if (item is IAdjustableAudioComponent adjustable)
                     adjustable.BindAdjustments(this);
+
                 Items.Add(item);
+                ItemAdded(item);
             });
         }
 
@@ -45,11 +47,20 @@ namespace osu.Framework.Audio
                 if (!item.IsAlive)
                 {
                     Items.RemoveAt(i--);
+                    ItemRemoved(item);
                     continue;
                 }
 
                 item.Update();
             }
+        }
+
+        protected virtual void ItemAdded(T item)
+        {
+        }
+
+        protected virtual void ItemRemoved(T item)
+        {
         }
 
         protected override void Dispose(bool disposing)

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -170,13 +170,6 @@ namespace osu.Framework.Audio
             });
         }
 
-        protected override void UpdateChildren()
-        {
-            base.UpdateChildren();
-
-            activeMixers.RemoveAll(m => m.HasCompleted);
-        }
-
         protected override void Dispose(bool disposing)
         {
             cancelSource.Cancel();
@@ -217,9 +210,22 @@ namespace osu.Framework.Audio
         private AudioMixer createAudioMixer(AudioMixer globalMixer)
         {
             var mixer = new BassAudioMixer(globalMixer);
-            activeMixers.Add(mixer);
             AddItem(mixer);
             return mixer;
+        }
+
+        protected override void ItemAdded(AudioComponent item)
+        {
+            base.ItemAdded(item);
+            if (item is AudioMixer mixer)
+                activeMixers.Add(mixer);
+        }
+
+        protected override void ItemRemoved(AudioComponent item)
+        {
+            base.ItemRemoved(item);
+            if (item is AudioMixer mixer)
+                activeMixers.Remove(mixer);
         }
 
         /// <summary>


### PR DESCRIPTION
The "add" calls were coming from the update thread while the "remove" calls were happening on the audio thread. Dangerous.