### PR TITLE
Add mixer output levels to audio visualizer

### DIFF
--- a/osu.Framework/Graphics/Visualisation/Audio/AudioChannelDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/AudioChannelDisplay.cs
@@ -9,7 +9,6 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osuTK;
-using osuTK.Graphics;
 
 namespace osu.Framework.Graphics.Visualisation.Audio
 {
@@ -24,13 +23,16 @@ namespace osu.Framework.Graphics.Visualisation.Audio
         private readonly Drawable volBarR;
         private readonly SpriteText peakText;
         private readonly SpriteText maxPeakText;
+        private readonly SpriteText mixerLabel;
 
         private float maxPeak = float.MinValue;
         private double lastMaxPeakTime;
+        private readonly bool isOutputChannel;
 
-        public AudioChannelDisplay(int channelHandle)
+        public AudioChannelDisplay(int channelHandle, bool isOutputChannel = false)
         {
             ChannelHandle = channelHandle;
+            this.isOutputChannel = isOutputChannel;
 
             RelativeSizeAxes = Axes.Y;
             AutoSizeAxes = Axes.X;
@@ -66,7 +68,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
                                     Origin = Anchor.BottomLeft,
                                     RelativeSizeAxes = Axes.Y,
                                     Width = 30,
-                                    Colour = Color4.YellowGreen
+                                    Colour = isOutputChannel ? FrameworkColour.YellowGreen : FrameworkColour.Green
                                 },
                                 volBarR = new Box
                                 {
@@ -74,7 +76,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
                                     Origin = Anchor.BottomLeft,
                                     RelativeSizeAxes = Axes.Y,
                                     Width = 30,
-                                    Colour = Color4.YellowGreen
+                                    Colour = isOutputChannel ? FrameworkColour.YellowGreen : FrameworkColour.Green
                                 }
                             }
                         }
@@ -90,6 +92,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
                             {
                                 peakText = new SpriteText { Text = "N/A", Font = FrameworkFont.Condensed.With(size: 14f) },
                                 maxPeakText = new SpriteText { Text = "N/A", Font = FrameworkFont.Condensed.With(size: 14f) },
+                                mixerLabel = new SpriteText { Text = " ", Font = FrameworkFont.Condensed.With(size: 14f), Colour = FrameworkColour.Yellow },
                             }
                         }
                     }
@@ -102,7 +105,11 @@ namespace osu.Framework.Graphics.Visualisation.Audio
             base.Update();
 
             float[] levels = new float[2];
-            BassMix.ChannelGetLevel(ChannelHandle, levels, 1 / 1000f * sample_window, LevelRetrievalFlags.Stereo);
+
+            if (isOutputChannel)
+                Bass.ChannelGetLevel(ChannelHandle, levels, 1 / 1000f * sample_window, LevelRetrievalFlags.Stereo);
+            else
+                BassMix.ChannelGetLevel(ChannelHandle, levels, 1 / 1000f * sample_window, LevelRetrievalFlags.Stereo);
 
             float curPeakL = levels[0];
             float curPeakR = levels[1];
@@ -125,6 +132,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
             maxPeakText.Text = $"peak: {maxPeakDisplay}dB";
             peakText.Colour = BassUtils.LevelToDb(curPeak) > 0 ? Colour4.Red : Colour4.White;
             maxPeakText.Colour = BassUtils.LevelToDb(maxPeak) > 0 ? Colour4.Red : Colour4.White;
+            mixerLabel.Text = isOutputChannel ? "MIXER OUT" : " ";
         }
     }
 }

--- a/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/MixerDisplay.cs
@@ -18,7 +18,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
     {
         public readonly AudioMixer Mixer;
 
-        private readonly FillFlowContainer<AudioChannelDisplay> channelsContainer;
+        private readonly FillFlowContainer<AudioChannelDisplay> mixerChannelsContainer;
 
         public MixerDisplay(AudioMixer mixer)
         {
@@ -26,6 +26,8 @@ namespace osu.Framework.Graphics.Visualisation.Audio
 
             RelativeSizeAxes = Axes.Y;
             AutoSizeAxes = Axes.X;
+
+            Container outputChannelContainer;
 
             InternalChild = new Container
             {
@@ -47,20 +49,47 @@ namespace osu.Framework.Graphics.Visualisation.Audio
                         Colour = FrameworkColour.Yellow,
                         Padding = new MarginPadding(2),
                     },
-                    channelsContainer = new FillFlowContainer<AudioChannelDisplay>
+                    new FillFlowContainer
                     {
                         RelativeSizeAxes = Axes.Y,
                         AutoSizeAxes = Axes.X,
                         Direction = FillDirection.Horizontal,
-                        Spacing = new Vector2(10),
                         Padding = new MarginPadding
                         {
                             Horizontal = 10,
                             Bottom = 20
+                        },
+                        Children = new Drawable[]
+                        {
+                            outputChannelContainer = new Container
+                            {
+                                RelativeSizeAxes = Axes.Y,
+                                AutoSizeAxes = Axes.X,
+                                Padding = new MarginPadding
+                                {
+                                    Left = 10,
+                                    Bottom = 20
+                                }
+                            },
+                            mixerChannelsContainer = new FillFlowContainer<AudioChannelDisplay>
+                            {
+                                RelativeSizeAxes = Axes.Y,
+                                AutoSizeAxes = Axes.X,
+                                Direction = FillDirection.Horizontal,
+                                Spacing = new Vector2(10),
+                                Padding = new MarginPadding
+                                {
+                                    Horizontal = 10,
+                                    Bottom = 20
+                                }
+                            }
                         }
                     }
                 }
             };
+
+            if (Mixer is BassAudioMixer bassMixer)
+                outputChannelContainer.Add(new AudioChannelDisplay(bassMixer.Handle, true));
         }
 
         protected override void Update()
@@ -77,11 +106,11 @@ namespace osu.Framework.Graphics.Visualisation.Audio
 
             foreach (int channel in channels)
             {
-                if (channelsContainer.All(ch => ch.ChannelHandle != channel))
-                    channelsContainer.Add(new AudioChannelDisplay(channel));
+                if (mixerChannelsContainer.All(ch => ch.ChannelHandle != channel))
+                    mixerChannelsContainer.Add(new AudioChannelDisplay(channel));
             }
 
-            channelsContainer.RemoveAll(ch => !channels.Contains(ch.ChannelHandle));
+            mixerChannelsContainer.RemoveAll(ch => !channels.Contains(ch.ChannelHandle));
         }
     }
 }


### PR DESCRIPTION
Previously only the levels of the source/mixer channels would be shown, not the mixer output itself.