### PR TITLE
Add "iPhone Developer" codesign key to iOS projects

### DIFF
--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -10,6 +10,7 @@
     <MtouchExtraArgs>$(DefaultMtouchExtraArgs) -gcc_flags "$(DefaultMtouchGccFlags)"</MtouchExtraArgs>
     <MtouchHttpClientHandler>NSUrlSessionHandler</MtouchHttpClientHandler>
     <MtouchVerbosity></MtouchVerbosity>
+    <CodesignKey>iPhone Developer</CodesignKey>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Matches [osu!](https://github.com/ppy/osu/blob/f208a931b8c725ab49413f2f715b0f86b986fec0/osu.iOS.props#L15) and [the template game projects](https://github.com/ppy/osu-framework/blob/a8429246cd22b686db420a89c049a57792f37923/osu.Framework.Templates/templates/template-empty/TemplateGame.iOS/TemplateGame.iOS.csproj#L58). Saves time having to set the codesign key everytime (although I would still have to change the bundle identifier to match my provisioning profile anyways)