### PR TITLE
Revert no longer necessary iOS `GameHost` DI changes

### DIFF
--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -4,13 +4,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.States;
 using osu.Framework.Logging;
-using osu.Framework.Platform;
 using osuTK;
 
 namespace osu.Framework.Input.Bindings
@@ -392,13 +390,6 @@ namespace osu.Framework.Input.Bindings
     /// </summary>
     public abstract class KeyBindingContainer : Container
     {
-        // This is only specified here (rather than in PlatformContainer, where it is consumed) to workaround
-        // a critical iOS / Xamarin bug, where consumer applications may crash during startup at an unmanaged level.
-        // It should eventually be removed when the issue is identified and fixed upstream.
-        // See https://github.com/ppy/osu-framework/pull/4263 for discussion.
-        [Resolved]
-        protected GameHost Host { get; private set; }
-
         protected IEnumerable<IKeyBinding> KeyBindings;
 
         public abstract IEnumerable<IKeyBinding> DefaultKeyBindings { get; }

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Collections.Generic;
+using osu.Framework.Allocation;
 using osu.Framework.Input.Bindings;
+using osu.Framework.Platform;
 
 namespace osu.Framework.Input
 {
@@ -14,12 +16,15 @@ namespace osu.Framework.Input
     /// </summary>
     public class PlatformActionContainer : KeyBindingContainer<PlatformAction>, IHandleGlobalKeyboardInput
     {
+        [Resolved]
+        private GameHost host { get; set; }
+
         public PlatformActionContainer()
             : base(SimultaneousBindingMode.None, KeyCombinationMatchingMode.Modifiers)
         {
         }
 
-        public override IEnumerable<IKeyBinding> DefaultKeyBindings => Host.PlatformKeyBindings;
+        public override IEnumerable<IKeyBinding> DefaultKeyBindings => host.PlatformKeyBindings;
 
         protected override bool Prioritised => true;
 


### PR DESCRIPTION
Reverts https://github.com/ppy/osu-framework/pull/4263 as it appears to be no longer required from testing with osu! on Release configuration multiple times.