### PR TITLE
Remove `KeyBindingContainer.SendRepeats`

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -207,7 +207,7 @@ namespace osu.Framework.Tests.Visual.Input
             AddStep("release A", () => InputManager.ReleaseKey(Key.A));
             AddAssert("release received", () => releasedReceived);
 
-            AddAssert("one one press received", () => pressedReceived == 1);
+            AddAssert("only one press received", () => pressedReceived == 1);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingContainer.cs
@@ -174,38 +174,40 @@ namespace osu.Framework.Tests.Visual.Input
         [Test]
         public void TestSingleKeyRepeatEvents()
         {
-            bool pressedReceived = false;
-            bool repeatedReceived = false;
+            int pressedReceived = 0;
+            int repeatedReceived = 0;
             bool releasedReceived = false;
 
             AddStep("add container", () =>
             {
-                pressedReceived = false;
-                repeatedReceived = false;
+                pressedReceived = 0;
+                repeatedReceived = 0;
                 releasedReceived = false;
 
-                Child = new TestKeyBindingContainer(true)
+                Child = new TestKeyBindingContainer
                 {
                     Child = new TestKeyBindingReceptor
                     {
-                        Pressed = a => pressedReceived = a == TestAction.ActionA,
-                        Repeated = a => repeatedReceived = a == TestAction.ActionA,
+                        Pressed = a => pressedReceived += a == TestAction.ActionA ? 1 : 0,
+                        Repeated = a => repeatedReceived += a == TestAction.ActionA ? 1 : 0,
                         Released = a => releasedReceived = a == TestAction.ActionA
                     }
                 };
             });
 
             AddStep("press A", () => InputManager.PressKey(Key.A));
-            AddAssert("press received", () => pressedReceived);
+            AddAssert("press received", () => pressedReceived == 1);
 
             for (int i = 0; i < 10; i++)
             {
-                AddUntilStep($"repeat #{1 + i} received", () => repeatedReceived);
-                AddStep("reset for next repeat", () => repeatedReceived = false);
+                int localI = i + 1;
+                AddUntilStep($"repeat #{1 + i} received", () => repeatedReceived >= localI);
             }
 
             AddStep("release A", () => InputManager.ReleaseKey(Key.A));
             AddAssert("release received", () => releasedReceived);
+
+            AddAssert("one one press received", () => pressedReceived == 1);
         }
 
         [Test]
@@ -221,7 +223,7 @@ namespace osu.Framework.Tests.Visual.Input
                 repeatedReceived = false;
                 releasedReceived = false;
 
-                Child = new TestKeyBindingContainer(true)
+                Child = new TestKeyBindingContainer
                 {
                     Child = new TestKeyBindingReceptor
                     {
@@ -284,13 +286,6 @@ namespace osu.Framework.Tests.Visual.Input
 
         private class TestKeyBindingContainer : KeyBindingContainer<TestAction>
         {
-            protected override bool SendRepeats { get; }
-
-            public TestKeyBindingContainer(bool sendRepeats = false)
-            {
-                SendRepeats = sendRepeats;
-            }
-
             public override IEnumerable<IKeyBinding> DefaultKeyBindings => new IKeyBinding[]
             {
                 new KeyBinding(InputKey.A, TestAction.ActionA),

--- a/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneKeyBindingsGrid.cs
@@ -547,17 +547,19 @@ namespace osu.Framework.Tests.Visual.Input
             {
                 if (Action == e.Action)
                 {
-                    if (Concurrency != SimultaneousBindingMode.All)
-                        Trace.Assert(OnPressedCount == OnReleasedCount);
-                    ++OnPressedCount;
+                    if (!e.Repeat)
+                    {
+                        if (Concurrency != SimultaneousBindingMode.All)
+                            Trace.Assert(OnPressedCount == OnReleasedCount);
+                        ++OnPressedCount;
 
-                    alphaTarget += 0.2f;
-                    Background.Alpha = alphaTarget;
+                        alphaTarget += 0.2f;
+                        Background.Alpha = alphaTarget;
+                    }
 
                     highlight.ClearTransforms();
                     highlight.Alpha = 1f;
                     highlight.FadeOut(200);
-
                     return true;
                 }
 

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -75,12 +75,6 @@ namespace osu.Framework.Input.Bindings
         }
 
         /// <summary>
-        /// Override to enable or disable sending of repeated actions (disabled by default).
-        /// Each repeated action will have its own pressed/released event pair.
-        /// </summary>
-        protected virtual bool SendRepeats => false;
-
-        /// <summary>
         /// Whether this <see cref="KeyBindingContainer"/> should attempt to handle input before any of its children.
         /// </summary>
         protected virtual bool Prioritised => false;
@@ -118,9 +112,6 @@ namespace osu.Framework.Input.Bindings
                     return false;
 
                 case KeyDownEvent keyDown:
-                    if (keyDown.Repeat && !SendRepeats)
-                        return pressedBindings.Count > 0;
-
                     if (handleNewPressed(state, KeyCombination.FromKey(keyDown.Key), keyDown.Repeat))
                         return true;
 

--- a/osu.Framework/Input/Bindings/KeyBindingContainer.cs
+++ b/osu.Framework/Input/Bindings/KeyBindingContainer.cs
@@ -204,7 +204,13 @@ namespace osu.Framework.Input.Bindings
             {
                 // we handled a new binding and there is an existing one. if we don't want concurrency, let's propagate a released event.
                 if (simultaneousMode == SimultaneousBindingMode.None)
-                    releasePressedActions(state);
+                {
+                    // in the case of a key repeat we don't want to send the "released" action, even in the case of "none" simultaneous mode.
+                    if (repeat)
+                        pressedActions.Clear();
+                    else
+                        releasePressedActions(state);
+                }
 
                 List<Drawable> inputQueue = getInputQueue(newBinding, true);
                 Drawable handledBy = PropagatePressed(inputQueue, state, newBinding.GetAction<T>(), scrollAmount, isPrecise, repeat);

--- a/osu.Framework/Input/PlatformActionContainer.cs
+++ b/osu.Framework/Input/PlatformActionContainer.cs
@@ -22,7 +22,5 @@ namespace osu.Framework.Input
         public override IEnumerable<IKeyBinding> DefaultKeyBindings => Host.PlatformKeyBindings;
 
         protected override bool Prioritised => true;
-
-        protected override bool SendRepeats => true;
     }
 }


### PR DESCRIPTION
Reasoning mentioned in https://github.com/ppy/osu-framework/issues/4773.

See a pretty shocking oversight in db22119df which went unnoticed until now as tests were focused on the non-event-based repeat handling (which is removed in this PR). Existing tests cover the fail case - revert the commit to confirm.

# Breaking Changes

## `KeyBindingContainer.SendRepeats` no longer exists

Use the `KeyBindingPressEvent` provided in `OnPressed` delegates to identify (and ignore or handle) repeats instead.