### PR TITLE
Fix improper access to rented array in `FillFlowContainer` with `^` indexer

### DIFF
--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -226,7 +226,7 @@ namespace osu.Framework.Graphics.Containers
                     current.X += stride.X;
                 }
 
-                float height = layoutPositions[^1].Y;
+                float height = layoutPositions[children.Length - 1].Y;
 
                 Vector2 ourRelativeAnchor = children[0].RelativeAnchorPosition;
 


### PR DESCRIPTION
This fixes an issue where an array rented from `ArrayPool` would have its `Length` read. The reason why you should never read the length of a rented array is because you have no guarantee on its size since (documentation) it is **at least** the requested size, meaning it can be longer than requested.
In this case the `[^1]` indexer is translated to `[target.Length - 1]` and as such it could access an element outside the requested range, which caused longer `FillFlowContainer`s to read `0` or a "random" value as their total height.