### PR TITLE
Include `ManagedBass` dllmaps in projects referencing via nupkg

### DIFF
--- a/osu.Framework.iOS/osu.Framework.iOS.Dllmaps.props
+++ b/osu.Framework.iOS/osu.Framework.iOS.Dllmaps.props
@@ -1,0 +1,10 @@
+﻿<!-- This is automatically imported in all projects referencing osu.Framework.iOS via package,
+     mainly for setting up all dllmap references required for libraries to work on iOS. -->
+<Project>
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)..\dllmaps\*.dll.config">
+      <Link>%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -35,10 +35,13 @@
       <Type>Non-Resx</Type>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Label="Dllmaps (local)">
     <!-- Without separate dll configs and using BundleResource, dllmaps won't work properly
          See https://github.com/ManagedBass/ManagedBass/issues/76 -->
-    <BundleResource Include="ManagedBass.Fx.dll.config" />
-    <BundleResource Include="ManagedBass.Mix.dll.config" />
+    <BundleResource Include="$(MSBuildThisFileDirectory)*.dll.config" />
+  </ItemGroup>
+  <ItemGroup Label="Dllmaps (package)">
+    <None Include="$(MSBuildThisFileDirectory)*.dll.config" Pack="true" PackagePath="dllmaps" />
+    <Content Include="$(MSBuildThisFileDirectory)osu.Framework.iOS.Dllmaps.props" Pack="true" PackagePath="build\$(PackageId).props" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Turns out the current dllmap configuration (via `BundleResource`) was only working with projects referencing framework locally.

While looking at a way for nupkg reference support, I've stumbled upon [Realm](https://github.com/realm/realm-dotnet/blob/588d58c5efcd0f4a3d1fea55f868dc7f92e7ad2c/Realm/Realm/Realm.csproj#L42-L48)'s [iOS setup](https://github.com/realm/realm-dotnet/blob/588d58c5efcd0f4a3d1fea55f868dc7f92e7ad2c/Realm/Realm/RealmWrappersReferences.props#L5-L14), which was perfect for referencing dllmap configuration in all projects referencing via nupkg, as the `.dll.config` files get automatically included in the projects as can be seen:

<img width="302" alt="CleanShot 2021-11-19 at 15 25 40@2x" src="https://user-images.githubusercontent.com/22781491/142622534-efaeb763-874b-42e4-ae8e-77fb3f2b2b23.png">

Tested this to work with osu!framework local projects, osu! via local reference, and osu! via nupkg reference.

---

One issue with this however is that, for some reason, including the `osu.Framework.iOS.Dllmaps.props` with `Content` build action specifically causes the following warning:
```
0>/usr/local/share/dotnet/sdk/5.0.400/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(221,5): Warning  : File '/Users/salman/Desktop/osu-framework/osu.Framework.iOS/osu.Framework.iOS.Dllmaps.props' is not added because the package already contains file 'build/ppy.osu.Framework.iOS.props'
```

<img width="1293" alt="CleanShot 2021-11-19 at 15 30 17@2x" src="https://user-images.githubusercontent.com/22781491/142623105-c26adccd-f2b2-4445-b7ec-04c9d7488260.png">

I've went back and forth with this one for hours, having absolutely no clue why it's happening. Yet there's actually no issue with the generated nupkg, as I have extracted the package and checked inside, finding the `.props` file with the right content as expected.