### PR TITLE
Improve readability and handling of fill directions in `FillFlowContainer`

### DIFF
--- a/osu.Framework.Tests/Visual/Layout/TestSceneFillFlowContainer.cs
+++ b/osu.Framework.Tests/Visual/Layout/TestSceneFillFlowContainer.cs
@@ -375,6 +375,13 @@ namespace osu.Framework.Tests.Visual.Layout
             fillContainer.Spacing = new Vector2(5, 5);
         }
 
+        [FlowTestCase(FlowTestType.FullVertical)]
+        private void test4()
+        {
+            fillContainer.Direction = FillDirection.FullVertical;
+            fillContainer.Spacing = new Vector2(5, 5);
+        }
+
         private class TestSceneDropdownHeader : DropdownHeader
         {
             private readonly SpriteText label;
@@ -423,6 +430,7 @@ namespace osu.Framework.Tests.Visual.Layout
             Full,
             Horizontal,
             Vertical,
+            FullVertical,
         }
     }
 }

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -146,7 +146,7 @@ namespace osu.Framework.Graphics.Containers
                     float spanMainSize = spanBeginOffset + current.Main + (1 - spacingFactor.Main) * size.Main;
 
                     // We've exceeded our allowed main size, move to a new span
-                    if ((Direction.AffectedAxes() == Axes.Both && Precision.DefinitelyBigger(spanMainSize, max.Main)) || ForceNewRow(c))
+                    if ((Direction.AffectedAxes() == Axes.Both && Precision.DefinitelyBigger(spanMainSize, max.Main)) || ForceNewSpan(c))
                     {
                         current.Main = 0;
                         current.Cross += spanCrossSize;
@@ -289,7 +289,18 @@ namespace osu.Framework.Graphics.Containers
         /// </summary>
         /// <param name="child">The child to check.</param>
         /// <returns>True if the given child should be placed on a new row, false otherwise.</returns>
+        [Obsolete("Use ForceNewSpan instead")]
         protected virtual bool ForceNewRow(Drawable child) => false;
+
+        /// <summary>
+        /// Returns true if the given child should be placed on a new span, false otherwise. This will be called automatically for each child in this FillFlowContainers FlowingChildren-List.
+        /// A span can refer to either row or column, depending on <see cref="Direction"/>.
+        /// </summary>
+        /// <param name="child">The child to check.</param>
+        /// <returns>True if the given child should be placed on a new row, false otherwise.</returns>
+#pragma warning disable CS0618 // Type or member is obsolete
+        protected virtual bool ForceNewSpan(Drawable child) => ForceNewRow(child);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// An ad-hoc <see cref="Vector2"/> which uses a concept of "main" and "cross" axes rather than "x" and "y"

--- a/osu.Framework/Graphics/Containers/FillFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/FillFlowContainer.cs
@@ -325,6 +325,9 @@ namespace osu.Framework.Graphics.Containers
                 };
         }
 
+        /// <summary>
+        /// Converts a <see cref="Vector2"/> to a <see cref="CrossVector"/> with the current <see cref="FillDirection"/>.
+        /// </summary>
         protected CrossVector ToCross(Vector2 vector)
         {
             if (Direction.MainAxis() == Axes.X)
@@ -345,6 +348,9 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
+        /// <summary>
+        /// Converts a <see cref="CrossVector"/> to a <see cref="Vector2"/> assuming its orientation is the current <see cref="FillDirection"/>.
+        /// </summary>
         protected Vector2 ToVector(CrossVector vector)
         {
             if (Direction.MainAxis() == Axes.X)
@@ -394,6 +400,9 @@ namespace osu.Framework.Graphics.Containers
 
     public static class FillDirectionExtensions
     {
+        /// <summary>
+        /// The used axes - if it's a "Full" direction, <see cref="Axes.Both"/>, otherwise, the main axis.
+        /// </summary>
         public static Axes AffectedAxes(this FillDirection direction)
         {
             if (direction == FillDirection.Full || direction == FillDirection.FullVertical)
@@ -402,6 +411,9 @@ namespace osu.Framework.Graphics.Containers
                 return direction.MainAxis();
         }
 
+        /// <summary>
+        /// The primary axis.
+        /// </summary>
         public static Axes MainAxis(this FillDirection direction)
         {
             if (direction == FillDirection.Full || direction == FillDirection.Horizontal)
@@ -410,6 +422,9 @@ namespace osu.Framework.Graphics.Containers
                 return Axes.Y;
         }
 
+        /// <summary>
+        /// The secondary axis, orthogonal to the main axis.
+        /// </summary>
         public static Axes CrossAxis(this FillDirection direction)
             => direction.MainAxis() == Axes.X ? Axes.Y : Axes.X;
     }

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -439,7 +439,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        protected override bool ForceNewRow(Drawable child) => child is NewLineContainer;
+        protected override bool ForceNewSpan(Drawable child) => child is NewLineContainer;
 
         public class NewLineContainer : Container
         {


### PR DESCRIPTION
This PR introduces a concept used by flexboxes (and probably some other UI design components) called main and cross axes. This is basically a `Vector2` except rather than having `X` and `Y`, it has `Main` and `Cross` which can be interpreted depending on orientation. For example for `FillDirection.{Full, Horizontal}` the main axis is `Axes.X` and the cross axis is `Axes.Y`, and the opposite is true for the other `FillDirection`s.

This allows us to ignore the actual direction we are using (only converting at the beginning and end) and operate as if we were handling just `Full` or `Horizontal` with `Main` and `Cross` rather than `X` and `Y` respectively. Due to this this PR also introduces a new `FillDirection` - `FullVertical`.

This PR makes some cases, especially new row handling, easier to read. Speaking of rows, (namingwise) I replaced them with "spans" as they, just like cross axes, lack orientation. `FillFlowContainer`s have a `ForceNewRow` method, which I believe originally forced a row, even for the `Vertical` orientation, which did effectively nothing. Now, `ForceNewRow` was made obsolete and replaced with `ForceNewSpan` which would instead create a new column in such case. This is only a rename, as FFCs now use spans rather than rows and columns. **[request: add when the obsolete member can be removed]**

You might notice that `ForceNewSpan` creates a new span even if the direction should not create new spans (the not "Full" fill directions). This is how it worked originally too (for horizontal orientations, since it did nothing for vertical), but I think it should be discussed whether this is correct behaviour.

This PR also refactored child validation into its own method, rather than `if`s scattered across the method.