### PR TITLE
Fix customizable text container placeholders being disposed on localisation parameter change

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneCustomizableTextContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneCustomizableTextContainer.cs
@@ -1,0 +1,59 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Localisation;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Containers
+{
+    public class TestSceneCustomizableTextContainer : FrameworkTestScene
+    {
+        [Resolved]
+        private FrameworkConfigManager configManager { get; set; }
+
+        [Test]
+        public void TestLanguageSwitch()
+        {
+            CustomizableTextContainer container = null;
+
+            AddStep("create container", () => Child = container = new CustomizableTextContainer
+            {
+                RelativeSizeAxes = Axes.Both
+            });
+
+            AddStep("add content to container", () =>
+            {
+                int first = container.AddPlaceholder(new SpriteIcon
+                {
+                    Size = new Vector2(16),
+                    Icon = FontAwesome.Regular.Comment
+                });
+
+                int second = container.AddPlaceholder(new CircularContainer
+                {
+                    Size = new Vector2(30, 16),
+                    Masking = true,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Colour4.Goldenrod
+                    }
+                });
+
+                container.AddText(new RomanisableString(
+                    $"this original [{first}] text has [{second}] placeholder",
+                    $"this romanised text [{first}] has placeholder [{second}]"));
+            });
+
+            AddStep("prefer unicode", () => configManager.SetValue(FrameworkSetting.ShowUnicode, true));
+            AddStep("prefer ASCII", () => configManager.SetValue(FrameworkSetting.ShowUnicode, false));
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
+++ b/osu.Framework/Graphics/Containers/CustomizableTextContainer.cs
@@ -91,5 +91,15 @@ namespace osu.Framework.Graphics.Containers
 
         protected internal override TextChunk<TSpriteText> CreateChunkFor<TSpriteText>(LocalisableString text, bool newLineIsParagraph, Func<TSpriteText> creationFunc, Action<TSpriteText> creationParameters = null)
             => new CustomizableTextChunk<TSpriteText>(text, newLineIsParagraph, creationFunc, creationParameters);
+
+        protected override void RecreateAllParts()
+        {
+            // placeholders via AddPlaceholder() are similar to manual text parts
+            // in that they were added/registered externally and cannot be recreated.
+            // remove them before proceeding with part recreation to avoid accidentally disposing them in the process.
+            RemoveRange(Placeholders);
+
+            base.RecreateAllParts();
+        }
     }
 }

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -147,7 +147,7 @@ namespace osu.Framework.Graphics.Containers
             base.LoadAsyncComplete();
 
             localisationParameters.Value = Localisation.CurrentParameters.Value;
-            recreateAllParts();
+            RecreateAllParts();
         }
 
         protected override void LoadComplete()
@@ -169,7 +169,7 @@ namespace osu.Framework.Graphics.Containers
             base.Update();
 
             if (!partsCache.IsValid)
-                recreateAllParts();
+                RecreateAllParts();
         }
 
         public override IEnumerable<Drawable> FlowingChildren
@@ -315,7 +315,7 @@ namespace osu.Framework.Graphics.Containers
             return true;
         }
 
-        private void recreateAllParts()
+        protected virtual void RecreateAllParts()
         {
             // manual parts need to be manually removed before clearing contents,
             // to avoid accidentally disposing of them in the process.


### PR DESCRIPTION
Which includes both the language/locale setting and the 'prefer unicode'/romanisation setting.

This was crashing because I missed that `CustomizableTextContainer` was keeping placeholders in a separate list, and so they are like manual text parts in that they are given once externally and cannot be recreated if disposed. The fix is analogous to manual text parts - the placeholders are removed manually before every text flow content recreation triggered by the localisation parameters changing.

Test coverage included.

Closes ppy/osu#15698.