### PR TITLE
Hide `TextBox` caret when `GameHost` is inactive / keyboard focus is lost

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -155,14 +155,13 @@ namespace osu.Framework.Graphics.UserInterface
         {
             textInput = host.GetTextInput();
             clipboard = host.GetClipboard();
-
             isActive = host.IsActive.GetBoundCopy();
-            isActive.BindValueChanged(_ => Scheduler.AddOnce(updateCaretVisibility));
         }
 
         protected override void LoadComplete()
         {
             base.LoadComplete();
+            isActive.BindValueChanged(_ => Scheduler.AddOnce(updateCaretVisibility));
             setText(Text);
         }
 

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -726,13 +726,10 @@ namespace osu.Framework.Graphics.UserInterface
 
         private void updateCaretVisibility()
         {
-            bool newVisibility =
-                // only show if we're focused
-                HasFocus && (
-                    // and the host is active
-                    isActive.Value
-                    // or if text is selected
-                    || selectionLength != 0);
+            // a blinking cursor signals to the user that keyboard input will appear at that cursor,
+            // hide the caret when we don't have keyboard focus to conform with that expectation.
+            // importantly, we want want the caret to remain visible when there is a selection.
+            bool newVisibility = HasFocus && (isActive.Value || selectionLength != 0);
 
             if (caretVisible != newVisibility)
             {

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -413,9 +413,12 @@ namespace osu.Framework.Graphics.UserInterface
         {
             base.UpdateAfterChildren();
 
-            //have to run this after children flow
+            // have to run this after children flow
             if (!cursorAndLayout.IsValid)
             {
+                // update in case selection length has changed.
+                updateCaretVisibility();
+
                 updateCursorAndLayout();
                 cursorAndLayout.Validate();
             }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -730,7 +730,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             // a blinking cursor signals to the user that keyboard input will appear at that cursor,
             // hide the caret when we don't have keyboard focus to conform with that expectation.
-            // importantly, we want want the caret to remain visible when there is a selection.
+            // importantly, we want the caret to remain visible when there is a selection.
             bool newVisibility = HasFocus && (isActive.Value || selectionLength != 0);
 
             if (caretVisible != newVisibility)


### PR DESCRIPTION
A blinking cursor signals to the user that keyboard input will appear at that cursor.
This PR hides the caret when we lose keyboard focus to conform with that expectation.

Only hides the caret if there is no selection. The current show/hide logic on focus/unfocus is kept.
Native applications will usually grey-out the selection when inactive, but that is unnecessary for us.