### PR TITLE
Downgrade `Markdig` back to avoid runtime issue on iOS

### DIFF
--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -56,7 +56,6 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup Label="Package References">
-    <PackageReference Include="Markdig" Version="0.26.0" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
@@ -80,6 +79,10 @@
     <!-- Any version ahead of this will cause AOT issues with iOS
          See https://github.com/mono/mono/issues/21188 -->
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401"/>
+
+    <!-- Any version ahead of this will cause runtime issues on iOS
+         See https://github.com/xoofx/markdig/issues/564 -->
+    <PackageReference Include="Markdig" Version="0.23.0" />
   </ItemGroup>
   <!-- Workaround for System.Memory conflicts on MSBuild v16
        See https://jaylee.org/archive/2019/03/31/using-span-of-t-in-xamarin-cross-targeted-projects.html -->

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -22,7 +22,6 @@
   </PropertyGroup>
   <ItemGroup Label="Package References">
     <PackageReference Include="managed-midi" Version="1.9.14" />
-    <PackageReference Include="Markdig" Version="0.26.0" />
     <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
     <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.11" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
@@ -44,6 +43,10 @@
     <!-- Any version ahead of this will cause AOT issues with iOS
          See https://github.com/mono/mono/issues/21188 -->
     <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401"/>
+
+    <!-- Any version ahead of this will cause runtime issues on iOS
+         See https://github.com/xoofx/markdig/issues/564 -->
+    <PackageReference Include="Markdig" Version="0.23.0" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFrameworkIdentifier) == '.NETCoreApp'">
     <PackageReference Include="ppy.osu.Framework.NativeLibs" Version="2021.805.0" />


### PR DESCRIPTION
Resolves a runtime issue with `Markdown` seen in osu! when running in Release configuration:
```
2021-11-22 20:29:27 [error]: An unhandled error has occurred.
2021-11-22 20:29:27 [error]: System.TypeInitializationException: The type initializer for 'Markdig.Markdown' threw an exception. ---> System.IndexOutOfRangeException: Index was outside the bounds of the array.
2021-11-22 20:29:27 [error]: at Markdig.Markdown..cctor () <0x10c023520 + 0x00050> in <303bd4757e5f496993647645edf2c14e#ea2eaafc0823b3d3502b57b3688dec27>:0
2021-11-22 20:29:27 [error]: --- End of inner exception stack trace ---
2021-11-22 20:29:27 [error]: at osu.Framework.Graphics.Containers.Markdown.MarkdownContainer.validateContent () <0x105ee71a0 + 0x00070> in <dc6fe624359a411c96b2b0dddc1c998c#ea2eaafc0823b3d3502b57b3688dec27>:0
2021-11-22 20:29:27 [error]: at osu.Framework.Graphics.Containers.Markdown.MarkdownContainer.load () <0x105ee7180 + 0x00013> in <dc6fe624359a411c96b2b0dddc1c998c#ea2eaafc0823b3d3502b57b3688dec27>:0
2021-11-22 20:29:27 [error]: at (wrapper managed-to-native) System.Reflection.RuntimeMethodInfo.InternalInvoke(System.Reflection.RuntimeMethodInfo,object,object[],System.Exception&)
2021-11-22 20:29:27 [error]: at System.Reflection.RuntimeMethodInfo.Invoke (System.Object obj, System.Reflection.BindingFlags invokeAttr, System.Reflection.Binder binder, System.Object[] parameters, System.Globalization.CultureInfo culture) <0x104fb47c0 + 0x000ef> in <25bf495f7d6b4944aa395b3ab5293479#ea2eaafc0823b3d3502b57b3688dec27>:0
```

See https://github.com/xoofx/markdig/issues/564.