### PR TITLE
Temporarily bypass FXSetPriority in NUnit runs

### DIFF
--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -12,6 +12,7 @@ using System.Runtime.InteropServices;
 using ManagedBass;
 using ManagedBass.Mix;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Statistics;
@@ -404,7 +405,11 @@ namespace osu.Framework.Audio.Mixing.Bass
                     effect.Priority = -i;
 
                     if (effect.Handle != 0)
-                        ManagedBass.Bass.FXSetPriority(effect.Handle, effect.Priority);
+                    {
+                        // Todo: Temporary bypass to attempt to fix failing test runs.
+                        if (!DebugUtils.IsNUnitRunning)
+                            ManagedBass.Bass.FXSetPriority(effect.Handle, effect.Priority);
+                    }
                     else
                         effect.Handle = ManagedBass.Bass.ChannelSetFX(Handle, effect.Effect.FXType, effect.Priority);
 


### PR DESCRIPTION
I intend to get this out in a release to see if this fixes all crashed test runs. E.g.:
https://github.com/ppy/osu/runs/4306364513?check_suite_focus=true
https://github.com/ppy/osu/runs/4306364580?check_suite_focus=true
https://github.com/ppy/osu/runs/4307525554?check_suite_focus=true
https://github.com/ppy/osu/runs/4307525591?check_suite_focus=true

I have a suspicion it may be caused by applying effects on the no-sound device.