### PR TITLE
Add additional safeguards to BASS device cleanup

### DIFF
--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -139,18 +139,19 @@ namespace osu.Framework.Threading
             Debug.Assert(ThreadSafety.IsAudioThread);
 
             int selectedDevice = Bass.CurrentDevice;
-            bool selectedDeviceInitialised = Bass.GetDeviceInfo(selectedDevice, out var lastDeviceInfo) && lastDeviceInfo.IsInitialized;
 
-            if (canFreeDevice(deviceId))
+            if (canFreeDevice(deviceId) && canSelectDevice(deviceId))
             {
                 Bass.CurrentDevice = deviceId;
                 Bass.Free();
             }
 
-            if (selectedDevice != deviceId && selectedDeviceInitialised)
+            if (selectedDevice != deviceId && canSelectDevice(selectedDevice))
                 Bass.CurrentDevice = selectedDevice;
 
             initialised_devices.Remove(deviceId);
+
+            static bool canSelectDevice(int deviceId) => Bass.GetDeviceInfo(deviceId, out var deviceInfo) && deviceInfo.IsInitialized;
         }
 
         /// <summary>
@@ -169,10 +170,6 @@ namespace osu.Framework.Threading
         /// Whether a device can be freed.
         /// On Linux, freeing device 0 is disallowed as it can cause deadlocks which don't surface immediately.
         /// </summary>
-        private static bool canFreeDevice(int deviceId)
-        {
-            return (deviceId != 0 || RuntimeInfo.OS != RuntimeInfo.Platform.Linux)
-                   && Bass.GetDeviceInfo(deviceId, out var deviceInfo) && deviceInfo.IsInitialized;
-        }
+        private static bool canFreeDevice(int deviceId) => deviceId != 0 || RuntimeInfo.OS != RuntimeInfo.Platform.Linux;
     }
 }

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -168,6 +168,10 @@ namespace osu.Framework.Threading
         /// Whether a device can be freed.
         /// On Linux, freeing device 0 is disallowed as it can cause deadlocks which don't surface immediately.
         /// </summary>
-        private static bool canFreeDevice(int deviceId) => deviceId != 0 || RuntimeInfo.OS != RuntimeInfo.Platform.Linux;
+        private static bool canFreeDevice(int deviceId)
+        {
+            return (deviceId != 0 || RuntimeInfo.OS != RuntimeInfo.Platform.Linux)
+                   && Bass.GetDeviceInfo(deviceId, out var deviceInfo) && deviceInfo.IsInitialized;
+        }
     }
 }

--- a/osu.Framework/Threading/AudioThread.cs
+++ b/osu.Framework/Threading/AudioThread.cs
@@ -138,7 +138,8 @@ namespace osu.Framework.Threading
         {
             Debug.Assert(ThreadSafety.IsAudioThread);
 
-            int lastDevice = Bass.CurrentDevice;
+            int selectedDevice = Bass.CurrentDevice;
+            bool selectedDeviceInitialised = Bass.GetDeviceInfo(selectedDevice, out var lastDeviceInfo) && lastDeviceInfo.IsInitialized;
 
             if (canFreeDevice(deviceId))
             {
@@ -146,8 +147,8 @@ namespace osu.Framework.Threading
                 Bass.Free();
             }
 
-            if (lastDevice != deviceId)
-                Bass.CurrentDevice = lastDevice;
+            if (selectedDevice != deviceId && selectedDeviceInitialised)
+                Bass.CurrentDevice = selectedDevice;
 
             initialised_devices.Remove(deviceId);
         }


### PR DESCRIPTION
Attempting to fix test intermittent such as https://github.com/ppy/osu/runs/4311311823?check_suite_focus=true

Thinking it's something like the audio device getting cleaned up external to osu!, since it only happens on the macOS test runners.