### PR TITLE
Add support for nested AudioMixers

### DIFF
--- a/osu.Framework.Tests/Audio/BassAudioMixerTest.cs
+++ b/osu.Framework.Tests/Audio/BassAudioMixerTest.cs
@@ -74,9 +74,9 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
-        public void TestMovedToGlobalMixerWhenRemovedFromMixer()
+        public void TestMovedToParentMixerWhenRemovedFromMixer()
         {
-            var secondMixer = bass.CreateMixer();
+            var secondMixer = bass.CreateMixer(bass.Mixer);
 
             secondMixer.Add(track);
             secondMixer.Remove(track);
@@ -108,9 +108,9 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
-        public void TestChannelMovedToGlobalMixerAfterDispose()
+        public void TestChannelMovedToParentMixerAfterDispose()
         {
-            var secondMixer = bass.CreateMixer();
+            var secondMixer = bass.CreateMixer(bass.Mixer);
 
             secondMixer.Add(track);
             bass.Update();

--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using JetBrains.Annotations;
 using ManagedBass;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Mixing.Bass;
@@ -52,9 +53,9 @@ namespace osu.Framework.Tests.Audio
 
         public void Add(params AudioComponent[] component) => components.AddRange(component);
 
-        internal BassAudioMixer CreateMixer()
+        internal BassAudioMixer CreateMixer([CanBeNull] BassAudioMixer bassMixer = null, string identifier = "Test mixer")
         {
-            var mixer = new BassAudioMixer(Mixer, "Test mixer");
+            var mixer = new BassAudioMixer(bassMixer, identifier);
             components.Insert(0, mixer);
             return mixer;
         }

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -313,10 +313,10 @@ namespace osu.Framework.Audio.Mixing.Bass
             foreach (var channel in toAdd)
                 AddChannelToBassMix(channel);
 
-            // Initialize sub-mixers that were added prior to mixer being loaded.
+            // Initialize sub-mixers that were added prior to this mixer being initialized.
             foreach (var item in Items)
             {
-                if (item is BassAudioMixer mixer && mixer.IsAlive)
+                if (item is BassAudioMixer mixer && !mixer.IsDisposed)
                 {
                     if (mixer.Handle == 0)
                         mixer.createMixer();

--- a/osu.Framework/Audio/Mixing/IAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/IAudioMixer.cs
@@ -24,6 +24,11 @@ namespace osu.Framework.Audio.Mixing
         BindableList<IEffectParameter> Effects { get; }
 
         /// <summary>
+        /// The currently active channels.
+        /// </summary>
+        BindableList<IAudioChannel> Channels { get; }
+
+        /// <summary>
         /// Adds a channel to the mix.
         /// </summary>
         /// <param name="channel">The channel to add.</param>

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -217,7 +217,11 @@ namespace osu.Framework.Audio.Sample
 
             if (hasChannel)
             {
-                bassMixer.StreamFree(this);
+                if (Mixer != null)
+                    bassMixer.StreamFree(this);
+                else
+                    Bass.StreamFree(channel);
+
                 channel = 0;
             }
 

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -440,7 +440,11 @@ namespace osu.Framework.Audio.Track
             if (activeStream != 0)
             {
                 isRunning = false;
-                bassMixer.StreamFree(this);
+
+                if (Mixer != null)
+                    bassMixer.StreamFree(this);
+                else
+                    Bass.StreamFree(activeStream);
             }
 
             activeStream = 0;

--- a/osu.Framework/Graphics/Audio/DrawableAudioMixer.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioMixer.cs
@@ -24,6 +24,8 @@ namespace osu.Framework.Graphics.Audio
 
         public BindableList<IEffectParameter> Effects { get; } = new BindableList<IEffectParameter>();
 
+        public BindableList<IAudioChannel> Channels => mixer.Channels;
+
         public void Add(IAudioChannel channel)
         {
             if (LoadState < LoadState.Ready)


### PR DESCRIPTION
This functionality is a pre-requisite for applying processing to groupings of audio channels in Lazer, and affords the ability to chain mixers with different processing/effects.

Utilising this capability, a `GlobalMixer` has been added (which `TrackMixer` and `SampleMixer` are now routed into). This will allow for monitoring of the final summed audio output and for any final audio processing to happen just prior to output.