### PR TITLE
Update AudioMixerVisualiser to support nested mixers

### DIFF
--- a/osu.Framework.Tests/Audio/BassAudioMixerTest.cs
+++ b/osu.Framework.Tests/Audio/BassAudioMixerTest.cs
@@ -74,9 +74,9 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
-        public void TestMovedToGlobalMixerWhenRemovedFromMixer()
+        public void TestMovedToParentMixerWhenRemovedFromMixer()
         {
-            var secondMixer = bass.CreateMixer();
+            var secondMixer = bass.CreateMixer(bass.Mixer);
 
             secondMixer.Add(track);
             secondMixer.Remove(track);
@@ -108,9 +108,9 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
-        public void TestChannelMovedToGlobalMixerAfterDispose()
+        public void TestChannelMovedToParentMixerAfterDispose()
         {
-            var secondMixer = bass.CreateMixer();
+            var secondMixer = bass.CreateMixer(bass.Mixer);
 
             secondMixer.Add(track);
             bass.Update();

--- a/osu.Framework.Tests/Audio/BassTestComponents.cs
+++ b/osu.Framework.Tests/Audio/BassTestComponents.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using JetBrains.Annotations;
 using ManagedBass;
 using osu.Framework.Audio;
 using osu.Framework.Audio.Mixing.Bass;
@@ -52,9 +53,9 @@ namespace osu.Framework.Tests.Audio
 
         public void Add(params AudioComponent[] component) => components.AddRange(component);
 
-        internal BassAudioMixer CreateMixer()
+        internal BassAudioMixer CreateMixer([CanBeNull] BassAudioMixer bassMixer = null, string identifier = "Test mixer")
         {
-            var mixer = new BassAudioMixer(Mixer, "Test mixer");
+            var mixer = new BassAudioMixer(bassMixer, identifier);
             components.Insert(0, mixer);
             return mixer;
         }

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -130,9 +130,6 @@ namespace osu.Framework.Audio
         /// </summary>
         public Scheduler EventScheduler;
 
-        internal IBindableList<AudioMixer> ActiveMixers => activeMixers;
-        private readonly BindableList<AudioMixer> activeMixers = new BindableList<AudioMixer>();
-
         private readonly Lazy<TrackStore> globalTrackStore;
         private readonly Lazy<SampleStore> globalSampleStore;
 
@@ -239,20 +236,6 @@ namespace osu.Framework.Audio
             parentMixer.Add(mixer);
 
             return mixer;
-        }
-
-        protected override void ItemAdded(AudioComponent item)
-        {
-            base.ItemAdded(item);
-            if (item is AudioMixer mixer)
-                activeMixers.Add(mixer);
-        }
-
-        protected override void ItemRemoved(AudioComponent item)
-        {
-            base.ItemRemoved(item);
-            if (item is AudioMixer mixer)
-                activeMixers.Remove(mixer);
         }
 
         /// <summary>

--- a/osu.Framework/Audio/BassAmplitudeProcessor.cs
+++ b/osu.Framework/Audio/BassAmplitudeProcessor.cs
@@ -29,8 +29,6 @@ namespace osu.Framework.Audio
 
         private float[]? frequencyData;
 
-        private readonly float[] channelLevels = new float[2];
-
         public void Update()
         {
             if (channel.Handle == 0)
@@ -38,8 +36,7 @@ namespace osu.Framework.Audio
 
             bool active = channel.Mixer.ChannelIsActive(channel) == PlaybackState.Playing;
 
-            channel.Mixer.ChannelGetLevel(channel, channelLevels, 1 / 60f, LevelRetrievalFlags.Stereo);
-
+            float[] channelLevels = channel.GetLevel(1 / 60f);
             float leftChannel = active ? channelLevels[0] : -1;
             float rightChannel = active ? channelLevels[1] : -1;
 

--- a/osu.Framework/Audio/Mixing/AudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/AudioMixer.cs
@@ -94,6 +94,10 @@ namespace osu.Framework.Audio.Mixing
         /// <param name="channel">The <see cref="IAudioChannel"/> to remove.</param>
         protected abstract void RemoveInternal(IAudioChannel channel);
 
+        public abstract float[] GetLevel(float length);
+
+        public abstract float[] GetChannelLevel(IAudioChannel channel, float length);
+
         #region IAudioChannel
 
         public AudioMixer? Mixer { get; }

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -244,6 +244,31 @@ namespace osu.Framework.Audio.Mixing.Bass
             => BassMix.ChannelRemoveSync(channel.Handle, sync);
 
         /// <summary>
+        /// Retrieves the level (peak amplitude) of the mixer output.
+        /// </summary>
+        /// <remarks>See: <see cref="ManagedBass.Bass.ChannelGetLevel(int, float[], float, LevelRetrievalFlags)"/>.</remarks>
+        /// <param name="levels">The array in which the levels are to be returned.</param>
+        /// <param name="length">How much data (in seconds) to look at to get the level (limited to 1 second).</param>
+        /// <param name="flags">What levels to retrieve.</param>
+        /// <returns><c>true</c> if successful, false otherwise.</returns>
+        public bool MixerGetLevel([In, Out] float[] levels, float length, LevelRetrievalFlags flags)
+            => ManagedBass.Bass.ChannelGetLevel(Handle, levels, length, flags);
+
+        /// <summary>
+        /// Retrieves the immediate sample data (or an FFT representation of it) of the mixer output.
+        /// </summary>
+        /// <remarks>See: <see cref="ManagedBass.Bass.ChannelGetData(int, float[], int)"/>.</remarks>
+        /// <param name="buffer">float[] to write the data to.</param>
+        /// <param name="length">Number of bytes wanted, and/or <see cref="T:ManagedBass.DataFlags"/>.</param>
+        /// <returns>If an error occurs, -1 is returned, use <see cref="P:ManagedBass.Bass.LastError"/> to get the error code.
+        /// <para>When requesting FFT data, the number of bytes read from the channel (to perform the FFT) is returned.</para>
+        /// <para>When requesting sample data, the number of bytes written to buffer will be returned (not necessarily the same as the number of bytes read when using the <see cref="F:ManagedBass.DataFlags.Float"/> or DataFlags.Fixed flag).</para>
+        /// <para>When using the <see cref="F:ManagedBass.DataFlags.Available"/> flag, the number of bytes in the channel's buffer is returned.</para>
+        /// </returns>
+        public int MixerGetData(float[] buffer, int length)
+            => ManagedBass.Bass.ChannelGetData(Handle, buffer, length);
+
+        /// <summary>
         /// Frees a channel's resources.
         /// </summary>
         /// <param name="channel">The <see cref="IBassAudioChannel"/> to free.</param>

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -313,10 +313,10 @@ namespace osu.Framework.Audio.Mixing.Bass
             foreach (var channel in toAdd)
                 AddChannelToBassMix(channel);
 
-            // Initialize sub-mixers that were added prior to mixer being loaded.
+            // Initialize sub-mixers that were added prior to this mixer being initialized.
             foreach (var item in Items)
             {
-                if (item is BassAudioMixer mixer && mixer.IsAlive)
+                if (item is BassAudioMixer mixer && !mixer.IsDisposed)
                 {
                     if (mixer.Handle == 0)
                         mixer.createMixer();

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -197,7 +197,7 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// <summary>
         /// Retrieves the level (peak amplitude) of a channel.
         /// </summary>
-        /// <remarks>See: <see cref="ManagedBass.Bass.ChannelGetLevel(int, float[], float, LevelRetrievalFlags)"/>.</remarks>
+        /// <remarks>See: <see cref="BassMix.ChannelGetLevel(int, float[], float, LevelRetrievalFlags)"/>.</remarks>
         /// <param name="channel">The <see cref="IBassAudioChannel"/> to get the levels of.</param>
         /// <param name="levels">The array in which the levels are to be returned.</param>
         /// <param name="length">How much data (in seconds) to look at to get the level (limited to 1 second).</param>
@@ -209,7 +209,7 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// <summary>
         /// Retrieves the immediate sample data (or an FFT representation of it) of a channel.
         /// </summary>
-        /// <remarks>See: <see cref="ManagedBass.Bass.ChannelGetData(int, float[], int)"/>.</remarks>
+        /// <remarks>See: <see cref="BassMix.ChannelGetData(int, float[], int)"/>.</remarks>
         /// <param name="channel">The <see cref="IBassAudioChannel"/> to retrieve the data of.</param>
         /// <param name="buffer">float[] to write the data to.</param>
         /// <param name="length">Number of bytes wanted, and/or <see cref="T:ManagedBass.DataFlags"/>.</param>

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -279,20 +279,6 @@ namespace osu.Framework.Audio.Mixing.Bass
             => ManagedBass.Bass.ChannelGetLevel(Handle, levels, length, flags);
 
         /// <summary>
-        /// Retrieves the immediate sample data (or an FFT representation of it) of the mixer output.
-        /// </summary>
-        /// <remarks>See: <see cref="ManagedBass.Bass.ChannelGetData(int, float[], int)"/>.</remarks>
-        /// <param name="buffer">float[] to write the data to.</param>
-        /// <param name="length">Number of bytes wanted, and/or <see cref="T:ManagedBass.DataFlags"/>.</param>
-        /// <returns>If an error occurs, -1 is returned, use <see cref="P:ManagedBass.Bass.LastError"/> to get the error code.
-        /// <para>When requesting FFT data, the number of bytes read from the channel (to perform the FFT) is returned.</para>
-        /// <para>When requesting sample data, the number of bytes written to buffer will be returned (not necessarily the same as the number of bytes read when using the <see cref="F:ManagedBass.DataFlags.Float"/> or DataFlags.Fixed flag).</para>
-        /// <para>When using the <see cref="F:ManagedBass.DataFlags.Available"/> flag, the number of bytes in the channel's buffer is returned.</para>
-        /// </returns>
-        public int MixerGetData(float[] buffer, int length)
-            => ManagedBass.Bass.ChannelGetData(Handle, buffer, length);
-
-        /// <summary>
         /// Frees a channel's resources.
         /// </summary>
         /// <param name="channel">The <see cref="IBassAudioChannel"/> to free.</param>

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -60,6 +60,30 @@ namespace osu.Framework.Audio.Mixing.Bass
 
         public override BindableList<IAudioChannel> Channels => new BindableList<IAudioChannel>(ActiveChannels.ToArray());
 
+        public override float[] GetLevel(float length)
+        {
+            float[] levels = new float[2];
+
+            if (parentMixer != null)
+                levels = parentMixer.GetChannelLevel(this, length);
+            else
+                MixerGetLevel(levels, length, LevelRetrievalFlags.Stereo);
+
+            return levels;
+        }
+
+        public override float[] GetChannelLevel(IAudioChannel channel, float length)
+        {
+            float[] levels = new float[2];
+
+            if (!(channel is IBassAudioChannel bassAudioChannel))
+                return levels;
+
+            ChannelGetLevel(bassAudioChannel, levels, length, LevelRetrievalFlags.Stereo);
+
+            return levels;
+        }
+
         protected override void AddInternal(IAudioChannel channel)
         {
             Debug.Assert(CanPerformInline);

--- a/osu.Framework/Audio/Mixing/IAudioChannel.cs
+++ b/osu.Framework/Audio/Mixing/IAudioChannel.cs
@@ -24,5 +24,11 @@ namespace osu.Framework.Audio.Mixing
         /// <param name="action">The action to perform.</param>
         /// <returns>A task which can be used for continuation logic. May return a <see cref="Task.CompletedTask"/> if called while already on the audio thread.</returns>
         internal Task EnqueueAction(Action action);
+
+        /// <summary>
+        /// Retrieves the level (peak amplitude) of the channel.
+        /// </summary>
+        /// <param name="length">How much data (in seconds) to look at to get the level (limited to 1 second).</param>
+        public float[] GetLevel(float length);
     }
 }

--- a/osu.Framework/Audio/Mixing/IAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/IAudioMixer.cs
@@ -39,5 +39,12 @@ namespace osu.Framework.Audio.Mixing
         /// </summary>
         /// <param name="channel">The channel to remove.</param>
         void Remove(IAudioChannel channel);
+
+        /// <summary>
+        /// Retrieves the level (peak amplitude) of a channel.
+        /// </summary>
+        /// <param name="channel">The <see cref="IAudioChannel"/> to retrieve the levels for.</param>
+        /// <param name="length">How much data (in seconds) to look at to get the level (limited to 1 second).</param>
+        float[] GetChannelLevel(IAudioChannel channel, float length);
     }
 }

--- a/osu.Framework/Audio/Mixing/IAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/IAudioMixer.cs
@@ -24,6 +24,11 @@ namespace osu.Framework.Audio.Mixing
         BindableList<IEffectParameter> Effects { get; }
 
         /// <summary>
+        /// The currently active channels.
+        /// </summary>
+        BindableList<IAudioChannel> Channels { get; }
+
+        /// <summary>
         /// Adds a channel to the mix.
         /// </summary>
         /// <param name="channel">The channel to add.</param>

--- a/osu.Framework/Audio/Sample/SampleChannel.cs
+++ b/osu.Framework/Audio/Sample/SampleChannel.cs
@@ -44,6 +44,8 @@ namespace osu.Framework.Audio.Sample
 
         public virtual ChannelAmplitudes CurrentAmplitudes { get; } = ChannelAmplitudes.Empty;
 
+        public abstract float[] GetLevel(float length);
+
         #region Mixing
 
         protected virtual AudioMixer? Mixer { get; set; }

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -217,7 +217,11 @@ namespace osu.Framework.Audio.Sample
 
             if (hasChannel)
             {
-                bassMixer.StreamFree(this);
+                if (Mixer != null)
+                    bassMixer.StreamFree(this);
+                else
+                    Bass.StreamFree(channel);
+
                 channel = 0;
             }
 

--- a/osu.Framework/Audio/Sample/SampleChannelBass.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelBass.cs
@@ -206,6 +206,8 @@ namespace osu.Framework.Audio.Sample
 
         bool IBassAudioChannel.MixerChannelPaused { get; set; } = true;
 
+        public override float[] GetLevel(float length) => Mixer != null ? bassMixer.GetChannelLevel(this, length) : new float[2];
+
         BassAudioMixer IBassAudioChannel.Mixer => bassMixer;
 
         #endregion

--- a/osu.Framework/Audio/Sample/SampleChannelVirtual.cs
+++ b/osu.Framework/Audio/Sample/SampleChannelVirtual.cs
@@ -13,6 +13,8 @@ namespace osu.Framework.Audio.Sample
 
         public override bool Playing => playing;
 
+        public override float[] GetLevel(float length) => new float[2];
+
         protected override void UpdateState()
         {
             base.UpdateState();

--- a/osu.Framework/Audio/Track/Track.cs
+++ b/osu.Framework/Audio/Track/Track.cs
@@ -111,6 +111,8 @@ namespace osu.Framework.Audio.Track
 
         public virtual ChannelAmplitudes CurrentAmplitudes { get; } = ChannelAmplitudes.Empty;
 
+        public float[] GetLevel(float length) => Mixer?.GetChannelLevel(this, length) ?? new float[2];
+
         protected override void UpdateState()
         {
             FrameStatistics.Increment(StatisticsCounterType.Tracks);

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -440,7 +440,11 @@ namespace osu.Framework.Audio.Track
             if (activeStream != 0)
             {
                 isRunning = false;
-                bassMixer.StreamFree(this);
+
+                if (Mixer != null)
+                    bassMixer.StreamFree(this);
+                else
+                    Bass.StreamFree(activeStream);
             }
 
             activeStream = 0;

--- a/osu.Framework/Graphics/Audio/DrawableAudioMixer.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioMixer.cs
@@ -26,6 +26,8 @@ namespace osu.Framework.Graphics.Audio
 
         public BindableList<IAudioChannel> Channels => mixer.Channels;
 
+        public float[] GetChannelLevel(IAudioChannel channel, float length) => mixer.GetChannelLevel(channel, length);
+
         public void Add(IAudioChannel channel)
         {
             if (LoadState < LoadState.Ready)

--- a/osu.Framework/Graphics/Audio/DrawableAudioMixer.cs
+++ b/osu.Framework/Graphics/Audio/DrawableAudioMixer.cs
@@ -24,6 +24,8 @@ namespace osu.Framework.Graphics.Audio
 
         public BindableList<IEffectParameter> Effects { get; } = new BindableList<IEffectParameter>();
 
+        public BindableList<IAudioChannel> Channels => mixer.Channels;
+
         public void Add(IAudioChannel channel)
         {
             if (LoadState < LoadState.Ready)

--- a/osu.Framework/Graphics/Visualisation/Audio/AudioMixerVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/Audio/AudioMixerVisualiser.cs
@@ -1,13 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Collections.Specialized;
-using System.Diagnostics;
-using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
-using osu.Framework.Audio.Mixing;
-using osu.Framework.Bindables;
 using osu.Framework.Graphics.Containers;
 using osuTK;
 
@@ -19,7 +14,6 @@ namespace osu.Framework.Graphics.Visualisation.Audio
         private AudioManager audioManager { get; set; }
 
         private readonly FillFlowContainer<MixerDisplay> mixerFlow;
-        private readonly IBindableList<AudioMixer> activeMixers = new BindableList<AudioMixer>();
 
         public AudioMixerVisualiser()
             : base("AudioMixer", "(Ctrl+F9 to toggle)")
@@ -28,7 +22,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
             MainHorizontalContent.Add(new BasicScrollContainer(Direction.Horizontal)
             {
                 RelativeSizeAxes = Axes.Y,
-                Width = WIDTH,
+                Width = WIDTH * 2,
                 Children = new[]
                 {
                     mixerFlow = new FillFlowContainer<MixerDisplay>
@@ -46,25 +40,7 @@ namespace osu.Framework.Graphics.Visualisation.Audio
         {
             base.LoadComplete();
 
-            activeMixers.BindTo(audioManager.ActiveMixers);
-            activeMixers.BindCollectionChanged(onActiveMixerHandlesChanged, true);
+            mixerFlow.Add(new MixerDisplay(audioManager.GlobalMixer));
         }
-
-        private void onActiveMixerHandlesChanged(object sender, NotifyCollectionChangedEventArgs e) => Schedule(() =>
-        {
-            switch (e.Action)
-            {
-                case NotifyCollectionChangedAction.Add:
-                    Debug.Assert(e.NewItems != null);
-                    foreach (var mixer in e.NewItems.OfType<AudioMixer>())
-                        mixerFlow.Add(new MixerDisplay(mixer));
-                    break;
-
-                case NotifyCollectionChangedAction.Remove:
-                    Debug.Assert(e.OldItems != null);
-                    mixerFlow.RemoveAll(m => e.OldItems.OfType<AudioMixer>().Contains(m.Mixer));
-                    break;
-            }
-        });
     }
 }


### PR DESCRIPTION
Also refactored it a bit along the way to make it a less coupled to BASS (for whatever that's worth?).

I'm also kinda passing around the levels in a `float[]` (as returned from BASS), I'm not sure if this is the best approach? Worth creating a data structure for it or nah?

- [ ] depends on #4915 (for `GlobalMixer` and its hierarchy)

(I broke this out into a separate PR as the other one got kinda big.)