### PR TITLE
Fix caret potentially going out of textbox bounds with sufficiently high LeftRightPadding

### DIFF
--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -383,7 +383,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (selectionLength > 0)
                 selectionWidth = getPositionAt(selectionRight) - cursorPos;
 
-            float cursorRelativePositionAxesInBox = (cursorPosEnd - textContainerPosX) / DrawWidth;
+            float cursorRelativePositionAxesInBox = (cursorPosEnd - textContainerPosX) / (DrawWidth - 2 * LeftRightPadding);
 
             //we only want to reposition the view when the cursor reaches near the extremities.
             if (cursorRelativePositionAxesInBox < 0.1 || cursorRelativePositionAxesInBox > 0.9)


### PR DESCRIPTION
For example, latest `master` with `LeftRightPadding = 100`:

https://user-images.githubusercontent.com/16479013/143657321-d029b6e7-1c18-4e6d-8dd0-84001cb2448d.mp4

Happens because [this check](https://github.com/ppy/osu-framework/blob/fe00cc23f6393fd8891fc1d94e3ee37041e242fc/osu.Framework/Graphics/UserInterface/TextBox.cs#L389-L392) doesn't succeed because of wrongly calculated `cursorRelativePositionAxesInBox`.

This isn't easily noticeable with TextBox's default of 5, or OsuTextBox's default of 10, but the caret will go ever so slightly more to the right before scrolling the view.

**This PR:**

https://user-images.githubusercontent.com/16479013/143657575-e6629333-4108-46a1-9019-b465dbcc4297.mp4


