### PR TITLE
Improve IPC to allow sending responses

### DIFF
--- a/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
@@ -104,6 +104,7 @@ namespace osu.Framework.Tests.Platform
                             Assert.AreEqual("example", message.Bar);
                             // ReSharper disable once AccessToDisposedClosure
                             received.Set();
+                            return null;
                         };
 
                         clientChannel.SendMessageAsync(new Foobar { Bar = "example" }).Wait();

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.Platform
             if (ipcProvider != null)
                 return;
 
-            ipcProvider = new TcpIpcProvider();
+            ipcProvider = new TcpIpcProvider(45356);
             IsPrimaryInstance = ipcProvider.Bind();
 
             if (IsPrimaryInstance)

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -19,6 +19,8 @@ namespace osu.Framework.Platform
 {
     public abstract class DesktopGameHost : GameHost
     {
+        public const int IPC_PORT = 45356;
+
         private TcpIpcProvider ipcProvider;
         private readonly bool bindIPCPort;
         private Thread ipcThread;
@@ -66,7 +68,7 @@ namespace osu.Framework.Platform
             if (ipcProvider != null)
                 return;
 
-            ipcProvider = new TcpIpcProvider(45356);
+            ipcProvider = new TcpIpcProvider(IPC_PORT);
             IsPrimaryInstance = ipcProvider.Bind();
 
             if (IsPrimaryInstance)

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -94,7 +94,7 @@ namespace osu.Framework.Platform
         /// </summary>
         public event Func<Exception, bool> ExceptionThrown;
 
-        public event Action<IpcMessage> MessageReceived;
+        public event Func<IpcMessage, IpcMessage> MessageReceived;
 
         /// <summary>
         /// Whether the on screen keyboard covers a portion of the game window when presented to the user.
@@ -111,11 +111,7 @@ namespace osu.Framework.Platform
         /// </summary>
         protected virtual bool LimitedMemoryEnvironment => false;
 
-        protected IpcMessage OnMessageReceived(IpcMessage message)
-        {
-            MessageReceived?.Invoke(message);
-            return null;
-        }
+        protected IpcMessage OnMessageReceived(IpcMessage message) => MessageReceived?.Invoke(message);
 
         public virtual Task SendMessageAsync(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -111,7 +111,11 @@ namespace osu.Framework.Platform
         /// </summary>
         protected virtual bool LimitedMemoryEnvironment => false;
 
-        protected void OnMessageReceived(IpcMessage message) => MessageReceived?.Invoke(message);
+        protected IpcMessage OnMessageReceived(IpcMessage message)
+        {
+            MessageReceived?.Invoke(message);
+            return null;
+        }
 
         public virtual Task SendMessageAsync(IpcMessage message) => throw new NotSupportedException("This platform does not implement IPC.");
 

--- a/osu.Framework/Platform/IIpcHost.cs
+++ b/osu.Framework/Platform/IIpcHost.cs
@@ -8,8 +8,16 @@ namespace osu.Framework.Platform
 {
     public interface IIpcHost
     {
+        /// <summary>
+        /// Invoked when a message is received by this IPC server.
+        /// Returns either a response in the form of an <see cref="IpcMessage"/>, or <c>null</c> for no response.
+        /// </summary>
         event Func<IpcMessage, IpcMessage> MessageReceived;
 
+        /// <summary>
+        /// Send a message to the IPC server.
+        /// </summary>
+        /// <param name="ipcMessage">The message to send.</param>
         Task SendMessageAsync(IpcMessage ipcMessage);
     }
 }

--- a/osu.Framework/Platform/IIpcHost.cs
+++ b/osu.Framework/Platform/IIpcHost.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Platform
 {
     public interface IIpcHost
     {
-        event Action<IpcMessage> MessageReceived;
+        event Func<IpcMessage, IpcMessage> MessageReceived;
 
         Task SendMessageAsync(IpcMessage ipcMessage);
     }

--- a/osu.Framework/Platform/IpcChannel.cs
+++ b/osu.Framework/Platform/IpcChannel.cs
@@ -9,7 +9,7 @@ namespace osu.Framework.Platform
     public class IpcChannel<T> : IDisposable
     {
         private readonly IIpcHost host;
-        public event Action<T> MessageReceived;
+        public event Func<T, IpcMessage> MessageReceived;
 
         public IpcChannel(IIpcHost host)
         {
@@ -23,12 +23,12 @@ namespace osu.Framework.Platform
             Value = message,
         });
 
-        private void handleMessage(IpcMessage message)
+        private IpcMessage handleMessage(IpcMessage message)
         {
             if (message.Type != typeof(T).AssemblyQualifiedName)
-                return;
+                return null;
 
-            MessageReceived?.Invoke((T)message.Value);
+            return MessageReceived?.Invoke((T)message.Value);
         }
 
         public void Dispose()

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using osu.Framework.Logging;
 
 namespace osu.Framework.Platform
 {
@@ -63,7 +64,9 @@ namespace osu.Framework.Platform
                     {
                         using (var stream = client.GetStream())
                         {
-                            var message = await receive(stream, cancellationToken: token).ConfigureAwait(false);
+                            var message = await receive(stream, token).ConfigureAwait(false);
+                            if (message == null)
+                                continue;
 
                             var response = MessageReceived?.Invoke(message);
 
@@ -130,6 +133,8 @@ namespace osu.Framework.Platform
             await stream.ReadAsync(header.AsMemory(), cancellationToken).ConfigureAwait(false);
 
             int len = BitConverter.ToInt32(header, 0);
+            if (len == 0)
+                return null;
 
             byte[] data = new byte[len];
             await stream.ReadAsync(data.AsMemory(), cancellationToken).ConfigureAwait(false);

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -19,10 +19,14 @@ namespace osu.Framework.Platform
     /// </summary>
     public class TcpIpcProvider : IDisposable
     {
+        /// <summary>
+        /// Invoked when a message is received by this IPC server.
+        /// Returns either a response in the form of an <see cref="IpcMessage"/>, or <c>null</c> for no response.
+        /// </summary>
+        public event Func<IpcMessage, IpcMessage> MessageReceived;
+
         private TcpListener listener;
         private CancellationTokenSource cancelListener;
-
-        public event Func<IpcMessage, IpcMessage> MessageReceived;
 
         private readonly int port;
 

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -11,22 +11,26 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using osu.Framework.Logging;
 
 namespace osu.Framework.Platform
 {
     public class TcpIpcProvider : IDisposable
     {
-        private const int ipc_port = 45356;
-
         private TcpListener listener;
         private CancellationTokenSource cancelListener;
 
         public event Func<IpcMessage, IpcMessage> MessageReceived;
 
+        private readonly int port;
+
+        public TcpIpcProvider(int port)
+        {
+            this.port = port;
+        }
+
         public bool Bind()
         {
-            listener = new TcpListener(IPAddress.Loopback, ipc_port);
+            listener = new TcpListener(IPAddress.Loopback, port);
 
             try
             {
@@ -95,7 +99,7 @@ namespace osu.Framework.Platform
         {
             using (var client = new TcpClient())
             {
-                await client.ConnectAsync(IPAddress.Loopback, ipc_port).ConfigureAwait(false);
+                await client.ConnectAsync(IPAddress.Loopback, port).ConfigureAwait(false);
 
                 using (var stream = client.GetStream())
                     await send(stream, message).ConfigureAwait(false);
@@ -106,7 +110,7 @@ namespace osu.Framework.Platform
         {
             using (var client = new TcpClient())
             {
-                await client.ConnectAsync(IPAddress.Loopback, ipc_port).ConfigureAwait(false);
+                await client.ConnectAsync(IPAddress.Loopback, port).ConfigureAwait(false);
 
                 using (var stream = client.GetStream())
                 {

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -14,6 +14,9 @@ using Newtonsoft.Json.Linq;
 
 namespace osu.Framework.Platform
 {
+    /// <summary>
+    /// An inter-process communication provider that runs over a specified TCP port, binding to the loopback address.
+    /// </summary>
     public class TcpIpcProvider : IDisposable
     {
         private TcpListener listener;
@@ -23,11 +26,19 @@ namespace osu.Framework.Platform
 
         private readonly int port;
 
+        /// <summary>
+        /// Create a new provider.
+        /// </summary>
+        /// <param name="port">The port to operate on.</param>
         public TcpIpcProvider(int port)
         {
             this.port = port;
         }
 
+        /// <summary>
+        /// Attempt to bind as the "server" instance.
+        /// </summary>
+        /// <returns>Whether the bind was successful. If <c>false</c>, another instance is likely already running (and can be messaged using <see cref="SendMessageAsync"/> or <see cref="SendMessageWithResponseAsync"/>).</returns>
         public bool Bind()
         {
             listener = new TcpListener(IPAddress.Loopback, port);
@@ -49,6 +60,9 @@ namespace osu.Framework.Platform
             }
         }
 
+        /// <summary>
+        /// Start processing events received by the listener. <see cref="Bind"/> must be called first.
+        /// </summary>
         public async Task StartAsync()
         {
             var token = cancelListener.Token;
@@ -95,6 +109,10 @@ namespace osu.Framework.Platform
             }
         }
 
+        /// <summary>
+        /// Send a message to the IPC server.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
         public async Task SendMessageAsync(IpcMessage message)
         {
             using (var client = new TcpClient())
@@ -106,6 +124,11 @@ namespace osu.Framework.Platform
             }
         }
 
+        /// <summary>
+        /// Send a message to the IPC server.
+        /// </summary>
+        /// <param name="message">The message to send.</param>
+        /// <returns>The response from the server.</returns>
         public async Task<IpcMessage> SendMessageWithResponseAsync(IpcMessage message)
         {
             using (var client = new TcpClient())


### PR DESCRIPTION
1. Allows sending responses back to incoming requests.
2. Allows sending an IPC request with a response.
3. Extracts the port out from a const.

The goal here is to be able to accept IPC messages from osu!stable (e.g. to calculate difficulty) and send a response back.