### PR TITLE
Fix video seek tests failing on macOS

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -67,6 +67,8 @@ namespace osu.Framework.Tests.Visual.Sprites
             });
             AddUntilStep("Wait for video to load", () => video.IsLoaded);
             AddStep("Reset clock", () => clock.CurrentTime = 0);
+
+            AddUntilStep("Wait for decode start", () => video.CurrentFrameTime > 0);
         }
 
         [Test]

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -167,8 +167,8 @@ namespace osu.Framework.Tests.Visual.Sprites
         {
             loadNewVideo(videoFormat);
 
-            AddStep("Jump close to end", () => clock.CurrentTime = video.Duration - 10000);
-            AddUntilStep("Video seeked", () => video.CurrentFrameTime >= video.Duration - 15000);
+            AddStep("Jump close to end", () => clock.CurrentTime = video.Duration - 1000);
+            AddUntilStep("Video seeked", () => video.CurrentFrameTime >= video.Duration - 1500);
 
             AddUntilStep("Reached end", () => video.State == VideoDecoder.DecoderState.EndOfStream);
             AddStep("reset decode state", () => didDecode = false);

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneVideo.cs
@@ -213,12 +213,16 @@ namespace osu.Framework.Tests.Visual.Sprites
         private int fps;
         private int lastFramesProcessed;
 
+        private readonly FramedClock realtimeClock = new FramedClock();
+
         protected override void Update()
         {
             base.Update();
 
+            realtimeClock.ProcessFrame();
+
             if (clock != null)
-                clock.CurrentTime += Clock.ElapsedFrameTime;
+                clock.CurrentTime += realtimeClock.ElapsedFrameTime;
 
             if (video != null)
             {


### PR DESCRIPTION
Saw this a few times [on CI](https://github.com/ppy/osu-framework/runs/4349401930?check_suite_focus=true), but I could reproduce 100% on a certain subset of the tests. The main issue revolves around the test scene running in accelerated time, causing the elapsed time to not match the decode process' expectations. This can lead to things potentially getting in a weird state where the decode never starts process frames, or reaches the end of the video when it shouldn't.

Without these changes, I would see the following failures 100% of the time:

![20211130 135916 (JetBrains Rider-EAP)](https://user-images.githubusercontent.com/191335/143988316-8310a61f-9e09-4e49-80e9-a000189bc336.png)

Post changes, I ran for 10 minutes with no failures.
