### PR TITLE
Keep BASS audio output from pausing on device processing timeout

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -367,6 +367,7 @@ namespace osu.Framework.Audio
             Bass.Configure(ManagedBass.Configuration.IncludeDefaultDevice, true);
 
             // Disable BASS_CONFIG_DEV_TIMEOUT flag to keep BASS audio output from pausing on device processing timeout.
+            // See https://www.un4seen.com/forum/?topic=19601 for more information.
             Bass.Configure((ManagedBass.Configuration)70, false);
 
             return AudioThread.InitDevice(device);

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -366,6 +366,9 @@ namespace osu.Framework.Audio
             // Always provide a default device. This should be a no-op, but we have asserts for this behaviour.
             Bass.Configure(ManagedBass.Configuration.IncludeDefaultDevice, true);
 
+            // Disable BASS_CONFIG_DEV_TIMEOUT flag to keep BASS audio output from pausing on device processing timeout.
+            Bass.Configure((ManagedBass.Configuration)70, false);
+
             return AudioThread.InitDevice(device);
         }
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu/issues/14729
- Resolves https://github.com/ppy/osu/discussions/15886

Starting in BASS 2.4.16, BASS pauses audio output completely when the selected audio device stops processing, which can happen when a computer switches to sleep mode, for example.

There is a flag defined for this behaviour (`BASS_CONFIG_DEV_TIMEOUT`) which has now been disabled in this PR, bringing back the old behaviour which is to keep audio output running regardless of whether the selected audio device has stopped processing, resolving both of the issues mentioned at the top.

See https://www.un4seen.com/forum/?topic=19601 for discussion.

---

Also in case anyone wondering, I've got the bits of the `BASS_CONFIG_DEV_TIMEOUT` flag via the `bass.h` header included in the BASS libraries, which is `70`:
```c
#define BASS_CONFIG_DEV_TIMEOUT		70
```