### PR TITLE
Force flushing logger during unhandled/unobserved exception handling

### DIFF
--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -332,6 +332,11 @@ namespace osu.Framework.Platform
             AppDomain.CurrentDomain.UnhandledException -= unhandledExceptionHandler;
             TaskScheduler.UnobservedTaskException -= unobservedExceptionHandler;
 
+            // In the case of an unhandled or unobserved exception, it's feasible that the disposal flow for `GameHost` doesn't run.
+            // This can result in the exception not being logged (or being partially logged) due to the logger running asynchronously.
+            // We force flushing the logger here to ensure logging completes.
+            Logger.Flush();
+
             var captured = ExceptionDispatchInfo.Capture(exception);
             var thrownEvent = new ManualResetEventSlim(false);
 

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -332,7 +332,7 @@ namespace osu.Framework.Platform
             AppDomain.CurrentDomain.UnhandledException -= unhandledExceptionHandler;
             TaskScheduler.UnobservedTaskException -= unobservedExceptionHandler;
 
-            // In the case of an unhandled or unobserved exception, it's feasible that the disposal flow for `GameHost` doesn't run.
+            // In the case of an unhandled exception, it's feasible that the disposal flow for `GameHost` doesn't run.
             // This can result in the exception not being logged (or being partially logged) due to the logger running asynchronously.
             // We force flushing the logger here to ensure logging completes.
             Logger.Flush();


### PR DESCRIPTION
Fixes exceptions potentially not appearing in logs even though they occurred and caused a halt in execution.

Closes https://github.com/ppy/osu-framework/issues/4920.