### PR TITLE
Disable minimum frame durations on iOS framework projects

### DIFF
--- a/SampleGame.iOS/Info.plist
+++ b/SampleGame.iOS/Info.plist
@@ -38,6 +38,8 @@
 	<true/>
 	<key>UIRequiresFullScreen</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 </dict>

--- a/SampleGame.iOS/Info.plist
+++ b/SampleGame.iOS/Info.plist
@@ -38,5 +38,7 @@
 	<true/>
 	<key>UIRequiresFullScreen</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.Android" Version="1.0.178" />
+    <PackageReference Include="ppy.osuTK.Android" Version="1.0.180" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\**\*.so" />

--- a/osu.Framework.Tests.iOS/Info.plist
+++ b/osu.Framework.Tests.iOS/Info.plist
@@ -40,5 +40,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -61,7 +61,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.178" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.180" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.178" />
+    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.180" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="ManagedBass.Mix" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.178" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.180" />
     <PackageReference Include="StbiSharp" Version="1.0.13" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.468-alpha" />
 


### PR DESCRIPTION
Unlocks `CADisplayLink` to reach frame rates higher than 60hz (when combined with https://github.com/ppy/osuTK/pull/71).

Also adds a missing key to `SampleGame.iOS` that is already present in `osu.Framework.Tetss.iOS`, while there.