### PR TITLE
Improve exception messaging when calling `CompositeDrawable.InternalChild` on disposed drawable

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -267,7 +267,7 @@ namespace osu.Framework.Graphics.Containers
             try
             {
                 if (IsDisposed)
-                    throw new ObjectDisposedException(ToString(), "Disposed Drawables may not have children added.");
+                    throw new ObjectDisposedException(ToString(), "Disposed drawables may not have children added.");
 
                 child.Load(Clock, Dependencies, false);
 
@@ -346,7 +346,7 @@ namespace osu.Framework.Graphics.Containers
             set
             {
                 if (IsDisposed)
-                    throw new ObjectDisposedException(ToString(), "Disposed Drawables may not have children set.");
+                    throw new ObjectDisposedException(ToString(), "Disposed drawables may not have children set.");
 
                 ClearInternal();
                 AddInternal(value);

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -345,6 +345,9 @@ namespace osu.Framework.Graphics.Containers
             }
             set
             {
+                if (IsDisposed)
+                    throw new ObjectDisposedException(ToString(), "Disposed Drawables may not have children set.");
+
                 ClearInternal();
                 AddInternal(value);
             }

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -417,6 +417,9 @@ namespace osu.Framework.Graphics.Containers
         {
             set
             {
+                if (IsDisposed)
+                    throw new ObjectDisposedException(ToString(), "Children cannot be mutated on a disposed drawable.");
+
                 ClearInternal();
                 AddRangeInternal(value);
             }
@@ -503,6 +506,9 @@ namespace osu.Framework.Graphics.Containers
         {
             EnsureChildMutationAllowed();
 
+            if (IsDisposed)
+                throw new ObjectDisposedException(ToString(), "Children cannot be cleared on a disposed drawable.");
+
             if (internalChildren.Count == 0) return;
 
             foreach (Drawable t in internalChildren)
@@ -542,7 +548,7 @@ namespace osu.Framework.Graphics.Containers
             EnsureChildMutationAllowed();
 
             if (IsDisposed)
-                throw new ObjectDisposedException(ToString(), "Disposed Drawables may not have children added.");
+                throw new ObjectDisposedException(ToString(), "Children cannot be mutated on a disposed drawable.");
 
             if (drawable == null)
                 throw new ArgumentNullException(nameof(drawable), $"null {nameof(Drawable)}s may not be added to {nameof(CompositeDrawable)}.");

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -136,6 +136,9 @@ namespace osu.Framework.Graphics.Containers
         {
             set
             {
+                if (IsDisposed)
+                    throw new ObjectDisposedException(ToString(), "Children cannot be mutated on a disposed drawable.");
+
                 Clear();
                 AddRange(value);
             }
@@ -156,6 +159,9 @@ namespace osu.Framework.Graphics.Containers
             }
             set
             {
+                if (IsDisposed)
+                    throw new ObjectDisposedException(ToString(), "Children cannot be mutated on a disposed drawable.");
+
                 Clear();
                 Add(value);
             }


### PR DESCRIPTION
Until now, this was falling through to an exception firing on the (framework-internal) logic of nulling the `Parent` (see https://github.com/ppy/osu-framework/blob/dde9eb08ede4aa94d21590f92b7c60f85cac3947/osu.Framework/Graphics/Drawable.cs#L1481-L1482) which doesn't read too well to a framework consumer.

![20211209 183808 (Safari)](https://user-images.githubusercontent.com/191335/145372032-3f06e34f-5b48-4952-a85a-35626010283d.png)

In the above example ([ci failure](https://github.com/ppy/osu/runs/4453854462?check_suite_focus=true)) it reads so badly the actual cause of failure is uncertain.