### PR TITLE
Refactor `TcpIpcProvider` to bring up to date with code standards

### DIFF
--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -66,7 +66,6 @@ namespace osu.Framework.Platform
                 };
 
                 thread.Start();
-
                 cancellationSource = new CancellationTokenSource();
                 return true;
             }
@@ -210,6 +209,7 @@ namespace osu.Framework.Platform
             if (listener != null)
             {
                 cancellationSource.Cancel();
+                thread.Join();
             }
         }
     }

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -27,7 +27,7 @@ namespace osu.Framework.Platform
         /// Invoked when a message is received when running as a server.
         /// Returns either a response in the form of an <see cref="IpcMessage"/>, or <c>null</c> for no response.
         /// </summary>
-        public event Func<IpcMessage, IpcMessage>? MessageReceived;
+        public event Func<IpcMessage, IpcMessage?>? MessageReceived;
 
         private Thread? thread;
 

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -207,10 +207,13 @@ namespace osu.Framework.Platform
 
         public void Dispose()
         {
+            const int thread_join_timeout = 2000;
+
             if (thread != null)
             {
                 cancellationSource.Cancel();
-                thread.Join();
+                if (!thread.Join(thread_join_timeout))
+                    Logger.Log($"IPC thread failed to exit in allocated time ({thread_join_timeout}ms).", LoggingTarget.Runtime, LogLevel.Important);
             }
         }
     }

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -81,7 +81,7 @@ namespace osu.Framework.Platform
             }
         }
 
-        private async void listen(TcpListener listener)
+        private void listen(TcpListener listener)
         {
             var token = cancellationSource.Token;
 
@@ -91,23 +91,23 @@ namespace osu.Framework.Platform
                 {
                     while (!listener.Pending())
                     {
-                        await Task.Delay(10, token).ConfigureAwait(false);
+                        Thread.Sleep(10);
                         if (token.IsCancellationRequested)
                             return;
                     }
 
-                    using (var client = await listener.AcceptTcpClientAsync().ConfigureAwait(false))
+                    using (var client = listener.AcceptTcpClient())
                     {
                         using (var stream = client.GetStream())
                         {
-                            var message = await receive(stream, token).ConfigureAwait(false);
+                            var message = receive(stream, token).Result;
                             if (message == null)
                                 continue;
 
                             var response = MessageReceived?.Invoke(message);
 
                             if (response != null)
-                                await send(stream, response).ConfigureAwait(false);
+                                send(stream, response).Wait(token);
                         }
                     }
                 }


### PR DESCRIPTION
The hope here is that this will fix intermittent test failures I see specifically on my local macOS install, osu!-side. I believe the root cause was the short `ipcThread.Join()` length meaning the socket potentially wasn't unbound in time.

But at the same time, this was a dated class and needed some clean-up.

Note that I'm still using a thread to do the listening loop as `TcpListener` isn't a great `async` resident, without proper support for `CancellationTokens`. Sticking to what works for now.

![20211216 164718 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/146329984-25cbc777-feb2-4d9d-a4ee-56ee6675b592.png)

