### PR TITLE
Add screen stack logging

### DIFF
--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -10,6 +10,7 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 
 namespace osu.Framework.Screens
 {
@@ -108,6 +109,7 @@ namespace osu.Framework.Screens
                 suspend(source, newScreen);
 
             stack.Push(newScreen);
+            logTransition(source, newScreen, false);
             ScreenPushed?.Invoke(source, newScreen);
 
             // this needs to be queued here before the load is begun so it preceed any potential OnSuspending event (also attached to OnLoadComplete).
@@ -303,6 +305,7 @@ namespace osu.Framework.Screens
 
             exited.Add(toExit.AsDrawable());
 
+            logTransition(toExit, CurrentScreen, true);
             ScreenExited?.Invoke(toExit, CurrentScreen);
 
             // Resume the next current screen from the exited one
@@ -311,6 +314,9 @@ namespace osu.Framework.Screens
 
             return false;
         }
+
+        private void logTransition(IScreen screen1, IScreen screen2, bool wasExit) =>
+            Logger.Log($"[{GetType().Name}] transition ({screen1?.GetType().Name ?? "none"} {(wasExit ? "<<" : ">>")} {screen2?.GetType().Name ?? "none"})");
 
         /// <summary>
         /// Unbind and return leases for all <see cref="Bindable{T}"/>s managed by the exiting screen.


### PR DESCRIPTION
Generally pushing screens is quite a rare event, and should add context to most log usages (tracking down issues reported by users etc.).

We already did this osu! side but moving to framework seems to make sense. I've left at a `Verbose` level so it is actually logged in release builds.

Not sure about the log format, especially the `[]` as they are also used for the verbosity level.

```csharp

985366: Running ScreenStack (TestSceneScreenStack) visual test cases...
[runtime] 2021-12-16 08:47:43 [verbose]: [ScreenStack] transition (none >> TestScreen)
985366: TestSceneScreenStack
[runtime] 2021-12-16 08:47:43 [verbose]: [ScreenStack] transition (TestScreen >> TestScreen)
985566: step 1 push screen1
985766: step 2 Repeat: ensure current (1 tries)
985966: step 3 preload screen2
986166: step 4 Repeat: wait for load (1 tries)
[runtime] 2021-12-16 08:47:43 [verbose]: [ScreenStack] transition (TestScreen >> TestScreen)
986366: step 5 push screen2
986566: step 6 Repeat: ensure current (1 tries)
[runtime] 2021-12-16 08:47:43 [verbose]: [ScreenStack] transition (TestScreen << TestScreen)
986766: step 7 exit screen2
986966: step 8 Repeat: ensure exited (1 tries)
[runtime] 2021-12-16 08:47:43 [verbose]: [ScreenStack] transition (TestScreen << TestScreen)
987166: step 9 push screen2
987366: step 10 Repeat: ensure exited (1 tries)
987566: step 11 Assert: order is correct
987766: step 12 unblock any slow loaders

```