### PR TITLE
Fix `AddOnce` scheduled tasks not getting updates to data from subsequent calls

### DIFF
--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -262,14 +262,14 @@ namespace osu.Framework.Tests.Threading
                     // allow catch-up to potentially occur.
                     scheduler.Update();
 
-                int expectedInovations;
+                int expectedInvocations;
 
                 if (performCatchUp)
-                    expectedInovations = (int)(d / 500);
+                    expectedInvocations = (int)(d / 500);
                 else
-                    expectedInovations = (int)(d / 2000);
+                    expectedInvocations = (int)(d / 2000);
 
-                Assert.AreEqual(expectedInovations, invocations);
+                Assert.AreEqual(expectedInvocations, invocations);
             }
         }
 

--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -355,6 +355,20 @@ namespace osu.Framework.Tests.Threading
         }
 
         [Test]
+        public void TestAddOnceWithDataUsesMostRecentData()
+        {
+            int receivedData = 0;
+
+            void action(int i) => receivedData = i;
+
+            scheduler.AddOnce(action, 1);
+            scheduler.AddOnce(action, 2);
+
+            scheduler.Update();
+            Assert.AreEqual(2, receivedData);
+        }
+
+        [Test]
         public void TestAddOnceInlineFunctionWithVariable()
         {
             int invocations = 0;

--- a/osu.Framework/Threading/ScheduledDelegate.cs
+++ b/osu.Framework/Threading/ScheduledDelegate.cs
@@ -40,12 +40,16 @@ namespace osu.Framework.Threading
         /// <summary>
         /// The work task.
         /// </summary>
-        internal readonly Action Task;
+        internal Action Task;
 
         public ScheduledDelegate(Action task, double executionTime = 0, double repeatInterval = -1)
+            : this(executionTime, repeatInterval)
         {
             Task = task;
+        }
 
+        protected ScheduledDelegate(double executionTime = 0, double repeatInterval = -1)
+        {
             ExecutionTime = executionTime;
             RepeatInterval = repeatInterval;
         }

--- a/osu.Framework/Threading/ScheduledDelegateWithData.cs
+++ b/osu.Framework/Threading/ScheduledDelegateWithData.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace osu.Framework.Threading
 {
-    public class ScheduledDelegateWithData<T> : ScheduledDelegate
+    internal class ScheduledDelegateWithData<T> : ScheduledDelegate
     {
         public new readonly Action<T> Task;
 

--- a/osu.Framework/Threading/ScheduledDelegateWithData.cs
+++ b/osu.Framework/Threading/ScheduledDelegateWithData.cs
@@ -9,10 +9,15 @@ namespace osu.Framework.Threading
     {
         public new readonly Action<T> Task;
 
+        public T Data;
+
         public ScheduledDelegateWithData(Action<T> task, T data, double executionTime = 0, double repeatInterval = -1)
-            : base(() => task(data), executionTime, repeatInterval)
+            : base(executionTime, repeatInterval)
         {
             Task = task;
+            Data = data;
+
+            base.Task = () => Task(Data);
         }
     }
 }

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -283,8 +283,14 @@ namespace osu.Framework.Threading
         {
             lock (queueLock)
             {
-                if (runQueue.OfType<ScheduledDelegateWithData<T>>().Any(sd => sd.Task == task))
+                var existing = runQueue.OfType<ScheduledDelegateWithData<T>>().SingleOrDefault(sd => sd.Task == task);
+
+                if (existing != null)
+                {
+                    // ensure the single queued instance always has the most recent data.
+                    existing.Data = data;
                     return false;
+                }
 
                 runQueue.Enqueue(new ScheduledDelegateWithData<T>(task, data));
             }


### PR DESCRIPTION
Bit of an unfortunate scenario with the constructor requiring a static delegate. Open to suggestions on how to improve this.