### PR TITLE
Use icons and reduce clutter in test logging

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneLifetimeManagementContainer.cs
@@ -9,6 +9,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Performance;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Logging;
 using osu.Framework.Timing;
 
 namespace osu.Framework.Tests.Visual.Containers
@@ -246,7 +247,7 @@ namespace osu.Framework.Tests.Visual.Containers
             void removeChild()
             {
                 var child = container.InternalChildren[rng.Next(container.InternalChildren.Count)];
-                Console.WriteLine($"removeChild: {child.ChildID}");
+                Logger.Log($"removeChild: {child.ChildID}");
                 container.RemoveInternal(child);
             }
 
@@ -254,7 +255,7 @@ namespace osu.Framework.Tests.Visual.Containers
             {
                 var child = container.InternalChildren[rng.Next(container.InternalChildren.Count)];
                 randomLifetime(out double l, out double r);
-                Console.WriteLine($"changeLifetime: {child.ChildID}, {l}, {r}");
+                Logger.Log($"changeLifetime: {child.ChildID}, {l}, {r}");
                 child.LifetimeStart = l;
                 child.LifetimeEnd = r;
 
@@ -266,7 +267,7 @@ namespace osu.Framework.Tests.Visual.Containers
             void changeTime()
             {
                 int time = rng.Next(6);
-                Console.WriteLine($"changeTime: {time}");
+                Logger.Log($"changeTime: {time}");
                 manualClock.CurrentTime = time;
                 checkAll();
             }
@@ -276,7 +277,7 @@ namespace osu.Framework.Tests.Visual.Containers
                 addChild();
                 container.OnCrossing += e =>
                 {
-                    Console.WriteLine($"OnCrossing({e})");
+                    Logger.Log($"OnCrossing({e})");
                     changeLifetime();
                 };
             });

--- a/osu.Framework.Tests/Visual/Input/TestSceneMidi.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneMidi.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Linq;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -11,6 +10,7 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
 using osu.Framework.Input.Events;
 using osu.Framework.Input.Handlers.Midi;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
@@ -51,20 +51,20 @@ namespace osu.Framework.Tests.Visual.Input
 
         protected override bool OnMidiDown(MidiDownEvent e)
         {
-            Console.WriteLine(e);
+            Logger.Log(e.ToString());
             return base.OnMidiDown(e);
         }
 
         protected override void OnMidiUp(MidiUpEvent e)
         {
-            Console.WriteLine(e);
+            Logger.Log(e.ToString());
             base.OnMidiUp(e);
         }
 
         protected override bool Handle(UIEvent e)
         {
             if (!(e is MouseEvent))
-                Console.WriteLine("Event: " + e);
+                Logger.Log("Event: " + e);
             return base.Handle(e);
         }
 

--- a/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneBorderless.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
@@ -141,7 +142,7 @@ namespace osu.Framework.Tests.Visual.Platform
 
             if (window == null)
             {
-                Console.WriteLine("No suitable window found");
+                Logger.Log("No suitable window found");
                 return;
             }
 

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -316,7 +316,7 @@ namespace osu.Framework.Screens
         }
 
         private void logTransition(IScreen screen1, IScreen screen2, bool wasExit) =>
-            Logger.Log($"[{GetType().Name}] transition ({screen1?.GetType().Name ?? "none"} {(wasExit ? "<<" : ">>")} {screen2?.GetType().Name ?? "none"})");
+            Logger.Log($"📺 {GetType().Name} transition ({screen1?.GetType().Name ?? "none"} {(wasExit ? "«" : "»")} {screen2?.GetType().Name ?? "none"})");
 
         /// <summary>
         /// Unbind and return leases for all <see cref="Bindable{T}"/>s managed by the exiting screen.

--- a/osu.Framework/Testing/Drawables/Steps/UntilStepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/UntilStepButton.cs
@@ -80,6 +80,6 @@ namespace osu.Framework.Testing.Drawables.Steps
 
         private void updateText() => base.Text = $@"{Text} ({invocations} tries)";
 
-        public override string ToString() => "Repeat: " + base.ToString();
+        public override string ToString() => "Until: " + base.ToString();
     }
 }

--- a/osu.Framework/Testing/TestBrowserTestRunner.cs
+++ b/osu.Framework/Testing/TestBrowserTestRunner.cs
@@ -7,6 +7,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 
 namespace osu.Framework.Testing
@@ -43,7 +44,7 @@ namespace osu.Framework.Testing
 
             AddInternal(browser);
 
-            Console.WriteLine($@"{(int)Time.Current}: Running {browser.TestTypes.Count} visual test cases...");
+            Logger.Log($@"Running {browser.TestTypes.Count} visual test cases...");
 
             runNext();
         }

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -205,27 +205,15 @@ namespace osu.Framework.Testing
                 return;
             }
 
-            string text = ".";
-
-            if (actionRepetition == 0)
-            {
-                text = $"{(int)Time.Current}: ".PadLeft(7);
-
-                if (actionIndex < 0)
-                    text += $"{GetType().ReadableName()}";
-                else
-                    text += $"step {actionIndex + 1} {loadableStep?.ToString() ?? string.Empty}";
-            }
-
-            Console.Write(text);
-
             actionRepetition++;
 
             if (actionRepetition > (loadableStep?.RequiredRepetitions ?? 1) - 1)
             {
+                if (actionIndex >= 0)
+                    Logging.Logger.Log($"🔸 Step #{actionIndex + 1} {loadableStep?.ToString() ?? string.Empty}");
+
                 actionIndex++;
                 actionRepetition = 0;
-                Console.WriteLine();
 
                 if (loadableStep != null && stopCondition?.Invoke(loadableStep) == true)
                     return;

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -201,6 +201,7 @@ namespace osu.Framework.Testing
             }
             catch (Exception e)
             {
+                Logging.Logger.Log($"💥 Step #{actionIndex + 1} {loadableStep?.ToString() ?? string.Empty}");
                 onError?.Invoke(e);
                 return;
             }
@@ -221,6 +222,7 @@ namespace osu.Framework.Testing
 
             if (actionIndex > StepsContainer.Children.Count - 1)
             {
+                Logging.Logger.Log($"✅ {GetType().ReadableName()} completed");
                 onCompletion?.Invoke();
                 return;
             }

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -10,6 +9,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 
 namespace osu.Framework.Testing
@@ -82,7 +82,7 @@ namespace osu.Framework.Testing
                 {
                     AddInternal(test);
 
-                    Console.WriteLine($@"{(int)Time.Current}: Running {test} visual test cases...");
+                    Logger.Log($@"💨 {test} running");
 
                     // Nunit will run the tests in the TestScene with the same TestScene instance so the TestScene
                     // needs to be removed before the host is exited, otherwise it will end up disposed


### PR DESCRIPTION
Also uses `Logger` rather than `Console.WriteLine` everywhere.

![20211216 190736 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/146352931-52c8e353-92af-40c8-83ee-e23698e51ffc.png)
![20211216 190754 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/146352942-5f7b49e6-2c1b-457c-b399-4b54adbaf71b.png)
![20211216 191723 (JetBrains Rider)](https://user-images.githubusercontent.com/191335/146352969-7e383d8f-bebe-4a1b-af62-7282bf130814.png)
