### PR TITLE
Log loading components on test failure or game exit

### DIFF
--- a/osu.Framework/Logging/LoadingComponentsLogger.cs
+++ b/osu.Framework/Logging/LoadingComponentsLogger.cs
@@ -33,13 +33,8 @@ namespace osu.Framework.Logging
             {
                 Logger.Log("⏳ Currently loading components");
 
-                lock (loading_components)
-                {
-                    foreach (var c in loading_components)
-                    {
-                        Logger.Log($"- {c.GetType().ReadableName(),-16} LoadState:{c.LoadState,-5} Thread:{c.LoadThread.Name}");
-                    }
-                }
+                foreach (var c in loading_components)
+                    Logger.Log($"- {c.GetType().ReadableName(),-16} LoadState:{c.LoadState,-5} Thread:{c.LoadThread.Name}");
 
                 loading_components.Clear();
             }

--- a/osu.Framework/Logging/LoadingComponentsLogger.cs
+++ b/osu.Framework/Logging/LoadingComponentsLogger.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Diagnostics;
+using osu.Framework.Extensions.TypeExtensions;
+using osu.Framework.Graphics;
+using osu.Framework.Lists;
+
+namespace osu.Framework.Logging
+{
+    internal static class LoadingComponentsLogger
+    {
+        private static readonly WeakList<Drawable> loading_components = new WeakList<Drawable>();
+
+        [Conditional("DEBUG")]
+        public static void Add(Drawable component)
+        {
+            lock (loading_components)
+                loading_components.Add(component);
+        }
+
+        [Conditional("DEBUG")]
+        public static void Remove(Drawable component)
+        {
+            lock (loading_components)
+                loading_components.Remove(component);
+        }
+
+        [Conditional("DEBUG")]
+        public static void LogAndFlush()
+        {
+            lock (loading_components)
+            {
+                Logger.Log("⏳ Currently loading components");
+
+                lock (loading_components)
+                {
+                    foreach (var c in loading_components)
+                    {
+                        Logger.Log($"- {c.GetType().ReadableName(),-16} LoadState:{c.LoadState,-5} Thread:{c.LoadThread.Name}");
+                    }
+                }
+
+                loading_components.Clear();
+            }
+        }
+    }
+}

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -1097,6 +1097,7 @@ namespace osu.Framework.Platform
 
             Window?.Dispose();
 
+            LoadingComponentsLogger.LogAndFlush();
             Logger.Flush();
         }
 

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -16,6 +16,7 @@ using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
+using osu.Framework.Logging;
 using osu.Framework.Platform;
 using osu.Framework.Testing.Drawables.Steps;
 using osu.Framework.Threading;
@@ -202,6 +203,7 @@ namespace osu.Framework.Testing
             catch (Exception e)
             {
                 Logging.Logger.Log($"💥 Step #{actionIndex + 1} {loadableStep?.ToString() ?? string.Empty}");
+                LoadingComponentsLogger.LogAndFlush();
                 onError?.Invoke(e);
                 return;
             }

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -42,7 +42,7 @@
 
     <!-- Any version ahead of this will cause AOT issues with iOS
          See https://github.com/mono/mono/issues/21188 -->
-    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401"/>
+    <PackageReference Include="Microsoft.Diagnostics.Runtime" Version="2.0.161401" />
 
     <!-- Any version ahead of this will cause runtime issues on iOS
          See https://github.com/xoofx/markdig/issues/564 -->


### PR DESCRIPTION
May help with figuring out the cause of intermittent failing tests. Just maybe.

- [x] Depends on #4937.

```csharp
[runtime] 2021-12-16 10:42:53 [verbose]: 🔸 Step #4 push slow
[runtime] 2021-12-16 10:42:53 [verbose]: 🔸 Step #5 push slow
[runtime] 2021-12-16 10:42:53 [verbose]: 📺 ScreenStack transition (TestScreenSlow » TestScreenSlow)
[runtime] 2021-12-16 10:42:53 [verbose]: 🔸 Step #6 push slow
[runtime] 2021-12-16 10:43:03 [verbose]: 💥 Step #7 Until: wait for screen 2 to load (23962 tries)
[runtime] 2021-12-16 10:43:03 [verbose]: ⏳ Currently loading components
[runtime] 2021-12-16 10:43:03 [verbose]: - TestSceneScreenStack+TestScreenSlow LoadState:Loading Thread:ThreadedTaskScheduler (LoadComponentsAsync (standard))
[runtime] 2021-12-16 10:43:03 [verbose]: - TestSceneScreenStack+TestScreenSlow LoadState:Loading Thread:ThreadedTaskScheduler (LoadComponentsAsync (standard))
[runtime] 2021-12-16 10:43:03 [error]: An unhandled error has occurred.
```