### PR TITLE
Add Shadow Colour and Offset to SpriteIcon

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
@@ -75,6 +75,8 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddStep("toggle shadows", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.Shadow = !i.SpriteIcon.Shadow));
             AddStep("change icons", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.Icon = new IconUsage((char)(i.SpriteIcon.Icon.Icon + 1))));
             AddStep("white background", () => background.FadeColour(Color4.White, 200));
+            AddStep("move shadow offset", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.ShadowOffset += Vector2.One));
+            AddStep("change shadow color", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.ShadowColour = Color4.Pink));
         }
 
         private class Icon : Container, IHasTooltip

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteIcon.cs
@@ -76,7 +76,12 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddStep("change icons", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.Icon = new IconUsage((char)(i.SpriteIcon.Icon.Icon + 1))));
             AddStep("white background", () => background.FadeColour(Color4.White, 200));
             AddStep("move shadow offset", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.ShadowOffset += Vector2.One));
-            AddStep("change shadow color", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.ShadowColour = Color4.Pink));
+            AddStep("change shadow colour", () => flow.Children.OfType<Icon>().ForEach(i => i.SpriteIcon.ShadowColour = Color4.Pink));
+            AddStep("add new icon with colour and offset", () =>
+                flow.Add(new Icon("FontAwesome.Regular.Handshake", FontAwesome.Regular.Handshake)
+                {
+                    SpriteIcon = { Shadow = true, ShadowColour = Color4.Orange, ShadowOffset = new Vector2(5, 1) }
+                }));
         }
 
         private class Icon : Container, IHasTooltip

--- a/osu.Framework/Graphics/Sprites/SpriteIcon.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteIcon.cs
@@ -132,7 +132,8 @@ namespace osu.Framework.Graphics.Sprites
             {
                 shadowColour = value;
 
-                spriteShadow.Colour = shadowColour;
+                if (spriteShadow != null)
+                    spriteShadow.Colour = shadowColour;
             }
         }
 
@@ -148,7 +149,8 @@ namespace osu.Framework.Graphics.Sprites
             {
                 shadowOffset = value;
 
-                spriteShadow.Position = shadowOffset;
+                if (spriteShadow != null)
+                    spriteShadow.Position = shadowOffset;
             }
         }
 

--- a/osu.Framework/Graphics/Sprites/SpriteIcon.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteIcon.cs
@@ -48,8 +48,8 @@ namespace osu.Framework.Graphics.Sprites
                         Origin = Anchor.Centre,
                         RelativeSizeAxes = Axes.Both,
                         FillMode = FillMode.Fit,
-                        Y = 2,
-                        Colour = new Color4(0f, 0f, 0f, 0.2f),
+                        Position = shadowOffset,
+                        Colour = shadowColour
                     },
                     Alpha = shadow ? 1 : 0,
                 },
@@ -117,6 +117,38 @@ namespace osu.Framework.Graphics.Sprites
                 shadow = value;
                 if (shadowVisibility != null)
                     shadowVisibility.Alpha = value ? 1 : 0;
+            }
+        }
+
+        private Color4 shadowColour = new Color4(0f, 0f, 0f, 0.2f);
+
+        /// <summary>
+        /// The colour of the shadow displayed around the icon. A shadow will only be displayed if the <see cref="Shadow"/> property is set to true.
+        /// </summary>
+        public Color4 ShadowColour
+        {
+            get => shadowColour;
+            set
+            {
+                shadowColour = value;
+
+                spriteShadow.Colour = shadowColour;
+            }
+        }
+
+        private Vector2 shadowOffset = new Vector2(0, 2f);
+
+        /// <summary>
+        /// The offset of the shadow displayed around the icon. A shadow will only be displayed if the <see cref="Shadow"/> property is set to true.
+        /// </summary>
+        public Vector2 ShadowOffset
+        {
+            get => shadowOffset;
+            set
+            {
+                shadowOffset = value;
+
+                spriteShadow.Position = shadowOffset;
             }
         }
 

--- a/osu.Framework/Graphics/Sprites/SpriteIcon.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteIcon.cs
@@ -69,6 +69,7 @@ namespace osu.Framework.Graphics.Sprites
         {
             base.LoadComplete();
             updateTexture();
+            updateShadow();
         }
 
         private IconUsage loadedIcon;
@@ -115,8 +116,9 @@ namespace osu.Framework.Graphics.Sprites
             set
             {
                 shadow = value;
-                if (shadowVisibility != null)
-                    shadowVisibility.Alpha = value ? 1 : 0;
+
+                if (IsLoaded)
+                    updateShadow();
             }
         }
 
@@ -132,8 +134,8 @@ namespace osu.Framework.Graphics.Sprites
             {
                 shadowColour = value;
 
-                if (spriteShadow != null)
-                    spriteShadow.Colour = shadowColour;
+                if (IsLoaded)
+                    updateShadow();
             }
         }
 
@@ -149,9 +151,16 @@ namespace osu.Framework.Graphics.Sprites
             {
                 shadowOffset = value;
 
-                if (spriteShadow != null)
-                    spriteShadow.Position = shadowOffset;
+                if (IsLoaded)
+                    updateShadow();
             }
+        }
+
+        private void updateShadow()
+        {
+            shadowVisibility.Alpha = shadow ? 1 : 0;
+            spriteShadow.Colour = shadowColour;
+            spriteShadow.Position = shadowOffset;
         }
 
         private IconUsage icon;
@@ -164,7 +173,7 @@ namespace osu.Framework.Graphics.Sprites
                 if (icon.Equals(value)) return;
 
                 icon = value;
-                if (LoadState == LoadState.Loaded)
+                if (IsLoaded)
                     updateTexture();
             }
         }


### PR DESCRIPTION
Added properties for `ShadowOffset` and `ShadowColour`. 
Noticed these weren't exposed when working on my own framework project.

Example
![image](https://user-images.githubusercontent.com/7267697/146402196-23f5a3ec-a958-4f93-b234-564e4605fc4f.png)

Default values have been set to visually match previous behaviour. 
Test steps also added to `TestSceneSpriteIcon`.