### PR TITLE
Fix incorrect usages of `ConditionalAttribute` for debug isolation

### DIFF
--- a/osu.Framework/Logging/LoadingComponentsLogger.cs
+++ b/osu.Framework/Logging/LoadingComponentsLogger.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System.Diagnostics;
+using osu.Framework.Development;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Lists;
@@ -12,23 +12,26 @@ namespace osu.Framework.Logging
     {
         private static readonly WeakList<Drawable> loading_components = new WeakList<Drawable>();
 
-        [Conditional("DEBUG")]
         public static void Add(Drawable component)
         {
+            if (!DebugUtils.IsDebugBuild) return;
+
             lock (loading_components)
                 loading_components.Add(component);
         }
 
-        [Conditional("DEBUG")]
         public static void Remove(Drawable component)
         {
+            if (!DebugUtils.IsDebugBuild) return;
+
             lock (loading_components)
                 loading_components.Remove(component);
         }
 
-        [Conditional("DEBUG")]
         public static void LogAndFlush()
         {
+            if (!DebugUtils.IsDebugBuild) return;
+
             lock (loading_components)
             {
                 Logger.Log("⏳ Currently loading components");

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -3,13 +3,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using osu.Framework.Platform;
 using System.Linq;
 using System.Threading;
 using osu.Framework.Development;
+using osu.Framework.Platform;
 using osu.Framework.Statistics;
 using osu.Framework.Threading;
 
@@ -267,9 +266,11 @@ namespace osu.Framework.Logging
         /// Logs a new message with the <see cref="LogLevel.Debug"/> and will only be logged if your project is built in the Debug configuration. Please note that the default setting for <see cref="Level"/> is <see cref="LogLevel.Verbose"/> so unless you increase the <see cref="Level"/> to <see cref="LogLevel.Debug"/> messages printed with this method will not appear in the output.
         /// </summary>
         /// <param name="message">The message that should be logged.</param>
-        [Conditional("DEBUG")]
         public void Debug(string message = @"")
         {
+            if (!DebugUtils.IsDebugBuild)
+                return;
+
             Add(message, LogLevel.Debug);
         }
 


### PR DESCRIPTION
These are cases we expect to work when a framework consumer (running a release framework build) builds as debug. The attribute won't work as it is compile-time baked.