### PR TITLE
Add native Windows IME support

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -1011,5 +1011,36 @@ namespace osu.Framework.Platform.SDL2
             str = Marshal.PtrToStringUTF8(ptr) ?? string.Empty;
             return true;
         }
+
+        // ReSharper disable InconsistentNaming (mimics SDL and SDL2-CS naming)
+        // ReSharper disable IdentifierTypo
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct INTERNAL_windows_wmmsg
+        {
+            public IntPtr hwnd;
+            public uint msg;
+            public ulong wParam;
+            public long lParam;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct INTERNAL_SysWMmsgUnion
+        {
+            [FieldOffset(0)]
+            public INTERNAL_windows_wmmsg win;
+            // could add more native events here if required
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct SDL_SysWMmsg
+        {
+            public SDL.SDL_version version;
+            public SDL.SDL_SYSWM_TYPE subsystem;
+            public INTERNAL_SysWMmsgUnion msg;
+        }
+
+        // ReSharper restore InconsistentNaming
+        // ReSharper restore IdentifierTypo
     }
 }

--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -1011,37 +1011,5 @@ namespace osu.Framework.Platform.SDL2
             str = Marshal.PtrToStringUTF8(ptr) ?? string.Empty;
             return true;
         }
-
-        // ReSharper disable InconsistentNaming (mimics SDL and SDL2-CS naming)
-        // ReSharper disable IdentifierTypo
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct INTERNAL_windows_wmmsg
-        {
-            public IntPtr hwnd;
-            public uint msg;
-            public ulong wParam;
-            public long lParam;
-        }
-
-        [StructLayout(LayoutKind.Explicit)]
-        internal struct INTERNAL_SysWMmsgUnion
-        {
-            [FieldOffset(0)]
-            public INTERNAL_windows_wmmsg win;
-
-            // could add more native events here if required
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        internal struct SDL_SysWMmsg
-        {
-            public SDL.SDL_version version;
-            public SDL.SDL_SYSWM_TYPE subsystem;
-            public INTERNAL_SysWMmsgUnion msg;
-        }
-
-        // ReSharper restore InconsistentNaming
-        // ReSharper restore IdentifierTypo
     }
 }

--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -1029,6 +1029,7 @@ namespace osu.Framework.Platform.SDL2
         {
             [FieldOffset(0)]
             public INTERNAL_windows_wmmsg win;
+
             // could add more native events here if required
         }
 

--- a/osu.Framework/Platform/SDL2/SDL2Structs.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Structs.cs
@@ -1,0 +1,48 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+using SDL2;
+
+// ReSharper disable MemberCanBePrivate.Global
+// (Some members not currently used)
+
+// ReSharper disable InconsistentNaming
+// ReSharper disable IdentifierTypo
+// (Mimics SDL and SDL2-CS naming)
+
+namespace osu.Framework.Platform.SDL2
+{
+    internal static class SDL2Structs
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        internal struct INTERNAL_windows_wmmsg
+        {
+            public IntPtr hwnd;
+            public uint msg;
+            public ulong wParam;
+            public long lParam;
+        }
+
+        [StructLayout(LayoutKind.Explicit)]
+        internal struct INTERNAL_SysWMmsgUnion
+        {
+            [FieldOffset(0)]
+            public INTERNAL_windows_wmmsg win;
+
+            // could add more native events here if required
+        }
+
+        /// <summary>
+        /// Member <c>msg</c> of <see cref="SDL.SDL_SysWMEvent"/>.
+        /// </summary>
+        [StructLayout(LayoutKind.Sequential)]
+        public struct SDL_SysWMmsg
+        {
+            public SDL.SDL_version version;
+            public SDL.SDL_SYSWM_TYPE subsystem;
+            public INTERNAL_SysWMmsgUnion msg;
+        }
+    }
+}

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -718,6 +718,10 @@ namespace osu.Framework.Platform
                 case SDL.SDL_EventType.SDL_DROPCOMPLETE:
                     handleDropEvent(e.drop);
                     break;
+
+                case SDL.SDL_EventType.SDL_SYSWMEVENT:
+                    HandleSysWMEvent(e.syswm);
+                    break;
             }
         }
 
@@ -984,6 +988,19 @@ namespace osu.Framework.Platform
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
                     break;
             }
+        }
+
+        /// <summary>
+        /// Override if platform requires special handling of native events.
+        /// </summary>
+        /// <remarks>
+        /// Make sure to enable the events with
+        ///   <code>
+        ///     SDL.SDL_EventState(SDL.SDL_EventType.SDL_SYSWMEVENT, SDL.SDL_ENABLE);
+        ///   </code>
+        /// </remarks>
+        protected virtual void HandleSysWMEvent(SDL.SDL_SysWMEvent sysWM)
+        {
         }
 
         /// <summary>

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -721,10 +721,6 @@ namespace osu.Framework.Platform
                 case SDL.SDL_EventType.SDL_DROPCOMPLETE:
                     handleDropEvent(e.drop);
                     break;
-
-                case SDL.SDL_EventType.SDL_SYSWMEVENT:
-                    HandleSysWMEvent(e.syswm);
-                    break;
             }
         }
 
@@ -991,19 +987,6 @@ namespace osu.Framework.Platform
                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_CLOSE:
                     break;
             }
-        }
-
-        /// <summary>
-        /// Override if platform requires special handling of native events.
-        /// </summary>
-        /// <remarks>
-        /// Make sure to enable the events with
-        ///   <code>
-        ///     SDL.SDL_EventState(SDL.SDL_EventType.SDL_SYSWMEVENT, SDL.SDL_ENABLE);
-        ///   </code>
-        /// </remarks>
-        protected virtual void HandleSysWMEvent(SDL.SDL_SysWMEvent sysWM)
-        {
         }
 
         /// <summary>

--- a/osu.Framework/Platform/Windows/Native/Imm.cs
+++ b/osu.Framework/Platform/Windows/Native/Imm.cs
@@ -5,6 +5,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
+using osu.Framework.Extensions.EnumExtensions;
 
 namespace osu.Framework.Platform.Windows.Native
 {
@@ -33,12 +34,12 @@ namespace osu.Framework.Platform.Windows.Native
         {
             private readonly InputContextHandle handle;
 
-            private readonly long lParam;
+            private readonly CompositionString lParam;
 
             public InputContext(IntPtr hWnd, long lParam = 0)
             {
                 handle = new InputContextHandle(hWnd);
-                this.lParam = lParam;
+                this.lParam = (CompositionString)lParam;
             }
 
             /// <summary>
@@ -110,11 +111,6 @@ namespace osu.Framework.Platform.Windows.Native
             }
 
             /// <summary>
-            /// Returns true if <see cref="lParam"/> has the specified <paramref name="flag"/>.
-            /// </summary>
-            private bool lParamHasFlag(CompositionString flag) => (lParam & (long)flag) != 0;
-
-            /// <summary>
             /// Get the <paramref name="size"/> of the corresponding <paramref name="compositionString"/> from the IMM.
             /// </summary>
             /// <remarks>
@@ -128,7 +124,7 @@ namespace osu.Framework.Platform.Windows.Native
             {
                 size = -1;
 
-                if (!lParamHasFlag(compositionString))
+                if (!lParam.HasFlagFast(compositionString))
                     return false;
 
                 size = ImmGetCompositionString(handle, compositionString, null, 0);
@@ -275,6 +271,7 @@ namespace osu.Framework.Platform.Windows.Native
         /// <c>lParam</c> values of <see cref="WM_IME_COMPOSITION"/> event.
         /// Parameter <c>dwIndex</c> of <see cref="ImmGetCompositionString"/>.
         /// </summary>
+        [Flags]
         private enum CompositionString : uint
         {
             /// <summary>

--- a/osu.Framework/Platform/Windows/Native/Imm.cs
+++ b/osu.Framework/Platform/Windows/Native/Imm.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
+using Microsoft.Win32.SafeHandles;
 
 namespace osu.Framework.Platform.Windows.Native
 {
@@ -14,47 +15,6 @@ namespace osu.Framework.Platform.Windows.Native
     internal static class Imm
     {
         /// <summary>
-        /// Gets the current composition text and selection.
-        /// </summary>
-        internal static bool TryGetImeComposition(InputContext inputContext, long lParam, out string compositionText, out int start, out int length)
-        {
-            if (!tryGetCompositionText(inputContext, lParam, CompositionString.GCS_COMPSTR, out compositionText))
-            {
-                start = 0;
-                length = 0;
-                return false;
-            }
-
-            if (tryGetCompositionTargetRange(inputContext, lParam, out int targetStart, out int targetEnd))
-            {
-                start = targetStart;
-                length = targetEnd - targetStart;
-                return true;
-            }
-
-            // couldn't get selection length, so default to 0
-            length = 0;
-
-            if (tryGetCompositionSize(inputContext, lParam, CompositionString.GCS_CURSORPOS, out int cursorPosition))
-            {
-                start = cursorPosition;
-                return true;
-            }
-
-            // couldn't get selection start, so default to end of string.
-            start = compositionText.Length;
-            return true;
-        }
-
-        /// <summary>
-        /// Gets the current result text.
-        /// </summary>
-        internal static bool TryGetImeResult(InputContext inputContext, long lParam, out string resultText)
-        {
-            return tryGetCompositionText(inputContext, lParam, CompositionString.GCS_RESULTSTR, out resultText);
-        }
-
-        /// <summary>
         /// Cancels the currently active IME composition (if any).
         /// Resets the internal composition string and hides the candidate window.
         /// </summary>
@@ -62,130 +22,248 @@ namespace osu.Framework.Platform.Windows.Native
         {
             using (var inputContext = new InputContext(hWnd))
             {
-                ImmNotifyIME(inputContext.Handle, NotificationCode.NI_COMPOSITIONSTR, (uint)CompositionStringAction.CPS_CANCEL, 0);
+                inputContext.CancelComposition();
             }
         }
 
         /// <summary>
-        /// Returns true if <paramref name="lParam"/> has the specified <paramref name="flag"/>.
+        /// Provides an IMC (Input Method Context) allowing interaction with the IMM (Input Method Manager).
         /// </summary>
-        private static bool hasFlag(this long lParam, CompositionString flag) => (lParam & (long)flag) != 0;
-
-        /// <summary>
-        /// Get the <paramref name="size"/> of the corresponding <paramref name="compositionString"/> from the IMM.
-        /// </summary>
-        /// <remarks>
-        /// The size has a different meaning, depending on the provided <paramref name="compositionString"/>:
-        ///   <list type="bullet">
-        ///     <item>For most <see cref="CompositionString"/>s, returns the size of buffer required to store the data.</item>
-        ///     <item>For <see cref="CompositionString.GCS_CURSORPOS"/>, returns the cursor position in the current composition text.</item>
-        ///   </list>
-        /// </remarks>
-        private static bool tryGetCompositionSize(InputContext inputContext, long lParam, CompositionString compositionString, out int size)
+        internal class InputContext : IDisposable
         {
-            size = -1;
+            private readonly InputContextHandle handle;
 
-            if (!lParam.hasFlag(compositionString))
-                return false;
+            private readonly long lParam;
 
-            size = ImmGetCompositionString(inputContext.Handle, compositionString, null, 0);
-
-            // negative return value means that an error has occured.
-            return size >= 0;
-        }
-
-        /// <summary>
-        /// Get the <paramref name="size"/> and <paramref name="data"/> of the corresponding <paramref name="compositionString"/> from the IMM.
-        /// </summary>
-        /// <remarks>
-        /// The <paramref name="size"/> and <paramref name="data"/> have different meanings, depending on the provided <paramref name="compositionString"/>:
-        ///   <list type="bullet">
-        ///     <item>For <see cref="CompositionString.GCS_COMPSTR"/> and <see cref="CompositionString.GCS_RESULTSTR"/> data is UTF-16 encoded text.</item>
-        ///     <item>For <see cref="CompositionString.GCS_COMPATTR"/> .</item>
-        ///   </list>
-        /// </remarks>
-        private static bool tryGetCompositionString(InputContext inputContext, long lParam, CompositionString compositionString, out int size, out byte[] data)
-        {
-            data = null;
-
-            if (!tryGetCompositionSize(inputContext, lParam, compositionString, out size))
-                return false;
-
-            data = new byte[size];
-            int ret = ImmGetCompositionString(inputContext.Handle, compositionString, data, (uint)size);
-
-            // negative return value means that an error has occured.
-            return ret >= 0;
-        }
-
-        /// <summary>
-        /// Gets the text of the current composition (<see cref="CompositionString.GCS_COMPSTR"/>) or result (<see cref="CompositionString.GCS_RESULTSTR"/>).
-        /// </summary>
-        private static bool tryGetCompositionText(InputContext inputContext, long lParam, CompositionString compositionString, out string text)
-        {
-            if (tryGetCompositionString(inputContext, lParam, compositionString, out _, out byte[] buffer))
+            public InputContext(IntPtr hWnd, long lParam = 0)
             {
-                text = Encoding.Unicode.GetString(buffer);
+                handle = new InputContextHandle(hWnd);
+                this.lParam = lParam;
+            }
+
+            /// <summary>
+            /// Gets the current composition text and selection.
+            /// </summary>
+            public bool TryGetImeComposition(out string compositionText, out int start, out int length)
+            {
+                if (handle.IsClosed || handle.IsInvalid)
+                {
+                    start = 0;
+                    length = 0;
+                    compositionText = null;
+                    return false;
+                }
+
+                if (!tryGetCompositionText(CompositionString.GCS_COMPSTR, out compositionText))
+                {
+                    start = 0;
+                    length = 0;
+                    return false;
+                }
+
+                if (tryGetCompositionTargetRange(out int targetStart, out int targetEnd))
+                {
+                    start = targetStart;
+                    length = targetEnd - targetStart;
+                    return true;
+                }
+
+                // couldn't get selection length, so default to 0
+                length = 0;
+
+                if (tryGetCompositionSize(CompositionString.GCS_CURSORPOS, out int cursorPosition))
+                {
+                    start = cursorPosition;
+                    return true;
+                }
+
+                // couldn't get selection start, so default to end of string.
+                start = compositionText.Length;
                 return true;
             }
 
-            text = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Determines whether or not the given attribute represents a target (a.k.a. a selection).
-        /// </summary>
-        private static bool isTargetAttribute(byte attribute) => attribute == (byte)Attribute.ATTR_TARGET_CONVERTED || attribute == (byte)Attribute.ATTR_TARGET_NOTCONVERTED;
-
-        /// <summary>
-        /// Gets the target range that's selected by the user in the current composition string.
-        /// </summary>
-        private static bool tryGetCompositionTargetRange(InputContext inputContext, long lParam, out int targetStart, out int targetEnd)
-        {
-            targetStart = 0;
-            targetEnd = 0;
-
-            if (!tryGetCompositionString(inputContext, lParam, CompositionString.GCS_COMPATTR, out int size, out byte[] attributeData))
-                return false;
-
-            int start;
-            int end;
-            bool targetFound = false;
-
-            // find the first character that is part of the current conversion.
-            for (start = 0; start < size; start++)
+            /// <summary>
+            /// Gets the current result text.
+            /// </summary>
+            public bool TryGetImeResult(out string resultText)
             {
-                if (isTargetAttribute(attributeData[start]))
+                if (handle.IsClosed || handle.IsInvalid)
                 {
-                    targetFound = true;
-                    break;
+                    resultText = null;
+                    return false;
                 }
+
+                return tryGetCompositionText(CompositionString.GCS_RESULTSTR, out resultText);
             }
 
-            if (!targetFound)
-                return false;
-
-            // find the last character that is part of the current conversion.
-            for (end = start; end < size; end++)
+            /// <summary>
+            /// Cancels the currently active IME composition (if any).
+            /// </summary>
+            /// <remarks>
+            /// Resets the internal composition string and hides the candidate window.
+            /// </remarks>
+            public void CancelComposition()
             {
-                if (!isTargetAttribute(attributeData[end]))
-                    break;
+                if (handle.IsClosed || handle.IsInvalid) return;
+
+                ImmNotifyIME(handle, NotificationCode.NI_COMPOSITIONSTR, (uint)CompositionStringAction.CPS_CANCEL, 0);
             }
 
-            targetStart = start;
-            targetEnd = end;
-            return true;
+            /// <summary>
+            /// Returns true if <see cref="lParam"/> has the specified <paramref name="flag"/>.
+            /// </summary>
+            private bool lParamHasFlag(CompositionString flag) => (lParam & (long)flag) != 0;
+
+            /// <summary>
+            /// Get the <paramref name="size"/> of the corresponding <paramref name="compositionString"/> from the IMM.
+            /// </summary>
+            /// <remarks>
+            /// The size has a different meaning, depending on the provided <paramref name="compositionString"/>:
+            ///   <list type="bullet">
+            ///     <item>For most <see cref="CompositionString"/>s, returns the size of buffer required to store the data.</item>
+            ///     <item>For <see cref="CompositionString.GCS_CURSORPOS"/>, returns the cursor position in the current composition text.</item>
+            ///   </list>
+            /// </remarks>
+            private bool tryGetCompositionSize(CompositionString compositionString, out int size)
+            {
+                size = -1;
+
+                if (!lParamHasFlag(compositionString))
+                    return false;
+
+                size = ImmGetCompositionString(handle, compositionString, null, 0);
+
+                // negative return value means that an error has occured.
+                return size >= 0;
+            }
+
+            /// <summary>
+            /// Get the <paramref name="size"/> and <paramref name="data"/> of the corresponding <paramref name="compositionString"/> from the IMM.
+            /// </summary>
+            /// <remarks>
+            /// The <paramref name="size"/> and <paramref name="data"/> have different meanings, depending on the provided <paramref name="compositionString"/>:
+            ///   <list type="bullet">
+            ///     <item>For <see cref="CompositionString.GCS_COMPSTR"/> and <see cref="CompositionString.GCS_RESULTSTR"/> data is UTF-16 encoded text.</item>
+            ///     <item>For <see cref="CompositionString.GCS_COMPATTR"/> .</item>
+            ///   </list>
+            /// </remarks>
+            private bool tryGetCompositionString(CompositionString compositionString, out int size, out byte[] data)
+            {
+                data = null;
+
+                if (!tryGetCompositionSize(compositionString, out size))
+                    return false;
+
+                data = new byte[size];
+                int ret = ImmGetCompositionString(handle, compositionString, data, (uint)size);
+
+                // negative return value means that an error has occured.
+                return ret >= 0;
+            }
+
+            /// <summary>
+            /// Gets the text of the current composition (<see cref="CompositionString.GCS_COMPSTR"/>) or result (<see cref="CompositionString.GCS_RESULTSTR"/>).
+            /// </summary>
+            private bool tryGetCompositionText(CompositionString compositionString, out string text)
+            {
+                if (tryGetCompositionString(compositionString, out _, out byte[] buffer))
+                {
+                    text = Encoding.Unicode.GetString(buffer);
+                    return true;
+                }
+
+                text = null;
+                return false;
+            }
+
+            /// <summary>
+            /// Determines whether or not the given attribute represents a target (a.k.a. a selection).
+            /// </summary>
+            private bool isTargetAttribute(byte attribute) => attribute == (byte)Attribute.ATTR_TARGET_CONVERTED || attribute == (byte)Attribute.ATTR_TARGET_NOTCONVERTED;
+
+            /// <summary>
+            /// Gets the target range that's selected by the user in the current composition string.
+            /// </summary>
+            private bool tryGetCompositionTargetRange(out int targetStart, out int targetEnd)
+            {
+                targetStart = 0;
+                targetEnd = 0;
+
+                if (!tryGetCompositionString(CompositionString.GCS_COMPATTR, out int size, out byte[] attributeData))
+                    return false;
+
+                int start;
+                int end;
+                bool targetFound = false;
+
+                // find the first character that is part of the current conversion.
+                for (start = 0; start < size; start++)
+                {
+                    if (isTargetAttribute(attributeData[start]))
+                    {
+                        targetFound = true;
+                        break;
+                    }
+                }
+
+                if (!targetFound)
+                    return false;
+
+                // find the last character that is part of the current conversion.
+                for (end = start; end < size; end++)
+                {
+                    if (!isTargetAttribute(attributeData[end]))
+                        break;
+                }
+
+                targetStart = start;
+                targetEnd = end;
+                return true;
+            }
+
+            public void Dispose()
+            {
+                handle.Dispose();
+            }
         }
+
+        #region Native functions and handles
+
+        private class InputContextHandle : SafeHandleZeroOrMinusOneIsInvalid
+        {
+            [DllImport("imm32.dll", SetLastError = true)]
+            private static extern IntPtr ImmGetContext(IntPtr hWnd);
+
+            [DllImport("imm32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            private static extern bool ImmReleaseContext(IntPtr hWnd, IntPtr hImc);
+
+            private readonly IntPtr windowHandle;
+
+            public InputContextHandle(IntPtr windowHandle)
+                : base(true)
+            {
+                if (windowHandle == IntPtr.Zero)
+                    throw new ArgumentException($"Invalid {nameof(windowHandle)}");
+
+                this.windowHandle = windowHandle;
+                SetHandle(ImmGetContext(windowHandle));
+            }
+
+            protected override bool ReleaseHandle()
+            {
+                return ImmReleaseContext(windowHandle, handle);
+            }
+        }
+
+        // ReSharper disable IdentifierTypo
 
         [DllImport("imm32.dll", CharSet = CharSet.Unicode)]
-        private static extern int ImmGetCompositionString(IntPtr hImc, CompositionString dwIndex, byte[] lpBuf, uint dwBufLen);
+        private static extern int ImmGetCompositionString(InputContextHandle hImc, CompositionString dwIndex, byte[] lpBuf, uint dwBufLen);
 
         [DllImport("imm32.dll", CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool ImmNotifyIME(IntPtr hImc, NotificationCode dwAction, uint dwIndex, uint dwValue);
-
-        // ReSharper disable IdentifierTypo
+        private static extern bool ImmNotifyIME(InputContextHandle hImc, NotificationCode dwAction, uint dwIndex, uint dwValue);
 
         // window messages
         internal const int WM_IME_STARTCOMPOSITION = 0x010D;
@@ -394,51 +472,6 @@ namespace osu.Framework.Platform.Windows.Native
 
         // ReSharper restore IdentifierTypo
 
-        internal class InputContext : IDisposable
-        {
-            [DllImport("imm32.dll", SetLastError = true)]
-            private static extern IntPtr ImmGetContext(IntPtr hWnd);
-
-            [DllImport("imm32.dll", SetLastError = true)]
-            [return: MarshalAs(UnmanagedType.Bool)]
-            private static extern bool ImmReleaseContext(IntPtr hWnd, IntPtr hImc);
-
-            private bool disposed;
-
-            private readonly IntPtr hWnd;
-
-            public IntPtr Handle { get; private set; }
-
-            public InputContext(IntPtr hWnd)
-            {
-                this.hWnd = hWnd;
-                Handle = ImmGetContext(hWnd);
-            }
-
-            ~InputContext()
-            {
-                Dispose(false);
-            }
-
-            protected virtual void Dispose(bool disposing)
-            {
-                if (disposed)
-                    return;
-
-                if (Handle != IntPtr.Zero)
-                {
-                    ImmReleaseContext(hWnd, Handle);
-                    Handle = IntPtr.Zero;
-                }
-
-                disposed = true;
-            }
-
-            public void Dispose()
-            {
-                Dispose(true);
-                GC.SuppressFinalize(this);
-            }
-        }
+        #endregion
     }
 }

--- a/osu.Framework/Platform/Windows/Native/Imm.cs
+++ b/osu.Framework/Platform/Windows/Native/Imm.cs
@@ -1,0 +1,444 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence resultText.
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace osu.Framework.Platform.Windows.Native
+{
+    /// <summary>
+    /// Static class for interacting with the Input Method Manager,
+    /// the interface between applications and the IME.
+    /// </summary>
+    internal static class Imm
+    {
+        /// <summary>
+        /// Gets the current composition text and selection.
+        /// </summary>
+        internal static bool TryGetImeComposition(InputContext inputContext, long lParam, out string compositionText, out int start, out int length)
+        {
+            if (!tryGetCompositionText(inputContext, lParam, CompositionString.GCS_COMPSTR, out compositionText))
+            {
+                start = 0;
+                length = 0;
+                return false;
+            }
+
+            if (tryGetCompositionTargetRange(inputContext, lParam, out int targetStart, out int targetEnd))
+            {
+                start = targetStart;
+                length = targetEnd - targetStart;
+                return true;
+            }
+
+            // couldn't get selection length, so default to 0
+            length = 0;
+
+            if (tryGetCompositionSize(inputContext, lParam, CompositionString.GCS_CURSORPOS, out int cursorPosition))
+            {
+                start = cursorPosition;
+                return true;
+            }
+
+            // couldn't get selection start, so default to end of string.
+            start = compositionText.Length;
+            return true;
+        }
+
+        /// <summary>
+        /// Gets the current result text.
+        /// </summary>
+        internal static bool TryGetImeResult(InputContext inputContext, long lParam, out string resultText)
+        {
+            return tryGetCompositionText(inputContext, lParam, CompositionString.GCS_RESULTSTR, out resultText);
+        }
+
+        /// <summary>
+        /// Cancels the currently active IME composition (if any).
+        /// Resets the internal composition string and hides the candidate window.
+        /// </summary>
+        internal static void CancelComposition(IntPtr hWnd)
+        {
+            using (var inputContext = new InputContext(hWnd))
+            {
+                ImmNotifyIME(inputContext.Handle, NotificationCode.NI_COMPOSITIONSTR, (uint)CompositionStringAction.CPS_CANCEL, 0);
+            }
+        }
+
+        /// <summary>
+        /// Returns true if <paramref name="lParam"/> has the specified <paramref name="flag"/>.
+        /// </summary>
+        private static bool hasFlag(this long lParam, CompositionString flag) => (lParam & (long)flag) != 0;
+
+        /// <summary>
+        /// Get the <paramref name="size"/> of the corresponding <paramref name="compositionString"/> from the IMM.
+        /// </summary>
+        /// <remarks>
+        /// The size has a different meaning, depending on the provided <paramref name="compositionString"/>:
+        ///   <list type="bullet">
+        ///     <item>For most <see cref="CompositionString"/>s, returns the size of buffer required to store the data.</item>
+        ///     <item>For <see cref="CompositionString.GCS_CURSORPOS"/>, returns the cursor position in the current composition text.</item>
+        ///   </list>
+        /// </remarks>
+        private static bool tryGetCompositionSize(InputContext inputContext, long lParam, CompositionString compositionString, out int size)
+        {
+            size = -1;
+
+            if (!lParam.hasFlag(compositionString))
+                return false;
+
+            size = ImmGetCompositionString(inputContext.Handle, compositionString, null, 0);
+
+            // negative return value means that an error has occured.
+            return size >= 0;
+        }
+
+        /// <summary>
+        /// Get the <paramref name="size"/> and <paramref name="data"/> of the corresponding <paramref name="compositionString"/> from the IMM.
+        /// </summary>
+        /// <remarks>
+        /// The <paramref name="size"/> and <paramref name="data"/> have different meanings, depending on the provided <paramref name="compositionString"/>:
+        ///   <list type="bullet">
+        ///     <item>For <see cref="CompositionString.GCS_COMPSTR"/> and <see cref="CompositionString.GCS_RESULTSTR"/> data is UTF-16 encoded text.</item>
+        ///     <item>For <see cref="CompositionString.GCS_COMPATTR"/> .</item>
+        ///   </list>
+        /// </remarks>
+        private static bool tryGetCompositionString(InputContext inputContext, long lParam, CompositionString compositionString, out int size, out byte[] data)
+        {
+            data = null;
+
+            if (!tryGetCompositionSize(inputContext, lParam, compositionString, out size))
+                return false;
+
+            data = new byte[size];
+            int ret = ImmGetCompositionString(inputContext.Handle, compositionString, data, (uint)size);
+
+            // negative return value means that an error has occured.
+            return ret >= 0;
+        }
+
+        /// <summary>
+        /// Gets the text of the current composition (<see cref="CompositionString.GCS_COMPSTR"/>) or result (<see cref="CompositionString.GCS_RESULTSTR"/>).
+        /// </summary>
+        private static bool tryGetCompositionText(InputContext inputContext, long lParam, CompositionString compositionString, out string text)
+        {
+            if (tryGetCompositionString(inputContext, lParam, compositionString, out _, out byte[] buffer))
+            {
+                text = Encoding.Unicode.GetString(buffer);
+                return true;
+            }
+
+            text = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Determines whether or not the given attribute represents a target (a.k.a. a selection).
+        /// </summary>
+        private static bool isTargetAttribute(byte attribute) => attribute == (byte)Attribute.ATTR_TARGET_CONVERTED || attribute == (byte)Attribute.ATTR_TARGET_NOTCONVERTED;
+
+        /// <summary>
+        /// Gets the target range that's selected by the user in the current composition string.
+        /// </summary>
+        private static bool tryGetCompositionTargetRange(InputContext inputContext, long lParam, out int targetStart, out int targetEnd)
+        {
+            targetStart = 0;
+            targetEnd = 0;
+
+            if (!tryGetCompositionString(inputContext, lParam, CompositionString.GCS_COMPATTR, out int size, out byte[] attributeData))
+                return false;
+
+            int start;
+            int end;
+            bool targetFound = false;
+
+            // find the first character that is part of the current conversion.
+            for (start = 0; start < size; start++)
+            {
+                if (isTargetAttribute(attributeData[start]))
+                {
+                    targetFound = true;
+                    break;
+                }
+            }
+
+            if (!targetFound)
+                return false;
+
+            // find the last character that is part of the current conversion.
+            for (end = start; end < size; end++)
+            {
+                if (!isTargetAttribute(attributeData[end]))
+                    break;
+            }
+
+            targetStart = start;
+            targetEnd = end;
+            return true;
+        }
+
+        [DllImport("imm32.dll", CharSet = CharSet.Unicode)]
+        private static extern int ImmGetCompositionString(IntPtr hImc, CompositionString dwIndex, byte[] lpBuf, uint dwBufLen);
+
+        [DllImport("imm32.dll", CharSet = CharSet.Unicode)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ImmNotifyIME(IntPtr hImc, NotificationCode dwAction, uint dwIndex, uint dwValue);
+
+        // ReSharper disable IdentifierTypo
+
+        // window messages
+        internal const int WM_IME_STARTCOMPOSITION = 0x010D;
+        internal const int WM_IME_ENDCOMPOSITION = 0x010E;
+        internal const int WM_IME_COMPOSITION = 0x010F;
+
+        /// <summary>
+        /// IME composition string values.
+        /// <c>lParam</c> values of <see cref="WM_IME_COMPOSITION"/> event.
+        /// Parameter <c>dwIndex</c> of <see cref="ImmGetCompositionString"/>.
+        /// </summary>
+        private enum CompositionString : uint
+        {
+            /// <summary>
+            /// Retrieve or update the reading string of the current composition.
+            /// </summary>
+            GCS_COMPREADSTR = 0x0001,
+
+            /// <summary>
+            /// Retrieve or update the <see cref="Attribute"/>s of the reading string of the current composition.
+            /// </summary>
+            GCS_COMPREADATTR = 0x0002,
+
+            /// <summary>
+            /// Retrieve or update the clause information of the reading string of the composition string.
+            /// </summary>
+            GCS_COMPREADCLAUSE = 0x0004,
+
+            /// <summary>
+            /// Retrieve or update the current composition string.
+            /// </summary>
+            GCS_COMPSTR = 0x0008,
+
+            /// <summary>
+            /// Retrieve or update the <see cref="Attribute"/>s of the composition string.
+            /// </summary>
+            GCS_COMPATTR = 0x0010,
+
+            /// <summary>
+            /// Retrieve or update clause information of the composition string.
+            /// </summary>
+            GCS_COMPCLAUSE = 0x0020,
+
+            /// <summary>
+            /// Retrieve or update the cursor position in composition string.
+            /// </summary>
+            GCS_CURSORPOS = 0x0080,
+
+            /// <summary>
+            /// Retrieve or update the starting position of any changes in composition string.
+            /// </summary>
+            GCS_DELTASTART = 0x0100,
+
+            /// <summary>
+            /// Retrieve or update the reading string.
+            /// </summary>
+            GCS_RESULTREADSTR = 0x0200,
+
+            /// <summary>
+            /// Retrieve or update clause information of the result string.
+            /// </summary>
+            GCS_RESULTREADCLAUSE = 0x0400,
+
+            /// <summary>
+            /// Retrieve or update the string of the composition result.
+            /// </summary>
+            GCS_RESULTSTR = 0x0800,
+
+            /// <summary>
+            /// Retrieve or update clause information of the result string.
+            /// </summary>
+            GCS_RESULTCLAUSE = 0x1000,
+
+            /// <summary>
+            /// Insert the wParam composition character at the current insertion point.
+            /// An application should display the composition character if it processes this message.
+            /// </summary>
+            CS_INSERTCHAR = 0x2000,
+
+            /// <summary>
+            /// Do not move the caret position as a result of processing the message.
+            /// </summary>
+            CS_NOMOVECARET = 0x4000,
+        }
+
+        /// <summary>
+        /// Attribute for each character in the current composition string (<see cref="CompositionString.GCS_COMPSTR"/>).
+        /// </summary>
+        private enum Attribute : byte
+        {
+            /// <summary>
+            /// Character being entered by the user. The IME has yet to convert this character.
+            /// </summary>
+            ATTR_INPUT = 0x00,
+
+            /// <summary>
+            /// Character selected by the user and then converted by the IME.
+            /// </summary>
+            ATTR_TARGET_CONVERTED = 0x01,
+
+            /// <summary>
+            /// Character that the IME has already converted.
+            /// </summary>
+            ATTR_CONVERTED = 0x02,
+
+            /// <summary>
+            /// Character being converted. The user has selected this character but the IME has not yet converted it.
+            /// </summary>
+            ATTR_TARGET_NOTCONVERTED = 0x03,
+
+            /// <summary>
+            /// An error character that the IME cannot convert. For example, the IME cannot put together some consonants.
+            /// </summary>
+            ATTR_INPUT_ERROR = 0x04,
+
+            /// <summary>
+            /// Character that the IME will no longer convert.
+            /// </summary>
+            ATTR_FIXEDCONVERTED = 0x05,
+        }
+
+        /// <summary>
+        /// dwAction for <see cref="ImmNotifyIME"/>.
+        /// </summary>
+        private enum NotificationCode : uint
+        {
+            /// <summary>
+            /// An application directs the IME to open a candidate list.
+            /// The dwIndex parameter specifies the index of the list to open, and dwValue is not used.
+            /// </summary>
+            NI_OPENCANDIDATE = 0x0010,
+
+            /// <summary>
+            /// An application directs the IME to close a candidate list.
+            /// The dwIndex parameter specifies an index of the list to close, and dwValue is not used.
+            /// </summary>
+            NI_CLOSECANDIDATE = 0x0011,
+
+            /// <summary>
+            /// An application has selected one of the candidates.
+            /// The dwIndex parameter specifies an index of a candidate list to be selected.
+            /// The dwValue parameter specifies an index of a candidate string in the selected candidate list.
+            /// </summary>
+            NI_SELECTCANDIDATESTR = 0x0012,
+
+            /// <summary>
+            /// An application changed the current selected candidate.
+            /// The dwIndex parameter specifies an index of a candidate list to be selected and dwValue is not used.
+            /// </summary>
+            NI_CHANGECANDIDATELIST = 0x0013,
+
+            NI_FINALIZECONVERSIONRESULT = 0x0014,
+
+            /// <summary>
+            /// An application directs the IME to carry out an action on the composition string.
+            /// The dwIndex parameter can be from <see cref="CompositionStringAction"/>.
+            /// </summary>
+            NI_COMPOSITIONSTR = 0x0015,
+
+            /// <summary>
+            /// The application changes the page starting index of a candidate list.
+            /// The dwIndex parameter specifies the candidate list to be changed and must have a value in the range 0 to 3.
+            /// The dwValue parameter specifies the new page start index.
+            /// </summary>
+            NI_SETCANDIDATE_PAGESTART = 0x0016,
+
+            /// <summary>
+            /// The application changes the page size of a candidate list.
+            /// The dwIndex parameter specifies the candidate list to be changed and must have a value in the range 0 to 3.
+            /// The dwValue parameter specifies the new page size.
+            /// </summary>
+            NI_SETCANDIDATE_PAGESIZE = 0x0017,
+
+            /// <summary>
+            /// An application directs the IME to allow the application to handle the specified menu.
+            /// The dwIndex parameter specifies the ID of the menu and dwValue is an application-defined value for that menu item.
+            /// </summary>
+            NI_IMEMENUSELECTED = 0x0018,
+        }
+
+        /// <summary>
+        /// dwIndex for <see cref="ImmNotifyIME"/> when using <see cref="NotificationCode.NI_COMPOSITIONSTR"/>.
+        /// </summary>
+        private enum CompositionStringAction : uint
+        {
+            /// <summary>
+            /// Set the composition string as the result string.
+            /// </summary>
+            CPS_COMPLETE = 0x0001,
+
+            /// <summary>
+            /// Convert the composition string.
+            /// </summary>
+            CPS_CONVERT = 0x0002,
+
+            /// <summary>
+            /// Cancel the current composition string and set the composition string to be the unconverted string.
+            /// </summary>
+            CPS_REVERT = 0x0003,
+
+            /// <summary>
+            /// Clear the composition string and set the status to no composition string.
+            /// </summary>
+            CPS_CANCEL = 0x0004,
+        }
+
+        // ReSharper restore IdentifierTypo
+
+        internal class InputContext : IDisposable
+        {
+            [DllImport("imm32.dll", SetLastError = true)]
+            private static extern IntPtr ImmGetContext(IntPtr hWnd);
+
+            [DllImport("imm32.dll", SetLastError = true)]
+            [return: MarshalAs(UnmanagedType.Bool)]
+            private static extern bool ImmReleaseContext(IntPtr hWnd, IntPtr hImc);
+
+            private bool disposed;
+
+            private readonly IntPtr hWnd;
+
+            public IntPtr Handle { get; private set; }
+
+            public InputContext(IntPtr hWnd)
+            {
+                this.hWnd = hWnd;
+                Handle = ImmGetContext(hWnd);
+            }
+
+            ~InputContext()
+            {
+                Dispose(false);
+            }
+
+            protected virtual void Dispose(bool disposing)
+            {
+                if (disposed)
+                    return;
+
+                if (Handle != IntPtr.Zero)
+                {
+                    ImmReleaseContext(hWnd, Handle);
+                    Handle = IntPtr.Zero;
+                }
+
+                disposed = true;
+            }
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+        }
+    }
+}

--- a/osu.Framework/Platform/Windows/Native/Imm.cs
+++ b/osu.Framework/Platform/Windows/Native/Imm.cs
@@ -1,5 +1,5 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence resultText.
+// See the LICENCE file in the repository root for full licence text.
 
 using System;
 using System.Runtime.InteropServices;

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -73,6 +73,12 @@ namespace osu.Framework.Platform.Windows
                 return;
             }
 
+            // also block if there is an ongoing composition (unlikely to occur).
+            if (!string.IsNullOrEmpty(lastComposition))
+            {
+                return;
+            }
+
             ScheduleEvent(() => TriggerTextInput(text));
         }
 

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -98,7 +98,7 @@ namespace osu.Framework.Platform.Windows
             switch (uMsg)
             {
                 case Imm.WM_IME_STARTCOMPOSITION:
-                    imeCompositionActive = false;
+                    imeCompositionActive = true;
                     ScheduleEvent(() => TriggerTextEditing(string.Empty, 0, 0));
                     break;
 

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -45,6 +45,8 @@ namespace osu.Framework.Platform.Windows
             OnSDLEvent += handleSDLEvent;
         }
 
+        #region IME handling
+
         private void handleSDLEvent(SDL.SDL_Event e)
         {
             if (e.type != SDL.SDL_EventType.SDL_SYSWMEVENT) return;
@@ -128,6 +130,8 @@ namespace osu.Framework.Platform.Windows
                     break;
             }
         }
+
+        #endregion
 
         protected override Size SetBorderless()
         {

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -94,9 +94,9 @@ namespace osu.Framework.Platform.Windows
                     break;
 
                 case Imm.WM_IME_COMPOSITION:
-                    using (var inputContext = new Imm.InputContext(hWnd))
+                    using (var inputContext = new Imm.InputContext(hWnd, lParam))
                     {
-                        if (Imm.TryGetImeResult(inputContext, lParam, out string resultText))
+                        if (inputContext.TryGetImeResult(out string resultText))
                         {
                             if (string.IsNullOrEmpty(resultText) && !string.IsNullOrEmpty(lastComposition))
                             {
@@ -114,7 +114,7 @@ namespace osu.Framework.Platform.Windows
                             ScheduleEvent(() => TriggerTextInput(resultText));
                         }
 
-                        if (Imm.TryGetImeComposition(inputContext, lParam, out string compositionText, out int start, out int length))
+                        if (inputContext.TryGetImeComposition(out string compositionText, out int start, out int length))
                         {
                             lastComposition = compositionText;
                             ScheduleEvent(() => TriggerTextEditing(compositionText, start, length));

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -47,7 +47,7 @@ namespace osu.Framework.Platform.Windows
 
         protected override void HandleSysWMEvent(SDL.SDL_SysWMEvent sysWM)
         {
-            var wmMsg = Marshal.PtrToStructure<SDL2Extensions.SDL_SysWMmsg>(sysWM.msg);
+            var wmMsg = Marshal.PtrToStructure<SDL2Structs.SDL_SysWMmsg>(sysWM.msg);
             var m = wmMsg.msg.win;
 
             switch (m.msg)

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -42,22 +42,24 @@ namespace osu.Framework.Platform.Windows
             // enable window message events to use with `OnSDLEvent` below.
             SDL.SDL_EventState(SDL.SDL_EventType.SDL_SYSWMEVENT, SDL.SDL_ENABLE);
 
-            OnSDLEvent += e =>
+            OnSDLEvent += handleSDLEvent;
+        }
+
+        private void handleSDLEvent(SDL.SDL_Event e)
+        {
+            if (e.type != SDL.SDL_EventType.SDL_SYSWMEVENT) return;
+
+            var wmMsg = Marshal.PtrToStructure<SDL2Structs.SDL_SysWMmsg>(e.syswm.msg);
+            var m = wmMsg.msg.win;
+
+            switch (m.msg)
             {
-                if (e.type != SDL.SDL_EventType.SDL_SYSWMEVENT) return;
-
-                var wmMsg = Marshal.PtrToStructure<SDL2Structs.SDL_SysWMmsg>(e.syswm.msg);
-                var m = wmMsg.msg.win;
-
-                switch (m.msg)
-                {
-                    case Imm.WM_IME_STARTCOMPOSITION:
-                    case Imm.WM_IME_COMPOSITION:
-                    case Imm.WM_IME_ENDCOMPOSITION:
-                        handleImeMessage(m.hwnd, m.msg, m.lParam);
-                        break;
-                }
-            };
+                case Imm.WM_IME_STARTCOMPOSITION:
+                case Imm.WM_IME_COMPOSITION:
+                case Imm.WM_IME_ENDCOMPOSITION:
+                    handleImeMessage(m.hwnd, m.msg, m.lParam);
+                    break;
+            }
         }
 
         public override void ResetIme() => ScheduleCommand(() => Imm.CancelComposition(WindowHandle));

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -85,6 +85,7 @@ namespace osu.Framework.Platform.Windows
         /// <summary>
         /// Whether IME composition is active.
         /// </summary>
+        /// <remarks>Used for blocking SDL IME results since we handle those ourselves.</remarks>
         private bool imeCompositionActive;
 
         /// <summary>
@@ -107,14 +108,12 @@ namespace osu.Framework.Platform.Windows
                     {
                         if (inputContext.TryGetImeResult(out string resultText))
                         {
-                            imeCompositionActive = false;
                             recentImeResult = true;
                             ScheduleEvent(() => TriggerTextInput(resultText));
                         }
 
                         if (inputContext.TryGetImeComposition(out string compositionText, out int start, out int length))
                         {
-                            imeCompositionActive = true;
                             ScheduleEvent(() => TriggerTextEditing(compositionText, start, length));
                         }
                     }

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -100,7 +100,7 @@ namespace osu.Framework.Platform.Windows
                         {
                             if (string.IsNullOrEmpty(resultText) && !string.IsNullOrEmpty(lastComposition))
                             {
-                                // These events are somewhat delayed as they go trough SDL's event queue,
+                                // These events are somewhat delayed as they go through SDL's event queue,
                                 // so it's possible that the internal IME state has changed by the time we get the event,
                                 // especially so if a ongoing composition is finished and a new one is started with a single keystroke.
                                 // In case the internal IME state has changed and we get empty result text,

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -60,11 +60,8 @@ namespace osu.Framework.Platform.Windows
             }
         }
 
-        protected override unsafe void HandleTextInputEvent(SDL.SDL_TextInputEvent evtText)
+        protected override void HandleTextInputEvent(SDL.SDL_TextInputEvent evtText)
         {
-            if (!SDL2Extensions.TryGetStringFromBytePointer(evtText.text, out string text))
-                return;
-
             // block SDL text input if there was a recent result from `handleImeMessage()`.
             if (recentImeResult)
             {
@@ -78,7 +75,7 @@ namespace osu.Framework.Platform.Windows
                 return;
             }
 
-            ScheduleEvent(() => TriggerTextInput(text));
+            base.HandleTextInputEvent(evtText);
         }
 
         protected override void HandleTextEditingEvent(SDL.SDL_TextEditingEvent evtEdit)


### PR DESCRIPTION
SDL2 text input shows some problems, mainly the 10 character limit and selection not working properly.
Existing issues on SDL's side: https://github.com/libsdl-org/SDL/issues/1879 and https://github.com/libsdl-org/SDL/issues/3385.

So I decided to write my own implementation for Windows IME handling. This is completely transparent to `TextBox` and even to `SDL2DesktopWindowTextInput`. The composition text is no longer arbitrarily limited, and selection works as expected.

It's unfortunate that we can't use `SDL_SetWindowsMessageHook` as we do in [`WindowsMouseHandler`](https://github.com/ppy/osu-framework/blob/6a2250ee584f1e38601b5cdb4b7397d27f730304/osu.Framework/Platform/Windows/WindowsMouseHandler.cs#L40) (reasoning: eb44a5c44aa43a383ef671c8b82759c14a92900e). Seems a bit strange that this was the case, but the alternative way of receiving window messages works just fine (albeit with a [minor issue](https://github.com/ppy/osu-framework/blob/06d5682369514dd5522558157b93d72bae0e312e/osu.Framework/Platform/Windows/WindowsWindow.cs#L103-L107)).

Some native IMM/IME code adapted from [chromium](https://github.com/chromium/chromium/blob/master/ui/base/ime/win/imm32_manager.cc).

---

With this in, we're one step closer to providing an in-game candidate window for composition. I've already got the native part working, but adding a candidate window in-game is a bit daunting to me.