### PR TITLE
Add option to disallow IME to `TextBox`

### DIFF
--- a/osu.Framework.Android/Input/AndroidTextInput.cs
+++ b/osu.Framework.Android/Input/AndroidTextInput.cs
@@ -34,7 +34,7 @@ namespace osu.Framework.Android.Input
                 AddPendingText(((char)e.UnicodeChar).ToString());
         }
 
-        protected override void ActivateTextInput()
+        protected override void ActivateTextInput(bool allowIme)
         {
             view.KeyDown += keyDown;
             view.CommitText += commitText;
@@ -46,7 +46,7 @@ namespace osu.Framework.Android.Input
             });
         }
 
-        protected override void EnsureTextInputActivated()
+        protected override void EnsureTextInputActivated(bool allowIme)
         {
             activity.RunOnUiThread(() =>
             {

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneTextBox.cs
@@ -809,6 +809,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         private class NumberTextBox : BasicTextBox
         {
             protected override bool CanAddCharacter(char character) => character.IsAsciiDigit();
+
+            protected override bool AllowIme => false;
         }
 
         private class CustomTextBox : BasicTextBox

--- a/osu.Framework.iOS/Input/IOSTextInput.cs
+++ b/osu.Framework.iOS/Input/IOSTextInput.cs
@@ -21,13 +21,13 @@ namespace osu.Framework.iOS.Input
                 AddPendingText(text);
         }
 
-        protected override void ActivateTextInput()
+        protected override void ActivateTextInput(bool allowIme)
         {
             view.KeyboardTextField.HandleShouldChangeCharacters += handleShouldChangeCharacters;
             view.KeyboardTextField.UpdateFirstResponder(true);
         }
 
-        protected override void EnsureTextInputActivated()
+        protected override void EnsureTextInputActivated(bool allowIme)
         {
             // If the user has manually closed the keyboard, it will not be shown until another TextBox is focused.
             // Calling `view.KeyboardTextField.UpdateFirstResponder` over and over again won't work, due to how

--- a/osu.Framework/Graphics/UserInterface/BasicPasswordTextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/BasicPasswordTextBox.cs
@@ -13,6 +13,8 @@ namespace osu.Framework.Graphics.UserInterface
 
         protected override bool AllowWordNavigation => false;
 
+        protected override bool AllowIme => false;
+
         protected override Drawable AddCharacterToFlow(char c) => base.AddCharacterToFlow(MaskCharacter);
     }
 }

--- a/osu.Framework/Graphics/UserInterface/TextBox.cs
+++ b/osu.Framework/Graphics/UserInterface/TextBox.cs
@@ -64,6 +64,18 @@ namespace osu.Framework.Graphics.UserInterface
         public virtual bool HandleLeftRightArrows => true;
 
         /// <summary>
+        /// Whether to allow IME input when this text box has input focus.
+        /// </summary>
+        /// <remarks>
+        /// This is just a hint to the native implementation, some might respect this,
+        /// while others will ignore and always have the IME (dis)allowed.
+        /// </remarks>
+        /// <example>
+        /// Useful for situations where IME input is not wanted, such as for passwords, numbers, or romanised text.
+        /// </example>
+        protected virtual bool AllowIme => true;
+
+        /// <summary>
         /// Check if a character can be added to this TextBox.
         /// </summary>
         /// <param name="character">The pending character.</param>
@@ -1200,7 +1212,7 @@ namespace osu.Framework.Graphics.UserInterface
         protected override bool OnClick(ClickEvent e)
         {
             if (!ReadOnly && inputBound)
-                textInput.EnsureActivated();
+                textInput.EnsureActivated(AllowIme);
 
             return !ReadOnly;
         }
@@ -1225,11 +1237,11 @@ namespace osu.Framework.Graphics.UserInterface
         {
             if (inputBound)
             {
-                textInput.EnsureActivated();
+                textInput.EnsureActivated(AllowIme);
                 return;
             }
 
-            textInput.Activate();
+            textInput.Activate(AllowIme);
             textInput.OnImeComposition += handleImeComposition;
             textInput.OnImeResult += handleImeResult;
 

--- a/osu.Framework/Input/SDL2DesktopWindowTextInput.cs
+++ b/osu.Framework/Input/SDL2DesktopWindowTextInput.cs
@@ -37,16 +37,16 @@ namespace osu.Framework.Input
             TriggerImeComposition(text, selectionStart, selectionLength);
         }
 
-        protected override void ActivateTextInput()
+        protected override void ActivateTextInput(bool allowIme)
         {
             window.TextInput += handleTextInput;
             window.TextEditing += handleTextEditing;
-            window.StartTextInput();
+            window.StartTextInput(allowIme);
         }
 
-        protected override void EnsureTextInputActivated()
+        protected override void EnsureTextInputActivated(bool allowIme)
         {
-            window.StartTextInput();
+            window.StartTextInput(allowIme);
         }
 
         protected override void DeactivateTextInput()

--- a/osu.Framework/Input/TextInputSource.cs
+++ b/osu.Framework/Input/TextInputSource.cs
@@ -47,23 +47,28 @@ namespace osu.Framework.Input
         /// Activates this <see cref="TextInputSource"/>.
         /// User text input can be acquired through <see cref="GetPendingText"/>, <see cref="OnImeComposition"/> and <see cref="OnImeResult"/>.
         /// </summary>
+        /// <param name="allowIme">Whether input using IME should be allowed.</param>
         /// <remarks>
         /// Each <see cref="Activate"/> must be followed by a <see cref="Deactivate"/>.
         /// </remarks>
-        public void Activate()
+        public void Activate(bool allowIme)
         {
             if (Interlocked.Increment(ref activationCounter) == 1)
-                ActivateTextInput();
+                ActivateTextInput(allowIme);
+            else
+                // the latest consumer that activated should always take precedence in (dis)allowing IME.
+                EnsureActivated(allowIme);
         }
 
         /// <summary>
         /// Ensures that the native implementation that retrieves user text input is activated
         /// and that the user can start entering text.
         /// </summary>
-        public void EnsureActivated()
+        /// <param name="allowIme">Whether input using IME should be allowed.</param>
+        public void EnsureActivated(bool allowIme)
         {
             if (activationCounter >= 1)
-                EnsureTextInputActivated();
+                EnsureTextInputActivated(allowIme);
         }
 
         /// <summary>
@@ -133,11 +138,12 @@ namespace osu.Framework.Input
         /// Activates the native implementation that provides text input.
         /// Should be overriden per-platform.
         /// </summary>
+        /// <param name="allowIme">Whether input using IME should be allowed.</param>
         /// <remarks>
         /// An active native implementation should add user input text with <see cref="AddPendingText"/>.
         /// and forward IME composition events through <see cref="TriggerImeComposition"/> and <see cref="TriggerImeResult"/>.
         /// </remarks>
-        protected virtual void ActivateTextInput()
+        protected virtual void ActivateTextInput(bool allowIme)
         {
         }
 
@@ -146,7 +152,7 @@ namespace osu.Framework.Input
         /// <remarks>
         /// Only called if the native implementation has been activated with <see cref="Activate"/>.
         /// </remarks>
-        protected virtual void EnsureTextInputActivated()
+        protected virtual void EnsureTextInputActivated(bool allowIme)
         {
         }
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -576,7 +576,7 @@ namespace osu.Framework.Platform
             ScheduleEvent(() => MouseMove?.Invoke(new Vector2(rx * Scale, ry * Scale)));
         }
 
-        public void StartTextInput() => ScheduleCommand(SDL.SDL_StartTextInput);
+        public virtual void StartTextInput(bool allowIme) => ScheduleCommand(SDL.SDL_StartTextInput);
 
         public void StopTextInput() => ScheduleCommand(SDL.SDL_StopTextInput);
 

--- a/osu.Framework/Platform/Windows/Native/Imm.cs
+++ b/osu.Framework/Platform/Windows/Native/Imm.cs
@@ -67,6 +67,18 @@ namespace osu.Framework.Platform.Windows.Native
         }
 
         /// <summary>
+        /// Sets whether IME is allowed.
+        /// </summary>
+        /// <remarks>
+        /// If IME is disallowed, text input is active and a language that uses IME is selected,
+        /// then IME will be forced into alphanumeric mode, behaving as normal keyboard input (no compositing will happen).
+        /// </remarks>
+        internal static void SetImeAllowed(IntPtr hWnd, bool allowed)
+        {
+            ImmAssociateContextEx(hWnd, IntPtr.Zero, allowed ? AssociationFlags.IACE_DEFAULT : AssociationFlags.IACE_IGNORENOCONTEXT);
+        }
+
+        /// <summary>
         /// Returns true if <paramref name="lParam"/> has the specified <paramref name="flag"/>.
         /// </summary>
         private static bool hasFlag(this long lParam, CompositionString flag) => (lParam & (long)flag) != 0;
@@ -184,6 +196,10 @@ namespace osu.Framework.Platform.Windows.Native
         [DllImport("imm32.dll", CharSet = CharSet.Unicode)]
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool ImmNotifyIME(IntPtr hImc, NotificationCode dwAction, uint dwIndex, uint dwValue);
+
+        [DllImport("imm32.dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool ImmAssociateContextEx(IntPtr hWnd, IntPtr hImc, AssociationFlags dwFlags);
 
         // ReSharper disable IdentifierTypo
 
@@ -390,6 +406,28 @@ namespace osu.Framework.Platform.Windows.Native
             /// Clear the composition string and set the status to no composition string.
             /// </summary>
             CPS_CANCEL = 0x0004,
+        }
+
+        /// <summary>
+        /// Flags specifying the type of association between the window and the input method context.
+        /// dwFlags for <see cref="ImmAssociateContextEx"/>.
+        /// </summary>
+        private enum AssociationFlags : uint
+        {
+            /// <summary>
+            /// Associate the input method context to the child windows of the specified window only.
+            /// </summary>
+            IACE_CHILDREN = 0x0001,
+
+            /// <summary>
+            /// Restore the default input method context of the window.
+            /// </summary>
+            IACE_DEFAULT = 0x0010,
+
+            /// <summary>
+            /// Do not associate the input method context with windows that are not associated with any input method context.
+            /// </summary>
+            IACE_IGNORENOCONTEXT = 0x0020,
         }
 
         // ReSharper restore IdentifierTypo

--- a/osu.Framework/Platform/Windows/Native/Imm.cs
+++ b/osu.Framework/Platform/Windows/Native/Imm.cs
@@ -1,5 +1,5 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
-// See the LICENCE file in the repository root for full licence resultText.
+// See the LICENCE file in the repository root for full licence text.
 
 using System;
 using System.Runtime.InteropServices;

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -43,6 +43,12 @@ namespace osu.Framework.Platform.Windows
             SDL.SDL_EventState(SDL.SDL_EventType.SDL_SYSWMEVENT, SDL.SDL_ENABLE);
         }
 
+        public override void StartTextInput(bool allowIme)
+        {
+            base.StartTextInput(allowIme);
+            ScheduleCommand(() => Imm.SetImeAllowed(WindowHandle, allowIme));
+        }
+
         public override void ResetIme() => ScheduleCommand(() => Imm.CancelComposition(WindowHandle));
 
         protected override void HandleSysWMEvent(SDL.SDL_SysWMEvent sysWM)


### PR DESCRIPTION
- [x] Depends on #4941

Adds a new option `AllowIme` to `TextBox` that can be used to disallow/disable the IME when that text box has focus. (Currently, the IME will always be active/allowed.)
This is useful for situations where IME input is not wanted, such as for passwords, numbers, romanised text, etc.

Currently only works on windows.