### PR TITLE
Stop virtual tracks on disposal

### DIFF
--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -65,6 +65,30 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
+        public void TestStopWhenDisposed()
+        {
+            track.StartAsync();
+            bass.Update();
+
+            Thread.Sleep(50);
+            bass.Update();
+
+            Assert.IsTrue(track.IsAlive);
+            Assert.IsTrue(track.IsRunning);
+
+            track.Dispose();
+            bass.Update();
+
+            Assert.IsFalse(track.IsAlive);
+            Assert.IsFalse(track.IsRunning);
+
+            double expectedTime = track.CurrentTime;
+            Thread.Sleep(50);
+
+            Assert.AreEqual(expectedTime, track.CurrentTime);
+        }
+
+        [Test]
         public void TestStopAtEnd()
         {
             startPlaybackAt(track.Length - 1);

--- a/osu.Framework.Tests/Audio/TrackVirtualTest.cs
+++ b/osu.Framework.Tests/Audio/TrackVirtualTest.cs
@@ -85,6 +85,29 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
+        public void TestStopWhenDisposed()
+        {
+            startPlaybackAt(0);
+
+            Thread.Sleep(50);
+            updateTrack();
+
+            Assert.IsTrue(track.IsAlive);
+            Assert.IsTrue(track.IsRunning);
+
+            track.Dispose();
+            updateTrack();
+
+            Assert.IsFalse(track.IsAlive);
+            Assert.IsFalse(track.IsRunning);
+
+            double expectedTime = track.CurrentTime;
+            Thread.Sleep(50);
+
+            Assert.AreEqual(expectedTime, track.CurrentTime);
+        }
+
+        [Test]
         public void TestSeek()
         {
             track.Seek(1000);

--- a/osu.Framework/Audio/Track/TrackVirtual.cs
+++ b/osu.Framework/Audio/Track/TrackVirtual.cs
@@ -95,5 +95,13 @@ namespace osu.Framework.Audio.Track
             lock (clock)
                 clock.Rate = Rate;
         }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!IsDisposed)
+                Stop();
+
+            base.Dispose(disposing);
+        }
     }
 }


### PR DESCRIPTION
After trying and failing to write a game-side test for a scenario involving track disposals, I've discovered that `TrackBass` and `TrackVirtual` do not behave the same wrt disposal. The former would stop the track (as in `Clock.CurrentTime` would not increase), and the latter would let the inner stopwatch continue, and therefore you could have a virtual track which is both disposed and elapsing.

This PR changes the behaviour of `TrackVirtual` to stop the track on disposal.

While disposal is a bit of a grey / undefined area in these sorts of cases, I feel like stopping the track in such a case is not unreasonable and unifies expectations across different `Track` implementations. Samples [already behave in a similar manner](https://github.com/ppy/osu-framework/blob/7d8e6d048d75cf0fb60e14d9c62f4d1ae8e2def9/osu.Framework/Audio/Sample/SampleChannel.cs#L63-L64).