### PR TITLE
Add more detailed `ScreenStack` logging

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2694,7 +2694,7 @@ namespace osu.Framework.Graphics
             string shortClass = GetType().ReadableName();
 
             if (!string.IsNullOrEmpty(Name))
-                return $@"{Name} ({shortClass})";
+                return $@"{Name}({shortClass})";
             else
                 return shortClass;
         }

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -334,7 +334,7 @@ namespace osu.Framework.Screens
             if (o == null)
                 return "[empty]";
 
-            return $"{o.GetType().Name}#{o.GetHashCode().ToString("000").Substring(0, 3)}";
+            return $"{o}#{o.GetHashCode().ToString("000").Substring(0, 3)}";
         }
 
         /// <summary>

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -122,7 +122,7 @@ namespace osu.Framework.Screens
                 else
                 {
                     log($"scheduling push {getTypeString(newScreen)}");
-                    Scheduler.Add(() => finishPush(null, newScreen));
+                    Schedule(() => finishPush(null, newScreen));
                 }
             }
             else
@@ -202,7 +202,7 @@ namespace osu.Framework.Screens
                 else
                 {
                     log($"scheduling load {getTypeString(toLoad)}");
-                    Scheduler.Add(() => LoadScreen(loader, toLoad, continuation));
+                    Schedule(() => LoadScreen(loader, toLoad, continuation));
                 }
             }
         }

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -120,7 +120,10 @@ namespace osu.Framework.Screens
                 if (LoadState >= LoadState.Ready)
                     LoadScreen(this, newScreenDrawable, () => finishPush(null, newScreen));
                 else
-                    Schedule(() => finishPush(null, newScreen));
+                {
+                    log($"scheduling push {getTypeString(newScreen)}");
+                    Scheduler.Add(() => finishPush(null, newScreen));
+                }
             }
             else
                 LoadScreen((CompositeDrawable)source, newScreenDrawable, () => finishPush(source, newScreen));
@@ -197,7 +200,10 @@ namespace osu.Framework.Screens
                     loader.LoadComponentAsync(toLoad, _ => continuation?.Invoke(), scheduler: Scheduler);
                 }
                 else
-                    Schedule(() => LoadScreen(loader, toLoad, continuation));
+                {
+                    log($"scheduling load {getTypeString(toLoad)}");
+                    Scheduler.Add(() => LoadScreen(loader, toLoad, continuation));
+                }
             }
         }
 

--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -109,7 +109,6 @@ namespace osu.Framework.Screens
                 suspend(source, newScreen);
 
             stack.Push(newScreen);
-            logTransition(source, newScreen, false);
             ScreenPushed?.Invoke(source, newScreen);
 
             // this needs to be queued here before the load is begun so it preceed any potential OnSuspending event (also attached to OnLoadComplete).
@@ -146,6 +145,7 @@ namespace osu.Framework.Screens
                 suspend(parent, child);
 
             AddInternal(child.AsDrawable());
+            log($"entered {getTypeString(child)}");
         }
 
         /// <summary>
@@ -155,7 +155,7 @@ namespace osu.Framework.Screens
         /// <param name="to">The screen being entered.</param>
         private void suspend(IScreen from, IScreen to)
         {
-            var sourceDrawable = from?.AsDrawable();
+            var sourceDrawable = from.AsDrawable();
             if (sourceDrawable == null)
                 return;
 
@@ -169,6 +169,7 @@ namespace osu.Framework.Screens
 
             void performSuspend()
             {
+                log($"suspended {getTypeString(from)} (waiting on {getTypeString(to)})");
                 from.OnSuspending(to);
                 sourceDrawable.Expire();
             }
@@ -191,7 +192,10 @@ namespace osu.Framework.Screens
             else
             {
                 if (loader.LoadState >= LoadState.Ready)
+                {
+                    log($"loading {getTypeString(toLoad)}");
                     loader.LoadComponentAsync(toLoad, _ => continuation?.Invoke(), scheduler: Scheduler);
+                }
                 else
                     Schedule(() => LoadScreen(loader, toLoad, continuation));
             }
@@ -305,7 +309,9 @@ namespace osu.Framework.Screens
 
             exited.Add(toExit.AsDrawable());
 
-            logTransition(toExit, CurrentScreen, true);
+            log($"exit from {getTypeString(toExit)}");
+            log($"resume to {getTypeString(CurrentScreen)}");
+
             ScreenExited?.Invoke(toExit, CurrentScreen);
 
             // Resume the next current screen from the exited one
@@ -315,8 +321,15 @@ namespace osu.Framework.Screens
             return false;
         }
 
-        private void logTransition(IScreen screen1, IScreen screen2, bool wasExit) =>
-            Logger.Log($"📺 {GetType().Name} transition ({screen1?.GetType().Name ?? "none"} {(wasExit ? "«" : "»")} {screen2?.GetType().Name ?? "none"})");
+        private void log(string message) => Logger.Log($"📺 {getTypeString(this)}(depth:{stack.Count}) {message}");
+
+        private static string getTypeString(object o)
+        {
+            if (o == null)
+                return "[empty]";
+
+            return $"{o.GetType().Name}#{o.GetHashCode().ToString("000").Substring(0, 3)}";
+        }
 
         /// <summary>
         /// Unbind and return leases for all <see cref="Bindable{T}"/>s managed by the exiting screen.


### PR DESCRIPTION
There may be a problem somewhere within its logic, so I've added some more verbose logging so we can maybe track it down. May remove the "scheduled load" logs after we resolve any issues, as those aren't really helpful to the user (should just be part of the "push" logging under one name).

This also splits out the transition events into two lines, describing the individual operations. This makes more sense because in the case of a `Push` operation, the point at which the new screen is pushed versus when the previous screen is separated could be separated by a longer duration, due to load times.

- [x] Depends on #4944 kind of.

Example output:

```csharp
[runtime] 2021-12-20 06:42:14 [verbose]: Opened realm "/var/folders/qt/mf5nyxrn07s0_mwpb_t8bl5h0000gn/T/of-test-headless/TestSceneHostOnlyQueueMode-b481a6a0-ae7d-438e-9111-ef907459e395/client.realm" at version 12
[performance] 2021-12-20 06:42:15 [verbose]: TextureAtlas initialised (1024x1024)
[runtime] 2021-12-20 06:42:15 [verbose]: 💨 HostOnlyQueueMode (TestSceneHostOnlyQueueMode) running
[runtime] 2021-12-20 06:42:15 [verbose]: 🔸 Step #1 Until: exit all screens
[runtime] 2021-12-20 06:42:15 [verbose]: 🔸 Step #2 import beatmap
[database] 2021-12-20 06:42:15 [verbose]: [dce8f] Beginning import...
[database] 2021-12-20 06:42:15 [verbose]: [dce8f] Import successfully completed!
[runtime] 2021-12-20 06:42:15 [verbose]: 🔸 Step #3 load multiplayer
[runtime] 2021-12-20 06:42:15 [verbose]: 📺 OsuScreenStack#572(depth:1) scheduling push TestMultiplayer#374
[runtime] 2021-12-20 06:42:15 [verbose]: ScreenTestScene screen changed → TestMultiplayerScreenStack
[runtime] 2021-12-20 06:42:15 [verbose]: 📺 OsuScreenStack#521(depth:1) loading TestMultiplayerScreenStack#853
[runtime] 2021-12-20 06:42:15 [verbose]: 🔸 Step #4 Until: wait for multiplayer to load
[runtime] 2021-12-20 06:42:15 [verbose]: 📺 OsuScreenStack#521(depth:1) entered TestMultiplayerScreenStack#853
[runtime] 2021-12-20 06:42:15 [verbose]: 📺 OsuScreenStack#572(depth:1) entered TestMultiplayer#374
[runtime] 2021-12-20 06:42:15 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:1) loading MultiplayerLoungeSubScreen#357
[runtime] 2021-12-20 06:42:15 [verbose]: ✔️ 5 repetitions
[runtime] 2021-12-20 06:42:15 [verbose]: 🔸 Step #5 Until: wait for lounge to load
[runtime] 2021-12-20 06:42:16 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:1) entered MultiplayerLoungeSubScreen#357
[runtime] 2021-12-20 06:42:16 [verbose]: Polling adjusted (listing: 15000)
[runtime] 2021-12-20 06:42:16 [verbose]: 📺 BackgroundScreenStack#374(depth:1) loading LoungeBackgroundScreen#588
[runtime] 2021-12-20 06:42:16 [verbose]: Polling adjusted (listing: 15000)
[runtime] 2021-12-20 06:42:16 [debug]: Focus changed from nothing to SearchTextBox.
[performance] 2021-12-20 06:42:16 [verbose]: Texture requested (1366x768) which exceeds TextureStore's atlas size (1024x1024) - bypassing atlasing. Consider using LargeTextureStore.
[runtime] 2021-12-20 06:42:16 [verbose]: 📺 BackgroundScreenStack#374(depth:1) entered LoungeBackgroundScreen#588
[runtime] 2021-12-20 06:42:16 [verbose]: ✔️ 107 repetitions
[runtime] 2021-12-20 06:42:16 [verbose]: 🔸 Step #6 Until: wait for lounge
[runtime] 2021-12-20 06:42:16 [verbose]: 🔸 Step #7 open room
[runtime] 2021-12-20 06:42:16 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:1) suspended MultiplayerLoungeSubScreen#357 (waiting on MultiplayerMatchSubScreen#687)
[runtime] 2021-12-20 06:42:16 [verbose]: Polling adjusted (listing: 0)
[runtime] 2021-12-20 06:42:16 [debug]: Focus changed from SearchTextBox to nothing.
[runtime] 2021-12-20 06:42:16 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:2) loading MultiplayerMatchSubScreen#687
[runtime] 2021-12-20 06:42:16 [verbose]: 🔸 Step #8 Until: wait for room open
[runtime] 2021-12-20 06:42:16 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:2) entered MultiplayerMatchSubScreen#687
[runtime] 2021-12-20 06:42:16 [verbose]: 📺 BackgroundScreenStack#374(depth:2) loading RoomBackgroundScreen#226
[runtime] 2021-12-20 06:42:16 [verbose]: 📺 BackgroundScreenStack#374(depth:2) suspended LoungeBackgroundScreen#588 (waiting on RoomBackgroundScreen#226)
[runtime] 2021-12-20 06:42:16 [verbose]: 📺 BackgroundScreenStack#374(depth:2) entered RoomBackgroundScreen#226
[runtime] 2021-12-20 06:42:16 [debug]: Focus changed from nothing to MultiplayerMatchSettingsOverlay.
[runtime] 2021-12-20 06:42:16 [verbose]: ✔️ 194 repetitions
[runtime] 2021-12-20 06:42:16 [verbose]: 🔸 Step #9 Repeat: wait for transition 0/2
[runtime] 2021-12-20 06:42:16 [verbose]: ✔️ 2 repetitions
[runtime] 2021-12-20 06:42:16 [verbose]: 🔸 Step #10 create room
[runtime] 2021-12-20 06:42:16 [debug]: MouseDownEvent(Left) handled by MultiplayerMatchSettingsOverlay.
[runtime] 2021-12-20 06:42:16 [debug]: Focus changed from MultiplayerMatchSettingsOverlay to nothing.
[runtime] 2021-12-20 06:42:16 [debug]: ClickEvent(Left) handled by MultiplayerMatchSettingsOverlay+CreateOrUpdateButton.
[runtime] 2021-12-20 06:42:16 [debug]: MouseClick handled by MultiplayerMatchSettingsOverlay+CreateOrUpdateButton.
[runtime] 2021-12-20 06:42:16 [debug]: Focus changed from nothing to StandAloneChatDisplay+ChatTextBox.
[runtime] 2021-12-20 06:42:17 [verbose]: 🔸 Step #11 Until: wait for join
[runtime] 2021-12-20 06:42:17 [verbose]: 🔸 Step #12 click add button
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:2) suspended MultiplayerMatchSubScreen#687 (waiting on MultiplayerMatchSongSelect#244)
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:3) loading MultiplayerMatchSongSelect#244
[runtime] 2021-12-20 06:42:17 [debug]: ClickEvent(Left) handled by MultiplayerMatchSubScreen+AddItemButton.
[runtime] 2021-12-20 06:42:17 [debug]: Focus changed from StandAloneChatDisplay+ChatTextBox to nothing.
[runtime] 2021-12-20 06:42:17 [debug]: MouseClick handled by MultiplayerMatchSubScreen+AddItemButton.
[runtime] 2021-12-20 06:42:17 [verbose]: decoupled ruleset transferred ("" -> "osu!")
[runtime] 2021-12-20 06:42:17 [verbose]: 🔸 Step #13 Until: wait for song select
[performance] 2021-12-20 06:42:17 [verbose]: TextureAtlas size exceeded 1 time(s); generating new texture (1024x1024)
[network] 2021-12-20 06:42:17 [verbose]: Request to https://a.ppy.sh/1001 failed with System.Net.WebException: NotFound.
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:3) entered MultiplayerMatchSongSelect#244
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 BackgroundScreenStack#374(depth:3) loading BackgroundScreenBeatmap#668
[network] 2021-12-20 06:42:17 [verbose]: Request to https://a.ppy.sh/1001.png failed with System.Net.WebException: NotFound.
[runtime] 2021-12-20 06:42:17 [debug]: Focus changed from nothing to SeekLimitedSearchTextBox.
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 BackgroundScreenStack#374(depth:3) suspended RoomBackgroundScreen#226 (waiting on BackgroundScreenBeatmap#668)
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 BackgroundScreenStack#374(depth:3) entered BackgroundScreenBeatmap#668
[runtime] 2021-12-20 06:42:17 [verbose]: ✔️ 193 repetitions
[runtime] 2021-12-20 06:42:17 [verbose]: updating selection with beatmap:5 ruleset:0
[network] 2021-12-20 06:42:17 [verbose]: Failing request osu.Game.Online.API.Requests.GetBeatmapRequest (System.NotSupportedException: A APIAccess is required to perform requests.)
[network] 2021-12-20 06:42:17 [verbose]: Request to https://a.ppy.sh/1001.jpg failed with System.Net.WebException: NotFound.
[runtime] 2021-12-20 06:42:17 [verbose]: 🔸 Step #14 select other beatmap
[runtime] 2021-12-20 06:42:17 [verbose]: updating selection with beatmap:7 ruleset:0
[runtime] 2021-12-20 06:42:17 [verbose]: beatmap changed from "Soleily - RenatusQuick (Gamu) [Insane]" to "Soleily - RenatusQuick (Gamu) [Normal]"
[runtime] 2021-12-20 06:42:17 [verbose]: Song select working beatmap updated to Soleily - RenatusQuick (Gamu) [Normal]
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 BackgroundScreenStack#374(depth:2) exit from BackgroundScreenBeatmap#668
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 BackgroundScreenStack#374(depth:2) resume to RoomBackgroundScreen#226
[runtime] 2021-12-20 06:42:17 [debug]: Focus changed from SeekLimitedSearchTextBox to nothing.
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:2) exit from MultiplayerMatchSongSelect#244
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:2) resume to MultiplayerMatchSubScreen#687
[network] 2021-12-20 06:42:17 [verbose]: Failing request osu.Game.Online.API.Requests.GetBeatmapRequest (System.NotSupportedException: A APIAccess is required to perform requests.)
[runtime] 2021-12-20 06:42:17 [debug]: Focus changed from nothing to StandAloneChatDisplay+ChatTextBox.
[runtime] 2021-12-20 06:42:17 [verbose]: 🔸 Step #15 Until: wait for return to match
[runtime] 2021-12-20 06:42:17 [verbose]: 🔸 Step #16 Assert: playlist contains two items
[runtime] 2021-12-20 06:42:17 [verbose]: 🔸 Step #17 Until: exit all screens
[runtime] 2021-12-20 06:42:17 [verbose]: Focus contention triggered by DialogOverlay.
[runtime] 2021-12-20 06:42:17 [debug]: Focus changed from StandAloneChatDisplay+ChatTextBox to nothing.
[runtime] 2021-12-20 06:42:17 [debug]: Focus changed from nothing to DialogOverlay.
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 BackgroundScreenStack#374(depth:1) exit from RoomBackgroundScreen#226
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 BackgroundScreenStack#374(depth:1) resume to LoungeBackgroundScreen#588
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:1) exit from MultiplayerMatchSubScreen#687
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OnlinePlaySubScreenStack#523(depth:1) resume to MultiplayerLoungeSubScreen#357
[runtime] 2021-12-20 06:42:17 [verbose]: Polling adjusted (listing: 15000)
[runtime] 2021-12-20 06:42:17 [debug]: Focus changed from DialogOverlay to nothing.
[runtime] 2021-12-20 06:42:17 [debug]: Focus changed from nothing to SearchTextBox.
[runtime] 2021-12-20 06:42:17 [verbose]: Polling adjusted (listing: 0)
[runtime] 2021-12-20 06:42:17 [debug]: Focus changed from SearchTextBox to nothing.
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OsuScreenStack#572(depth:0) exit from TestMultiplayer#374
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OsuScreenStack#572(depth:0) resume to [empty]
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OsuScreenStack#521(depth:0) exit from TestMultiplayerScreenStack#853
[runtime] 2021-12-20 06:42:17 [verbose]: 📺 OsuScreenStack#521(depth:0) resume to [empty]
[runtime] 2021-12-20 06:42:17 [verbose]: ScreenTestScene screen changed ←
[runtime] 2021-12-20 06:42:17 [verbose]: ✔️ 5 repetitions
[runtime] 2021-12-20 06:42:17 [verbose]: ✅ TestSceneHostOnlyQueueMode completed


```