### PR TITLE
Add logging of `ScreenStack` push failures due to `ValidForPush` being `false`

### DIFF
--- a/osu.Framework/Screens/ScreenStack.cs
+++ b/osu.Framework/Screens/ScreenStack.cs
@@ -141,6 +141,7 @@ namespace osu.Framework.Screens
                 if (child == CurrentScreen)
                     exitFrom(null, shouldFireExitEvent: false, shouldFireResumeEvent: suspendImmediately);
 
+                log($"push of {getTypeString(child)} cancelled due to {nameof(child.ValidForPush)} becoming false");
                 return;
             }
 


### PR DESCRIPTION
Weren't being logged, to the point the last log entry could say "loading" followed by radio silence. Note that this would only be the case for the top level screen. In the case where it's not, the `exitFrom` would likely log.