### PR TITLE
Adjust Android lifecycle code in line with context preservation changes

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -73,13 +73,6 @@ namespace osu.Framework.Android
             };
         }
 
-        protected override void OnPause()
-        {
-            base.OnPause();
-            // Because Android is not playing nice with Background - we just kill it
-            Process.GetCurrentProcess().Kill();
-        }
-
         public override void OnBackPressed()
         {
             // Avoid the default implementation that does close the app.

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -73,6 +73,18 @@ namespace osu.Framework.Android
             };
         }
 
+        protected override void OnPause()
+        {
+            base.OnPause();
+            gameView.Host?.Suspend();
+        }
+
+        protected override void OnResume()
+        {
+            base.OnResume();
+            gameView.Host?.Resume();
+        }
+
         public override void OnBackPressed()
         {
             // Avoid the default implementation that does close the app.

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -6,6 +6,7 @@ using Android.Content;
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
+using ManagedBass;
 using Process = System.Diagnostics.Process;
 
 namespace osu.Framework.Android
@@ -77,12 +78,14 @@ namespace osu.Framework.Android
         {
             base.OnPause();
             gameView.Host?.Suspend();
+            Bass.Pause();
         }
 
         protected override void OnResume()
         {
             base.OnResume();
             gameView.Host?.Resume();
+            Bass.Start();
         }
 
         public override void OnBackPressed()

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -108,7 +108,8 @@ namespace osu.Framework.Android
         {
             base.OnLoad(e);
 
-            RenderGame();
+            if (Host == null)
+                RenderGame();
         }
 
         [STAThread]

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -108,6 +108,8 @@ namespace osu.Framework.Android
         {
             base.OnLoad(e);
 
+            // osuTK calls `OnLoad()` every time the application surface is created, which will also happen upon a resume,
+            // at which point the host is already present and running, so there is no reason to create another one.
             if (Host == null)
                 RenderGame();
         }

--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -23,7 +23,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.Android" Version="1.0.185" />
+    <PackageReference Include="ppy.osuTK.Android" Version="1.0.187" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\**\*.so" />

--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -61,7 +61,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.185" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.187" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -24,7 +24,7 @@
     <ProjectReference Include="..\osu.Framework\osu.Framework.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.185" />
+    <PackageReference Include="ppy.osuTK.iOS" Version="1.0.187" />
     <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
   </ItemGroup>
   <ItemGroup>

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="ManagedBass.Mix" Version="3.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2021.3.0" />
-    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.185" />
+    <PackageReference Include="ppy.osuTK.NS20" Version="1.0.187" />
     <PackageReference Include="StbiSharp" Version="1.0.13" />
     <PackageReference Include="ppy.SDL2-CS" Version="1.0.486-alpha" />
 


### PR DESCRIPTION
- [x] Depends on https://github.com/ppy/osuTK/pull/74

* Removes the "kill on pause" behaviour which was in place due to the context loss.
* Ensures that the game host is not created multiple times on resuming game.
* Suspends all threads on activity pause and resumes them again on activity resume.
* Additionally I've had to manually pause/start all audio output on pause/resume via BASS as unfortunately pausing the audio thread itself did not appear to be sufficient (the audio would continue playing even after the app was paused/backgrounded). Not sure how this isn't an issue on iOS.

Tested on two Android devices that I own:

* Samsung Galaxy J7 2016 / SM-J710F (Android 7),
* OnePlus 8T / KB2003 (Android 11)