### PR TITLE
Add setting to apply fix for Android keyboard not working for some users

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -30,6 +30,11 @@ namespace osu.Framework.Android
             this.gameView = gameView;
         }
 
+        /// <summary>
+        /// Allows <see cref="AndroidGameView"/> to access the config.
+        /// </summary>
+        internal new FrameworkConfigManager Config => base.Config;
+
         protected override void SetupConfig(IDictionary<FrameworkSetting, object> defaultOverrides)
         {
             if (!defaultOverrides.ContainsKey(FrameworkSetting.ExecutionMode))

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -9,6 +9,8 @@ using Android.Util;
 using Android.Views;
 using Android.Views.InputMethods;
 using osu.Framework.Android.Input;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
 using osuTK.Graphics;
 
 namespace osu.Framework.Android
@@ -18,6 +20,8 @@ namespace osu.Framework.Android
         public AndroidGameHost Host { get; private set; }
 
         private readonly Game game;
+
+        private readonly Bindable<bool> keyboardFix = new Bindable<bool>();
 
         public new event Action<Keycode, KeyEvent> KeyDown;
         public new event Action<Keycode, KeyEvent> KeyUp;
@@ -117,6 +121,7 @@ namespace osu.Framework.Android
             Host = new AndroidGameHost(this);
             Host.ExceptionThrown += handleException;
             Host.Run(game);
+            Host.Config.BindWith(FrameworkSetting.AndroidKeyboardFix, keyboardFix);
             HostStarted?.Invoke(Host);
         }
 
@@ -134,8 +139,14 @@ namespace osu.Framework.Android
 
         public override IInputConnection OnCreateInputConnection(EditorInfo outAttrs)
         {
-            outAttrs.ImeOptions = ImeFlags.NoExtractUi;
-            outAttrs.InputType = InputTypes.Null;
+            outAttrs.ImeOptions = ImeFlags.NoExtractUi | ImeFlags.NoFullscreen;
+
+            // Use alternative InputType if setting is enabled. This alternative should fix https://github.com/ppy/osu/issues/8264.
+            // https://github.com/termux/termux-app/blob/af16e79bf8e422811885f435c3aaf74d619dd7e6/terminal-view/src/main/java/com/termux/view/TerminalView.java#L265-L283
+            outAttrs.InputType = keyboardFix.Value
+                ? InputTypes.TextVariationVisiblePassword | InputTypes.TextFlagNoSuggestions
+                : InputTypes.Null;
+
             return new AndroidInputConnection(this, true);
         }
     }

--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -39,6 +39,7 @@ namespace osu.Framework.Configuration
             SetDefault(FrameworkSetting.WindowMode, WindowMode.Windowed);
             SetDefault(FrameworkSetting.ShowUnicode, false);
             SetDefault(FrameworkSetting.Locale, string.Empty);
+            SetDefault(FrameworkSetting.AndroidKeyboardFix, false);
 
 #pragma warning disable 618
             SetDefault(FrameworkSetting.MapAbsoluteInputToWindow, false);
@@ -95,6 +96,8 @@ namespace osu.Framework.Configuration
 
         ShowUnicode,
         Locale,
+
+        AndroidKeyboardFix,
 
         [Obsolete("Input-related settings are now stored in InputConfigManager. Adjustments should be made via Host.AvailableInputHandlers bindables directly.")] // can be removed 20210911
         IgnoredInputHandlers,


### PR DESCRIPTION
Decided the to go with a new setting instead of a bindable in `AndroidKeyboardHandler` because of https://github.com/ppy/osu-framework/issues/4950.

Should hopefully resolve https://github.com/ppy/osu/issues/8264.

I can't confirm that this will fix it. None of my tested phones exhibited the above issue.
On a device that doesn't have this issue, enabling the setting doesn't break input.

We're seeing the same keyboard problems as those mentioned in the comments [here (https://github.com/termux)](https://github.com/termux/termux-app/blob/af16e79bf8e422811885f435c3aaf74d619dd7e6/terminal-view/src/main/java/com/termux/view/TerminalView.java#L265-L283).
I've applied the same fix that is used there.

Snippet from https://wiki.termux.com/wiki/Terminal_Settings#Workaround_for_some_keyboards_issues:

> **Workaround for some keyboards issues**
> 
> Some keyboards, e.g. a default one on Samsung devices, have issues with text input: text appearing only after pressing "enter", wrong keyboard layout being opened, etc. They are not compatible with the Termux input method because enforcing a **word-based input.**
> 
> As workaround, you can set the following option: 
> 
> [...]

Word-based input is exactly what we're seeing the the video of the issue. Keyboards forcing suggestions and word input.

I'm optimistic about this fix, but we can't know until it reaches end-users.