### PR TITLE
Add `CancellationToken` support to `IResourceStore.GetAsync`

### DIFF
--- a/osu.Framework.Tests/Localisation/LocalisationTest.cs
+++ b/osu.Framework.Tests/Localisation/LocalisationTest.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Configuration;
@@ -417,7 +418,8 @@ namespace osu.Framework.Tests.Localisation
                 EffectiveCulture = new CultureInfo(locale);
             }
 
-            public async Task<string> GetAsync(string name) => await Task.Run(() => Get(name)).ConfigureAwait(false);
+            public async Task<string> GetAsync(string name, CancellationToken cancellationToken = default) =>
+                await Task.Run(() => Get(name), cancellationToken).ConfigureAwait(false);
 
             public string Get(string name)
             {

--- a/osu.Framework.Tests/Visual/Localisation/TestSceneTextFlowContainerLocalisation.cs
+++ b/osu.Framework.Tests/Visual/Localisation/TestSceneTextFlowContainerLocalisation.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
@@ -248,7 +249,7 @@ namespace osu.Framework.Tests.Visual.Localisation
 
             public string Get(string key) => translations.TryGetValue(key, out string value) ? value : null;
 
-            public Task<string> GetAsync(string key) => Task.FromResult(Get(key));
+            public Task<string> GetAsync(string key, CancellationToken cancellationToken = default) => Task.FromResult(Get(key));
 
             public Stream GetStream(string name) => throw new NotSupportedException();
 

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneSpriteTextScenarios.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -289,7 +290,8 @@ namespace osu.Framework.Tests.Visual.Sprites
                 EffectiveCulture = new CultureInfo(locale);
             }
 
-            public async Task<string> GetAsync(string name) => await Task.Run(() => Get(name)).ConfigureAwait(false);
+            public async Task<string> GetAsync(string name, CancellationToken cancellationToken = default) =>
+                await Task.Run(() => Get(name), cancellationToken).ConfigureAwait(false);
 
             public string Get(string name)
             {

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneTextures.cs
@@ -211,7 +211,8 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             public byte[] Get(string name) => getWithBlocking(name, baseStore.Get);
 
-            public Task<byte[]> GetAsync(string name) => getWithBlocking(name, baseStore.GetAsync);
+            public Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default) =>
+                getWithBlocking(name, name1 => baseStore.GetAsync(name1, cancellationToken));
 
             public Stream GetStream(string name) => getWithBlocking(name, baseStore.GetStream);
 

--- a/osu.Framework/Audio/Sample/SampleStore.cs
+++ b/osu.Framework/Audio/Sample/SampleStore.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Audio.Mixing;
@@ -55,7 +56,8 @@ namespace osu.Framework.Audio.Sample
             }
         }
 
-        public Task<Sample> GetAsync(string name) => Task.Run(() => Get(name));
+        public Task<Sample> GetAsync(string name, CancellationToken cancellationToken = default) =>
+            Task.Run(() => Get(name), cancellationToken);
 
         protected override void UpdateState()
         {

--- a/osu.Framework/Audio/Track/TrackStore.cs
+++ b/osu.Framework/Audio/Track/TrackStore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Audio.Mixing;
@@ -52,7 +53,8 @@ namespace osu.Framework.Audio.Track
             return trackBass;
         }
 
-        public Task<Track> GetAsync(string name) => Task.Run(() => Get(name));
+        public Task<Track> GetAsync(string name, CancellationToken cancellationToken = default) =>
+            Task.Run(() => Get(name), cancellationToken);
 
         public Stream GetStream(string name) => store.GetStream(name);
 

--- a/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureLoaderStore.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.IO.Stores;
 using SixLabors.ImageSharp;
@@ -22,7 +23,8 @@ namespace osu.Framework.Graphics.Textures
             (store as ResourceStore<byte[]>)?.AddExtension(@"jpg");
         }
 
-        public Task<TextureUpload> GetAsync(string name) => Task.Run(() => Get(name));
+        public Task<TextureUpload> GetAsync(string name, CancellationToken cancellationToken = default) =>
+            Task.Run(() => Get(name), cancellationToken);
 
         public TextureUpload Get(string name)
         {

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -7,6 +7,7 @@ using osu.Framework.Graphics.OpenGL.Textures;
 using osu.Framework.IO.Stores;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Logging;
@@ -49,8 +50,6 @@ namespace osu.Framework.Graphics.Textures
             }
         }
 
-        private async Task<Texture> getTextureAsync(string name, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None) => loadRaw(await base.GetAsync(name).ConfigureAwait(false), wrapModeS, wrapModeT);
-
         private Texture getTexture(string name, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None) => loadRaw(base.Get(name), wrapModeS, wrapModeT);
 
         private Texture loadRaw(TextureUpload upload, WrapMode wrapModeS = WrapMode.None, WrapMode wrapModeT = WrapMode.None)
@@ -81,8 +80,9 @@ namespace osu.Framework.Graphics.Textures
         /// Retrieves a texture from the store and adds it to the atlas.
         /// </summary>
         /// <param name="name">The name of the texture.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The texture.</returns>
-        public new Task<Texture> GetAsync(string name) => GetAsync(name, default, default);
+        public new Task<Texture> GetAsync(string name, CancellationToken cancellationToken) => GetAsync(name, default, default, cancellationToken);
 
         /// <summary>
         /// Retrieves a texture from the store and adds it to the atlas.
@@ -90,9 +90,10 @@ namespace osu.Framework.Graphics.Textures
         /// <param name="name">The name of the texture.</param>
         /// <param name="wrapModeS">The texture wrap mode in horizontal direction.</param>
         /// <param name="wrapModeT">The texture wrap mode in vertical direction.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The texture.</returns>
-        public Task<Texture> GetAsync(string name, WrapMode wrapModeT, WrapMode wrapModeS) =>
-            Task.Run(() => Get(name, wrapModeS, wrapModeT)); // TODO: best effort. need to re-think textureCache data structure to fix this.
+        public Task<Texture> GetAsync(string name, WrapMode wrapModeT, WrapMode wrapModeS, CancellationToken cancellationToken = default) =>
+            Task.Run(() => Get(name, wrapModeS, wrapModeT), cancellationToken); // TODO: best effort. need to re-think textureCache data structure to fix this.
 
         /// <summary>
         /// Retrieves a texture from the store and adds it to the atlas.

--- a/osu.Framework/IO/Stores/DllResourceStore.cs
+++ b/osu.Framework/IO/Stores/DllResourceStore.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace osu.Framework.IO.Stores
@@ -51,7 +52,7 @@ namespace osu.Framework.IO.Stores
             }
         }
 
-        public virtual async Task<byte[]> GetAsync(string name)
+        public virtual async Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default)
         {
             this.LogIfNonBackgroundThread(name);
 
@@ -61,7 +62,7 @@ namespace osu.Framework.IO.Stores
                     return null;
 
                 byte[] buffer = new byte[input.Length];
-                await input.ReadAsync(buffer.AsMemory()).ConfigureAwait(false);
+                await input.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
                 return buffer;
             }
         }

--- a/osu.Framework/IO/Stores/IResourceStore.cs
+++ b/osu.Framework/IO/Stores/IResourceStore.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Development;
 using osu.Framework.Extensions.TypeExtensions;
@@ -27,8 +28,9 @@ namespace osu.Framework.IO.Stores
         /// Retrieves an object from the store asynchronously.
         /// </summary>
         /// <param name="name">The name of the object.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The object.</returns>
-        Task<T> GetAsync(string name);
+        Task<T> GetAsync(string name, CancellationToken cancellationToken = default);
 
         Stream GetStream(string name);
 

--- a/osu.Framework/IO/Stores/OnlineStore.cs
+++ b/osu.Framework/IO/Stores/OnlineStore.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using WebRequest = osu.Framework.IO.Network.WebRequest;
 
@@ -12,7 +13,7 @@ namespace osu.Framework.IO.Stores
 {
     public class OnlineStore : IResourceStore<byte[]>
     {
-        public async Task<byte[]> GetAsync(string url)
+        public async Task<byte[]> GetAsync(string url, CancellationToken cancellationToken = default)
         {
             this.LogIfNonBackgroundThread(url);
 
@@ -20,7 +21,7 @@ namespace osu.Framework.IO.Stores
             {
                 using (WebRequest req = new WebRequest($@"{url}"))
                 {
-                    await req.PerformAsync().ConfigureAwait(false);
+                    await req.PerformAsync(cancellationToken).ConfigureAwait(false);
                     return req.GetResponseData();
                 }
             }

--- a/osu.Framework/IO/Stores/ResourceStore.cs
+++ b/osu.Framework/IO/Stores/ResourceStore.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace osu.Framework.IO.Stores
@@ -77,12 +78,7 @@ namespace osu.Framework.IO.Stores
                 stores.Remove(store);
         }
 
-        /// <summary>
-        /// Retrieves an object from the store.
-        /// </summary>
-        /// <param name="name">The name of the object.</param>
-        /// <returns>The object.</returns>
-        public virtual async Task<T> GetAsync(string name)
+        public virtual async Task<T> GetAsync(string name, CancellationToken cancellationToken = default)
         {
             if (name == null)
                 return null;
@@ -93,7 +89,7 @@ namespace osu.Framework.IO.Stores
             {
                 foreach (string f in filenames)
                 {
-                    T result = await store.GetAsync(f).ConfigureAwait(false);
+                    T result = await store.GetAsync(f, cancellationToken).ConfigureAwait(false);
                     if (result != null)
                         return result;
                 }

--- a/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
+++ b/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using osu.Framework.Platform;
 
@@ -36,7 +37,7 @@ namespace osu.Framework.IO.Stores
             }
         }
 
-        public virtual async Task<byte[]> GetAsync(string name)
+        public virtual async Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default)
         {
             this.LogIfNonBackgroundThread(name);
 
@@ -45,7 +46,7 @@ namespace osu.Framework.IO.Stores
                 if (stream == null) return null;
 
                 byte[] buffer = new byte[stream.Length];
-                await stream.ReadAsync(buffer.AsMemory()).ConfigureAwait(false);
+                await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
                 return buffer;
             }
         }


### PR DESCRIPTION
Noticed that a lot of avatars get stuck in a loading state, even though they are likely not required for loading purposes (they have since been disposed or forgotten).

Having cancellation token support should allow for improving such cases, cancelling the underlying web request if it is already in progress.

Note that this will require usages to be updated to pass the `CancellationToken` from DI. And maybe `async` support for BDL. But it's a start and doesn't look to break anything.