### PR TITLE
Output test method name in log output

### DIFF
--- a/osu.Framework/Testing/Drawables/Steps/StepButton.cs
+++ b/osu.Framework/Testing/Drawables/Steps/StepButton.cs
@@ -142,6 +142,6 @@ namespace osu.Framework.Testing.Drawables.Steps
             Light.FadeColour(Color4.YellowGreen);
         }
 
-        public override string ToString() => Text.ToString();
+        public override string ToString() => $@"""{Text}"" " + base.ToString();
     }
 }

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -198,7 +198,7 @@ namespace osu.Framework.Testing
                 if (loadableStep != null)
                 {
                     if (actionRepetition == 0)
-                        Logger.Log($"🔸 Step #{actionIndex + 1} {loadableStep?.ToString() ?? string.Empty}");
+                        Logger.Log($"🔸 Step #{actionIndex + 1} {loadableStep?.Text}");
 
                     scroll.ScrollIntoView(loadableStep);
                     loadableStep.PerformStep();

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -198,7 +198,7 @@ namespace osu.Framework.Testing
                 if (loadableStep != null)
                 {
                     if (actionRepetition == 0)
-                        Logging.Logger.Log($"🔸 Step #{actionIndex + 1} {loadableStep?.ToString() ?? string.Empty}");
+                        Logger.Log($"🔸 Step #{actionIndex + 1} {loadableStep?.ToString() ?? string.Empty}");
 
                     scroll.ScrollIntoView(loadableStep);
                     loadableStep.PerformStep();
@@ -206,7 +206,7 @@ namespace osu.Framework.Testing
             }
             catch (Exception e)
             {
-                Logging.Logger.Log(actionRepetition > 0
+                Logger.Log(actionRepetition > 0
                     ? $"💥 Failed (on attempt {actionRepetition:0,#})"
                     : "💥 Failed");
 
@@ -220,7 +220,7 @@ namespace osu.Framework.Testing
             if (actionRepetition > (loadableStep?.RequiredRepetitions ?? 1) - 1)
             {
                 if (actionIndex >= 0 && actionRepetition > 1)
-                    Logging.Logger.Log($"✔️ {actionRepetition} repetitions");
+                    Logger.Log($"✔️ {actionRepetition} repetitions");
 
                 actionIndex++;
                 actionRepetition = 0;
@@ -231,7 +231,7 @@ namespace osu.Framework.Testing
 
             if (actionIndex > StepsContainer.Children.Count - 1)
             {
-                Logging.Logger.Log($"✅ {GetType().ReadableName()} completed");
+                Logger.Log($"✅ {GetType().ReadableName()} completed");
                 onCompletion?.Invoke();
                 return;
             }

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -22,6 +22,7 @@ using osu.Framework.Testing.Drawables.Steps;
 using osu.Framework.Threading;
 using osuTK;
 using osuTK.Graphics;
+using Logger = osu.Framework.Logging.Logger;
 
 namespace osu.Framework.Testing
 {
@@ -265,6 +266,8 @@ namespace osu.Framework.Testing
 
             step.Action = () =>
             {
+                Logger.Log($@"💨 {this} {description}");
+
                 // kinda hacky way to avoid this doesn't get triggered by automated runs.
                 if (step.IsHovered)
                     RunAllSteps(startFromStep: step, stopCondition: s => s is LabelStep);

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
+using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Logging;
@@ -83,7 +84,8 @@ namespace osu.Framework.Testing
                 {
                     AddInternal(test);
 
-                    Logger.Log($@"💨 {test} {TestContext.CurrentContext.Test.Name}");
+                    Logger.Log($@"💨 Class: {test.GetType().ReadableName()}");
+                    Logger.Log($@"🔶 Test:  {TestContext.CurrentContext.Test.Name}");
 
                     // Nunit will run the tests in the TestScene with the same TestScene instance so the TestScene
                     // needs to be removed before the host is exited, otherwise it will end up disposed

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -83,9 +83,7 @@ namespace osu.Framework.Testing
                 {
                     AddInternal(test);
 
-                    Logger.Log(TestContext.CurrentContext != null
-                        ? $@"💨 {test} {TestContext.CurrentContext.Test.Name}"
-                        : $@"💨 {test}");
+                    Logger.Log($@"💨 {test} {TestContext.CurrentContext.Test.Name}");
 
                     // Nunit will run the tests in the TestScene with the same TestScene instance so the TestScene
                     // needs to be removed before the host is exited, otherwise it will end up disposed

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -4,6 +4,7 @@
 using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
+using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
@@ -82,7 +83,9 @@ namespace osu.Framework.Testing
                 {
                     AddInternal(test);
 
-                    Logger.Log($@"💨 {test} running");
+                    Logger.Log(TestContext.CurrentContext != null
+                        ? $@"💨 {test} {TestContext.CurrentContext.Test.Name}"
+                        : $@"💨 {test}");
 
                     // Nunit will run the tests in the TestScene with the same TestScene instance so the TestScene
                     // needs to be removed before the host is exited, otherwise it will end up disposed


### PR DESCRIPTION
Was bugging me

```
[runtime] 2021-12-23 07:03:47 [verbose]: 💨 Video(TestSceneVideo) TestJumpForward("avi")
[runtime] 2021-12-23 07:03:47 [verbose]: 🔸 Step #1 "Reset clock" SingleStepButton
[runtime] 2021-12-23 07:03:47 [verbose]: 🔸 Step #2 "load .avi video" SingleStepButton
[runtime] 2021-12-23 07:03:47 [verbose]: Successfully opened hardware video decoder context AV_HWDEVICE_TYPE_VIDEOTOOLBOX for codec h264
[runtime] 2021-12-23 07:03:47 [verbose]: Successfully initialized decoder: h264
[runtime] 2021-12-23 07:03:47 [verbose]: 🔸 Step #3 Until: "Wait for video to load" UntilStepButton
[runtime] 2021-12-23 07:03:47 [verbose]: 🔸 Step #4 "Reset clock" SingleStepButton
[runtime] 2021-12-23 07:03:47 [verbose]: 🔸 Step #5 Until: "Wait for decode start" UntilStepButton
[runtime] 2021-12-23 07:03:47 [verbose]: ✔️ 39 repetitions
[runtime] 2021-12-23 07:03:47 [verbose]: 🔸 Step #6 "Jump ahead by 10 seconds" SingleStepButton
[runtime] 2021-12-23 07:03:47 [verbose]: Video too far out of sync (66.66666666666667), seeking to 10049.154132
[runtime] 2021-12-23 07:03:47 [verbose]: Video too far out of sync (66.66666666666667), seeking to 10050.708079
[runtime] 2021-12-23 07:03:47 [verbose]: Video too far out of sync (83.33333333333333), seeking to 10051.790171
[runtime] 2021-12-23 07:03:47 [verbose]: 🔸 Step #7 Until: "Video seeked" UntilStepButton
[runtime] 2021-12-23 07:03:47 [verbose]: ✔️ 54 repetitions
[runtime] 2021-12-23 07:03:47 [verbose]: ✅ TestSceneVideo completed
```