### PR TITLE
Use fullscreen mode in Android visual test activity

### DIFF
--- a/osu.Framework.Tests.Android/TestGameActivity.cs
+++ b/osu.Framework.Tests.Android/TestGameActivity.cs
@@ -3,6 +3,8 @@
 
 using Android.App;
 using Android.Content.PM;
+using Android.OS;
+using Android.Views;
 using osu.Framework.Android;
 
 namespace osu.Framework.Tests.Android
@@ -12,5 +14,12 @@ namespace osu.Framework.Tests.Android
     {
         protected override Game CreateGame()
             => new VisualTestGame();
+
+        protected override void OnCreate(Bundle savedInstanceState)
+        {
+            base.OnCreate(savedInstanceState);
+
+            Window.AddFlags(WindowManagerFlags.Fullscreen);
+        }
     }
 }


### PR DESCRIPTION
Fixes the titlebar being constantly visible and therefore hiding the test search box as well as a few first items on the test list, making audio visual tests nigh unreachable on mobile.

Method used [stolen from game](https://github.com/ppy/osu/blob/048ca98f4aa11c1685ee3af41fbb33429129bba4/osu.Android/OsuGameActivity.cs#L62). Didn't set `WindowManagerFlags.KeepScreenOn` because I don't really think that's super needed in a test activity.