### PR TITLE
Standardize Android activity and permissions

### DIFF
--- a/SampleGame.Android/SampleGameActivity.cs
+++ b/SampleGame.Android/SampleGameActivity.cs
@@ -2,13 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using Android.App;
-using Android.Content.PM;
 using osu.Framework;
 using osu.Framework.Android;
 
 namespace SampleGame.Android
 {
-    [Activity(MainLauncher = true, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, Theme = "@android:style/Theme.NoTitleBar")]
+    [Activity(ConfigurationChanges = DEFAULT_CONFIG_CHANGES, LaunchMode = DEFAULT_LAUNCH_MODE, MainLauncher = true)]
     public class SampleGameActivity : AndroidGameActivity
     {
         protected override Game CreateGame() => new SampleGameGame();

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -3,16 +3,28 @@
 
 using Android.App;
 using Android.Content;
+using Android.Content.PM;
 using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using ManagedBass;
-using Process = System.Diagnostics.Process;
 
 namespace osu.Framework.Android
 {
+    // since `ActivityAttribute` can't be inherited, the below is only provided as an illustrative example of how to setup an activity for best compatibility.
+    [Activity(ConfigurationChanges = DEFAULT_CONFIG_CHANGES, LaunchMode = DEFAULT_LAUNCH_MODE, MainLauncher = true)]
     public abstract class AndroidGameActivity : Activity
     {
+        protected const ConfigChanges DEFAULT_CONFIG_CHANGES = ConfigChanges.Keyboard
+                                                               | ConfigChanges.KeyboardHidden
+                                                               | ConfigChanges.Orientation
+                                                               | ConfigChanges.ScreenLayout
+                                                               | ConfigChanges.ScreenSize
+                                                               | ConfigChanges.SmallestScreenSize
+                                                               | ConfigChanges.UiMode;
+
+        protected const LaunchMode DEFAULT_LAUNCH_MODE = LaunchMode.SingleInstance;
+
         protected abstract Game CreateGame();
 
         /// <summary>

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -52,6 +52,11 @@ namespace osu.Framework.Android
 
         protected override void OnCreate(Bundle savedInstanceState)
         {
+            // The default current directory on android is '/'.
+            // On some devices '/' maps to the app data directory. On others it maps to the root of the internal storage.
+            // In order to have a consistent current directory on all devices the full path of the app data directory is set as the current directory.
+            System.Environment.CurrentDirectory = System.Environment.GetFolderPath(System.Environment.SpecialFolder.Personal);
+
             base.OnCreate(savedInstanceState);
 
             SetContentView(gameView = new AndroidGameView(this, CreateGame()));

--- a/osu.Framework.Android/Properties/AssemblyInfo.cs
+++ b/osu.Framework.Android/Properties/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System.Runtime.CompilerServices;
+using Android;
 using Android.App;
 
 // We publish our internal attributes to other sub-projects of the framework.
@@ -11,5 +12,13 @@ using Android.App;
 [assembly: InternalsVisibleTo("osu.Framework.Tests")]
 [assembly: InternalsVisibleTo("osu.Framework.Tests.Dynamic")]
 
-// https://docs.microsoft.com/en-us/answers/questions/182601/does-xamarinandroid-suppor-manifest-merging.html
-[assembly: UsesPermission(Android.Manifest.Permission.ReadExternalStorage)]
+[assembly: Application(
+    HardwareAccelerated = false,
+    ResizeableActivity = true,
+    Theme = "@android:style/Theme.Black.NoTitleBar"
+)]
+[assembly: UsesPermission(Manifest.Permission.ReadExternalStorage)]
+[assembly: UsesPermission(Manifest.Permission.WriteExternalStorage)]
+[assembly: UsesPermission(Manifest.Permission.WakeLock)]
+[assembly: UsesPermission(Manifest.Permission.ReadFrameBuffer)]
+[assembly: UsesPermission(Manifest.Permission.Internet)]

--- a/osu.Framework.Tests.Android/TestGameActivity.cs
+++ b/osu.Framework.Tests.Android/TestGameActivity.cs
@@ -2,14 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using Android.App;
-using Android.Content.PM;
 using Android.OS;
 using Android.Views;
 using osu.Framework.Android;
 
 namespace osu.Framework.Tests.Android
 {
-    [Activity(MainLauncher = true, ConfigurationChanges = ConfigChanges.Orientation | ConfigChanges.ScreenSize, Theme = "@android:style/Theme.NoTitleBar")]
+    [Activity(ConfigurationChanges = DEFAULT_CONFIG_CHANGES, LaunchMode = DEFAULT_LAUNCH_MODE, MainLauncher = true)]
     public class TestGameActivity : AndroidGameActivity
     {
         protected override Game CreateGame()


### PR DESCRIPTION
Relevant osu!-side permissions have been moved over. Theme is changed to a pure black one, so we don't get the ugly gradient at startup. Added some relevant config changes, so the activity doesn't unwantedly get restarted.