### PR TITLE
Avoid doing individual file operations for each line of log output

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkLogger.cs
+++ b/osu.Framework.Benchmarks/BenchmarkLogger.cs
@@ -1,0 +1,55 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Logging;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkLogger
+    {
+        private const int line_count = 10000;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            Logger.Storage = new TemporaryNativeStorage(Guid.NewGuid().ToString());
+        }
+
+        [Benchmark]
+        public void LogManyLinesDebug()
+        {
+            for (int i = 0; i < line_count; i++)
+            {
+                Logger.Log("This is a test log line.", level: LogLevel.Debug);
+            }
+
+            Logger.Flush();
+        }
+
+        [Benchmark]
+        public void LogManyMultiLineLines()
+        {
+            for (int i = 0; i < line_count; i++)
+            {
+                Logger.Log("This\nis\na\ntest\nlog\nline.");
+            }
+
+            Logger.Flush();
+        }
+
+        [Benchmark]
+        public void LogManyLines()
+        {
+            for (int i = 0; i < line_count; i++)
+            {
+                Logger.Log("This is a test log line.");
+            }
+
+            Logger.Flush();
+        }
+    }
+}


### PR DESCRIPTION
Came up while I was profiling the test threading issue, and I couldn't help myself (sorry). While running tests, logger overhead is around 10% so seems quite beneficial.

I believe we used to have something along the lines of this, but switched to scheduling the full stream operation for some reason or another.

Before:

|                Method |         Mean |      Error |     StdDev |      Gen 0 |     Gen 1 |  Allocated |
|---------------------- |-------------:|-----------:|-----------:|-----------:|----------:|-----------:|
|     LogManyLinesDebug |     1.256 ms |  0.0160 ms |  0.0133 ms |   89.8438  |         - |   1,016 KB |
| LogManyMultiLineLines | 1,457.323 ms | 27.5232 ms | 43.6547 ms | 11000.0000 | 1000.0000 | 128,522 KB |
|          LogManyLines | 1,384.930 ms | 27.5977 ms | 36.8421 ms | 10000.0000 | 1000.0000 | 112,818 KB |

After:

|                Method |       Mean |     Error |    StdDev |     Median | Gen 0     |    Gen 1 |    Gen 2 | Allocated |
|---------------------- |-----------:|----------:|----------:|-----------:|----------:|---------:|---------:|----------:|
|     LogManyLinesDebug |   1.254 ms | 0.0199 ms | 0.0186 ms |   1.249 ms | 76.1719   |        - |        - |    859 KB |
| LogManyMultiLineLines | 139.133 ms | 2.9731 ms | 8.7196 ms | 142.542 ms | 2000.0000 | 500.0000 | 250.0000 | 23,534 KB |
|          LogManyLines | 110.806 ms | 1.2311 ms | 1.1515 ms | 111.478 ms | 600.0000  | 200.0000 |        - |  7,434 KB |

Pretty sure there's a lot more room for improvement, but just low hanging fruit for now.