### PR TITLE
Opportunistically trim WeakList<T> on additions after many removals or additions

### DIFF
--- a/osu.Framework.Benchmarks/BenchmarkWeakList.cs
+++ b/osu.Framework.Benchmarks/BenchmarkWeakList.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using osu.Framework.Lists;
@@ -89,6 +90,64 @@ namespace osu.Framework.Benchmarks
 
             weakList.Clear();
             return weakList.ToArray();
+        }
+
+        [Benchmark]
+        public void ManyAddsAndRemoveFromStartWithNoEnumeration()
+        {
+            weakList = new WeakList<object>();
+
+            object obj = new object();
+            weakList.Add(obj);
+
+            for (int i = 0; i < ItemCount * 1000; i++)
+            {
+                weakList.Add(obj);
+                weakList.RemoveAt(0);
+
+                if (i % 1000 == 0)
+                    GC.Collect();
+            }
+        }
+
+        [Benchmark]
+        public void ManyAddsAndRemoveFromEndWithNoEnumeration()
+        {
+            weakList = new WeakList<object>();
+
+            object obj = new object();
+            weakList.Add(obj);
+
+            for (int i = 0; i < ItemCount * 1000; i++)
+            {
+                weakList.Add(obj);
+                weakList.RemoveAt(1);
+
+                if (i % 1000 == 0)
+                    GC.Collect();
+            }
+        }
+
+        [Benchmark]
+        public void ManyAddsAndRemoveFromMiddleWithNoEnumeration()
+        {
+            weakList = new WeakList<object>();
+
+            object obj = new object();
+            object obj2 = new object();
+
+            weakList.Add(new object());
+            weakList.Add(obj2);
+            weakList.Add(obj);
+
+            for (int i = 0; i < ItemCount * 1000; i++)
+            {
+                weakList.Remove(i % 2 == 0 ? obj2 : obj);
+                weakList.Add(i % 2 == 0 ? obj2 : obj);
+
+                if (i % 1000 == 0)
+                    GC.Collect();
+            }
         }
 
         private void init()


### PR DESCRIPTION
@peppy Please re-test this with your scenario, as the previous code used Gen2 GC callbacks.

This change will trim the `WeakList<T>` once the number of items changed (either added to increase the count of the list or removed) since the last trim crosses a threshold of 100. It is aimed to fix cases where many items are added and removed from `WeakList<T>` without an enumeration ever taking place.

Baseline measurements:
```
## ManyAddsAndRemoveFromMiddleWithNoEnumeration DID NOT COMPLETE

|                                      Method | ItemCount |               Mean |            Error |           StdDev |     Ratio | RatioSD |        Gen 0 |        Gen 1 |        Gen 2 |    Allocated |
|-------------------------------------------- |---------- |-------------------:|-----------------:|-----------------:|----------:|--------:|-------------:|-------------:|-------------:|-------------:|
|                                         Add |         1 |           241.0 ns |          4.78 ns |          6.22 ns |      1.00 |    0.00 |       0.0019 |            - |            - |        176 B |
|                                   RemoveOne |         1 |           250.4 ns |          4.97 ns |          6.28 ns |      1.04 |    0.03 |       0.0019 |            - |            - |        176 B |
|                        RemoveAllIteratively |         1 |           266.3 ns |          4.41 ns |          4.13 ns |      1.11 |    0.04 |       0.0019 |            - |            - |        176 B |
|                          RemoveAllStaggered |         1 |           271.0 ns |          3.03 ns |          2.69 ns |      1.13 |    0.03 |       0.0019 |            - |            - |        176 B |
|                                       Clear |         1 |           240.4 ns |          4.84 ns |          4.52 ns |      1.00 |    0.02 |       0.0019 |            - |            - |        176 B |
|                                    Contains |         1 |           255.9 ns |          5.00 ns |          6.68 ns |      1.06 |    0.04 |       0.0019 |            - |            - |        176 B |
|                             AddAndEnumerate |         1 |           446.8 ns |          5.41 ns |          5.06 ns |      1.86 |    0.05 |       0.0033 |            - |            - |        304 B |
|                           ClearAndEnumerate |         1 |           381.6 ns |          6.83 ns |          6.39 ns |      1.59 |    0.04 |       0.0024 |            - |            - |        216 B |
| ManyAddsAndRemoveFromStartWithNoEnumeration |         1 |       289,086.8 ns |      5,206.96 ns |      4,870.59 ns |  1,203.03 |   48.57 |    1000.0000 |    1000.0000 |    1000.0000 |     57,320 B |
|   ManyAddsAndRemoveFromEndWithNoEnumeration |         1 |       272,497.8 ns |      5,120.92 ns |      4,790.11 ns |  1,133.70 |   36.54 |    1000.0000 |    1000.0000 |    1000.0000 |     24,488 B |
|                                             |           |                    |                  |                  |           |         |              |              |              |              |
|                                         Add |        10 |         2,011.2 ns |         19.75 ns |         16.49 ns |      1.00 |    0.00 |       0.0076 |            - |            - |        824 B |
|                                   RemoveOne |        10 |         2,014.8 ns |         29.24 ns |         27.35 ns |      1.00 |    0.02 |       0.0076 |            - |            - |        824 B |
|                        RemoveAllIteratively |        10 |         2,321.0 ns |         45.52 ns |         63.81 ns |      1.16 |    0.04 |       0.0076 |            - |            - |        824 B |
|                          RemoveAllStaggered |        10 |         2,278.1 ns |         23.91 ns |         21.20 ns |      1.13 |    0.02 |       0.0076 |            - |            - |        824 B |
|                                       Clear |        10 |         1,984.4 ns |         32.29 ns |         30.21 ns |      0.99 |    0.02 |       0.0076 |            - |            - |        824 B |
|                                    Contains |        10 |         2,060.0 ns |         40.71 ns |         48.46 ns |      1.04 |    0.02 |       0.0076 |            - |            - |        824 B |
|                             AddAndEnumerate |        10 |         2,583.6 ns |         39.98 ns |         35.44 ns |      1.29 |    0.02 |       0.0114 |            - |            - |      1,200 B |
|                           ClearAndEnumerate |        10 |         1,999.5 ns |         38.42 ns |         42.70 ns |      1.00 |    0.02 |       0.0076 |            - |            - |        864 B |
| ManyAddsAndRemoveFromStartWithNoEnumeration |        10 |     3,007,248.6 ns |      9,140.96 ns |      7,136.66 ns |  1,495.51 |   14.08 |   10000.0000 |   10000.0000 |   10000.0000 |    767,530 B |
|   ManyAddsAndRemoveFromEndWithNoEnumeration |        10 |     2,789,569.5 ns |     19,143.76 ns |     17,907.09 ns |  1,388.94 |   12.75 |   10000.0000 |   10000.0000 |   10000.0000 |    243,082 B |
|                                             |           |                    |                  |                  |           |         |              |              |              |              |
|                                         Add |       100 |        18,241.8 ns |        135.73 ns |        113.34 ns |      1.00 |    0.00 |       0.0610 |            - |            - |      6,640 B |
|                                   RemoveOne |       100 |        18,711.5 ns |         55.99 ns |         43.72 ns |      1.03 |    0.01 |       0.0610 |            - |            - |      6,640 B |
|                        RemoveAllIteratively |       100 |        20,423.9 ns |         42.73 ns |         37.88 ns |      1.12 |    0.01 |       0.0610 |            - |            - |      6,640 B |
|                          RemoveAllStaggered |       100 |        28,782.6 ns |        130.69 ns |        115.85 ns |      1.58 |    0.01 |       0.0610 |            - |            - |      6,640 B |
|                                       Clear |       100 |        18,243.2 ns |        131.94 ns |        123.41 ns |      1.00 |    0.01 |       0.0610 |            - |            - |      6,640 B |
|                                    Contains |       100 |        18,744.7 ns |         91.42 ns |         76.34 ns |      1.03 |    0.01 |       0.0610 |            - |            - |      6,640 B |
|                             AddAndEnumerate |       100 |        21,724.0 ns |        237.02 ns |        197.92 ns |      1.19 |    0.01 |       0.0916 |            - |            - |      8,760 B |
|                           ClearAndEnumerate |       100 |        18,569.8 ns |        150.08 ns |        125.32 ns |      1.02 |    0.01 |       0.0610 |            - |            - |      6,680 B |
| ManyAddsAndRemoveFromStartWithNoEnumeration |       100 |    45,055,679.4 ns |    384,108.77 ns |    340,502.42 ns |  2,469.87 |   24.00 |  100000.0000 |  100000.0000 |  100000.0000 |  6,623,560 B |
|   ManyAddsAndRemoveFromEndWithNoEnumeration |       100 |    27,287,260.8 ns |    244,792.78 ns |    228,979.32 ns |  1,496.43 |   10.66 |  100000.0000 |  100000.0000 |  100000.0000 |  2,429,018 B |
|                                             |           |                    |                  |                  |           |         |              |              |              |              |
|                                         Add |      1000 |       177,295.8 ns |      1,398.21 ns |      1,167.57 ns |      1.00 |    0.00 |       0.4883 |            - |            - |     56,984 B |
|                                   RemoveOne |      1000 |       178,890.9 ns |      1,171.89 ns |        978.59 ns |      1.01 |    0.01 |       0.4883 |            - |            - |     56,984 B |
|                        RemoveAllIteratively |      1000 |       198,348.1 ns |      1,085.42 ns |        962.20 ns |      1.12 |    0.01 |       0.4883 |            - |            - |     56,984 B |
|                          RemoveAllStaggered |      1000 |       824,331.2 ns |      2,785.80 ns |      2,469.54 ns |      4.65 |    0.03 |            - |            - |            - |     56,984 B |
|                                       Clear |      1000 |       177,608.5 ns |      1,490.11 ns |      1,393.85 ns |      1.00 |    0.01 |       0.4883 |            - |            - |     56,984 B |
|                                    Contains |      1000 |       179,119.8 ns |      2,293.42 ns |      2,033.06 ns |      1.01 |    0.01 |       0.4883 |            - |            - |     56,984 B |
|                             AddAndEnumerate |      1000 |       209,843.4 ns |      1,666.47 ns |      1,558.82 ns |      1.18 |    0.01 |       0.7324 |            - |            - |     73,632 B |
|                           ClearAndEnumerate |      1000 |       169,108.8 ns |      1,620.19 ns |      1,436.26 ns |      0.95 |    0.01 |       0.4883 |            - |            - |     57,024 B |
| ManyAddsAndRemoveFromStartWithNoEnumeration |      1000 | 1,840,754,822.0 ns | 25,584,458.72 ns | 23,931,718.56 ns | 10,392.52 |  142.31 | 1000000.0000 | 1000000.0000 | 1000000.0000 | 57,843,224 B |
|   ManyAddsAndRemoveFromEndWithNoEnumeration |      1000 |   284,514,560.5 ns |  2,242,194.21 ns |  2,097,349.85 ns |  1,605.14 |   18.54 | 1000000.0000 | 1000000.0000 | 1000000.0000 | 24,289,864 B |
```

This PR:
```
|                                       Method | ItemCount |             Mean |           Error |          StdDev |    Ratio | RatioSD |        Gen 0 |        Gen 1 |        Gen 2 |    Allocated |
|--------------------------------------------- |---------- |-----------------:|----------------:|----------------:|---------:|--------:|-------------:|-------------:|-------------:|-------------:|
|                                          Add |         1 |         244.6 ns |         3.24 ns |         3.03 ns |     1.00 |    0.00 |       0.0021 |            - |            - |        184 B |
|                                    RemoveOne |         1 |         243.9 ns |         1.72 ns |         1.61 ns |     1.00 |    0.02 |       0.0019 |            - |            - |        184 B |
|                         RemoveAllIteratively |         1 |         256.6 ns |         2.30 ns |         2.15 ns |     1.05 |    0.01 |       0.0019 |            - |            - |        184 B |
|                           RemoveAllStaggered |         1 |         262.5 ns |         2.61 ns |         2.32 ns |     1.07 |    0.02 |       0.0019 |            - |            - |        184 B |
|                                        Clear |         1 |         237.7 ns |         2.18 ns |         2.04 ns |     0.97 |    0.02 |       0.0021 |            - |            - |        184 B |
|                                     Contains |         1 |         244.0 ns |         1.01 ns |         0.90 ns |     1.00 |    0.01 |       0.0019 |            - |            - |        184 B |
|                              AddAndEnumerate |         1 |         458.8 ns |         5.23 ns |         4.89 ns |     1.88 |    0.03 |       0.0033 |            - |            - |        312 B |
|                            ClearAndEnumerate |         1 |         367.8 ns |         6.19 ns |         5.79 ns |     1.50 |    0.03 |       0.0024 |            - |            - |        224 B |
|  ManyAddsAndRemoveFromStartWithNoEnumeration |         1 |     279,954.3 ns |     2,967.85 ns |     2,776.13 ns | 1,144.50 |   19.22 |    1000.0000 |    1000.0000 |    1000.0000 |     28,584 B |
|    ManyAddsAndRemoveFromEndWithNoEnumeration |         1 |     274,285.7 ns |     2,479.12 ns |     2,197.67 ns | 1,120.13 |   17.34 |    1000.0000 |    1000.0000 |    1000.0000 |     24,496 B |
| ManyAddsAndRemoveFromMiddleWithNoEnumeration |         1 |     313,821.1 ns |     2,150.71 ns |     2,011.78 ns | 1,282.90 |   14.65 |    1000.0000 |    1000.0000 |    1000.0000 |     28,680 B |
|                                              |           |                  |                 |                 |          |         |              |              |              |              |
|                                          Add |        10 |       1,994.5 ns |        14.46 ns |        12.08 ns |     1.00 |    0.00 |       0.0095 |            - |            - |        832 B |
|                                    RemoveOne |        10 |       1,958.9 ns |        28.27 ns |        26.45 ns |     0.98 |    0.01 |       0.0076 |            - |            - |        832 B |
|                         RemoveAllIteratively |        10 |       2,153.3 ns |        34.39 ns |        32.17 ns |     1.08 |    0.02 |       0.0076 |            - |            - |        832 B |
|                           RemoveAllStaggered |        10 |       2,155.8 ns |        14.75 ns |        12.32 ns |     1.08 |    0.01 |       0.0076 |            - |            - |        832 B |
|                                        Clear |        10 |       2,009.8 ns |         9.28 ns |         8.68 ns |     1.01 |    0.01 |       0.0095 |            - |            - |        832 B |
|                                     Contains |        10 |       1,929.0 ns |        22.30 ns |        19.77 ns |     0.97 |    0.01 |       0.0076 |            - |            - |        832 B |
|                              AddAndEnumerate |        10 |       2,604.8 ns |        24.90 ns |        23.30 ns |     1.30 |    0.01 |       0.0114 |            - |            - |      1,208 B |
|                            ClearAndEnumerate |        10 |       2,129.3 ns |        17.20 ns |        14.36 ns |     1.07 |    0.01 |       0.0076 |            - |            - |        872 B |
|  ManyAddsAndRemoveFromStartWithNoEnumeration |        10 |   2,792,548.4 ns |    30,965.98 ns |    27,450.53 ns | 1,398.07 |   15.53 |   10000.0000 |   10000.0000 |   10000.0000 |    247,178 B |
|    ManyAddsAndRemoveFromEndWithNoEnumeration |        10 |   2,722,532.8 ns |    21,266.11 ns |    18,851.85 ns | 1,365.12 |   11.18 |   10000.0000 |   10000.0000 |   10000.0000 |    243,084 B |
| ManyAddsAndRemoveFromMiddleWithNoEnumeration |        10 |   3,159,907.3 ns |    15,962.98 ns |    12,462.85 ns | 1,585.16 |   12.51 |   10000.0000 |   10000.0000 |   10000.0000 |    247,274 B |
|                                              |           |                  |                 |                 |          |         |              |              |              |              |
|                                          Add |       100 |      19,148.0 ns |       363.39 ns |       432.59 ns |     1.00 |    0.00 |       0.0610 |            - |            - |      6,648 B |
|                                    RemoveOne |       100 |      19,808.1 ns |       384.91 ns |       411.85 ns |     1.03 |    0.04 |       0.0610 |            - |            - |      6,648 B |
|                         RemoveAllIteratively |       100 |      21,445.1 ns |       338.48 ns |       316.61 ns |     1.12 |    0.03 |       0.0610 |            - |            - |      6,648 B |
|                           RemoveAllStaggered |       100 |      29,771.2 ns |       487.60 ns |       456.10 ns |     1.55 |    0.05 |       0.0610 |            - |            - |      6,648 B |
|                                        Clear |       100 |      19,095.5 ns |       374.96 ns |       332.40 ns |     1.00 |    0.02 |       0.0610 |            - |            - |      6,648 B |
|                                     Contains |       100 |      18,934.4 ns |       314.61 ns |       262.71 ns |     0.99 |    0.02 |       0.0610 |            - |            - |      6,648 B |
|                              AddAndEnumerate |       100 |      21,922.4 ns |       133.18 ns |       118.06 ns |     1.14 |    0.03 |       0.0916 |            - |            - |      8,768 B |
|                            ClearAndEnumerate |       100 |      18,626.2 ns |       168.56 ns |       157.67 ns |     0.97 |    0.03 |       0.0610 |            - |            - |      6,688 B |
|  ManyAddsAndRemoveFromStartWithNoEnumeration |       100 |  27,547,995.7 ns |   155,215.86 ns |   137,594.81 ns | 1,436.69 |   41.04 |  100000.0000 |  100000.0000 |  100000.0000 |  2,433,114 B |
|    ManyAddsAndRemoveFromEndWithNoEnumeration |       100 |  27,445,977.1 ns |   164,828.19 ns |   154,180.39 ns | 1,430.40 |   35.15 |  100000.0000 |  100000.0000 |  100000.0000 |  2,429,026 B |
| ManyAddsAndRemoveFromMiddleWithNoEnumeration |       100 |  30,571,756.1 ns |   228,124.38 ns |   202,226.32 ns | 1,594.18 |   37.21 |  100000.0000 |  100000.0000 |  100000.0000 |  2,433,210 B |
|                                              |           |                  |                 |                 |          |         |              |              |              |              |
|                                          Add |      1000 |     184,106.0 ns |     2,378.61 ns |     2,224.95 ns |     1.00 |    0.00 |       0.4883 |            - |            - |     56,992 B |
|                                    RemoveOne |      1000 |     182,037.7 ns |     2,216.83 ns |     2,073.62 ns |     0.99 |    0.01 |       0.4883 |            - |            - |     56,992 B |
|                         RemoveAllIteratively |      1000 |     208,189.3 ns |     2,064.66 ns |     1,931.28 ns |     1.13 |    0.02 |       0.4883 |            - |            - |     56,992 B |
|                           RemoveAllStaggered |      1000 |     824,296.9 ns |     4,314.31 ns |     4,035.61 ns |     4.48 |    0.05 |            - |            - |            - |     56,992 B |
|                                        Clear |      1000 |     178,118.6 ns |     1,075.45 ns |     1,005.98 ns |     0.97 |    0.01 |       0.4883 |            - |            - |     56,992 B |
|                                     Contains |      1000 |     186,192.7 ns |     1,705.44 ns |     1,595.27 ns |     1.01 |    0.02 |       0.4883 |            - |            - |     56,992 B |
|                              AddAndEnumerate |      1000 |     204,933.7 ns |     1,622.78 ns |     1,355.10 ns |     1.11 |    0.02 |       0.7324 |            - |            - |     73,640 B |
|                            ClearAndEnumerate |      1000 |     174,722.4 ns |     1,200.51 ns |     1,002.48 ns |     0.95 |    0.02 |       0.4883 |            - |            - |     57,032 B |
|  ManyAddsAndRemoveFromStartWithNoEnumeration |      1000 | 278,152,875.8 ns | 2,059,741.45 ns | 1,926,683.43 ns | 1,511.06 |   23.16 | 1000000.0000 | 1000000.0000 | 1000000.0000 | 24,293,544 B |
|    ManyAddsAndRemoveFromEndWithNoEnumeration |      1000 | 271,096,204.4 ns | 2,664,123.90 ns | 2,492,023.15 ns | 1,472.74 |   25.29 | 1000000.0000 | 1000000.0000 | 1000000.0000 | 24,288,496 B |
| ManyAddsAndRemoveFromMiddleWithNoEnumeration |      1000 | 308,113,419.2 ns | 2,752,476.59 ns | 2,574,668.31 ns | 1,673.81 |   25.51 | 1000000.0000 | 1000000.0000 | 1000000.0000 | 24,293,640 B |
```

The [initial implementation](https://github.com/smoogipoo/osu-framework/tree/weaklist-gen2-trim) used Gen2 GC callbacks, which result in the following measurements.
```
|                                       Method | ItemCount |             Mean |           Error |          StdDev |    Ratio | RatioSD |        Gen 0 |        Gen 1 |        Gen 2 |    Allocated |
|--------------------------------------------- |---------- |-----------------:|----------------:|----------------:|---------:|--------:|-------------:|-------------:|-------------:|-------------:|
|                                          Add |         1 |         239.2 ns |         4.03 ns |         3.77 ns |     1.00 |    0.00 |       0.0021 |            - |            - |        184 B |
|                                    RemoveOne |         1 |         246.0 ns |         3.44 ns |         3.22 ns |     1.03 |    0.02 |       0.0019 |            - |            - |        184 B |
|                         RemoveAllIteratively |         1 |         255.3 ns |         1.60 ns |         1.42 ns |     1.07 |    0.02 |       0.0019 |            - |            - |        184 B |
|                           RemoveAllStaggered |         1 |         259.6 ns |         1.81 ns |         1.60 ns |     1.09 |    0.02 |       0.0019 |            - |            - |        184 B |
|                                        Clear |         1 |         241.2 ns |         1.74 ns |         1.63 ns |     1.01 |    0.02 |       0.0021 |            - |            - |        184 B |
|                                     Contains |         1 |         240.0 ns |         2.27 ns |         2.12 ns |     1.00 |    0.02 |       0.0019 |            - |            - |        184 B |
|                              AddAndEnumerate |         1 |         460.8 ns |         6.29 ns |         5.88 ns |     1.93 |    0.05 |       0.0033 |            - |            - |        312 B |
|                            ClearAndEnumerate |         1 |         365.1 ns |         3.87 ns |         3.62 ns |     1.53 |    0.02 |       0.0024 |            - |            - |        224 B |
|  ManyAddsAndRemoveFromStartWithNoEnumeration |         1 |     287,122.2 ns |     2,479.75 ns |     2,319.56 ns | 1,200.52 |   20.45 |    1000.0000 |    1000.0000 |    1000.0000 |     57,368 B |
|    ManyAddsAndRemoveFromEndWithNoEnumeration |         1 |     272,493.5 ns |     1,911.58 ns |     1,788.09 ns | 1,139.41 |   22.33 |    1000.0000 |    1000.0000 |    1000.0000 |     24,496 B |
| ManyAddsAndRemoveFromMiddleWithNoEnumeration |         1 |     917,598.5 ns |     4,150.87 ns |     3,679.64 ns | 3,840.37 |   72.50 |    1000.0000 |    1000.0000 |    1000.0000 |     57,464 B |
|                                              |           |                  |                 |                 |          |         |              |              |              |              |
|                                          Add |        10 |       1,919.3 ns |        18.76 ns |        17.54 ns |     1.00 |    0.00 |       0.0076 |            - |            - |        832 B |
|                                    RemoveOne |        10 |       1,944.2 ns |        11.50 ns |        10.76 ns |     1.01 |    0.01 |       0.0076 |            - |            - |        832 B |
|                         RemoveAllIteratively |        10 |       2,187.4 ns |        12.74 ns |        11.29 ns |     1.14 |    0.01 |       0.0076 |            - |            - |        832 B |
|                           RemoveAllStaggered |        10 |       2,184.1 ns |        22.99 ns |        21.51 ns |     1.14 |    0.01 |       0.0076 |            - |            - |        832 B |
|                                        Clear |        10 |       1,933.1 ns |        13.00 ns |        12.16 ns |     1.01 |    0.01 |       0.0076 |            - |            - |        832 B |
|                                     Contains |        10 |       1,930.1 ns |        11.36 ns |        10.62 ns |     1.01 |    0.01 |       0.0076 |            - |            - |        832 B |
|                              AddAndEnumerate |        10 |       2,641.6 ns |        26.93 ns |        23.88 ns |     1.38 |    0.01 |       0.0114 |            - |            - |      1,208 B |
|                            ClearAndEnumerate |        10 |       2,130.7 ns |        23.60 ns |        20.92 ns |     1.11 |    0.01 |       0.0076 |            - |            - |        872 B |
|  ManyAddsAndRemoveFromStartWithNoEnumeration |        10 |   2,854,414.0 ns |    40,507.65 ns |    35,908.97 ns | 1,488.10 |   26.64 |   10000.0000 |   10000.0000 |   10000.0000 |    304,910 B |
|    ManyAddsAndRemoveFromEndWithNoEnumeration |        10 |   2,728,811.8 ns |    22,347.49 ns |    19,810.47 ns | 1,422.56 |   15.82 |   10000.0000 |   10000.0000 |   10000.0000 |    243,090 B |
| ManyAddsAndRemoveFromMiddleWithNoEnumeration |        10 |   3,705,851.4 ns |    13,161.24 ns |    12,311.03 ns | 1,930.95 |   18.49 |   10000.0000 |   10000.0000 |   10000.0000 |    279,772 B |
|                                              |           |                  |                 |                 |          |         |              |              |              |              |
|                                          Add |       100 |      19,358.1 ns |        93.57 ns |        87.53 ns |     1.00 |    0.00 |       0.0610 |            - |            - |      6,648 B |
|                                    RemoveOne |       100 |      19,545.2 ns |        67.11 ns |        56.04 ns |     1.01 |    0.01 |       0.0610 |            - |            - |      6,648 B |
|                         RemoveAllIteratively |       100 |      21,283.7 ns |       422.71 ns |       395.40 ns |     1.10 |    0.02 |       0.0610 |            - |            - |      6,648 B |
|                           RemoveAllStaggered |       100 |      29,193.5 ns |       424.02 ns |       396.63 ns |     1.51 |    0.02 |       0.0610 |            - |            - |      6,648 B |
|                                        Clear |       100 |      19,056.3 ns |       103.70 ns |        91.92 ns |     0.98 |    0.01 |       0.0610 |            - |            - |      6,648 B |
|                                     Contains |       100 |      19,041.8 ns |       257.48 ns |       240.85 ns |     0.98 |    0.01 |       0.0610 |            - |            - |      6,648 B |
|                              AddAndEnumerate |       100 |      21,663.0 ns |        90.11 ns |        79.88 ns |     1.12 |    0.01 |       0.0916 |            - |            - |      8,768 B |
|                            ClearAndEnumerate |       100 |      18,588.5 ns |       254.14 ns |       237.72 ns |     0.96 |    0.01 |       0.0610 |            - |            - |      6,688 B |
|  ManyAddsAndRemoveFromStartWithNoEnumeration |       100 |  28,347,179.9 ns |   133,754.58 ns |   118,569.95 ns | 1,464.32 |    9.47 |  100000.0000 |  100000.0000 |  100000.0000 |  2,482,393 B |
|    ManyAddsAndRemoveFromEndWithNoEnumeration |       100 |  27,225,480.9 ns |   170,993.43 ns |   151,581.22 ns | 1,406.38 |   10.74 |  100000.0000 |  100000.0000 |  100000.0000 |  2,429,026 B |
| ManyAddsAndRemoveFromMiddleWithNoEnumeration |       100 |  31,046,941.9 ns |    82,425.60 ns |    68,829.11 ns | 1,605.10 |    7.41 |  100000.0000 |  100000.0000 |  100000.0000 |  2,480,440 B |
|                                              |           |                  |                 |                 |          |         |              |              |              |              |
|                                          Add |      1000 |     179,663.6 ns |     1,314.60 ns |     1,229.68 ns |     1.00 |    0.00 |       0.4883 |            - |            - |     56,992 B |
|                                    RemoveOne |      1000 |     179,280.1 ns |     1,344.92 ns |     1,192.24 ns |     1.00 |    0.01 |       0.4883 |            - |            - |     56,992 B |
|                         RemoveAllIteratively |      1000 |     205,078.0 ns |     1,110.07 ns |     1,038.36 ns |     1.14 |    0.01 |       0.4883 |            - |            - |     56,992 B |
|                           RemoveAllStaggered |      1000 |     813,608.8 ns |       559.17 ns |       523.05 ns |     4.53 |    0.03 |            - |            - |            - |     56,992 B |
|                                        Clear |      1000 |     178,131.9 ns |       638.81 ns |       566.29 ns |     0.99 |    0.01 |       0.4883 |            - |            - |     56,992 B |
|                                     Contains |      1000 |     183,710.3 ns |       581.88 ns |       544.29 ns |     1.02 |    0.01 |       0.4883 |            - |            - |     56,992 B |
|                              AddAndEnumerate |      1000 |     201,911.5 ns |     1,782.03 ns |     1,579.72 ns |     1.12 |    0.01 |       0.7324 |            - |            - |     73,640 B |
|                            ClearAndEnumerate |      1000 |     176,134.9 ns |     1,342.64 ns |     1,190.21 ns |     0.98 |    0.01 |       0.4883 |            - |            - |     57,032 B |
|  ManyAddsAndRemoveFromStartWithNoEnumeration |      1000 | 287,534,998.8 ns | 1,849,387.54 ns | 1,729,918.26 ns | 1,600.47 |   13.90 | 1000000.0000 | 1000000.0000 | 1000000.0000 | 24,356,056 B |
|    ManyAddsAndRemoveFromEndWithNoEnumeration |      1000 | 282,237,466.6 ns | 1,301,059.70 ns | 1,217,012.05 ns | 1,570.99 |   12.48 | 1000000.0000 | 1000000.0000 | 1000000.0000 | 24,290,328 B |
| ManyAddsAndRemoveFromMiddleWithNoEnumeration |      1000 | 308,819,423.8 ns | 1,917,468.70 ns | 1,699,786.06 ns | 1,718.42 |   15.24 | 1000000.0000 | 1000000.0000 | 1000000.0000 | 24,354,396 B |
```
Since these are pretty much in-line with the measurements from this PR, I'm taking the safe route and avoiding the overhead of an extra finalizer for the time being.