### PR TITLE
Fix `LoadComponentAsync` running load continuation asynchronously

### DIFF
--- a/osu.Framework.Tests/Containers/TestSceneLoadComponentAsync.cs
+++ b/osu.Framework.Tests/Containers/TestSceneLoadComponentAsync.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -127,6 +128,63 @@ namespace osu.Framework.Tests.Containers
             AddStep("Allow child 1 load", () => composite.AllowLoad.Set());
 
             AddUntilStep("Scheduled content run", () => scheduleRun);
+        }
+
+        /// <summary>
+        /// Ensure the work load, and importantly, the continuations do not run on the TPL thread pool.
+        /// Since we have our own task schedulers handling these load tasks.
+        /// </summary>
+        [Test]
+        public void TestNoTplThreadPoolReliance()
+        {
+            Container screen = null;
+
+            ManualResetEventSlim resetEvent = new ManualResetEventSlim();
+
+            int workerMin = 0;
+            int completionMin = 0;
+            int workerMax = 0;
+            int completionMax = 0;
+
+            int runCount = 0;
+
+            AddStep("set limited threadpool capacity", () =>
+            {
+                ThreadPool.GetMinThreads(out workerMin, out completionMin);
+                ThreadPool.GetMaxThreads(out workerMax, out completionMax);
+
+                ThreadPool.SetMinThreads(2, 2);
+                ThreadPool.SetMaxThreads(2, 2);
+            });
+
+            AddStep("saturate threadpool", () =>
+            {
+                for (int i = 0; i < 4; i++)
+                {
+                    Task.Run(() =>
+                    {
+                        Interlocked.Increment(ref runCount);
+                        return resetEvent.Wait(60000);
+                    });
+                }
+            });
+
+            AddAssert("Not all tasks started", () => runCount <= 2);
+
+            AddStep("load component asynchronously", () =>
+            {
+                LoadComponentAsync(screen = new Container(), Add);
+            });
+
+            AddUntilStep("wait for load", () => screen.IsLoaded);
+
+            AddStep("restore capacity", () =>
+            {
+                resetEvent.Set();
+
+                ThreadPool.SetMinThreads(workerMin, completionMin);
+                ThreadPool.SetMaxThreads(workerMax, completionMax);
+            });
         }
 
         private class AsyncChildrenLoadingComposite : CompositeDrawable

--- a/osu.Framework.Tests/Containers/TestSceneLoadComponentAsync.cs
+++ b/osu.Framework.Tests/Containers/TestSceneLoadComponentAsync.cs
@@ -137,7 +137,7 @@ namespace osu.Framework.Tests.Containers
         [Test]
         public void TestNoTplThreadPoolReliance()
         {
-            Container screen = null;
+            Container container = null;
 
             ManualResetEventSlim resetEvent = new ManualResetEventSlim();
 
@@ -173,10 +173,10 @@ namespace osu.Framework.Tests.Containers
 
             AddStep("load component asynchronously", () =>
             {
-                LoadComponentAsync(screen = new Container(), Add);
+                LoadComponentAsync(container = new Container(), Add);
             });
 
-            AddUntilStep("wait for load", () => screen.IsLoaded);
+            AddUntilStep("wait for load", () => container.IsLoaded);
 
             AddStep("restore capacity", () =>
             {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -203,7 +203,7 @@ namespace osu.Framework.Graphics.Containers
                         linkedSource.Dispose();
                     }
                 });
-            }, CancellationToken.None);
+            }, TaskContinuationOptions.ExecuteSynchronously);
         }
 
         /// <summary>

--- a/osu.Framework/Logging/LoadingComponentsLogger.cs
+++ b/osu.Framework/Logging/LoadingComponentsLogger.cs
@@ -58,8 +58,12 @@ namespace osu.Framework.Logging
             ThreadPool.GetMaxThreads(out int workerMax, out int completionMax);
 
             Logger.Log("🎱 Thread pool");
-            Logger.Log($"worker:     min {workerMin,-6:#,0} max {workerMax,-6:#,0} available {workerAvailable,-6:#,0}");
-            Logger.Log($"completion: min {completionMin,-6:#,0} max {completionMax,-6:#,0} available {completionAvailable,-6:#,0}");
+            // TODO: use after net6
+            // Logger.Log($"threads:         {ThreadPool.ThreadCount:#,0}");
+            // Logger.Log($"work pending:    {ThreadPool.PendingWorkItemCount:#,0}");
+            // Logger.Log($"work completed:  {ThreadPool.CompletedWorkItemCount:#,0}");
+            Logger.Log($"worker:          min {workerMin,-6:#,0} max {workerMax,-6:#,0} available {workerAvailable,-6:#,0}");
+            Logger.Log($"completion:      min {completionMin,-6:#,0} max {completionMax,-6:#,0} available {completionAvailable,-6:#,0}");
         }
     }
 }


### PR DESCRIPTION
There is no reason for this to be run asynchronously. It's a lean continuation and has no user code. This should improve performance of async load tasks as there is one less thread transition.

It also means if the TPL thread pool is saturated, drawables will still load. This may in turn cause unblocking of other threads in the thread pool (due to bad user implementations in drawable load code, for instance) and avoid potential deadlocks.

This should 100% resolve the `TestMultiplayer` failures where screens are stuck in a `Ready` but not `Loaded` state.

It does *not* fix the actual TPL saturation in said case, which is likely due to bad `async` implementation (ie. a `.Wait()` waiting on a blocking `Task.Run`). Haven't pinpointed yet but am going through all usages systematically. `TestMultiplayerClient` seems likely, and is written in a way that's very hard to track `async` usages (probably should not inherit `MultiplayerClient`) but it could be something else.