### PR TITLE
Reduce allocation overheads on all GL disposal paths

### DIFF
--- a/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
+++ b/osu.Framework/Graphics/BufferedDrawNodeSharedData.cs
@@ -106,7 +106,7 @@ namespace osu.Framework.Graphics
 
         public void Dispose()
         {
-            GLWrapper.ScheduleDisposal(() => Dispose(true));
+            GLWrapper.ScheduleDisposal(d => d.Dispose(true), this);
             GC.SuppressFinalize(this);
         }
 

--- a/osu.Framework/Graphics/DrawNode.cs
+++ b/osu.Framework/Graphics/DrawNode.cs
@@ -291,7 +291,7 @@ namespace osu.Framework.Graphics
             if (Interlocked.Decrement(ref referenceCount) != 0)
                 return;
 
-            GLWrapper.ScheduleDisposal(() => Dispose(true));
+            GLWrapper.ScheduleDisposal(node => node.Dispose(true), this);
             GC.SuppressFinalize(this);
         }
 

--- a/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/FrameBuffer.cs
@@ -111,7 +111,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         ~FrameBuffer()
         {
-            GLWrapper.ScheduleDisposal(() => Dispose(false));
+            GLWrapper.ScheduleDisposal(b => b.Dispose(false), this);
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/RenderBuffer.cs
@@ -73,7 +73,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         ~RenderBuffer()
         {
-            GLWrapper.ScheduleDisposal(() => Dispose(false));
+            GLWrapper.ScheduleDisposal(b => b.Dispose(false), this);
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
+++ b/osu.Framework/Graphics/OpenGL/Buffers/VertexBuffer.cs
@@ -72,7 +72,7 @@ namespace osu.Framework.Graphics.OpenGL.Buffers
 
         ~VertexBuffer()
         {
-            GLWrapper.ScheduleDisposal(() => Dispose(false));
+            GLWrapper.ScheduleDisposal(v => v.Dispose(false), this);
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/OpenGL/GLDisposalQueue.cs
+++ b/osu.Framework/Graphics/OpenGL/GLDisposalQueue.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Graphics.OpenGL
         public void ScheduleDisposal<T>(Action<T> disposalAction, T target)
         {
             lock (newDisposals)
-                newDisposals.Add(new PendingDisposal<T>(target, disposalAction));
+                newDisposals.Add(new PendingDisposal<T>(disposalAction, target));
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace osu.Framework.Graphics.OpenGL
 
             private readonly T target;
 
-            public PendingDisposal(T target, Action<T> disposeAction)
+            public PendingDisposal(Action<T> disposeAction, T target)
             {
                 action = disposeAction;
                 this.target = target;

--- a/osu.Framework/Graphics/OpenGL/GLDisposalQueue.cs
+++ b/osu.Framework/Graphics/OpenGL/GLDisposalQueue.cs
@@ -12,13 +12,13 @@ namespace osu.Framework.Graphics.OpenGL
     /// </summary>
     internal class GLDisposalQueue
     {
-        private readonly List<PendingDisposal> newDisposals;
-        private readonly List<PendingDisposal> pendingDisposals;
+        private readonly List<IPendingDisposal> newDisposals;
+        private readonly List<IPendingDisposal> pendingDisposals;
 
         public GLDisposalQueue()
         {
-            newDisposals = new List<PendingDisposal>();
-            pendingDisposals = new List<PendingDisposal>();
+            newDisposals = new List<IPendingDisposal>();
+            pendingDisposals = new List<IPendingDisposal>();
         }
 
         /// <summary>
@@ -27,10 +27,11 @@ namespace osu.Framework.Graphics.OpenGL
         /// By default the disposal will run <see cref="GLWrapper.MAX_DRAW_NODES"/> frames after enqueueing.
         /// </summary>
         /// <param name="disposalAction">The disposal action to be executed.</param>
-        public void ScheduleDisposal(Action disposalAction)
+        /// <param name="target">The target.</param>
+        public void ScheduleDisposal<T>(Action<T> disposalAction, T target)
         {
             lock (newDisposals)
-                newDisposals.Add(new PendingDisposal(disposalAction));
+                newDisposals.Add(new PendingDisposal<T>(target, disposalAction));
         }
 
         /// <summary>
@@ -58,7 +59,7 @@ namespace osu.Framework.Graphics.OpenGL
 
                 if (item.RemainingFrameDelay-- == 0)
                 {
-                    item.Action();
+                    item.Run();
                     lastExecutedDisposal = i;
                 }
             }
@@ -74,16 +75,29 @@ namespace osu.Framework.Graphics.OpenGL
             pendingDisposals.RemoveRange(0, lastExecutedDisposal + 1);
         }
 
-        private class PendingDisposal
+        private class PendingDisposal<T> : IPendingDisposal
         {
-            public int RemainingFrameDelay = GLWrapper.MAX_DRAW_NODES;
+            public int RemainingFrameDelay { get; set; }
 
-            public readonly Action Action;
+            private readonly Action<T> action;
 
-            public PendingDisposal(Action action)
+            private readonly T target;
+
+            public PendingDisposal(T target, Action<T> disposeAction)
             {
-                Action = action;
+                action = disposeAction;
+                this.target = target;
+                RemainingFrameDelay = GLWrapper.MAX_DRAW_NODES;
             }
+
+            public void Run() => action(target);
+        }
+
+        private interface IPendingDisposal
+        {
+            void Run();
+
+            int RemainingFrameDelay { get; set; }
         }
     }
 }

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -119,12 +119,12 @@ namespace osu.Framework.Graphics.OpenGL
 
         private static readonly GLDisposalQueue disposal_queue = new GLDisposalQueue();
 
-        internal static void ScheduleDisposal(Action disposalAction)
+        internal static void ScheduleDisposal<T>(Action<T> disposalAction, T target)
         {
             if (host != null && host.TryGetTarget(out _))
-                disposal_queue.ScheduleDisposal(disposalAction);
+                disposal_queue.ScheduleDisposal(disposalAction, target);
             else
-                disposalAction.Invoke();
+                disposalAction.Invoke(target);
         }
 
         private static void checkPendingDisposals()

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -879,7 +879,7 @@ namespace osu.Framework.Graphics.OpenGL
             while (frame_buffer_stack.Peek() == frameBuffer)
                 UnbindFrameBuffer(frameBuffer);
 
-            ScheduleDisposal(() => { GL.DeleteFramebuffer(frameBuffer); });
+            ScheduleDisposal(GL.DeleteFramebuffer, frameBuffer);
         }
 
         private static int currentShader;

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -48,7 +48,10 @@ namespace osu.Framework.Graphics.OpenGL.Textures
 
         private bool isDisposed;
 
-        protected virtual void Dispose(bool isDisposing) => GLWrapper.ScheduleDisposal(() => Available = false);
+        protected virtual void Dispose(bool isDisposing)
+        {
+            GLWrapper.ScheduleDisposal(t => t.Available = false, this);
+        }
 
         public void Dispose()
         {

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -106,24 +106,24 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             while (tryGetNextUpload(out var upload))
                 upload.Dispose();
 
-            GLWrapper.ScheduleDisposal(unload);
+            GLWrapper.ScheduleDisposal(unload, this);
         }
 
         /// <summary>
         /// Removes texture from GL memory.
         /// </summary>
-        private void unload()
+        private static void unload(TextureGLSingle texture)
         {
-            int disposableId = textureId;
+            int disposableId = texture.textureId;
 
             if (disposableId <= 0)
                 return;
 
             GL.DeleteTextures(1, new[] { disposableId });
 
-            memoryLease?.Dispose();
+            texture.memoryLease?.Dispose();
 
-            textureId = 0;
+            texture.textureId = 0;
         }
 
         #endregion

--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGLSingle.cs
@@ -106,24 +106,19 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             while (tryGetNextUpload(out var upload))
                 upload.Dispose();
 
-            GLWrapper.ScheduleDisposal(unload, this);
-        }
+            GLWrapper.ScheduleDisposal(texture =>
+            {
+                int disposableId = texture.textureId;
 
-        /// <summary>
-        /// Removes texture from GL memory.
-        /// </summary>
-        private static void unload(TextureGLSingle texture)
-        {
-            int disposableId = texture.textureId;
+                if (disposableId <= 0)
+                    return;
 
-            if (disposableId <= 0)
-                return;
+                GL.DeleteTextures(1, new[] { disposableId });
 
-            GL.DeleteTextures(1, new[] { disposableId });
+                texture.memoryLease?.Dispose();
 
-            texture.memoryLease?.Dispose();
-
-            texture.textureId = 0;
+                texture.textureId = 0;
+            }, this);
         }
 
         #endregion

--- a/osu.Framework/Graphics/Shaders/Shader.cs
+++ b/osu.Framework/Graphics/Shaders/Shader.cs
@@ -221,7 +221,7 @@ namespace osu.Framework.Graphics.Shaders
 
         ~Shader()
         {
-            GLWrapper.ScheduleDisposal(() => Dispose(false));
+            GLWrapper.ScheduleDisposal(s => s.Dispose(false), this);
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/Shaders/ShaderManager.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderManager.cs
@@ -120,14 +120,14 @@ namespace osu.Framework.Graphics.Shaders
 
                 store.Dispose();
 
-                GLWrapper.ScheduleDisposal(() =>
+                GLWrapper.ScheduleDisposal(s =>
                 {
-                    foreach (var shader in shaderCache.Values)
+                    foreach (var shader in s.shaderCache.Values)
                         shader.Dispose();
 
-                    foreach (var part in partCache.Values)
+                    foreach (var part in s.partCache.Values)
                         part.Dispose();
-                });
+                }, this);
             }
         }
 

--- a/osu.Framework/Graphics/Shaders/ShaderPart.cs
+++ b/osu.Framework/Graphics/Shaders/ShaderPart.cs
@@ -156,7 +156,7 @@ namespace osu.Framework.Graphics.Shaders
 
         ~ShaderPart()
         {
-            GLWrapper.ScheduleDisposal(() => Dispose(false));
+            GLWrapper.ScheduleDisposal(s => s.Dispose(false), this);
         }
 
         public void Dispose()

--- a/osu.Framework/Graphics/Video/VideoTexture.cs
+++ b/osu.Framework/Graphics/Video/VideoTexture.cs
@@ -134,18 +134,20 @@ namespace osu.Framework.Graphics.Video
 
             memoryLease?.Dispose();
 
-            GLWrapper.ScheduleDisposal(unload);
+            GLWrapper.ScheduleDisposal(unload, this);
         }
 
-        private void unload()
+        private void unload(VideoTexture v)
         {
-            if (textureIds == null)
+            int[] ids = v.textureIds;
+
+            if (ids == null)
                 return;
 
-            for (int i = 0; i < textureIds.Length; i++)
+            for (int i = 0; i < ids.Length; i++)
             {
-                if (textureIds[i] >= 0)
-                    GL.DeleteTextures(1, new[] { textureIds[i] });
+                if (ids[i] >= 0)
+                    GL.DeleteTextures(1, new[] { ids[i] });
             }
         }
 

--- a/osu.Framework/Graphics/Video/VideoTexture.cs
+++ b/osu.Framework/Graphics/Video/VideoTexture.cs
@@ -134,21 +134,19 @@ namespace osu.Framework.Graphics.Video
 
             memoryLease?.Dispose();
 
-            GLWrapper.ScheduleDisposal(unload, this);
-        }
-
-        private void unload(VideoTexture v)
-        {
-            int[] ids = v.textureIds;
-
-            if (ids == null)
-                return;
-
-            for (int i = 0; i < ids.Length; i++)
+            GLWrapper.ScheduleDisposal(v =>
             {
-                if (ids[i] >= 0)
-                    GL.DeleteTextures(1, new[] { ids[i] });
-            }
+                int[] ids = v.textureIds;
+
+                if (ids == null)
+                    return;
+
+                for (int i = 0; i < ids.Length; i++)
+                {
+                    if (ids[i] >= 0)
+                        GL.DeleteTextures(1, new[] { ids[i] });
+                }
+            }, this);
         }
 
         #endregion


### PR DESCRIPTION
Testing at song select since that's where I noticed it the most (`DrawNode` specifically).

Before:

![20211226 144605 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/147400112-39f22bd0-76dc-4e0d-8794-8ac6a498ff88.png)

After:

![20211226 145550 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/147400256-aac40503-c213-4c8d-8745-f491aec448ea.png)

Of note, the delegate overhead is gone. The remaining allocation cost is from `PendingDisposal`. Could theoretically make is a `struct`, but due to the generic `T`, it would incur one boxing cast for the interface. Not sure it's worth that. For `DrawNode` the invocation is always inline, so `PendingDisposal` is never constructed, so that particular case is fixed 100%.

![20211226 145651 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/147400271-0efe7120-28cd-4da1-98b3-9656df1894e7.png)
