### PR TITLE
Reduce delegate allocation overheads

### DIFF
--- a/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
+++ b/osu.Framework/Graphics/Containers/DelayedLoadWrapper.cs
@@ -202,7 +202,7 @@ namespace osu.Framework.Graphics.Containers
             // The scheduled delegate will be cancelled if this wrapper has its UpdateSubTreeMasking() invoked, as more accurate intersections can be computed there instead.
             if (isIntersectingResetDelegate == null)
             {
-                isIntersectingResetDelegate = Game?.Scheduler.AddDelayed(() => IsIntersecting = false, 0);
+                isIntersectingResetDelegate = Game?.Scheduler.AddDelayed(wrapper => wrapper.IsIntersecting = false, this, 0);
                 result = true;
             }
 

--- a/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
+++ b/osu.Framework/Graphics/Pooling/PoolableDrawable.cs
@@ -109,11 +109,13 @@ namespace osu.Framework.Graphics.Pooling
             // prepare call is scheduled as it may contain user code dependent on the clock being updated.
             // must use Scheduler.Add, not Schedule as we may have the wrong clock at this point in load.
             scheduledPrepare?.Cancel();
-            scheduledPrepare = Scheduler.Add(() =>
+            scheduledPrepare = Scheduler.Add(prepare, this);
+
+            void prepare(PoolableDrawable drawable)
             {
-                PrepareForUse();
-                waitingForPrepare = false;
-            });
+                drawable.PrepareForUse();
+                drawable.waitingForPrepare = false;
+            }
         }
 
         protected override bool OnInvalidate(Invalidation invalidation, InvalidationSource source)

--- a/osu.Framework/Threading/ScheduledDelegate.cs
+++ b/osu.Framework/Threading/ScheduledDelegate.cs
@@ -89,7 +89,7 @@ namespace osu.Framework.Threading
 
                 State = RunState.Running;
 
-                Task();
+                InvokeTask();
 
                 // task may have been cancelled during execution.
                 if (State == RunState.Cancelled)
@@ -99,6 +99,8 @@ namespace osu.Framework.Threading
                 State = RunState.Complete;
             }
         }
+
+        protected virtual void InvokeTask() => Task();
 
         /// <summary>
         /// Cancel a task.

--- a/osu.Framework/Threading/ScheduledDelegateWithData.cs
+++ b/osu.Framework/Threading/ScheduledDelegateWithData.cs
@@ -16,8 +16,8 @@ namespace osu.Framework.Threading
         {
             Task = task;
             Data = data;
-
-            base.Task = () => Task(Data);
         }
+
+        protected override void InvokeTask() => Task(Data);
     }
 }


### PR DESCRIPTION
Tested at osu! song select while scrolling. I've only addressed the cases which are excessive for now.

Before:
![20211226 154033 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/147400979-bf5513c4-7376-49d7-8215-b438d273fe83.png)


After:
![20211226 152913 (Parallels Desktop app)](https://user-images.githubusercontent.com/191335/147400970-27b1713f-8f27-4d54-a3cc-98876f456d83.png)

Main targets are `DelayedLoadWrapper` and mouse movement.

Note that `DelayedLoadWrapper` still allocates quite a few `ScheduledDelegateWithData`, but this is harder to avoid. Still an improvement.