### PR TITLE
Improve Android mouse input and restructure Android input handlers

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -17,10 +17,12 @@ namespace osu.Framework.Android
     {
         protected const ConfigChanges DEFAULT_CONFIG_CHANGES = ConfigChanges.Keyboard
                                                                | ConfigChanges.KeyboardHidden
+                                                               | ConfigChanges.Navigation
                                                                | ConfigChanges.Orientation
                                                                | ConfigChanges.ScreenLayout
                                                                | ConfigChanges.ScreenSize
                                                                | ConfigChanges.SmallestScreenSize
+                                                               | ConfigChanges.Touchscreen
                                                                | ConfigChanges.UiMode;
 
         protected const LaunchMode DEFAULT_LAUNCH_MODE = LaunchMode.SingleInstance;

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -51,6 +51,7 @@ namespace osu.Framework.Android
         protected override IEnumerable<InputHandler> CreateAvailableInputHandlers() =>
             new InputHandler[]
             {
+                new AndroidMouseHandler(gameView),
                 new AndroidKeyboardHandler(gameView),
                 new AndroidTouchHandler(gameView),
                 new MidiHandler()

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -79,107 +79,23 @@ namespace osu.Framework.Android
                 case Keycode.VolumeUp:
                 case Keycode.VolumeMute:
                     return false;
-            }
 
-            // some implementations might send Mouse1 and Mouse2 as keyboard keycodes, so forward those only to the mouse event.
-            switch (e.Source)
-            {
-                case InputSourceType.Keyboard:
+                default:
                     KeyDown?.Invoke(keyCode, e);
                     return true;
-
-                case InputSourceType.Mouse:
-                case InputSourceType.Touchpad:
-                    MouseKeyDown?.Invoke(keyCode, e);
-                    return true;
             }
-
-            return base.OnKeyDown(keyCode, e);
         }
 
         public override bool OnKeyLongPress([GeneratedEnum] Keycode keyCode, KeyEvent e)
         {
-            switch (e.Source)
-            {
-                case InputSourceType.Keyboard:
-                    KeyLongPress?.Invoke(keyCode, e);
-                    return true;
-
-                case InputSourceType.Mouse:
-                case InputSourceType.Touchpad:
-                    MouseKeyLongPress?.Invoke(keyCode, e);
-                    return true;
-            }
-
-            return base.OnKeyLongPress(keyCode, e);
+            KeyLongPress?.Invoke(keyCode, e);
+            return true;
         }
 
         public override bool OnKeyUp([GeneratedEnum] Keycode keyCode, KeyEvent e)
         {
-            switch (e.Source)
-            {
-                case InputSourceType.Keyboard:
-                    KeyUp?.Invoke(keyCode, e);
-                    return true;
-
-                case InputSourceType.Mouse:
-                case InputSourceType.Touchpad:
-                    MouseKeyUp?.Invoke(keyCode, e);
-                    return true;
-            }
-
-            return base.OnKeyUp(keyCode, e);
-        }
-
-        public override bool OnHoverEvent(MotionEvent e)
-        {
-            switch (e.Source)
-            {
-                case InputSourceType.BluetoothStylus:
-                case InputSourceType.Stylus:
-                case InputSourceType.Touchscreen:
-                    Hover?.Invoke(e);
-                    return true;
-
-                case InputSourceType.Mouse:
-                case InputSourceType.Touchpad:
-                    MouseHover?.Invoke(e);
-                    return true;
-            }
-
-            return base.OnHoverEvent(e);
-        }
-
-        public override bool OnTouchEvent(MotionEvent e)
-        {
-            switch (e.Source)
-            {
-                case InputSourceType.BluetoothStylus:
-                case InputSourceType.Stylus:
-                case InputSourceType.Touchscreen:
-                    Touch?.Invoke(e);
-                    return true;
-
-                case InputSourceType.Mouse:
-                case InputSourceType.Touchpad:
-                    MouseTouch?.Invoke(e);
-                    return true;
-            }
-
-            return base.OnTouchEvent(e);
-        }
-
-        public override bool OnGenericMotionEvent(MotionEvent e)
-        {
-            switch (e.Source)
-            {
-                case InputSourceType.Mouse:
-                case InputSourceType.Touchpad:
-                    MouseGenericMotion?.Invoke(e);
-                    return true;
-            }
-
-            return base.OnGenericMotionEvent(e);
+            KeyUp?.Invoke(keyCode, e);
+            return true;
         }
 
         protected override void OnLoad(EventArgs e)
@@ -223,79 +139,19 @@ namespace osu.Framework.Android
         #region Events
 
         /// <summary>
-        /// Invoked on a key down event sourced from a <see cref="InputSourceType.Keyboard"/>.
+        /// Invoked on a key down event.
         /// </summary>
         public new event Action<Keycode, KeyEvent> KeyDown;
 
         /// <summary>
-        /// Invoked on a key up event sourced from a <see cref="InputSourceType.Keyboard"/>.
+        /// Invoked on a key up event.
         /// </summary>
         public new event Action<Keycode, KeyEvent> KeyUp;
 
         /// <summary>
-        /// Invoked on a key long press event sourced from a <see cref="InputSourceType.Keyboard"/>.
+        /// Invoked on a key long press event.
         /// </summary>
         public event Action<Keycode, KeyEvent> KeyLongPress;
-
-        /// <summary>
-        /// Invoked on a hover event sourced from a touch-type device.
-        /// </summary>
-        /// <remarks>
-        /// Invoked if the source is <see cref="InputSourceType.BluetoothStylus"/>, <see cref="InputSourceType.Stylus"/>
-        /// or <see cref="InputSourceType.Touchscreen"/>.
-        /// </remarks>
-        public new event Action<MotionEvent> Hover;
-
-        /// <summary>
-        /// Invoked on a touch event sourced from a touch-type device.
-        /// </summary>
-        /// <remarks>
-        /// Invoked if the source is <see cref="InputSourceType.BluetoothStylus"/>, <see cref="InputSourceType.Stylus"/>
-        /// or <see cref="InputSourceType.Touchscreen"/>.
-        /// </remarks>
-        public new event Action<MotionEvent> Touch;
-
-        /// <summary>
-        /// Invoked on a key down event sourced from a mouse-type device.
-        /// </summary>
-        /// <remarks>Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.</remarks>
-        public event Action<Keycode, KeyEvent> MouseKeyDown;
-
-        /// <summary>
-        /// Invoked on a key up event sourced from a mouse-type device.
-        /// </summary>
-        /// <remarks>Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.</remarks>
-        public event Action<Keycode, KeyEvent> MouseKeyUp;
-
-        /// <summary>
-        /// Invoked on a key long press event sourced from a mouse-type device.
-        /// </summary>
-        /// <remarks>Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.</remarks>
-        public event Action<Keycode, KeyEvent> MouseKeyLongPress;
-
-        /// <summary>
-        /// Invoked on a hover event sourced from a mouse-type device.
-        /// </summary>
-        /// <remarks>
-        /// Similar to <see cref="MouseTouch"/> but invoked when no buttons are pressed.
-        /// Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.
-        /// </remarks>
-        public event Action<MotionEvent> MouseHover;
-
-        /// <summary>
-        /// Invoked on a touch sourced from a mouse-type device.
-        /// </summary>
-        /// <remarks>
-        /// Similar to <see cref="MouseHover"/> but invoked when one or more buttons are pressed.
-        /// Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.
-        /// </remarks>
-        public event Action<MotionEvent> MouseTouch;
-
-        /// <summary>
-        /// Invoked on a generic motion sourced from a mouse-type device.
-        /// </summary>
-        /// <remarks>Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.</remarks>
-        public event Action<MotionEvent> MouseGenericMotion;
 
         /// <summary>
         /// Invoked when text is committed by an <see cref="AndroidInputConnection"/>.

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -19,12 +19,6 @@ namespace osu.Framework.Android
 
         private readonly Game game;
 
-        public new event Action<Keycode, KeyEvent> KeyDown;
-        public new event Action<Keycode, KeyEvent> KeyUp;
-        public event Action<Keycode, KeyEvent> KeyLongPress;
-        public event Action<string> CommitText;
-        public event Action<AndroidGameHost> HostStarted;
-
         public AndroidGameView(Context context, Game game)
             : base(context)
         {
@@ -104,6 +98,18 @@ namespace osu.Framework.Android
             return true;
         }
 
+        public override bool OnHoverEvent(MotionEvent e)
+        {
+            Hover?.Invoke(e);
+            return true;
+        }
+
+        public override bool OnTouchEvent(MotionEvent e)
+        {
+            Touch?.Invoke(e);
+            return true;
+        }
+
         protected override void OnLoad(EventArgs e)
         {
             base.OnLoad(e);
@@ -141,5 +147,44 @@ namespace osu.Framework.Android
             outAttrs.InputType = InputTypes.TextVariationVisiblePassword | InputTypes.TextFlagNoSuggestions;
             return new AndroidInputConnection(this, true);
         }
+
+        #region Events
+
+        /// <summary>
+        /// Invoked on a key down event.
+        /// </summary>
+        public new event Action<Keycode, KeyEvent> KeyDown;
+
+        /// <summary>
+        /// Invoked on a key up event.
+        /// </summary>
+        public new event Action<Keycode, KeyEvent> KeyUp;
+
+        /// <summary>
+        /// Invoked on a key long press event.
+        /// </summary>
+        public event Action<Keycode, KeyEvent> KeyLongPress;
+
+        /// <summary>
+        /// Invoked on a hover event.
+        /// </summary>
+        public new event Action<MotionEvent> Hover;
+
+        /// <summary>
+        /// Invoked on a touch event.
+        /// </summary>
+        public new event Action<MotionEvent> Touch;
+
+        /// <summary>
+        /// Invoked when text is committed by an <see cref="AndroidInputConnection"/>.
+        /// </summary>
+        public event Action<string> CommitText;
+
+        /// <summary>
+        /// Invoked when the <see cref="game"/> has been started on the <see cref="Host"/>.
+        /// </summary>
+        public event Action<AndroidGameHost> HostStarted;
+
+        #endregion
     }
 }

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -79,35 +79,107 @@ namespace osu.Framework.Android
                 case Keycode.VolumeUp:
                 case Keycode.VolumeMute:
                     return false;
+            }
 
-                default:
+            // some implementations might send Mouse1 and Mouse2 as keyboard keycodes, so forward those only to the mouse event.
+            switch (e.Source)
+            {
+                case InputSourceType.Keyboard:
                     KeyDown?.Invoke(keyCode, e);
                     return true;
+
+                case InputSourceType.Mouse:
+                case InputSourceType.Touchpad:
+                    MouseKeyDown?.Invoke(keyCode, e);
+                    return true;
             }
+
+            return base.OnKeyDown(keyCode, e);
         }
 
         public override bool OnKeyLongPress([GeneratedEnum] Keycode keyCode, KeyEvent e)
         {
-            KeyLongPress?.Invoke(keyCode, e);
-            return true;
+            switch (e.Source)
+            {
+                case InputSourceType.Keyboard:
+                    KeyLongPress?.Invoke(keyCode, e);
+                    return true;
+
+                case InputSourceType.Mouse:
+                case InputSourceType.Touchpad:
+                    MouseKeyLongPress?.Invoke(keyCode, e);
+                    return true;
+            }
+
+            return base.OnKeyLongPress(keyCode, e);
         }
 
         public override bool OnKeyUp([GeneratedEnum] Keycode keyCode, KeyEvent e)
         {
-            KeyUp?.Invoke(keyCode, e);
-            return true;
+            switch (e.Source)
+            {
+                case InputSourceType.Keyboard:
+                    KeyUp?.Invoke(keyCode, e);
+                    return true;
+
+                case InputSourceType.Mouse:
+                case InputSourceType.Touchpad:
+                    MouseKeyUp?.Invoke(keyCode, e);
+                    return true;
+            }
+
+            return base.OnKeyUp(keyCode, e);
         }
 
         public override bool OnHoverEvent(MotionEvent e)
         {
-            Hover?.Invoke(e);
-            return true;
+            switch (e.Source)
+            {
+                case InputSourceType.BluetoothStylus:
+                case InputSourceType.Stylus:
+                case InputSourceType.Touchscreen:
+                    Hover?.Invoke(e);
+                    return true;
+
+                case InputSourceType.Mouse:
+                case InputSourceType.Touchpad:
+                    MouseHover?.Invoke(e);
+                    return true;
+            }
+
+            return base.OnHoverEvent(e);
         }
 
         public override bool OnTouchEvent(MotionEvent e)
         {
-            Touch?.Invoke(e);
-            return true;
+            switch (e.Source)
+            {
+                case InputSourceType.BluetoothStylus:
+                case InputSourceType.Stylus:
+                case InputSourceType.Touchscreen:
+                    Touch?.Invoke(e);
+                    return true;
+
+                case InputSourceType.Mouse:
+                case InputSourceType.Touchpad:
+                    MouseTouch?.Invoke(e);
+                    return true;
+            }
+
+            return base.OnTouchEvent(e);
+        }
+
+        public override bool OnGenericMotionEvent(MotionEvent e)
+        {
+            switch (e.Source)
+            {
+                case InputSourceType.Mouse:
+                case InputSourceType.Touchpad:
+                    MouseGenericMotion?.Invoke(e);
+                    return true;
+            }
+
+            return base.OnGenericMotionEvent(e);
         }
 
         protected override void OnLoad(EventArgs e)
@@ -151,29 +223,79 @@ namespace osu.Framework.Android
         #region Events
 
         /// <summary>
-        /// Invoked on a key down event.
+        /// Invoked on a key down event sourced from a <see cref="InputSourceType.Keyboard"/>.
         /// </summary>
         public new event Action<Keycode, KeyEvent> KeyDown;
 
         /// <summary>
-        /// Invoked on a key up event.
+        /// Invoked on a key up event sourced from a <see cref="InputSourceType.Keyboard"/>.
         /// </summary>
         public new event Action<Keycode, KeyEvent> KeyUp;
 
         /// <summary>
-        /// Invoked on a key long press event.
+        /// Invoked on a key long press event sourced from a <see cref="InputSourceType.Keyboard"/>.
         /// </summary>
         public event Action<Keycode, KeyEvent> KeyLongPress;
 
         /// <summary>
-        /// Invoked on a hover event.
+        /// Invoked on a hover event sourced from a touch-type device.
         /// </summary>
+        /// <remarks>
+        /// Invoked if the source is <see cref="InputSourceType.BluetoothStylus"/>, <see cref="InputSourceType.Stylus"/>
+        /// or <see cref="InputSourceType.Touchscreen"/>.
+        /// </remarks>
         public new event Action<MotionEvent> Hover;
 
         /// <summary>
-        /// Invoked on a touch event.
+        /// Invoked on a touch event sourced from a touch-type device.
         /// </summary>
+        /// <remarks>
+        /// Invoked if the source is <see cref="InputSourceType.BluetoothStylus"/>, <see cref="InputSourceType.Stylus"/>
+        /// or <see cref="InputSourceType.Touchscreen"/>.
+        /// </remarks>
         public new event Action<MotionEvent> Touch;
+
+        /// <summary>
+        /// Invoked on a key down event sourced from a mouse-type device.
+        /// </summary>
+        /// <remarks>Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.</remarks>
+        public event Action<Keycode, KeyEvent> MouseKeyDown;
+
+        /// <summary>
+        /// Invoked on a key up event sourced from a mouse-type device.
+        /// </summary>
+        /// <remarks>Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.</remarks>
+        public event Action<Keycode, KeyEvent> MouseKeyUp;
+
+        /// <summary>
+        /// Invoked on a key long press event sourced from a mouse-type device.
+        /// </summary>
+        /// <remarks>Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.</remarks>
+        public event Action<Keycode, KeyEvent> MouseKeyLongPress;
+
+        /// <summary>
+        /// Invoked on a hover event sourced from a mouse-type device.
+        /// </summary>
+        /// <remarks>
+        /// Similar to <see cref="MouseTouch"/> but invoked when no buttons are pressed.
+        /// Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.
+        /// </remarks>
+        public event Action<MotionEvent> MouseHover;
+
+        /// <summary>
+        /// Invoked on a touch sourced from a mouse-type device.
+        /// </summary>
+        /// <remarks>
+        /// Similar to <see cref="MouseHover"/> but invoked when one or more buttons are pressed.
+        /// Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.
+        /// </remarks>
+        public event Action<MotionEvent> MouseTouch;
+
+        /// <summary>
+        /// Invoked on a generic motion sourced from a mouse-type device.
+        /// </summary>
+        /// <remarks>Invoked if the source is <see cref="InputSourceType.Mouse"/> or <see cref="InputSourceType.Touchpad"/>.</remarks>
+        public event Action<MotionEvent> MouseGenericMotion;
 
         /// <summary>
         /// Invoked when text is committed by an <see cref="AndroidInputConnection"/>.

--- a/osu.Framework.Android/Input/AndroidInputExtensions.cs
+++ b/osu.Framework.Android/Input/AndroidInputExtensions.cs
@@ -1,0 +1,65 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using Android.Views;
+using osuTK.Input;
+
+namespace osu.Framework.Android.Input
+{
+    public static class AndroidInputExtensions
+    {
+        /// <summary>
+        /// Returns the corresponding <see cref="MouseButton"/> for a mouse button given as a <see cref="MotionEventButtonState"/>.
+        /// </summary>
+        /// <param name="motionEventMouseButton">The given button. Must not be a raw state or a non-mouse button.</param>
+        /// <returns>The corresponding <see cref="MouseButton"/>.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the provided button <paramref name="motionEventMouseButton"/> is not a </exception>
+        public static MouseButton ToMouseButton(this MotionEventButtonState motionEventMouseButton)
+        {
+            switch (motionEventMouseButton)
+            {
+                case MotionEventButtonState.Primary:
+                    return MouseButton.Left;
+
+                case MotionEventButtonState.Secondary:
+                    return MouseButton.Right;
+
+                case MotionEventButtonState.Tertiary:
+                    return MouseButton.Middle;
+
+                case MotionEventButtonState.Back:
+                    return MouseButton.Button1;
+
+                case MotionEventButtonState.Forward:
+                    return MouseButton.Button2;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(motionEventMouseButton), motionEventMouseButton, "Given button is not a mouse button.");
+            }
+        }
+
+        /// <summary>
+        /// Returns the corresponding <see cref="MouseButton"/> for a mouse button given as a <see cref="Keycode"/>.
+        /// </summary>
+        /// <param name="keycode">The given keycode. Should be <see cref="Keycode.Back"/> or <see cref="Keycode.Forward"/>.</param>
+        /// <param name="button">The corresponding <see cref="MouseButton"/>.</param>
+        /// <returns><c>true</c> if this <paramref name="keycode"/> is a valid <see cref="MouseButton"/>.</returns>
+        public static bool TryGetMouseButton(this Keycode keycode, out MouseButton button)
+        {
+            switch (keycode)
+            {
+                case Keycode.Back:
+                    button = MouseButton.Button1;
+                    return true;
+
+                case Keycode.Forward:
+                    button = MouseButton.Button2;
+                    return true;
+            }
+
+            button = MouseButton.LastButton;
+            return false;
+        }
+    }
+}

--- a/osu.Framework.Android/Input/AndroidInputHandler.cs
+++ b/osu.Framework.Android/Input/AndroidInputHandler.cs
@@ -83,6 +83,7 @@ namespace osu.Framework.Android.Input
         /// </remarks>
         protected virtual void OnCapturedPointer(MotionEvent capturedPointerEvent)
         {
+            throw new NotSupportedException($"{nameof(InputEventType.CapturedPointer)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
         }
 
         /// <summary>
@@ -93,6 +94,7 @@ namespace osu.Framework.Android.Input
         /// </remarks>
         protected virtual void OnGenericMotion(MotionEvent genericMotionEvent)
         {
+            throw new NotSupportedException($"{nameof(InputEventType.GenericMotion)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
         }
 
         /// <summary>
@@ -103,6 +105,7 @@ namespace osu.Framework.Android.Input
         /// </remarks>
         protected virtual void OnHover(MotionEvent hoverEvent)
         {
+            throw new NotSupportedException($"{nameof(InputEventType.Hover)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
         }
 
         /// <summary>
@@ -113,6 +116,7 @@ namespace osu.Framework.Android.Input
         /// </remarks>
         protected virtual void OnKeyDown(Keycode keycode, KeyEvent e)
         {
+            throw new NotSupportedException($"{nameof(InputEventType.KeyDown)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
         }
 
         /// <summary>
@@ -123,6 +127,7 @@ namespace osu.Framework.Android.Input
         /// </remarks>
         protected virtual void OnKeyUp(Keycode keycode, KeyEvent e)
         {
+            throw new NotSupportedException($"{nameof(InputEventType.KeyUp)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
         }
 
         /// <summary>
@@ -133,6 +138,7 @@ namespace osu.Framework.Android.Input
         /// </remarks>
         protected virtual void OnTouch(MotionEvent touchEvent)
         {
+            throw new NotSupportedException($"{nameof(InputEventType.Touch)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
         }
 
         #region Event handlers

--- a/osu.Framework.Android/Input/AndroidInputHandler.cs
+++ b/osu.Framework.Android/Input/AndroidInputHandler.cs
@@ -25,12 +25,6 @@ namespace osu.Framework.Android.Input
         protected abstract IEnumerable<InputSourceType> HandledEventSources { get; }
 
         /// <summary>
-        /// The <see cref="InputEventType"/>s that this <see cref="AndroidInputHandler"/> will handle.
-        /// </summary>
-        /// <remarks>For each <see cref="InputEventType"/> specified here, this <see cref="AndroidInputHandler"/> should override the appropriate method.</remarks>
-        protected abstract IEnumerable<InputEventType> HandledEventTypes { get; }
-
-        /// <summary>
         /// The view that this <see cref="AndroidInputHandler"/> is handling events from.
         /// </summary>
         protected readonly AndroidGameView View;
@@ -58,156 +52,76 @@ namespace osu.Framework.Android.Input
                 inputSourceBitmask |= inputSource;
             }
 
-            Enabled.BindValueChanged(enabled =>
-            {
-                if (enabled.NewValue)
-                {
-                    foreach (var eventType in HandledEventTypes)
-                        subscribeToEvent(eventType);
-                }
-                else
-                {
-                    foreach (var eventType in HandledEventTypes)
-                        unsubscribeFromEvent(eventType);
-                }
-            }, true);
-
             return true;
         }
 
         /// <summary>
-        /// Invoked on every <see cref="InputEventType.CapturedPointer"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// Invoked on every <see cref="AndroidGameView.CapturedPointer"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="InputEventType.CapturedPointer"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// Subscribe <see cref="HandleCapturedPointer"/> to <see cref="View"/>.<see cref="AndroidGameView.CapturedPointer"/> to receive events here.
         /// </remarks>
         protected virtual void OnCapturedPointer(MotionEvent capturedPointerEvent)
         {
-            throw new NotSupportedException($"{nameof(InputEventType.CapturedPointer)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
+            throw new NotSupportedException($"{nameof(HandleCapturedPointer)} subscribed to {nameof(View.CapturedPointer)} but the relevant method was not overriden.");
         }
 
         /// <summary>
-        /// Invoked on every <see cref="InputEventType.GenericMotion"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// Invoked on every <see cref="AndroidGameView.GenericMotion"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="InputEventType.GenericMotion"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// Subscribe <see cref="HandleGenericMotion"/> to <see cref="View"/>.<see cref="AndroidGameView.GenericMotion"/> to receive events here.
         /// </remarks>
         protected virtual void OnGenericMotion(MotionEvent genericMotionEvent)
         {
-            throw new NotSupportedException($"{nameof(InputEventType.GenericMotion)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
+            throw new NotSupportedException($"{nameof(HandleGenericMotion)} subscribed to {nameof(View.GenericMotion)} but the relevant method was not overriden.");
         }
 
         /// <summary>
-        /// Invoked on every <see cref="InputEventType.Hover"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// Invoked on every <see cref="AndroidGameView.Hover"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="InputEventType.Hover"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// Subscribe <see cref="HandleHover"/> to <see cref="View"/>.<see cref="AndroidGameView.Hover"/> to receive events here.
         /// </remarks>
         protected virtual void OnHover(MotionEvent hoverEvent)
         {
-            throw new NotSupportedException($"{nameof(InputEventType.Hover)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
+            throw new NotSupportedException($"{nameof(HandleHover)} subscribed to {nameof(View.Hover)} but the relevant method was not overriden.");
         }
 
         /// <summary>
-        /// Invoked on every <see cref="InputEventType.KeyDown"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// Invoked on every <see cref="AndroidGameView.KeyDown"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="InputEventType.KeyDown"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// Subscribe <see cref="HandleKeyDown"/> to <see cref="View"/>.<see cref="AndroidGameView.KeyDown"/> to receive events here.
         /// </remarks>
         protected virtual void OnKeyDown(Keycode keycode, KeyEvent e)
         {
-            throw new NotSupportedException($"{nameof(InputEventType.KeyDown)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
+            throw new NotSupportedException($"{nameof(HandleKeyDown)} subscribed to {nameof(View.KeyDown)} but the relevant method was not overriden.");
         }
 
         /// <summary>
-        /// Invoked on every <see cref="InputEventType.KeyUp"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// Invoked on every <see cref="AndroidGameView.KeyUp"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="InputEventType.KeyUp"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// Subscribe <see cref="HandleKeyUp"/> to <see cref="View"/>.<see cref="AndroidGameView.KeyUp"/> to receive events here.
         /// </remarks>
         protected virtual void OnKeyUp(Keycode keycode, KeyEvent e)
         {
-            throw new NotSupportedException($"{nameof(InputEventType.KeyUp)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
+            throw new NotSupportedException($"{nameof(HandleKeyUp)} subscribed to {nameof(View.KeyUp)} but the relevant method was not overriden.");
         }
 
         /// <summary>
-        /// Invoked on every <see cref="InputEventType.Touch"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// Invoked on every <see cref="AndroidGameView.Touch"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
         /// </summary>
         /// <remarks>
-        /// <see cref="InputEventType.Touch"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// Subscribe <see cref="HandleTouch"/> to <see cref="View"/>.<see cref="AndroidGameView.Touch"/> to receive events here.
         /// </remarks>
         protected virtual void OnTouch(MotionEvent touchEvent)
         {
-            throw new NotSupportedException($"{nameof(InputEventType.Touch)} specified in {nameof(HandledEventTypes)} but the relevant method was not overriden.");
+            throw new NotSupportedException($"{nameof(HandleTouch)} subscribed to {nameof(View.Touch)} but the relevant method was not overriden.");
         }
 
         #region Event handlers
-
-        private void subscribeToEvent(InputEventType eventType)
-        {
-            switch (eventType)
-            {
-                case InputEventType.CapturedPointer:
-                    View.CapturedPointer += handleCapturedPointer;
-                    break;
-
-                case InputEventType.GenericMotion:
-                    View.GenericMotion += handleGenericMotion;
-                    break;
-
-                case InputEventType.Hover:
-                    View.Hover += handleHover;
-                    break;
-
-                case InputEventType.KeyDown:
-                    View.KeyDown += handleKeyDown;
-                    break;
-
-                case InputEventType.KeyUp:
-                    View.KeyUp += handleKeyUp;
-                    break;
-
-                case InputEventType.Touch:
-                    View.Touch += handleTouch;
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(eventType), eventType, $"Invalid {nameof(InputEventType)}.");
-            }
-        }
-
-        private void unsubscribeFromEvent(InputEventType eventType)
-        {
-            switch (eventType)
-            {
-                case InputEventType.CapturedPointer:
-                    View.CapturedPointer -= handleCapturedPointer;
-                    break;
-
-                case InputEventType.GenericMotion:
-                    View.GenericMotion -= handleGenericMotion;
-                    break;
-
-                case InputEventType.Hover:
-                    View.Hover -= handleHover;
-                    break;
-
-                case InputEventType.KeyDown:
-                    View.KeyDown -= handleKeyDown;
-                    break;
-
-                case InputEventType.KeyUp:
-                    View.KeyUp -= handleKeyUp;
-                    break;
-
-                case InputEventType.Touch:
-                    View.Touch -= handleTouch;
-                    break;
-
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(eventType), eventType, $"Invalid {nameof(InputEventType)}.");
-            }
-        }
 
         /// <summary>
         /// Checks whether the <paramref name="inputEvent"/> should be handled by this <see cref="AndroidInputHandler"/>.
@@ -220,7 +134,10 @@ namespace osu.Framework.Android.Input
             return inputEvent != null && inputSourceBitmask.HasFlagFast(inputEvent.Source);
         }
 
-        private void handleCapturedPointer(object sender, View.CapturedPointerEventArgs e)
+        /// <summary>
+        /// Handler for <see cref="AndroidGameView.CapturedPointer"/> events.
+        /// </summary>
+        protected void HandleCapturedPointer(object sender, View.CapturedPointerEventArgs e)
         {
             if (shouldHandleEvent(e.Event))
             {
@@ -229,7 +146,10 @@ namespace osu.Framework.Android.Input
             }
         }
 
-        private void handleGenericMotion(object sender, View.GenericMotionEventArgs e)
+        /// <summary>
+        /// Handler for <see cref="AndroidGameView.GenericMotion"/> events.
+        /// </summary>
+        protected void HandleGenericMotion(object sender, View.GenericMotionEventArgs e)
         {
             if (shouldHandleEvent(e.Event))
             {
@@ -238,7 +158,10 @@ namespace osu.Framework.Android.Input
             }
         }
 
-        private void handleHover(object sender, View.HoverEventArgs e)
+        /// <summary>
+        /// Handler for <see cref="AndroidGameView.Hover"/> events.
+        /// </summary>
+        protected void HandleHover(object sender, View.HoverEventArgs e)
         {
             if (shouldHandleEvent(e.Event))
             {
@@ -247,7 +170,10 @@ namespace osu.Framework.Android.Input
             }
         }
 
-        private void handleKeyDown(Keycode keycode, KeyEvent e)
+        /// <summary>
+        /// Handler for <see cref="AndroidGameView.KeyDown"/> events.
+        /// </summary>
+        protected void HandleKeyDown(Keycode keycode, KeyEvent e)
         {
             if (shouldHandleEvent(e))
             {
@@ -255,7 +181,10 @@ namespace osu.Framework.Android.Input
             }
         }
 
-        private void handleKeyUp(Keycode keycode, KeyEvent e)
+        /// <summary>
+        /// Handler for <see cref="AndroidGameView.KeyUp"/> events.
+        /// </summary>
+        protected void HandleKeyUp(Keycode keycode, KeyEvent e)
         {
             if (shouldHandleEvent(e))
             {
@@ -263,7 +192,10 @@ namespace osu.Framework.Android.Input
             }
         }
 
-        private void handleTouch(object sender, View.TouchEventArgs e)
+        /// <summary>
+        /// Handler for <see cref="AndroidGameView.Touch"/> events.
+        /// </summary>
+        protected void HandleTouch(object sender, View.TouchEventArgs e)
         {
             if (shouldHandleEvent(e.Event))
             {
@@ -273,47 +205,5 @@ namespace osu.Framework.Android.Input
         }
 
         #endregion
-
-        /// <summary>
-        /// Types of <see cref="InputEvent"/>s that are provided by <see cref="View"/> and <see cref="AndroidGameView"/>.
-        /// </summary>
-        protected enum InputEventType
-        {
-            /// <summary>
-            /// Event type for <see cref="View.CapturedPointer"/>.
-            /// </summary>
-            /// <remarks>Relevant method to override: <see cref="OnCapturedPointer"/>.</remarks>
-            CapturedPointer,
-
-            /// <summary>
-            /// Event type for <see cref="View.GenericMotion"/>.
-            /// </summary>
-            /// <remarks>Relevant method to override: <see cref="OnGenericMotion"/>.</remarks>
-            GenericMotion,
-
-            /// <summary>
-            /// Event type for <see cref="View.Hover"/>.
-            /// </summary>
-            /// <remarks>Relevant method to override: <see cref="OnHover"/>.</remarks>
-            Hover,
-
-            /// <summary>
-            /// Event type for <see cref="AndroidGameView.KeyDown"/>.
-            /// </summary>
-            /// <remarks>Relevant method to override: <see cref="OnKeyDown"/>.</remarks>
-            KeyDown,
-
-            /// <summary>
-            /// Event type for <see cref="AndroidGameView.KeyUp"/>.
-            /// </summary>
-            /// <remarks>Relevant method to override: <see cref="OnKeyUp"/>.</remarks>
-            KeyUp,
-
-            /// <summary>
-            /// Event type for <see cref="View.Touch"/>.
-            /// </summary>
-            /// <remarks>Relevant method to override: <see cref="OnTouch"/>.</remarks>
-            Touch
-        }
     }
 }

--- a/osu.Framework.Android/Input/AndroidInputHandler.cs
+++ b/osu.Framework.Android/Input/AndroidInputHandler.cs
@@ -53,7 +53,8 @@ namespace osu.Framework.Android.Input
             // compute the bitmask for later use.
             foreach (var inputSource in HandledEventSources)
             {
-                // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags (InputSourceType is a flags enum, but is not properly marked as such)
+                // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags
+                // (InputSourceType is a flags enum, but is not properly marked as such)
                 inputSourceBitmask |= inputSource;
             }
 

--- a/osu.Framework.Android/Input/AndroidInputHandler.cs
+++ b/osu.Framework.Android/Input/AndroidInputHandler.cs
@@ -1,0 +1,67 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Android.Views;
+using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Input.Handlers;
+using osu.Framework.Platform;
+
+#nullable enable
+
+namespace osu.Framework.Android.Input
+{
+    /// <summary>
+    /// Base input handler for handling events dispatched by <see cref="AndroidGameView"/>.
+    /// Provides consistent and unified means for handling <see cref="InputEvent"/>s only from specific <see cref="InputSourceType"/>s.
+    /// </summary>
+    public abstract class AndroidInputHandler : InputHandler
+    {
+        /// <summary>
+        /// The <see cref="InputSourceType"/>s that this <see cref="InputHandler"/> will handle.
+        /// </summary>
+        protected abstract IEnumerable<InputSourceType> HandledInputSources { get; }
+
+        /// <summary>
+        /// The view that this <see cref="InputHandler"/> is handling events from.
+        /// </summary>
+        protected readonly AndroidGameView View;
+
+        /// <summary>
+        /// Bitmask of all <see cref="HandledInputSources"/>.
+        /// </summary>
+        private InputSourceType inputSourceBitmask;
+
+        protected AndroidInputHandler(AndroidGameView view)
+        {
+            View = view;
+        }
+
+        public override bool Initialize(GameHost host)
+        {
+            if (!base.Initialize(host))
+                return false;
+
+            // compute the bitmask for later use.
+            foreach (var inputSource in HandledInputSources)
+            {
+                // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags (InputSourceType is a flags enum, but is not properly marked as such)
+                inputSourceBitmask |= inputSource;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Checks whether the <paramref name="inputEvent"/> should be handled by this <see cref="InputHandler"/>.
+        /// </summary>
+        /// <param name="inputEvent">The <see cref="InputEvent"/> to check.</param>
+        /// <returns><c>true</c> if the <paramref name="inputEvent"/>'s <see cref="InputSourceType"/> matches <see cref="HandledInputSources"/>.</returns>
+        /// <remarks>Should be checked before handling events.</remarks>
+        protected bool ShouldHandleEvent([NotNullWhen(true)] InputEvent? inputEvent)
+        {
+            return inputEvent != null && inputSourceBitmask.HasFlagFast(inputEvent.Source);
+        }
+    }
+}

--- a/osu.Framework.Android/Input/AndroidInputHandler.cs
+++ b/osu.Framework.Android/Input/AndroidInputHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Android.Views;
@@ -19,17 +20,23 @@ namespace osu.Framework.Android.Input
     public abstract class AndroidInputHandler : InputHandler
     {
         /// <summary>
-        /// The <see cref="InputSourceType"/>s that this <see cref="InputHandler"/> will handle.
+        /// The <see cref="InputSourceType"/>s that this <see cref="AndroidInputHandler"/> will handle.
         /// </summary>
-        protected abstract IEnumerable<InputSourceType> HandledInputSources { get; }
+        protected abstract IEnumerable<InputSourceType> HandledEventSources { get; }
 
         /// <summary>
-        /// The view that this <see cref="InputHandler"/> is handling events from.
+        /// The <see cref="InputEventType"/>s that this <see cref="AndroidInputHandler"/> will handle.
+        /// </summary>
+        /// <remarks>For each <see cref="InputEventType"/> specified here, this <see cref="AndroidInputHandler"/> should override the appropriate method.</remarks>
+        protected abstract IEnumerable<InputEventType> HandledEventTypes { get; }
+
+        /// <summary>
+        /// The view that this <see cref="AndroidInputHandler"/> is handling events from.
         /// </summary>
         protected readonly AndroidGameView View;
 
         /// <summary>
-        /// Bitmask of all <see cref="HandledInputSources"/>.
+        /// Bitmask of all <see cref="HandledEventSources"/>.
         /// </summary>
         private InputSourceType inputSourceBitmask;
 
@@ -44,24 +51,262 @@ namespace osu.Framework.Android.Input
                 return false;
 
             // compute the bitmask for later use.
-            foreach (var inputSource in HandledInputSources)
+            foreach (var inputSource in HandledEventSources)
             {
                 // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags (InputSourceType is a flags enum, but is not properly marked as such)
                 inputSourceBitmask |= inputSource;
             }
 
+            Enabled.BindValueChanged(enabled =>
+            {
+                if (enabled.NewValue)
+                {
+                    foreach (var eventType in HandledEventTypes)
+                        subscribeToEvent(eventType);
+                }
+                else
+                {
+                    foreach (var eventType in HandledEventTypes)
+                        unsubscribeFromEvent(eventType);
+                }
+            }, true);
+
             return true;
         }
 
         /// <summary>
-        /// Checks whether the <paramref name="inputEvent"/> should be handled by this <see cref="InputHandler"/>.
+        /// Invoked on every <see cref="InputEventType.CapturedPointer"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="InputEventType.CapturedPointer"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// </remarks>
+        protected virtual void OnCapturedPointer(MotionEvent capturedPointerEvent)
+        {
+        }
+
+        /// <summary>
+        /// Invoked on every <see cref="InputEventType.GenericMotion"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="InputEventType.GenericMotion"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// </remarks>
+        protected virtual void OnGenericMotion(MotionEvent genericMotionEvent)
+        {
+        }
+
+        /// <summary>
+        /// Invoked on every <see cref="InputEventType.Hover"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="InputEventType.Hover"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// </remarks>
+        protected virtual void OnHover(MotionEvent hoverEvent)
+        {
+        }
+
+        /// <summary>
+        /// Invoked on every <see cref="InputEventType.KeyDown"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="InputEventType.KeyDown"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// </remarks>
+        protected virtual void OnKeyDown(Keycode keycode, KeyEvent e)
+        {
+        }
+
+        /// <summary>
+        /// Invoked on every <see cref="InputEventType.KeyUp"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="InputEventType.KeyUp"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// </remarks>
+        protected virtual void OnKeyUp(Keycode keycode, KeyEvent e)
+        {
+        }
+
+        /// <summary>
+        /// Invoked on every <see cref="InputEventType.Touch"/> event that matches an <see cref="InputSourceType"/> from <see cref="HandledEventSources"/>.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="InputEventType.Touch"/> must be specified in <see cref="HandledEventTypes"/> to receive events here.
+        /// </remarks>
+        protected virtual void OnTouch(MotionEvent touchEvent)
+        {
+        }
+
+        #region Event handlers
+
+        private void subscribeToEvent(InputEventType eventType)
+        {
+            switch (eventType)
+            {
+                case InputEventType.CapturedPointer:
+                    View.CapturedPointer += handleCapturedPointer;
+                    break;
+
+                case InputEventType.GenericMotion:
+                    View.GenericMotion += handleGenericMotion;
+                    break;
+
+                case InputEventType.Hover:
+                    View.Hover += handleHover;
+                    break;
+
+                case InputEventType.KeyDown:
+                    View.KeyDown += handleKeyDown;
+                    break;
+
+                case InputEventType.KeyUp:
+                    View.KeyUp += handleKeyUp;
+                    break;
+
+                case InputEventType.Touch:
+                    View.Touch += handleTouch;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(eventType), eventType, $"Invalid {nameof(InputEventType)}.");
+            }
+        }
+
+        private void unsubscribeFromEvent(InputEventType eventType)
+        {
+            switch (eventType)
+            {
+                case InputEventType.CapturedPointer:
+                    View.CapturedPointer -= handleCapturedPointer;
+                    break;
+
+                case InputEventType.GenericMotion:
+                    View.GenericMotion -= handleGenericMotion;
+                    break;
+
+                case InputEventType.Hover:
+                    View.Hover -= handleHover;
+                    break;
+
+                case InputEventType.KeyDown:
+                    View.KeyDown -= handleKeyDown;
+                    break;
+
+                case InputEventType.KeyUp:
+                    View.KeyUp -= handleKeyUp;
+                    break;
+
+                case InputEventType.Touch:
+                    View.Touch -= handleTouch;
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(eventType), eventType, $"Invalid {nameof(InputEventType)}.");
+            }
+        }
+
+        /// <summary>
+        /// Checks whether the <paramref name="inputEvent"/> should be handled by this <see cref="AndroidInputHandler"/>.
         /// </summary>
         /// <param name="inputEvent">The <see cref="InputEvent"/> to check.</param>
-        /// <returns><c>true</c> if the <paramref name="inputEvent"/>'s <see cref="InputSourceType"/> matches <see cref="HandledInputSources"/>.</returns>
+        /// <returns><c>true</c> if the <paramref name="inputEvent"/>'s <see cref="InputSourceType"/> matches <see cref="HandledEventSources"/>.</returns>
         /// <remarks>Should be checked before handling events.</remarks>
-        protected bool ShouldHandleEvent([NotNullWhen(true)] InputEvent? inputEvent)
+        private bool shouldHandleEvent([NotNullWhen(true)] InputEvent? inputEvent)
         {
             return inputEvent != null && inputSourceBitmask.HasFlagFast(inputEvent.Source);
+        }
+
+        private void handleCapturedPointer(object sender, View.CapturedPointerEventArgs e)
+        {
+            if (shouldHandleEvent(e.Event))
+            {
+                OnCapturedPointer(e.Event);
+                e.Handled = true;
+            }
+        }
+
+        private void handleGenericMotion(object sender, View.GenericMotionEventArgs e)
+        {
+            if (shouldHandleEvent(e.Event))
+            {
+                OnGenericMotion(e.Event);
+                e.Handled = true;
+            }
+        }
+
+        private void handleHover(object sender, View.HoverEventArgs e)
+        {
+            if (shouldHandleEvent(e.Event))
+            {
+                OnHover(e.Event);
+                e.Handled = true;
+            }
+        }
+
+        private void handleKeyDown(Keycode keycode, KeyEvent e)
+        {
+            if (shouldHandleEvent(e))
+            {
+                OnKeyDown(keycode, e);
+            }
+        }
+
+        private void handleKeyUp(Keycode keycode, KeyEvent e)
+        {
+            if (shouldHandleEvent(e))
+            {
+                OnKeyUp(keycode, e);
+            }
+        }
+
+        private void handleTouch(object sender, View.TouchEventArgs e)
+        {
+            if (shouldHandleEvent(e.Event))
+            {
+                OnTouch(e.Event);
+                e.Handled = true;
+            }
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Types of <see cref="InputEvent"/>s that are provided by <see cref="View"/> and <see cref="AndroidGameView"/>.
+        /// </summary>
+        protected enum InputEventType
+        {
+            /// <summary>
+            /// Event type for <see cref="View.CapturedPointer"/>.
+            /// </summary>
+            /// <remarks>Relevant method to override: <see cref="OnCapturedPointer"/>.</remarks>
+            CapturedPointer,
+
+            /// <summary>
+            /// Event type for <see cref="View.GenericMotion"/>.
+            /// </summary>
+            /// <remarks>Relevant method to override: <see cref="OnGenericMotion"/>.</remarks>
+            GenericMotion,
+
+            /// <summary>
+            /// Event type for <see cref="View.Hover"/>.
+            /// </summary>
+            /// <remarks>Relevant method to override: <see cref="OnHover"/>.</remarks>
+            Hover,
+
+            /// <summary>
+            /// Event type for <see cref="AndroidGameView.KeyDown"/>.
+            /// </summary>
+            /// <remarks>Relevant method to override: <see cref="OnKeyDown"/>.</remarks>
+            KeyDown,
+
+            /// <summary>
+            /// Event type for <see cref="AndroidGameView.KeyUp"/>.
+            /// </summary>
+            /// <remarks>Relevant method to override: <see cref="OnKeyUp"/>.</remarks>
+            KeyUp,
+
+            /// <summary>
+            /// Event type for <see cref="View.Touch"/>.
+            /// </summary>
+            /// <remarks>Relevant method to override: <see cref="OnTouch"/>.</remarks>
+            Touch
         }
     }
 }

--- a/osu.Framework.Android/Input/AndroidInputHandler.cs
+++ b/osu.Framework.Android/Input/AndroidInputHandler.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Android.Input
         /// <summary>
         /// Bitmask of all <see cref="HandledEventSources"/>.
         /// </summary>
-        private InputSourceType inputSourceBitmask;
+        private InputSourceType eventSourceBitmask;
 
         protected AndroidInputHandler(AndroidGameView view)
         {
@@ -45,11 +45,11 @@ namespace osu.Framework.Android.Input
                 return false;
 
             // compute the bitmask for later use.
-            foreach (var inputSource in HandledEventSources)
+            foreach (var eventSource in HandledEventSources)
             {
                 // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags
                 // (InputSourceType is a flags enum, but is not properly marked as such)
-                inputSourceBitmask |= inputSource;
+                eventSourceBitmask |= eventSource;
             }
 
             return true;
@@ -131,7 +131,7 @@ namespace osu.Framework.Android.Input
         /// <remarks>Should be checked before handling events.</remarks>
         private bool shouldHandleEvent([NotNullWhen(true)] InputEvent? inputEvent)
         {
-            return inputEvent != null && inputSourceBitmask.HasFlagFast(inputEvent.Source);
+            return inputEvent != null && eventSourceBitmask.HasFlagFast(inputEvent.Source);
         }
 
         /// <summary>

--- a/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
+++ b/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
@@ -2,31 +2,30 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using Android.Views;
-using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
-using osu.Framework.Platform;
 using osuTK.Input;
 
 namespace osu.Framework.Android.Input
 {
-    public class AndroidKeyboardHandler : InputHandler
+    public class AndroidKeyboardHandler : AndroidInputHandler
     {
-        private readonly AndroidGameView view;
+        protected override IEnumerable<InputSourceType> HandledInputSources => new[] { InputSourceType.Keyboard };
 
         public AndroidKeyboardHandler(AndroidGameView view)
+            : base(view)
         {
-            this.view = view;
-            view.KeyDown += keyDown;
-            view.KeyUp += keyUp;
+            View.KeyDown += keyDown;
+            View.KeyUp += keyUp;
         }
 
         public override bool IsActive => true;
 
-        public override bool Initialize(GameHost host) => true;
-
         private void keyDown(Keycode keycode, KeyEvent e)
         {
+            if (!ShouldHandleEvent(e)) return;
+
             var key = GetKeyCodeAsKey(keycode);
 
             if (key != Key.Unknown)
@@ -35,6 +34,8 @@ namespace osu.Framework.Android.Input
 
         private void keyUp(Keycode keycode, KeyEvent e)
         {
+            if (!ShouldHandleEvent(e)) return;
+
             var key = GetKeyCodeAsKey(keycode);
 
             if (key != Key.Unknown)
@@ -160,8 +161,8 @@ namespace osu.Framework.Android.Input
 
         protected override void Dispose(bool disposing)
         {
-            view.KeyDown -= keyDown;
-            view.KeyUp -= keyUp;
+            View.KeyDown -= keyDown;
+            View.KeyUp -= keyUp;
             base.Dispose(disposing);
         }
     }

--- a/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
+++ b/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using Android.Views;
 using osu.Framework.Input.StateChanges;
+using osu.Framework.Platform;
 using osuTK.Input;
 
 namespace osu.Framework.Android.Input
@@ -13,11 +14,31 @@ namespace osu.Framework.Android.Input
     {
         protected override IEnumerable<InputSourceType> HandledEventSources => new[] { InputSourceType.Keyboard };
 
-        protected override IEnumerable<InputEventType> HandledEventTypes => new[] { InputEventType.KeyDown, InputEventType.KeyUp };
-
         public AndroidKeyboardHandler(AndroidGameView view)
             : base(view)
         {
+        }
+
+        public override bool Initialize(GameHost host)
+        {
+            if (!base.Initialize(host))
+                return false;
+
+            Enabled.BindValueChanged(enabled =>
+            {
+                if (enabled.NewValue)
+                {
+                    View.KeyDown += HandleKeyDown;
+                    View.KeyUp += HandleKeyUp;
+                }
+                else
+                {
+                    View.KeyDown -= HandleKeyDown;
+                    View.KeyUp -= HandleKeyUp;
+                }
+            }, true);
+
+            return true;
         }
 
         public override bool IsActive => true;

--- a/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
+++ b/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
@@ -11,31 +11,27 @@ namespace osu.Framework.Android.Input
 {
     public class AndroidKeyboardHandler : AndroidInputHandler
     {
-        protected override IEnumerable<InputSourceType> HandledInputSources => new[] { InputSourceType.Keyboard };
+        protected override IEnumerable<InputSourceType> HandledEventSources => new[] { InputSourceType.Keyboard };
+
+        protected override IEnumerable<InputEventType> HandledEventTypes => new[] { InputEventType.KeyDown, InputEventType.KeyUp };
 
         public AndroidKeyboardHandler(AndroidGameView view)
             : base(view)
         {
-            View.KeyDown += keyDown;
-            View.KeyUp += keyUp;
         }
 
         public override bool IsActive => true;
 
-        private void keyDown(Keycode keycode, KeyEvent e)
+        protected override void OnKeyDown(Keycode keycode, KeyEvent e)
         {
-            if (!ShouldHandleEvent(e)) return;
-
             var key = GetKeyCodeAsKey(keycode);
 
             if (key != Key.Unknown)
                 PendingInputs.Enqueue(new KeyboardKeyInput(key, true));
         }
 
-        private void keyUp(Keycode keycode, KeyEvent e)
+        protected override void OnKeyUp(Keycode keycode, KeyEvent e)
         {
-            if (!ShouldHandleEvent(e)) return;
-
             var key = GetKeyCodeAsKey(keycode);
 
             if (key != Key.Unknown)
@@ -157,13 +153,6 @@ namespace osu.Framework.Android.Input
 
             // this is the worst case scenario. Please note that the osu-framework keyboard handling cannot cope with Key.Unknown.
             return Key.Unknown;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            View.KeyDown -= keyDown;
-            View.KeyUp -= keyUp;
-            base.Dispose(disposing);
         }
     }
 }

--- a/osu.Framework.Android/Input/AndroidMouseHandler.cs
+++ b/osu.Framework.Android/Input/AndroidMouseHandler.cs
@@ -4,6 +4,7 @@
 using System.Collections.Generic;
 using Android.Views;
 using osu.Framework.Input.StateChanges;
+using osu.Framework.Platform;
 using osu.Framework.Statistics;
 using osuTK;
 using osuTK.Input;
@@ -21,12 +22,37 @@ namespace osu.Framework.Android.Input
 
         protected override IEnumerable<InputSourceType> HandledEventSources => new[] { InputSourceType.Mouse, InputSourceType.Touchpad };
 
-        protected override IEnumerable<InputEventType> HandledEventTypes
-            => new[] { InputEventType.GenericMotion, InputEventType.Hover, InputEventType.KeyDown, InputEventType.KeyUp, InputEventType.Touch };
-
         public AndroidMouseHandler(AndroidGameView view)
             : base(view)
         {
+        }
+
+        public override bool Initialize(GameHost host)
+        {
+            if (!base.Initialize(host))
+                return false;
+
+            Enabled.BindValueChanged(enabled =>
+            {
+                if (enabled.NewValue)
+                {
+                    View.GenericMotion += HandleGenericMotion;
+                    View.Hover += HandleHover;
+                    View.KeyDown += HandleKeyDown;
+                    View.KeyUp += HandleKeyUp;
+                    View.Touch += HandleTouch;
+                }
+                else
+                {
+                    View.GenericMotion -= HandleGenericMotion;
+                    View.Hover -= HandleHover;
+                    View.KeyDown -= HandleKeyDown;
+                    View.KeyUp -= HandleKeyUp;
+                    View.Touch -= HandleTouch;
+                }
+            }, true);
+
+            return true;
         }
 
         protected override void OnKeyDown(Keycode keycode, KeyEvent e)

--- a/osu.Framework.Android/Input/AndroidMouseHandler.cs
+++ b/osu.Framework.Android/Input/AndroidMouseHandler.cs
@@ -1,0 +1,136 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using Android.Views;
+using osu.Framework.Input.Handlers;
+using osu.Framework.Input.StateChanges;
+using osu.Framework.Platform;
+using osu.Framework.Statistics;
+using osuTK;
+using osuTK.Input;
+
+namespace osu.Framework.Android.Input
+{
+    /// <summary>
+    /// Input handler for Android mouse-type devices: the <see cref="InputSourceType.Mouse"/> and <see cref="InputSourceType.Touchpad"/>.
+    /// </summary>
+    public class AndroidMouseHandler : InputHandler
+    {
+        public override string Description => "Mouse";
+
+        public override bool IsActive => true;
+
+        private readonly AndroidGameView view;
+
+        public AndroidMouseHandler(AndroidGameView view)
+        {
+            this.view = view;
+        }
+
+        public override bool Initialize(GameHost host)
+        {
+            if (!base.Initialize(host))
+                return false;
+
+            Enabled.BindValueChanged(enabled =>
+            {
+                if (enabled.NewValue)
+                {
+                    view.MouseKeyDown += onKeyDown;
+                    view.MouseKeyLongPress += onKeyDown;
+                    view.MouseKeyUp += onKeyUp;
+                    view.MouseHover += onHover;
+                    view.MouseTouch += onTouch;
+                    view.MouseGenericMotion += onGenericMotion;
+                }
+                else
+                {
+                    view.MouseKeyDown -= onKeyDown;
+                    view.MouseKeyLongPress -= onKeyDown;
+                    view.MouseKeyUp -= onKeyUp;
+                    view.MouseHover -= onHover;
+                    view.MouseTouch -= onTouch;
+                    view.MouseGenericMotion -= onGenericMotion;
+                }
+            }, true);
+
+            return true;
+        }
+
+        private void onKeyDown(Keycode keycode, KeyEvent e)
+        {
+            // some implementations might send Mouse1 and Mouse2 as keyboard keycodes, so we handle those here.
+            if (keycode.TryGetMouseButton(out var button))
+                handleMouseDown(button);
+        }
+
+        private void onKeyUp(Keycode keycode, KeyEvent e)
+        {
+            if (keycode.TryGetMouseButton(out var button))
+                handleMouseUp(button);
+        }
+
+        private void onHover(MotionEvent hoverEvent)
+        {
+            switch (hoverEvent.Action)
+            {
+                case MotionEventActions.HoverMove:
+                    handleMouseMoveEvent(hoverEvent);
+                    break;
+            }
+        }
+
+        private void onTouch(MotionEvent touchEvent)
+        {
+            switch (touchEvent.Action)
+            {
+                case MotionEventActions.Move:
+                    handleMouseMoveEvent(touchEvent);
+                    break;
+            }
+        }
+
+        private void onGenericMotion(MotionEvent motionEvent)
+        {
+            switch (motionEvent.Action)
+            {
+                case MotionEventActions.ButtonPress:
+                    handleMouseDown(motionEvent.ActionButton.ToMouseButton());
+                    break;
+
+                case MotionEventActions.ButtonRelease:
+                    handleMouseUp(motionEvent.ActionButton.ToMouseButton());
+                    break;
+
+                case MotionEventActions.Scroll:
+                    handleMouseWheel(getEventScroll(motionEvent));
+                    break;
+            }
+        }
+
+        private Vector2 getEventScroll(MotionEvent e) => new Vector2(e.GetAxisValue(Axis.Hscroll), e.GetAxisValue(Axis.Vscroll));
+
+        private void handleMouseMoveEvent(MotionEvent evt)
+        {
+            // https://developer.android.com/reference/android/view/MotionEvent#batching
+            for (int i = 0; i < evt.HistorySize; i++)
+                handleMouseMove(new Vector2(evt.GetHistoricalX(i), evt.GetHistoricalY(i)));
+
+            handleMouseMove(new Vector2(evt.RawX, evt.RawY));
+        }
+
+        private void handleMouseMove(Vector2 position) => enqueueInput(new MousePositionAbsoluteInput { Position = position });
+
+        private void handleMouseDown(MouseButton button) => enqueueInput(new MouseButtonInput(button, true));
+
+        private void handleMouseUp(MouseButton button) => enqueueInput(new MouseButtonInput(button, false));
+
+        private void handleMouseWheel(Vector2 delta) => enqueueInput(new MouseScrollRelativeInput { Delta = delta });
+
+        private void enqueueInput(IInput input)
+        {
+            PendingInputs.Enqueue(input);
+            FrameStatistics.Increment(StatisticsCounterType.MouseEvents);
+        }
+    }
+}

--- a/osu.Framework.Android/Input/AndroidTouchHandler.cs
+++ b/osu.Framework.Android/Input/AndroidTouchHandler.cs
@@ -2,47 +2,46 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Collections.Generic;
 using Android.Views;
 using osu.Framework.Input;
-using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.States;
-using osu.Framework.Platform;
 using osuTK;
 using osuTK.Input;
 
 namespace osu.Framework.Android.Input
 {
-    public class AndroidTouchHandler : InputHandler
+    public class AndroidTouchHandler : AndroidInputHandler
     {
-        private readonly AndroidGameView view;
-
         public override bool IsActive => true;
 
+        protected override IEnumerable<InputSourceType> HandledInputSources => new[] { InputSourceType.BluetoothStylus, InputSourceType.Stylus, InputSourceType.Touchscreen };
+
         public AndroidTouchHandler(AndroidGameView view)
+            : base(view)
         {
-            this.view = view;
-            view.Touch += handleTouch;
-            view.Hover += handleHover;
+            View.Touch += handleTouch;
+            View.Hover += handleHover;
         }
 
-        public override bool Initialize(GameHost host) => true;
-
-        private void handleTouch(MotionEvent touchEvent)
+        private void handleTouch(object sender, View.TouchEventArgs e)
         {
-            if (touchEvent.Action == MotionEventActions.Move)
+            if (!ShouldHandleEvent(e.Event)) return;
+
+            if (e.Event.Action == MotionEventActions.Move)
             {
-                for (int i = 0; i < Math.Min(touchEvent.PointerCount, TouchState.MAX_TOUCH_COUNT); i++)
+                for (int i = 0; i < Math.Min(e.Event.PointerCount, TouchState.MAX_TOUCH_COUNT); i++)
                 {
-                    var touch = getEventTouch(touchEvent, i);
+                    var touch = getEventTouch(e.Event, i);
                     PendingInputs.Enqueue(new TouchInput(touch, true));
                 }
             }
-            else if (touchEvent.ActionIndex < TouchState.MAX_TOUCH_COUNT)
+            else if (e.Event.ActionIndex < TouchState.MAX_TOUCH_COUNT)
             {
-                var touch = getEventTouch(touchEvent, touchEvent.ActionIndex);
+                var touch = getEventTouch(e.Event, e.Event.ActionIndex);
 
-                switch (touchEvent.ActionMasked)
+                switch (e.Event.ActionMasked)
                 {
                     case MotionEventActions.Down:
                     case MotionEventActions.PointerDown:
@@ -58,19 +57,21 @@ namespace osu.Framework.Android.Input
             }
         }
 
-        private void handleHover(MotionEvent hoverEvent)
+        private void handleHover(object sender, View.HoverEventArgs e)
         {
-            PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = getEventPosition(hoverEvent) });
-            PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, hoverEvent.IsButtonPressed(MotionEventButtonState.StylusPrimary)));
+            if (!ShouldHandleEvent(e.Event)) return;
+
+            PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = getEventPosition(e.Event) });
+            PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, e.Event.IsButtonPressed(MotionEventButtonState.StylusPrimary)));
         }
 
         private Touch getEventTouch(MotionEvent e, int index) => new Touch((TouchSource)e.GetPointerId(index), getEventPosition(e, index));
-        private Vector2 getEventPosition(MotionEvent e, int index = 0) => new Vector2(e.GetX(index) * view.ScaleX, e.GetY(index) * view.ScaleY);
+        private Vector2 getEventPosition(MotionEvent e, int index = 0) => new Vector2(e.GetX(index) * View.ScaleX, e.GetY(index) * View.ScaleY);
 
         protected override void Dispose(bool disposing)
         {
-            view.Touch -= handleTouch;
-            view.Hover -= handleHover;
+            View.Touch -= handleTouch;
+            View.Hover -= handleHover;
             base.Dispose(disposing);
         }
     }

--- a/osu.Framework.Android/Input/AndroidTouchHandler.cs
+++ b/osu.Framework.Android/Input/AndroidTouchHandler.cs
@@ -7,6 +7,7 @@ using Android.Views;
 using osu.Framework.Input;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.States;
+using osu.Framework.Platform;
 using osuTK;
 using osuTK.Input;
 
@@ -18,11 +19,31 @@ namespace osu.Framework.Android.Input
 
         protected override IEnumerable<InputSourceType> HandledEventSources => new[] { InputSourceType.BluetoothStylus, InputSourceType.Stylus, InputSourceType.Touchscreen };
 
-        protected override IEnumerable<InputEventType> HandledEventTypes => new[] { InputEventType.Hover, InputEventType.Touch };
-
         public AndroidTouchHandler(AndroidGameView view)
             : base(view)
         {
+        }
+
+        public override bool Initialize(GameHost host)
+        {
+            if (!base.Initialize(host))
+                return false;
+
+            Enabled.BindValueChanged(enabled =>
+            {
+                if (enabled.NewValue)
+                {
+                    View.Hover += HandleHover;
+                    View.Touch += HandleTouch;
+                }
+                else
+                {
+                    View.Hover -= HandleHover;
+                    View.Touch -= HandleTouch;
+                }
+            }, true);
+
+            return true;
         }
 
         protected override void OnTouch(MotionEvent touchEvent)

--- a/osu.Framework.Android/Input/AndroidTouchHandler.cs
+++ b/osu.Framework.Android/Input/AndroidTouchHandler.cs
@@ -28,21 +28,21 @@ namespace osu.Framework.Android.Input
 
         public override bool Initialize(GameHost host) => true;
 
-        private void handleTouch(object sender, View.TouchEventArgs e)
+        private void handleTouch(MotionEvent touchEvent)
         {
-            if (e.Event.Action == MotionEventActions.Move)
+            if (touchEvent.Action == MotionEventActions.Move)
             {
-                for (int i = 0; i < Math.Min(e.Event.PointerCount, TouchState.MAX_TOUCH_COUNT); i++)
+                for (int i = 0; i < Math.Min(touchEvent.PointerCount, TouchState.MAX_TOUCH_COUNT); i++)
                 {
-                    var touch = getEventTouch(e.Event, i);
+                    var touch = getEventTouch(touchEvent, i);
                     PendingInputs.Enqueue(new TouchInput(touch, true));
                 }
             }
-            else if (e.Event.ActionIndex < TouchState.MAX_TOUCH_COUNT)
+            else if (touchEvent.ActionIndex < TouchState.MAX_TOUCH_COUNT)
             {
-                var touch = getEventTouch(e.Event, e.Event.ActionIndex);
+                var touch = getEventTouch(touchEvent, touchEvent.ActionIndex);
 
-                switch (e.Event.ActionMasked)
+                switch (touchEvent.ActionMasked)
                 {
                     case MotionEventActions.Down:
                     case MotionEventActions.PointerDown:
@@ -58,10 +58,10 @@ namespace osu.Framework.Android.Input
             }
         }
 
-        private void handleHover(object sender, View.HoverEventArgs e)
+        private void handleHover(MotionEvent hoverEvent)
         {
-            PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = getEventPosition(e.Event) });
-            PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, e.Event.ButtonState == MotionEventButtonState.StylusPrimary));
+            PendingInputs.Enqueue(new MousePositionAbsoluteInput { Position = getEventPosition(hoverEvent) });
+            PendingInputs.Enqueue(new MouseButtonInput(MouseButton.Right, hoverEvent.IsButtonPressed(MotionEventButtonState.StylusPrimary)));
         }
 
         private Touch getEventTouch(MotionEvent e, int index) => new Touch((TouchSource)e.GetPointerId(index), getEventPosition(e, index));

--- a/osu.Framework/Properties/AssemblyInfo.cs
+++ b/osu.Framework/Properties/AssemblyInfo.cs
@@ -7,6 +7,7 @@ using System.Runtime.CompilerServices;
 // Note, that we omit visual tests as they are meant to test the framework
 // behavior "in the wild".
 
+[assembly: InternalsVisibleTo("osu.Framework.Android")]
 [assembly: InternalsVisibleTo("osu.Framework.Benchmarks")]
 [assembly: InternalsVisibleTo("osu.Framework.Tests")]
 [assembly: InternalsVisibleTo("osu.Framework.Tests.Dynamic")]


### PR DESCRIPTION
This brings us one step closer to resolving https://github.com/ppy/osu-framework/issues/4373.

In addition to separating mouse from touch events, `AndroidMouseHandler` enables the following:
- support for all mouse buttons (including forward and back)
- support for scrolling
- starting point for implementing [pointer capture](https://github.com/ppy/osu-framework/issues/4373#issuecomment-836278499).

---

Tested on Realme 6, Android 11 (API 30) with a bluetooth mouse.
On-screen keyboard input works as expected.

Test works with:
- [ ] touchpad (not required, but would be nice to test)

Test existing behaviour isn't broken for:
- [ ] physical keyboard
- [x] stylus