### PR TITLE
Fix multiple deadlock cases in `WebRequest`

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -708,8 +708,6 @@ namespace osu.Framework.Tests.IO
             int workerMax;
             int completionMax;
 
-            ManualResetEventSlim resetEvent = new ManualResetEventSlim();
-
             // set limited threadpool capacity
             ThreadPool.GetMinThreads(out workerMin, out completionMin);
             ThreadPool.GetMaxThreads(out workerMax, out completionMax);
@@ -730,8 +728,6 @@ namespace osu.Framework.Tests.IO
             request.Perform();
 
             // restore capacity
-            resetEvent.Set();
-
             ThreadPool.SetMinThreads(workerMin, completionMin);
             ThreadPool.SetMaxThreads(workerMax, completionMax);
         }

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -712,6 +712,12 @@ namespace osu.Framework.Tests.IO
             ThreadPool.GetMinThreads(out workerMin, out completionMin);
             ThreadPool.GetMaxThreads(out workerMax, out completionMax);
 
+            // Note that we explicitly choose two threads here to reproduce a classic thread pool deadlock scenario (which was surfacing due to a `.Wait()` call from within an `async` context).
+            // If set to one, a task required by the NUnit testing process will cause requests to never work.
+            // If set to above two, the deadlock will not reliably reproduce.
+
+            // Also note that the TPL thread pool generally gets much higher values than this (based on logical core count) and will expand with demand.
+            // This is explicitly testing for a case that came up on Github Actions due to limited processor count and refusal to expand the thread pool (for whatever reason).
             ThreadPool.SetMinThreads(2, 2);
             ThreadPool.SetMaxThreads(2, 2);
 

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -712,12 +712,17 @@ namespace osu.Framework.Tests.IO
             ThreadPool.GetMinThreads(out workerMin, out completionMin);
             ThreadPool.GetMaxThreads(out workerMax, out completionMax);
 
-            // Note that we explicitly choose two threads here to reproduce a classic thread pool deadlock scenario (which was surfacing due to a `.Wait()` call from within an `async` context).
-            // If set to one, a task required by the NUnit testing process will cause requests to never work.
-            // If set to above two, the deadlock will not reliably reproduce.
+            /*
+            Note that we explicitly choose two threads here to reproduce a classic thread pool deadlock scenario (which was surfacing due to a `.Wait()` call from within an `async` context).
+            If set to one, a task required by the NUnit hosting process (usage of ManualResetEventSlim.Wait) will cause requests to never work.
+            If set to above two, the deadlock will not reliably reproduce.
 
-            // Also note that the TPL thread pool generally gets much higher values than this (based on logical core count) and will expand with demand.
-            // This is explicitly testing for a case that came up on Github Actions due to limited processor count and refusal to expand the thread pool (for whatever reason).
+            Also note that the TPL thread pool generally gets much higher values than this (based on logical core count) and will expand with demand.
+            This is explicitly testing for a case that came up on Github Actions due to limited processor count and refusal to expand the thread pool (for whatever reason).
+
+            This may require adjustment in the future if we end up using more thread pool threads in the background, or if NUnit changes how they used them.
+            */
+
             ThreadPool.SetMinThreads(2, 2);
             ThreadPool.SetMaxThreads(2, 2);
 

--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Tests.IO
             request.Failed += exception => hasThrown = exception != null;
 
             if (async)
-                Assert.DoesNotThrowAsync(request.PerformAsync);
+                Assert.DoesNotThrowAsync(() => request.PerformAsync());
             else
                 Assert.DoesNotThrow(request.Perform);
 
@@ -172,7 +172,7 @@ namespace osu.Framework.Tests.IO
             request.Failed += exception => finishedException = exception;
 
             if (async)
-                Assert.ThrowsAsync<HttpRequestException>(request.PerformAsync);
+                Assert.ThrowsAsync<HttpRequestException>(() => request.PerformAsync());
             else
                 Assert.Throws<HttpRequestException>(request.Perform);
 
@@ -195,7 +195,7 @@ namespace osu.Framework.Tests.IO
             request.Failed += exception => hasThrown = exception != null;
 
             if (async)
-                Assert.ThrowsAsync<WebException>(request.PerformAsync);
+                Assert.ThrowsAsync<WebException>(() => request.PerformAsync());
             else
                 Assert.Throws<WebException>(request.Perform);
 
@@ -219,7 +219,7 @@ namespace osu.Framework.Tests.IO
             request.Failed += exception => hasThrown = exception != null;
 
             if (async)
-                Assert.ThrowsAsync<ArgumentException>(request.PerformAsync);
+                Assert.ThrowsAsync<ArgumentException>(() => request.PerformAsync());
             else
                 Assert.Throws<ArgumentException>(request.Perform);
 
@@ -250,7 +250,7 @@ namespace osu.Framework.Tests.IO
             request.Started += () => request.Abort();
 
             if (async)
-                Assert.DoesNotThrowAsync(request.PerformAsync);
+                Assert.DoesNotThrowAsync(() => request.PerformAsync());
             else
                 Assert.DoesNotThrow(request.Perform);
 
@@ -313,7 +313,7 @@ namespace osu.Framework.Tests.IO
             Assert.DoesNotThrow(request.Abort);
 
             if (async)
-                Assert.ThrowsAsync<InvalidOperationException>(request.PerformAsync);
+                Assert.ThrowsAsync<InvalidOperationException>(() => request.PerformAsync());
             else
                 Assert.Throws<InvalidOperationException>(request.Perform);
 
@@ -399,7 +399,7 @@ namespace osu.Framework.Tests.IO
             cancellationSource.Cancel();
             request.PerformAsync(cancellationSource.Token);
 
-            Assert.ThrowsAsync<InvalidOperationException>(request.PerformAsync);
+            Assert.ThrowsAsync<InvalidOperationException>(() => request.PerformAsync(cancellationSource.Token));
 
             Assert.IsTrue(request.Completed);
             Assert.IsTrue(request.Aborted);
@@ -569,7 +569,7 @@ namespace osu.Framework.Tests.IO
             request.AddParameter("testkey2", "testval2");
 
             if (async)
-                Assert.DoesNotThrowAsync(request.PerformAsync);
+                Assert.DoesNotThrowAsync(() => request.PerformAsync());
             else
                 Assert.DoesNotThrow(request.Perform);
 
@@ -605,7 +605,7 @@ namespace osu.Framework.Tests.IO
             request.AddRaw(JsonConvert.SerializeObject(testObject));
 
             if (async)
-                Assert.DoesNotThrowAsync(request.PerformAsync);
+                Assert.DoesNotThrowAsync(() => request.PerformAsync());
             else
                 Assert.DoesNotThrow(request.Perform);
 
@@ -631,7 +631,7 @@ namespace osu.Framework.Tests.IO
             };
 
             if (async)
-                Assert.DoesNotThrowAsync(request.PerformAsync);
+                Assert.DoesNotThrowAsync(() => request.PerformAsync());
             else
                 Assert.DoesNotThrow(request.Perform);
 
@@ -713,7 +713,7 @@ namespace osu.Framework.Tests.IO
                 request.AddParameter("chunk_size", chunk_size.ToString());
 
             if (async)
-                Assert.DoesNotThrowAsync(request.PerformAsync);
+                Assert.DoesNotThrowAsync(() => request.PerformAsync());
             else
                 Assert.DoesNotThrow(request.Perform);
 

--- a/osu.Framework/IO/Network/FileWebRequest.cs
+++ b/osu.Framework/IO/Network/FileWebRequest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace osu.Framework.IO.Network
 {
@@ -30,7 +31,7 @@ namespace osu.Framework.IO.Network
             Filename = filename;
         }
 
-        protected override void Complete(Exception e = null)
+        protected override Task Complete(Exception e = null)
         {
             ResponseStream?.Close();
 
@@ -46,7 +47,7 @@ namespace osu.Framework.IO.Network
                 }
             }
 
-            base.Complete(e);
+            return base.Complete(e);
         }
     }
 }

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -228,13 +228,8 @@ namespace osu.Framework.IO.Network
         /// <summary>
         /// Performs the request asynchronously.
         /// </summary>
-        public Task PerformAsync() => PerformAsync(default);
-
-        /// <summary>
-        /// Performs the request asynchronously.
-        /// </summary>
         /// <param name="cancellationToken">A token to cancel the request.</param>
-        public async Task PerformAsync(CancellationToken cancellationToken)
+        public async Task PerformAsync(CancellationToken cancellationToken = default)
         {
             if (Completed)
                 throw new InvalidOperationException($"The {nameof(WebRequest)} has already been run.");

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -134,6 +134,19 @@ namespace osu.Framework.IO.Network
         /// </summary>
         public bool AllowRetryOnTimeout { get; set; } = true;
 
+        private CancellationToken? userToken;
+        private CancellationTokenSource abortToken;
+        private CancellationTokenSource timeoutToken;
+
+        private LengthTrackingStream requestStream;
+        private HttpResponseMessage response;
+
+        private long contentLength => requestStream?.Length ?? 0;
+
+        private const string form_boundary = "-----------------------------28947758029299";
+
+        private const string form_content_type = "multipart/form-data; boundary=" + form_boundary;
+
         private static readonly HttpClient client = new HttpClient(
 #if NET5_0
             new SocketsHttpHandler
@@ -211,19 +224,6 @@ namespace osu.Framework.IO.Network
         }
 
         public HttpResponseHeaders ResponseHeaders => response.Headers;
-
-        private CancellationToken? userToken;
-        private CancellationTokenSource abortToken;
-        private CancellationTokenSource timeoutToken;
-
-        private LengthTrackingStream requestStream;
-        private HttpResponseMessage response;
-
-        private long contentLength => requestStream?.Length ?? 0;
-
-        private const string form_boundary = "-----------------------------28947758029299";
-
-        private const string form_content_type = "multipart/form-data; boundary=" + form_boundary;
 
         /// <summary>
         /// Performs the request asynchronously.

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -409,7 +409,9 @@ namespace osu.Framework.IO.Network
         {
             try
             {
-                PerformAsync().Wait();
+                // Start a long-running task to ensure we don't block on a TPL thread pool thread.
+                // Unfortunately we can't use a full synchronous flow due to IPv4 fallback logic *requiring* the async path for now.
+                Task.Factory.StartNew(() => PerformAsync().Wait(), TaskCreationOptions.LongRunning).Wait();
             }
             catch (AggregateException ae)
             {


### PR DESCRIPTION
Would have liked to split into synchronous and asynchronous paths completely, but can't be done until https://github.com/dotnet/runtime/pull/45300 is available to use (.net 6) as we depend on it for IPv4 fallback.