### PR TITLE
Don't throw when returning a leased bindable that has already been returned

### DIFF
--- a/osu.Framework.Tests/Bindables/BindableLeasingTest.cs
+++ b/osu.Framework.Tests/Bindables/BindableLeasingTest.cs
@@ -31,7 +31,7 @@ namespace osu.Framework.Tests.Bindables
             Assert.AreEqual(original.Value, 2);
             Assert.AreEqual(original.Value, leased.Value);
 
-            leased.Return();
+            Assert.AreEqual(true, leased.Return());
 
             Assert.AreEqual(original.Value, revert ? 1 : 2);
         }
@@ -58,20 +58,28 @@ namespace osu.Framework.Tests.Bindables
         public void TestConsecutiveLeases()
         {
             var leased1 = original.BeginLease(false);
-            leased1.Return();
+            Assert.AreEqual(true, leased1.Return());
             var leased2 = original.BeginLease(false);
-            leased2.Return();
+            Assert.AreEqual(true, leased2.Return());
         }
 
         [Test]
         public void TestModifyAfterReturnFail()
         {
-            var leased1 = original.BeginLease(false);
-            leased1.Return();
+            var leased = original.BeginLease(false);
+            Assert.AreEqual(true, leased.Return());
 
-            Assert.Throws<InvalidOperationException>(() => leased1.Value = 2);
-            Assert.Throws<InvalidOperationException>(() => leased1.Disabled = true);
-            Assert.Throws<InvalidOperationException>(() => leased1.Return());
+            Assert.Throws<InvalidOperationException>(() => leased.Value = 2);
+            Assert.Throws<InvalidOperationException>(() => leased.Disabled = true);
+        }
+
+        [Test]
+        public void TestDoubleReturnSilentlyNoops()
+        {
+            var leased = original.BeginLease(false);
+
+            Assert.AreEqual(true, leased.Return());
+            Assert.AreEqual(false, leased.Return());
         }
 
         [Test]
@@ -125,7 +133,7 @@ namespace osu.Framework.Tests.Bindables
             Assert.IsTrue(original.Disabled);
             Assert.IsTrue(leased.Disabled);
 
-            leased.Return();
+            Assert.AreEqual(true, leased.Return());
 
             Assert.IsFalse(original.Disabled);
         }
@@ -181,7 +189,7 @@ namespace osu.Framework.Tests.Bindables
 
             var leased = original.BeginLease(revert);
 
-            leased.Return();
+            Assert.AreEqual(true, leased.Return());
 
             // regardless of revert specification, disabled should always be reverted to the original value.
             Assert.IsTrue(original.Disabled);
@@ -221,7 +229,7 @@ namespace osu.Framework.Tests.Bindables
             leasedCopy.Disabled = false;
             leasedCopy.Disabled = true;
 
-            leased.Return();
+            Assert.AreEqual(true, leased.Return());
 
             original.Value = 1;
 

--- a/osu.Framework/Bindables/ILeasedBindable.cs
+++ b/osu.Framework/Bindables/ILeasedBindable.cs
@@ -11,7 +11,10 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// End the lease on the source <see cref="Bindable{T}"/>.
         /// </summary>
-        void Return();
+        /// <returns>
+        /// Whether the lease was returned. Will be <c>false</c> if already returned.
+        /// </returns>
+        bool Return();
     }
 
     /// <summary>

--- a/osu.Framework/Bindables/ILeasedBindable.cs
+++ b/osu.Framework/Bindables/ILeasedBindable.cs
@@ -12,7 +12,7 @@ namespace osu.Framework.Bindables
         /// End the lease on the source <see cref="Bindable{T}"/>.
         /// </summary>
         /// <returns>
-        /// Whether the lease was returned. Will be <c>false</c> if already returned.
+        /// Whether the lease was returned by this call. Will be <c>false</c> if already returned.
         /// </returns>
         bool Return();
     }

--- a/osu.Framework/Bindables/LeasedBindable.cs
+++ b/osu.Framework/Bindables/LeasedBindable.cs
@@ -45,18 +45,16 @@ namespace osu.Framework.Bindables
 
         private bool hasBeenReturned;
 
-        /// <summary>
-        /// End the lease on the source <see cref="Bindable{T}"/>.
-        /// </summary>
-        public void Return()
+        public bool Return()
         {
+            if (hasBeenReturned)
+                return false;
+
             if (source == null)
                 throw new InvalidOperationException($"Must {nameof(Return)} from original leased source");
 
-            if (hasBeenReturned)
-                throw new InvalidOperationException($"This bindable has already been {nameof(Return)}ed.");
-
             UnbindAll();
+            return true;
         }
 
         public override T Value


### PR DESCRIPTION
Leases are commonly returned automatically by the framework. One such example is `ScreenStack` (https://github.com/ppy/osu-framework/blob/ceef26fa2675e89937e01b87e2ea40be83d14c58/osu.Framework/Screens/ScreenStack.cs#L349).

We likely do want this automatic cleanup, but it turns out to be very hidden to the end user. If a user attempts to clean up themselves without understanding this detail, it can lead to unexpected failures.

The example that came up is an osu!-side test failure which took 2-3 hours to hunt down the cause. Said example is very well protected against to the point I thought the issue was a threading one, but it turns out it is not: https://github.com/ppy/osu/blob/c6ca0e58956c2d64f69c2d24eef2b87eb0c76e79/osu.Game/Screens/OnlinePlay/Lounge/LoungeSubScreen.cs#L247-L251.

I don't think we were gaining anything from the `throw` this method was doing previously.

This fixes the test failure seen at https://github.com/peppy/osu/runs/4678044996?check_suite_focus=true.