### PR TITLE
Replace all usages of `Task.Wait`/`Task.Result` with safer alternatives

### DIFF
--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -5,4 +5,4 @@ T:System.IComparable;Don't use non-generic IComparable. Use generic version inst
 M:System.Enum.HasFlag(System.Enum);Use osu.Framework.Extensions.EnumExtensions.HasFlagFast<T>() instead.
 F:System.UriKind.RelativeOrAbsolute;Incompatible results when run on mono (see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/). Use Validation.TryParseUri(string, out Uri?) instead.
 M:System.Threading.Tasks.Task.Wait();Don't use Task.Wait. Use Task.WaitSafely() to ensure we avoid deadlocks.
-P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.WaitSafelyForResult() to ensure we avoid deadlocks.
+P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.GetCompletedResult() to safely retrieve the result of a completed task, or Task.WaitSafelyForResult() to synchronously wait for and retrieve the result of a not-completed task in a way that ensures that it will not deadlock.

--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -5,4 +5,4 @@ T:System.IComparable;Don't use non-generic IComparable. Use generic version inst
 M:System.Enum.HasFlag(System.Enum);Use osu.Framework.Extensions.EnumExtensions.HasFlagFast<T>() instead.
 F:System.UriKind.RelativeOrAbsolute;Incompatible results when run on mono (see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/). Use Validation.TryParseUri(string, out Uri?) instead.
 M:System.Threading.Tasks.Task.Wait();Don't use Task.Wait. Use Task.WaitSafely() to ensure we avoid deadlocks.
-P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.GetCompletedResult() to safely retrieve the result of a completed task, or Task.WaitSafelyForResult() to synchronously wait for and retrieve the result of a not-completed task in a way that ensures that it will not deadlock.
+P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.WaitSafelyForResult() to ensure we avoid deadlocks.

--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -4,3 +4,4 @@ M:System.ValueType.Equals(System.Object)~System.Boolean;Don't use object.Equals(
 T:System.IComparable;Don't use non-generic IComparable. Use generic version instead.
 M:System.Enum.HasFlag(System.Enum);Use osu.Framework.Extensions.EnumExtensions.HasFlagFast<T>() instead.
 F:System.UriKind.RelativeOrAbsolute;Incompatible results when run on mono (see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/). Use Validation.TryParseUri(string, out Uri?) instead.
+M:System.Threading.Tasks.Task.Wait();Don't use Task.Wait. Use Task.WaitSafely() to ensure we avoid deadlocks.

--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -5,4 +5,4 @@ T:System.IComparable;Don't use non-generic IComparable. Use generic version inst
 M:System.Enum.HasFlag(System.Enum);Use osu.Framework.Extensions.EnumExtensions.HasFlagFast<T>() instead.
 F:System.UriKind.RelativeOrAbsolute;Incompatible results when run on mono (see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/). Use Validation.TryParseUri(string, out Uri?) instead.
 M:System.Threading.Tasks.Task.Wait();Don't use Task.Wait. Use Task.WaitSafely() to ensure we avoid deadlocks.
-P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.WaitSafelyForResult() to ensure we avoid deadlocks.
+P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.GetResultSafely() to ensure we avoid deadlocks.

--- a/CodeAnalysis/BannedSymbols.txt
+++ b/CodeAnalysis/BannedSymbols.txt
@@ -5,3 +5,4 @@ T:System.IComparable;Don't use non-generic IComparable. Use generic version inst
 M:System.Enum.HasFlag(System.Enum);Use osu.Framework.Extensions.EnumExtensions.HasFlagFast<T>() instead.
 F:System.UriKind.RelativeOrAbsolute;Incompatible results when run on mono (see https://www.mono-project.com/docs/faq/known-issues/urikind-relativeorabsolute/). Use Validation.TryParseUri(string, out Uri?) instead.
 M:System.Threading.Tasks.Task.Wait();Don't use Task.Wait. Use Task.WaitSafely() to ensure we avoid deadlocks.
+P:System.Threading.Tasks.Task`1.Result;Don't use Task.Result. Use Task.WaitSafelyForResult() to ensure we avoid deadlocks.

--- a/osu.Framework.Benchmarks/BenchmarkFontLoading.cs
+++ b/osu.Framework.Benchmarks/BenchmarkFontLoading.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Reflection;
 using BenchmarkDotNet.Attributes;
 using NUnit.Framework;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.IO.Stores;
 using osu.Framework.Testing;
@@ -80,7 +81,7 @@ namespace osu.Framework.Benchmarks
 
         private void runFor(GlyphStore store)
         {
-            store.LoadFontAsync().Wait();
+            store.LoadFontAsync().WaitSafely();
 
             var props = typeof(FontAwesome.Solid).GetProperties(BindingFlags.Public | BindingFlags.Static);
 

--- a/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
+++ b/osu.Framework.Tests/Exceptions/TestLoadExceptions.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -261,7 +262,7 @@ namespace osu.Framework.Tests.Exceptions
             [BackgroundDependencyLoader]
             private void load()
             {
-                Task.Delay((int)(1000 / Clock.Rate)).Wait();
+                Task.Delay((int)(1000 / Clock.Rate)).WaitSafely();
                 if (throws)
                     throw new AsyncTestException();
             }

--- a/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Development;
+using osu.Framework.Extensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 using osu.Framework.Tests.IO;
@@ -77,7 +78,7 @@ namespace osu.Framework.Tests.Platform
                     isAudioThread = ThreadSafety.IsAudioThread;
                 }, TaskCreationOptions.LongRunning);
 
-                task.Wait();
+                task.WaitSafely();
 
                 Assert.That(!isDrawThread && !isUpdateThread && !isInputThread && !isAudioThread);
             }
@@ -107,7 +108,7 @@ namespace osu.Framework.Tests.Platform
                             return null;
                         };
 
-                        clientChannel.SendMessageAsync(new Foobar { Bar = "example" }).Wait();
+                        clientChannel.SendMessageAsync(new Foobar { Bar = "example" }).WaitSafely();
 
                         received.Wait();
                     }

--- a/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
+++ b/osu.Framework.Tests/Platform/HeadlessGameHostTest.cs
@@ -96,7 +96,7 @@ namespace osu.Framework.Tests.Platform
                 var serverChannel = new IpcChannel<Foobar>(server);
                 var clientChannel = new IpcChannel<Foobar>(client);
 
-                void waitAction()
+                async void waitAction()
                 {
                     using (var received = new ManualResetEventSlim(false))
                     {
@@ -108,7 +108,7 @@ namespace osu.Framework.Tests.Platform
                             return null;
                         };
 
-                        clientChannel.SendMessageAsync(new Foobar { Bar = "example" }).WaitSafely();
+                        await clientChannel.SendMessageAsync(new Foobar { Bar = "example" }).ConfigureAwait(false);
 
                         received.Wait();
                     }

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             host.TakeScreenshotAsync().ContinueWith(t => Schedule(() =>
             {
-                var image = t.GetCompletedResult();
+                var image = t.GetResultSafely();
 
                 var tex = new Texture(image.Width, image.Height);
                 tex.SetData(new TextureUpload(image));

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
@@ -56,7 +56,7 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             host.TakeScreenshotAsync().ContinueWith(t => Schedule(() =>
             {
-                var image = t.WaitSafelyForResult();
+                var image = t.GetCompletedResult();
 
                 var tex = new Texture(image.Width, image.Height);
                 tex.SetData(new TextureUpload(image));

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneScreenshot.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -55,7 +56,7 @@ namespace osu.Framework.Tests.Visual.Sprites
 
             host.TakeScreenshotAsync().ContinueWith(t => Schedule(() =>
             {
-                var image = t.Result;
+                var image = t.WaitSafelyForResult();
 
                 var tex = new Texture(image.Width, image.Height);
                 tex.SetData(new TextureUpload(image));

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using osu.Framework.Audio.Callbacks;
 using osu.Framework.Audio.Mixing;
 using osu.Framework.Audio.Mixing.Bass;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Utils;
 
@@ -206,7 +207,7 @@ namespace osu.Framework.Audio.Track
         {
             base.Stop();
 
-            StopAsync().Wait();
+            StopAsync().WaitSafely();
         }
 
         public Task StopAsync() => EnqueueAction(() =>
@@ -229,7 +230,7 @@ namespace osu.Framework.Audio.Track
         {
             base.Start();
 
-            StartAsync().Wait();
+            StartAsync().WaitSafely();
         }
 
         public Task StartAsync() => EnqueueAction(() =>

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -266,7 +266,7 @@ namespace osu.Framework.Audio.Track
             }
         }
 
-        public override bool Seek(double seek) => SeekAsync(seek).WaitSafelyForResult();
+        public override bool Seek(double seek) => SeekAsync(seek).GetResultSafely();
 
         public async Task<bool> SeekAsync(double seek)
         {

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -266,7 +266,7 @@ namespace osu.Framework.Audio.Track
             }
         }
 
-        public override bool Seek(double seek) => SeekAsync(seek).Result;
+        public override bool Seek(double seek) => SeekAsync(seek).WaitSafelyForResult();
 
         public async Task<bool> SeekAsync(double seek)
         {

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -281,7 +281,12 @@ namespace osu.Framework.Audio.Track
         /// <summary>
         /// Gets the number of channels represented by each <see cref="Point"/>.
         /// </summary>
-        public int GetChannels() => GetChannelsAsync().WaitSafelyForResult();
+        public int GetChannels()
+        {
+            readTask?.WaitSafely();
+
+            return channels;
+        }
 
         /// <summary>
         /// Gets the number of channels represented by each <see cref="Point"/>.

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -263,7 +263,7 @@ namespace osu.Framework.Audio.Track
         /// <summary>
         /// Gets all the points represented by this <see cref="Waveform"/>.
         /// </summary>
-        public List<Point> GetPoints() => GetPointsAsync().WaitSafelyForResult();
+        public List<Point> GetPoints() => GetPointsAsync().GetResultSafely();
 
         /// <summary>
         /// Gets all the points represented by this <see cref="Waveform"/>.

--- a/osu.Framework/Audio/Track/Waveform.cs
+++ b/osu.Framework/Audio/Track/Waveform.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using ManagedBass;
 using osu.Framework.Utils;
 using osu.Framework.Audio.Callbacks;
+using osu.Framework.Extensions;
 
 namespace osu.Framework.Audio.Track
 {
@@ -262,7 +263,7 @@ namespace osu.Framework.Audio.Track
         /// <summary>
         /// Gets all the points represented by this <see cref="Waveform"/>.
         /// </summary>
-        public List<Point> GetPoints() => GetPointsAsync().Result;
+        public List<Point> GetPoints() => GetPointsAsync().WaitSafelyForResult();
 
         /// <summary>
         /// Gets all the points represented by this <see cref="Waveform"/>.
@@ -280,7 +281,7 @@ namespace osu.Framework.Audio.Track
         /// <summary>
         /// Gets the number of channels represented by each <see cref="Point"/>.
         /// </summary>
-        public int GetChannels() => GetChannelsAsync().Result;
+        public int GetChannels() => GetChannelsAsync().WaitSafelyForResult();
 
         /// <summary>
         /// Gets the number of channels represented by each <see cref="Point"/>.

--- a/osu.Framework/Extensions/TaskExtensions.cs
+++ b/osu.Framework/Extensions/TaskExtensions.cs
@@ -27,7 +27,11 @@ namespace osu.Framework.Extensions
         /// </summary>
         public static T WaitSafelyForResult<T>(this Task<T> task)
         {
-            if (Thread.CurrentThread.IsThreadPoolThread)
+            // We commonly access `.Result` from within `ContinueWith`, which is a safe usage (the task is guaranteed to be completed).
+            // Unfortunately, the only way to allow these usages is to check whether the task is completed or not here.
+            // This does mean that there could be edge cases where this safety is skipped (ie. if the majority of executions complete
+            // immediately).
+            if (Thread.CurrentThread.IsThreadPoolThread && !task.IsCompleted)
                 throw new InvalidOperationException($"Can't use {nameof(WaitSafelyForResult)} from inside an async operation.");
 
 #pragma warning disable RS0030

--- a/osu.Framework/Extensions/TaskExtensions.cs
+++ b/osu.Framework/Extensions/TaskExtensions.cs
@@ -23,35 +23,16 @@ namespace osu.Framework.Extensions
         }
 
         /// <summary>
-        /// Safe alternative to Task.Result which asserts that the task has already been completed (and thus will not block).
-        /// </summary>
-        /// <remarks>
-        /// If unsure that the task has completed, use <see cref="WaitSafelyForResult{T}"/> instead.
-        /// </remarks>
-        public static T GetCompletedResult<T>(this Task<T> task)
-        {
-            if (!task.IsCompleted)
-                throw new InvalidOperationException($"Can't use {nameof(GetCompletedResult)} when the task has not yet completed.");
-
-#pragma warning disable RS0030
-            return task.Result;
-#pragma warning restore RS0030
-        }
-
-        /// <summary>
         /// Safe alternative to Task.Result which ensures the calling thread is not a thread pool thread.
         /// </summary>
-        /// <remarks>
-        /// If sure that the task has completed, use <see cref="GetCompletedResult{T}"/> instead.
-        /// </remarks>
-        public static T WaitSafelyForResult<T>(this Task<T> task)
+        public static T GetResultSafely<T>(this Task<T> task)
         {
             // We commonly access `.Result` from within `ContinueWith`, which is a safe usage (the task is guaranteed to be completed).
             // Unfortunately, the only way to allow these usages is to check whether the task is completed or not here.
             // This does mean that there could be edge cases where this safety is skipped (ie. if the majority of executions complete
             // immediately).
             if (Thread.CurrentThread.IsThreadPoolThread && !task.IsCompleted)
-                throw new InvalidOperationException($"Can't use {nameof(WaitSafelyForResult)} from inside an async operation.");
+                throw new InvalidOperationException($"Can't use {nameof(GetResultSafely)} from inside an async operation.");
 
 #pragma warning disable RS0030
             return task.Result;

--- a/osu.Framework/Extensions/TaskExtensions.cs
+++ b/osu.Framework/Extensions/TaskExtensions.cs
@@ -9,6 +9,9 @@ namespace osu.Framework.Extensions
 {
     public static class TaskExtensions
     {
+        /// <summary>
+        /// Safe alternative to Task.Wait which ensures the calling thread is not a thread pool thread.
+        /// </summary>
         public static void WaitSafely(this Task task)
         {
             if (Thread.CurrentThread.IsThreadPoolThread)
@@ -16,6 +19,19 @@ namespace osu.Framework.Extensions
 
 #pragma warning disable RS0030
             task.Wait();
+#pragma warning restore RS0030
+        }
+
+        /// <summary>
+        /// Safe alternative to Task.Result which ensures the calling thread is not a thread pool thread.
+        /// </summary>
+        public static T WaitSafelyForResult<T>(this Task<T> task)
+        {
+            if (Thread.CurrentThread.IsThreadPoolThread)
+                throw new InvalidOperationException($"Can't use {nameof(WaitSafelyForResult)} from inside an async operation.");
+
+#pragma warning disable RS0030
+            return task.Result;
 #pragma warning restore RS0030
         }
     }

--- a/osu.Framework/Extensions/TaskExtensions.cs
+++ b/osu.Framework/Extensions/TaskExtensions.cs
@@ -23,8 +23,27 @@ namespace osu.Framework.Extensions
         }
 
         /// <summary>
+        /// Safe alternative to Task.Result which asserts that the task has already been completed (and thus will not block).
+        /// </summary>
+        /// <remarks>
+        /// If unsure that the task has completed, use <see cref="WaitSafelyForResult{T}"/> instead.
+        /// </remarks>
+        public static T GetCompletedResult<T>(this Task<T> task)
+        {
+            if (!task.IsCompleted)
+                throw new InvalidOperationException($"Can't use {nameof(GetCompletedResult)} when the task has not yet completed.");
+
+#pragma warning disable RS0030
+            return task.Result;
+#pragma warning restore RS0030
+        }
+
+        /// <summary>
         /// Safe alternative to Task.Result which ensures the calling thread is not a thread pool thread.
         /// </summary>
+        /// <remarks>
+        /// If sure that the task has completed, use <see cref="GetCompletedResult{T}"/> instead.
+        /// </remarks>
         public static T WaitSafelyForResult<T>(this Task<T> task)
         {
             // We commonly access `.Result` from within `ContinueWith`, which is a safe usage (the task is guaranteed to be completed).

--- a/osu.Framework/Extensions/TaskExtensions.cs
+++ b/osu.Framework/Extensions/TaskExtensions.cs
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Extensions
+{
+    public static class TaskExtensions
+    {
+        public static void WaitSafely(this Task task)
+        {
+            if (Thread.CurrentThread.IsThreadPoolThread)
+                throw new InvalidOperationException($"Can't use {nameof(WaitSafely)} from inside an async operation.");
+
+#pragma warning disable RS0030
+            task.Wait();
+#pragma warning restore RS0030
+        }
+    }
+}

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -199,7 +199,7 @@ namespace osu.Framework.Graphics.Audio
 
                 Waveform.GenerateResampledAsync((int)Math.Max(0, Math.Ceiling(DrawWidth * Scale.X) * Resolution), token).ContinueWith(task =>
                 {
-                    var resampled = task.GetCompletedResult();
+                    var resampled = task.GetResultSafely();
 
                     var points = resampled.GetPoints();
                     int channels = resampled.GetChannels();

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -197,10 +197,12 @@ namespace osu.Framework.Graphics.Audio
                 cancelSource = new CancellationTokenSource();
                 var token = cancelSource.Token;
 
-                Waveform.GenerateResampledAsync((int)Math.Max(0, Math.Ceiling(DrawWidth * Scale.X) * Resolution), token).ContinueWith(w =>
+                Waveform.GenerateResampledAsync((int)Math.Max(0, Math.Ceiling(DrawWidth * Scale.X) * Resolution), token).ContinueWith(task =>
                 {
-                    var points = w.WaitSafelyForResult().GetPoints();
-                    int channels = w.WaitSafelyForResult().GetChannels();
+                    var resampled = task.WaitSafelyForResult();
+
+                    var points = resampled.GetPoints();
+                    int channels = resampled.GetChannels();
                     double maxHighIntensity = points.Count > 0 ? points.Max(p => p.HighIntensity) : 0;
                     double maxMidIntensity = points.Count > 0 ? points.Max(p => p.MidIntensity) : 0;
                     double maxLowIntensity = points.Count > 0 ? points.Max(p => p.LowIntensity) : 0;
@@ -213,7 +215,7 @@ namespace osu.Framework.Graphics.Audio
                         resampledMaxMidIntensity = maxMidIntensity;
                         resampledMaxLowIntensity = maxLowIntensity;
 
-                        OnWaveformRegenerated(w.WaitSafelyForResult());
+                        OnWaveformRegenerated(resampled);
 
                         Invalidate(Invalidation.DrawNode);
                     });

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using osu.Framework.Allocation;
 using osu.Framework.Audio.Track;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics.Batches;
 using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.OpenGL.Vertices;
@@ -198,8 +199,8 @@ namespace osu.Framework.Graphics.Audio
 
                 Waveform.GenerateResampledAsync((int)Math.Max(0, Math.Ceiling(DrawWidth * Scale.X) * Resolution), token).ContinueWith(w =>
                 {
-                    var points = w.Result.GetPoints();
-                    int channels = w.Result.GetChannels();
+                    var points = w.WaitSafelyForResult().GetPoints();
+                    int channels = w.WaitSafelyForResult().GetChannels();
                     double maxHighIntensity = points.Count > 0 ? points.Max(p => p.HighIntensity) : 0;
                     double maxMidIntensity = points.Count > 0 ? points.Max(p => p.MidIntensity) : 0;
                     double maxLowIntensity = points.Count > 0 ? points.Max(p => p.LowIntensity) : 0;
@@ -212,7 +213,7 @@ namespace osu.Framework.Graphics.Audio
                         resampledMaxMidIntensity = maxMidIntensity;
                         resampledMaxLowIntensity = maxLowIntensity;
 
-                        OnWaveformRegenerated(w.Result);
+                        OnWaveformRegenerated(w.WaitSafelyForResult());
 
                         Invalidate(Invalidation.DrawNode);
                     });

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -199,7 +199,7 @@ namespace osu.Framework.Graphics.Audio
 
                 Waveform.GenerateResampledAsync((int)Math.Max(0, Math.Ceiling(DrawWidth * Scale.X) * Resolution), token).ContinueWith(task =>
                 {
-                    var resampled = task.WaitSafelyForResult();
+                    var resampled = task.GetCompletedResult();
 
                     var points = resampled.GetPoints();
                     int channels = resampled.GetChannels();

--- a/osu.Framework/Graphics/Textures/TextureStore.cs
+++ b/osu.Framework/Graphics/Textures/TextureStore.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using osu.Framework.Extensions;
 using osu.Framework.Logging;
 using osuTK.Graphics.ES30;
 
@@ -135,7 +136,7 @@ namespace osu.Framework.Graphics.Textures
             // handle the case where a lookup is already in progress.
             if (task != null)
             {
-                task.Wait();
+                task.WaitSafely();
 
                 // always perform re-lookups through TryGetCached (see LargeTextureStore which has a custom implementation of this where it matters).
                 if (TryGetCached(key, out var cached))

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -16,7 +16,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
-using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -177,7 +176,7 @@ namespace osu.Framework.Graphics.Video
         public void StartDecoding()
         {
             if (decodingTask != null)
-                throw new InvalidOperationException($"Cannot start decoding once already started. Call {nameof(StopDecoding)} first.");
+                throw new InvalidOperationException($"Cannot start decoding once already started. Call {nameof(StopDecodingAsync)} first.");
 
             // only prepare for decoding if this is our first time starting the decoding process
             if (formatContext == null)
@@ -201,34 +200,23 @@ namespace osu.Framework.Graphics.Video
         }
 
         /// <summary>
-        /// Stops the decoding process. Optionally waits for the decoder thread to terminate.
+        /// Stops the decoding process.
         /// </summary>
-        /// <param name="waitForDecoderExit">True if this method should wait for the decoder thread to terminate, false otherwise.</param>
-        public void StopDecoding(bool waitForDecoderExit)
+        public Task StopDecodingAsync()
         {
             if (decodingTask == null)
-                return;
+                return Task.CompletedTask;
 
             decodingTaskCancellationTokenSource.Cancel();
 
-            if (waitForDecoderExit)
+            return decodingTask.ContinueWith(_ =>
             {
-                try
-                {
-                    decodingTask.WaitSafely();
-                }
-                catch
-                {
-                    // Can throw an TaskCanceledException (inside of an AggregateException)
-                    // if the decoding task was enqueued but not running yet.
-                }
-            }
+                decodingTask = null;
+                decodingTaskCancellationTokenSource.Dispose();
+                decodingTaskCancellationTokenSource = null;
 
-            decodingTask = null;
-            decodingTaskCancellationTokenSource.Dispose();
-            decodingTaskCancellationTokenSource = null;
-
-            State = DecoderState.Ready;
+                State = DecoderState.Ready;
+            });
         }
 
         /// <summary>
@@ -840,45 +828,46 @@ namespace osu.Framework.Graphics.Video
 
             decoderCommands.Clear();
 
-            StopDecoding(true);
-
-            if (formatContext != null && inputOpened)
+            StopDecodingAsync().ContinueWith(_ =>
             {
-                fixed (AVFormatContext** ptr = &formatContext)
-                    ffmpeg.avformat_close_input(ptr);
-            }
+                if (formatContext != null && inputOpened)
+                {
+                    fixed (AVFormatContext** ptr = &formatContext)
+                        ffmpeg.avformat_close_input(ptr);
+                }
 
-            if (codecContext != null)
-            {
-                fixed (AVCodecContext** ptr = &codecContext)
-                    ffmpeg.avcodec_free_context(ptr);
-            }
+                if (codecContext != null)
+                {
+                    fixed (AVCodecContext** ptr = &codecContext)
+                        ffmpeg.avcodec_free_context(ptr);
+                }
 
-            seekCallback = null;
-            readPacketCallback = null;
+                seekCallback = null;
+                readPacketCallback = null;
 
-            videoStream.Dispose();
-            videoStream = null;
+                videoStream.Dispose();
+                videoStream = null;
 
-            if (swsContext != null)
-                ffmpeg.sws_freeContext(swsContext);
+                if (swsContext != null)
+                    ffmpeg.sws_freeContext(swsContext);
 
-            while (decodedFrames.TryDequeue(out var f))
-            {
-                ((VideoTexture)f.Texture.TextureGL).FlushUploads();
-                f.Texture.Dispose();
-            }
+                while (decodedFrames.TryDequeue(out var f))
+                {
+                    ((VideoTexture)f.Texture.TextureGL).FlushUploads();
+                    f.Texture.Dispose();
+                }
 
-            while (availableTextures.TryDequeue(out var t))
-                t.Dispose();
+                while (availableTextures.TryDequeue(out var t))
+                    t.Dispose();
 
-            while (hwTransferFrames.TryDequeue(out var hwF))
-                hwF.Dispose();
+                while (hwTransferFrames.TryDequeue(out var hwF))
+                    hwF.Dispose();
 
-            while (scalerFrames.TryDequeue(out var sf))
-                sf.Dispose();
+                while (scalerFrames.TryDequeue(out var sf))
+                    sf.Dispose();
 
-            handle.Dispose();
+                handle.Dispose();
+            });
         }
 
         #endregion

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -16,6 +16,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -214,7 +215,7 @@ namespace osu.Framework.Graphics.Video
             {
                 try
                 {
-                    decodingTask.Wait();
+                    decodingTask.WaitSafely();
                 }
                 catch
                 {

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -15,6 +15,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.ExceptionExtensions;
 using osu.Framework.Logging;
 
@@ -414,7 +415,7 @@ namespace osu.Framework.IO.Network
         {
             try
             {
-                PerformAsync().Wait();
+                PerformAsync().WaitSafely();
             }
             catch (AggregateException ae)
             {
@@ -511,7 +512,7 @@ namespace osu.Framework.IO.Network
                     logger.Add($@"Request to {Url} failed with {e} (retrying {RetryCount}/{MAX_RETRIES}).");
 
                     //do a retry
-                    internalPerform().Wait();
+                    internalPerform().WaitSafely();
                     return;
                 }
 

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -35,7 +35,7 @@ namespace osu.Framework.IO.Stores
         protected readonly ResourceStore<byte[]> Store;
 
         [CanBeNull]
-        protected BitmapFont Font => completionSource.Task.WaitSafelyForResult();
+        protected BitmapFont Font => completionSource.Task.GetResultSafely();
 
         private readonly TaskCompletionSource<BitmapFont> completionSource = new TaskCompletionSource<BitmapFont>();
 

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics.Textures;
 using osu.Framework.Logging;
 using osu.Framework.Text;
@@ -34,7 +35,7 @@ namespace osu.Framework.IO.Stores
         protected readonly ResourceStore<byte[]> Store;
 
         [CanBeNull]
-        protected BitmapFont Font => completionSource.Task.Result;
+        protected BitmapFont Font => completionSource.Task.WaitSafelyForResult();
 
         private readonly TaskCompletionSource<BitmapFont> completionSource = new TaskCompletionSource<BitmapFont>();
 

--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -8,6 +8,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Commons.Music.Midi;
+using osu.Framework.Extensions;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -87,7 +88,7 @@ namespace osu.Framework.Input.Handlers.Midi
                     {
                         if (openedDevices.All(x => x.Key != input.Id))
                         {
-                            var newInput = MidiAccessManager.Default.OpenInputAsync(input.Id).Result;
+                            var newInput = MidiAccessManager.Default.OpenInputAsync(input.Id).WaitSafelyForResult();
                             newInput.MessageReceived += onMidiMessageReceived;
                             openedDevices[input.Id] = newInput;
 

--- a/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
+++ b/osu.Framework/Input/Handlers/Midi/MidiHandler.cs
@@ -88,7 +88,7 @@ namespace osu.Framework.Input.Handlers.Midi
                     {
                         if (openedDevices.All(x => x.Key != input.Id))
                         {
-                            var newInput = MidiAccessManager.Default.OpenInputAsync(input.Id).WaitSafelyForResult();
+                            var newInput = MidiAccessManager.Default.OpenInputAsync(input.Id).GetResultSafely();
                             newInput.MessageReceived += onMidiMessageReceived;
                             openedDevices[input.Id] = newInput;
 

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using osu.Framework.Extensions;
 using osu.Framework.Logging;
 
 #nullable enable
@@ -101,7 +102,7 @@ namespace osu.Framework.Platform
                         {
                             try
                             {
-                                var message = receive(stream, token).Result;
+                                var message = receive(stream, token).WaitSafelyForResult();
 
                                 if (message == null)
                                     continue;

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -102,7 +102,7 @@ namespace osu.Framework.Platform
                         {
                             try
                             {
-                                var message = receive(stream, token).WaitSafelyForResult();
+                                var message = receive(stream, token).GetResultSafely();
 
                                 if (message == null)
                                     continue;

--- a/osu.Framework/Testing/TestScene.cs
+++ b/osu.Framework/Testing/TestScene.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 using NUnit.Framework.Internal;
 using osu.Framework.Allocation;
 using osu.Framework.Development;
+using osu.Framework.Extensions;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -433,7 +434,7 @@ namespace osu.Framework.Testing
 
             try
             {
-                runTask.Wait();
+                runTask.WaitSafely();
             }
             finally
             {
@@ -453,7 +454,7 @@ namespace osu.Framework.Testing
         private void checkForErrors()
         {
             if (host.ExecutionState == ExecutionState.Stopping)
-                runTask.Wait();
+                runTask.WaitSafely();
 
             if (runTask.Exception != null)
                 throw runTask.Exception;


### PR DESCRIPTION
As seen recently, it is quite easy in our semi-`async` world to accidentally cause a deadlock in the TPL thread pool. The cause of this is a `.Wait()` or `.Result` from within an already `async` context.

Finding these cases by reading code is quite hard, as they can be nested multiple calls deep. Likewise, I couldn't find an existing analyser that finds such cases (and to some it is considered a non-issue as the thread pool should grow to add new threads when it gets in this state - but for us this can take too long).

This is a proposal to replace all calls with a custom method with added safety. Note that this PR will intentionally fail as it points out the issues that are fixed in https://github.com/ppy/osu-framework/pull/4973.

The rationale for this change was that I couldn't cover all cases in osu!  side `TestMultiplayerClient` by reading the code alone.