### PR TITLE
Consume touch `IsActive` state rather than checking for "any" touch for mouse mapping

### DIFF
--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -713,9 +713,9 @@ namespace osu.Framework.Input
         }
 
         /// <summary>
-        /// The number of touches which are currently down, causing a single cumulative "mouse down" state.
+        /// The number of touches which are currently active, causing a single cumulative "mouse down" state.
         /// </summary>
-        private int mouseMappedTouchesDown;
+        private readonly HashSet<TouchSource> mouseMappedTouchesDown = new HashSet<TouchSource>();
 
         /// <summary>
         /// Handles latest activated touch state change event to produce mouse input from.
@@ -735,10 +735,18 @@ namespace osu.Framework.Input
                 }.Apply(CurrentState, this);
             }
 
-            if (e.IsActive != null)
-                mouseMappedTouchesDown += (e.IsActive.Value ? 1 : -1);
+            switch (e.IsActive)
+            {
+                case true:
+                    mouseMappedTouchesDown.Add(e.Touch.Source);
+                    break;
 
-            new MouseButtonInputFromTouch(MouseButton.Left, mouseMappedTouchesDown > 0, e).Apply(CurrentState, this);
+                case false:
+                    mouseMappedTouchesDown.Remove(e.Touch.Source);
+                    break;
+            }
+
+            new MouseButtonInputFromTouch(MouseButton.Left, mouseMappedTouchesDown.Count > 0, e).Apply(CurrentState, this);
             return true;
         }
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -730,7 +730,7 @@ namespace osu.Framework.Input
                 }.Apply(CurrentState, this);
             }
 
-            new MouseButtonInputFromTouch(MouseButton.Left, e.State.Touch.ActiveSources.HasAnyButtonPressed, e).Apply(CurrentState, this);
+            new MouseButtonInputFromTouch(MouseButton.Left, e.IsActive != false, e).Apply(CurrentState, this);
             return true;
         }
 

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -713,6 +713,11 @@ namespace osu.Framework.Input
         }
 
         /// <summary>
+        /// The number of touches which are currently down, causing a single cumulative "mouse down" state.
+        /// </summary>
+        private int mouseMappedTouchesDown;
+
+        /// <summary>
         /// Handles latest activated touch state change event to produce mouse input from.
         /// </summary>
         /// <param name="e">The latest activated touch state change event.</param>
@@ -730,7 +735,10 @@ namespace osu.Framework.Input
                 }.Apply(CurrentState, this);
             }
 
-            new MouseButtonInputFromTouch(MouseButton.Left, e.IsActive != false, e).Apply(CurrentState, this);
+            if (e.IsActive != null)
+                mouseMappedTouchesDown += (e.IsActive.Value ? 1 : -1);
+
+            new MouseButtonInputFromTouch(MouseButton.Left, mouseMappedTouchesDown > 0, e).Apply(CurrentState, this);
             return true;
         }
 


### PR DESCRIPTION
While the previous method worked fine, it means that a consumer would not be able to alter the flow of events (ie. blocking the "click" operations by changing the incoming touch).

In osu!, we wish to use this to allow the user to block the "click" portion while still convey movement of the "cursor".

Tested against iOS.