### PR TITLE
Remove obsoleted methods/members

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneSliderBar.cs
@@ -1,15 +1,14 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using NUnit.Framework;
 using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Graphics.UserInterface;
-using osu.Framework.Utils;
 using osu.Framework.Testing;
+using osu.Framework.Utils;
 using osuTK;
 using osuTK.Graphics;
 using osuTK.Input;
@@ -121,19 +120,16 @@ namespace osu.Framework.Tests.Visual.UserInterface
             checkValue(0, false);
         }
 
-        [TestCase(false)]
-        [TestCase(true)]
-        public void TestKeyboardInput(bool allowOutside)
+        [Test]
+        public void TestKeyboardInput()
         {
-            AddStep($"allow outside: {allowOutside}", () => sliderBar.KeyboardInput = allowOutside);
-
-            checkValue(0, allowOutside);
             AddStep("Press right arrow key", () =>
             {
                 InputManager.PressKey(Key.Right);
                 InputManager.ReleaseKey(Key.Right);
             });
-            checkValue(1, !allowOutside);
+
+            checkValue(0, true);
 
             AddStep("move mouse inside", () =>
             {
@@ -145,7 +141,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 InputManager.PressKey(Key.Right);
                 InputManager.ReleaseKey(Key.Right);
             });
-            checkValue(allowOutside ? 2 : 1, false);
+            checkValue(1, false);
         }
 
         [TestCase(false)]
@@ -219,10 +215,6 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         public class TestSliderBar : BasicSliderBar<double>
         {
-            public bool KeyboardInput;
-
-            [Obsolete("Implement this kind of behaviour separately instead.")]
-            protected override bool AllowKeyboardInputWhenNotHovered => KeyboardInput;
         }
     }
 }

--- a/osu.Framework/Configuration/ConfigManager.cs
+++ b/osu.Framework/Configuration/ConfigManager.cs
@@ -56,24 +56,6 @@ namespace osu.Framework.Configuration
                 bindable.Value = value;
         }
 
-        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
-        public BindableDouble Set(TLookup lookup, double value, double? min = null, double? max = null, double? precision = null) => SetDefault(lookup, value, min, max, precision);
-
-        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
-        public BindableFloat Set(TLookup lookup, float value, float? min = null, float? max = null, float? precision = null) => SetDefault(lookup, value, min, max, precision);
-
-        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
-        public BindableInt Set(TLookup lookup, int value, int? min = null, int? max = null) => SetDefault(lookup, value, min, max);
-
-        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
-        public BindableBool Set(TLookup lookup, bool value) => SetDefault(lookup, value);
-
-        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
-        public BindableSize Set(TLookup lookup, Size value, Size? min = null, Size? max = null) => SetDefault(lookup, value, min, max);
-
-        [Obsolete("In derived classes, use SetDefault() to set the default value. In public contexts, use SetValue() to set the value.")] // Can be removed 20210915
-        public Bindable<TValue> Set<TValue>(TLookup lookup, TValue value) => SetDefault(lookup, value);
-
         /// <summary>
         /// Sets a configuration's default value.
         /// </summary>

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -54,14 +54,6 @@ namespace osu.Framework.Extensions
         }
 
         /// <summary>
-        /// Try to get a value from the <paramref name="dictionary"/>. Returns a default(TValue) if the key does not exist.
-        /// </summary>
-        /// <param name="dictionary">The dictionary.</param>
-        /// <param name="lookup">The lookup key.</param>
-        [Obsolete("Use System.Collections.Generic.CollectionExtensions.GetValueOrDefault instead.")] // Can be removed 20220115
-        public static TValue GetOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey lookup) => dictionary.GetValueOrDefault(lookup);
-
-        /// <summary>
         /// Converts a rectangular array to a jagged array.
         /// <para>
         /// The jagged array will contain empty arrays if there are no columns in the rectangular array.

--- a/osu.Framework/Graphics/UserInterface/SliderBar.cs
+++ b/osu.Framework/Graphics/UserInterface/SliderBar.cs
@@ -21,12 +21,6 @@ namespace osu.Framework.Graphics.UserInterface
         /// </summary>
         public float RangePadding;
 
-        /// <summary>
-        /// Whether keyboard control should be allowed even when the bar is not hovered.
-        /// </summary>
-        [Obsolete("Implement this kind of behaviour separately instead.")] // Can be removed 20220107
-        protected virtual bool AllowKeyboardInputWhenNotHovered => false;
-
         public float UsableWidth => DrawWidth - 2 * RangePadding;
 
         /// <summary>
@@ -166,10 +160,7 @@ namespace osu.Framework.Graphics.UserInterface
             if (currentNumberInstantaneous.Disabled)
                 return false;
 
-#pragma warning disable 618
-            bool shouldHandle = IsHovered || AllowKeyboardInputWhenNotHovered;
-#pragma warning restore 618
-            if (!shouldHandle)
+            if (!IsHovered)
                 return false;
 
             float step = KeyboardStep != 0 ? KeyboardStep : (Convert.ToSingle(currentNumberInstantaneous.MaxValue) - Convert.ToSingle(currentNumberInstantaneous.MinValue)) / 20;


### PR DESCRIPTION
Have not addressed `FrameworkConfigManager` input related items yet. They require further attention.

Note that one of these is not obsolete for 9 more days but figured it's easier to batch it here. If we care enough then hold off merge, but probably fine at this point.