### PR TITLE
Refactor menu test scenes to be less rigid

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneClosableMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneClosableMenu.cs
@@ -12,31 +12,35 @@ namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestSceneClosableMenu : MenuTestScene
     {
-        protected override Menu CreateMenu() => new AnimatedMenu(Direction.Vertical)
+        [SetUpSteps]
+        public void SetUpSteps()
         {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            State = MenuState.Open,
-            Items = new[]
+            CreateMenu(() => new AnimatedMenu(Direction.Vertical)
             {
-                new MenuItem("Item #1")
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                State = MenuState.Open,
+                Items = new[]
                 {
-                    Items = new[]
+                    new MenuItem("Item #1")
                     {
-                        new MenuItem("Sub-item #1"),
-                        new MenuItem("Sub-item #2"),
-                    }
-                },
-                new MenuItem("Item #2")
-                {
-                    Items = new[]
+                        Items = new[]
+                        {
+                            new MenuItem("Sub-item #1"),
+                            new MenuItem("Sub-item #2"),
+                        }
+                    },
+                    new MenuItem("Item #2")
                     {
-                        new MenuItem("Sub-item #1"),
-                        new MenuItem("Sub-item #2"),
-                    }
-                },
-            }
-        };
+                        Items = new[]
+                        {
+                            new MenuItem("Sub-item #1"),
+                            new MenuItem("Sub-item #2"),
+                        }
+                    },
+                }
+            });
+        }
 
         [Test]
         public void TestClickItemClosesMenus()

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
@@ -21,9 +21,12 @@ namespace osu.Framework.Tests.Visual.UserInterface
         private Random rng;
 
         [SetUp]
-        public new void SetUp() => rng = new Random(1337);
+        public new void SetUp()
+        {
+            rng = new Random(1337);
+        }
 
-        protected override Menu CreateMenu() => new ClickOpenMenu(TimePerAction)
+        private void createMenu() => CreateMenu(() => new ClickOpenMenu(TimePerAction)
         {
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
@@ -33,7 +36,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
                 generateRandomMenuItem("Second"),
                 generateRandomMenuItem("Third"),
             }
-        };
+        });
 
         private class ClickOpenMenu : BasicMenu
         {
@@ -55,6 +58,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestAlwaysOpen()
         {
+            createMenu();
+
             AddStep("Click outside", () => InputManager.Click(MouseButton.Left));
             AddAssert("Check AlwaysOpen = true", () => Menus.GetSubMenu(0).State == MenuState.Open);
         }
@@ -65,6 +70,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestHoverState()
         {
+            createMenu();
+
             AddAssert("Check submenu closed", () => Menus.GetSubMenu(1)?.State != MenuState.Open);
             AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetMenuItems()[0]));
             AddAssert("Check item hovered", () => Menus.GetMenuItems()[0].IsHovered);
@@ -76,6 +83,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestTopLevelMenu()
         {
+            createMenu();
+
             AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(0).GetMenuItems()[0]));
             AddAssert("Check closed", () => Menus.GetSubMenu(1)?.State != MenuState.Open);
             AddAssert("Check closed", () => Menus.GetSubMenu(1)?.State != MenuState.Open);
@@ -90,6 +99,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestDoubleClick()
         {
+            createMenu();
+
             AddStep("Click item", () => ClickItem(0, 0));
             AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
             AddStep("Click item", () => ClickItem(0, 0));
@@ -102,6 +113,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestInstantOpen()
         {
+            createMenu();
+
             AddStep("Click item", () => ClickItem(0, 1));
             AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
             AddStep("Click item", () => ClickItem(1, 0));
@@ -114,6 +127,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestActionClick()
         {
+            createMenu();
+
             AddStep("Click item", () => ClickItem(0, 0));
             AddStep("Click item", () => ClickItem(1, 0));
             AddAssert("Check closed", () => Menus.GetSubMenu(1)?.State != MenuState.Open);
@@ -125,6 +140,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestHoverOpen()
         {
+            createMenu();
+
             AddStep("Click item", () => ClickItem(0, 1));
             AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(1).GetMenuItems()[0]));
             AddAssert("Check closed", () => Menus.GetSubMenu(2)?.State != MenuState.Open);
@@ -141,6 +158,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestHoverChange()
         {
+            createMenu();
+
             IReadOnlyList<MenuItem> currentItems = null;
             AddStep("Click item", () => { ClickItem(0, 0); });
 
@@ -178,6 +197,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestDelayedHoverChange()
         {
+            createMenu();
+
             AddStep("Click item", () => ClickItem(0, 2));
             AddStep("Hover item", () => InputManager.MoveMouseTo(Menus.GetSubStructure(1).GetMenuItems()[0]));
             AddAssert("Check closed", () => Menus.GetSubMenu(2)?.State != MenuState.Open);
@@ -215,6 +236,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestMenuClicksDontClose()
         {
+            createMenu();
+
             AddStep("Click item", () => ClickItem(0, 1));
             AddStep("Click item", () => ClickItem(1, 0));
             AddStep("Click item", () => ClickItem(2, 0));
@@ -246,6 +269,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestMenuClickClosesSubMenus()
         {
+            createMenu();
+
             AddStep("Click item", () => ClickItem(0, 1));
             AddStep("Click item", () => ClickItem(1, 0));
             AddStep("Click item", () => ClickItem(2, 0));
@@ -271,6 +296,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestActionClickClosesMenus()
         {
+            createMenu();
+
             AddStep("Click item", () => ClickItem(0, 1));
             AddStep("Click item", () => ClickItem(1, 0));
             AddStep("Click item", () => ClickItem(2, 0));
@@ -298,6 +325,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [TestCase(true)]
         public void TestClickingOutsideClosesMenus(bool hoverPrevious)
         {
+            createMenu();
+
             for (int i = 0; i <= 3; i++)
             {
                 int i2 = i;
@@ -334,6 +363,8 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestSelectedState()
         {
+            createMenu();
+
             AddStep("Click item", () => ClickItem(0, 2));
             AddAssert("Check open", () => Menus.GetSubMenu(1).State == MenuState.Open);
 

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneUnclosableMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneUnclosableMenu.cs
@@ -10,13 +10,17 @@ namespace osu.Framework.Tests.Visual.UserInterface
 {
     public class TestSceneUnclosableMenu : MenuTestScene
     {
-        protected override Menu CreateMenu() => new TestMenu
+        [SetUpSteps]
+        public void SetUpSteps()
         {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            State = MenuState.Open,
-            Items = new[] { new MenuItem("Item #1") { Items = new[] { new MenuItem("Sub-item #1") } } }
-        };
+            CreateMenu(() => new TestMenu
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                State = MenuState.Open,
+                Items = new[] { new MenuItem("Item #1") { Items = new[] { new MenuItem("Sub-item #1") } } }
+            });
+        }
 
         private class TestMenu : BasicMenu
         {

--- a/osu.Framework/Testing/MenuTestScene.cs
+++ b/osu.Framework/Testing/MenuTestScene.cs
@@ -1,9 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.UserInterface;
@@ -18,14 +18,13 @@ namespace osu.Framework.Testing
     {
         protected MenuStructure Menus;
 
-        [SetUp]
-        public new void SetUp() => Schedule(() =>
+        protected void CreateMenu(Func<Menu> creationFunc) => AddStep("create menu", () =>
         {
             Menu menu;
             Child = new Container
             {
                 RelativeSizeAxes = Axes.Both,
-                Child = menu = CreateMenu(),
+                Child = menu = creationFunc.Invoke(),
             };
 
             Menus = new MenuStructure(menu);
@@ -41,8 +40,6 @@ namespace osu.Framework.Testing
             InputManager.MoveMouseTo(Menus.GetSubStructure(menuIndex).GetMenuItems()[itemIndex]);
             InputManager.Click(MouseButton.Left);
         }
-
-        protected abstract Menu CreateMenu();
 
         /// <summary>
         /// Helper class used to retrieve various internal properties/items from a <see cref="Menu"/>.


### PR DESCRIPTION
`MenuTestScene` was overly rigid to the point wherein you *had* to share one single menu with a single configuration for all tests in a file which is kind of wasteful and difficult to work with. You can't, for instance. switch the direction of the menu, without creating a whole separate test scene for that.

This changes that by exposing the set-up of `MenuTestScene` members to inheritors via a `CreateMenu()` method rather than hard-coupling the entire test fixture to a given menu via `[SetUp]`.

I need this for tests for a fix to #3861 (coming shortly after this).