### PR TITLE
Fix nested menus overflowing past screen bounds

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
@@ -42,13 +42,24 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
         private class ClickOpenMenu : BasicMenu
         {
-            protected override Menu CreateSubMenu() => new ClickOpenMenu(Direction, HoverOpenDelay, false);
+            private readonly int depth;
 
-            public ClickOpenMenu(Direction direction, double timePerAction, bool topLevel = true)
-                : base(direction, topLevel)
+            protected override Menu CreateSubMenu() => new ClickOpenMenu(Direction, HoverOpenDelay, depth + 1);
+
+            public ClickOpenMenu(Direction direction, double timePerAction, int depth = 0)
+                : base(direction, depth == 0)
             {
                 HoverOpenDelay = timePerAction;
+                this.depth = depth;
             }
+
+            protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) =>
+                base.CreateDrawableMenuItem(item).With(drawableItem =>
+                {
+                    float hue = (float)depth / max_depth;
+                    drawableItem.BackgroundColour = Colour4.FromHSV(hue, 1, 0.3f);
+                    drawableItem.BackgroundColourHover = Colour4.FromHSV(hue, 0.6f, 0.5f);
+                });
         }
 
         #region Test Cases

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
@@ -27,30 +27,33 @@ namespace osu.Framework.Tests.Visual.UserInterface
             rng = new Random(1337);
         }
 
-        private void createMenu(Direction direction = Direction.Vertical) => CreateMenu(() => new ClickOpenMenu(direction, TimePerAction)
-        {
-            Anchor = Anchor.Centre,
-            Origin = Anchor.Centre,
-            RelativePositionAxes = Axes.Both,
-            Items = new[]
+        private void createMenu(Direction mainDirection = Direction.Vertical, Direction subMenuDirection = Direction.Vertical)
+            => CreateMenu(() => new ClickOpenMenu(mainDirection, subMenuDirection, TimePerAction)
             {
-                generateRandomMenuItem("First"),
-                generateRandomMenuItem("Second"),
-                generateRandomMenuItem("Third"),
-            }
-        });
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                RelativePositionAxes = Axes.Both,
+                Items = new[]
+                {
+                    generateRandomMenuItem("First"),
+                    generateRandomMenuItem("Second"),
+                    generateRandomMenuItem("Third"),
+                }
+            });
 
         private class ClickOpenMenu : BasicMenu
         {
             private readonly int depth;
+            private readonly Direction subMenuDirection;
 
-            protected override Menu CreateSubMenu() => new ClickOpenMenu(Direction, HoverOpenDelay, depth + 1);
+            protected override Menu CreateSubMenu() => new ClickOpenMenu(subMenuDirection, subMenuDirection, HoverOpenDelay, depth + 1);
 
-            public ClickOpenMenu(Direction direction, double timePerAction, int depth = 0)
-                : base(direction, depth == 0)
+            public ClickOpenMenu(Direction mainDirection, Direction subMenuDirection, double timePerAction, int depth = 0)
+                : base(mainDirection, depth == 0)
             {
                 HoverOpenDelay = timePerAction;
                 this.depth = depth;
+                this.subMenuDirection = subMenuDirection;
             }
 
             protected override DrawableMenuItem CreateDrawableMenuItem(MenuItem item) =>
@@ -432,9 +435,9 @@ namespace osu.Framework.Tests.Visual.UserInterface
         }
 
         [Test]
-        public void TestSubMenuOverflowPlayground([Values] Direction direction)
+        public void TestSubMenuOverflowPlayground([Values] Direction direction, [Values] Direction subMenuDirection)
         {
-            createMenu(direction);
+            createMenu(direction, subMenuDirection);
             AddStep("anchor menu to top left", () =>
             {
                 var menu = Menus.GetSubMenu(0);

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneNestedMenus.cs
@@ -31,6 +31,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
         {
             Anchor = Anchor.Centre,
             Origin = Anchor.Centre,
+            RelativePositionAxes = Axes.Both,
             Items = new[]
             {
                 generateRandomMenuItem("First"),
@@ -416,6 +417,46 @@ namespace osu.Framework.Tests.Visual.UserInterface
             {
                 var menu = Menus.GetSubMenu(index);
                 return menu.State == MenuState.Open && menu.ScreenSpaceDrawQuad.GetVertices().ToArray().All(v => Precision.AlmostBigger(ScreenSpaceDrawQuad.BottomRight.X, v.X, 1) && Precision.AlmostBigger(ScreenSpaceDrawQuad.BottomRight.Y, v.Y, 1));
+            });
+        }
+
+        [Test]
+        public void TestSubMenuOverflowPlayground([Values] Direction direction)
+        {
+            createMenu(direction);
+            AddStep("anchor menu to top left", () =>
+            {
+                var menu = Menus.GetSubMenu(0);
+                menu.Anchor = menu.Origin = Anchor.TopLeft;
+            });
+
+            AddStep("Click item", () => ClickItem(0, 1));
+            AddStep("Click item", () => ClickItem(1, 0));
+            AddStep("Click item", () => ClickItem(2, 0));
+            AddStep("Click item", () => ClickItem(3, 0));
+
+            AddSliderStep("set top-level menu width", 50, 250, 50, width =>
+            {
+                var menu = Menus?.GetSubMenu(0);
+                if (menu == null || menu.IsDisposed) return;
+
+                menu.Width = width;
+            });
+
+            AddSliderStep("move top-level menu X", 0, 1, 0f, x =>
+            {
+                var menu = Menus?.GetSubMenu(0);
+                if (menu == null || menu.IsDisposed) return;
+
+                menu.X = x;
+            });
+
+            AddSliderStep("move top-level menu Y", 0, 1, 0f, y =>
+            {
+                var menu = Menus?.GetSubMenu(0);
+                if (menu == null || menu.IsDisposed) return;
+
+                menu.Y = y;
             });
         }
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -353,7 +353,7 @@ namespace osu.Framework.Graphics.UserInterface
                 var inputManager = GetContainingInputManager();
 
                 // This is the default position to which this menu should be anchored to the parent menu item which triggered it (top left of the triggering item)
-                var itemAlignmentPosition = triggeringItem.ToSpaceOfOtherDrawable(Vector2.Zero, parentMenu);
+                var triggeringItemTopLeftPosition = triggeringItem.ToSpaceOfOtherDrawable(Vector2.Zero, parentMenu);
 
                 // The "maximum" position is the worst case position of the bottom right corner of this menu
                 // if this menu is anchored top-left to the triggering item.
@@ -377,13 +377,13 @@ namespace osu.Framework.Graphics.UserInterface
                     {
                         // switch the origin and position of the submenu container so that it's right-aligned to the left side of the triggering item.
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x0, Anchor.x2);
-                        parentSubmenuContainer.X = 0;
+                        parentSubmenuContainer.X = triggeringItemTopLeftPosition.X;
                     }
                     else
                     {
                         // otherwise, switch the origin and position of the submenu container so that it's left-aligned to the right side of the triggering item.
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x2, Anchor.x0);
-                        parentSubmenuContainer.X = triggeringItem.DrawWidth;
+                        parentSubmenuContainer.X = triggeringItemTopLeftPosition.X + triggeringItem.DrawWidth;
                     }
 
                     // If this menu won't fit on the screen vertically if its top edge is aligned to the top of the triggering item,
@@ -392,13 +392,13 @@ namespace osu.Framework.Graphics.UserInterface
                     {
                         // switch the origin and position of the submenu container so that it's bottom-aligned to the bottom of the triggering item.
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y0, Anchor.y2);
-                        parentSubmenuContainer.Y = itemAlignmentPosition.Y + triggeringItem.DrawHeight;
+                        parentSubmenuContainer.Y = triggeringItemTopLeftPosition.Y + triggeringItem.DrawHeight;
                     }
                     else
                     {
                         // otherwise, switch the origin and position of the submenu container so that it's top-aligned to the top of the triggering item.
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y2, Anchor.y0);
-                        parentSubmenuContainer.Y = itemAlignmentPosition.Y;
+                        parentSubmenuContainer.Y = triggeringItemTopLeftPosition.Y;
                     }
                 }
                 // the "horizontal" case is the same as above, but with the axes everywhere swapped.
@@ -407,23 +407,23 @@ namespace osu.Framework.Graphics.UserInterface
                     if (menuMaximumPosition.Y > inputManager.DrawHeight && menuMinimumPosition.Y > 0)
                     {
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y0, Anchor.y2);
-                        parentSubmenuContainer.Y = 0;
+                        parentSubmenuContainer.Y = triggeringItemTopLeftPosition.Y;
                     }
                     else
                     {
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y2, Anchor.y0);
-                        parentSubmenuContainer.Y = triggeringItem.DrawHeight;
+                        parentSubmenuContainer.Y = triggeringItemTopLeftPosition.Y + triggeringItem.DrawHeight;
                     }
 
                     if (menuMaximumPosition.X > inputManager.DrawWidth && menuMinimumPosition.X > 0)
                     {
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x0, Anchor.x2);
-                        parentSubmenuContainer.X = itemAlignmentPosition.X + triggeringItem.DrawWidth;
+                        parentSubmenuContainer.X = triggeringItemTopLeftPosition.X + triggeringItem.DrawWidth;
                     }
                     else
                     {
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x2, Anchor.x0);
-                        parentSubmenuContainer.X = itemAlignmentPosition.X;
+                        parentSubmenuContainer.X = triggeringItemTopLeftPosition.X;
                     }
                 }
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -352,40 +352,56 @@ namespace osu.Framework.Graphics.UserInterface
             {
                 var inputManager = GetContainingInputManager();
 
+                // This is the default position to which this menu should be anchored to the parent menu item which triggered it (top left of the triggering item)
                 var itemAlignmentPosition = triggeringItem.ToSpaceOfOtherDrawable(Vector2.Zero, parentMenu);
 
+                // The "maximum" position is the worst case position of the bottom right corner of this menu
+                // if this menu is anchored top-left to the triggering item.
                 var menuMaximumPosition = triggeringItem.ToSpaceOfOtherDrawable(
                     new Vector2(
                         triggeringItem.DrawWidth + DrawWidth,
                         triggeringItem.DrawHeight + DrawHeight), inputManager);
+
+                // The "minimum" position is the worst case position of the top left corner of this menu
+                // if this menu is anchored bottom-right to the parent menu item that triggered it.
                 var menuMinimumPosition = triggeringItem.ToSpaceOfOtherDrawable(new Vector2(-DrawWidth, -DrawHeight), inputManager);
 
+                // We will be making anchor adjustments by changing the parent's "submenu container" to be positioned and anchored correctly to the parent menu.
+                // Therefore note that all X and Y adjustments below will occur in the parent menu's coordinates.
                 var parentSubmenuContainer = parentMenu.submenuContainer;
 
                 if (Direction == Direction.Vertical)
                 {
+                    // If this menu won't fit on the screen horizontally if it's anchored to the right of its triggering item, but it will fit when anchored to the left...
                     if (menuMaximumPosition.X > inputManager.DrawWidth && menuMinimumPosition.X > 0)
                     {
+                        // switch the origin and position of the submenu container so that it's right-aligned to the left side of the triggering item.
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x0, Anchor.x2);
                         parentSubmenuContainer.X = 0;
                     }
                     else
                     {
+                        // otherwise, switch the origin and position of the submenu container so that it's left-aligned to the right side of the triggering item.
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x2, Anchor.x0);
                         parentSubmenuContainer.X = triggeringItem.DrawWidth;
                     }
 
+                    // If this menu won't fit on the screen vertically if its top edge is aligned to the top of the triggering item,
+                    // but it will fit if its bottom edge is aligned to the bottom of the triggering item...
                     if (menuMaximumPosition.Y > inputManager.DrawHeight && menuMinimumPosition.Y > 0)
                     {
+                        // switch the origin and position of the submenu container so that it's bottom-aligned to the bottom of the triggering item.
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y0, Anchor.y2);
                         parentSubmenuContainer.Y = itemAlignmentPosition.Y + triggeringItem.DrawHeight;
                     }
                     else
                     {
+                        // otherwise, switch the origin and position of the submenu container so that it's top-aligned to the top of the triggering item.
                         parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y2, Anchor.y0);
                         parentSubmenuContainer.Y = itemAlignmentPosition.Y;
                     }
                 }
+                // the "horizontal" case is the same as above, but with the axes everywhere swapped.
                 else
                 {
                     if (menuMaximumPosition.Y > inputManager.DrawHeight && menuMinimumPosition.Y > 0)

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -66,7 +66,7 @@ namespace osu.Framework.Graphics.UserInterface
         private readonly Box background;
 
         private readonly Container<Menu> submenuContainer;
-        private readonly LayoutValue positionLayout = new LayoutValue(Invalidation.RequiredParentSizeToFit);
+        private readonly LayoutValue positionLayout = new LayoutValue(Invalidation.DrawInfo | Invalidation.RequiredParentSizeToFit);
 
         /// <summary>
         /// Constructs a menu.

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -360,32 +360,60 @@ namespace osu.Framework.Graphics.UserInterface
                         triggeringItem.DrawHeight + DrawHeight), inputManager);
                 var menuMinimumPosition = triggeringItem.ToSpaceOfOtherDrawable(new Vector2(-DrawWidth, -DrawHeight), inputManager);
 
+                var parentSubmenuContainer = parentMenu.submenuContainer;
+
                 if (Direction == Direction.Vertical)
                 {
                     if (menuMaximumPosition.X > inputManager.DrawWidth && menuMinimumPosition.X > 0)
-                        X = -DrawWidth;
+                    {
+                        parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x0, Anchor.x2);
+                        parentSubmenuContainer.X = 0;
+                    }
                     else
-                        X = triggeringItem.DrawWidth;
+                    {
+                        parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x2, Anchor.x0);
+                        parentSubmenuContainer.X = triggeringItem.DrawWidth;
+                    }
 
                     if (menuMaximumPosition.Y > inputManager.DrawHeight && menuMinimumPosition.Y > 0)
-                        Y = itemAlignmentPosition.Y + triggeringItem.DrawHeight - DrawHeight;
+                    {
+                        parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y0, Anchor.y2);
+                        parentSubmenuContainer.Y = itemAlignmentPosition.Y + triggeringItem.DrawHeight;
+                    }
                     else
-                        Y = itemAlignmentPosition.Y;
+                    {
+                        parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y2, Anchor.y0);
+                        parentSubmenuContainer.Y = itemAlignmentPosition.Y;
+                    }
                 }
                 else
                 {
                     if (menuMaximumPosition.Y > inputManager.DrawHeight && menuMinimumPosition.Y > 0)
-                        Y = -DrawHeight;
+                    {
+                        parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y0, Anchor.y2);
+                        parentSubmenuContainer.Y = 0;
+                    }
                     else
-                        Y = triggeringItem.DrawHeight;
+                    {
+                        parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.y2, Anchor.y0);
+                        parentSubmenuContainer.Y = triggeringItem.DrawHeight;
+                    }
 
                     if (menuMaximumPosition.X > inputManager.DrawWidth && menuMinimumPosition.X > 0)
-                        X = itemAlignmentPosition.X + triggeringItem.DrawWidth - DrawWidth;
+                    {
+                        parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x0, Anchor.x2);
+                        parentSubmenuContainer.X = itemAlignmentPosition.X + triggeringItem.DrawWidth;
+                    }
                     else
-                        X = itemAlignmentPosition.X;
+                    {
+                        parentSubmenuContainer.Origin = switchAxisAnchors(parentSubmenuContainer.Origin, Anchor.x2, Anchor.x0);
+                        parentSubmenuContainer.X = itemAlignmentPosition.X;
+                    }
                 }
 
                 positionLayout.Validate();
+
+                Anchor switchAxisAnchors(Anchor originalValue, Anchor toDisable, Anchor toEnable) => (originalValue & ~toDisable) | toEnable;
             }
         }
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -353,28 +353,33 @@ namespace osu.Framework.Graphics.UserInterface
                 var inputManager = GetContainingInputManager();
 
                 var itemAlignmentPosition = triggeringItem.ToSpaceOfOtherDrawable(Vector2.Zero, parentMenu);
-                var menuMaximumPosition = triggeringItem.ToSpaceOfOtherDrawable(new Vector2(triggeringItem.DrawWidth + DrawWidth, triggeringItem.DrawHeight + DrawHeight), inputManager);
+
+                var menuMaximumPosition = triggeringItem.ToSpaceOfOtherDrawable(
+                    new Vector2(
+                        triggeringItem.DrawWidth + DrawWidth,
+                        triggeringItem.DrawHeight + DrawHeight), inputManager);
+                var menuMinimumPosition = triggeringItem.ToSpaceOfOtherDrawable(new Vector2(-DrawWidth, -DrawHeight), inputManager);
 
                 if (Direction == Direction.Vertical)
                 {
-                    if (menuMaximumPosition.X > inputManager.DrawWidth)
+                    if (menuMaximumPosition.X > inputManager.DrawWidth && menuMinimumPosition.X > 0)
                         X = -DrawWidth;
                     else
                         X = triggeringItem.DrawWidth;
 
-                    if (menuMaximumPosition.Y > inputManager.DrawHeight)
+                    if (menuMaximumPosition.Y > inputManager.DrawHeight && menuMinimumPosition.Y > 0)
                         Y = itemAlignmentPosition.Y + triggeringItem.DrawHeight - DrawHeight;
                     else
                         Y = itemAlignmentPosition.Y;
                 }
                 else
                 {
-                    if (menuMaximumPosition.Y > inputManager.DrawHeight)
+                    if (menuMaximumPosition.Y > inputManager.DrawHeight && menuMinimumPosition.Y > 0)
                         Y = -DrawHeight;
                     else
                         Y = triggeringItem.DrawHeight;
 
-                    if (menuMaximumPosition.X > inputManager.DrawWidth)
+                    if (menuMaximumPosition.X > inputManager.DrawWidth && menuMinimumPosition.X > 0)
                         X = itemAlignmentPosition.X + triggeringItem.DrawWidth - DrawWidth;
                     else
                         X = itemAlignmentPosition.X;

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -350,9 +350,29 @@ namespace osu.Framework.Graphics.UserInterface
 
             if (!positionLayout.IsValid && parentMenu != null)
             {
-                Position = triggeringItem.ToSpaceOfOtherDrawable(new Vector2(
-                    Direction == Direction.Vertical ? triggeringItem.DrawWidth : 0,
-                    Direction == Direction.Horizontal ? triggeringItem.DrawHeight : 0), parentMenu);
+                var inputManager = GetContainingInputManager();
+
+                var itemAlignmentPosition = triggeringItem.ToSpaceOfOtherDrawable(Vector2.Zero, parentMenu);
+                var menuMaximumPosition = triggeringItem.ToSpaceOfOtherDrawable(new Vector2(triggeringItem.DrawWidth + DrawWidth, triggeringItem.DrawHeight + DrawHeight), inputManager);
+
+                if (Direction == Direction.Vertical)
+                {
+                    if (menuMaximumPosition.X > inputManager.DrawWidth)
+                        X = -DrawWidth;
+                    else
+                        X = triggeringItem.DrawWidth;
+
+                    Y = itemAlignmentPosition.Y;
+                }
+                else
+                {
+                    if (menuMaximumPosition.Y > inputManager.DrawHeight)
+                        Y = -DrawHeight;
+                    else
+                        Y = triggeringItem.DrawHeight;
+
+                    X = itemAlignmentPosition.X;
+                }
 
                 positionLayout.Validate();
             }
@@ -452,6 +472,7 @@ namespace osu.Framework.Graphics.UserInterface
             }
 
             submenu.triggeringItem = item;
+            submenu.positionLayout.Invalidate();
 
             submenu.Items = item.Item.Items;
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -362,7 +362,10 @@ namespace osu.Framework.Graphics.UserInterface
                     else
                         X = triggeringItem.DrawWidth;
 
-                    Y = itemAlignmentPosition.Y;
+                    if (menuMaximumPosition.Y > inputManager.DrawHeight)
+                        Y = itemAlignmentPosition.Y + triggeringItem.DrawHeight - DrawHeight;
+                    else
+                        Y = itemAlignmentPosition.Y;
                 }
                 else
                 {
@@ -371,7 +374,10 @@ namespace osu.Framework.Graphics.UserInterface
                     else
                         Y = triggeringItem.DrawHeight;
 
-                    X = itemAlignmentPosition.X;
+                    if (menuMaximumPosition.X > inputManager.DrawWidth)
+                        X = itemAlignmentPosition.X + triggeringItem.DrawWidth - DrawWidth;
+                    else
+                        X = itemAlignmentPosition.X;
                 }
 
                 positionLayout.Validate();

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -370,7 +370,7 @@ namespace osu.Framework.Graphics.UserInterface
                 // Therefore note that all X and Y adjustments below will occur in the parent menu's coordinates.
                 var parentSubmenuContainer = parentMenu.submenuContainer;
 
-                if (Direction == Direction.Vertical)
+                if (parentMenu.Direction == Direction.Vertical)
                 {
                     // If this menu won't fit on the screen horizontally if it's anchored to the right of its triggering item, but it will fit when anchored to the left...
                     if (menuMaximumPosition.X > inputManager.DrawWidth && menuMinimumPosition.X > 0)


### PR DESCRIPTION
- [x] Depends on #4986
- Fixes #3861

https://user-images.githubusercontent.com/20418176/148696343-f1198d58-0aaa-49be-910c-c227abacf608.mp4

PRing primarily for comment.

This implementation mirrors observed behaviour of most nested menus that I could find, namely that determining whether to flip a menu or not happens locally to the given menu level (i.e. even if the parent menu is right-aligned to its parent's left side, the child menu of that can be left-aligned again if there is enough space).

The contentious part of this may be that I'm using `GetContainingInputManager()` to perform this positioning. This is done because the menu's parent is not necessarily its clipping bounds. And it's not like the menu *has* to have a parenting `ContextMenuContainer` or other drawable to work correctly. So clipping to the input manager seemed like the closest thing to "clipping to window bounds".

The implementation is a little repetitive too, with explicit branches for both orientations, but I'm not sure how to make better without making it read even worse than what's already there.
