### PR TITLE
Allow waiting on tasks which were created with `LongRunning` regardless of thread

### DIFF
--- a/osu.Framework.Tests/IO/TestWebRequest.cs
+++ b/osu.Framework.Tests/IO/TestWebRequest.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NUnit.Framework;
+using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.IO.Network;
 using WebRequest = osu.Framework.IO.Network.WebRequest;
@@ -57,6 +58,23 @@ namespace osu.Framework.Tests.IO
             };
 
             testValidGetInternal(async, request, "osu-framework");
+        }
+
+        /// <summary>
+        /// Ensure that synchronous requests can be run without issue from within a TPL thread pool thread.
+        /// Not recommended as it would block the thread, but we've deemed to allow this for now.
+        /// </summary>
+        [Test, Retry(5)]
+        public void TestValidGetFromTask()
+        {
+            string url = $"https://{host}/get";
+            var request = new JsonWebRequest<HttpBinGetResponse>(url)
+            {
+                Method = HttpMethod.Get,
+                AllowInsecureRequests = true
+            };
+
+            Task.Run(() => testValidGetInternal(false, request, "osu-framework")).WaitSafely();
         }
 
         [Test, Retry(5)]


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/16396#issuecomment-1008687513.

Not 100% sure on this since long running tasks shouldn't really be run within `Task.Run` in the first place, but let's make things work again for the time being.