### PR TITLE
Add support for Android pointer capture

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Android.Content;
+using Android.OS;
 using Android.Runtime;
 using Android.Text;
 using Android.Util;
@@ -16,6 +17,31 @@ namespace osu.Framework.Android
     public class AndroidGameView : osuTK.Android.AndroidGameView
     {
         public AndroidGameHost Host { get; private set; }
+
+        /// <summary>
+        /// Represents whether the mouse pointer is captured, as reported by Android through <see cref="OnPointerCaptureChange"/>.
+        /// </summary>
+        private bool pointerCaptured;
+
+        /// <summary>
+        /// Set Android's pointer capture.
+        /// </summary>
+        public bool PointerCapture
+        {
+            get => pointerCaptured;
+            set
+            {
+                // Pointer capture is only available on Android 8.0 and up
+                if (Build.VERSION.SdkInt < BuildVersionCodes.O) return;
+
+                if (pointerCaptured == value) return;
+
+                if (value)
+                    RequestPointerCapture();
+                else
+                    ReleasePointerCapture();
+            }
+        }
 
         private readonly Game game;
 
@@ -96,6 +122,12 @@ namespace osu.Framework.Android
         {
             KeyUp?.Invoke(keyCode, e);
             return true;
+        }
+
+        public override void OnPointerCaptureChange(bool hasCapture)
+        {
+            base.OnPointerCaptureChange(hasCapture);
+            pointerCaptured = hasCapture;
         }
 
         protected override void OnLoad(EventArgs e)

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -24,6 +24,21 @@ namespace osu.Framework.Android
             set { }
         }
 
+        public event Action CursorStateChanged;
+
+        private CursorState cursorState = CursorState.Confined;
+
+        public override CursorState CursorState
+        {
+            get => cursorState;
+            set
+            {
+                // cursor should always be confined on mobile platforms, to have UserInputManager confine the cursor to window bounds
+                cursorState = value | CursorState.Confined;
+                CursorStateChanged?.Invoke();
+            }
+        }
+
         public AndroidGameWindow(AndroidGameView view)
             : base(view)
         {

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -190,7 +190,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Controls the state of the OS cursor.
         /// </summary>
-        public CursorState CursorState
+        public virtual CursorState CursorState
         {
             get => cursorState;
             set


### PR DESCRIPTION
Closes #4373.

https://developer.android.com/training/gestures/movement#pointer-capture

>The system can take the capture away from the view without you explicitly calling `releasePointerCapture()`, most commonly because the view hierarchy that contains the view that requested capture has lost focus.

We don't have to handle disabling capture ourselves when we lose focus, Android does it for us.

Unfortunately, Android's focus changed events aren't very useful. We can lose focus and get focus without any events being sent.
Example: Pulling down the status bar. Since the status bar is a system overlay/dialog, Android doesn't consider it as changing focus for this event, but does forcefully disabled pointer capture,

So we update capture on every non-relative mouse move event.

**Changes:**

`CursorState` was made to always be confined on Android. This is needed so that the cursor can't leave window bounds. Leaving window bounds doesn't make sense in fullscreen mobile apps.

**Issues:**

The only problem here is that we currently can't have a settings section for `AndroidMouseHandler` in osu!, as the android project isn't referenced. Since `InputHandler`s are supposed to be platform specific, we should create a way to do that.