### PR TITLE
Output performance log messages when schedulers have long queues

### DIFF
--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -4,6 +4,7 @@
 using System;
 using NUnit.Framework;
 using osu.Framework.Logging;
+using osu.Framework.Testing;
 using osu.Framework.Threading;
 using osu.Framework.Timing;
 
@@ -27,44 +28,48 @@ namespace osu.Framework.Tests.Threading
         {
             int matchingLogCount = 0;
 
-            Logger.Enabled = true;
-            Logger.Storage = null;
-            Logger.NewEntry += logTest;
-
-            Assert.AreEqual(0, matchingLogCount);
-
-            for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
+            using (var storage = new TemporaryNativeStorage(nameof(TestLogOutputFromManyQueuedTasks)))
             {
-                scheduler.Add(() => { });
-                if (withFlushing) scheduler.Update();
-            }
+                Logger.Storage = storage;
+                Logger.Enabled = true;
 
-            Assert.AreEqual(0, matchingLogCount);
+                Logger.NewEntry += logTest;
 
-            for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
-            {
-                scheduler.Add(() => { });
-                if (withFlushing) scheduler.Update();
-            }
+                Assert.AreEqual(0, matchingLogCount);
 
-            Assert.AreEqual(withFlushing ? 0 : 1, matchingLogCount);
+                for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
+                {
+                    scheduler.Add(() => { });
+                    if (withFlushing) scheduler.Update();
+                }
 
-            for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL; i++)
-            {
-                scheduler.Add(() => { });
-                if (withFlushing) scheduler.Update();
-            }
+                Assert.AreEqual(0, matchingLogCount);
 
-            Assert.AreEqual(withFlushing ? 0 : 2, matchingLogCount);
+                for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
+                {
+                    scheduler.Add(() => { });
+                    if (withFlushing) scheduler.Update();
+                }
 
-            Logger.NewEntry -= logTest;
-            Logger.Storage = null;
-            Logger.Enabled = false;
+                Assert.AreEqual(withFlushing ? 0 : 1, matchingLogCount);
 
-            void logTest(LogEntry entry)
-            {
-                if (entry.Target == LoggingTarget.Performance && entry.Message.Contains("tasks pending"))
-                    matchingLogCount++;
+                for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL; i++)
+                {
+                    scheduler.Add(() => { });
+                    if (withFlushing) scheduler.Update();
+                }
+
+                Assert.AreEqual(withFlushing ? 0 : 2, matchingLogCount);
+
+                Logger.NewEntry -= logTest;
+                Logger.Enabled = false;
+                Logger.Flush();
+
+                void logTest(LogEntry entry)
+                {
+                    if (entry.Target == LoggingTarget.Performance && entry.Message.Contains("tasks pending"))
+                        matchingLogCount++;
+                }
             }
         }
 
@@ -73,42 +78,48 @@ namespace osu.Framework.Tests.Threading
         {
             int matchingLogCount = 0;
 
-            Logger.NewEntry += logTest;
-            Logger.Enabled = true;
-
-            Assert.AreEqual(0, matchingLogCount);
-
-            for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
+            using (var storage = new TemporaryNativeStorage(nameof(TestLogOutputFromManyQueuedTasks)))
             {
-                scheduler.AddDelayed(() => { }, 0);
-                if (withFlushing) scheduler.Update();
-            }
+                Logger.Storage = storage;
+                Logger.Enabled = true;
 
-            Assert.AreEqual(0, matchingLogCount);
+                Logger.NewEntry += logTest;
 
-            for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
-            {
-                scheduler.AddDelayed(() => { }, 0);
-                if (withFlushing) scheduler.Update();
-            }
+                Assert.AreEqual(0, matchingLogCount);
 
-            Assert.AreEqual(withFlushing ? 0 : 1, matchingLogCount);
+                for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
+                {
+                    scheduler.AddDelayed(() => { }, 0);
+                    if (withFlushing) scheduler.Update();
+                }
 
-            for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL; i++)
-            {
-                scheduler.AddDelayed(() => { }, 0);
-                if (withFlushing) scheduler.Update();
-            }
+                Assert.AreEqual(0, matchingLogCount);
 
-            Assert.AreEqual(withFlushing ? 0 : 2, matchingLogCount);
+                for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
+                {
+                    scheduler.AddDelayed(() => { }, 0);
+                    if (withFlushing) scheduler.Update();
+                }
 
-            Logger.NewEntry -= logTest;
-            Logger.Enabled = false;
+                Assert.AreEqual(withFlushing ? 0 : 1, matchingLogCount);
 
-            void logTest(LogEntry entry)
-            {
-                if (entry.Target == LoggingTarget.Performance && entry.Message.Contains("tasks pending"))
-                    matchingLogCount++;
+                for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL; i++)
+                {
+                    scheduler.AddDelayed(() => { }, 0);
+                    if (withFlushing) scheduler.Update();
+                }
+
+                Assert.AreEqual(withFlushing ? 0 : 2, matchingLogCount);
+
+                Logger.NewEntry -= logTest;
+                Logger.Enabled = false;
+                Logger.Flush();
+
+                void logTest(LogEntry entry)
+                {
+                    if (entry.Target == LoggingTarget.Performance && entry.Message.Contains("tasks pending"))
+                        matchingLogCount++;
+                }
             }
         }
 

--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -28,6 +28,7 @@ namespace osu.Framework.Tests.Threading
             int matchingLogCount = 0;
 
             Logger.Enabled = true;
+            Logger.Storage = null;
             Logger.NewEntry += logTest;
 
             Assert.AreEqual(0, matchingLogCount);
@@ -57,6 +58,7 @@ namespace osu.Framework.Tests.Threading
             Assert.AreEqual(withFlushing ? 0 : 2, matchingLogCount);
 
             Logger.NewEntry -= logTest;
+            Logger.Storage = null;
             Logger.Enabled = false;
 
             void logTest(LogEntry entry)

--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -78,7 +78,7 @@ namespace osu.Framework.Tests.Threading
         {
             int matchingLogCount = 0;
 
-            using (var storage = new TemporaryNativeStorage(nameof(TestLogOutputFromManyQueuedTasks)))
+            using (var storage = new TemporaryNativeStorage(nameof(TestLogOutputFromManyQueuedScheduledTasks)))
             {
                 Logger.Storage = storage;
                 Logger.Enabled = true;

--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -25,13 +25,11 @@ namespace osu.Framework.Tests.Threading
         [Test]
         public void TestLogOutputFromManyQueuedTasks([Values(false, true)] bool withFlushing)
         {
-            var performanceLogger = Logger.GetLogger(LoggingTarget.Performance);
+            int matchingLogCount = 0;
 
-            performanceLogger.Add(string.Empty);
+            Logger.NewEntry += logTest;
 
-            int operationCount = performanceLogger.TotalLogOperations;
-
-            Assert.AreEqual(operationCount, performanceLogger.TotalLogOperations);
+            Assert.AreEqual(0, matchingLogCount);
 
             for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
             {
@@ -39,7 +37,7 @@ namespace osu.Framework.Tests.Threading
                 if (withFlushing) scheduler.Update();
             }
 
-            Assert.AreEqual(operationCount, performanceLogger.TotalLogOperations);
+            Assert.AreEqual(0, matchingLogCount);
 
             for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
             {
@@ -47,7 +45,7 @@ namespace osu.Framework.Tests.Threading
                 if (withFlushing) scheduler.Update();
             }
 
-            Assert.AreEqual(operationCount + (withFlushing ? 0 : 1), performanceLogger.TotalLogOperations);
+            Assert.AreEqual(withFlushing ? 0 : 1, matchingLogCount);
 
             for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL; i++)
             {
@@ -55,19 +53,25 @@ namespace osu.Framework.Tests.Threading
                 if (withFlushing) scheduler.Update();
             }
 
-            Assert.AreEqual(operationCount + (withFlushing ? 0 : 2), performanceLogger.TotalLogOperations);
+            Assert.AreEqual(withFlushing ? 0 : 2, matchingLogCount);
+
+            Logger.NewEntry -= logTest;
+
+            void logTest(LogEntry entry)
+            {
+                if (entry.Target == LoggingTarget.Performance && entry.Message.Contains("tasks pending"))
+                    matchingLogCount++;
+            }
         }
 
         [Test]
         public void TestLogOutputFromManyQueuedScheduledTasks([Values(false, true)] bool withFlushing)
         {
-            var performanceLogger = Logger.GetLogger(LoggingTarget.Performance);
+            int matchingLogCount = 0;
 
-            performanceLogger.Add(string.Empty);
+            Logger.NewEntry += logTest;
 
-            int operationCount = performanceLogger.TotalLogOperations;
-
-            Assert.AreEqual(operationCount, performanceLogger.TotalLogOperations);
+            Assert.AreEqual(0, matchingLogCount);
 
             for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
             {
@@ -75,7 +79,7 @@ namespace osu.Framework.Tests.Threading
                 if (withFlushing) scheduler.Update();
             }
 
-            Assert.AreEqual(operationCount, performanceLogger.TotalLogOperations);
+            Assert.AreEqual(0, matchingLogCount);
 
             for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL / 2; i++)
             {
@@ -83,7 +87,7 @@ namespace osu.Framework.Tests.Threading
                 if (withFlushing) scheduler.Update();
             }
 
-            Assert.AreEqual(operationCount + (withFlushing ? 0 : 1), performanceLogger.TotalLogOperations);
+            Assert.AreEqual(withFlushing ? 0 : 1, matchingLogCount);
 
             for (int i = 0; i < Scheduler.LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL; i++)
             {
@@ -91,7 +95,15 @@ namespace osu.Framework.Tests.Threading
                 if (withFlushing) scheduler.Update();
             }
 
-            Assert.AreEqual(operationCount + (withFlushing ? 0 : 2), performanceLogger.TotalLogOperations);
+            Assert.AreEqual(withFlushing ? 0 : 2, matchingLogCount);
+
+            Logger.NewEntry -= logTest;
+
+            void logTest(LogEntry entry)
+            {
+                if (entry.Target == LoggingTarget.Performance && entry.Message.Contains("tasks pending"))
+                    matchingLogCount++;
+            }
         }
 
         [Test]

--- a/osu.Framework.Tests/Threading/SchedulerTest.cs
+++ b/osu.Framework.Tests/Threading/SchedulerTest.cs
@@ -27,6 +27,7 @@ namespace osu.Framework.Tests.Threading
         {
             int matchingLogCount = 0;
 
+            Logger.Enabled = true;
             Logger.NewEntry += logTest;
 
             Assert.AreEqual(0, matchingLogCount);
@@ -56,6 +57,7 @@ namespace osu.Framework.Tests.Threading
             Assert.AreEqual(withFlushing ? 0 : 2, matchingLogCount);
 
             Logger.NewEntry -= logTest;
+            Logger.Enabled = false;
 
             void logTest(LogEntry entry)
             {
@@ -70,6 +72,7 @@ namespace osu.Framework.Tests.Threading
             int matchingLogCount = 0;
 
             Logger.NewEntry += logTest;
+            Logger.Enabled = true;
 
             Assert.AreEqual(0, matchingLogCount);
 
@@ -98,6 +101,7 @@ namespace osu.Framework.Tests.Threading
             Assert.AreEqual(withFlushing ? 0 : 2, matchingLogCount);
 
             Logger.NewEntry -= logTest;
+            Logger.Enabled = false;
 
             void logTest(LogEntry entry)
             {

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -83,6 +83,8 @@ namespace osu.Framework.Logging
         /// </summary>
         public string Filename => $@"{Name}.log";
 
+        public int TotalLogOperations => logCount.Value;
+
         private readonly GlobalStatistic<int> logCount;
 
         private static readonly HashSet<string> reserved_names = new HashSet<string>(Enum.GetNames(typeof(LoggingTarget)).Select(n => n.ToLower()));

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -28,7 +28,7 @@ namespace osu.Framework.Threading
 
         private readonly object queueLock = new object();
 
-        internal const int LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL = 100;
+        internal const int LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL = 1000;
 
         /// <summary>
         /// Whether there are any tasks queued to run (including delayed tasks in the future).

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -280,7 +280,7 @@ namespace osu.Framework.Threading
             {
                 timedTasks.AddInPlace(task);
                 if (timedTasks.Count % LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL == 0)
-                    Logger.Log($"{nameof(Scheduler)} has {timedTasks.Count} timed tasks pending", LoggingTarget.Performance);
+                    Logger.Log($"{this} has {timedTasks.Count} timed tasks pending", LoggingTarget.Performance);
             }
         }
 

--- a/osu.Framework/Threading/Scheduler.cs
+++ b/osu.Framework/Threading/Scheduler.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using JetBrains.Annotations;
 using osu.Framework.Extensions;
+using osu.Framework.Logging;
 using osu.Framework.Timing;
 
 namespace osu.Framework.Threading
@@ -26,6 +27,8 @@ namespace osu.Framework.Threading
         private double currentTime => clock?.CurrentTime ?? 0;
 
         private readonly object queueLock = new object();
+
+        internal const int LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL = 100;
 
         /// <summary>
         /// Whether there are any tasks queued to run (including delayed tasks in the future).
@@ -143,7 +146,7 @@ namespace osu.Framework.Threading
 
                         if (sd.RepeatInterval > 0)
                         {
-                            if (timedTasks.Count > 1000)
+                            if (timedTasks.Count > LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL)
                                 throw new ArgumentException("Too many timed tasks are in the queue!");
 
                             // schedule the next repeat of the task.
@@ -151,7 +154,7 @@ namespace osu.Framework.Threading
                             tasksToSchedule.Add(sd);
                         }
 
-                        if (!sd.Completed) runQueue.Enqueue(sd);
+                        if (!sd.Completed) enqueue(sd);
                     }
                 }
 
@@ -181,7 +184,7 @@ namespace osu.Framework.Threading
                     continue;
                 }
 
-                runQueue.Enqueue(task);
+                enqueue(task);
             }
         }
 
@@ -233,8 +236,7 @@ namespace osu.Framework.Threading
 
             var del = new ScheduledDelegateWithData<T>(task, data);
 
-            lock (queueLock)
-                runQueue.Enqueue(del);
+            enqueue(del);
 
             return del;
         }
@@ -258,8 +260,7 @@ namespace osu.Framework.Threading
 
             var del = new ScheduledDelegate(task);
 
-            lock (queueLock)
-                runQueue.Enqueue(del);
+            enqueue(del);
 
             return del;
         }
@@ -276,7 +277,11 @@ namespace osu.Framework.Threading
                 throw new InvalidOperationException($"Can not add a {nameof(ScheduledDelegate)} that has been already {nameof(ScheduledDelegate.Completed)}");
 
             lock (queueLock)
+            {
                 timedTasks.AddInPlace(task);
+                if (timedTasks.Count % LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL == 0)
+                    Logger.Log($"{nameof(Scheduler)} has {timedTasks.Count} timed tasks pending", LoggingTarget.Performance);
+            }
         }
 
         /// <summary>
@@ -337,7 +342,7 @@ namespace osu.Framework.Threading
                     return false;
                 }
 
-                runQueue.Enqueue(new ScheduledDelegateWithData<T>(task, data));
+                enqueue(new ScheduledDelegateWithData<T>(task, data));
             }
 
             return true;
@@ -356,10 +361,20 @@ namespace osu.Framework.Threading
                 if (runQueue.Any(sd => sd.Task == task))
                     return false;
 
-                runQueue.Enqueue(new ScheduledDelegate(task));
+                enqueue(new ScheduledDelegate(task));
             }
 
             return true;
+        }
+
+        private void enqueue(ScheduledDelegate task)
+        {
+            lock (queueLock)
+            {
+                runQueue.Enqueue(task);
+                if (runQueue.Count % LOG_EXCESSSIVE_QUEUE_LENGTH_INTERVAL == 0)
+                    Logger.Log($"{this} has {runQueue.Count} tasks pending", LoggingTarget.Performance);
+            }
         }
     }
 }


### PR DESCRIPTION
This intends to expose cases of schedulers being enqueued to but not running, which is something that has come up in the past and can cause unforeseen overheads or memory leaks.

Would be nice if we could better identify the owner of the scheduler, but not sure it's worth passing a reference in to the drawable or not. Can be added if that's seen as a requirement.