### PR TITLE
Change `[MeansImplicitUse]` attribute on BDL so that unused params are treated as such

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -225,7 +225,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMethodReturnValue_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMethodReturnValue_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002ELocal/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002EGlobal/@EntryIndexedValue">WARNING</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedType_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseAwaitUsing/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseCollectionCountProperty/@EntryIndexedValue">WARNING</s:String>

--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -225,7 +225,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMethodReturnValue_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMethodReturnValue_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002ELocal/@EntryIndexedValue">WARNING</s:String>
-	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002EGlobal/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedParameter_002EGlobal/@EntryIndexedValue">WARNING</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedType_002EGlobal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseAwaitUsing/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UseCollectionCountProperty/@EntryIndexedValue">WARNING</s:String>

--- a/osu.Framework.Benchmarks/BenchmarkDependencyContainer.cs
+++ b/osu.Framework.Benchmarks/BenchmarkDependencyContainer.cs
@@ -3,6 +3,7 @@
 
 using System.Threading;
 using BenchmarkDotNet.Attributes;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Audio;
@@ -52,6 +53,7 @@ namespace osu.Framework.Benchmarks
 
         private class TestBdlReceiver : Drawable
         {
+            [UsedImplicitly] // params used implicitly
             [BackgroundDependencyLoader]
             private void load(Game game, TextureStore textures, AudioManager audio)
             {

--- a/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
+++ b/osu.Framework.Tests/Dependencies/DependencyContainerTest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using JetBrains.Annotations;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing.Dependencies;
@@ -420,6 +421,7 @@ namespace osu.Framework.Tests.Dependencies
 
         private class Receiver12
         {
+            [UsedImplicitly] // param used implicitly
             [BackgroundDependencyLoader]
             private void load(int testObject)
             {

--- a/osu.Framework.Tests/Visual/Testing/TestSceneAudioMixerVisualiser.cs
+++ b/osu.Framework.Tests/Visual/Testing/TestSceneAudioMixerVisualiser.cs
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using osu.Framework.Allocation;
-using osu.Framework.Audio;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
 using osu.Framework.Graphics;
@@ -18,7 +17,7 @@ namespace osu.Framework.Tests.Visual.Testing
         private TestAudioPlayingSource globalSource;
 
         [BackgroundDependencyLoader]
-        private void load(AudioManager audioManager)
+        private void load()
         {
             AudioMixerVisualiser visualiser;
 

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Allocation
     /// <summary>
     /// Marks a method as the (potentially asynchronous) initialization method of a <see cref="osu.Framework.Graphics.Drawable"/>, allowing for automatic injection of dependencies via the parameters of the method.
     /// </summary>
-    [MeansImplicitUse]
+    [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     [AttributeUsage(AttributeTargets.Method)]
     public class BackgroundDependencyLoaderAttribute : Attribute
     {

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -10,7 +10,6 @@ using osu.Framework.Configuration;
 using osu.Framework.Graphics.Animations;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
-using osu.Framework.Graphics.Shaders;
 using osuTK;
 
 namespace osu.Framework.Graphics.Video
@@ -105,7 +104,7 @@ namespace osu.Framework.Graphics.Video
         }
 
         [BackgroundDependencyLoader]
-        private void load(GameHost gameHost, FrameworkConfigManager config, ShaderManager shaders)
+        private void load(GameHost gameHost, FrameworkConfigManager config)
         {
             decoder = gameHost.CreateVideoDecoder(stream);
             decoder.Looping = Loop;

--- a/osu.Framework/Graphics/Video/VideoSprite.cs
+++ b/osu.Framework/Graphics/Video/VideoSprite.cs
@@ -4,7 +4,6 @@
 using osu.Framework.Allocation;
 using osu.Framework.Graphics.Shaders;
 using osu.Framework.Graphics.Sprites;
-using osu.Framework.Platform;
 
 namespace osu.Framework.Graphics.Video
 {
@@ -21,7 +20,7 @@ namespace osu.Framework.Graphics.Video
         }
 
         [BackgroundDependencyLoader]
-        private void load(GameHost gameHost, ShaderManager shaders)
+        private void load(ShaderManager shaders)
         {
             TextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.VIDEO);
             RoundedTextureShader = shaders.Load(VertexShaderDescriptor.TEXTURE_2, FragmentShaderDescriptor.VIDEO_ROUNDED);

--- a/osu.Framework/Graphics/Visualisation/LogOverlay.cs
+++ b/osu.Framework/Graphics/Visualisation/LogOverlay.cs
@@ -7,8 +7,6 @@ using osu.Framework.Graphics.Sprites;
 using osu.Framework.Logging;
 using osuTK;
 using osuTK.Graphics;
-using osu.Framework.Allocation;
-using osu.Framework.Configuration;
 using osu.Framework.Development;
 using osu.Framework.Timing;
 using osuTK.Input;
@@ -116,11 +114,6 @@ namespace osu.Framework.Graphics.Visualisation
         {
             box.Alpha = controlPressed ? 1 : background_alpha;
             if (clock != null) clock.Rate = controlPressed ? 0 : 1;
-        }
-
-        [BackgroundDependencyLoader]
-        private void load(FrameworkConfigManager config)
-        {
         }
 
         protected override void PopIn()

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -26,7 +26,6 @@ using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Input;
 using osu.Framework.Input.Bindings;
 using osu.Framework.Input.Events;
-using osu.Framework.IO.Stores;
 using osu.Framework.Platform;
 using osu.Framework.Testing.Drawables;
 using osu.Framework.Testing.Drawables.Steps;
@@ -127,7 +126,7 @@ namespace osu.Framework.Testing
         private readonly BindableDouble audioRateAdjust = new BindableDouble(1);
 
         [BackgroundDependencyLoader]
-        private void load(Storage storage, GameHost host, FrameworkConfigManager frameworkConfig, FontStore fonts, AudioManager audio)
+        private void load(Storage storage, GameHost host, AudioManager audio)
         {
             interactive = host.Window != null;
             config = new TestBrowserConfig(storage);


### PR DESCRIPTION
Adds `ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature` to `[MeansImplicitUse]` attribute for BDL.
The flag does exactly what we'd want, the BDL method itself is treated as used implicitly, but the params are not.

![image](https://user-images.githubusercontent.com/16479013/149428858-0e6f2bcb-4c62-4931-9906-081be658eadc.png)

"More" info on jetbrains' site:
https://www.jetbrains.com/help/resharper/Reference__Code_Annotation_Attributes.html#ImplicitUseKindFlags

Discussed shortly on [discord](https://discord.com/channels/188630481301012481/589331078574112768/931314763718340628).