### PR TITLE
Avoid rounding when calculating video duration

### DIFF
--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -336,9 +336,9 @@ namespace osu.Framework.Graphics.Video
             timeBaseInSeconds = stream->time_base.GetValue();
 
             if (stream->duration > 0)
-                Duration = stream->duration * timeBaseInSeconds * 1000;
+                Duration = stream->duration * timeBaseInSeconds * 1000.0;
             else
-                Duration = formatContext->duration / AGffmpeg.AV_TIME_BASE * 1000;
+                Duration = formatContext->duration / (double)AGffmpeg.AV_TIME_BASE * 1000.0;
         }
 
         private void recreateCodecContext()


### PR DESCRIPTION
When using the AVFormatContext calculated duration, cast AV_TIME_BASE to double to avoid rounding that could result in an inaccurate duration.