### PR TITLE
Fix texture bind early return bypassing glActiveTexture()

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -396,6 +396,8 @@ namespace osu.Framework.Graphics.OpenGL
 
         private static readonly int[] last_bound_texture = new int[16];
         private static readonly bool[] last_bound_texture_is_atlas = new bool[16];
+        private static TextureUnit lastActiveTextureUnit;
+
         internal static int GetTextureUnitId(TextureUnit unit) => (int)unit - (int)TextureUnit.Texture0;
         internal static bool AtlasTextureIsBound(TextureUnit unit) => last_bound_texture_is_atlas[GetTextureUnitId(unit)];
 
@@ -441,7 +443,7 @@ namespace osu.Framework.Graphics.OpenGL
                 CurrentWrapModeT = wrapModeT;
             }
 
-            if (last_bound_texture[index] == textureId)
+            if (lastActiveTextureUnit == unit && last_bound_texture[index] == textureId)
                 return false;
 
             FlushCurrentBatch();
@@ -451,6 +453,7 @@ namespace osu.Framework.Graphics.OpenGL
 
             last_bound_texture[index] = textureId;
             last_bound_texture_is_atlas[GetTextureUnitId(unit)] = false;
+            lastActiveTextureUnit = unit;
 
             FrameStatistics.Increment(StatisticsCounterType.TextureBinds);
             return true;

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -390,9 +390,12 @@ namespace osu.Framework.Graphics.OpenGL
             vertex_buffers_in_use.RemoveAll(b => !b.InUse);
         }
 
+        internal static WrapMode CurrentWrapModeS { get; private set; }
+
+        internal static WrapMode CurrentWrapModeT { get; private set; }
+
         private static readonly int[] last_bound_texture = new int[16];
         private static readonly bool[] last_bound_texture_is_atlas = new bool[16];
-
         internal static int GetTextureUnitId(TextureUnit unit) => (int)unit - (int)TextureUnit.Texture0;
         internal static bool AtlasTextureIsBound(TextureUnit unit) => last_bound_texture_is_atlas[GetTextureUnitId(unit)];
 
@@ -412,9 +415,6 @@ namespace osu.Framework.Graphics.OpenGL
             return didBind;
         }
 
-        internal static WrapMode CurrentWrapModeS;
-        internal static WrapMode CurrentWrapModeT;
-
         /// <summary>
         /// Binds a texture to draw with.
         /// </summary>
@@ -429,12 +429,14 @@ namespace osu.Framework.Graphics.OpenGL
 
             if (wrapModeS != CurrentWrapModeS)
             {
+                // Will flush the current batch internally.
                 GlobalPropertyManager.Set(GlobalProperty.WrapModeS, (int)wrapModeS);
                 CurrentWrapModeS = wrapModeS;
             }
 
             if (wrapModeT != CurrentWrapModeT)
             {
+                // Will flush the current batch internally.
                 GlobalPropertyManager.Set(GlobalProperty.WrapModeT, (int)wrapModeT);
                 CurrentWrapModeT = wrapModeT;
             }


### PR DESCRIPTION
Fixes https://github.com/ppy/osu-framework/issues/5000

The most simple fix because I don't expect performance to be impacted as a result of potentially one redundant `glBindTexture` call.