### PR TITLE
Add ability to control console output logging

### DIFF
--- a/osu.Framework/Configuration/FrameworkConfigManager.cs
+++ b/osu.Framework/Configuration/FrameworkConfigManager.cs
@@ -22,6 +22,7 @@ namespace osu.Framework.Configuration
         protected override void InitialiseDefaults()
         {
             SetDefault(FrameworkSetting.ShowLogOverlay, false);
+            SetDefault(FrameworkSetting.LogConsoleOutput, Logging.LogConsoleOutputSetting.Default);
 
             SetDefault(FrameworkSetting.WindowedSize, new Size(1366, 768), new Size(640, 480));
             SetDefault(FrameworkSetting.ConfineMouseMode, ConfineMouseMode.Fullscreen);
@@ -73,6 +74,7 @@ namespace osu.Framework.Configuration
     public enum FrameworkSetting
     {
         ShowLogOverlay,
+        LogConsoleOutput,
 
         AudioDevice,
         VolumeUniversal,

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -149,6 +149,8 @@ namespace osu.Framework
             config.BindWith(FrameworkSetting.VolumeEffect, Audio.VolumeSample);
             config.BindWith(FrameworkSetting.VolumeMusic, Audio.VolumeTrack);
 
+            config.BindWith(FrameworkSetting.LogConsoleOutput, Logging.Logger.LogOutputConsole);
+
             Shaders = new ShaderManager(new NamespacedResourceStore<byte[]>(Resources, @"Shaders"));
             dependencies.Cache(Shaders);
 

--- a/osu.Framework/Logging/Logger.cs
+++ b/osu.Framework/Logging/Logger.cs
@@ -11,6 +11,7 @@ using osu.Framework.Development;
 using osu.Framework.Platform;
 using osu.Framework.Statistics;
 using osu.Framework.Threading;
+using osu.Framework.Bindables;
 
 namespace osu.Framework.Logging
 {
@@ -30,6 +31,18 @@ namespace osu.Framework.Logging
         /// Whether logging is enabled. Setting this to false will disable all logging.
         /// </summary>
         public static bool Enabled = true;
+
+        /// <summary>
+        /// Whether to show output in console.
+        /// </summary>
+        public static readonly Bindable<LogConsoleOutputSetting> LogOutputConsole = new Bindable<LogConsoleOutputSetting>(LogConsoleOutputSetting.Default);
+
+        private static bool LogMessageToConsole => LogOutputConsole.Value switch
+        {
+            LogConsoleOutputSetting.Default => DebugUtils.IsDebugBuild,
+            LogConsoleOutputSetting.Always => true,
+            _ => false,
+        };
 
         /// <summary>
         /// The minimum log-level a logged message needs to have to be logged. Default is <see cref="LogLevel.Verbose"/>. Please note that setting this to <see cref="LogLevel.Debug"/>  will log input events, including keypresses when entering a password.
@@ -323,7 +336,7 @@ namespace osu.Framework.Logging
                     Exception = exception
                 });
 
-                if (DebugUtils.IsDebugBuild)
+                if (LogMessageToConsole)
                 {
                     static void consoleLog(string msg)
                     {
@@ -536,6 +549,22 @@ namespace osu.Framework.Logging
         /// Log-level for error messages. This is the highest level (lowest verbosity).
         /// </summary>
         Error
+    }
+
+    public enum LogConsoleOutputSetting
+    {
+        /// <summary>
+        /// Only logs to console when DebugUtils.IsDebugBuild is true.
+        /// </summary>
+        Default,
+        /// <summary>
+        /// Always logs to console.
+        /// </summary>
+        Always,
+        /// <summary>
+        /// Never logs to console.
+        /// </summary>
+        Never
     }
 
     /// <summary>


### PR DESCRIPTION
It introduces a switch that allows to force enable or force disable logging output to console, regardless whether it's a debug build.

On osu! side it will introduce a control in debug settings section.