### PR TITLE
Use `for` loop instead of `foreach` for critically hot path in invalidation

### DIFF
--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1785,8 +1785,10 @@ namespace osu.Framework.Graphics
             bool anyInvalidated = (invalidation & Invalidation.DrawNode) > 0;
 
             // Invalidate all layout members
-            foreach (var member in layoutMembers)
+            for (int i = 0; i < layoutMembers.Count; i++)
             {
+                var member = layoutMembers[i];
+
                 // Only invalidate layout members that accept the given source.
                 if ((member.Source & source) == 0)
                     continue;


### PR DESCRIPTION
Usually we'd avoid this level of micro optimisation, but this was showing up when assessing remaining song select performance concerns and seems like a no-brainer fix (the list is safe as it cannot be used post-load).

If this requires any thought beyond a quick merge then closing is fine. Had this left over from a profiling session.

![unknown](https://user-images.githubusercontent.com/191335/151733315-7482d188-e1dd-4f31-abc9-7df940b175b9.png)

(removes the `MoveNext` overhead at 18% of invalidation flow)