### PR TITLE
Hide iOS home indicator when possible

### DIFF
--- a/osu.Framework.iOS/GameViewController.cs
+++ b/osu.Framework.iOS/GameViewController.cs
@@ -14,6 +14,8 @@ namespace osu.Framework.iOS
 
         public override bool PrefersStatusBarHidden() => true;
 
+        public override bool PrefersHomeIndicatorAutoHidden => true;
+
         public override UIRectEdge PreferredScreenEdgesDeferringSystemGestures => UIRectEdge.All;
 
         public GameViewController(IOSGameView view, GameHost host)


### PR DESCRIPTION
Not much to say. Works as one would expect. I think making this default behaviour is fine until a framework consumer requests otherwise (we are already doing the same for the status bar).