### PR TITLE
Improve `SafeAreaDefiningContainer` bindable callback thread safety

### DIFF
--- a/osu.Framework/Graphics/Containers/SafeAreaDefiningContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaDefiningContainer.cs
@@ -35,12 +35,25 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        [BackgroundDependencyLoader]
-        private void load(GameHost host)
+        [Resolved]
+        private GameHost host { get; set; }
+
+        private IBindable<MarginPadding> hostSafeArea;
+
+        protected override void LoadComplete()
         {
-            if (!usesCustomBinding && host.Window != null)
-                safeArea.BindTo(host.Window.SafeAreaPadding);
+            base.LoadComplete();
+
+            if (usesCustomBinding || host.Window == null)
+                return;
+
+            hostSafeArea = host.Window.SafeAreaPadding.GetBoundCopy();
+            hostSafeArea.BindValueChanged(_ => Scheduler.AddOnce(updateSafeAreaFromHost));
+
+            updateSafeAreaFromHost();
         }
+
+        private void updateSafeAreaFromHost() => safeArea.Value = hostSafeArea.Value;
 
         #region ISafeArea Implementation
 

--- a/osu.Framework/Graphics/Containers/SafeAreaDefiningContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaDefiningContainer.cs
@@ -38,7 +38,7 @@ namespace osu.Framework.Graphics.Containers
         [Resolved]
         private GameHost host { get; set; }
 
-        private IBindable<MarginPadding> hostSafeArea;
+        private readonly IBindable<MarginPadding> hostSafeArea = new BindableSafeArea();
 
         protected override void LoadComplete()
         {
@@ -47,7 +47,7 @@ namespace osu.Framework.Graphics.Containers
             if (usesCustomBinding || host.Window == null)
                 return;
 
-            hostSafeArea = host.Window.SafeAreaPadding.GetBoundCopy();
+            hostSafeArea.BindTo(host.Window.SafeAreaPadding);
             hostSafeArea.BindValueChanged(_ => Scheduler.AddOnce(updateSafeAreaFromHost));
 
             updateSafeAreaFromHost();


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu/pull/16772#discussion_r799393996. Changes from the `host.Window.SafeAreaPadding` bindable are scheduled to the update thread instead of unsafely propagating them down the drawable hierarchy (also moved to `LoadComplete` becuase we probably don't want to bind on BDL?).