### PR TITLE
Remove no longer required SDL2 P/Invokes in Linux clipboard

### DIFF
--- a/osu.Framework/Platform/Linux/SDL2/SDL2Clipboard.cs
+++ b/osu.Framework/Platform/Linux/SDL2/SDL2Clipboard.cs
@@ -1,36 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
-using System.Runtime.InteropServices;
+using SDL2;
 
 namespace osu.Framework.Platform.Linux.SDL2
 {
     public class SDL2Clipboard : Clipboard
     {
-        private const string lib = "libSDL2.so";
+        public override string GetText() => SDL.SDL_GetClipboardText();
 
-        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_free", ExactSpelling = true)]
-        internal static extern void SDL_free(IntPtr ptr);
-
-        /// <returns>Returns the clipboard text on success or <see cref="IntPtr.Zero"/> on failure. </returns>
-        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_GetClipboardText", ExactSpelling = true)]
-        internal static extern IntPtr SDL_GetClipboardText();
-
-        [DllImport(lib, CallingConvention = CallingConvention.Cdecl, EntryPoint = "SDL_SetClipboardText", ExactSpelling = true)]
-        internal static extern int SDL_SetClipboardText(string text);
-
-        public override string GetText()
-        {
-            IntPtr ptrToText = SDL_GetClipboardText();
-            string text = Marshal.PtrToStringAnsi(ptrToText);
-            SDL_free(ptrToText);
-            return text;
-        }
-
-        public override void SetText(string selectedText)
-        {
-            SDL_SetClipboardText(selectedText);
-        }
+        public override void SetText(string selectedText) => SDL.SDL_SetClipboardText(selectedText);
     }
 }


### PR DESCRIPTION
The code existed in late 2018, way back before SDL2 was fully implemented to osu!framework. Seems it can now directly use the `SDL2` wrapper and simplify linux clipboard code.

Would appreciate testing this as I'm slightly hesitant about this given it's linux but I'm not sure about just leaving it behind.