### PR TITLE
Fetch safe area padding values on Android

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -3,11 +3,13 @@
 
 using System;
 using Android.Content;
+using Android.OS;
 using Android.Runtime;
 using Android.Text;
 using Android.Util;
 using Android.Views;
 using Android.Views.InputMethods;
+using JetBrains.Annotations;
 using osu.Framework.Android.Input;
 using osuTK.Graphics;
 
@@ -135,6 +137,35 @@ namespace osu.Framework.Android
             outAttrs.InputType = InputTypes.TextVariationVisiblePassword | InputTypes.TextFlagNoSuggestions;
             return new AndroidInputConnection(this, true);
         }
+
+        #region Safe area / display cutout handling
+
+        [CanBeNull]
+        private DisplayCutout displayCutout;
+
+        [CanBeNull]
+        internal DisplayCutout DisplayCutout
+        {
+            get => displayCutout;
+            set
+            {
+                if (value?.Equals(displayCutout) == true)
+                    return;
+
+                displayCutout = value;
+                OnResize(EventArgs.Empty);
+            }
+        }
+
+        public override WindowInsets OnApplyWindowInsets(WindowInsets insets)
+        {
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.P)
+                DisplayCutout = insets.DisplayCutout;
+
+            return base.OnApplyWindowInsets(insets);
+        }
+
+        #endregion
 
         #region Events
 

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using osu.Framework.Configuration;
+using osu.Framework.Graphics;
 using osu.Framework.Platform;
 using osuTK;
 using osuTK.Graphics;
@@ -32,6 +33,7 @@ namespace osu.Framework.Android
 
         public override void SetupWindow(FrameworkConfigManager config)
         {
+            Resize += onResize;
         }
 
         protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new[]
@@ -48,6 +50,20 @@ namespace osu.Framework.Android
         {
             get => DisplayDevice.Default;
             set => throw new InvalidOperationException();
+        }
+
+        private void onResize(object sender, EventArgs e)
+        {
+            if (view.DisplayCutout != null)
+            {
+                SafeAreaPadding.Value = new MarginPadding
+                {
+                    Top = view.DisplayCutout.SafeInsetTop,
+                    Left = view.DisplayCutout.SafeInsetLeft,
+                    Right = view.DisplayCutout.SafeInsetRight,
+                    Bottom = view.DisplayCutout.SafeInsetBottom
+                };
+            }
         }
     }
 }


### PR DESCRIPTION
The safe area padding feature was never actually implemented for Android (see #2144), therefore making ppy/osu#16772 not have the desired effect there. Seems about as good a time to make work as any.

API reference:

* [`View.OnApplyWindowInsets(WindowInsets)`](https://developer.android.com/reference/android/view/View#onApplyWindowInsets(android.view.WindowInsets)) (API level 20, so below the minimum agreed supported level 21)
* [`WindowInsets.getDisplayCutout()`](https://developer.android.com/reference/android/view/WindowInsets#getDisplayCutout()) (API level 28, requires a runtime version check to not-crash on older devices)

Tested on:

* Samsung Galaxy J7 2016 / SM-J710F (Android 7 / API level 24),
* OnePlus 8T / KB2003 (Android 11 / API level 30)