### PR TITLE
Create `AudioMixerVirtual`

### DIFF
--- a/osu.Framework/Audio/Mixing/AudioMixerVirtual.cs
+++ b/osu.Framework/Audio/Mixing/AudioMixerVirtual.cs
@@ -1,0 +1,28 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+#nullable enable
+
+using ManagedBass;
+using osu.Framework.Bindables;
+
+namespace osu.Framework.Audio.Mixing
+{
+    public class AudioMixerVirtual : AudioMixer
+    {
+        public AudioMixerVirtual()
+            : base(null, nameof(AudioMixerVirtual))
+        {
+        }
+
+        public override BindableList<IEffectParameter> Effects { get; } = new BindableList<IEffectParameter>();
+
+        protected override void AddInternal(IAudioChannel channel)
+        {
+        }
+
+        protected override void RemoveInternal(IAudioChannel channel)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Re: https://github.com/ppy/osu/pull/16771#discussion_r799795987

Context: The final goal is to expose audio mixers to mods so that they can apply audio filters in song select. After some discussion (linked above), the agreed-upon method is to include an `AudioMixer` parameter in `IApplicableToTrack.ApplyToTrack` method. Since this method is sometimes used in situations where the mixer is irreverent (e.g. in diff calc), this PR creates a dummy audio mixer that can be used in those cases.

Don't think tests are needed for this, since the only job of this dummy mixer is to carry the `Effects` list.