### PR TITLE
Implement `SafeAreaPadding` on Android

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -23,7 +23,7 @@ namespace osu.Framework.Android
     {
         public AndroidGameHost Host { get; private set; }
 
-        public readonly AndroidGameActivity Activity;
+        public AndroidGameActivity Activity { get; }
 
         private readonly Game game;
 

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -32,7 +32,7 @@ namespace osu.Framework.Android
 
         public override void SetupWindow(FrameworkConfigManager config)
         {
-            view.SafeAreaChanged += safeArea => SafeAreaPadding.Value = safeArea;
+            SafeAreaPadding.BindTo(view.SafeAreaPadding);
         }
 
         protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new[]

--- a/osu.Framework.Android/AndroidGameWindow.cs
+++ b/osu.Framework.Android/AndroidGameWindow.cs
@@ -32,6 +32,7 @@ namespace osu.Framework.Android
 
         public override void SetupWindow(FrameworkConfigManager config)
         {
+            view.SafeAreaChanged += safeArea => SafeAreaPadding.Value = safeArea;
         }
 
         protected override IEnumerable<WindowMode> DefaultSupportedWindowModes => new[]


### PR DESCRIPTION
Superseded https://github.com/ppy/osu-framework/pull/5012.

Tested on:
- Realme 6 / RMX2001 (Android 11 / API 30)
- LG G7 Fit / LG-Q850EMW (Android 9 / API 28)
- LG G Pad 8.3 / LG-V500 (Android 8.1 / API 27)

Testing methodology involves using multi-window and trying out different screen orientations.

Some of the extra code (compared to the original PR) seems to be working around a platform issue with my main device (Realme 6), as the original PR works just fine on the LG G7 Fit 🙃

At least we got non-complaint devices covered.

Anyways, I feel much safer calculating all the insets on the screen area, and then intersecting with the view at the very end.