### PR TITLE
Fix `InputManager.ChangeFocus()` potentially switching focus to an invalid target

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
@@ -133,10 +133,24 @@ namespace osu.Framework.Tests.Visual.Drawables
         }
 
         /// <summary>
+        /// Ensures that performing <see cref="InputManager.ChangeFocus"/> to a drawable with disabled <see cref="Drawable.AcceptsFocus"/> returns <see langword="false"/>.
+        /// </summary>
+        [Test]
+        public void DisabledFocusDrawableCannotReceiveFocusViaChangeFocus()
+        {
+            checkFocused(() => requestingFocus);
+
+            AddStep("disable focus from top left", () => focusTopLeft.AllowAcceptingFocus = false);
+            AddAssert("cannot switch focus to top left", () => !InputManager.ChangeFocus(focusTopLeft));
+
+            checkFocused(() => requestingFocus);
+        }
+
+        /// <summary>
         /// Ensures that performing <see cref="InputManager.ChangeFocus"/> to a non-present drawable returns <see langword="false"/>.
         /// </summary>
         [Test]
-        public void NotPresentDrawableCannotReceiveFocus()
+        public void NotPresentDrawableCannotReceiveFocusViaChangeFocus()
         {
             checkFocused(() => requestingFocus);
 
@@ -150,7 +164,7 @@ namespace osu.Framework.Tests.Visual.Drawables
         /// Ensures that performing <see cref="InputManager.ChangeFocus"/> to a drawable of a non-present parent returns <see langword="false"/>.
         /// </summary>
         [Test]
-        public void DrawableOfNotPresentParentCannotReceiveFocus()
+        public void DrawableOfNotPresentParentCannotReceiveFocusViaChangeFocus()
         {
             checkFocused(() => requestingFocus);
 
@@ -346,7 +360,9 @@ namespace osu.Framework.Tests.Visual.Drawables
 
             protected override bool OnClick(ClickEvent e) => true;
 
-            public override bool AcceptsFocus => true;
+            public bool AllowAcceptingFocus = true;
+
+            public override bool AcceptsFocus => AllowAcceptingFocus;
 
             protected override void OnFocus(FocusEvent e)
             {

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneFocus.cs
@@ -132,6 +132,46 @@ namespace osu.Framework.Tests.Visual.Drawables
             checkFocused(() => focusBottomRight);
         }
 
+        /// <summary>
+        /// Ensures that performing <see cref="InputManager.ChangeFocus"/> to a non-present drawable returns <see langword="false"/>.
+        /// </summary>
+        [Test]
+        public void NotPresentDrawableCannotReceiveFocus()
+        {
+            checkFocused(() => requestingFocus);
+
+            AddStep("hide top left", () => focusTopLeft.Alpha = 0);
+            AddAssert("cannot switch focus to top left", () => !InputManager.ChangeFocus(focusTopLeft));
+
+            checkFocused(() => requestingFocus);
+        }
+
+        /// <summary>
+        /// Ensures that performing <see cref="InputManager.ChangeFocus"/> to a drawable of a non-present parent returns <see langword="false"/>.
+        /// </summary>
+        [Test]
+        public void DrawableOfNotPresentParentCannotReceiveFocus()
+        {
+            checkFocused(() => requestingFocus);
+
+            AddStep("wrap top left in hidden container", () =>
+            {
+                Container container;
+
+                Add(container = new Container
+                {
+                    Alpha = 0,
+                    RelativeSizeAxes = Axes.Both,
+                });
+
+                Remove(focusTopLeft);
+                container.Add(focusTopLeft);
+            });
+            AddAssert("cannot switch focus to top left", () => !InputManager.ChangeFocus(focusTopLeft));
+
+            checkFocused(() => requestingFocus);
+        }
+
         [Test]
         public void ShowOverlayInteractions()
         {

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -384,7 +384,7 @@ namespace osu.Framework.Input
             if (potentialFocusTarget == FocusedDrawable)
                 return true;
 
-            if (potentialFocusTarget != null && (!potentialFocusTarget.IsPresent || !potentialFocusTarget.AcceptsFocus))
+            if (potentialFocusTarget != null && !isDrawableValidForFocus(potentialFocusTarget))
                 return false;
 
             var previousFocus = FocusedDrawable;
@@ -906,18 +906,28 @@ namespace osu.Framework.Input
         {
             if (FocusedDrawable == null) return true;
 
-            bool stillValid = FocusedDrawable.IsAlive && FocusedDrawable.IsPresent && FocusedDrawable.Parent != null;
+            if (isDrawableValidForFocus(FocusedDrawable))
+                return false;
 
-            if (stillValid)
+            Logger.Log($"Focus on \"{FocusedDrawable}\" no longer valid as a result of {nameof(unfocusIfNoLongerValid)}.", LoggingTarget.Runtime, LogLevel.Debug);
+            ChangeFocus(null);
+            return true;
+        }
+
+        private bool isDrawableValidForFocus(Drawable drawable)
+        {
+            bool valid = drawable.IsAlive && drawable.IsPresent && drawable.Parent != null;
+
+            if (valid)
             {
                 //ensure we are visible
-                CompositeDrawable d = FocusedDrawable.Parent;
+                CompositeDrawable d = drawable.Parent;
 
                 while (d != null)
                 {
                     if (!d.IsPresent || !d.IsAlive)
                     {
-                        stillValid = false;
+                        valid = false;
                         break;
                     }
 
@@ -925,12 +935,7 @@ namespace osu.Framework.Input
                 }
             }
 
-            if (stillValid)
-                return false;
-
-            Logger.Log($"Focus on \"{FocusedDrawable}\" no longer valid as a result of {nameof(unfocusIfNoLongerValid)}.", LoggingTarget.Runtime, LogLevel.Debug);
-            ChangeFocus(null);
-            return true;
+            return valid;
         }
 
         protected virtual void ChangeFocusFromClick(Drawable clickedDrawable)

--- a/osu.Framework/Input/InputManager.cs
+++ b/osu.Framework/Input/InputManager.cs
@@ -384,7 +384,7 @@ namespace osu.Framework.Input
             if (potentialFocusTarget == FocusedDrawable)
                 return true;
 
-            if (potentialFocusTarget != null && !isDrawableValidForFocus(potentialFocusTarget))
+            if (potentialFocusTarget != null && (!isDrawableValidForFocus(potentialFocusTarget) || !potentialFocusTarget.AcceptsFocus))
                 return false;
 
             var previousFocus = FocusedDrawable;


### PR DESCRIPTION
- Resolves https://github.com/ppy/osu/discussions/16797
- See https://github.com/ppy/osu/discussions/16797#discussioncomment-2120029 for the reason behind this, which led to this PR.