### PR TITLE
Fix crash with empty markdown fenced code blocks

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
@@ -301,6 +301,12 @@ soft break with '\'";
             AddAssert("has correct autolink", () => markdownContainer.AutoLinks[0].Url == "https://discord.gg/ppy");
         }
 
+        [Test]
+        public void TestEmptyFencedBlock()
+        {
+            AddStep("set empty fenced block", () => markdownContainer.Text = @"```");
+        }
+
         private class TestMarkdownContainer : MarkdownContainer
         {
             public new string DocumentUrl

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneMarkdownContainer.cs
@@ -302,9 +302,16 @@ soft break with '\'";
         }
 
         [Test]
+        public void TestUnbalancedFencedBlock()
+        {
+            AddStep("set unbalanced fenced block", () => markdownContainer.Text = @"```");
+        }
+
+        [Test]
         public void TestEmptyFencedBlock()
         {
-            AddStep("set empty fenced block", () => markdownContainer.Text = @"```");
+            AddStep("set empty fenced block", () => markdownContainer.Text = @"```
+```");
         }
 
         private class TestMarkdownContainer : MarkdownContainer

--- a/osu.Framework/Graphics/Containers/Markdown/MarkdownFencedCodeBlock.cs
+++ b/osu.Framework/Graphics/Containers/Markdown/MarkdownFencedCodeBlock.cs
@@ -41,8 +41,11 @@ namespace osu.Framework.Graphics.Containers.Markdown
                 textFlowContainer = CreateTextFlow(),
             };
 
-            foreach (var line in fencedCodeBlock.Lines.Lines)
-                textFlowContainer.AddParagraph(line.ToString());
+            if (fencedCodeBlock.Lines.Count > 0)
+            {
+                foreach (var line in fencedCodeBlock.Lines.Lines)
+                    textFlowContainer.AddParagraph(line.ToString());
+            }
         }
 
         protected virtual Drawable CreateBackground() => new Box


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/16808

It still draws the background, which looks to be expected for this sort of input (tested via both dillinger.io and github).