### PR TITLE
Create helper methods to ensure stream reads are read correctly to the expected length

### DIFF
--- a/osu.Framework.Tests/Extensions/TestStreamExtensions.cs
+++ b/osu.Framework.Tests/Extensions/TestStreamExtensions.cs
@@ -1,0 +1,160 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+
+namespace osu.Framework.Tests.Extensions
+{
+    [TestFixture]
+    public class TestStreamExtensions
+    {
+        private readonly byte[] sampleData = File.ReadAllBytes("osu.Framework.dll");
+
+        [Test]
+        public void TestReadMemoryStream()
+        {
+            var ms = new MemoryStream(sampleData);
+
+            byte[] readBytes = ms.ReadAllBytesToArray();
+
+            Assert.That(ms.Length, Is.EqualTo(readBytes.Length));
+            Assert.That(ms.ComputeMD5Hash(), Is.EqualTo(new MemoryStream(readBytes).ComputeMD5Hash()));
+        }
+
+        [Test]
+        public async Task TestReadMemoryStreamAsync()
+        {
+            var ms = new MemoryStream(sampleData);
+
+            byte[] readBytes = await ms.ReadAllBytesToArrayAsync().ConfigureAwait(false);
+
+            Assert.That(ms.Length, Is.EqualTo(readBytes.Length));
+            Assert.That(ms.ComputeMD5Hash(), Is.EqualTo(new MemoryStream(readBytes).ComputeMD5Hash()));
+        }
+
+        [Test]
+        public void TestReadPartialMemoryStream()
+        {
+            const int read_length = 32;
+
+            var ms = new MemoryStream(sampleData);
+
+            byte[] readBytes = ms.ReadBytesToArray(read_length);
+
+            Assert.That(readBytes.Length, Is.EqualTo(read_length));
+
+            Assert.That(readBytes, Is.EqualTo(ms.ToArray().Take(read_length)));
+        }
+
+        [Test]
+        public async Task TestReadPartialMemoryStreamAsync()
+        {
+            const int read_length = 32;
+
+            var ms = new MemoryStream(sampleData);
+
+            byte[] readBytes = await ms.ReadBytesToArrayAsync(read_length).ConfigureAwait(false);
+
+            Assert.That(readBytes.Length, Is.EqualTo(read_length));
+
+            Assert.That(readBytes, Is.EqualTo(ms.ToArray().Take(read_length)));
+        }
+
+        [Test]
+        public void TestReadPartialSeekedMemoryStream()
+        {
+            const int seek_amount = 50;
+            const int read_length = 32;
+
+            var ms = new MemoryStream(sampleData);
+
+            // seek should affect ReadBytesToArray operation.
+            ms.Seek(seek_amount, SeekOrigin.Begin);
+            byte[] readBytes = ms.ReadBytesToArray(read_length);
+
+            Assert.That(readBytes.Length, Is.EqualTo(read_length));
+
+            Assert.That(readBytes, Is.EqualTo(ms.ToArray().Skip(seek_amount).Take(read_length)));
+        }
+
+        [Test]
+        public async Task TestReadPartialSeekedMemoryStreamAsync()
+        {
+            const int seek_amount = 50;
+            const int read_length = 32;
+
+            var ms = new MemoryStream(sampleData);
+
+            // seek should affect ReadBytesToArray operation.
+            ms.Seek(seek_amount, SeekOrigin.Begin);
+
+            byte[] readBytes = await ms.ReadBytesToArrayAsync(read_length).ConfigureAwait(false);
+
+            Assert.That(readBytes.Length, Is.EqualTo(read_length));
+
+            Assert.That(readBytes, Is.EqualTo(ms.ToArray().Skip(seek_amount).Take(read_length)));
+        }
+
+        [Test]
+        public void TestReadSeekedMemoryStream()
+        {
+            var ms = new MemoryStream(sampleData);
+
+            // seek should not affect ReadAllBytes operation.
+            ms.Seek(50, SeekOrigin.Begin);
+
+            byte[] readBytes = ms.ReadAllBytesToArray();
+
+            Assert.That(ms.Length, Is.EqualTo(readBytes.Length));
+            Assert.That(ms.ComputeMD5Hash(), Is.EqualTo(new MemoryStream(readBytes).ComputeMD5Hash()));
+        }
+
+        [Test]
+        public async Task TestReadSeekedMemoryStreamAsync()
+        {
+            var ms = new MemoryStream(sampleData);
+
+            // seek should not affect ReadAllBytes operation.
+            ms.Seek(50, SeekOrigin.Begin);
+
+            byte[] readBytes = await ms.ReadAllBytesToArrayAsync().ConfigureAwait(false);
+
+            Assert.That(ms.Length, Is.EqualTo(readBytes.Length));
+            Assert.That(ms.ComputeMD5Hash(), Is.EqualTo(new MemoryStream(readBytes).ComputeMD5Hash()));
+        }
+
+        [Test]
+        public void TestReadRemainingBytes()
+        {
+            const int read_last_byte_count = 128;
+
+            var ms = new MemoryStream(sampleData);
+
+            ms.Seek(-read_last_byte_count, SeekOrigin.End);
+
+            byte[] readBytes = ms.ReadAllRemainingBytesToArray();
+
+            Assert.That(readBytes.Length, Is.EqualTo(read_last_byte_count));
+            Assert.That(readBytes, Is.EqualTo(ms.ToArray().TakeLast(read_last_byte_count)));
+        }
+
+        [Test]
+        public async Task TestReadRemainingBytesAsync()
+        {
+            const int read_last_byte_count = 128;
+
+            var ms = new MemoryStream(sampleData);
+
+            ms.Seek(-read_last_byte_count, SeekOrigin.End);
+
+            byte[] readBytes = await ms.ReadAllRemainingBytesToArrayAsync().ConfigureAwait(false);
+
+            Assert.That(readBytes.Length, Is.EqualTo(read_last_byte_count));
+            Assert.That(readBytes, Is.EqualTo(ms.ToArray().TakeLast(read_last_byte_count)));
+        }
+    }
+}

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -4,15 +4,12 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
@@ -350,93 +347,5 @@ namespace osu.Framework.Extensions
         /// <returns>A <see cref="DisplayMode"/> structure populated with the corresponding properties.</returns>
         internal static DisplayMode ToDisplayMode(this DisplayResolution resolution) =>
             new DisplayMode(null, new Size(resolution.Width, resolution.Height), resolution.BitsPerPixel, (int)Math.Round(resolution.RefreshRate), 0, 0);
-
-        /// <summary>
-        /// Read the full content of a stream.
-        /// </summary>
-        /// <param name="stream">The stream to read.</param>
-        /// <returns>The full byte content.</returns>
-        public static byte[] ReadAllBytesToArray(this Stream stream)
-        {
-            Debug.Assert(stream.Length < int.MaxValue);
-
-            return stream.ReadBytesToArray((int)stream.Length);
-        }
-
-        /// <summary>
-        /// Read the full content of a stream.
-        /// </summary>
-        /// <param name="stream">The stream to read.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>The full byte content.</returns>
-        public static Task<byte[]> ReadAllBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken)
-        {
-            Debug.Assert(stream.Length < int.MaxValue);
-
-            return stream.ReadBytesToArrayAsync((int)stream.Length, cancellationToken);
-        }
-
-        /// <summary>
-        /// Read specified length from current position in stream.
-        /// </summary>
-        /// <param name="stream">The stream to read.</param>
-        /// <param name="length">The length to read.</param>
-        /// <returns>The full byte content.</returns>
-        public static byte[] ReadBytesToArray(this Stream stream, int length)
-        {
-            if (stream is MemoryStream ms && length == ms.GetBuffer().Length)
-                return ms.GetBuffer();
-
-            byte[] buffer = new byte[16 * 1024];
-
-            using (ms = new MemoryStream(length))
-            {
-                int read;
-                int totalRead = 0;
-
-                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
-                {
-                    ms.Write(buffer, 0, read);
-                    totalRead += read;
-                }
-
-                if (totalRead != length)
-                    throw new EndOfStreamException();
-
-                return ms.GetBuffer();
-            }
-        }
-
-        /// <summary>
-        /// Read the full content of a stream.
-        /// </summary>
-        /// <param name="stream">The stream to read.</param>
-        /// <param name="length">The length to read.</param>
-        /// <param name="cancellationToken">A cancellation token.</param>
-        /// <returns>The full byte content.</returns>
-        public static async Task<byte[]> ReadBytesToArrayAsync(this Stream stream, int length, CancellationToken cancellationToken)
-        {
-            if (stream is MemoryStream ms && length == ms.GetBuffer().Length)
-                return ms.GetBuffer();
-
-            byte[] buffer = new byte[16 * 1024];
-
-            using (ms = new MemoryStream(length))
-            {
-                int read;
-                int totalRead = 0;
-
-                while ((read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
-                {
-                    await ms.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
-                    totalRead += read;
-                }
-
-                if (totalRead != length)
-                    throw new EndOfStreamException();
-
-                return ms.GetBuffer();
-            }
-        }
     }
 }

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -428,7 +428,7 @@ namespace osu.Framework.Extensions
 
                 while ((read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
                 {
-                    ms.Write(buffer, 0, read);
+                    await ms.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
                     totalRead += read;
                 }
 

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -4,12 +4,15 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 using osu.Framework.Extensions.ObjectExtensions;
 using osu.Framework.Localisation;
 using osu.Framework.Platform;
@@ -347,5 +350,93 @@ namespace osu.Framework.Extensions
         /// <returns>A <see cref="DisplayMode"/> structure populated with the corresponding properties.</returns>
         internal static DisplayMode ToDisplayMode(this DisplayResolution resolution) =>
             new DisplayMode(null, new Size(resolution.Width, resolution.Height), resolution.BitsPerPixel, (int)Math.Round(resolution.RefreshRate), 0, 0);
+
+        /// <summary>
+        /// Read the full content of a stream.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <returns>The full byte content.</returns>
+        public static byte[] ReadAllBytesToArray(this Stream stream)
+        {
+            Debug.Assert(stream.Length < int.MaxValue);
+
+            return stream.ReadBytesToArray((int)stream.Length);
+        }
+
+        /// <summary>
+        /// Read the full content of a stream.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The full byte content.</returns>
+        public static Task<byte[]> ReadAllBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken)
+        {
+            Debug.Assert(stream.Length < int.MaxValue);
+
+            return stream.ReadBytesToArrayAsync((int)stream.Length, cancellationToken);
+        }
+
+        /// <summary>
+        /// Read specified length from current position in stream.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <param name="length">The length to read.</param>
+        /// <returns>The full byte content.</returns>
+        public static byte[] ReadBytesToArray(this Stream stream, int length)
+        {
+            if (stream is MemoryStream ms && length == ms.GetBuffer().Length)
+                return ms.GetBuffer();
+
+            byte[] buffer = new byte[16 * 1024];
+
+            using (ms = new MemoryStream(length))
+            {
+                int read;
+                int totalRead = 0;
+
+                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    ms.Write(buffer, 0, read);
+                    totalRead += read;
+                }
+
+                if (totalRead != length)
+                    throw new EndOfStreamException();
+
+                return ms.GetBuffer();
+            }
+        }
+
+        /// <summary>
+        /// Read the full content of a stream.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <param name="length">The length to read.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The full byte content.</returns>
+        public static async Task<byte[]> ReadBytesToArrayAsync(this Stream stream, int length, CancellationToken cancellationToken)
+        {
+            if (stream is MemoryStream ms && length == ms.GetBuffer().Length)
+                return ms.GetBuffer();
+
+            byte[] buffer = new byte[16 * 1024];
+
+            using (ms = new MemoryStream(length))
+            {
+                int read;
+                int totalRead = 0;
+
+                while ((read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
+                {
+                    ms.Write(buffer, 0, read);
+                    totalRead += read;
+                }
+
+                if (totalRead != length)
+                    throw new EndOfStreamException();
+
+                return ms.GetBuffer();
+            }
+        }
     }
 }

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -56,18 +56,19 @@ namespace osu.Framework.Extensions
         {
             byte[] buffer = new byte[16 * 1024];
 
+            int remainingRead = length;
+
             using (var ms = new MemoryStream(length))
             {
                 int read;
-                int totalRead = 0;
 
-                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                while ((read = stream.Read(buffer, 0, Math.Min(remainingRead, buffer.Length))) > 0)
                 {
                     ms.Write(buffer, 0, read);
-                    totalRead += read;
+                    remainingRead -= read;
                 }
 
-                if (totalRead != length)
+                if (remainingRead != 0)
                     throw new EndOfStreamException();
 
                 return ms.GetBuffer();
@@ -85,18 +86,19 @@ namespace osu.Framework.Extensions
         {
             byte[] buffer = new byte[16 * 1024];
 
+            int remainingRead = length;
+
             using (var ms = new MemoryStream(length))
             {
                 int read;
-                int totalRead = 0;
 
-                while ((read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
+                while ((read = await stream.ReadAsync(buffer, 0, Math.Min(buffer.Length, remainingRead), cancellationToken).ConfigureAwait(false)) > 0)
                 {
                     await ms.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
-                    totalRead += read;
+                    remainingRead -= read;
                 }
 
-                if (totalRead != length)
+                if (remainingRead != 0)
                     throw new EndOfStreamException();
 
                 return ms.GetBuffer();

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -146,15 +146,9 @@ namespace osu.Framework.Extensions
         /// <returns>The full byte content.</returns>
         public static async Task<byte[]> ReadAllRemainingBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
-            byte[] buffer = new byte[buffer_size];
-
             using (var ms = new MemoryStream())
             {
-                int read;
-
-                while ((read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
-                    await ms.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
-
+                await stream.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
                 return ms.ToArray();
             }
         }

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -20,6 +20,7 @@ namespace osu.Framework.Extensions
         {
             if (stream.CanSeek)
             {
+                stream.Seek(0, SeekOrigin.Begin);
                 Debug.Assert(stream.Length < int.MaxValue);
                 return stream.ReadBytesToArray((int)stream.Length);
             }
@@ -37,6 +38,7 @@ namespace osu.Framework.Extensions
         {
             if (stream.CanSeek)
             {
+                stream.Seek(0, SeekOrigin.Begin);
                 Debug.Assert(stream.Length < int.MaxValue);
                 return stream.ReadBytesToArrayAsync((int)stream.Length, cancellationToken);
             }

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -52,12 +52,9 @@ namespace osu.Framework.Extensions
         /// <returns>The full byte content.</returns>
         public static byte[] ReadBytesToArray(this Stream stream, int length)
         {
-            if (stream is MemoryStream ms && length == ms.GetBuffer().Length)
-                return ms.GetBuffer();
-
             byte[] buffer = new byte[16 * 1024];
 
-            using (ms = new MemoryStream(length))
+            using (var ms = new MemoryStream(length))
             {
                 int read;
                 int totalRead = 0;
@@ -84,12 +81,9 @@ namespace osu.Framework.Extensions
         /// <returns>The full byte content.</returns>
         public static async Task<byte[]> ReadBytesToArrayAsync(this Stream stream, int length, CancellationToken cancellationToken)
         {
-            if (stream is MemoryStream ms && length == ms.GetBuffer().Length)
-                return ms.GetBuffer();
-
             byte[] buffer = new byte[16 * 1024];
 
-            using (ms = new MemoryStream(length))
+            using (var ms = new MemoryStream(length))
             {
                 int read;
                 int totalRead = 0;

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -1,0 +1,102 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace osu.Framework.Extensions
+{
+    public static class StreamExtensions
+    {
+        /// <summary>
+        /// Read the full content of a stream.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <returns>The full byte content.</returns>
+        public static byte[] ReadAllBytesToArray(this Stream stream)
+        {
+            Debug.Assert(stream.Length < int.MaxValue);
+
+            return stream.ReadBytesToArray((int)stream.Length);
+        }
+
+        /// <summary>
+        /// Read the full content of a stream.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The full byte content.</returns>
+        public static Task<byte[]> ReadAllBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken)
+        {
+            Debug.Assert(stream.Length < int.MaxValue);
+
+            return stream.ReadBytesToArrayAsync((int)stream.Length, cancellationToken);
+        }
+
+        /// <summary>
+        /// Read specified length from current position in stream.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <param name="length">The length to read.</param>
+        /// <returns>The full byte content.</returns>
+        public static byte[] ReadBytesToArray(this Stream stream, int length)
+        {
+            if (stream is MemoryStream ms && length == ms.GetBuffer().Length)
+                return ms.GetBuffer();
+
+            byte[] buffer = new byte[16 * 1024];
+
+            using (ms = new MemoryStream(length))
+            {
+                int read;
+                int totalRead = 0;
+
+                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    ms.Write(buffer, 0, read);
+                    totalRead += read;
+                }
+
+                if (totalRead != length)
+                    throw new EndOfStreamException();
+
+                return ms.GetBuffer();
+            }
+        }
+
+        /// <summary>
+        /// Read the full content of a stream.
+        /// </summary>
+        /// <param name="stream">The stream to read.</param>
+        /// <param name="length">The length to read.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The full byte content.</returns>
+        public static async Task<byte[]> ReadBytesToArrayAsync(this Stream stream, int length, CancellationToken cancellationToken)
+        {
+            if (stream is MemoryStream ms && length == ms.GetBuffer().Length)
+                return ms.GetBuffer();
+
+            byte[] buffer = new byte[16 * 1024];
+
+            using (ms = new MemoryStream(length))
+            {
+                int read;
+                int totalRead = 0;
+
+                while ((read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
+                {
+                    await ms.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
+                    totalRead += read;
+                }
+
+                if (totalRead != length)
+                    throw new EndOfStreamException();
+
+                return ms.GetBuffer();
+            }
+        }
+    }
+}

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -125,15 +125,9 @@ namespace osu.Framework.Extensions
         /// <returns>The full byte content.</returns>
         public static byte[] ReadAllRemainingBytesToArray(this Stream stream)
         {
-            byte[] buffer = new byte[buffer_size];
-
             using (var ms = new MemoryStream())
             {
-                int read;
-
-                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
-                    ms.Write(buffer, 0, read);
-
+                stream.CopyTo(ms);
                 return ms.ToArray();
             }
         }

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -14,38 +14,40 @@ namespace osu.Framework.Extensions
         private const int buffer_size = 16 * 1024; // Matches generally what .NET uses internally.
 
         /// <summary>
-        /// Read the full content of a stream.
+        /// Read the full content of a seekable stream.
         /// </summary>
+        /// <remarks>
+        /// For a non-seekable stream, use <see cref="ReadAllRemainingBytesToArray"/> instead.
+        /// </remarks>
         /// <param name="stream">The stream to read.</param>
         /// <returns>The full byte content.</returns>
         public static byte[] ReadAllBytesToArray(this Stream stream)
         {
-            if (stream.CanSeek)
-            {
-                stream.Seek(0, SeekOrigin.Begin);
-                Debug.Assert(stream.Length < int.MaxValue);
-                return stream.ReadBytesToArray((int)stream.Length);
-            }
+            if (!stream.CanSeek)
+                throw new ArgumentException($"Stream must be seekable to use this function. Consider using {nameof(ReadAllRemainingBytesToArray)} instead.", nameof(stream));
 
-            return stream.ReadAllRemainingBytesToArray();
+            stream.Seek(0, SeekOrigin.Begin);
+            Debug.Assert(stream.Length < int.MaxValue);
+            return stream.ReadBytesToArray((int)stream.Length);
         }
 
         /// <summary>
-        /// Read the full content of a stream.
+        /// Read the full content of a seekable stream.
         /// </summary>
+        /// <remarks>
+        /// For a non-seekable stream, use <see cref="ReadAllRemainingBytesToArray"/> instead.
+        /// </remarks>
         /// <param name="stream">The stream to read.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The full byte content.</returns>
         public static Task<byte[]> ReadAllBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
-            if (stream.CanSeek)
-            {
-                stream.Seek(0, SeekOrigin.Begin);
-                Debug.Assert(stream.Length < int.MaxValue);
-                return stream.ReadBytesToArrayAsync((int)stream.Length, cancellationToken);
-            }
+            if (!stream.CanSeek)
+                throw new ArgumentException($"Stream must be seekable to use this function. Consider using {nameof(ReadAllRemainingBytesToArray)} instead.", nameof(stream));
 
-            return stream.ReadAllRemainingBytesToArrayAsync(cancellationToken);
+            stream.Seek(0, SeekOrigin.Begin);
+            Debug.Assert(stream.Length < int.MaxValue);
+            return stream.ReadBytesToArrayAsync((int)stream.Length, cancellationToken);
         }
 
         /// <summary>

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -71,7 +71,12 @@ namespace osu.Framework.Extensions
                 if (remainingRead != 0)
                     throw new EndOfStreamException();
 
-                return ms.GetBuffer();
+                byte[] bytes = ms.GetBuffer();
+
+                // We are guaranteed that the buffer is the correct length due to the above length checks along with the ctor length specification.
+                Debug.Assert(bytes.Length == length);
+
+                return bytes;
             }
         }
 

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -148,7 +148,7 @@ namespace osu.Framework.Extensions
             {
                 int read;
 
-                while ((read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
+                while ((read = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false)) > 0)
                     await ms.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
 
                 return ms.ToArray();

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -11,6 +11,8 @@ namespace osu.Framework.Extensions
 {
     public static class StreamExtensions
     {
+        private const int buffer_size = 16 * 1024; // Matches generally what .NET uses internally.
+
         /// <summary>
         /// Read the full content of a stream.
         /// </summary>
@@ -54,7 +56,7 @@ namespace osu.Framework.Extensions
         /// <returns>The full byte content.</returns>
         public static byte[] ReadBytesToArray(this Stream stream, int length)
         {
-            byte[] buffer = new byte[16 * 1024];
+            byte[] buffer = new byte[buffer_size];
 
             int remainingRead = length;
 
@@ -89,7 +91,7 @@ namespace osu.Framework.Extensions
         /// <returns>The full byte content.</returns>
         public static async Task<byte[]> ReadBytesToArrayAsync(this Stream stream, int length, CancellationToken cancellationToken = default)
         {
-            byte[] buffer = new byte[16 * 1024];
+            byte[] buffer = new byte[buffer_size];
 
             int remainingRead = length;
 
@@ -117,7 +119,7 @@ namespace osu.Framework.Extensions
         /// <returns>The full byte content.</returns>
         public static byte[] ReadAllRemainingBytesToArray(this Stream stream)
         {
-            byte[] buffer = new byte[16 * 1024];
+            byte[] buffer = new byte[buffer_size];
 
             using (var ms = new MemoryStream())
             {
@@ -138,7 +140,7 @@ namespace osu.Framework.Extensions
         /// <returns>The full byte content.</returns>
         public static async Task<byte[]> ReadAllRemainingBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
-            byte[] buffer = new byte[16 * 1024];
+            byte[] buffer = new byte[buffer_size];
 
             using (var ms = new MemoryStream())
             {

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Extensions
                 return stream.ReadBytesToArray((int)stream.Length);
             }
 
-            return stream.ReadArbitraryBytesToArray();
+            return stream.ReadAllRemainingBytesToArray();
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace osu.Framework.Extensions
         /// <param name="stream">The stream to read.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The full byte content.</returns>
-        public static Task<byte[]> ReadAllBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken)
+        public static Task<byte[]> ReadAllBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
             if (stream.CanSeek)
             {
@@ -43,7 +43,7 @@ namespace osu.Framework.Extensions
                 return stream.ReadBytesToArrayAsync((int)stream.Length, cancellationToken);
             }
 
-            return stream.ReadArbitraryBytesToArrayAsync(cancellationToken);
+            return stream.ReadAllRemainingBytesToArrayAsync(cancellationToken);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace osu.Framework.Extensions
         /// <param name="length">The length to read.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The full byte content.</returns>
-        public static async Task<byte[]> ReadBytesToArrayAsync(this Stream stream, int length, CancellationToken cancellationToken)
+        public static async Task<byte[]> ReadBytesToArrayAsync(this Stream stream, int length, CancellationToken cancellationToken = default)
         {
             byte[] buffer = new byte[16 * 1024];
 
@@ -110,7 +110,7 @@ namespace osu.Framework.Extensions
         /// </summary>
         /// <param name="stream">The stream to read.</param>
         /// <returns>The full byte content.</returns>
-        public static byte[] ReadArbitraryBytesToArray(this Stream stream)
+        public static byte[] ReadAllRemainingBytesToArray(this Stream stream)
         {
             byte[] buffer = new byte[16 * 1024];
 
@@ -121,7 +121,7 @@ namespace osu.Framework.Extensions
                 while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
                     ms.Write(buffer, 0, read);
 
-                return ms.GetBuffer();
+                return ms.ToArray();
             }
         }
 
@@ -131,7 +131,7 @@ namespace osu.Framework.Extensions
         /// <param name="stream">The stream to read.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The full byte content.</returns>
-        public static async Task<byte[]> ReadArbitraryBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken)
+        public static async Task<byte[]> ReadAllRemainingBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
             byte[] buffer = new byte[16 * 1024];
 
@@ -142,7 +142,7 @@ namespace osu.Framework.Extensions
                 while ((read = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false)) > 0)
                     await ms.WriteAsync(buffer, 0, read, cancellationToken).ConfigureAwait(false);
 
-                return ms.GetBuffer();
+                return ms.ToArray();
             }
         }
     }

--- a/osu.Framework/Extensions/StreamExtensions.cs
+++ b/osu.Framework/Extensions/StreamExtensions.cs
@@ -21,6 +21,7 @@ namespace osu.Framework.Extensions
         /// </remarks>
         /// <param name="stream">The stream to read.</param>
         /// <returns>The full byte content.</returns>
+        /// <exception cref="ArgumentException">The <paramref name="stream"/> provided must allow seeking.</exception>
         public static byte[] ReadAllBytesToArray(this Stream stream)
         {
             if (!stream.CanSeek)
@@ -40,6 +41,7 @@ namespace osu.Framework.Extensions
         /// <param name="stream">The stream to read.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The full byte content.</returns>
+        /// <exception cref="ArgumentException">The <paramref name="stream"/> provided must allow seeking.</exception>
         public static Task<byte[]> ReadAllBytesToArrayAsync(this Stream stream, CancellationToken cancellationToken = default)
         {
             if (!stream.CanSeek)
@@ -56,6 +58,7 @@ namespace osu.Framework.Extensions
         /// <param name="stream">The stream to read.</param>
         /// <param name="length">The length to read.</param>
         /// <returns>The full byte content.</returns>
+        /// <exception cref="EndOfStreamException">The <paramref name="length"/> specified exceeded the available data in the stream.</exception>
         public static byte[] ReadBytesToArray(this Stream stream, int length)
         {
             byte[] buffer = new byte[buffer_size];
@@ -91,6 +94,7 @@ namespace osu.Framework.Extensions
         /// <param name="length">The length to read.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         /// <returns>The full byte content.</returns>
+        /// <exception cref="EndOfStreamException">The <paramref name="length"/> specified exceeded the available data in the stream.</exception>
         public static async Task<byte[]> ReadBytesToArrayAsync(this Stream stream, int length, CancellationToken cancellationToken = default)
         {
             byte[] buffer = new byte[buffer_size];

--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -213,15 +213,9 @@ namespace osu.Framework.IO.Network
         {
             try
             {
-                byte[] data = new byte[ResponseStream.Length];
                 ResponseStream.Seek(0, SeekOrigin.Begin);
 
-                int readBytes = ResponseStream.Read(data, 0, data.Length);
-
-                if (readBytes < data.Length)
-                    throw new EndOfStreamException();
-
-                return data;
+                return ResponseStream.ReadAllBytesToArray();
             }
             catch
             {

--- a/osu.Framework/IO/Stores/DllResourceStore.cs
+++ b/osu.Framework/IO/Stores/DllResourceStore.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Framework.Extensions;
 
 namespace osu.Framework.IO.Stores
 {
@@ -42,37 +43,15 @@ namespace osu.Framework.IO.Stores
             this.LogIfNonBackgroundThread(name);
 
             using (Stream input = GetStream(name))
-            {
-                if (input == null)
-                    return null;
-
-                byte[] buffer = new byte[input.Length];
-                int readBytes = input.Read(buffer, 0, buffer.Length);
-
-                if (readBytes < input.Length)
-                    throw new EndOfStreamException();
-
-                return buffer;
-            }
+                return input?.ReadAllBytesToArray();
         }
 
-        public virtual async Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default)
+        public virtual Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default)
         {
             this.LogIfNonBackgroundThread(name);
 
             using (Stream input = GetStream(name))
-            {
-                if (input == null)
-                    return null;
-
-                byte[] buffer = new byte[input.Length];
-                int readBytes = await input.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
-
-                if (readBytes < input.Length)
-                    throw new EndOfStreamException();
-
-                return buffer;
-            }
+                return input?.ReadAllBytesToArrayAsync(cancellationToken);
         }
 
         /// <summary>

--- a/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
+++ b/osu.Framework/IO/Stores/StorageBackedResourceStore.cs
@@ -1,12 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using osu.Framework.Extensions;
 using osu.Framework.Platform;
 
 namespace osu.Framework.IO.Stores
@@ -28,35 +28,15 @@ namespace osu.Framework.IO.Stores
             this.LogIfNonBackgroundThread(name);
 
             using (Stream stream = storage.GetStream(name))
-            {
-                if (stream == null) return null;
-
-                byte[] buffer = new byte[stream.Length];
-                int readBytes = stream.Read(buffer, 0, buffer.Length);
-
-                if (readBytes < buffer.Length)
-                    throw new EndOfStreamException();
-
-                return buffer;
-            }
+                return stream?.ReadAllBytesToArray();
         }
 
-        public virtual async Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default)
+        public virtual Task<byte[]> GetAsync(string name, CancellationToken cancellationToken = default)
         {
             this.LogIfNonBackgroundThread(name);
 
             using (Stream stream = storage.GetStream(name))
-            {
-                if (stream == null) return null;
-
-                byte[] buffer = new byte[stream.Length];
-                int readBytes = await stream.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
-
-                if (readBytes < buffer.Length)
-                    throw new EndOfStreamException();
-
-                return buffer;
-            }
+                return stream?.ReadAllBytesToArrayAsync(cancellationToken);
         }
 
         public Stream GetStream(string name)

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -184,6 +184,9 @@ namespace osu.Framework.Platform
         {
             const int header_length = sizeof(int);
 
+            if (stream.Length < header_length)
+                return null;
+
             byte[] header = await stream.ReadBytesToArrayAsync(header_length, cancellationToken).ConfigureAwait(false);
 
             int contentLength = BitConverter.ToInt32(header, 0);

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -184,10 +184,12 @@ namespace osu.Framework.Platform
         {
             const int header_length = sizeof(int);
 
-            if (stream.Length < header_length)
-                return null;
+            byte[] header = new byte[header_length];
 
-            byte[] header = await stream.ReadBytesToArrayAsync(header_length, cancellationToken).ConfigureAwait(false);
+            int read = await stream.ReadAsync(header.AsMemory(), cancellationToken).ConfigureAwait(false);
+
+            if (read < header_length)
+                return null;
 
             int contentLength = BitConverter.ToInt32(header, 0);
 

--- a/osu.Framework/Platform/TcpIpcProvider.cs
+++ b/osu.Framework/Platform/TcpIpcProvider.cs
@@ -182,21 +182,16 @@ namespace osu.Framework.Platform
 
         private async Task<IpcMessage?> receive(Stream stream, CancellationToken cancellationToken = default)
         {
-            byte[] header = new byte[sizeof(int)];
-            int readBytes = await stream.ReadAsync(header.AsMemory(), cancellationToken).ConfigureAwait(false);
+            const int header_length = sizeof(int);
 
-            if (readBytes < header.Length)
-                throw new EndOfStreamException();
+            byte[] header = await stream.ReadBytesToArrayAsync(header_length, cancellationToken).ConfigureAwait(false);
 
-            int len = BitConverter.ToInt32(header, 0);
-            if (len == 0)
+            int contentLength = BitConverter.ToInt32(header, 0);
+
+            if (contentLength == 0)
                 return null;
 
-            byte[] data = new byte[len];
-            readBytes = await stream.ReadAsync(data.AsMemory(), cancellationToken).ConfigureAwait(false);
-
-            if (readBytes < data.Length)
-                throw new EndOfStreamException();
+            byte[] data = await stream.ReadBytesToArrayAsync(contentLength, cancellationToken).ConfigureAwait(false);
 
             string str = Encoding.UTF8.GetString(data);
 


### PR DESCRIPTION
Based loosely around the solution proposed [here](https://stackoverflow.com/a/221941).

The only thing I'm not 100% on is whether we should use the `EndOfStreamException` here as there could be a super edge case where a stream reads past the end of the expected length? Not sure that will ever happen though.

- [x] Depends on #5022