### PR TITLE
Bring Android build to zero warnings and cleanup configuration

### DIFF
--- a/SampleGame.Android/SampleGame.Android.csproj
+++ b/SampleGame.Android/SampleGame.Android.csproj
@@ -10,7 +10,6 @@
     <AndroidApplication>True</AndroidApplication>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SampleGameActivity.cs" />

--- a/SampleGame.Android/SampleGame.Android.csproj
+++ b/SampleGame.Android/SampleGame.Android.csproj
@@ -16,18 +16,9 @@
     <None Include="Properties\AndroidManifest.xml" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\osu.Framework.Android\osu.Framework.Android.csproj">
-      <Project>{4D112E30-462B-4264-B44D-53B61ABB185E}</Project>
-      <Name>osu.Framework.Android</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\osu.Framework\osu.Framework.csproj">
-      <Project>{c76bf5b3-985e-4d39-95fe-97c9c879b83a}</Project>
-      <Name>osu.Framework</Name>
-    </ProjectReference>
     <ProjectReference Include="..\SampleGame\SampleGame.csproj">
       <Project>{2A66DD92-ADB1-4994-89E2-C94E04ACDA0D}</Project>
       <Name>SampleGame</Name>
     </ProjectReference>
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/SampleGame.Android/SampleGame.Android.csproj
+++ b/SampleGame.Android/SampleGame.Android.csproj
@@ -7,9 +7,7 @@
     <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <RootNamespace>SampleGame.Android</RootNamespace>
     <AssemblyName>SampleGame.Android</AssemblyName>
-    <AndroidApplication>True</AndroidApplication>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="SampleGameActivity.cs" />

--- a/osu.Framework.Android.props
+++ b/osu.Framework.Android.props
@@ -31,7 +31,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugSymbols>false</DebugSymbols>
-    <DebugType>portable</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <AndroidManagedSymbols>false</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>

--- a/osu.Framework.Android.props
+++ b/osu.Framework.Android.props
@@ -11,8 +11,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidApplication>True</AndroidApplication>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
-    <!-- This does not take effect, unlike osu game repo.  -->
-    <!--<TargetFrameworkVersion>v10.0</TargetFrameworkVersion>-->
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>

--- a/osu.Framework.Android.props
+++ b/osu.Framework.Android.props
@@ -40,14 +40,6 @@
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
   </PropertyGroup>
   <ItemGroup>
-    <AndroidNativeLibrary Include="..\osu.Framework.Android\armeabi-v7a\*.so">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </AndroidNativeLibrary>
-    <AndroidNativeLibrary Include="..\osu.Framework.Android\arm64-v8a\*.so">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </AndroidNativeLibrary>
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />

--- a/osu.Framework.Android.props
+++ b/osu.Framework.Android.props
@@ -18,7 +18,6 @@
     <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <MandroidI18n>cjk,mideast,other,rare,west</MandroidI18n>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
@@ -29,6 +28,7 @@
     <AndroidManagedSymbols>false</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>true</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk>false</EmbedAssembliesIntoApk>
+    <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugSymbols>false</DebugSymbols>
@@ -37,6 +37,7 @@
     <AndroidManagedSymbols>false</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
   </PropertyGroup>
   <ItemGroup>
     <AndroidNativeLibrary Include="..\osu.Framework.Android\armeabi-v7a\*.so">

--- a/osu.Framework.Android.props
+++ b/osu.Framework.Android.props
@@ -46,4 +46,15 @@
     <Reference Include="Mono.Android" />
     <Reference Include="Java.Interop" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\osu.Framework.Android\osu.Framework.Android.csproj">
+      <Project>{4D112E30-462B-4264-B44D-53B61ABB185E}</Project>
+      <Name>osu.Framework.Android</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\osu.Framework\osu.Framework.csproj">
+      <Project>{C76BF5B3-985E-4D39-95FE-97C9C879B83A}</Project>
+      <Name>osu.Framework</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/osu.Framework.Android.props
+++ b/osu.Framework.Android.props
@@ -22,7 +22,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DebugSymbols>True</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>False</Optimize>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <AndroidManagedSymbols>false</AndroidManagedSymbols>
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugSymbols>false</DebugSymbols>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <AndroidManagedSymbols>false</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>

--- a/osu.Framework.Android/osu.Framework.Android.csproj
+++ b/osu.Framework.Android/osu.Framework.Android.csproj
@@ -26,6 +26,8 @@
     <PackageReference Include="ppy.osuTK.Android" Version="1.0.187" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\**\*.so" />
+    <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\arm64-v8a\*.so" />
+    <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\armeabi-v7a\*.so" />
+    <EmbeddedNativeLibrary Include="$(MSBuildThisFileDirectory)\x86\*.so" />
   </ItemGroup>
 </Project>

--- a/osu.Framework.Tests.Android/osu.Framework.Tests.Android.csproj
+++ b/osu.Framework.Tests.Android/osu.Framework.Tests.Android.csproj
@@ -24,17 +24,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\osu.Framework.Android\osu.Framework.Android.csproj">
-      <Project>{4d112e30-462b-4264-b44d-53b61abb185e}</Project>
-      <Name>osu.Framework.Android</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\osu.Framework\osu.Framework.csproj">
-      <Project>{c76bf5b3-985e-4d39-95fe-97c9c879b83a}</Project>
-      <Name>osu.Framework</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="System.Numerics" />
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/osu.Framework.Tests.Android/osu.Framework.Tests.Android.csproj
+++ b/osu.Framework.Tests.Android/osu.Framework.Tests.Android.csproj
@@ -10,7 +10,6 @@
     <AssemblyName>osu.Framework.Tests.Android</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestGameActivity.cs" />

--- a/osu.Framework.Tests.Android/osu.Framework.Tests.Android.csproj
+++ b/osu.Framework.Tests.Android/osu.Framework.Tests.Android.csproj
@@ -1,7 +1,6 @@
 ﻿<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\osu.Framework.Android.props" />
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{320089C6-A141-4D3E-BD5F-C4A6CE9E567B}</ProjectGuid>
@@ -9,7 +8,6 @@
     <RootNamespace>osu.Framework.Tests.Android</RootNamespace>
     <AssemblyName>osu.Framework.Tests.Android</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidSupportedAbis>armeabi-v7a;x86;arm64-v8a</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="TestGameActivity.cs" />


### PR DESCRIPTION
Sample of the warnings we currently get:

### [XA0119](https://github.com/xamarin/xamarin-android/blob/main/Documentation/guides/messages/xa0119.md)
- C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Xamarin\Android\Xamarin.Android.Common.targets(434,3): Warning XA0119 : Using fast deployment and the linker at the same time is not recommended. Use fast deployment for Debug configurations and the linker for Release configurations.

- The docs also suggest to `<UseInterpreter>true</UseInterpreter>` for hot reload support, but this makes the game really laggy.

### [XA0125](https://github.com/xamarin/xamarin-android/blob/main/Documentation/guides/messages/xa0125.md)
- C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Xamarin\Android\Xamarin.Android.Legacy.targets(400,5): Warning XA0125 : 'osu.Framework.Tests.Android.pdb' is using a deprecated debug information level.
Set the debugging information to Portable in the Visual Studio project property pages or edit the project file in a text editor and set the 'DebugType' MSBuild property to 'portable' to use the newer, cross-platform debug information level.

- changed `DebugType` use the same as [`osu.Android.props`](https://github.com/ppy/osu/blob/b06caf2bf7b3a8705d26101f5e1fba464542a701/osu.Android.props#L25-L34)

### [XA4301](https://docs.microsoft.com/en-us/xamarin/android/errors-and-warnings/xa4301)
- C:\...\osu-framework\osu.Framework.Tests.Android\obj\Debug\100\lp\1\nl\arm64-v8a\libavcodec.so:
Warning XA4301 : APK already contains the item lib/arm64-v8a/libavcodec.so; ignoring.

---

Also used this opportunity to cleanup the Android `.props` and `.csproj` files. Just some cleanup work, no changes to build.

Tested to build and install fine on Rider 2021.3.3 and VS 2022.