### PR TITLE
Cleanup Android (and use fullscreen by default)

### DIFF
--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -63,7 +63,7 @@ namespace osu.Framework.Android
 
             SetContentView(gameView = new AndroidGameView(this, CreateGame()));
 
-            UIVisibilityFlags = SystemUiFlags.LayoutFlags | SystemUiFlags.ImmersiveSticky | SystemUiFlags.HideNavigation;
+            UIVisibilityFlags = SystemUiFlags.LayoutFlags | SystemUiFlags.ImmersiveSticky | SystemUiFlags.HideNavigation | SystemUiFlags.Fullscreen;
 
             // Firing up the on-screen keyboard (eg: interacting with textboxes) may cause the UI visibility flags to be altered thus showing the navigation bar and potentially the status bar
             // This sets back the UI flags to hidden once the interaction with the on-screen keyboard has finished.

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -93,16 +93,16 @@ namespace osu.Framework.Android
             };
         }
 
-        protected override void OnPause()
+        protected override void OnStop()
         {
-            base.OnPause();
+            base.OnStop();
             gameView.Host?.Suspend();
             Bass.Pause();
         }
 
-        protected override void OnResume()
+        protected override void OnRestart()
         {
-            base.OnResume();
+            base.OnRestart();
             gameView.Host?.Resume();
             Bass.Start();
         }

--- a/osu.Framework.Android/AndroidGameActivity.cs
+++ b/osu.Framework.Android/AndroidGameActivity.cs
@@ -8,6 +8,7 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using ManagedBass;
+using Debug = System.Diagnostics.Debug;
 
 namespace osu.Framework.Android
 {
@@ -34,9 +35,14 @@ namespace osu.Framework.Android
         /// </summary>
         public SystemUiFlags UIVisibilityFlags
         {
-            get => (SystemUiFlags)Window.DecorView.SystemUiVisibility;
+            get
+            {
+                Debug.Assert(Window != null);
+                return (SystemUiFlags)Window.DecorView.SystemUiVisibility;
+            }
             set
             {
+                Debug.Assert(Window != null);
                 systemUiFlags = value;
                 Window.DecorView.SystemUiVisibility = (StatusBarVisibility)value;
             }
@@ -65,6 +71,8 @@ namespace osu.Framework.Android
 
             UIVisibilityFlags = SystemUiFlags.LayoutFlags | SystemUiFlags.ImmersiveSticky | SystemUiFlags.HideNavigation | SystemUiFlags.Fullscreen;
 
+            Debug.Assert(Window != null);
+
             // Firing up the on-screen keyboard (eg: interacting with textboxes) may cause the UI visibility flags to be altered thus showing the navigation bar and potentially the status bar
             // This sets back the UI flags to hidden once the interaction with the on-screen keyboard has finished.
             Window.DecorView.SystemUiVisibilityChange += (_, e) =>
@@ -76,7 +84,10 @@ namespace osu.Framework.Android
             };
 
             if (Build.VERSION.SdkInt >= BuildVersionCodes.P)
+            {
+                Debug.Assert(Window.Attributes != null);
                 Window.Attributes.LayoutInDisplayCutoutMode = LayoutInDisplayCutoutMode.ShortEdges;
+            }
 
             gameView.HostStarted += host =>
             {

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -75,14 +75,12 @@ namespace osu.Framework.Android
 
         public override void OpenUrlExternally(string url)
         {
-            var activity = (Activity)gameView.Context;
-
-            if (activity?.PackageManager == null) return;
+            if (gameView.Activity.PackageManager == null) return;
 
             using (var intent = new Intent(Intent.ActionView, Uri.Parse(url)))
             {
-                if (intent.ResolveActivity(activity.PackageManager) != null)
-                    activity.StartActivity(intent);
+                if (intent.ResolveActivity(gameView.Activity.PackageManager) != null)
+                    gameView.Activity.StartActivity(intent);
             }
         }
 

--- a/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
+++ b/osu.Framework.Android/Input/AndroidKeyboardHandler.cs
@@ -81,10 +81,10 @@ namespace osu.Framework.Android.Input
                 return Key.A + code - first_letter_key;
 
             // function keys
-            const int first_funtion_key = (int)Keycode.F1;
+            const int first_function_key = (int)Keycode.F1;
             const int last_function_key = (int)Keycode.F12;
-            if (code >= first_funtion_key && code <= last_function_key)
-                return Key.F1 + code - first_funtion_key;
+            if (code >= first_function_key && code <= last_function_key)
+                return Key.F1 + code - first_function_key;
 
             // keypad keys
             const int first_keypad_key = (int)Keycode.Numpad0;

--- a/osu.Framework.Android/Input/AndroidTextInput.cs
+++ b/osu.Framework.Android/Input/AndroidTextInput.cs
@@ -11,16 +11,12 @@ namespace osu.Framework.Android.Input
     public class AndroidTextInput : TextInputSource
     {
         private readonly AndroidGameView view;
-        private readonly AndroidGameActivity activity;
         private readonly InputMethodManager inputMethodManager;
 
         public AndroidTextInput(AndroidGameView view)
         {
             this.view = view;
-            activity = (AndroidGameActivity)view.Context;
-
-            if (view.Context != null)
-                inputMethodManager = view.Context.GetSystemService(Context.InputMethodService) as InputMethodManager;
+            inputMethodManager = view.Activity.GetSystemService(Context.InputMethodService) as InputMethodManager;
         }
 
         private void commitText(string text)
@@ -39,7 +35,7 @@ namespace osu.Framework.Android.Input
             view.KeyDown += keyDown;
             view.CommitText += commitText;
 
-            activity.RunOnUiThread(() =>
+            view.Activity.RunOnUiThread(() =>
             {
                 view.RequestFocus();
                 inputMethodManager?.ShowSoftInput(view, 0);
@@ -48,7 +44,7 @@ namespace osu.Framework.Android.Input
 
         protected override void EnsureTextInputActivated(bool allowIme)
         {
-            activity.RunOnUiThread(() =>
+            view.Activity.RunOnUiThread(() =>
             {
                 view.RequestFocus();
                 inputMethodManager?.ShowSoftInput(view, 0);
@@ -60,7 +56,7 @@ namespace osu.Framework.Android.Input
             view.KeyDown -= keyDown;
             view.CommitText -= commitText;
 
-            activity.RunOnUiThread(() =>
+            view.Activity.RunOnUiThread(() =>
             {
                 inputMethodManager?.HideSoftInputFromWindow(view.WindowToken, HideSoftInputFlags.None);
                 view.ClearFocus();

--- a/osu.Framework.Tests.Android/TestGameActivity.cs
+++ b/osu.Framework.Tests.Android/TestGameActivity.cs
@@ -13,12 +13,5 @@ namespace osu.Framework.Tests.Android
     {
         protected override Game CreateGame()
             => new VisualTestGame();
-
-        protected override void OnCreate(Bundle savedInstanceState)
-        {
-            base.OnCreate(savedInstanceState);
-
-            Window.AddFlags(WindowManagerFlags.Fullscreen);
-        }
     }
 }


### PR DESCRIPTION
5161624f036e68e82672a6232b2579964dce6bbb **Use correct lifecycle methods for suspending and resuming host**
- the host would get suspended (even it was visible) when using split-screen on older android version (in Android 9 and lower) https://source.android.com/devices/tech/display/multi_display/multi-resume
- more info: https://developer.android.com/guide/components/activities/activity-lifecycle#alc - the image explains it well

dac31eb47340ca40ee52ad6a5565fa09d6d60783 **Always hide the status bar**
- we don't really support showing the status bar right now, so it's best to always hide it
- this matches iOS system bars behaviour
- can be revisited in the future if there is demand for showing it