### PR TITLE
Use `View` properties instead of osuTK ones for calculating `SafeArea`

### DIFF
--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -218,7 +218,7 @@ namespace osu.Framework.Android
 
             int[] location = new int[2];
             GetLocationOnScreen(location);
-            var viewArea = new RectangleI(location[0], location[1], (this as View).Width, (this as View).Height);
+            var viewArea = new RectangleI(location[0], location[1], ((View)this).Width, ((View)this).Height);
 
             // intersect with the usable area and treat the the difference as unsafe.
 

--- a/osu.Framework.Android/AndroidGameView.cs
+++ b/osu.Framework.Android/AndroidGameView.cs
@@ -162,14 +162,12 @@ namespace osu.Framework.Android
         public void RenderGame()
         {
             LayoutChange += (_, __) => updateSafeArea();
+            updateSafeArea();
 
             Host = new AndroidGameHost(this);
             Host.ExceptionThrown += handleException;
             Host.Run(game);
             HostStarted?.Invoke(Host);
-
-            // if this is run immediately, we'll have an invalid layout (Width == Height == 0).
-            Host.InputThread.Scheduler.Add(updateSafeArea);
         }
 
         private bool handleException(Exception ex)
@@ -220,7 +218,7 @@ namespace osu.Framework.Android
 
             int[] location = new int[2];
             GetLocationOnScreen(location);
-            var viewArea = new RectangleI(location[0], location[1], Width, Height);
+            var viewArea = new RectangleI(location[0], location[1], (this as View).Width, (this as View).Height);
 
             // intersect with the usable area and treat the the difference as unsafe.
 


### PR DESCRIPTION
Width and Height default to the ones in `GameViewBase`, no wonder they were invalid.

Since the native View properties are valid on creation, we can update earlier.