### PR TITLE
Don't subscribe to pointer capture events on unsupported Android devices

### DIFF
--- a/osu.Framework.Android/Input/AndroidMouseHandler.cs
+++ b/osu.Framework.Android/Input/AndroidMouseHandler.cs
@@ -82,21 +82,27 @@ namespace osu.Framework.Android.Input
             {
                 if (enabled.NewValue)
                 {
-                    View.CapturedPointer += HandleCapturedPointer;
                     View.GenericMotion += HandleGenericMotion;
                     View.Hover += HandleHover;
                     View.KeyDown += HandleKeyDown;
                     View.KeyUp += HandleKeyUp;
                     View.Touch += HandleTouch;
+
+                    // Pointer capture is only available on Android 8.0 and up
+                    if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+                        View.CapturedPointer += HandleCapturedPointer;
                 }
                 else
                 {
-                    View.CapturedPointer -= HandleCapturedPointer;
                     View.GenericMotion -= HandleGenericMotion;
                     View.Hover -= HandleHover;
                     View.KeyDown -= HandleKeyDown;
                     View.KeyUp -= HandleKeyUp;
                     View.Touch -= HandleTouch;
+
+                    // Pointer capture is only available on Android 8.0 and up
+                    if (Build.VERSION.SdkInt >= BuildVersionCodes.O)
+                        View.CapturedPointer -= HandleCapturedPointer;
                 }
 
                 updatePointerCapture();


### PR DESCRIPTION
Closes #5030.

All the other events in `AndroidMouseHandler` have been added prior to API 21 and as such do not require their own guards.

@Susko3 please test that this doesn't regress any mouse capture functionality from #4989 as I lack the requisite hardware.