### PR TITLE
Add support for gradiented border colour

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneBorderColour.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneBorderColour.cs
@@ -1,0 +1,47 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Drawables
+{
+    public class TestSceneBorderColour : FrameworkTestScene
+    {
+        [Test]
+        public void TestSolidBorder()
+        {
+            Container container = null;
+
+            AddStep("create box with solid border", () => Child = container = new Container
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(200),
+                Masking = true,
+                BorderThickness = 5,
+                BorderColour = Colour4.Red,
+                Child = new Box
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Colour = Colour4.Blue
+                }
+            });
+
+            AddSliderStep("change corner radius", 0, 100, 0, radius =>
+            {
+                if (container != null)
+                    container.CornerRadius = radius;
+            });
+
+            AddSliderStep("change corner exponent", 0.1f, 10, 1, exponent =>
+            {
+                if (container != null)
+                    container.CornerExponent = exponent;
+            });
+        }
+    }
+}

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneBorderColour.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneBorderColour.cs
@@ -23,9 +23,21 @@ namespace osu.Framework.Tests.Visual.Drawables
             ColourInfo.GradientVertical(Colour4.White, Colour4.Black),
             ColourInfo.GradientHorizontal(Colour4.Red, Colour4.Blue));
 
+        [Test]
+        public void TestAllFourCorners() => createBorderTest(
+            Colour4.Aquamarine,
+            new ColourInfo
+            {
+                TopLeft = Colour4.Red,
+                TopRight = Colour4.Yellow,
+                BottomLeft = Colour4.Magenta,
+                BottomRight = Colour4.Blue
+            });
+
         private void createBorderTest(ColourInfo fillColour, ColourInfo borderColour)
         {
             Container container = null;
+            Box box = null;
 
             AddStep("create box with solid border", () => Child = container = new Container
             {
@@ -35,12 +47,14 @@ namespace osu.Framework.Tests.Visual.Drawables
                 Masking = true,
                 BorderThickness = 5,
                 BorderColour = borderColour,
-                Child = new Box
+                Child = box = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
                     Colour = fillColour
                 }
             });
+
+            AddToggleStep("switch fill to border colour", useBorderColour => box.Colour = useBorderColour ? borderColour : fillColour);
 
             AddSliderStep("change corner radius", 0, 100, 0, radius =>
             {

--- a/osu.Framework.Tests/Visual/Drawables/TestSceneBorderColour.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneBorderColour.cs
@@ -3,6 +3,7 @@
 
 using NUnit.Framework;
 using osu.Framework.Graphics;
+using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
 using osuTK;
@@ -12,7 +13,17 @@ namespace osu.Framework.Tests.Visual.Drawables
     public class TestSceneBorderColour : FrameworkTestScene
     {
         [Test]
-        public void TestSolidBorder()
+        public void TestSolidBorder() => createBorderTest(Colour4.Blue, Colour4.Red);
+
+        [Test]
+        public void TestVerticalGradientBorder() => createBorderTest(Colour4.Green, ColourInfo.GradientVertical(Colour4.Black, Colour4.White));
+
+        [Test]
+        public void TestHorizontalGradientBorder() => createBorderTest(
+            ColourInfo.GradientVertical(Colour4.White, Colour4.Black),
+            ColourInfo.GradientHorizontal(Colour4.Red, Colour4.Blue));
+
+        private void createBorderTest(ColourInfo fillColour, ColourInfo borderColour)
         {
             Container container = null;
 
@@ -23,11 +34,11 @@ namespace osu.Framework.Tests.Visual.Drawables
                 Size = new Vector2(200),
                 Masking = true,
                 BorderThickness = 5,
-                BorderColour = Colour4.Red,
+                BorderColour = borderColour,
                 Child = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = Colour4.Blue
+                    Colour = fillColour
                 }
             });
 

--- a/osu.Framework/Graphics/Colour/ColourInfo.cs
+++ b/osu.Framework/Graphics/Colour/ColourInfo.cs
@@ -122,6 +122,14 @@ namespace osu.Framework.Graphics.Colour
             BottomRight = newBottomRight;
         }
 
+        internal static ColourInfo Multiply(ColourInfo first, ColourInfo second) => new ColourInfo
+        {
+            TopLeft = first.TopLeft * second.TopLeft,
+            BottomLeft = first.BottomLeft * second.BottomLeft,
+            TopRight = first.TopRight * second.TopRight,
+            BottomRight = first.BottomRight * second.BottomRight
+        };
+
         /// <summary>
         /// Created a new ColourInfo with the alpha value of the colours of all vertices
         /// multiplied by a given alpha parameter.

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1530,13 +1530,13 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        private SRGBColour borderColour = Color4.Black;
+        private ColourInfo borderColour = Color4.Black;
 
         /// <summary>
         /// Determines the color of the border controlled by <see cref="BorderThickness"/>.
         /// Only has an effect when <see cref="Masking"/> is true.
         /// </summary>
-        public SRGBColour BorderColour
+        public ColourInfo BorderColour
         {
             get => borderColour;
             protected set

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -193,7 +193,7 @@ namespace osu.Framework.Graphics.Containers
                 {
                     MaskingInfo info = maskingInfo.Value;
                     if (info.BorderThickness > 0)
-                        info.BorderColour *= DrawColourInfo.Colour.AverageColour;
+                        info.BorderColour = ColourInfo.Multiply(info.BorderColour, DrawColourInfo.Colour);
 
                     GLWrapper.PushMaskingInfo(info);
                 }

--- a/osu.Framework/Graphics/Containers/Container.cs
+++ b/osu.Framework/Graphics/Containers/Container.cs
@@ -377,7 +377,7 @@ namespace osu.Framework.Graphics.Containers
         /// Determines the color of the border controlled by <see cref="BorderThickness"/>.
         /// Only has an effect when <see cref="Masking"/> is true.
         /// </summary>
-        public new SRGBColour BorderColour
+        public new ColourInfo BorderColour
         {
             get => base.BorderColour;
             set => base.BorderColour = value;

--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -701,11 +701,27 @@ namespace osu.Framework.Graphics.OpenGL
 
             if (maskingInfo.BorderThickness > 0)
             {
-                GlobalPropertyManager.Set(GlobalProperty.BorderColour, new Vector4(
-                    maskingInfo.BorderColour.Linear.R,
-                    maskingInfo.BorderColour.Linear.G,
-                    maskingInfo.BorderColour.Linear.B,
-                    maskingInfo.BorderColour.Linear.A));
+                GlobalPropertyManager.Set(GlobalProperty.BorderColour, new Matrix4(
+                    // TopLeft
+                    maskingInfo.BorderColour.TopLeft.Linear.R,
+                    maskingInfo.BorderColour.TopLeft.Linear.G,
+                    maskingInfo.BorderColour.TopLeft.Linear.B,
+                    maskingInfo.BorderColour.TopLeft.Linear.A,
+                    // BottomLeft
+                    maskingInfo.BorderColour.BottomLeft.Linear.R,
+                    maskingInfo.BorderColour.BottomLeft.Linear.G,
+                    maskingInfo.BorderColour.BottomLeft.Linear.B,
+                    maskingInfo.BorderColour.BottomLeft.Linear.A,
+                    // TopRight
+                    maskingInfo.BorderColour.TopRight.Linear.R,
+                    maskingInfo.BorderColour.TopRight.Linear.G,
+                    maskingInfo.BorderColour.TopRight.Linear.B,
+                    maskingInfo.BorderColour.TopRight.Linear.A,
+                    // BottomRight
+                    maskingInfo.BorderColour.BottomRight.Linear.R,
+                    maskingInfo.BorderColour.BottomRight.Linear.G,
+                    maskingInfo.BorderColour.BottomRight.Linear.B,
+                    maskingInfo.BorderColour.BottomRight.Linear.A));
             }
 
             GlobalPropertyManager.Set(GlobalProperty.MaskingBlendRange, maskingInfo.BlendRange);
@@ -985,7 +1001,7 @@ namespace osu.Framework.Graphics.OpenGL
         public float CornerExponent;
 
         public float BorderThickness;
-        public SRGBColour BorderColour;
+        public ColourInfo BorderColour;
 
         public float BlendRange;
         public float AlphaExponent;

--- a/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
+++ b/osu.Framework/Graphics/Shaders/GlobalPropertyManager.cs
@@ -25,7 +25,7 @@ namespace osu.Framework.Graphics.Shaders
             global_properties[(int)GlobalProperty.CornerRadius] = new UniformMapping<float>("g_CornerRadius");
             global_properties[(int)GlobalProperty.CornerExponent] = new UniformMapping<float>("g_CornerExponent");
             global_properties[(int)GlobalProperty.BorderThickness] = new UniformMapping<float>("g_BorderThickness");
-            global_properties[(int)GlobalProperty.BorderColour] = new UniformMapping<Vector4>("g_BorderColour");
+            global_properties[(int)GlobalProperty.BorderColour] = new UniformMapping<Matrix4>("g_BorderColour");
             global_properties[(int)GlobalProperty.MaskingBlendRange] = new UniformMapping<float>("g_MaskingBlendRange");
             global_properties[(int)GlobalProperty.AlphaExponent] = new UniformMapping<float>("g_AlphaExponent");
             global_properties[(int)GlobalProperty.EdgeOffset] = new UniformMapping<Vector2>("g_EdgeOffset");

--- a/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
+++ b/osu.Framework/Graphics/Visualisation/DrawVisualiser.cs
@@ -253,7 +253,7 @@ namespace osu.Framework.Graphics.Visualisation
                     if (!composite.Masking)
                         return;
 
-                    if (composite.BorderThickness > 0 && composite.BorderColour.Linear.A > 0
+                    if (composite.BorderThickness > 0 && composite.BorderColour.MinAlpha > 0
                         || composite.EdgeEffect.Type != EdgeEffectType.None && composite.EdgeEffect.Radius > 0 && composite.EdgeEffect.Colour.Linear.A > 0)
                     {
                         drawableTarget = composite;

--- a/osu.Framework/Resources/Shaders/sh_Masking.h
+++ b/osu.Framework/Resources/Shaders/sh_Masking.h
@@ -7,7 +7,7 @@ uniform highp float g_CornerRadius;
 uniform highp float g_CornerExponent;
 uniform highp vec4 g_MaskingRect;
 uniform highp float g_BorderThickness;
-uniform lowp vec4 g_BorderColour;
+uniform lowp mat4 g_BorderColour;
 
 uniform mediump float g_MaskingBlendRange;
 
@@ -59,6 +59,14 @@ highp float distanceFromDrawingRect(mediump vec2 texCoord)
 	return max(xyDistance.x, xyDistance.y);
 }
 
+lowp vec4 getBorderColourAt(mediump vec2 texCoord)
+{
+    highp vec2 relativeTexCoord = texCoord / (v_TexRect.zw - v_TexRect.xy);
+    lowp vec4 top = mix(g_BorderColour[0], g_BorderColour[2], relativeTexCoord.x);
+    lowp vec4 bottom = mix(g_BorderColour[1], g_BorderColour[3], relativeTexCoord.x);
+    return mix(top, bottom, relativeTexCoord.y);
+}
+
 lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 {
 	highp float dist = distanceFromRoundedRect(vec2(0.0), g_CornerRadius);
@@ -104,13 +112,15 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 	highp float borderStart = 1.0 + fadeStart - g_BorderThickness;
 	lowp float colourWeight = min(borderStart - dist, 1.0);
 
+	lowp vec4 borderColour = getBorderColourAt(texCoord);
+
 	if (colourWeight <= 0.0)
 	{
-		return toSRGB(vec4(g_BorderColour.rgb, g_BorderColour.a * alphaFactor));
+		return toSRGB(vec4(borderColour.rgb, borderColour.a * alphaFactor));
 	}
 
 	lowp vec4 dest = toSRGB(vec4(v_Colour.rgb, v_Colour.a * alphaFactor)) * texel;
-	lowp vec4 src = vec4(g_BorderColour.rgb, g_BorderColour.a * (1.0 - colourWeight));
+	lowp vec4 src = vec4(borderColour.rgb, borderColour.a * (1.0 - colourWeight));
 
 	return blend(toSRGB(src), dest);
 }

--- a/osu.Framework/Resources/Shaders/sh_Masking.h
+++ b/osu.Framework/Resources/Shaders/sh_Masking.h
@@ -59,9 +59,9 @@ highp float distanceFromDrawingRect(mediump vec2 texCoord)
 	return max(xyDistance.x, xyDistance.y);
 }
 
-lowp vec4 getBorderColourAt(mediump vec2 texCoord)
+lowp vec4 getBorderColour()
 {
-    highp vec2 relativeTexCoord = texCoord / (v_TexRect.zw - v_TexRect.xy);
+    highp vec2 relativeTexCoord = v_MaskingPosition / (g_MaskingRect.zw - g_MaskingRect.xy);
     lowp vec4 top = mix(g_BorderColour[0], g_BorderColour[2], relativeTexCoord.x);
     lowp vec4 bottom = mix(g_BorderColour[1], g_BorderColour[3], relativeTexCoord.x);
     return mix(top, bottom, relativeTexCoord.y);
@@ -112,7 +112,7 @@ lowp vec4 getRoundedColor(lowp vec4 texel, mediump vec2 texCoord)
 	highp float borderStart = 1.0 + fadeStart - g_BorderThickness;
 	lowp float colourWeight = min(borderStart - dist, 1.0);
 
-	lowp vec4 borderColour = getBorderColourAt(texCoord);
+	lowp vec4 borderColour = getBorderColour();
 
 	if (colourWeight <= 0.0)
 	{


### PR DESCRIPTION
PRing this as a proposal.

Some of the [newer](https://www.figma.com/file/NkdREXr6wFkA99oLw8PnBv/Client%2FMod-Selection?node-id=0%3A17) [figma designs](https://www.figma.com/file/NkdREXr6wFkA99oLw8PnBv/Client%2FMod-Selection?node-id=0%3A17) feature subtle but very present gradient effects on some border elements:

<details>
<summary>see examples</summary>

| example from mod select design | example from chat design |
| :-: | :-: |
| ![2022-02-13-170241_162x306_scrot](https://user-images.githubusercontent.com/20418176/153761668-9a87e6b1-90f4-4df1-977e-a593d8189881.png) | ![2022-02-13-170301_189x184_scrot](https://user-images.githubusercontent.com/20418176/153761666-07a1c63e-4c57-4261-ba64-11bb21090976.png) |

</details>

While this does not necessarily need framework support, as a plausible workaround would be to nest two `CompositeDrawable`s - one larger with the gradient effect, and one smaller inside it with the solid colour, it feels rather finicky to do. So this PR is a proposal of how this could be supported natively.

Test coverage included:

https://user-images.githubusercontent.com/20418176/153761948-570d7a3e-e4c2-451c-8028-9659b45f4fb9.mp4

- [ ] Needs testing on iOS to make sure there are no problems with the shader (my initial version had similar issues as #4702, which I worked around by using masking attributes which are `highp`, so should hopefully work - it does on Android, at least).

---

# Breaking changes

## `CompositeDrawable.BorderColour` has changed type from `SRGBColour` to `ColourInfo`

To facilitate gradiented border support, the type of `CompositeDrawable.BorderColour` has changed from `SRGBColour` to `ColourInfo`. While some implicit conversions from `SRGBColour` to `ColourInfo` exist, some properties of `SRGBColour` are not available on `ColourInfo`, as the latter does not always represent a single colour, and may require appropriate adjustments.