### PR TITLE
Add separate build script for xamarin packing

### DIFF
--- a/appveyor_xamarin_deploy.yml
+++ b/appveyor_xamarin_deploy.yml
@@ -1,10 +1,10 @@
 clone_depth: 1
 version: '{build}'
-image: Visual Studio 2022
+image: Visual Studio 2019
 test: off
 skip_non_tags: true
 build_script:
-  - cmd: PowerShell -Version 2.0 .\build.ps1 -Target DeployFrameworkDesktop
+  - cmd: PowerShell -Version 2.0 .\build.ps1 -Target DeployFrameworkXamarin
 deploy:
   - provider: Environment
     name: nuget

--- a/build/build.cake
+++ b/build/build.cake
@@ -235,10 +235,16 @@ Task("Build")
     .IsDependentOn("PackTemplate")
     .IsDependentOn("Publish");
 
-Task("DeployFramework")
+Task("DeployFrameworkDesktop")
     .IsDependentOn("Clean")
     .IsDependentOn("DetermineAppveyorDeployProperties")
     .IsDependentOn("PackFramework")
+    .IsDependentOn("PackTemplate")
+    .IsDependentOn("Publish");
+
+Task("DeployFrameworkXamarin")
+    .IsDependentOn("Clean")
+    .IsDependentOn("DetermineAppveyorDeployProperties")
     .IsDependentOn("PackiOSFramework")
     .IsDependentOn("PackAndroidFramework")
     .IsDependentOn("PackTemplate")

--- a/build/build.cake
+++ b/build/build.cake
@@ -247,7 +247,6 @@ Task("DeployFrameworkXamarin")
     .IsDependentOn("DetermineAppveyorDeployProperties")
     .IsDependentOn("PackiOSFramework")
     .IsDependentOn("PackAndroidFramework")
-    .IsDependentOn("PackTemplate")
     .IsDependentOn("Publish");
 
 Task("DeployNativeLibs")


### PR DESCRIPTION
Minimal required changes to get nuget packing working again on appveyor.  Basically, xamarin builds need the 2019 image, while net6.0 requires the 2022 image.

Example passing runs:
https://ci.appveyor.com/project/peppy/osu-framework-ecq46/builds/42564987
https://ci.appveyor.com/project/peppy/osu-framework-a4n7e/builds/42565005