### PR TITLE
Fix crash in `SafeAreaContainer` when working with negative sizing

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaOverrides.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneSafeAreaOverrides.cs
@@ -17,6 +17,9 @@ namespace osu.Framework.Tests.Visual.Containers
             FillFlowContainer<OverrideTestContainer> container;
             Child = container = new FillFlowContainer<OverrideTestContainer>
             {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                AutoSizeAxes = Axes.Both,
                 Direction = FillDirection.Horizontal,
                 Margin = new MarginPadding(20),
                 Spacing = new Vector2(20),
@@ -35,6 +38,15 @@ namespace osu.Framework.Tests.Visual.Containers
 
             foreach (var child in container.Children)
                 addBoxAssert(child);
+
+            AddStep("Ensure negative size handles correctly", () =>
+            {
+                foreach (var child in container.Children)
+                {
+                    child.SafeAreaContainer.Size = -child.SafeAreaContainer.Size;
+                    child.SafeAreaContainer.Position = -child.SafeAreaContainer.Position;
+                }
+            });
         }
 
         private void addBoxAssert(OverrideTestContainer container)

--- a/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
+++ b/osu.Framework/Graphics/Containers/SafeAreaContainer.cs
@@ -7,6 +7,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Layout;
+using osuTK;
 
 namespace osu.Framework.Graphics.Containers
 {
@@ -75,12 +76,14 @@ namespace osu.Framework.Graphics.Containers
             var localTopLeft = safeArea.ToSpaceOfOtherDrawable(paddedRect.TopLeft, this);
             var localBottomRight = safeArea.ToSpaceOfOtherDrawable(paddedRect.BottomRight, this);
 
+            Vector2 absDrawSize = new Vector2(Math.Abs(DrawWidth), Math.Abs(DrawHeight));
+
             return new MarginPadding
             {
-                Left = SafeAreaOverrideEdges.HasFlagFast(Edges.Left) ? nonSafeLocalSpace.TopLeft.X : Math.Clamp(localTopLeft.X, 0, DrawSize.X),
-                Right = SafeAreaOverrideEdges.HasFlagFast(Edges.Right) ? DrawRectangle.BottomRight.X - nonSafeLocalSpace.BottomRight.X : Math.Clamp(DrawSize.X - localBottomRight.X, 0, DrawSize.X),
-                Top = SafeAreaOverrideEdges.HasFlagFast(Edges.Top) ? nonSafeLocalSpace.TopLeft.Y : Math.Clamp(localTopLeft.Y, 0, DrawSize.Y),
-                Bottom = SafeAreaOverrideEdges.HasFlagFast(Edges.Bottom) ? DrawRectangle.BottomRight.Y - nonSafeLocalSpace.BottomRight.Y : Math.Clamp(DrawSize.Y - localBottomRight.Y, 0, DrawSize.Y)
+                Left = SafeAreaOverrideEdges.HasFlagFast(Edges.Left) ? nonSafeLocalSpace.TopLeft.X : Math.Clamp(localTopLeft.X, 0, absDrawSize.X),
+                Right = SafeAreaOverrideEdges.HasFlagFast(Edges.Right) ? DrawRectangle.BottomRight.X - nonSafeLocalSpace.BottomRight.X : Math.Clamp(absDrawSize.X - localBottomRight.X, 0, absDrawSize.X),
+                Top = SafeAreaOverrideEdges.HasFlagFast(Edges.Top) ? nonSafeLocalSpace.TopLeft.Y : Math.Clamp(localTopLeft.Y, 0, absDrawSize.Y),
+                Bottom = SafeAreaOverrideEdges.HasFlagFast(Edges.Bottom) ? DrawRectangle.BottomRight.Y - nonSafeLocalSpace.BottomRight.Y : Math.Clamp(absDrawSize.Y - localBottomRight.Y, 0, absDrawSize.Y)
             };
         }
     }


### PR DESCRIPTION
I'm not 100% sure this will provide the correct behaviour when negatively sized. It's hard to tell what the expectation would be in this case (sizing the `SafeAreaContainer` in this manner will give completely unexpected results unless it completely ignores the negative component... since the intention of these containers is to handle device edge scenarios).

Fixes https://github.com/ppy/osu-framework/issues/5015.