### PR TITLE
Fix sub-menu getting an invalid position when parent menu is transferred to another drawable

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
@@ -32,6 +32,48 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [SetUp]
         public void Setup() => Schedule(Clear);
 
+        /// <summary>
+        /// Tests an edge case where the submenu is visible and continues updating for a short period of time after right clicking another item.
+        /// In such a case, the submenu should not update its position unless it's open.
+        /// </summary>
+        [Test]
+        public void TestNestedMenuTransferredWithFadeOut()
+        {
+            BoxWithNestedContextMenuItems box1 = null;
+            BoxWithNestedContextMenuItems box2 = null;
+
+            AddStep("setup", () =>
+            {
+                Child = new TestContextMenuContainerWithFade
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    Child = new FillFlowContainer
+                    {
+                        AutoSizeAxes = Axes.Both,
+                        Direction = FillDirection.Horizontal,
+                        Spacing = new Vector2(10),
+                        Children = new[]
+                        {
+                            box1 = new BoxWithNestedContextMenuItems { Size = new Vector2(100) },
+                            box2 = new BoxWithNestedContextMenuItems { Size = new Vector2(100) }
+                        }
+                    }
+                };
+            });
+
+            clickBoxStep(() => box1);
+            AddStep("hover over menu item", () => InputManager.MoveMouseTo(this.ChildrenOfType<Menu.DrawableMenuItem>().First()));
+
+            clickBoxStep(() => box2);
+            AddStep("hover over menu item", () => InputManager.MoveMouseTo(this.ChildrenOfType<Menu.DrawableMenuItem>().First()));
+
+            AddAssert("submenu opened and visible", () =>
+            {
+                var subMenu = this.ChildrenOfType<Menu>().Last();
+                return subMenu.State == MenuState.Open && subMenu.IsPresent && !subMenu.IsMaskedAway;
+            });
+        }
+
         [Test]
         public void TestMenuOpenedOnClick()
         {
@@ -287,11 +329,43 @@ namespace osu.Framework.Tests.Visual.UserInterface
             public MenuItem[] ContextMenuItems => actions?.Select((a, i) => new MenuItem($"Item {i}", a)).ToArray();
         }
 
+        private class BoxWithNestedContextMenuItems : Box, IHasContextMenu
+        {
+            public MenuItem[] ContextMenuItems => new[]
+            {
+                new MenuItem("First")
+                {
+                    Items = new[]
+                    {
+                        new MenuItem("Second")
+                    }
+                },
+            };
+        }
+
         private class TestContextMenuContainer : BasicContextMenuContainer
         {
             public Menu CurrentMenu { get; private set; }
 
             protected override Menu CreateMenu() => CurrentMenu = base.CreateMenu();
+        }
+
+        private class TestContextMenuContainerWithFade : BasicContextMenuContainer
+        {
+            protected override Menu CreateMenu() => new TestMenu();
+
+            private class TestMenu : BasicMenu
+            {
+                public TestMenu()
+                    : base(Direction.Vertical)
+                {
+                    ItemsContainer.Padding = new MarginPadding { Vertical = 2 };
+                }
+
+                protected override void AnimateClose() => this.FadeOut(1000, Easing.OutQuint);
+
+                protected override Menu CreateSubMenu() => new TestMenu();
+            }
         }
     }
 }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
@@ -39,12 +39,13 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestNestedMenuTransferredWithFadeOut()
         {
+            TestContextMenuContainerWithFade fadingMenuContainer = null;
             BoxWithNestedContextMenuItems box1 = null;
             BoxWithNestedContextMenuItems box2 = null;
 
             AddStep("setup", () =>
             {
-                Child = new TestContextMenuContainerWithFade
+                Child = fadingMenuContainer = new TestContextMenuContainerWithFade
                 {
                     RelativeSizeAxes = Axes.Both,
                     Child = new FillFlowContainer
@@ -62,14 +63,14 @@ namespace osu.Framework.Tests.Visual.UserInterface
             });
 
             clickBoxStep(() => box1);
-            AddStep("hover over menu item", () => InputManager.MoveMouseTo(this.ChildrenOfType<Menu.DrawableMenuItem>().First()));
+            AddStep("hover over menu item", () => InputManager.MoveMouseTo(fadingMenuContainer.ChildrenOfType<Menu.DrawableMenuItem>().First()));
 
             clickBoxStep(() => box2);
-            AddStep("hover over menu item", () => InputManager.MoveMouseTo(this.ChildrenOfType<Menu.DrawableMenuItem>().First()));
+            AddStep("hover over menu item", () => InputManager.MoveMouseTo(fadingMenuContainer.ChildrenOfType<Menu.DrawableMenuItem>().First()));
 
             AddAssert("submenu opened and visible", () =>
             {
-                var subMenu = this.ChildrenOfType<Menu>().Last();
+                var subMenu = fadingMenuContainer.ChildrenOfType<Menu>().Last();
                 return subMenu.State == MenuState.Open && subMenu.IsPresent && !subMenu.IsMaskedAway;
             });
         }

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneContextMenu.cs
@@ -70,8 +70,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddAssert("submenu opened and visible", () =>
             {
+                var targetItem = fadingMenuContainer.ChildrenOfType<Menu.DrawableMenuItem>().First();
                 var subMenu = fadingMenuContainer.ChildrenOfType<Menu>().Last();
-                return subMenu.State == MenuState.Open && subMenu.IsPresent && !subMenu.IsMaskedAway;
+
+                return subMenu.State == MenuState.Open && subMenu.IsPresent && !subMenu.IsMaskedAway && subMenu.ScreenSpaceDrawQuad.TopLeft.X > targetItem.ScreenSpaceDrawQuad.TopLeft.X;
             });
         }
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -348,7 +348,7 @@ namespace osu.Framework.Graphics.UserInterface
         {
             base.Update();
 
-            if (!positionLayout.IsValid && parentMenu != null)
+            if (!positionLayout.IsValid && State == MenuState.Open && parentMenu != null)
             {
                 var inputManager = GetContainingInputManager();
 


### PR DESCRIPTION
Fixes https://github.com/ppy/osu/issues/16953

I have other fixes/cleanups to this class coming up, but I want to test them out a little bit more while fixing the root cause of this issue.

The cause of this issue is that osu!-side menus fade out when closed: https://github.com/ppy/osu/blob/ebdffb3cd91e89466c0c6c00dcdbb8da814ee4e5/osu.Game/Graphics/UserInterface/OsuContextMenu.cs#L61-L69, and so when another Drawable is clicked and the parent menu is "transferred" to it (i.e. it adopts that new Drawable's elements) there is a period of time where the submenu is fading out and receiving updates.

During this time, if the submenu tries to reposition itself beside the `MenuItem` which opened it, it would be doing so with a Drawable that doesn't exist and would receive an undefined position. If that position ends up being outside of the screen, then the menu gets permanently masked away.

The easiest way I've found to repro this in-game is by right clicking on the beatmap set panel at the middle of the screen, and then right clicking on the first beatmap set panel above it. You can see a glimpse of what's happening in the following screenshot - notice the submenu in the top-left corner of the screen:
![image](https://user-images.githubusercontent.com/1329837/155143097-c23637b4-f46b-408e-a9b1-8936f8ee3163.png)