### PR TITLE
Don't use backtick syntax for inline command running in ffmpeg build script

### DIFF
--- a/osu.Framework.NativeLibs/runtimes/osx/source/ffmpeg/fetch_and_build.sh
+++ b/osu.Framework.NativeLibs/runtimes/osx/source/ffmpeg/fetch_and_build.sh
@@ -23,7 +23,7 @@ cd ffmpeg-4.3.3
 
 echo "-> Configuring..."
 ./configure --disable-programs --disable-doc --disable-static --disable-debug --enable-shared --arch=$arch --prefix=build-$arch --libdir=build-$arch/lib
-CORES=`sysctl -n hw.ncpu`
+CORES=$(sysctl -n hw.ncpu)
 echo "-> Building using $CORES threads..."
 make -j$CORES
 make install


### PR DESCRIPTION
Generally advised against, and codefactor was complaining.