### PR TITLE
Fix dropdown potentially mutating transforms when dealing with async bindable changes

### DIFF
--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -424,7 +424,6 @@ namespace osu.Framework.Graphics.UserInterface
 
             #region DrawableDropdownMenuItem
 
-            // must be public due to mono bug(?) https://github.com/ppy/osu/issues/1204
             public abstract class DrawableDropdownMenuItem : DrawableMenuItem
             {
                 public event Action<DropdownMenuItem<T>> PreselectionRequested;

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -269,7 +269,7 @@ namespace osu.Framework.Graphics.UserInterface
             Header.Label = SelectedItem?.Text.Value ?? default;
         }
 
-        private void selectionChanged(ValueChangedEvent<T> args)
+        private void selectionChanged(ValueChangedEvent<T> args) => Schedule(() =>
         {
             // refresh if SelectedItem and SelectedValue mismatched
             // null is not a valid value for Dictionary, so neither here
@@ -287,7 +287,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             Menu.SelectItem(selectedItem);
             Header.Label = selectedItem.Text.Value;
-        }
+        });
 
         /// <summary>
         /// Clear all the menu items.

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -215,7 +215,7 @@ namespace osu.Framework.Graphics.UserInterface
             Header.Action = Menu.Toggle;
             Header.ChangeSelection += selectionKeyPressed;
             Menu.PreselectionConfirmed += preselectionConfirmed;
-            Current.ValueChanged += selectionChanged;
+            Current.ValueChanged += val => Scheduler.AddOnce(selectionChanged, val);
             Current.DisabledChanged += disabled =>
             {
                 Header.Enabled.Value = !disabled;
@@ -269,7 +269,7 @@ namespace osu.Framework.Graphics.UserInterface
             Header.Label = SelectedItem?.Text.Value ?? default;
         }
 
-        private void selectionChanged(ValueChangedEvent<T> args) => Scheduler.AddOnce(() =>
+        private void selectionChanged(ValueChangedEvent<T> args)
         {
             // refresh if SelectedItem and SelectedValue mismatched
             // null is not a valid value for Dictionary, so neither here
@@ -287,7 +287,7 @@ namespace osu.Framework.Graphics.UserInterface
 
             Menu.SelectItem(selectedItem);
             Header.Label = selectedItem.Text.Value;
-        });
+        }
 
         /// <summary>
         /// Clear all the menu items.

--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -269,7 +269,7 @@ namespace osu.Framework.Graphics.UserInterface
             Header.Label = SelectedItem?.Text.Value ?? default;
         }
 
-        private void selectionChanged(ValueChangedEvent<T> args) => Schedule(() =>
+        private void selectionChanged(ValueChangedEvent<T> args) => Scheduler.AddOnce(() =>
         {
             // refresh if SelectedItem and SelectedValue mismatched
             // null is not a valid value for Dictionary, so neither here


### PR DESCRIPTION
Manifested in the following case (`TestSceneFullscreen`):

```csharp
Unhandled exception. osu.Framework.Graphics.Drawable+InvalidThreadForMutationException: Cannot mutate the Transforms on a Loaded Drawable while not on the update thread. Consider using Schedule to schedule the mutation operation.
   at osu.Framework.Graphics.Drawable.EnsureMutationAllowed(String action) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 2618
   at osu.Framework.Graphics.Drawable.EnsureTransformMutationAllowed() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Drawable.cs:line 2589
   at osu.Framework.Graphics.Transforms.Transformable.AddTransform(Transform transform, Nullable`1 customTransformID) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/Transforms/Transformable.cs:line 354
   at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis](TThis t, Transform transform) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 66
   at osu.Framework.Graphics.TransformableExtensions.TransformTo[TThis,TValue,TEasing](TThis t, String propertyOrFieldName, TValue newValue, Double duration, TEasing& easing, String grouping) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 53
   at osu.Framework.Graphics.TransformableExtensions.FadeColour[T,TEasing](T drawable, ColourInfo newColour, Double duration, TEasing& easing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 539
   at osu.Framework.Graphics.TransformableExtensions.FadeColour[T](T drawable, ColourInfo newColour, Double duration, Easing easing) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/TransformableExtensions.cs:line 313
   at osu.Framework.Graphics.UserInterface.Dropdown`1.DropdownMenu.DrawableDropdownMenuItem.UpdateBackgroundColour() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 508
   at osu.Framework.Graphics.UserInterface.Dropdown`1.DropdownMenu.DrawableDropdownMenuItem.OnSelectChange() in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 502
   at osu.Framework.Graphics.UserInterface.Dropdown`1.DropdownMenu.DrawableDropdownMenuItem.set_IsSelected(Boolean value) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 449
   at osu.Framework.Graphics.UserInterface.Dropdown`1.DropdownMenu.<>c__DisplayClass12_0.<SelectItem>b__0(DrawableDropdownMenuItem c) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 382
   at osu.Framework.Extensions.IEnumerableExtensions.EnumerableExtensions.ForEach[T](IEnumerable`1 collection, Action`1 action) in /Users/dean/Projects/osu-framework/osu.Framework/Extensions/IEnumerableExtensions/EnumerableExtensions.cs:line 23
   at osu.Framework.Graphics.UserInterface.Dropdown`1.DropdownMenu.SelectItem(DropdownMenuItem`1 item) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 380
   at osu.Framework.Graphics.UserInterface.Dropdown`1.selectionChanged(ValueChangedEvent`1 args) in /Users/dean/Projects/osu-framework/osu.Framework/Graphics/UserInterface/Dropdown.cs:line 288
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 289
   at osu.Framework.Bindables.Bindable`1.SetValue(T previousValue, T value, Boolean bypassChecks, Bindable`1 source) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 102
   at osu.Framework.Bindables.Bindable`1.TriggerValueChange(T previousValue, Bindable`1 source, Boolean propagateToBindings, Boolean bypassChecks) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 284
   at osu.Framework.Bindables.Bindable`1.SetValue(T previousValue, T value, Boolean bypassChecks, Bindable`1 source) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 102
   at osu.Framework.Bindables.Bindable`1.set_Value(T value) in /Users/dean/Projects/osu-framework/osu.Framework/Bindables/Bindable.cs:line 95
   at osu.Framework.Platform.SDL2DesktopWindow.updateWindowSpecifics() in /Users/dean/Projects/osu-framework/osu.Framework/Platform/SDL2DesktopWindow.cs:line 1018
```

Not sure if this fix will be accepted, but the alternative is ensuring that all input bindables for `Current` are only updated on the update thread. I'm not sure if this is a good restriction to have in place.