### PR TITLE
Handle changes to `CurrentDisplay` to allow switching active display

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1174,7 +1174,11 @@ namespace osu.Framework.Platform
             };
 
             config.BindWith(FrameworkSetting.LastDisplayDevice, windowDisplayIndexBindable);
-            windowDisplayIndexBindable.BindValueChanged(evt => CurrentDisplay = Displays.ElementAtOrDefault((int)evt.NewValue) ?? PrimaryDisplay, true);
+            windowDisplayIndexBindable.BindValueChanged(evt =>
+            {
+                CurrentDisplay = Displays.ElementAtOrDefault((int)evt.NewValue) ?? PrimaryDisplay;
+                pendingWindowState = windowState;
+            }, true);
 
             sizeFullscreen.ValueChanged += evt =>
             {


### PR DESCRIPTION
This used to work and likely regressed with the SDL implementation at some point.  Note that this implementation is MVP and may not work in certain configurations or on certain platforms, but is better than nothing (in theory).

See https://github.com/ppy/osu-framework/issues/5055.


Worth noting that this is now adding an extra pending mode change request on startup due to the initial trigger flag. In my limited testing this didn't seem to adversely affect anything on windows, but I'd appreciate testing on other platforms (and even on windows to confirm this).