### PR TITLE
Video playback and decoding fixes

### DIFF
--- a/osu.Framework.Android/Graphics/Video/AndroidVideoDecoder.cs
+++ b/osu.Framework.Android/Graphics/Video/AndroidVideoDecoder.cs
@@ -99,6 +99,9 @@ namespace osu.Framework.Android.Graphics.Video
         [DllImport(lib_avcodec)]
         private static extern int avcodec_send_packet(AVCodecContext* avctx, AVPacket* avpkt);
 
+        [DllImport(lib_avcodec)]
+        private static extern void avcodec_flush_buffers(AVCodecContext* avctx);
+
         [DllImport(lib_avformat)]
         private static extern AVFormatContext* avformat_alloc_context();
 
@@ -208,6 +211,7 @@ namespace osu.Framework.Android.Graphics.Video
             avcodec_open2 = avcodec_open2,
             avcodec_receive_frame = avcodec_receive_frame,
             avcodec_send_packet = avcodec_send_packet,
+            avcodec_flush_buffers = avcodec_flush_buffers,
             avformat_alloc_context = avformat_alloc_context,
             avformat_close_input = avformat_close_input,
             avformat_find_stream_info = avformat_find_stream_info,

--- a/osu.Framework.iOS/Graphics/Video/IOSVideoDecoder.cs
+++ b/osu.Framework.iOS/Graphics/Video/IOSVideoDecoder.cs
@@ -89,6 +89,9 @@ namespace osu.Framework.iOS.Graphics.Video
         private static extern int avcodec_send_packet(AVCodecContext* avctx, AVPacket* avpkt);
 
         [DllImport(dll_name)]
+        private static extern void avcodec_flush_buffers(AVCodecContext* avctx);
+
+        [DllImport(dll_name)]
         private static extern AVFormatContext* avformat_alloc_context();
 
         [DllImport(dll_name)]
@@ -155,6 +158,7 @@ namespace osu.Framework.iOS.Graphics.Video
             avcodec_open2 = avcodec_open2,
             avcodec_receive_frame = avcodec_receive_frame,
             avcodec_send_packet = avcodec_send_packet,
+            avcodec_flush_buffers = avcodec_flush_buffers,
             avformat_alloc_context = avformat_alloc_context,
             avformat_close_input = avformat_close_input,
             avformat_find_stream_info = avformat_find_stream_info,

--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
@@ -61,6 +61,8 @@ namespace osu.Framework.Graphics.Video
 
         public delegate int AvcodecSendPacketDelegate(AVCodecContext* avctx, AVPacket* avpkt);
 
+        public delegate void AvcodecFlushBuffersDelegate(AVCodecContext* avctx);
+
         public delegate AVFormatContext* AvformatAllocContextDelegate();
 
         public delegate void AvformatCloseInputDelegate(AVFormatContext** s);
@@ -108,6 +110,7 @@ namespace osu.Framework.Graphics.Video
         public AvcodecOpen2Delegate avcodec_open2;
         public AvcodecReceiveFrameDelegate avcodec_receive_frame;
         public AvcodecSendPacketDelegate avcodec_send_packet;
+        public AvcodecFlushBuffersDelegate avcodec_flush_buffers;
         public AvformatAllocContextDelegate avformat_alloc_context;
         public AvformatCloseInputDelegate avformat_close_input;
         public AvformatFindStreamInfoDelegate avformat_find_stream_info;

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -60,6 +60,7 @@ namespace osu.Framework.Graphics.Video
         private readonly Queue<DecodedFrame> availableFrames = new Queue<DecodedFrame>();
 
         private DecodedFrame lastFrame;
+        private bool lastFrameShown;
 
         /// <summary>
         /// The total number of frames processed by this instance.
@@ -155,7 +156,11 @@ namespace osu.Framework.Graphics.Video
             {
                 if (lastFrame != null) decoder.ReturnFrames(new[] { lastFrame });
                 lastFrame = availableFrames.Dequeue();
+                lastFrameShown = false;
+            }
 
+            if (!lastFrameShown && lastFrame != null)
+            {
                 var tex = lastFrame.Texture;
 
                 // Check if the new frame has been uploaded so we don't display an old frame
@@ -163,6 +168,7 @@ namespace osu.Framework.Graphics.Video
                 {
                     Sprite.Texture = tex;
                     UpdateSizing();
+                    lastFrameShown = true;
                 }
             }
 

--- a/osu.Framework/Graphics/Video/Video.cs
+++ b/osu.Framework/Graphics/Video/Video.cs
@@ -121,11 +121,13 @@ namespace osu.Framework.Graphics.Video
         {
             base.Update();
 
-            if (decoder.State == VideoDecoder.DecoderState.EndOfStream)
+            if (decoder.State == VideoDecoder.DecoderState.EndOfStream && availableFrames.Count == 0)
             {
                 // if at the end of the stream but our playback enters a valid time region again, a seek operation is required to get the decoder back on track.
-                if (PlaybackPosition < decoder.Duration)
+                if (PlaybackPosition < decoder.LastDecodedFrameTime)
+                {
                     seekIntoSync();
+                }
             }
 
             var peekFrame = availableFrames.Count > 0 ? availableFrames.Peek() : null;

--- a/osu.Framework/Graphics/Video/VideoTexture.cs
+++ b/osu.Framework/Graphics/Video/VideoTexture.cs
@@ -72,8 +72,6 @@ namespace osu.Framework.Graphics.Video
             if (!(upload is VideoTextureUpload videoUpload))
                 return;
 
-            int width, height;
-
             // Do we need to generate a new texture?
             if (textureIds == null)
             {
@@ -83,24 +81,17 @@ namespace osu.Framework.Graphics.Video
                 textureIds = new int[3];
                 GL.GenTextures(textureIds.Length, textureIds);
 
-                for (int i = 0; i < textureIds.Length; i++)
+                for (uint i = 0; i < textureIds.Length; i++)
                 {
                     GLWrapper.BindTexture(textureIds[i]);
 
-                    if (i == 0)
-                    {
-                        width = videoUpload.Frame->width;
-                        height = videoUpload.Frame->height;
-                    }
-                    else
-                    {
-                        width = (videoUpload.Frame->width + 1) / 2;
-                        height = (videoUpload.Frame->height + 1) / 2;
-                    }
+                    int width = videoUpload.GetPlaneWidth(i);
+                    int height = videoUpload.GetPlaneHeight(i);
 
                     textureSize += width * height;
 
-                    GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8, width, height, 0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
+                    GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8, width, height,
+                        0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
 
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)All.Linear);
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)All.Linear);
@@ -110,24 +101,14 @@ namespace osu.Framework.Graphics.Video
                 }
             }
 
-            for (int i = 0; i < textureIds.Length; i++)
+            for (uint i = 0; i < textureIds.Length; i++)
             {
                 GLWrapper.BindTexture(textureIds[i]);
 
-                GL.PixelStore(PixelStoreParameter.UnpackRowLength, videoUpload.Frame->linesize[(uint)i]);
+                GL.PixelStore(PixelStoreParameter.UnpackRowLength, videoUpload.Frame->linesize[i]);
 
-                if (i == 0)
-                {
-                    width = videoUpload.Frame->width;
-                    height = videoUpload.Frame->height;
-                }
-                else
-                {
-                    width = (videoUpload.Frame->width + 1) / 2;
-                    height = (videoUpload.Frame->height + 1) / 2;
-                }
-
-                GL.TexSubImage2D(TextureTarget2d.Texture2D, 0, 0, 0, width, height, PixelFormat.Red, PixelType.UnsignedByte, (IntPtr)videoUpload.Frame->data[(uint)i]);
+                GL.TexSubImage2D(TextureTarget2d.Texture2D, 0, 0, 0, videoUpload.GetPlaneWidth(i), videoUpload.GetPlaneHeight(i),
+                    PixelFormat.Red, PixelType.UnsignedByte, (IntPtr)videoUpload.Frame->data[i]);
             }
 
             GL.PixelStore(PixelStoreParameter.UnpackRowLength, 0);

--- a/osu.Framework/Graphics/Video/VideoTexture.cs
+++ b/osu.Framework/Graphics/Video/VideoTexture.cs
@@ -72,6 +72,8 @@ namespace osu.Framework.Graphics.Video
             if (!(upload is VideoTextureUpload videoUpload))
                 return;
 
+            int width, height;
+
             // Do we need to generate a new texture?
             if (textureIds == null)
             {
@@ -87,22 +89,18 @@ namespace osu.Framework.Graphics.Video
 
                     if (i == 0)
                     {
-                        int width = videoUpload.Frame->width;
-                        int height = videoUpload.Frame->height;
-
-                        GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8, width, height, 0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
-
-                        textureSize += width * height;
+                        width = videoUpload.Frame->width;
+                        height = videoUpload.Frame->height;
                     }
                     else
                     {
-                        int width = (videoUpload.Frame->width + 1) / 2;
-                        int height = (videoUpload.Frame->height + 1) / 2;
-
-                        GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8, width, height, 0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
-
-                        textureSize += width * height;
+                        width = (videoUpload.Frame->width + 1) / 2;
+                        height = (videoUpload.Frame->height + 1) / 2;
                     }
+
+                    textureSize += width * height;
+
+                    GL.TexImage2D(TextureTarget2d.Texture2D, 0, TextureComponentCount.R8, width, height, 0, PixelFormat.Red, PixelType.UnsignedByte, IntPtr.Zero);
 
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)All.Linear);
                     GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)All.Linear);
@@ -117,8 +115,19 @@ namespace osu.Framework.Graphics.Video
                 GLWrapper.BindTexture(textureIds[i]);
 
                 GL.PixelStore(PixelStoreParameter.UnpackRowLength, videoUpload.Frame->linesize[(uint)i]);
-                GL.TexSubImage2D(TextureTarget2d.Texture2D, 0, 0, 0, videoUpload.Frame->width / (i > 0 ? 2 : 1), videoUpload.Frame->height / (i > 0 ? 2 : 1),
-                    PixelFormat.Red, PixelType.UnsignedByte, (IntPtr)videoUpload.Frame->data[(uint)i]);
+
+                if (i == 0)
+                {
+                    width = videoUpload.Frame->width;
+                    height = videoUpload.Frame->height;
+                }
+                else
+                {
+                    width = (videoUpload.Frame->width + 1) / 2;
+                    height = (videoUpload.Frame->height + 1) / 2;
+                }
+
+                GL.TexSubImage2D(TextureTarget2d.Texture2D, 0, 0, 0, width, height, PixelFormat.Red, PixelType.UnsignedByte, (IntPtr)videoUpload.Frame->data[(uint)i]);
             }
 
             GL.PixelStore(PixelStoreParameter.UnpackRowLength, 0);

--- a/osu.Framework/Graphics/Video/VideoTextureUpload.cs
+++ b/osu.Framework/Graphics/Video/VideoTextureUpload.cs
@@ -14,6 +14,16 @@ namespace osu.Framework.Graphics.Video
     {
         public AVFrame* Frame => ffmpegFrame.Pointer;
 
+        public int GetPlaneWidth(uint plane)
+        {
+            return (plane == 0) ? Frame->width : (Frame->width + 1) / 2;
+        }
+
+        public int GetPlaneHeight(uint plane)
+        {
+            return (plane == 0) ? Frame->height : (Frame->height + 1) / 2;
+        }
+
         public ReadOnlySpan<Rgba32> Data => ReadOnlySpan<Rgba32>.Empty;
 
         public int Level => 0;


### PR DESCRIPTION
This fixes some issues I noticed in a simple video playback program using osu-framework.

1. If `UploadComplete` was false on the first attempt to display a frame, it wouldn't retry even after `UploadComplete` became true.
2. The check in `Video` to see if there was a seek after the video had finished would fire before the video was actually done playing, causing the video to jump around at the end. This was 2 issues. First, while the decoder state was EOF there could still be available frames. Second, checking if `PlaybackPosition` is less than `VideoDecoder.Duration` will be true even after the last frame is shown.
3. `Video` would not show the last couple frames or only return them after a seek.  This was because the decoder was not flushed on EOF.