### PR TITLE
Fix potential out-of-order execution with `Drawable` scheduling method

### DIFF
--- a/osu.Framework.Tests/Graphics/TestSceneDrawableScheduling.cs
+++ b/osu.Framework.Tests/Graphics/TestSceneDrawableScheduling.cs
@@ -1,0 +1,45 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using NUnit.Framework;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
+using osu.Framework.Tests.Visual;
+using osu.Framework.Threading;
+
+namespace osu.Framework.Tests.Graphics
+{
+    [HeadlessTest]
+    public class TestSceneDrawableScheduling : FrameworkTestScene
+    {
+        /// <summary>
+        /// Ensures scheduled delegates between <see cref="Drawable.Schedule"/> and <see cref="Scheduler.Add(Action, bool)"/> with no delays execute in correct order.
+        /// </summary>
+        [Test]
+        public void TestExecutionOrder([Values] bool afterChildren)
+        {
+            Container container = null;
+            bool firstExecutedInOrder = false;
+            bool secondExecutedInOrder = false;
+
+            AddStep("load container", () => Child = container = new Container());
+            AddStep("schedule delegates", () =>
+            {
+                if (!afterChildren)
+                {
+                    container.Schedule(() => firstExecutedInOrder = true);
+                    container.Scheduler.Add(() => secondExecutedInOrder = firstExecutedInOrder);
+                }
+                else
+                {
+                    container.ScheduleAfterChildren(() => firstExecutedInOrder = true);
+                    container.SchedulerAfterChildren.Add(() => secondExecutedInOrder = firstExecutedInOrder);
+                }
+            });
+
+            AddAssert("second executed after first", () => secondExecutedInOrder);
+        }
+    }
+}

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1273,8 +1273,21 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        protected ScheduledDelegate ScheduleAfterChildren<T>(Action<T> action, T data) => SchedulerAfterChildren.AddDelayed(action, data, TransformDelay);
-        protected ScheduledDelegate ScheduleAfterChildren(Action action) => SchedulerAfterChildren.AddDelayed(action, TransformDelay);
+        protected ScheduledDelegate ScheduleAfterChildren<T>(Action<T> action, T data)
+        {
+            if (TransformDelay > 0)
+                return SchedulerAfterChildren.AddDelayed(action, data, TransformDelay);
+
+            return SchedulerAfterChildren.Add(action, data);
+        }
+
+        protected ScheduledDelegate ScheduleAfterChildren(Action action)
+        {
+            if (TransformDelay > 0)
+                return SchedulerAfterChildren.AddDelayed(action, TransformDelay);
+
+            return SchedulerAfterChildren.Add(action);
+        }
 
         public override IDisposable BeginAbsoluteSequence(double newTransformStartTime, bool recursive = true)
         {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1273,7 +1273,7 @@ namespace osu.Framework.Graphics.Containers
             }
         }
 
-        protected ScheduledDelegate ScheduleAfterChildren<T>(Action<T> action, T data)
+        protected internal ScheduledDelegate ScheduleAfterChildren<T>(Action<T> action, T data)
         {
             if (TransformDelay > 0)
                 return SchedulerAfterChildren.AddDelayed(action, data, TransformDelay);
@@ -1281,7 +1281,7 @@ namespace osu.Framework.Graphics.Containers
             return SchedulerAfterChildren.Add(action, data);
         }
 
-        protected ScheduledDelegate ScheduleAfterChildren(Action action)
+        protected internal ScheduledDelegate ScheduleAfterChildren(Action action)
         {
             if (TransformDelay > 0)
                 return SchedulerAfterChildren.AddDelayed(action, TransformDelay);

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2625,8 +2625,21 @@ namespace osu.Framework.Graphics
 
         #region Transforms
 
-        protected internal ScheduledDelegate Schedule<T>(Action<T> action, T data) => Scheduler.AddDelayed(action, data, TransformDelay);
-        protected internal ScheduledDelegate Schedule(Action action) => Scheduler.AddDelayed(action, TransformDelay);
+        protected internal ScheduledDelegate Schedule<T>(Action<T> action, T data)
+        {
+            if (TransformDelay > 0)
+                return Scheduler.AddDelayed(action, data, TransformDelay);
+
+            return Scheduler.Add(action, data);
+        }
+
+        protected internal ScheduledDelegate Schedule(Action action)
+        {
+            if (TransformDelay > 0)
+                return Scheduler.AddDelayed(action, TransformDelay);
+
+            return Scheduler.Add(action);
+        }
 
         /// <summary>
         /// Make this drawable automatically clean itself up after all transforms have finished playing.


### PR DESCRIPTION
In master, performing `Drawable.Schedule` with no transform delay prior to a regular `Scheduler.Add` does not make it execute in order, as the first gets enqueued to `timedTasks` while the second gets enqueued to `runQueue` directly, causing the second to execute before the first.

At first I was going to resolve this by making `Scheduler.AddDelayed(..., 0)` enqueue to `runQueue` directly, but looking at it again, I felt that to be weird and unnecessary logic compared to updating usages itself to use `Add` if there's no delay.

I'm honestly not sure which to pick at this point. For reference, here's a branch of the alternative direction (https://github.com/frenzibyte/osu-framework/compare/drawable-schedule-no-delay).

- [x] Depends on #5058 