### PR TITLE
Ensure scrollbar respects `ScrollContainer` padding

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
@@ -325,6 +325,48 @@ namespace osu.Framework.Tests.Visual.Containers
             });
         }
 
+        [Test]
+        public void TestScrollbarRespectsPadding()
+        {
+            const float container_height = 100;
+            const float box_height = 400;
+            const float padding = 10;
+
+            AddStep("Create scroll container", () =>
+            {
+                Add(new Container
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(container_height),
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            RelativeSizeAxes = Axes.Both,
+                            Colour = Colour4.Red,
+                        },
+                        scrollContainer = new BasicScrollContainer
+                        {
+                            Padding = new MarginPadding { Vertical = padding },
+                            RelativeSizeAxes = Axes.Both,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Child = new Box { Size = new Vector2(100, box_height) }
+                        },
+                    }
+                });
+            });
+
+            AddStep("Scroll to start", () => { scrollContainer.ScrollToStart(false); });
+
+            checkScrollbarPosition(0);
+
+            AddStep("Scroll to end", () => scrollContainer.ScrollToEnd(false));
+
+            checkScrollbarPosition(64);
+        }
+
         private void scrollIntoView(int index, float expectedPosition, float? heightAdjust = null, float? expectedPostAdjustPosition = null)
         {
             if (heightAdjust != null)

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -128,7 +128,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The maximum distance that the scrollbar can move in the scroll direction.
         /// </summary>
-        public float ScrollbarMovementExtent => Math.Max(DrawSize[ScrollDim] - Scrollbar.DrawSize[ScrollDim], 0);
+        public float ScrollbarMovementExtent => Math.Max(ChildSize[ScrollDim] - Scrollbar.DrawSize[ScrollDim], 0);
 
         /// <summary>
         /// Clamp a value to the available scroll range.

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -128,7 +128,7 @@ namespace osu.Framework.Graphics.Containers
         /// <summary>
         /// The maximum distance that the scrollbar can move in the scroll direction.
         /// </summary>
-        public float ScrollbarMovementExtent => Math.Max(ChildSize[ScrollDim] - Scrollbar.DrawSize[ScrollDim], 0);
+        public float ScrollbarMovementExtent => Math.Max(DisplayableContent - Scrollbar.DrawSize[ScrollDim], 0);
 
         /// <summary>
         /// Clamp a value to the available scroll range.


### PR DESCRIPTION
Well aware that I've made this change without prior discussion but this seemed like an obvious fix.

Before:

https://user-images.githubusercontent.com/8362491/156944239-5074b07e-1542-4a6b-bd84-c1fbc213d14e.mp4

After:

https://user-images.githubusercontent.com/8362491/156944232-c32eba55-34e8-48b6-9791-84361411b2e2.mp4