### PR TITLE
Set default of `CurrentDisplayBindable` to primary display

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneFullscreen.cs
@@ -129,6 +129,8 @@ namespace osu.Framework.Tests.Visual.Platform
             AddStep("query Window.CurrentDisplay", () => Logger.Log(window.CurrentDisplayBindable.ToString()));
 
             AddStep("query Window.CurrentDisplayMode", () => Logger.Log(window.CurrentDisplayMode.ToString()));
+
+            AddStep("set default display", () => window.CurrentDisplayBindable.SetDefault());
         }
 
         [Test]

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1168,6 +1168,7 @@ namespace osu.Framework.Platform
 
         public void SetupWindow(FrameworkConfigManager config)
         {
+            CurrentDisplayBindable.Default = PrimaryDisplay;
             CurrentDisplayBindable.ValueChanged += evt =>
             {
                 windowDisplayIndexBindable.Value = (DisplayIndex)evt.NewValue.Index;


### PR DESCRIPTION
Closes #5060.

Additionally adds relevant test step to `TestSceneFullscreen` for testing convenience but it's a bit useless for CI which runs headless and therefore is not able to check anything window-related.