### PR TITLE
Add a way to confine the mouse cursor to a specific window area

### DIFF
--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -6,6 +6,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Configuration;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Shapes;
 using osu.Framework.Graphics.Sprites;
 using osu.Framework.Input;
@@ -185,9 +186,12 @@ namespace osu.Framework.Tests.Visual.Input
             AddToggleStep("Toggle relative mode", setRelativeMode);
             AddToggleStep("Toggle ConfineMouseMode", setConfineMouseModeConfig);
             AddToggleStep("Toggle cursor visibility", setCursorVisibility);
+            AddToggleStep("Toggle cursor confine rect", setCursorConfineRect);
 
             setRelativeMode(false);
             setConfineMouseModeConfig(false);
+            setCursorConfineRect(false);
+
             AddStep("Reset handlers", () => host.ResetInputHandlers());
         }
 
@@ -230,6 +234,22 @@ namespace osu.Framework.Tests.Visual.Input
         private void setConfineMouseModeConfig(bool enabled)
         {
             config.SetValue(FrameworkSetting.ConfineMouseMode, enabled ? ConfineMouseMode.Always : ConfineMouseMode.Fullscreen);
+        }
+
+        private void setCursorConfineRect(bool enabled)
+        {
+            if (host.Window == null)
+                return;
+
+            host.Window.CursorConfineRect = enabled
+                ? new RectangleF
+                {
+                    X = host.Window.ClientSize.Width / 6f,
+                    Y = host.Window.ClientSize.Height / 6f,
+                    Width = host.Window.ClientSize.Width * 2 / 3f,
+                    Height = host.Window.ClientSize.Height * 2 / 3f,
+                }
+                : (RectangleF?)null;
         }
     }
 }

--- a/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneInputManager.cs
@@ -180,8 +180,8 @@ namespace osu.Framework.Tests.Visual.Input
         [BackgroundDependencyLoader]
         private void load()
         {
-            AddSliderStep("Cursor sensivity", 0.5, 5, 1, setCursorSensivityConfig);
-            setCursorSensivityConfig(1);
+            AddSliderStep("Cursor sensitivity", 0.5, 5, 1, setCursorSensitivityConfig);
+            setCursorSensitivityConfig(1);
             AddToggleStep("Toggle relative mode", setRelativeMode);
             AddToggleStep("Toggle ConfineMouseMode", setConfineMouseModeConfig);
             AddToggleStep("Toggle cursor visibility", setCursorVisibility);
@@ -191,7 +191,7 @@ namespace osu.Framework.Tests.Visual.Input
             AddStep("Reset handlers", () => host.ResetInputHandlers());
         }
 
-        private void setCursorSensivityConfig(double sensitivity)
+        private void setCursorSensitivityConfig(double sensitivity)
         {
             var mouseHandler = getMouseHandler();
 

--- a/osu.Framework/Input/UserInputManager.cs
+++ b/osu.Framework/Input/UserInputManager.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using osu.Framework.Extensions.EnumExtensions;
+using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input.Handlers;
 using osu.Framework.Input.StateChanges;
 using osu.Framework.Input.StateChanges.Events;
@@ -38,7 +39,8 @@ namespace osu.Framework.Input
                     if (Host.Window != null && Host.Window.CursorState.HasFlagFast(CursorState.Confined))
                     {
                         var clientSize = Host.Window.ClientSize;
-                        mouse.Position = Vector2.Clamp(mouse.Position, Vector2.Zero, new Vector2(clientSize.Width - 1, clientSize.Height - 1));
+                        var cursorConfineRect = Host.Window.CursorConfineRect ?? new RectangleF(0, 0, clientSize.Width, clientSize.Height);
+                        mouse.Position = Vector2.Clamp(mouse.Position, cursorConfineRect.Location, cursorConfineRect.Location + cursorConfineRect.Size - Vector2.One);
                     }
 
                     break;

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -69,7 +69,10 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Area to which the mouse cursor is confined to when <see cref="CursorState"/> is <see cref="Platform.CursorState.Confined"/>.
         /// </summary>
-        /// <remarks>Will confine to the whole window by default (or when set to <c>null</c>).</remarks>
+        /// <remarks>
+        /// Will confine to the whole window by default (or when set to <c>null</c>).
+        /// Supported fully on desktop platforms, and on Android when relative mode is enabled.
+        /// </remarks>
         RectangleF? CursorConfineRect { get; set; }
 
         /// <summary>

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -7,6 +7,7 @@ using System.Drawing;
 using JetBrains.Annotations;
 using osu.Framework.Bindables;
 using osu.Framework.Configuration;
+using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 
 namespace osu.Framework.Platform
 {
@@ -62,7 +63,14 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Controls the state of the OS cursor.
         /// </summary>
+        /// <remarks>If the cursor is <see cref="Platform.CursorState.Confined"/>, <see cref="CursorConfineRect"/> will be used.</remarks>
         CursorState CursorState { get; set; }
+
+        /// <summary>
+        /// Area to which the mouse cursor is confined to when <see cref="CursorState"/> is <see cref="Platform.CursorState.Confined"/>.
+        /// </summary>
+        /// <remarks>Will confine to the whole window by default (or when set to <c>null</c>).</remarks>
+        RectangleF? CursorConfineRect { get; set; }
 
         /// <summary>
         /// Controls the state of the window.

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -18,6 +18,7 @@ using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Threading;
+using RectangleF = osu.Framework.Graphics.Primitives.RectangleF;
 
 namespace osu.Framework.Platform
 {
@@ -201,6 +202,8 @@ namespace osu.Framework.Platform
                 }
             }
         }
+
+        public RectangleF? CursorConfineRect { get; set; }
 
         /// <summary>
         /// We do not support directly using <see cref="Cursor"/>.


### PR DESCRIPTION
Related: https://github.com/ppy/osu/issues/16956.

[SDL_SetWindowMouseRect](https://wiki.libsdl.org/SDL_SetWindowMouseRect) works quite well on Windows. Using the mouse rect and relative mode at the same time is intentionally avoided in case of SDL2 bugs (there were some weird bugs with it when I checked some time ago).

To verify this works on macOS and Linux, I suggest the following testing methodology;
- enable `ConfineMouseMode` and `cursor confine rect`
- verify the cursor is confined to the expected area (check the OS cursor with `Toggle cursor visibility`)
- check that toggling relative mode doesn't warp the cursor in any way (keep in mind that relative mode will not work with the OS cursor shown)
- repeat for other window modes
- also test that it works with display scaling != 100%
