### PR TITLE
Improve the Windows borderless hack

### DIFF
--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -14,6 +14,7 @@ using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input;
 using osu.Framework.Platform.SDL2;
+using osu.Framework.Platform.Windows;
 using osu.Framework.Platform.Windows.Native;
 using osu.Framework.Threading;
 using osuTK;
@@ -147,12 +148,25 @@ namespace osu.Framework.Platform
             get => size;
             private set
             {
+                // trick the game into thinking the borderless window has normal size so that it doesn't render into the extra space.
+                value.Width -= WindowsBorderlessWidthHack;
+
                 if (value.Equals(size)) return;
 
                 size = value;
                 Resized?.Invoke();
             }
         }
+
+        /// <summary>
+        /// Amount of extra width added to window size when in borderless mode on Windows.
+        /// Some drivers required this to avoid the window switching to exclusive fullscreen automatically.
+        /// </summary>
+        /// <remarks>
+        /// Either <c>0</c> or <c>1</c>, depending on if the Windows borderless hack is active.
+        /// See <see cref="WindowsWindow.SetBorderless"/>.
+        /// </remarks>
+        protected int WindowsBorderlessWidthHack;
 
         /// <summary>
         /// Provides a bindable that controls the window's <see cref="CursorStateBindable"/>.
@@ -1056,6 +1070,8 @@ namespace osu.Framework.Platform
         /// </summary>
         private void updateWindowStateAndSize()
         {
+            WindowsBorderlessWidthHack = 0;
+
             // this reset is required even on changing from one fullscreen resolution to another.
             // if it is not included, the GL context will not get the correct size.
             // this is mentioned by multiple sources as an SDL issue, which seems to resolve by similar means (see https://discourse.libsdl.org/t/sdl-setwindowsize-does-not-work-in-fullscreen/20711/4).

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -14,7 +14,6 @@ using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input;
 using osu.Framework.Platform.SDL2;
-using osu.Framework.Platform.Windows;
 using osu.Framework.Platform.Windows.Native;
 using osu.Framework.Threading;
 using osuTK;
@@ -143,30 +142,17 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Returns or sets the window's internal size, before scaling.
         /// </summary>
-        public Size Size
+        public virtual Size Size
         {
             get => size;
-            private set
+            protected set
             {
-                // trick the game into thinking the borderless window has normal size so that it doesn't render into the extra space.
-                value.Width -= WindowsBorderlessWidthHack;
-
                 if (value.Equals(size)) return;
 
                 size = value;
                 Resized?.Invoke();
             }
         }
-
-        /// <summary>
-        /// Amount of extra width added to window size when in borderless mode on Windows.
-        /// Some drivers required this to avoid the window switching to exclusive fullscreen automatically.
-        /// </summary>
-        /// <remarks>
-        /// Either <c>0</c> or <c>1</c>, depending on if the Windows borderless hack is active.
-        /// See <see cref="WindowsWindow.SetBorderless"/>.
-        /// </remarks>
-        protected int WindowsBorderlessWidthHack;
 
         /// <summary>
         /// Provides a bindable that controls the window's <see cref="CursorStateBindable"/>.
@@ -1070,8 +1056,6 @@ namespace osu.Framework.Platform
         /// </summary>
         private void updateWindowStateAndSize()
         {
-            WindowsBorderlessWidthHack = 0;
-
             // this reset is required even on changing from one fullscreen resolution to another.
             // if it is not included, the GL context will not get the correct size.
             // this is mentioned by multiple sources as an SDL issue, which seems to resolve by similar means (see https://discourse.libsdl.org/t/sdl-setwindowsize-does-not-work-in-fullscreen/20711/4).

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -143,14 +143,16 @@ namespace osu.Framework.Platform.Windows
         {
             SDL.SDL_SetWindowBordered(SDLWindowHandle, SDL.SDL_bool.SDL_FALSE);
 
-            Size positionOffsetHack = new Size(1, 1);
+            // use the 1px hack we've always used, but only expand the width.
+            // we also trick the game into thinking the window has normal size: see SDL2DesktopWindow.Size
 
-            var newSize = CurrentDisplay.Bounds.Size + positionOffsetHack;
-            var newPosition = CurrentDisplay.Bounds.Location - positionOffsetHack;
+            WindowsBorderlessWidthHack = 1;
 
-            // for now let's use the same 1px hack that we've always used to force borderless.
+            var sizeOffset = new Size(WindowsBorderlessWidthHack, 0);
+            var newSize = CurrentDisplay.Bounds.Size + sizeOffset;
+
             SDL.SDL_SetWindowSize(SDLWindowHandle, newSize.Width, newSize.Height);
-            Position = newPosition;
+            Position = CurrentDisplay.Bounds.Location;
 
             return newSize;
         }

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -139,6 +139,24 @@ namespace osu.Framework.Platform.Windows
 
         #endregion
 
+        public override Size Size
+        {
+            protected set
+            {
+                // trick the game into thinking the borderless window has normal size so that it doesn't render into the extra space.
+                if (WindowState == WindowState.FullscreenBorderless)
+                    value.Width -= windows_borderless_width_hack;
+
+                base.Size = value;
+            }
+        }
+
+        /// <summary>
+        /// Amount of extra width added to window size when in borderless mode on Windows.
+        /// Some drivers require this to avoid the window switching to exclusive fullscreen automatically.
+        /// </summary>
+        private const int windows_borderless_width_hack = 1;
+
         protected override Size SetBorderless()
         {
             SDL.SDL_SetWindowBordered(SDLWindowHandle, SDL.SDL_bool.SDL_FALSE);
@@ -146,9 +164,7 @@ namespace osu.Framework.Platform.Windows
             // use the 1px hack we've always used, but only expand the width.
             // we also trick the game into thinking the window has normal size: see SDL2DesktopWindow.Size
 
-            WindowsBorderlessWidthHack = 1;
-
-            var sizeOffset = new Size(WindowsBorderlessWidthHack, 0);
+            var sizeOffset = new Size(windows_borderless_width_hack, 0);
             var newSize = CurrentDisplay.Bounds.Size + sizeOffset;
 
             SDL.SDL_SetWindowSize(SDLWindowHandle, newSize.Width, newSize.Height);

--- a/osu.Framework/Platform/Windows/WindowsWindow.cs
+++ b/osu.Framework/Platform/Windows/WindowsWindow.cs
@@ -162,7 +162,7 @@ namespace osu.Framework.Platform.Windows
             SDL.SDL_SetWindowBordered(SDLWindowHandle, SDL.SDL_bool.SDL_FALSE);
 
             // use the 1px hack we've always used, but only expand the width.
-            // we also trick the game into thinking the window has normal size: see SDL2DesktopWindow.Size
+            // we also trick the game into thinking the window has normal size: see Size setter override
 
             var sizeOffset = new Size(windows_borderless_width_hack, 0);
             var newSize = CurrentDisplay.Bounds.Size + sizeOffset;


### PR DESCRIPTION
Closes https://github.com/ppy/osu-framework/issues/3456.

Goals for this change
---

1. have the hack not be noticeable by multi-monitor users
    - partially resolved, will now show black instead of bleeding the game over. would be great if the pixels could be transparent
2. render the game at display resolution
3. don't cause off-by-one errors (eg. in mouse input, when translating game coordinates to window/screen space)
4. don't break things reliant on window size, such as screenshots
5. still prevent windows or drivers from putting the game in exclusive fullscreen

Implementation/changes
---

Will now only increase the window width by 1px (as opposed to both width and height, in addition to offsetting the window position). This is done to satisfy 2. and 3. while keeping 5.

Modifying the height (while satisfying 2. and 3.) requires messing with the GL viewport, as the GL origin is the bottom left corner, while windows uses top left. So I decided against that.

Tricking the game into thinking the window is smaller seems to have no ill side effects. The only (minor) problem is the mouse being able to go one pixel too far when it's confined. This can be fixed with `SDL_SetWindowMouseRect`, but since most users will use relative mode (which works fine), I don't think it's worth it.

---

You can test out how the hack looks when the window is even wider, eg. set `WindowsBorderlessWidthHack` to `20` -- the game will neatly render on it's display, while showing a black bar on the display to the right.

On my machines, setting this to `0` will cause the game to enter quasi-exclusive fullscreen, eg. the screen will briefly flash black when alt-tabbing. So expanding only width seems to work just fine for tricking windows and drivers.

Tested on:
- Windows 10 21H1, AMD Radeon R7 370 (desktop)
- Windows 10 21H2, AMD Ryzen 7 5700U with Radeon graphics (laptop)