### PR TITLE
Fix `ClearTransforms` potentially discarding container autosizing

### DIFF
--- a/osu.Framework/Graphics/Containers/CompositeDrawable.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable.cs
@@ -1252,6 +1252,9 @@ namespace osu.Framework.Graphics.Containers
 
             base.ClearTransformsAfter(time, propagateChildren, targetMember);
 
+            if (AutoSizeAxes != Axes.None && AutoSizeDuration > 0)
+                childrenSizeDependencies.Invalidate();
+
             if (!propagateChildren)
                 return;
 


### PR DESCRIPTION
Closes #5064 

A similar case can be seen with `FlowContainer`'s layout transform, but that's more involved as the transforms are applied to the children, which makes catching them in `FlowContainer.ClearTransformsAfter` not enough to avoid the issue there (since the transform can still be cleared by the child itself).