### PR TITLE
Disable HW video decoding if an unexpected error occurs

### DIFF
--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -594,10 +594,7 @@ namespace osu.Framework.Graphics.Video
                     if (transferResult < 0)
                     {
                         Logger.Log($"Failed to transfer frame from HW decoder: {getErrorMessage(transferResult)}");
-
-                        // only try to continue with HW decoder in case the frame was just misconfigured
-                        if (transferResult != -AGffmpeg.EINVAL)
-                            tryDisableHwDecoding(transferResult);
+                        tryDisableHwDecoding(transferResult);
 
                         hwTransferFrame.Dispose();
                         continue;

--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -80,6 +80,7 @@ namespace osu.Framework.Graphics.Video
 
         private bool inputOpened;
         private bool isDisposed;
+        private bool hwDecodingAllowed = true;
         private Stream videoStream;
 
         private double timeBaseInSeconds;
@@ -348,9 +349,10 @@ namespace osu.Framework.Graphics.Video
                 return;
 
             var codecParams = *stream->codecpar;
+            var targetHwDecoders = hwDecodingAllowed ? TargetHardwareVideoDecoders.Value : HardwareVideoDecoder.None;
             bool openSuccessful = false;
 
-            foreach (var (decoder, hwDeviceType) in GetAvailableDecoders(formatContext->iformat, codecParams.codec_id, TargetHardwareVideoDecoders.Value))
+            foreach (var (decoder, hwDeviceType) in GetAvailableDecoders(formatContext->iformat, codecParams.codec_id, targetHwDecoders))
             {
                 // free context in case it was allocated in a previous iteration or recreate call.
                 if (codecContext != null)
@@ -535,9 +537,14 @@ namespace osu.Framework.Graphics.Video
             // Note: EAGAIN can be returned if there's too many pending frames, which we have to read,
             // otherwise we would get stuck in an infinite loop.
             if (sendPacketResult == 0 || sendPacketResult == -AGffmpeg.EAGAIN)
+            {
                 readDecodedFrames(receiveFrame);
+            }
             else
+            {
                 Logger.Log($"Failed to send avcodec packet: {getErrorMessage(sendPacketResult)}");
+                tryDisableHwDecoding(sendPacketResult);
+            }
 
             return sendPacketResult;
         }
@@ -556,6 +563,7 @@ namespace osu.Framework.Graphics.Video
                     if (receiveFrameResult != -AGffmpeg.EAGAIN && receiveFrameResult != AGffmpeg.AVERROR_EOF)
                     {
                         Logger.Log($"Failed to receive frame from avcodec: {getErrorMessage(receiveFrameResult)}");
+                        tryDisableHwDecoding(receiveFrameResult);
                     }
 
                     break;
@@ -587,7 +595,10 @@ namespace osu.Framework.Graphics.Video
                     {
                         Logger.Log($"Failed to transfer frame from HW decoder: {getErrorMessage(transferResult)}");
 
-                        // dispose of the frame instead of enqueueing it in case that the failure was caused by it's configuration.
+                        // only try to continue with HW decoder in case the frame was just misconfigured
+                        if (transferResult != -AGffmpeg.EINVAL)
+                            tryDisableHwDecoding(transferResult);
+
                         hwTransferFrame.Dispose();
                         continue;
                     }
@@ -678,6 +689,28 @@ namespace osu.Framework.Graphics.Video
             }
 
             return scalerFrame;
+        }
+
+        private void tryDisableHwDecoding(int errorCode)
+        {
+            if (!hwDecodingAllowed || TargetHardwareVideoDecoders.Value == HardwareVideoDecoder.None || codecContext == null || codecContext->hw_device_ctx == null)
+                return;
+
+            hwDecodingAllowed = false;
+
+            if (errorCode == -AGffmpeg.ENOMEM)
+            {
+                Logger.Log("Disabling hardware decoding of all videos due to a lack of memory");
+                TargetHardwareVideoDecoders.Value = HardwareVideoDecoder.None;
+
+                // `recreateCodecContext` will be called by the bindable hook
+            }
+            else
+            {
+                Logger.Log("Disabling hardware decoding of the current video due to an unexpected error");
+
+                decoderCommands.Enqueue(recreateCodecContext);
+            }
         }
 
         private string getErrorMessage(int errorCode)


### PR DESCRIPTION
Closes #4857

If any FFmpeg function that works with HW decoding fails with an unexpected error, HW decoding is disabled for the current "decoding session". If the error is `ENOMEM` then HW decoding is also disabled at framework config level.

I only tested this manually with the following patch:
```csharp
diff --git a/osu.Framework/Graphics/Video/VideoDecoder.cs b/osu.Framework/Graphics/Video/VideoDecoder.cs
index 8dd912716..b563d754f 100644
--- a/osu.Framework/Graphics/Video/VideoDecoder.cs
+++ b/osu.Framework/Graphics/Video/VideoDecoder.cs
@@ -534,6 +534,12 @@ private int sendPacket(AVFrame* receiveFrame, AVPacket* packet)
             // send the packet for decoding.
             int sendPacketResult = ffmpeg.avcodec_send_packet(codecContext, packet);
 
+            if (codecContext->hw_device_ctx != null && packet->dts * timeBaseInSeconds > 5)
+            {
+                // sendPacketResult = AGffmpeg.AVERROR_BUG2;
+                sendPacketResult = -AGffmpeg.ENOMEM;
+            }
+
             // Note: EAGAIN can be returned if there's too many pending frames, which we have to read,
             // otherwise we would get stuck in an infinite loop.
             if (sendPacketResult == 0 || sendPacketResult == -AGffmpeg.EAGAIN)
```