### PR TITLE
Change signature of `OpenFileExternally` and `PresentFileExternally` to gracefuly fail

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -69,9 +69,9 @@ namespace osu.Framework.Android
             Application.Context.GetExternalFilesDir(string.Empty)!.ToString(),
         };
 
-        public override void OpenFileExternally(string filename) => false;
+        public override bool OpenFileExternally(string filename) => false;
 
-        public override void PresentFileExternally(string filename) => false;
+        public override bool PresentFileExternally(string filename) => false;
 
         public override void OpenUrlExternally(string url)
         {

--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -69,11 +69,9 @@ namespace osu.Framework.Android
             Application.Context.GetExternalFilesDir(string.Empty)!.ToString(),
         };
 
-        public override void OpenFileExternally(string filename)
-            => throw new NotImplementedException();
+        public override void OpenFileExternally(string filename) => false;
 
-        public override void PresentFileExternally(string filename)
-            => throw new NotImplementedException();
+        public override void PresentFileExternally(string filename) => false;
 
         public override void OpenUrlExternally(string url)
         {

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -103,9 +103,9 @@ namespace osu.Framework.iOS
 
         public override Storage GetStorage(string path) => new IOSStorage(path, this);
 
-        public override void OpenFileExternally(string filename) => throw new NotImplementedException();
+        public override void OpenFileExternally(string filename) => false;
 
-        public override void PresentFileExternally(string filename) => throw new NotImplementedException();
+        public override void PresentFileExternally(string filename) => false;
 
         public override void OpenUrlExternally(string url)
         {

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -103,9 +103,9 @@ namespace osu.Framework.iOS
 
         public override Storage GetStorage(string path) => new IOSStorage(path, this);
 
-        public override void OpenFileExternally(string filename) => false;
+        public override bool OpenFileExternally(string filename) => false;
 
-        public override void PresentFileExternally(string filename) => false;
+        public override bool PresentFileExternally(string filename) => false;
 
         public override void OpenUrlExternally(string url)
         {

--- a/osu.Framework/Platform/DesktopGameHost.cs
+++ b/osu.Framework/Platform/DesktopGameHost.cs
@@ -76,13 +76,20 @@ namespace osu.Framework.Platform
 
         public override bool CapsLockEnabled => (Window as SDL2DesktopWindow)?.CapsLockPressed == true;
 
-        public override void OpenFileExternally(string filename) => openUsingShellExecute(filename);
+        public override bool OpenFileExternally(string filename)
+        {
+            openUsingShellExecute(filename);
+            return true;
+        }
 
         public override void OpenUrlExternally(string url) => openUsingShellExecute(url);
 
-        public override void PresentFileExternally(string filename)
+        public override bool PresentFileExternally(string filename)
+        {
             // should be overriden to highlight/select the file in the folder if such native API exists.
-            => OpenFileExternally(Path.GetDirectoryName(filename.TrimDirectorySeparator()));
+            OpenFileExternally(Path.GetDirectoryName(filename.TrimDirectorySeparator()));
+            return true;
+        }
 
         private void openUsingShellExecute(string path) => Process.Start(new ProcessStartInfo
         {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -127,14 +127,19 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Requests that a file be opened externally with an associated application, if available.
         /// </summary>
+        /// <remarks>
+        /// Some platforms do not support interacting with files externally (ie. mobile or sandboxed platforms), check the return value as to whether it succeeded.
+        /// </remarks>
         /// <param name="filename">The absolute path to the file which should be opened.</param>
-        public abstract void OpenFileExternally(string filename);
+        /// <returns>Whether the file was successfully opened.</returns>
+        public abstract bool OpenFileExternally(string filename);
 
         /// <summary>
         /// Requests to present a file externally in the platform's native file browser.
         /// </summary>
         /// <remarks>
         /// This will open the parent folder and, (if available) highlight the file.
+        /// Some platforms do not support interacting with files externally (ie. mobile or sandboxed platforms), check the return value as to whether it succeeded.
         /// </remarks>
         /// <example>
         ///     <para>"C:\Windows\explorer.exe" -> opens 'C:\Windows' and highlights 'explorer.exe' in the window.</para>
@@ -142,7 +147,8 @@ namespace osu.Framework.Platform
         ///     <para>"C:\Windows\System32\" -> opens 'C:\Windows\System32' and highlights nothing.</para>
         /// </example>
         /// <param name="filename">The absolute path to the file/folder to be shown in its parent folder.</param>
-        public abstract void PresentFileExternally(string filename);
+        /// <returns>Whether the file was successfully presented.</returns>
+        public abstract bool PresentFileExternally(string filename);
 
         /// <summary>
         /// Requests that a URL be opened externally in a web browser, if available.

--- a/osu.Framework/Platform/HeadlessGameHost.cs
+++ b/osu.Framework/Platform/HeadlessGameHost.cs
@@ -22,9 +22,17 @@ namespace osu.Framework.Platform
 
         protected override IFrameBasedClock SceneGraphClock => customClock ?? base.SceneGraphClock;
 
-        public override void OpenFileExternally(string filename) => Logger.Log($"Application has requested file \"{filename}\" to be opened.");
+        public override bool OpenFileExternally(string filename)
+        {
+            Logger.Log($"Application has requested file \"{filename}\" to be opened.");
+            return true;
+        }
 
-        public override void PresentFileExternally(string filename) => Logger.Log($"Application has requested file \"{filename}\" to be shown.");
+        public override bool PresentFileExternally(string filename)
+        {
+            Logger.Log($"Application has requested file \"{filename}\" to be shown.");
+            return true;
+        }
 
         public override void OpenUrlExternally(string url) => Logger.Log($"Application has requested URL \"{url}\" to be opened.");
 

--- a/osu.Framework/Platform/NativeStorage.cs
+++ b/osu.Framework/Platform/NativeStorage.cs
@@ -68,11 +68,11 @@ namespace osu.Framework.Platform
             return resolvedPath;
         }
 
-        public override void OpenFileExternally(string filename) =>
-            host?.OpenFileExternally(GetFullPath(filename));
+        public override bool OpenFileExternally(string filename) =>
+            host?.OpenFileExternally(GetFullPath(filename)) == true;
 
-        public override void PresentFileExternally(string filename) =>
-            host?.PresentFileExternally(GetFullPath(filename));
+        public override bool PresentFileExternally(string filename) =>
+            host?.PresentFileExternally(GetFullPath(filename)) == true;
 
         public override Stream GetStream(string path, FileAccess access = FileAccess.Read, FileMode mode = FileMode.OpenOrCreate)
         {

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -117,7 +117,7 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Opens a native file browser window to the root path of this storage.
         /// </summary>
-        /// <returns>Whether the file was successfully presented.</returns>
+        /// <returns>Whether the storage was successfully presented.</returns>
         public bool PresentExternally() => OpenFileExternally(string.Empty);
 
         /// <summary>

--- a/osu.Framework/Platform/Storage.cs
+++ b/osu.Framework/Platform/Storage.cs
@@ -111,12 +111,14 @@ namespace osu.Framework.Platform
         /// Requests that a file be opened externally with an associated application, if available.
         /// </summary>
         /// <param name="filename">The relative path to the file which should be opened.</param>
-        public abstract void OpenFileExternally(string filename);
+        /// <returns>Whether the file was successfully opened.</returns>
+        public abstract bool OpenFileExternally(string filename);
 
         /// <summary>
         /// Opens a native file browser window to the root path of this storage.
         /// </summary>
-        public void PresentExternally() => OpenFileExternally(string.Empty);
+        /// <returns>Whether the file was successfully presented.</returns>
+        public bool PresentExternally() => OpenFileExternally(string.Empty);
 
         /// <summary>
         /// Requests to present a file externally in the platform's native file browser.
@@ -125,6 +127,7 @@ namespace osu.Framework.Platform
         /// This will open the parent folder and, (if available) highlight the file.
         /// </remarks>
         /// <param name="filename">Relative path to the file.</param>
-        public abstract void PresentFileExternally(string filename);
+        /// <returns>Whether the file was successfully presented.</returns>
+        public abstract bool PresentFileExternally(string filename);
     }
 }

--- a/osu.Framework/Platform/Windows/WindowsGameHost.cs
+++ b/osu.Framework/Platform/Windows/WindowsGameHost.cs
@@ -37,7 +37,7 @@ namespace osu.Framework.Platform.Windows
         {
         }
 
-        public override void OpenFileExternally(string filename)
+        public override bool OpenFileExternally(string filename)
         {
             if (Directory.Exists(filename))
             {
@@ -45,13 +45,17 @@ namespace osu.Framework.Platform.Windows
                 string folder = filename.TrimDirectorySeparator() + Path.DirectorySeparatorChar;
 
                 Explorer.OpenFolderAndSelectItem(folder);
-                return;
+                return true;
             }
 
-            base.OpenFileExternally(filename);
+            return base.OpenFileExternally(filename);
         }
 
-        public override void PresentFileExternally(string filename) => Explorer.OpenFolderAndSelectItem(filename.TrimDirectorySeparator());
+        public override bool PresentFileExternally(string filename)
+        {
+            Explorer.OpenFolderAndSelectItem(filename.TrimDirectorySeparator());
+            return true;
+        }
 
         protected override IEnumerable<InputHandler> CreateAvailableInputHandlers()
         {


### PR DESCRIPTION
Mobile platforms were throwing `NotImplementedException` for these methods, which is very easy to overlook. Providing a return code makes it very clear that it is not guaranteed that these method will result in success.

Closes https://github.com/ppy/osu-framework/issues/5073.