### PR TITLE
Fix zero-size sprites being drawn

### DIFF
--- a/osu.Framework/Graphics/Shapes/Triangle.cs
+++ b/osu.Framework/Graphics/Shapes/Triangle.cs
@@ -44,12 +44,18 @@ namespace osu.Framework.Graphics.Shapes
 
             protected override void Blit(Action<TexturedVertex2D> vertexAction)
             {
+                if (DrawRectangle.Width == 0 || DrawRectangle.Height == 0)
+                    return;
+
                 DrawTriangle(Texture, toTriangle(ScreenSpaceDrawQuad), DrawColourInfo.Colour, null, null,
                     new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height), TextureCoords);
             }
 
             protected override void BlitOpaqueInterior(Action<TexturedVertex2D> vertexAction)
             {
+                if (DrawRectangle.Width == 0 || DrawRectangle.Height == 0)
+                    return;
+
                 var triangle = toTriangle(ConservativeScreenSpaceDrawQuad);
 
                 if (GLWrapper.IsMaskingActive)

--- a/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
+++ b/osu.Framework/Graphics/Sprites/SpriteDrawNode.cs
@@ -58,6 +58,9 @@ namespace osu.Framework.Graphics.Sprites
 
         protected virtual void Blit(Action<TexturedVertex2D> vertexAction)
         {
+            if (DrawRectangle.Width == 0 || DrawRectangle.Height == 0)
+                return;
+
             DrawQuad(Texture, ScreenSpaceDrawQuad, DrawColourInfo.Colour, null, vertexAction,
                 new Vector2(InflationAmount.X / DrawRectangle.Width, InflationAmount.Y / DrawRectangle.Height),
                 null, TextureCoords);
@@ -65,6 +68,9 @@ namespace osu.Framework.Graphics.Sprites
 
         protected virtual void BlitOpaqueInterior(Action<TexturedVertex2D> vertexAction)
         {
+            if (DrawRectangle.Width == 0 || DrawRectangle.Height == 0)
+                return;
+
             if (GLWrapper.IsMaskingActive)
                 DrawClipped(ref ConservativeScreenSpaceDrawQuad, Texture, DrawColourInfo.Colour, vertexAction: vertexAction);
             else


### PR DESCRIPTION
The real issue I wanted to address here is the `InflationAmount / DrawRectangle` divisions leading to `NaN` values, but I think it makes more sense to simply not draw sprites with zero sizes than inlining conditions.