### PR TITLE
Expose synchronisation context on `GameThread`

### DIFF
--- a/osu.Framework/Threading/GameThread.cs
+++ b/osu.Framework/Threading/GameThread.cs
@@ -81,6 +81,11 @@ namespace osu.Framework.Threading
         public EventHandler<UnhandledExceptionEventArgs> UnhandledException;
 
         /// <summary>
+        /// A synchronisation context which posts to this thread.
+        /// </summary>
+        public SynchronizationContext SynchronizationContext => synchronizationContext;
+
+        /// <summary>
         /// The culture of this thread.
         /// </summary>
         public CultureInfo CurrentCulture


### PR DESCRIPTION
Allows for a bit of added flexibility. I am able to use this for instance to give `RealmAccess` a way to subscribe for notifications without being required to be called from the update thread. Without exposing this context here, the earliest point of obtaining it is in `Game.LoadComplete` which can be too late (and less guaranteed) for such scenarios.