### PR TITLE
Fix tracks/samples not updating running state immediately

### DIFF
--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -89,6 +89,10 @@ namespace osu.Framework.Tests.Audio
             Assert.IsFalse(channel.Playing);
         }
 
+        /// <summary>
+        /// Tests the case where a play call can be run inline due to already being on the audio thread.
+        /// Because it's immediately executed, a `Bass.Update()` call is not required before the channel's state is updated.
+        /// </summary>
         [Test]
         public void TestPlayingUpdatedAfterInlinePlay()
         {
@@ -96,6 +100,10 @@ namespace osu.Framework.Tests.Audio
             Assert.That(channel.Playing, Is.True);
         }
 
+        /// <summary>
+        /// Tests the case where a stop call can be run inline due to already being on the audio thread.
+        /// Because it's immediately executed, a `Bass.Update()` call is not required before the channel's state is updated.
+        /// </summary>
         [Test]
         public void TestPlayingUpdatedAfterInlineStop()
         {

--- a/osu.Framework.Tests/Audio/SampleBassTest.cs
+++ b/osu.Framework.Tests/Audio/SampleBassTest.cs
@@ -88,5 +88,22 @@ namespace osu.Framework.Tests.Audio
 
             Assert.IsFalse(channel.Playing);
         }
+
+        [Test]
+        public void TestPlayingUpdatedAfterInlinePlay()
+        {
+            bass.RunOnAudioThread(() => channel = sample.Play());
+            Assert.That(channel.Playing, Is.True);
+        }
+
+        [Test]
+        public void TestPlayingUpdatedAfterInlineStop()
+        {
+            channel = sample.Play();
+            bass.Update();
+
+            bass.RunOnAudioThread(() => channel.Stop());
+            Assert.That(channel.Playing, Is.False);
+        }
     }
 }

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -392,6 +392,23 @@ namespace osu.Framework.Tests.Audio
         }
 
         [Test]
+        public void TestIsRunningUpdatedAfterInlineStart()
+        {
+            bass.RunOnAudioThread(() => track.Start());
+            Assert.That(track.IsRunning, Is.True);
+        }
+
+        [Test]
+        public void TestIsRunningUpdatedAfterInlineStop()
+        {
+            track.StartAsync();
+            bass.Update();
+
+            bass.RunOnAudioThread(() => track.Stop());
+            Assert.That(track.IsRunning, Is.False);
+        }
+
+        [Test]
         public void TestCurrentTimeUpdatedAfterInlineSeek()
         {
             track.StartAsync();

--- a/osu.Framework.Tests/Audio/TrackBassTest.cs
+++ b/osu.Framework.Tests/Audio/TrackBassTest.cs
@@ -391,6 +391,10 @@ namespace osu.Framework.Tests.Audio
             Assert.Greater(track.Bitrate, 0);
         }
 
+        /// <summary>
+        /// Tests the case where a start call can be run inline due to already being on the audio thread.
+        /// Because it's immediately executed, a `Bass.Update()` call is not required before the channel's state is updated.
+        /// </summary>
         [Test]
         public void TestIsRunningUpdatedAfterInlineStart()
         {
@@ -398,6 +402,10 @@ namespace osu.Framework.Tests.Audio
             Assert.That(track.IsRunning, Is.True);
         }
 
+        /// <summary>
+        /// Tests the case where a stop call can be run inline due to already being on the audio thread.
+        /// Because it's immediately executed, a `Bass.Update()` call is not required before the channel's state is updated.
+        /// </summary>
         [Test]
         public void TestIsRunningUpdatedAfterInlineStop()
         {
@@ -408,6 +416,10 @@ namespace osu.Framework.Tests.Audio
             Assert.That(track.IsRunning, Is.False);
         }
 
+        /// <summary>
+        /// Tests the case where a seek call can be run inline due to already being on the audio thread.
+        /// Because it's immediately executed, a `Bass.Update()` call is not required before the channel's state is updated.
+        /// </summary>
         [Test]
         public void TestCurrentTimeUpdatedAfterInlineSeek()
         {

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -195,7 +195,6 @@ namespace osu.Framework.Audio.Track
             // there will be a brief time where this track will be stopped, before we resume it manually (see comments in UpdateDevice(int).)
             // this makes us appear to be playing, even if we may not be.
             isRunning = running || (isPlayed && !hasCompleted);
-
             updateCurrentTime();
 
             bassAmplitudeProcessor?.Update();
@@ -213,7 +212,7 @@ namespace osu.Framework.Audio.Track
         public Task StopAsync() => EnqueueAction(() =>
         {
             stopInternal();
-            isPlayed = false;
+            isRunning = isPlayed = false;
         });
 
         private bool stopInternal() => isRunningState(bassMixer.ChannelIsActive(this)) && bassMixer.ChannelPause(this, true);
@@ -236,7 +235,7 @@ namespace osu.Framework.Audio.Track
         public Task StartAsync() => EnqueueAction(() =>
         {
             if (startInternal())
-                isPlayed = true;
+                isRunning = isPlayed = true;
         });
 
         private bool startInternal()

--- a/osu.Framework/Audio/Track/TrackBass.cs
+++ b/osu.Framework/Audio/Track/TrackBass.cs
@@ -215,7 +215,13 @@ namespace osu.Framework.Audio.Track
             isRunning = isPlayed = false;
         });
 
-        private bool stopInternal() => isRunningState(bassMixer.ChannelIsActive(this)) && bassMixer.ChannelPause(this, true);
+        private void stopInternal()
+        {
+            if (!isRunningState(bassMixer.ChannelIsActive(this)))
+                return;
+
+            bassMixer.ChannelPause(this, true);
+        }
 
         private int direction;
 


### PR DESCRIPTION
- Closes https://github.com/ppy/osu-framework/issues/4396 
- Resolves https://github.com/ppy/osu/discussions/17361

`SampleChannelBass` is refactored to work in a similar manner to `TrackBass`, for ensuring that the zero frequency handler doesn't affect the state of `playing` when manipulating that during a stop call.

It has been mentioned in https://github.com/ppy/osu-framework/pull/4395#issue-865952658 that this is a bit involved, so I'm slightly wondering if I'm missing something with the current solution (cc @smoogipoo).