### PR TITLE
Allow drawables to specify custom drag distance tolerance

### DIFF
--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -327,7 +327,7 @@ namespace osu.Framework.Graphics.Containers
             // similar calculation to what is already done in MouseButtonEventManager.HandlePositionChange
             // handles the case where a drag was triggered on an axis we are not interested in.
             // can be removed if/when drag events are split out per axis or contain direction information.
-            dragBlocksClick |= Math.Abs(e.MouseDownPosition[ScrollDim] - e.MousePosition[ScrollDim]) > dragButtonManager.ClickDragDistance;
+            dragBlocksClick |= Math.Abs(e.MouseDownPosition[ScrollDim] - e.MousePosition[ScrollDim]) > Content.DragTolerance;
 
             scrollByOffset(scrollOffset, false);
         }

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -2519,6 +2519,11 @@ namespace osu.Framework.Graphics
         public bool IsDragged { get; internal set; }
 
         /// <summary>
+        /// The distance a pointer needs to move to start dragging this drawable.
+        /// </summary>
+        public virtual float DragTolerance => 10f;
+
+        /// <summary>
         /// Determines whether this drawable receives positional input when the mouse is at the
         /// given screen-space position.
         /// </summary>

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -75,6 +75,11 @@ namespace osu.Framework.Input
         protected WeakReference<Drawable> ClickedDrawable = new WeakReference<Drawable>(null);
 
         /// <summary>
+        /// The drawable which handled the last MouseDown event.
+        /// </summary>
+        protected WeakReference<Drawable> PendingClickDrawable = new WeakReference<Drawable>(null);
+
+        /// <summary>
         /// Whether a drag operation has started and <see cref="DraggedDrawable"/> has been searched for.
         /// </summary>
         protected bool DragStarted;
@@ -88,10 +93,10 @@ namespace osu.Framework.Input
         {
             if (EnableDrag)
             {
-                if (!DragStarted)
+                if (!DragStarted && PendingClickDrawable.TryGetTarget(out Drawable target))
                 {
                     var mouse = state.Mouse;
-                    if (mouse.IsPressed(Button) && Vector2Extensions.Distance(MouseDownPosition ?? mouse.Position, mouse.Position) > ClickDragDistance)
+                    if (mouse.IsPressed(Button) && Vector2Extensions.Distance(MouseDownPosition ?? mouse.Position, mouse.Position) > target.DragTolerance)
                         handleDragStart(state);
                 }
 
@@ -108,6 +113,7 @@ namespace osu.Framework.Input
                 MouseDownPosition = state.Mouse.Position;
 
             Drawable handledBy = PropagateButtonEvent(targets, new MouseDownEvent(state, Button, MouseDownPosition));
+            PendingClickDrawable.SetTarget(handledBy);
 
             if (LastClickTime != null && GetCurrentTime() - LastClickTime < DoubleClickTime)
             {

--- a/osu.Framework/Input/MouseButtonEventManager.cs
+++ b/osu.Framework/Input/MouseButtonEventManager.cs
@@ -55,11 +55,6 @@ namespace osu.Framework.Input
         public virtual float DoubleClickTime => 250;
 
         /// <summary>
-        /// The distance that must be moved until a dragged click becomes invalid.
-        /// </summary>
-        public virtual float ClickDragDistance => 10;
-
-        /// <summary>
         /// The position of the mouse when the last time the button is pressed.
         /// </summary>
         public Vector2? MouseDownPosition { get; protected set; }


### PR DESCRIPTION
Related PR: https://github.com/ppy/osu/pull/17488

This PR implements a dragging tolerance parameter for drawables. This change allows an object to define how sensitive it should be to dragging.

Generally, most draggable elements should have some room for error where the mouse can move just a bit and the action should still be considered a click. However, in some cases it's desirable to handle the drag right away, ex.: for small adjustments in an editor.