### PR TITLE
Ignore `Normalize all the line endings` commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Normalize all the line endings
+7a598af5b92ef76e9a542170befd89ba2556a97c


### PR DESCRIPTION
ppy/osu#17569 but for framework