### PR TITLE
Bump `SixLabors.ImageSharp` to v2.1.0

### DIFF
--- a/osu.Framework.Android/AndroidGameHost.cs
+++ b/osu.Framework.Android/AndroidGameHost.cs
@@ -40,8 +40,6 @@ namespace osu.Framework.Android
 
         protected override IWindow CreateWindow() => new AndroidGameWindow(gameView);
 
-        protected override bool LimitedMemoryEnvironment => true;
-
         public override bool CanExit => false;
 
         public override bool CanSuspendToBackground => true;

--- a/osu.Framework.Benchmarks/BenchmarkFontLoading.cs
+++ b/osu.Framework.Benchmarks/BenchmarkFontLoading.cs
@@ -21,7 +21,7 @@ namespace osu.Framework.Benchmarks
 
         public override void SetUp()
         {
-            SixLabors.ImageSharp.Configuration.Default.MemoryAllocator = ArrayPoolMemoryAllocator.CreateDefault();
+            SixLabors.ImageSharp.Configuration.Default.MemoryAllocator = MemoryAllocator.Default;
 
             baseResources = new NamespacedResourceStore<byte[]>(new DllResourceStore(@"osu.Framework.dll"), @"Resources");
             sharedTemp = new TemporaryNativeStorage("fontstore-test-" + Guid.NewGuid());
@@ -66,7 +66,7 @@ namespace osu.Framework.Benchmarks
         [Benchmark]
         public void BenchmarkTimedExpiry()
         {
-            SixLabors.ImageSharp.Configuration.Default.MemoryAllocator = ArrayPoolMemoryAllocator.CreateDefault();
+            SixLabors.ImageSharp.Configuration.Default.MemoryAllocator = MemoryAllocator.Default;
 
             using (var store = new TimedExpiryGlyphStore(baseResources, font_name))
                 runFor(store);

--- a/osu.Framework.iOS.props
+++ b/osu.Framework.iOS.props
@@ -59,7 +59,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="FFmpeg.AutoGen" Version="4.3.0.1" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     <PackageReference Include="System.Drawing.Common" Version="5.0.2" />
     <PackageReference Include="ppy.osuTK.NS20" Version="1.0.187" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />

--- a/osu.Framework.iOS/GameAppDelegate.cs
+++ b/osu.Framework.iOS/GameAppDelegate.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Drawing;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using AVFoundation;
 using Foundation;
 using SixLabors.ImageSharp.Formats.Png;
@@ -54,7 +55,7 @@ namespace osu.Framework.iOS
 
             try
             {
-                new PngDecoder().Decode<Rgba32>(SixLabors.ImageSharp.Configuration.Default, null);
+                new PngDecoder().Decode<Rgba32>(SixLabors.ImageSharp.Configuration.Default, null, CancellationToken.None);
             }
             catch
             {

--- a/osu.Framework.iOS/IOSGameHost.cs
+++ b/osu.Framework.iOS/IOSGameHost.cs
@@ -85,8 +85,6 @@ namespace osu.Framework.iOS
 
         public override bool OnScreenKeyboardOverlapsGameWindow => true;
 
-        protected override bool LimitedMemoryEnvironment => true;
-
         public override bool CanExit => false;
 
         protected override TextInputSource CreateTextInput() => new IOSTextInput(gameView);

--- a/osu.Framework.iOS/osu.Framework.iOS.csproj
+++ b/osu.Framework.iOS/osu.Framework.iOS.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="ppy.osuTK.iOS" Version="1.0.187" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>
     <!-- Don't forget to update the linker attributes in AssemblyInfo.cs if you are modifying native libraries. -->

--- a/osu.Framework/Extensions/ImageExtensions/ImageExtensions.cs
+++ b/osu.Framework/Extensions/ImageExtensions/ImageExtensions.cs
@@ -5,6 +5,7 @@
 
 using System.Buffers;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.Extensions.ImageExtensions
@@ -52,10 +53,10 @@ namespace osu.Framework.Extensions.ImageExtensions
             where TPixel : unmanaged, IPixel<TPixel>
         {
             var allocatedOwner = SixLabors.ImageSharp.Configuration.Default.MemoryAllocator.Allocate<TPixel>(image.Width * image.Height);
-            var allocatedSpan = allocatedOwner.Memory.Span;
+            var allocatedMemory = allocatedOwner.Memory;
 
             for (int r = 0; r < image.Height; r++)
-                image.GetPixelRowSpan(r).CopyTo(allocatedSpan.Slice(r * image.Width));
+                image.DangerousGetPixelRowMemory(r).CopyTo(allocatedMemory.Slice(r * image.Width));
 
             return allocatedOwner;
         }

--- a/osu.Framework/Extensions/ImageExtensions/ReadOnlyPixelMemory.cs
+++ b/osu.Framework/Extensions/ImageExtensions/ReadOnlyPixelMemory.cs
@@ -22,7 +22,7 @@ namespace osu.Framework.Extensions.ImageExtensions
         {
             this.image = image;
 
-            if (image.TryGetSinglePixelSpan(out _))
+            if (image.DangerousTryGetSinglePixelMemory(out _))
             {
                 owner = null;
                 memory = null;
@@ -46,8 +46,8 @@ namespace osu.Framework.Extensions.ImageExtensions
                     return Span<TPixel>.Empty;
 
                 // If the image can be returned without extra contiguous memory allocation.
-                if (image.TryGetSinglePixelSpan(out var pixelSpan))
-                    return pixelSpan;
+                if (image.DangerousTryGetSinglePixelMemory(out var pixelMemory))
+                    return pixelMemory.Span;
 
                 Debug.Assert(memory != null);
                 return memory.Value.Span;

--- a/osu.Framework/Extensions/ImageExtensions/ReadOnlyPixelSpan.cs
+++ b/osu.Framework/Extensions/ImageExtensions/ReadOnlyPixelSpan.cs
@@ -22,10 +22,10 @@ namespace osu.Framework.Extensions.ImageExtensions
 
         internal ReadOnlyPixelSpan(Image<TPixel> image)
         {
-            if (image.TryGetSinglePixelSpan(out var span))
+            if (image.DangerousTryGetSinglePixelMemory(out var memory))
             {
                 owner = null;
-                Span = span;
+                Span = memory.Span;
             }
             else
             {

--- a/osu.Framework/IO/Stores/GlyphStore.cs
+++ b/osu.Framework/IO/Stores/GlyphStore.cs
@@ -15,6 +15,7 @@ using osu.Framework.Logging;
 using osu.Framework.Text;
 using SharpFNT;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.IO.Stores
@@ -153,11 +154,11 @@ namespace osu.Framework.IO.Stores
 
             for (int y = 0; y < character.Height; y++)
             {
-                var pixelRowSpan = image.GetPixelRowSpan(y);
+                var pixelRowMemory = image.DangerousGetPixelRowMemory(y);
                 int readOffset = (character.Y + y) * page.Width + character.X;
 
                 for (int x = 0; x < character.Width; x++)
-                    pixelRowSpan[x] = x < readableWidth && y < readableHeight ? source[readOffset + x] : new Rgba32(255, 255, 255, 0);
+                    pixelRowMemory.Span[x] = x < readableWidth && y < readableHeight ? source[readOffset + x] : new Rgba32(255, 255, 255, 0);
             }
 
             return new TextureUpload(image);

--- a/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
+++ b/osu.Framework/IO/Stores/RawCachingGlyphStore.cs
@@ -11,6 +11,7 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Platform;
 using SharpFNT;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace osu.Framework.IO.Stores
@@ -123,11 +124,11 @@ namespace osu.Framework.IO.Stores
 
             for (int y = 0; y < character.Height; y++)
             {
-                var pixelRowSpan = image.GetPixelRowSpan(y);
+                var pixelRowMemory = image.DangerousGetPixelRowMemory(y);
                 int readOffset = y * pageWidth + character.X;
 
                 for (int x = 0; x < character.Width; x++)
-                    pixelRowSpan[x] = new Rgba32(255, 255, 255, x < readableWidth && y < readableHeight ? readBuffer[readOffset + x] : (byte)0);
+                    pixelRowMemory.Span[x] = new Rgba32(255, 255, 255, x < readableWidth && y < readableHeight ? readBuffer[readOffset + x] : (byte)0);
             }
 
             return new TextureUpload(image);

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -40,7 +40,6 @@ using osu.Framework.Graphics.Textures;
 using osu.Framework.Graphics.Video;
 using osu.Framework.IO.Serialization;
 using osu.Framework.IO.Stores;
-using SixLabors.ImageSharp.Memory;
 using Image = SixLabors.ImageSharp.Image;
 using PixelFormat = osuTK.Graphics.ES30.PixelFormat;
 using Size = System.Drawing.Size;
@@ -114,11 +113,6 @@ namespace osu.Framework.Platform
         /// This and <see cref="SuspendToBackground"/> are an alternative way to exit on hosts that have <see cref="CanExit"/> <c>false</c>.
         /// </remarks>
         public virtual bool CanSuspendToBackground => false;
-
-        /// <summary>
-        /// Whether memory constraints should be considered before performance concerns.
-        /// </summary>
-        protected virtual bool LimitedMemoryEnvironment => false;
 
         protected IpcMessage OnMessageReceived(IpcMessage message) => MessageReceived?.Invoke(message);
 
@@ -664,12 +658,6 @@ namespace osu.Framework.Platform
             }
 
             GCSettings.LatencyMode = GCLatencyMode.SustainedLowLatency;
-
-            if (LimitedMemoryEnvironment)
-            {
-                // recommended middle-ground https://github.com/SixLabors/docs/blob/main/articles/imagesharp/memorymanagement.md#configuring-the-pool-size
-                SixLabors.ImageSharp.Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocatorOptions { MaximumPoolSizeMegabytes = 1 });
-            }
 
             if (ExecutionState != ExecutionState.Idle)
                 throw new InvalidOperationException("A game that has already been run cannot be restarted.");

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -667,8 +667,8 @@ namespace osu.Framework.Platform
 
             if (LimitedMemoryEnvironment)
             {
-                // recommended middle-ground https://github.com/SixLabors/docs/blob/master/articles/ImageSharp/MemoryManagement.md#working-in-memory-constrained-environments
-                SixLabors.ImageSharp.Configuration.Default.MemoryAllocator = ArrayPoolMemoryAllocator.CreateWithModeratePooling();
+                // recommended middle-ground https://github.com/SixLabors/docs/blob/main/articles/imagesharp/memorymanagement.md#configuring-the-pool-size
+                SixLabors.ImageSharp.Configuration.Default.MemoryAllocator = MemoryAllocator.Create(new MemoryAllocatorOptions { MaximumPoolSizeMegabytes = 1 });
             }
 
             if (ExecutionState != ExecutionState.Idle)

--- a/osu.Framework/osu.Framework.csproj
+++ b/osu.Framework/osu.Framework.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="NuGet.ProjectModel" Version="5.11.0" />
     <PackageReference Include="SharpFNT" Version="2.0.0" />
     <!-- Preview version of ImageSharp causes NU5104. -->
-    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.0" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="ManagedBass" Version="3.1.0" />
     <PackageReference Include="ManagedBass.Fx" Version="3.1.0" />


### PR DESCRIPTION
This is required for supporting macOS image clipboards, requiring TIFF encoder/decoder which is supported in ImageSharp v2.1.0.

Breaking changes come from https://github.com/SixLabors/ImageSharp/pull/1730/https://github.com/SixLabors/ImageSharp/issues/1739.

The important one is that `ArrayPoolMemoryAllocator` has been completely replaced with the new and default [`UniformUnmanagedMemoryPoolMemoryAllocator`](https://github.com/SixLabors/ImageSharp/blob/main/src/ImageSharp/Memory/Allocators/UniformUnmanagedMemoryPoolMemoryAllocator.cs), which is still partially `ArrayPool`-based for smaller allocations, but uses a [different pool implementation](https://github.com/SixLabors/ImageSharp/blob/main/src/ImageSharp/Memory/Allocators/Internals/UniformUnmanagedMemoryPool.cs) for larger allocations.

I can't check on the performance side of this, so would appreciate that being done prior to merge.