### PR TITLE
Add image clipboard support for macOS

### DIFF
--- a/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
@@ -29,12 +29,11 @@ namespace osu.Framework.Tests.Visual.Platform
             this.host = host;
         }
 
-        [SetUp]
-        public void SetUp() => Schedule(Clear);
-
         [Test]
         public void TestImage()
         {
+            AddStep("clear previous screenshots", Clear);
+
             AddStep("screenshot screen", () =>
             {
                 host.TakeScreenshotAsync().ContinueWith(t =>

--- a/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneClipboard.cs
@@ -4,6 +4,9 @@
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Graphics.Textures;
 using osu.Framework.Platform;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
@@ -26,8 +29,11 @@ namespace osu.Framework.Tests.Visual.Platform
             this.host = host;
         }
 
+        [SetUp]
+        public void SetUp() => Schedule(Clear);
+
         [Test]
-        public void TestImageCopy()
+        public void TestImage()
         {
             AddStep("screenshot screen", () =>
             {
@@ -48,7 +54,20 @@ namespace osu.Framework.Tests.Visual.Platform
 
             AddStep("retrieve image from clipboard", () =>
             {
-                clipboardImage = clipboard.GetImage<Rgba32>();
+                var image = clipboard.GetImage<Rgba32>();
+                clipboardImage = image.Clone();
+
+                var texture = new Texture(image.Width, image.Height);
+                texture.SetData(new TextureUpload(image));
+
+                Child = new Sprite
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    RelativeSizeAxes = Axes.Both,
+                    FillMode = FillMode.Fit,
+                    Texture = texture
+                };
             });
 
             AddAssert("image retrieved", () => clipboardImage != null);

--- a/osu.Framework/Platform/MacOS/MacOSClipboard.cs
+++ b/osu.Framework/Platform/MacOS/MacOSClipboard.cs
@@ -11,36 +11,35 @@ namespace osu.Framework.Platform.MacOS
     {
         private readonly NSPasteboard generalPasteboard = NSPasteboard.GeneralPasteboard();
 
-        public override string GetText()
-        {
-            NSArray classArray = NSArray.ArrayWithObject(Class.Get("NSString"));
+        public override string GetText() => Cocoa.FromNSString(getFromPasteboard(Class.Get("NSString")));
 
-            if (!generalPasteboard.CanReadObjectForClasses(classArray, null)) return string.Empty;
+        public override Image<TPixel> GetImage<TPixel>() => Cocoa.FromNSImage<TPixel>(getFromPasteboard(Class.Get("NSImage")));
+
+        public override void SetText(string selectedText) => setToPasteboard(Cocoa.ToNSString(selectedText));
+
+        public override bool SetImage(Image image) => setToPasteboard(Cocoa.ToNSImage(image));
+
+        private IntPtr getFromPasteboard(IntPtr @class)
+        {
+            NSArray classArray = NSArray.ArrayWithObject(@class);
+
+            if (!generalPasteboard.CanReadObjectForClasses(classArray, null))
+                return IntPtr.Zero;
 
             var result = generalPasteboard.ReadObjectsForClasses(classArray, null);
-
             var objects = result?.ToArray();
 
-            if (objects?.Length > 0 && objects[0] != IntPtr.Zero)
-                return Cocoa.FromNSString(objects[0]);
-
-            return string.Empty;
+            return objects?.Length > 0 ? objects[0] : IntPtr.Zero;
         }
 
-        public override void SetText(string selectedText)
+        private bool setToPasteboard(IntPtr handle)
         {
+            if (handle == IntPtr.Zero)
+                return false;
+
             generalPasteboard.ClearContents();
-            generalPasteboard.WriteObjects(NSArray.ArrayWithObject(Cocoa.ToNSString(selectedText)));
-        }
-
-        public override Image<TPixel> GetImage<TPixel>()
-        {
-            return null;
-        }
-
-        public override bool SetImage(Image image)
-        {
-            return false;
+            generalPasteboard.WriteObjects(NSArray.ArrayWithObject(handle));
+            return true;
         }
     }
 }

--- a/osu.Framework/Platform/MacOS/Native/NSData.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSData.cs
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace osu.Framework.Platform.MacOS.Native
+{
+    internal readonly struct NSData
+    {
+        internal IntPtr Handle { get; }
+
+        private static readonly IntPtr class_pointer = Class.Get("NSData");
+        private static readonly IntPtr sel_data_with_bytes = Selector.Get("dataWithBytes:length:");
+        private static readonly IntPtr sel_bytes = Selector.Get("bytes");
+        private static readonly IntPtr sel_length = Selector.Get("length");
+
+        internal NSData(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        internal byte[] ToBytes()
+        {
+            var pointer = Cocoa.SendIntPtr(Handle, sel_bytes);
+            int size = Cocoa.SendInt(Handle, sel_length);
+
+            byte[] bytes = new byte[size];
+            Marshal.Copy(pointer, bytes, 0, size);
+            return bytes;
+        }
+
+        internal static unsafe NSData FromBytes(byte[] bytes)
+        {
+            fixed (byte* ptr = bytes)
+            {
+                var handle = Cocoa.SendIntPtr(class_pointer, sel_data_with_bytes, (IntPtr)ptr, (ulong)bytes.LongLength);
+                return new NSData(handle);
+            }
+        }
+
+        public static implicit operator IntPtr(NSData data) => data.Handle;
+    }
+}


### PR DESCRIPTION
- [x] Depends on #5087 

The implementation focuses on conversion between `NSImage` and `ImageSharp.Image<TPixel>` using [`TIFFRepresentation`](https://developer.apple.com/documentation/appkit/nsimage/1519841-tiffrepresentation?language=objc) (which requires ImageSharp v2.1.0 for TIFF decoding/encoding support).

This would've been much easier without implementing the interop logic for it. Waiting for the day where we can separate macOS platform to its own project targeting `net6.0-macos`, and not have to do all this interop stuff.