### PR TITLE
Fix MaskingInfo equality not considering conservative quad

### DIFF
--- a/osu.Framework/Graphics/OpenGL/GLWrapper.cs
+++ b/osu.Framework/Graphics/OpenGL/GLWrapper.cs
@@ -1016,6 +1016,7 @@ namespace osu.Framework.Graphics.OpenGL
         public static bool operator ==(in MaskingInfo left, in MaskingInfo right) =>
             left.ScreenSpaceAABB == right.ScreenSpaceAABB &&
             left.MaskingRect == right.MaskingRect &&
+            left.ConservativeScreenSpaceQuad.Equals(right.ConservativeScreenSpaceQuad) &&
             left.ToMaskingSpace == right.ToMaskingSpace &&
             left.CornerRadius == right.CornerRadius &&
             left.CornerExponent == right.CornerExponent &&


### PR DESCRIPTION
Was causing issues in my VBO optimisations branch, because this is being used to clip quads in the FTB pass and would sometimes result in unmatching vertices.

Unsure if this would be noticeable normally.