### PR TITLE
Optimise texture opacity computation algorithm

### DIFF
--- a/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
+++ b/osu.Framework/Graphics/OpenGL/Textures/TextureGL.cs
@@ -157,25 +157,26 @@ namespace osu.Framework.Graphics.OpenGL.Textures
             // see https://github.com/ppy/osu/issues/9307
             return Opacity.Mixed;
 
-            // if (upload.Data.Length == 0)
+            // ReadOnlySpan<Rgba32> data = upload.Data;
+            //
+            // if (data.Length == 0)
             //     return Opacity.Transparent;
             //
-            // bool isTransparent = true;
-            // bool isOpaque = true;
+            // int firstPixelValue = data[0].A;
             //
-            // for (int i = 0; i < upload.Data.Length; ++i)
+            // // Check if the first pixel has partial transparency (neither fully-opaque nor fully-transparent).
+            // if (firstPixelValue != 0 && firstPixelValue != 255)
+            //     return Opacity.Mixed;
+            //
+            // // The first pixel is GUARANTEED to be either fully-opaque or fully-transparent.
+            // // Now we need to go through the rest of the image and check that every other pixel matches this value.
+            // for (int i = 1; i < data.Length; i++)
             // {
-            //     isTransparent &= upload.Data[i].A == 0;
-            //     isOpaque &= upload.Data[i].A == 255;
-            //
-            //     if (!isTransparent && !isOpaque)
+            //     if (data[i].A != firstPixelValue)
             //         return Opacity.Mixed;
             // }
             //
-            // if (isTransparent)
-            //     return Opacity.Transparent;
-            //
-            // return Opacity.Opaque;
+            // return firstPixelValue == 0 ? Opacity.Transparent : Opacity.Opaque;
         }
 
         protected void UpdateOpacity(ITextureUpload upload, ref Opacity? uploadOpacity)


### PR DESCRIPTION
At first I started over-complicating the algorithm further, before realising it doesn't need to be so complicated in the first place for basically 3-5x speedup in all cases.

I'm PRing this still in a disabled state because it's as good as the performance is going to get for this method, but I'm still not sure about enabling it because the worst case is still significant. Any other tricks like using `unsafe` or similar either doesn't yield any benefit or yields a benefit of 200us in the worst (3840x2160) case I tested.

For the record, I have done some profiling with this and:
1. This method takes ~2ms every entry of song select. Takes ~7ms scrolling through around 100 beatmaps in the beatmap listing.
2. On average get ~0.05ms HIGHER frametime, but also on average less GPU utilisation in multiplayer lounge, which is chalked up to the room panels' sprite-backgrounds now being considered for FTB causing the box-backgrounds underneath them to draw fewer pixels:
![image](https://user-images.githubusercontent.com/1329837/161543167-f9b903a6-ecdb-44fe-8bf0-11794d828632.png)

```diff
  |  Method |                             Size |         TestCase |            Mean |         Error |         StdDev |  Gen 0 | Allocated |
  |-------- |--------------------------------- |----------------- |----------------:|--------------:|---------------:|-------:|----------:|
- |   Old   |   Size [ Width=640, Height=360 ] | FullyTransparent |   268,914.99 ns |    465.633 ns |     363.535 ns |      - |      49 B |
+ |   New   |   Size [ Width=640, Height=360 ] | FullyTransparent |    63,308.84 ns |    310.530 ns |     275.277 ns |      - |      48 B |
- |   Old   |   Size [ Width=640, Height=360 ] |      FullyOpaque |   271,141.44 ns |  1,838.509 ns |   1,535.239 ns |      - |      59 B |
+ |   New   |   Size [ Width=640, Height=360 ] |      FullyOpaque |    62,815.67 ns |     97.706 ns |      86.614 ns |      - |      48 B |
- |   Old   |   Size [ Width=640, Height=360 ] |     MixedAtStart |       103.02 ns |      0.991 ns |       0.927 ns | 0.0005 |      48 B |
+ |   New   |   Size [ Width=640, Height=360 ] |     MixedAtStart |       100.18 ns |      1.267 ns |       1.123 ns | 0.0005 |      48 B |
- |   Old   |   Size [ Width=640, Height=360 ] |      MixedMiddle |   134,722.43 ns |    300.796 ns |     281.365 ns |      - |      55 B |
+ |   New   |   Size [ Width=640, Height=360 ] |      MixedMiddle |    31,504.57 ns |     16.651 ns |      13.904 ns |      - |      48 B |
- |   Old   |   Size [ Width=640, Height=360 ] |       MixedAtEnd |   268,374.88 ns |     81.376 ns |      72.138 ns |      - |      49 B |
+ |   New   |   Size [ Width=640, Height=360 ] |       MixedAtEnd |    62,990.14 ns |     93.254 ns |      82.667 ns |      - |      48 B |
- |   Old   |  Size [ Width=1280, Height=720 ] | FullyTransparent | 1,074,131.52 ns |  1,320.998 ns |   1,031.349 ns |      - |      50 B |
+ |   New   |  Size [ Width=1280, Height=720 ] | FullyTransparent |   251,537.38 ns |    714.286 ns |     557.668 ns |      - |      49 B |
- |   Old   |  Size [ Width=1280, Height=720 ] |      FullyOpaque | 1,074,507.39 ns |  2,134.522 ns |   1,996.633 ns |      - |      50 B |
+ |   New   |  Size [ Width=1280, Height=720 ] |      FullyOpaque |   251,819.80 ns |  1,247.532 ns |   1,105.905 ns |      - |      49 B |
- |   Old   |  Size [ Width=1280, Height=720 ] |     MixedAtStart |       102.49 ns |      1.924 ns |       1.799 ns | 0.0005 |      48 B |
+ |   New   |  Size [ Width=1280, Height=720 ] |     MixedAtStart |       100.74 ns |      1.450 ns |       1.356 ns | 0.0005 |      48 B |
- |   Old   |  Size [ Width=1280, Height=720 ] |      MixedMiddle |   539,885.17 ns |    902.858 ns |     844.534 ns |      - |      49 B |
+ |   New   |  Size [ Width=1280, Height=720 ] |      MixedMiddle |   126,143.40 ns |    803.180 ns |     711.998 ns |      - |      48 B |
- |   Old   |  Size [ Width=1280, Height=720 ] |       MixedAtEnd | 1,074,801.36 ns |  1,672.107 ns |   1,564.090 ns |      - |      51 B |
+ |   New   |  Size [ Width=1280, Height=720 ] |       MixedAtEnd |   250,653.85 ns |    853.044 ns |     797.938 ns |      - |      49 B |
- |   Old   | Size [ Width=1920, Height=1080 ] | FullyTransparent | 2,429,753.14 ns |  5,080.404 ns |   4,242.368 ns |      - |       5 B |
+ |   New   | Size [ Width=1920, Height=1080 ] | FullyTransparent |   566,536.18 ns |  1,464.838 ns |   1,370.210 ns |      - |       1 B |
- |   Old   | Size [ Width=1920, Height=1080 ] |      FullyOpaque | 2,417,958.19 ns |  3,190.738 ns |   2,828.506 ns |      - |       4 B |
+ |   New   | Size [ Width=1920, Height=1080 ] |      FullyOpaque |   566,254.37 ns |  2,470.906 ns |   2,311.287 ns |      - |       1 B |
- |   Old   | Size [ Width=1920, Height=1080 ] |     MixedAtStart |        22.90 ns |      0.032 ns |       0.030 ns |      - |         - |
+ |   New   | Size [ Width=1920, Height=1080 ] |     MixedAtStart |        22.16 ns |      0.167 ns |       0.156 ns |      - |         - |
- |   Old   | Size [ Width=1920, Height=1080 ] |      MixedMiddle | 1,214,088.83 ns |  6,236.065 ns |   5,833.219 ns |      - |      44 B |
+ |   New   | Size [ Width=1920, Height=1080 ] |      MixedMiddle |   283,434.42 ns |  2,105.630 ns |   1,758.296 ns |      - |       1 B |
- |   Old   | Size [ Width=1920, Height=1080 ] |       MixedAtEnd | 2,423,289.43 ns |  7,448.629 ns |   6,603.016 ns |      - |       5 B |
+ |   New   | Size [ Width=1920, Height=1080 ] |       MixedAtEnd |   573,199.05 ns |  4,687.309 ns |   3,914.115 ns |      - |       2 B |
- |   Old   | Size [ Width=3840, Height=2160 ] | FullyTransparent | 9,974,076.32 ns | 78,525.472 ns |  73,452.776 ns |      - |     355 B |
+ |   New   | Size [ Width=3840, Height=2160 ] | FullyTransparent | 3,374,889.59 ns | 59,332.934 ns |  46,323.252 ns |      - |       5 B |
- |   Old   | Size [ Width=3840, Height=2160 ] |      FullyOpaque | 9,905,951.99 ns | 55,383.278 ns |  51,805.552 ns |      - |      22 B |
+ |   New   | Size [ Width=3840, Height=2160 ] |      FullyOpaque | 3,520,427.30 ns | 69,188.636 ns | 109,740.509 ns |      - |       5 B |
- |   Old   | Size [ Width=3840, Height=2160 ] |     MixedAtStart |        21.69 ns |      0.166 ns |       0.155 ns |      - |         - |
+ |   New   | Size [ Width=3840, Height=2160 ] |     MixedAtStart |        22.15 ns |      0.177 ns |       0.148 ns |      - |         - |
- |   Old   | Size [ Width=3840, Height=2160 ] |      MixedMiddle | 4,990,955.16 ns | 46,302.534 ns |  43,311.419 ns |      - |      11 B |
+ |   New   | Size [ Width=3840, Height=2160 ] |      MixedMiddle | 1,436,846.48 ns | 27,501.190 ns |  28,241.697 ns |      - |       3 B |
- |   Old   | Size [ Width=3840, Height=2160 ] |       MixedAtEnd | 9,933,742.82 ns | 49,347.257 ns |  43,745.058 ns |      - |      22 B |
+ |   New   | Size [ Width=3840, Height=2160 ] |       MixedAtEnd | 3,242,651.53 ns | 25,853.477 ns |  21,588.825 ns |      - |       5 B |

```

There is no further performance gain to be had by using `unsafe`.

<details><summary>Benchmark (not included since it contains older code)</summary>

```diff
diff --git a/osu.Framework.Benchmarks/BenchmarkComputeTextureOpacity.cs b/osu.Framework.Benchmarks/BenchmarkComputeTextureOpacity.cs
new file mode 100644
index 0000000000..cb4ac11a95
--- /dev/null
+++ b/osu.Framework.Benchmarks/BenchmarkComputeTextureOpacity.cs
@@ -0,0 +1,131 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System;
+using System.Collections.Generic;
+using BenchmarkDotNet.Attributes;
+using osu.Framework.Graphics.OpenGL.Textures;
+using osu.Framework.Graphics.Textures;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace osu.Framework.Benchmarks
+{
+    [MemoryDiagnoser]
+    public class BenchmarkComputeTextureOpacity
+    {
+        [ParamsSource(nameof(SizeSource))]
+        public Size Size { get; set; }
+
+        [ParamsAllValues]
+        public CaseType TestCase { get; set; }
+
+        private ITextureUpload upload;
+
+        [GlobalSetup]
+        public void GlobalSetup()
+        {
+            // Create a mixed image.
+            Image<Rgba32> image;
+
+            switch (TestCase)
+            {
+                case CaseType.FullyOpaque:
+                    image = new Image<Rgba32>(Size.Width, Size.Height, new Rgba32(255, 255, 255, 255));
+                    break;
+
+                case CaseType.FullyTransparent:
+                    image = new Image<Rgba32>(Size.Width, Size.Height, new Rgba32(255, 255, 255, 0));
+                    break;
+
+                case CaseType.MixedAtStart:
+                    image = new Image<Rgba32>(Size.Width, Size.Height, new Rgba32(255, 255, 255, 255));
+                    image[0, 0] = new Rgba32(255, 255, 255, 0);
+                    break;
+
+                case CaseType.MixedMiddle:
+                    image = new Image<Rgba32>(Size.Width, Size.Height, new Rgba32(255, 255, 255, 255));
+                    image[Size.Width / 2, Size.Height / 2] = new Rgba32(255, 255, 255, 0);
+                    break;
+
+                case CaseType.MixedAtEnd:
+                    image = new Image<Rgba32>(Size.Width, Size.Height, new Rgba32(255, 255, 255, 255));
+                    image[Size.Width - 1, Size.Height - 1] = new Rgba32(255, 255, 255, 0);
+                    break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(TestCase));
+            }
+
+            upload = new TextureUpload(image);
+        }
+
+        [Benchmark]
+        public Opacity Method1()
+        {
+            ReadOnlySpan<Rgba32> data = upload.Data;
+
+            if (data.Length == 0)
+                return Opacity.Transparent;
+
+            bool isTransparent = true;
+            bool isOpaque = true;
+
+            for (int i = 0; i < data.Length; ++i)
+            {
+                isTransparent &= data[i].A == 0;
+                isOpaque &= data[i].A == 255;
+
+                if (!isTransparent && !isOpaque)
+                    return Opacity.Mixed;
+            }
+
+            if (isTransparent)
+                return Opacity.Transparent;
+
+            return Opacity.Opaque;
+        }
+
+        [Benchmark]
+        public Opacity Method2()
+        {
+            ReadOnlySpan<Rgba32> data = upload.Data;
+
+            if (data.Length == 0)
+                return Opacity.Transparent;
+
+            int firstPixelValue = data[0].A;
+
+            // Check if the first pixel has partial transparency (neither fully-opaque nor fully-transparent).
+            if (firstPixelValue != 0 && firstPixelValue != 255)
+                return Opacity.Mixed;
+
+            // The first pixel is GUARANTEED to be either fully-opaque or fully-transparent.
+            // Now we need to go through the rest of the image and check that every other pixel matches this value.
+            for (int i = 1; i < data.Length; i++)
+            {
+                if (data[i].A != firstPixelValue)
+                    return Opacity.Mixed;
+            }
+
+            return firstPixelValue == 0 ? Opacity.Transparent : Opacity.Opaque;
+        }
+
+        public static IEnumerable<Size> SizeSource => new[]
+        {
+            new Size(640, 360),
+            new Size(1280, 720),
+            new Size(1920, 1080),
+            new Size(3840, 2160)
+        };
+
+        public enum CaseType
+        {
+            FullyTransparent,
+            FullyOpaque,
+            MixedAtStart,
+            MixedMiddle,
+            MixedAtEnd,
+        }
+    }
+}
diff --git a/osu.Framework.Benchmarks/Program.cs b/osu.Framework.Benchmarks/Program.cs
index 0fb9705a83..83cdc70ffd 100644
--- a/osu.Framework.Benchmarks/Program.cs
+++ b/osu.Framework.Benchmarks/Program.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
 
 namespace osu.Framework.Benchmarks
@@ -12,7 +13,9 @@ public static void Main(string[] args)
         {
             BenchmarkSwitcher
                 .FromAssembly(typeof(Program).Assembly)
-                .Run(args, DefaultConfig.Instance.WithOption(ConfigOptions.DisableOptimizationsValidator, true));
+                .Run(args, DefaultConfig.Instance
+                                        .WithOption(ConfigOptions.DisableOptimizationsValidator, true)
+                                        .WithSummaryStyle(SummaryStyle.Default.WithMaxParameterColumnWidth(100)));
         }
     }
 }
```

</details>