### PR TITLE
Fix issues with `Animation.ClearFrames` behaviour

### DIFF
--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -265,7 +265,7 @@ namespace osu.Framework.Tests.Visual.Sprites
             AddAssert("animation is not showing frame", () => animation.ChildrenOfType<Sprite>().First().Texture == null);
 
             AddStep("add one frame back", () => animation.AddFrame(lastFrame));
-            AddAssert("animation is showing frame", () => animation.ChildrenOfType<Sprite>().First().Texture != null);
+            AddAssert("animation is showing frame", () => animation.ChildrenOfType<Sprite>().First().Texture == lastFrame);
         }
 
         private void loadNewAnimation(bool startFromCurrent = true, Action<TestAnimation> postLoadAction = null)

--- a/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
+++ b/osu.Framework.Tests/Visual/Sprites/TestSceneAnimation.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
@@ -249,13 +250,22 @@ namespace osu.Framework.Tests.Visual.Sprites
         [Test]
         public void TestClearFrames()
         {
+            Texture lastFrame = null;
+
             loadNewAnimation();
 
             AddUntilStep("animation is playing", () => animation.CurrentFrameIndex > 0);
 
+            AddStep("store current frame", () => lastFrame = animation.CurrentFrame);
+
             AddStep("clear frames", () => animation.ClearFrames());
+
             AddAssert("animation duration is 0", () => animation.Duration == 0);
             AddAssert("animation is at start", () => animation.CurrentFrameIndex == 0);
+            AddAssert("animation is not showing frame", () => animation.ChildrenOfType<Sprite>().First().Texture == null);
+
+            AddStep("add one frame back", () => animation.AddFrame(lastFrame));
+            AddAssert("animation is showing frame", () => animation.ChildrenOfType<Sprite>().First().Texture != null);
         }
 
         private void loadNewAnimation(bool startFromCurrent = true, Action<TestAnimation> postLoadAction = null)

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -77,6 +77,10 @@ namespace osu.Framework.Graphics.Animations
             frameData.Add(frame);
 
             OnFrameAdded(frame.Content, frame.Duration);
+
+            // This handles the case when the first frame is added, especially important after a `ClearFrames` operation.
+            if (frameData.Count == 1)
+                currentFrameCache.Invalidate();
         }
 
         /// <summary>

--- a/osu.Framework/Graphics/Animations/Animation.cs
+++ b/osu.Framework/Graphics/Animations/Animation.cs
@@ -108,6 +108,8 @@ namespace osu.Framework.Graphics.Animations
 
             Duration = 0;
             CurrentFrameIndex = 0;
+
+            ClearDisplay();
         }
 
         /// <summary>
@@ -116,6 +118,12 @@ namespace osu.Framework.Graphics.Animations
         /// <remarks>This method will only be called after <see cref="OnFrameAdded(T, double)"/> has been called at least once.</remarks>
         /// <param name="content">The content that will be displayed.</param>
         protected abstract void DisplayFrame(T content);
+
+        /// <summary>
+        /// Clear the currently displayed frame.
+        /// </summary>
+        /// <remarks>Called when resetting the animation, ie. on <see cref="ClearFrames"/>.</remarks>
+        protected abstract void ClearDisplay();
 
         /// <summary>
         /// Called whenever a new frame was added to this animation.

--- a/osu.Framework/Graphics/Animations/DrawableAnimation.cs
+++ b/osu.Framework/Graphics/Animations/DrawableAnimation.cs
@@ -22,6 +22,8 @@ namespace osu.Framework.Graphics.Animations
             container.Child = content;
         }
 
+        protected override void ClearDisplay() => container.Clear(false);
+
         public override Drawable CreateContent() => container = new Container { RelativeSizeAxes = Axes.Both };
 
         protected override Vector2 GetCurrentDisplaySize() => container.Children.FirstOrDefault()?.DrawSize ?? Vector2.Zero;

--- a/osu.Framework/Graphics/Animations/TextureAnimation.cs
+++ b/osu.Framework/Graphics/Animations/TextureAnimation.cs
@@ -28,6 +28,8 @@ namespace osu.Framework.Graphics.Animations
 
         protected override void DisplayFrame(Texture content) => textureHolder.Texture = content;
 
+        protected override void ClearDisplay() => textureHolder.Texture = null;
+
         protected override float GetFillAspectRatio() => textureHolder.FillAspectRatio;
 
         protected override Vector2 GetCurrentDisplaySize() =>


### PR DESCRIPTION
Added test fails at two different places depending on which of the two follow-up commits are built. Felt it was easier to bunch these together due to how intertangled they are.

- efc56b9bb Fixes `Animation` not updating display on adding a single frame after clearing previous frames.
- 0ce46fb60 Fixes previous display not getting cleared on calling `Animation.ClearFrames`