### PR TITLE
Add inspectcode CI cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,12 @@ jobs:
       - name: Restore Packages
         run: dotnet restore
 
+      - name: Restore inspectcode cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/inspectcode
+          key: inspectcode-${{ hashFiles('.config/dotnet-tools.json') }}-${{ hashFiles('.github/workflows/ci.yml' ) }}
+
       - name: CodeFileSanity
         run: |
           # TODO: Add ignore filters and GitHub Workflow Command Reporting in CFS. That way we don't have to do this workaround.
@@ -131,7 +137,7 @@ jobs:
       #   run: dotnet format --dry-run --check
 
       - name: InspectCode
-        run: dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --no-build --output="inspectcodereport.xml" --verbosity=WARN
+        run: dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --no-build --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN
 
       - name: NVika
         run: dotnet nvika parsereport "${{github.workspace}}/inspectcodereport.xml" --treatwarningsaserrors


### PR DESCRIPTION
Run 1:
https://github.com/smoogipoo/osu-framework/runs/6018943569?check_suite_focus=true

Run 2:
https://github.com/smoogipoo/osu-framework/runs/6019049500?check_suite_focus=true

According to https://github.com/actions/cache, the default branch cache is available in other branches.