### PR TITLE
Nullability annotations for bindables

### DIFF
--- a/osu-framework.sln.DotSettings
+++ b/osu-framework.sln.DotSettings
@@ -58,6 +58,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CollectionNeverQueried_002ELocal/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CommentTypo/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CompareOfFloatsByEqualityOperator/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConditionalAccessQualifierIsNonNullableAccordingToAPIContract/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertClosureToMethodGroup/@EntryIndexedValue">HINT</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertConditionalTernaryExpressionToSwitchExpression/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertIfDoToWhile/@EntryIndexedValue">WARNING</s:String>

--- a/osu.Framework/Bindables/AggregateBindable.cs
+++ b/osu.Framework/Bindables/AggregateBindable.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>
@@ -29,7 +31,7 @@ namespace osu.Framework.Bindables
         /// </summary>
         /// <param name="aggregateFunction">The function to be used for aggregation, taking two input <typeparamref name="T"/> values and returning one output.</param>
         /// <param name="resultBindable">An optional newly constructed bindable to use for <see cref="Result"/>. The initial value of this bindable is used as the initial value for the aggregate.</param>
-        public AggregateBindable(Func<T, T, T> aggregateFunction, Bindable<T> resultBindable = null)
+        public AggregateBindable(Func<T, T, T> aggregateFunction, Bindable<T>? resultBindable = null)
         {
             this.aggregateFunction = aggregateFunction;
             result = resultBindable ?? new Bindable<T>();
@@ -75,10 +77,10 @@ namespace osu.Framework.Bindables
             }
         }
 
-        private WeakRefPair findExistingPair(IBindable<T> bindable) =>
+        private WeakRefPair? findExistingPair(IBindable<T> bindable) =>
             sourceMapping.FirstOrDefault(p => p.WeakReference.TryGetTarget(out var target) && target == bindable);
 
-        private void recalculateAggregate(ValueChangedEvent<T> obj = null)
+        private void recalculateAggregate(ValueChangedEvent<T>? obj = null)
         {
             T calculated = initialValue;
 

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -130,7 +130,7 @@ namespace osu.Framework.Bindables
             TriggerDefaultChange(previousValue, source ?? this, true, bypassChecks);
         }
 
-        private WeakReference<Bindable<T>> weakReferenceInstance;
+        private WeakReference<Bindable<T>>? weakReferenceInstance;
 
         private WeakReference<Bindable<T>> weakReference => weakReferenceInstance ??= new WeakReference<Bindable<T>>(this);
 
@@ -139,7 +139,7 @@ namespace osu.Framework.Bindables
         /// </summary>
         [UsedImplicitly]
         private Bindable()
-            : this(default)
+            : this(default!)
         {
         }
 
@@ -147,12 +147,15 @@ namespace osu.Framework.Bindables
         /// Creates a new bindable instance initialised with a default value.
         /// </summary>
         /// <param name="defaultValue">The initial and default value for this bindable.</param>
-        public Bindable(T defaultValue = default)
+        /// <remarks>Consider to pass a default value for non-nullable T.</remarks>
+        public Bindable(T defaultValue = default!)
         {
-            value = Default = defaultValue;
+            // It lacks a way to represent "warn if called with non-nullable T".
+            // Not verifying to avoid breaking tons of existing usages.
+            value = this.defaultValue = defaultValue;
         }
 
-        protected LockedWeakList<Bindable<T>> Bindings { get; private set; }
+        protected LockedWeakList<Bindable<T>>? Bindings { get; private set; }
 
         void IBindable.BindTo(IBindable them)
         {
@@ -254,7 +257,7 @@ namespace osu.Framework.Bindables
 
                 default:
                     if (underlyingType.IsEnum)
-                        Value = (T)Enum.Parse(underlyingType, input.ToString());
+                        Value = (T)Enum.Parse(underlyingType, input.ToString()!);
                     else
                         Value = (T)Convert.ChangeType(input, underlyingType, CultureInfo.InvariantCulture);
 
@@ -376,7 +379,7 @@ namespace osu.Framework.Bindables
             tThem.removeWeakReference(weakReference);
         }
 
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         public override string ToString() => value?.ToString() ?? string.Empty;
 
@@ -409,7 +412,8 @@ namespace osu.Framework.Bindables
 
         void ISerializableBindable.DeserializeFrom(JsonReader reader, JsonSerializer serializer)
         {
-            Value = serializer.Deserialize<T>(reader);
+            // Deserialize returns null for json literal "null".
+            Value = serializer.Deserialize<T>(reader)!;
         }
 
         private LeasedBindable<T>? leasedBindable;

--- a/osu.Framework/Bindables/Bindable.cs
+++ b/osu.Framework/Bindables/Bindable.cs
@@ -11,6 +11,8 @@ using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.IO.Serialization;
 using osu.Framework.Lists;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>
@@ -22,17 +24,17 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// An event which is raised when <see cref="Value"/> has changed (or manually via <see cref="TriggerValueChange"/>).
         /// </summary>
-        public event Action<ValueChangedEvent<T>> ValueChanged;
+        public event Action<ValueChangedEvent<T>>? ValueChanged;
 
         /// <summary>
         /// An event which is raised when <see cref="Disabled"/> has changed (or manually via <see cref="TriggerDisabledChange"/>).
         /// </summary>
-        public event Action<bool> DisabledChanged;
+        public event Action<bool>? DisabledChanged;
 
         /// <summary>
         /// An event which is raised when <see cref="Default"/> has changed (or manually via <see cref="TriggerDefaultChange"/>).
         /// </summary>
-        public event Action<ValueChangedEvent<T>> DefaultChanged;
+        public event Action<ValueChangedEvent<T>>? DefaultChanged;
 
         private T value;
 
@@ -57,7 +59,7 @@ namespace osu.Framework.Bindables
             }
         }
 
-        internal void SetDisabled(bool value, bool bypassChecks = false, Bindable<T> source = null)
+        internal void SetDisabled(bool value, bool bypassChecks = false, Bindable<T>? source = null)
         {
             if (!bypassChecks)
                 throwIfLeased();
@@ -88,7 +90,7 @@ namespace osu.Framework.Bindables
                 // if the leased bindable decides to disable exclusive access (by setting Disabled = false) then anything will be able to write to Value.
 
                 if (Disabled)
-                    throw new InvalidOperationException($"Can not set value to \"{value.ToString()}\" as bindable is disabled.");
+                    throw new InvalidOperationException($"Can not set value to \"{value}\" as bindable is disabled.");
 
                 if (EqualityComparer<T>.Default.Equals(this.value, value)) return;
 
@@ -96,7 +98,7 @@ namespace osu.Framework.Bindables
             }
         }
 
-        internal void SetValue(T previousValue, T value, bool bypassChecks = false, Bindable<T> source = null)
+        internal void SetValue(T previousValue, T value, bool bypassChecks = false, Bindable<T>? source = null)
         {
             this.value = value;
             TriggerValueChange(previousValue, source ?? this, true, bypassChecks);
@@ -114,7 +116,7 @@ namespace osu.Framework.Bindables
                 // if the leased bindable decides to disable exclusive access (by setting Disabled = false) then anything will be able to write to Default.
 
                 if (Disabled)
-                    throw new InvalidOperationException($"Can not set default value to \"{value.ToString()}\" as bindable is disabled.");
+                    throw new InvalidOperationException($"Can not set default value to \"{value}\" as bindable is disabled.");
 
                 if (EqualityComparer<T>.Default.Equals(defaultValue, value)) return;
 
@@ -122,7 +124,7 @@ namespace osu.Framework.Bindables
             }
         }
 
-        internal void SetDefaultValue(T previousValue, T value, bool bypassChecks = false, Bindable<T> source = null)
+        internal void SetDefaultValue(T previousValue, T value, bool bypassChecks = false, Bindable<T>? source = null)
         {
             defaultValue = value;
             TriggerDefaultChange(previousValue, source ?? this, true, bypassChecks);
@@ -359,8 +361,7 @@ namespace osu.Framework.Bindables
 
         internal virtual void UnbindAllInternal()
         {
-            if (isLeased)
-                leasedBindable.Return();
+            leasedBindable?.Return();
 
             UnbindEvents();
             UnbindBindings();
@@ -411,7 +412,7 @@ namespace osu.Framework.Bindables
             Value = serializer.Deserialize<T>(reader);
         }
 
-        private LeasedBindable<T> leasedBindable;
+        private LeasedBindable<T>? leasedBindable;
 
         private bool isLeased => leasedBindable != null;
 

--- a/osu.Framework/Bindables/BindableList.cs
+++ b/osu.Framework/Bindables/BindableList.cs
@@ -9,6 +9,8 @@ using System.Linq;
 using osu.Framework.Caching;
 using osu.Framework.Lists;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     public class BindableList<T> : IBindableList<T>, IBindable, IParseable, IList<T>, IList
@@ -16,12 +18,12 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// An event which is raised when this <see cref="BindableList{T}"/> changes.
         /// </summary>
-        public event NotifyCollectionChangedEventHandler CollectionChanged;
+        public event NotifyCollectionChangedEventHandler? CollectionChanged;
 
         /// <summary>
         /// An event which is raised when <see cref="Disabled"/>'s state has changed (or manually via <see cref="triggerDisabledChange(bool)"/>).
         /// </summary>
-        public event Action<bool> DisabledChanged;
+        public event Action<bool>? DisabledChanged;
 
         private readonly List<T> collection = new List<T>();
 
@@ -29,13 +31,13 @@ namespace osu.Framework.Bindables
 
         private WeakReference<BindableList<T>> weakReference => weakReferenceCache.IsValid ? weakReferenceCache.Value : weakReferenceCache.Value = new WeakReference<BindableList<T>>(this);
 
-        private LockedWeakList<BindableList<T>> bindings;
+        private LockedWeakList<BindableList<T>>? bindings;
 
         /// <summary>
         /// Creates a new <see cref="BindableList{T}"/>, optionally adding the items of the given collection.
         /// </summary>
         /// <param name="items">The items that are going to be contained in the newly created <see cref="BindableList{T}"/>.</param>
-        public BindableList(IEnumerable<T> items = null)
+        public BindableList(IEnumerable<T>? items = null)
         {
             if (items != null)
                 collection.AddRange(items);
@@ -54,7 +56,7 @@ namespace osu.Framework.Bindables
             set => setIndex(index, value, null);
         }
 
-        private void setIndex(int index, T item, BindableList<T> caller)
+        private void setIndex(int index, T item, BindableList<T>? caller)
         {
             ensureMutationAllowed();
 
@@ -84,7 +86,7 @@ namespace osu.Framework.Bindables
         public void Add(T item)
             => add(item, null);
 
-        private void add(T item, BindableList<T> caller)
+        private void add(T item, BindableList<T>? caller)
         {
             ensureMutationAllowed();
 
@@ -120,7 +122,7 @@ namespace osu.Framework.Bindables
         public void Insert(int index, T item)
             => insert(index, item, null);
 
-        private void insert(int index, T item, BindableList<T> caller)
+        private void insert(int index, T item, BindableList<T>? caller)
         {
             ensureMutationAllowed();
 
@@ -147,7 +149,7 @@ namespace osu.Framework.Bindables
         public void Clear()
             => clear(null);
 
-        private void clear(BindableList<T> caller)
+        private void clear(BindableList<T>? caller)
         {
             ensureMutationAllowed();
 
@@ -190,7 +192,7 @@ namespace osu.Framework.Bindables
         public bool Remove(T item)
             => remove(item, null);
 
-        private bool remove(T item, BindableList<T> caller)
+        private bool remove(T item, BindableList<T>? caller)
         {
             ensureMutationAllowed();
 
@@ -231,7 +233,7 @@ namespace osu.Framework.Bindables
             removeRange(index, count, null);
         }
 
-        private void removeRange(int index, int count, BindableList<T> caller)
+        private void removeRange(int index, int count, BindableList<T>? caller)
         {
             ensureMutationAllowed();
 
@@ -264,7 +266,7 @@ namespace osu.Framework.Bindables
         public void RemoveAt(int index)
             => removeAt(index, null);
 
-        private void removeAt(int index, BindableList<T> caller)
+        private void removeAt(int index, BindableList<T>? caller)
         {
             ensureMutationAllowed();
 
@@ -293,7 +295,7 @@ namespace osu.Framework.Bindables
         public int RemoveAll(Predicate<T> match)
             => removeAll(match, null);
 
-        private int removeAll(Predicate<T> match, BindableList<T> caller)
+        private int removeAll(Predicate<T> match, BindableList<T>? caller)
         {
             ensureMutationAllowed();
 
@@ -347,25 +349,25 @@ namespace osu.Framework.Bindables
 
         #region IList
 
-        object IList.this[int index]
+        object? IList.this[int index]
         {
             get => this[index];
-            set => this[index] = (T)value;
+            set => this[index] = (T)value!;
         }
 
-        int IList.Add(object value)
+        int IList.Add(object? value)
         {
-            Add((T)value);
+            Add((T)value!);
             return Count - 1;
         }
 
-        bool IList.Contains(object value) => Contains((T)value);
+        bool IList.Contains(object? value) => Contains((T)value!);
 
-        int IList.IndexOf(object value) => IndexOf((T)value);
+        int IList.IndexOf(object? value) => IndexOf((T)value!);
 
-        void IList.Insert(int index, object value) => Insert(index, (T)value);
+        void IList.Insert(int index, object? value) => Insert(index, (T)value!);
 
-        void IList.Remove(object value) => Remove((T)value);
+        void IList.Remove(object? value) => Remove((T)value!);
 
         bool IList.IsFixedSize => false;
 
@@ -488,7 +490,7 @@ namespace osu.Framework.Bindables
 
         #region IHasDescription
 
-        public string Description { get; set; }
+        public string? Description { get; set; }
 
         #endregion IHasDescription
 
@@ -502,7 +504,7 @@ namespace osu.Framework.Bindables
         public void AddRange(IEnumerable<T> items)
             => addRange(items as IList ?? items.ToArray(), null);
 
-        private void addRange(IList items, BindableList<T> caller)
+        private void addRange(IList items, BindableList<T>? caller)
         {
             ensureMutationAllowed();
 
@@ -530,7 +532,7 @@ namespace osu.Framework.Bindables
         public void Move(int oldIndex, int newIndex)
             => move(oldIndex, newIndex, null);
 
-        private void move(int oldIndex, int newIndex, BindableList<T> caller)
+        private void move(int oldIndex, int newIndex, BindableList<T>? caller)
         {
             ensureMutationAllowed();
 

--- a/osu.Framework/Bindables/BindableNumber.cs
+++ b/osu.Framework/Bindables/BindableNumber.cs
@@ -6,12 +6,14 @@ using System.Diagnostics;
 using System.Globalization;
 using osu.Framework.Utils;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     public class BindableNumber<T> : RangeConstrainedBindable<T>, IBindableNumber<T>
         where T : struct, IComparable<T>, IConvertible, IEquatable<T>
     {
-        public event Action<T> PrecisionChanged;
+        public event Action<T>? PrecisionChanged;
 
         public BindableNumber(T defaultValue = default)
             : base(defaultValue)
@@ -177,7 +179,7 @@ namespace osu.Framework.Bindables
             TriggerPrecisionChange(this, false);
         }
 
-        protected void TriggerPrecisionChange(BindableNumber<T> source = null, bool propagateToBindings = true)
+        protected void TriggerPrecisionChange(BindableNumber<T>? source = null, bool propagateToBindings = true)
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = precision;

--- a/osu.Framework/Bindables/BindableNumberWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableNumberWithCurrent.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>
@@ -12,7 +14,7 @@ namespace osu.Framework.Bindables
     public class BindableNumberWithCurrent<T> : BindableNumber<T>, IBindableWithCurrent<T>
         where T : struct, IComparable<T>, IConvertible, IEquatable<T>
     {
-        private BindableNumber<T> currentBound;
+        private BindableNumber<T>? currentBound;
 
         public Bindable<T> Current
         {

--- a/osu.Framework/Bindables/BindableSize.cs
+++ b/osu.Framework/Bindables/BindableSize.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Drawing;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>

--- a/osu.Framework/Bindables/BindableWithCurrent.cs
+++ b/osu.Framework/Bindables/BindableWithCurrent.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>
@@ -11,7 +13,7 @@ namespace osu.Framework.Bindables
     /// <typeparam name="T">The type of our stored <see cref="Bindable{T}.Value"/>.</typeparam>
     public class BindableWithCurrent<T> : Bindable<T>, IBindableWithCurrent<T>
     {
-        private Bindable<T> currentBound;
+        private Bindable<T>? currentBound;
 
         public Bindable<T> Current
         {
@@ -26,9 +28,10 @@ namespace osu.Framework.Bindables
             }
         }
 
-        public BindableWithCurrent(T defaultValue = default)
+        public BindableWithCurrent(T defaultValue = default!)
             : base(defaultValue)
         {
+            // Not verifying, as base Bindable constructor
         }
 
         protected override Bindable<T> CreateInstance() => new BindableWithCurrent<T>();

--- a/osu.Framework/Bindables/IBindable.cs
+++ b/osu.Framework/Bindables/IBindable.cs
@@ -5,6 +5,8 @@ using System;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Utils;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>

--- a/osu.Framework/Bindables/IBindableList.cs
+++ b/osu.Framework/Bindables/IBindableList.cs
@@ -4,6 +4,8 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>

--- a/osu.Framework/Bindables/IBindableNumber.cs
+++ b/osu.Framework/Bindables/IBindableNumber.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     public interface IBindableNumber<T> : IBindable<T>

--- a/osu.Framework/Bindables/IBindableWithCurrent.cs
+++ b/osu.Framework/Bindables/IBindableWithCurrent.cs
@@ -5,6 +5,8 @@ using System;
 using osu.Framework.Graphics.UserInterface;
 using osu.Framework.Utils;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     public interface IBindableWithCurrent<T> : IBindable<T>, IHasCurrentValue<T>
@@ -17,7 +19,7 @@ namespace osu.Framework.Bindables
         public static IBindableWithCurrent<T> Create()
         {
             if (Validation.IsSupportedBindableNumberType<T>())
-                return (IBindableWithCurrent<T>)Activator.CreateInstance(typeof(BindableNumberWithCurrent<>).MakeGenericType(typeof(T)), default(T));
+                return (IBindableWithCurrent<T>)Activator.CreateInstance(typeof(BindableNumberWithCurrent<>).MakeGenericType(typeof(T)), default(T))!;
 
             return new BindableWithCurrent<T>();
         }

--- a/osu.Framework/Bindables/ICanBeDisabled.cs
+++ b/osu.Framework/Bindables/ICanBeDisabled.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>

--- a/osu.Framework/Bindables/IHasDescription.cs
+++ b/osu.Framework/Bindables/IHasDescription.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>
@@ -11,6 +13,6 @@ namespace osu.Framework.Bindables
         /// <summary>
         /// The description for this object.
         /// </summary>
-        string Description { get; }
+        string? Description { get; }
     }
 }

--- a/osu.Framework/Bindables/IParseable.cs
+++ b/osu.Framework/Bindables/IParseable.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>

--- a/osu.Framework/Bindables/IUnbindable.cs
+++ b/osu.Framework/Bindables/IUnbindable.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>

--- a/osu.Framework/Bindables/LeasedBindable.cs
+++ b/osu.Framework/Bindables/LeasedBindable.cs
@@ -3,7 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using JetBrains.Annotations;
+
+#nullable enable
 
 namespace osu.Framework.Bindables
 {
@@ -14,13 +15,13 @@ namespace osu.Framework.Bindables
     /// <typeparam name="T"></typeparam>
     public class LeasedBindable<T> : Bindable<T>, ILeasedBindable<T>
     {
-        private readonly Bindable<T> source;
+        private readonly Bindable<T>? source;
 
-        private readonly T valueBeforeLease;
+        private readonly T valueBeforeLease = default!;
         private readonly bool disabledBeforeLease;
         private readonly bool revertValueOnReturn;
 
-        internal LeasedBindable([NotNull] Bindable<T> source, bool revertValueOnReturn)
+        internal LeasedBindable(Bindable<T> source, bool revertValueOnReturn)
         {
             BindTo(source);
 
@@ -37,7 +38,7 @@ namespace osu.Framework.Bindables
             Disabled = true;
         }
 
-        private LeasedBindable(T defaultValue = default)
+        private LeasedBindable(T defaultValue = default!)
             : base(defaultValue)
         {
             // used for GetBoundCopy, where we don't want a source.

--- a/osu.Framework/Bindables/NonNullableBindable.cs
+++ b/osu.Framework/Bindables/NonNullableBindable.cs
@@ -3,6 +3,8 @@
 
 using System;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     public class NonNullableBindable<T> : Bindable<T>

--- a/osu.Framework/Bindables/RangeConstrainedBindable.cs
+++ b/osu.Framework/Bindables/RangeConstrainedBindable.cs
@@ -4,13 +4,15 @@
 using System;
 using System.Collections.Generic;
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     public abstract class RangeConstrainedBindable<T> : Bindable<T>
     {
-        public event Action<T> MinValueChanged;
+        public event Action<T>? MinValueChanged;
 
-        public event Action<T> MaxValueChanged;
+        public event Action<T>? MaxValueChanged;
 
         private T minValue;
 
@@ -62,7 +64,7 @@ namespace osu.Framework.Bindables
         public bool HasDefinedRange => !EqualityComparer<T>.Default.Equals(MinValue, DefaultMinValue) ||
                                        !EqualityComparer<T>.Default.Equals(MaxValue, DefaultMaxValue);
 
-        protected RangeConstrainedBindable(T defaultValue = default)
+        protected RangeConstrainedBindable(T defaultValue = default!)
             : base(defaultValue)
         {
             minValue = DefaultMinValue;
@@ -116,7 +118,7 @@ namespace osu.Framework.Bindables
             TriggerMaxValueChange(this, false);
         }
 
-        protected void TriggerMinValueChange(RangeConstrainedBindable<T> source = null, bool propagateToBindings = true)
+        protected void TriggerMinValueChange(RangeConstrainedBindable<T>? source = null, bool propagateToBindings = true)
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = minValue;
@@ -136,7 +138,7 @@ namespace osu.Framework.Bindables
                 MinValueChanged?.Invoke(minValue);
         }
 
-        protected void TriggerMaxValueChange(RangeConstrainedBindable<T> source = null, bool propagateToBindings = true)
+        protected void TriggerMaxValueChange(RangeConstrainedBindable<T>? source = null, bool propagateToBindings = true)
         {
             // check a bound bindable hasn't changed the value again (it will fire its own event)
             T beforePropagation = maxValue;

--- a/osu.Framework/Bindables/ValueChangedEvent.cs
+++ b/osu.Framework/Bindables/ValueChangedEvent.cs
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+#nullable enable
+
 namespace osu.Framework.Bindables
 {
     /// <summary>

--- a/osu.Framework/Localisation/ILocalisedBindableString.cs
+++ b/osu.Framework/Localisation/ILocalisedBindableString.cs
@@ -3,6 +3,8 @@
 
 using osu.Framework.Bindables;
 
+#nullable enable
+
 namespace osu.Framework.Localisation
 {
     /// <summary>

--- a/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
+++ b/osu.Framework/Localisation/LocalisationManager_LocalisedBindableString.cs
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
-#pragma warning disable 8632 // TODO: can be #nullable enable when Bindables are updated to also be.
+#nullable enable
 
 using osu.Framework.Bindables;
 
@@ -11,7 +11,7 @@ namespace osu.Framework.Localisation
     {
         private class LocalisedBindableString : Bindable<string>, ILocalisedBindableString
         {
-            private IBindable<LocalisationParameters> parameters;
+            private IBindable<LocalisationParameters>? parameters;
 
             private LocalisableString text;
 


### PR DESCRIPTION
Not bothering the thin value type wrappers (`BindableInt` etc).
The `Value` and `DefaultValue` property is annotated the same as type parameter, allowing both `Bindable<Class>` and `Bindable<Class?>`.

#### Risks

The default constructor of `Bindable<T>` can introduce null to non-null annotated properties. This does not change existing behavior, but *provides a fake sense of safety*. In the other hand, annotating `Value` to be always nullable can introduce too much noise for consumers. The best option should be warning for such constructor call, but it's not possible yet.

The resharper warning is somehow too aggressive that assuming not-yet annotated code to be non-nullable. It warns [here](https://github.com/ppy/osu-framework/blob/7477218aea5a2b38f720d3a6907fbdb0ff863413/osu.Framework/Graphics/Audio/DrawableTrack.cs#L111-L117) where it should be `ValueChangedEvent<IAudioMixer?>`. I tend to think it's not wrong to be defensive for not-yet annotated code.