### PR TITLE
Clear DI activators on hot reload

### DIFF
--- a/osu.Framework/Allocation/DependencyActivator.cs
+++ b/osu.Framework/Allocation/DependencyActivator.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Testing;
 
 namespace osu.Framework.Allocation
 {
@@ -28,6 +29,12 @@ namespace osu.Framework.Allocation
         private readonly List<CacheDependencyDelegate> buildCacheActivators = new List<CacheDependencyDelegate>();
 
         private readonly DependencyActivator baseActivator;
+
+        static DependencyActivator()
+        {
+            // Attributes could have been added or removed when using hot-reload.
+            HotReloadCallbackReceiver.CompilationFinished += _ => activator_cache.Clear();
+        }
 
         private DependencyActivator(Type type)
         {


### PR DESCRIPTION
Added to the static ctor since this can be used during normal game execution as well (though we don't encourage development that way).