### PR TITLE
Remove escape to exit test browser

### DIFF
--- a/osu.Framework.Tests/TestGame.cs
+++ b/osu.Framework.Tests/TestGame.cs
@@ -18,6 +18,6 @@ namespace osu.Framework.Tests
             Resources.AddStore(new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(TestGame).Assembly), "Resources"));
         }
 
-        protected override bool OnExiting() => BlockExit.Value;
+        protected override bool OnExiting() => !BlockExit.Value;
     }
 }

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -84,6 +84,9 @@ namespace osu.Framework.Platform
         /// </summary>
         public event Action Deactivated;
 
+        /// <summary>
+        /// Called when the host is requesting to exit. Return <c>false</c> to block the exit process.
+        /// </summary>
         public event Func<bool> Exiting;
 
         public event Action Exited;

--- a/osu.Framework/Testing/TestBrowser.cs
+++ b/osu.Framework/Testing/TestBrowser.cs
@@ -32,7 +32,6 @@ using osu.Framework.Testing.Drawables.Steps;
 using osu.Framework.Timing;
 using osuTK;
 using osuTK.Graphics;
-using osuTK.Input;
 using Logger = osu.Framework.Logging.Logger;
 
 namespace osu.Framework.Testing
@@ -119,8 +118,6 @@ namespace osu.Framework.Testing
 
         private const float test_list_width = 200;
 
-        private Action exit;
-
         private readonly BindableDouble audioRateAdjust = new BindableDouble(1);
 
         [BackgroundDependencyLoader]
@@ -128,11 +125,6 @@ namespace osu.Framework.Testing
         {
             interactive = host.Window != null;
             config = new TestBrowserConfig(storage);
-
-            if (host.CanExit)
-                exit = host.Exit;
-            else if (host.CanSuspendToBackground)
-                exit = () => host.SuspendToBackground();
 
             audio.AddAdjustment(AdjustableProperty.Frequency, audioRateAdjust);
 
@@ -314,21 +306,6 @@ namespace osu.Framework.Testing
                 leftContainer.Width = test_list_width;
                 mainContainer.Padding = new MarginPadding { Left = test_list_width };
             }
-        }
-
-        protected override bool OnKeyDown(KeyDownEvent e)
-        {
-            if (!e.Repeat)
-            {
-                switch (e.Key)
-                {
-                    case Key.Escape:
-                        exit?.Invoke();
-                        return true;
-                }
-            }
-
-            return base.OnKeyDown(e);
         }
 
         public override IEnumerable<IKeyBinding> DefaultKeyBindings => new[]


### PR DESCRIPTION
This has been a pain point while testing for the longest time, where you hit escape expecting to interact with a test scene but instead exit the test browser.

Use Alt+F4, Cmd-W/Q or similar to exit instead. Or hook escape back up in your own `TestBrowser` implementation if you so choose.