### PR TITLE
Always use "No sound" audio device on headless test runs

### DIFF
--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -15,6 +15,7 @@ using osu.Framework.Audio.Mixing.Bass;
 using osu.Framework.Audio.Sample;
 using osu.Framework.Audio.Track;
 using osu.Framework.Bindables;
+using osu.Framework.Development;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.IO.Stores;
 using osu.Framework.Logging;
@@ -309,6 +310,10 @@ namespace osu.Framework.Audio
 
             // device is invalid
             if (!device.IsEnabled)
+                return false;
+
+            // we don't want bass initializing with real audio device on headless test runs.
+            if (deviceIndex != Bass.NoSoundDevice && DebugUtils.IsNUnitRunning)
                 return false;
 
             // initialize new device

--- a/osu.Framework/Testing/TestSceneTestRunner.cs
+++ b/osu.Framework/Testing/TestSceneTestRunner.cs
@@ -6,8 +6,6 @@ using System.Runtime.ExceptionServices;
 using System.Threading;
 using NUnit.Framework;
 using osu.Framework.Allocation;
-using osu.Framework.Bindables;
-using osu.Framework.Configuration;
 using osu.Framework.Extensions.TypeExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -35,29 +33,12 @@ namespace osu.Framework.Testing
         {
             private const double time_between_tests = 200;
 
-            private Bindable<double> volume;
-            private double volumeAtStartup;
-
             [Resolved]
             private GameHost host { get; set; }
 
             public TestRunner()
             {
                 RelativeSizeAxes = Axes.Both;
-            }
-
-            [BackgroundDependencyLoader]
-            private void load(FrameworkConfigManager config)
-            {
-                volume = config.GetBindable<double>(FrameworkSetting.VolumeUniversal);
-                volumeAtStartup = volume.Value;
-                volume.Value = 0;
-            }
-
-            internal override void UnbindAllBindables()
-            {
-                base.UnbindAllBindables();
-                if (volume != null) volume.Value = volumeAtStartup;
             }
 
             /// <summary>


### PR DESCRIPTION
Over the past few days, it has been quite annoying running full tests suite in terms of audio, as initializing mixers could result in some soft audio ticks (due to mixers having 0ms buffer), and some tests may directly modify the audio volume levels for testing convenience (see https://github.com/ppy/osu/blob/0099af87ff7e43e75c30c2105cd39fc52cfc996a/osu.Game.Tests/Visual/Gameplay/TestScenePlayerLoader.cs#L239-L249).

Have gone with the simplest fix of limiting audio devices to only "No sound", to make sure absolutely nothing is outputted to any of my actual audio devices. This is done as a better replacement to the current `AudioManager.Volume.Value = 0` logic in `TestSceneTestRunner`.

Alternative solution would be muting BASS at a global level, but we might as well never output to an actual audio device in that case to begin with.