### PR TITLE
Improve `CurrentDisplayMode` logic in `SDL2DesktopWindow`

### DIFF
--- a/osu.Framework.Tests/Visual/Drawables/TestSceneUpdateBeforeDraw.cs
+++ b/osu.Framework.Tests/Visual/Drawables/TestSceneUpdateBeforeDraw.cs
@@ -12,7 +12,7 @@ using osuTK.Graphics;
 
 namespace osu.Framework.Tests.Visual.Drawables
 {
-    [Description("Tests whether drawable updates occur before drawing.")]
+    [System.ComponentModel.Description("Tests whether drawable updates occur before drawing.")]
     public class TestSceneUpdateBeforeDraw : FrameworkTestScene
     {
         /// <summary>

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -136,14 +136,16 @@ namespace osu.Framework.Tests.Visual.Platform
             AddAssert("display has current mode", () => currentDisplay.DisplayModes.Any(mode => modesSimilar(mode, displayMode)));
             AddAssert("mode has valid RefreshRate", () => displayMode.RefreshRate != 0);
 
-            // TODO: the current display bounds should match even in fullscreen, this doesn't seem to work currently
-
             if (checkResolutionAgainstFullscreen)
-                AddAssert("Size matches fullscreen resolution", () => displayMode.Size == configSizeFullscreen.Value);
-            else
+                AddAssert("Size matches config fullscreen resolution", () => displayMode.Size == configSizeFullscreen.Value);
+
+            if (!checkResolutionAgainstFullscreen)
+                // This assert should be equivalent to the one under it, but `currentDisplay` is not updated when only the resolution changes.
+                // Since the display resolution doesn't change in windowed and borderless, we can safely check this.
+                // In fullscreen, the display resolution changes, so we can't check against `currentDisplay`.
+                // TODO: fix CurrentDisplayBindable not updating when resolution changes
                 AddAssert("Size matches bindable display resolution", () => displayMode.Size == currentDisplay.Bounds.Size);
 
-            // this shouldn't work, but it does...
             AddAssert("Size matches actual display resolution", () => displayMode.Size == window.Displays.ElementAt(displayMode.DisplayIndex).Bounds.Size);
         }
 

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -38,33 +38,40 @@ namespace osu.Framework.Tests.Visual.Platform
 
         public TestSceneDisplayMode()
         {
-            Child = new FillFlowContainer
+            Child = new BasicScrollContainer
             {
-                Padding = new MarginPadding(10),
-                Spacing = new Vector2(10),
-                Children = new Drawable[]
+                RelativeSizeAxes = Axes.Both,
+                Child = new FillFlowContainer
                 {
-                    new SpriteText
+                    RelativeSizeAxes = Axes.X,
+                    AutoSizeAxes = Axes.Y,
+                    Direction = FillDirection.Vertical,
+                    Padding = new MarginPadding(10),
+                    Spacing = new Vector2(10),
+                    Children = new Drawable[]
                     {
-                        Text = "FrameworkConfigManager settings: ",
-                        Font = FrameworkFont.Regular.With(size: 24),
+                        new SpriteText
+                        {
+                            Text = "FrameworkConfigManager settings: ",
+                            Font = FrameworkFont.Regular.With(size: 24),
+                        },
+                        new SpriteText { Current = textConfigSizeFullscreen, Font = FrameworkFont.Condensed },
+                        new SpriteText { Current = textConfigWindowMode, Font = FrameworkFont.Condensed },
+                        new SpriteText
+                        {
+                            Text = "IWindow properties: ",
+                            Font = FrameworkFont.Regular.With(size: 24),
+                            Margin = new MarginPadding { Top = 7 },
+                        },
+                        new SpriteText { Current = textCurrentDisplay, Font = FrameworkFont.Condensed },
+                        new SpriteText { Current = textCurrentDisplayMode, Font = FrameworkFont.Condensed.With(size: 16) },
+                        new SpriteText { Text = "Available display modes for current display:", Font = FrameworkFont.Condensed },
+                        textWindowDisplayModes = new TextFlowContainer(text => text.Font = FrameworkFont.Condensed.With(size: 16))
+                        {
+                            Width = 1000,
+                            AutoSizeAxes = Axes.Y,
+                        }
                     },
-                    new SpriteText { Current = textConfigSizeFullscreen, Font = FrameworkFont.Condensed },
-                    new SpriteText { Current = textConfigWindowMode, Font = FrameworkFont.Condensed },
-                    new SpriteText
-                    {
-                        Text = "IWindow properties: ",
-                        Font = FrameworkFont.Regular.With(size: 24),
-                        Margin = new MarginPadding { Top = 7 },
-                    },
-                    new SpriteText { Current = textCurrentDisplay, Font = FrameworkFont.Condensed },
-                    new SpriteText { Current = textCurrentDisplayMode, Font = FrameworkFont.Condensed.With(size: 16) },
-                    new SpriteText { Text = "Available display modes for current display:", Font = FrameworkFont.Condensed },
-                    textWindowDisplayModes = new TextFlowContainer(text => text.Font = FrameworkFont.Condensed.With(size: 16))
-                    {
-                        Width = 1000,
-                        AutoSizeAxes = Axes.Y,
-                    }
                 },
             };
         }

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -16,6 +16,7 @@ using osuTK;
 namespace osu.Framework.Tests.Visual.Platform
 {
     [System.ComponentModel.Description("For complete validation, this test should run be with different WindowModes at startup, and with different resolutions in Fullscreen")]
+    [Ignore("This test cannot run in headless mode (a window instance is required).")]
     public class TestSceneDisplayMode : FrameworkTestScene
     {
         [Resolved]

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -15,7 +15,7 @@ using osuTK;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
-    [System.ComponentModel.Description("For complete validation, this test should run be with different WindowModes at startup, and with different resolutions in Fullscreen")]
+    [System.ComponentModel.Description("For complete validation, run this with different window modes and resolutions at startup.")]
     [Ignore("This test cannot run in headless mode (a window instance is required).")]
     public class TestSceneDisplayMode : FrameworkTestScene
     {

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -132,9 +132,6 @@ namespace osu.Framework.Tests.Visual.Platform
 
         private void checkDisplayModeSanity(bool checkResolutionAgainstFullscreen)
         {
-            // TODO: this should probably be valid
-            // AddAssert("mode has valid Index", () => displayMode.Index != -1);
-
             AddAssert("DisplayIndex matches display", () => displayMode.DisplayIndex == currentDisplay.Index);
             AddAssert("display has current mode", () => currentDisplay.DisplayModes.Any(mode => modesSimilar(mode, displayMode)));
             AddAssert("mode has valid RefreshRate", () => displayMode.RefreshRate != 0);
@@ -161,7 +158,6 @@ namespace osu.Framework.Tests.Visual.Platform
             && left.Size == right.Size
             && left.BitsPerPixel == right.BitsPerPixel
             && left.RefreshRate == right.RefreshRate
-            // && left.Index == right.Index
             && left.DisplayIndex == right.DisplayIndex;
     }
 }

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -113,32 +113,32 @@ namespace osu.Framework.Tests.Visual.Platform
             {
                 case null: // test startup
                     AddAssert("mode has valid DisplayIndex", () => displayMode.DisplayIndex != -1);
-                    checkDisplayModeSanity(configWindowMode.Value == WindowMode.Fullscreen && !configSizeFullscreen.IsDefault);
+                    checkDisplayModeSanity(configWindowMode.Value == WindowMode.Fullscreen && !configSizeFullscreen.IsDefault, configWindowMode.Value != WindowMode.Windowed);
                     break;
 
                 case WindowMode.Windowed:
                 case WindowMode.Borderless:
                     AddStep($"change to {windowMode}", () => configWindowMode.Value = windowMode.Value);
-                    checkDisplayModeSanity(false);
+                    checkDisplayModeSanity(false, windowMode != WindowMode.Windowed);
                     break;
 
                 case WindowMode.Fullscreen:
                     AddStep("change to fullscreen", () => configWindowMode.Value = WindowMode.Fullscreen);
 
                     setFullscreenResolution(new Size(9999, 9999));
-                    checkDisplayModeSanity(false); // importantly, at default fullscreen resolution, it should match the desktop resolution.
+                    checkDisplayModeSanity(false, true); // importantly, at default fullscreen resolution, it should match the desktop resolution.
 
                     // reload (Ctrl+R) the test if testing on another display.
                     setFullscreenResolution(currentDisplay.FindDisplayMode(new Size(1920, 1080)).Size);
-                    checkDisplayModeSanity(true);
+                    checkDisplayModeSanity(true, true);
 
                     setFullscreenResolution(currentDisplay.FindDisplayMode(new Size(1280, 720)).Size);
-                    checkDisplayModeSanity(true);
+                    checkDisplayModeSanity(true, true);
                     break;
             }
         }
 
-        private void checkDisplayModeSanity(bool checkResolutionAgainstFullscreen)
+        private void checkDisplayModeSanity(bool checkResolutionAgainstFullscreen, bool checkClientSize)
         {
             AddAssert("DisplayIndex matches display", () => displayMode.DisplayIndex == currentDisplay.Index);
             AddAssert("display has current mode", () => currentDisplay.DisplayModes.Any(mode => mode == displayMode));
@@ -155,6 +155,9 @@ namespace osu.Framework.Tests.Visual.Platform
                 AddAssert("Size matches bindable display resolution", () => displayMode.Size == currentDisplay.Bounds.Size);
 
             AddAssert("Size matches actual display resolution", () => displayMode.Size == window.Displays.ElementAt(displayMode.DisplayIndex).Bounds.Size);
+
+            if (checkClientSize)
+                AddAssert("Size matches client size", () => displayMode.Size == window.ClientSize); // not applicable in windowed
         }
 
         private void setFullscreenResolution(Size resolution)

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -15,6 +15,7 @@ using osuTK;
 
 namespace osu.Framework.Tests.Visual.Platform
 {
+    [System.ComponentModel.Description("For complete validation, this test should run be with different WindowModes at startup, and with different resolutions in Fullscreen")]
     public class TestSceneDisplayMode : FrameworkTestScene
     {
         [Resolved]

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -144,10 +144,14 @@ namespace osu.Framework.Tests.Visual.Platform
             AddAssert("mode has valid RefreshRate", () => displayMode.RefreshRate != 0);
 
             // TODO: the current display bounds should match even in fullscreen, this doesn't seem to work currently
+
             if (checkResolutionAgainstFullscreen)
                 AddAssert("Size matches fullscreen resolution", () => displayMode.Size == configSizeFullscreen.Value);
             else
-                AddAssert("Size matches display resolution", () => displayMode.Size == currentDisplay.Bounds.Size);
+                AddAssert("Size matches bindable display resolution", () => displayMode.Size == currentDisplay.Bounds.Size);
+
+            // this shouldn't work, but it does...
+            AddAssert("Size matches actual display resolution", () => displayMode.Size == window.Displays.ElementAt(displayMode.DisplayIndex).Bounds.Size);
         }
 
         private void setFullscreenResolution(int w, int h)

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -125,13 +125,14 @@ namespace osu.Framework.Tests.Visual.Platform
                 case WindowMode.Fullscreen:
                     AddStep("change to fullscreen", () => configWindowMode.Value = WindowMode.Fullscreen);
 
-                    setFullscreenResolution(9999, 9999);
+                    setFullscreenResolution(new Size(9999, 9999));
                     checkDisplayModeSanity(false); // importantly, at default fullscreen resolution, it should match the desktop resolution.
 
-                    setFullscreenResolution(1920, 1080);
+                    // reload (Ctrl+R) the test if testing on another display.
+                    setFullscreenResolution(currentDisplay.FindDisplayMode(new Size(1920, 1080)).Size);
                     checkDisplayModeSanity(true);
 
-                    setFullscreenResolution(1280, 720);
+                    setFullscreenResolution(currentDisplay.FindDisplayMode(new Size(1280, 720)).Size);
                     checkDisplayModeSanity(true);
                     break;
             }
@@ -156,9 +157,9 @@ namespace osu.Framework.Tests.Visual.Platform
             AddAssert("Size matches actual display resolution", () => displayMode.Size == window.Displays.ElementAt(displayMode.DisplayIndex).Bounds.Size);
         }
 
-        private void setFullscreenResolution(int w, int h)
+        private void setFullscreenResolution(Size resolution)
         {
-            AddStep($"set fullscreen to {w}x{h}", () => configSizeFullscreen.Value = new Size(w, h));
+            AddStep($"set fullscreen to {resolution.Width}x{resolution.Height}", () => configSizeFullscreen.Value = resolution);
             AddWaitStep("wait for resolution change", 5);
         }
 

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -1,0 +1,167 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Drawing;
+using System.Linq;
+using NUnit.Framework;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Configuration;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Platform;
+using osuTK;
+
+namespace osu.Framework.Tests.Visual.Platform
+{
+    public class TestSceneDisplayMode : FrameworkTestScene
+    {
+        [Resolved]
+        private FrameworkConfigManager config { get; set; }
+
+        private readonly BindableSize configSizeFullscreen = new BindableSize();
+        private readonly Bindable<WindowMode> configWindowMode = new Bindable<WindowMode>();
+
+        private IWindow window;
+
+        private DisplayMode displayMode => window.CurrentDisplayMode.Value;
+        private Display currentDisplay => window.CurrentDisplayBindable.Value;
+
+        private readonly Bindable<string> textConfigSizeFullscreen = new Bindable<string>();
+        private readonly Bindable<string> textConfigWindowMode = new Bindable<string>();
+        private readonly Bindable<string> textCurrentDisplay = new Bindable<string>();
+        private readonly Bindable<string> textCurrentDisplayMode = new Bindable<string>();
+        private readonly TextFlowContainer textWindowDisplayModes;
+
+        public TestSceneDisplayMode()
+        {
+            Child = new FillFlowContainer
+            {
+                Padding = new MarginPadding(10),
+                Spacing = new Vector2(10),
+                Children = new Drawable[]
+                {
+                    new SpriteText
+                    {
+                        Text = "FrameworkConfigManager settings: ",
+                        Font = FrameworkFont.Regular.With(size: 24),
+                    },
+                    new SpriteText { Current = textConfigSizeFullscreen, Font = FrameworkFont.Condensed },
+                    new SpriteText { Current = textConfigWindowMode, Font = FrameworkFont.Condensed },
+                    new SpriteText
+                    {
+                        Text = "IWindow properties: ",
+                        Font = FrameworkFont.Regular.With(size: 24),
+                        Margin = new MarginPadding { Top = 7 },
+                    },
+                    new SpriteText { Current = textCurrentDisplay, Font = FrameworkFont.Condensed },
+                    new SpriteText { Current = textCurrentDisplayMode, Font = FrameworkFont.Condensed.With(size: 16) },
+                    new SpriteText { Text = "Available display modes for current display:", Font = FrameworkFont.Condensed },
+                    textWindowDisplayModes = new TextFlowContainer(text => text.Font = FrameworkFont.Condensed.With(size: 16))
+                    {
+                        Width = 1000,
+                        AutoSizeAxes = Axes.Y,
+                    }
+                },
+            };
+        }
+
+        [BackgroundDependencyLoader]
+        private void load(GameHost host)
+        {
+            window = host.Window;
+        }
+
+        protected override void LoadComplete()
+        {
+            base.LoadComplete();
+
+            config.BindWith(FrameworkSetting.SizeFullscreen, configSizeFullscreen);
+            config.BindWith(FrameworkSetting.WindowMode, configWindowMode);
+
+            configSizeFullscreen.BindValueChanged(e => textConfigSizeFullscreen.Value = $"SizeFullscreen: {e.NewValue}", true);
+            configWindowMode.BindValueChanged(e => textConfigWindowMode.Value = $"WindowMode: {e.NewValue}", true);
+
+            window.CurrentDisplayMode.BindValueChanged(e => textCurrentDisplayMode.Value = $"CurrentDisplayMode: {e.NewValue}", true);
+            window.CurrentDisplayBindable.BindValueChanged(e => Schedule(() => textWindowDisplayModes.Text = string.Join('\n', e.NewValue.DisplayModes)), true);
+        }
+
+        protected override void Update()
+        {
+            base.Update();
+            // update every time, as Display.Equals will cause the bindable not to update if only the resolution changes.
+            textCurrentDisplay.Value = $"CurrentDisplay: {currentDisplay}";
+        }
+
+        [TestCase(null)]
+        [TestCase(WindowMode.Windowed)]
+        [TestCase(WindowMode.Borderless)]
+        [TestCase(WindowMode.Fullscreen)]
+        public void TestDisplayModeSanity(WindowMode? windowMode)
+        {
+            if (window == null)
+            {
+                Assert.Ignore("This test cannot run in headless mode (a window instance is required).");
+                return;
+            }
+
+            switch (windowMode)
+            {
+                case null: // test startup
+                    AddAssert("mode has valid DisplayIndex", () => displayMode.DisplayIndex != -1);
+                    checkDisplayModeSanity(configWindowMode.Value == WindowMode.Fullscreen && !configSizeFullscreen.IsDefault);
+                    break;
+
+                case WindowMode.Windowed:
+                case WindowMode.Borderless:
+                    AddStep($"change to {windowMode}", () => configWindowMode.Value = windowMode.Value);
+                    checkDisplayModeSanity(false);
+                    break;
+
+                case WindowMode.Fullscreen:
+                    AddStep("change to fullscreen", () => configWindowMode.Value = WindowMode.Fullscreen);
+
+                    setFullscreenResolution(9999, 9999);
+                    checkDisplayModeSanity(false); // importantly, at default fullscreen resolution, it should match the desktop resolution.
+
+                    setFullscreenResolution(1920, 1080);
+                    checkDisplayModeSanity(true);
+
+                    setFullscreenResolution(1280, 720);
+                    checkDisplayModeSanity(true);
+                    break;
+            }
+        }
+
+        private void checkDisplayModeSanity(bool checkResolutionAgainstFullscreen)
+        {
+            // TODO: this should probably be valid
+            // AddAssert("mode has valid Index", () => displayMode.Index != -1);
+
+            AddAssert("DisplayIndex matches display", () => displayMode.DisplayIndex == currentDisplay.Index);
+            AddAssert("display has current mode", () => currentDisplay.DisplayModes.Any(mode => modesSimilar(mode, displayMode)));
+            AddAssert("mode has valid RefreshRate", () => displayMode.RefreshRate != 0);
+
+            // TODO: the current display bounds should match even in fullscreen, this doesn't seem to work currently
+            if (checkResolutionAgainstFullscreen)
+                AddAssert("Size matches fullscreen resolution", () => displayMode.Size == configSizeFullscreen.Value);
+            else
+                AddAssert("Size matches display resolution", () => displayMode.Size == currentDisplay.Bounds.Size);
+        }
+
+        private void setFullscreenResolution(int w, int h)
+        {
+            AddStep($"set fullscreen to {w}x{h}", () => configSizeFullscreen.Value = new Size(w, h));
+            AddWaitStep("wait for resolution change", 5);
+        }
+
+        private bool modesSimilar(DisplayMode left, DisplayMode right) =>
+            left.Format == right.Format
+            && left.Size == right.Size
+            && left.BitsPerPixel == right.BitsPerPixel
+            && left.RefreshRate == right.RefreshRate
+            // && left.Index == right.Index
+            && left.DisplayIndex == right.DisplayIndex;
+    }
+}

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -141,7 +141,7 @@ namespace osu.Framework.Tests.Visual.Platform
         private void checkDisplayModeSanity(bool checkResolutionAgainstFullscreen)
         {
             AddAssert("DisplayIndex matches display", () => displayMode.DisplayIndex == currentDisplay.Index);
-            AddAssert("display has current mode", () => currentDisplay.DisplayModes.Any(mode => modesSimilar(mode, displayMode)));
+            AddAssert("display has current mode", () => currentDisplay.DisplayModes.Any(mode => mode == displayMode));
             AddAssert("mode has valid RefreshRate", () => displayMode.RefreshRate != 0);
 
             if (checkResolutionAgainstFullscreen)
@@ -162,12 +162,5 @@ namespace osu.Framework.Tests.Visual.Platform
             AddStep($"set fullscreen to {resolution.Width}x{resolution.Height}", () => configSizeFullscreen.Value = resolution);
             AddWaitStep("wait for resolution change", 5);
         }
-
-        private bool modesSimilar(DisplayMode left, DisplayMode right) =>
-            left.Format == right.Format
-            && left.Size == right.Size
-            && left.BitsPerPixel == right.BitsPerPixel
-            && left.RefreshRate == right.RefreshRate
-            && left.DisplayIndex == right.DisplayIndex;
     }
 }

--- a/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
+++ b/osu.Framework.Tests/Visual/Platform/TestSceneDisplayMode.cs
@@ -102,12 +102,6 @@ namespace osu.Framework.Tests.Visual.Platform
         [TestCase(WindowMode.Fullscreen)]
         public void TestDisplayModeSanity(WindowMode? windowMode)
         {
-            if (window == null)
-            {
-                Assert.Ignore("This test cannot run in headless mode (a window instance is required).");
-                return;
-            }
-
             switch (windowMode)
             {
                 case null: // test startup

--- a/osu.Framework/Extensions/ExtensionMethods.cs
+++ b/osu.Framework/Extensions/ExtensionMethods.cs
@@ -346,6 +346,6 @@ namespace osu.Framework.Extensions
         /// <param name="resolution">The <see cref="DisplayResolution"/> to convert.</param>
         /// <returns>A <see cref="DisplayMode"/> structure populated with the corresponding properties.</returns>
         internal static DisplayMode ToDisplayMode(this DisplayResolution resolution) =>
-            new DisplayMode(null, new Size(resolution.Width, resolution.Height), resolution.BitsPerPixel, (int)Math.Round(resolution.RefreshRate), 0, 0);
+            new DisplayMode(null, new Size(resolution.Width, resolution.Height), resolution.BitsPerPixel, (int)Math.Round(resolution.RefreshRate), 0);
     }
 }

--- a/osu.Framework/Platform/Display.cs
+++ b/osu.Framework/Platform/Display.cs
@@ -42,7 +42,7 @@ namespace osu.Framework.Platform
             DisplayModes = displayModes;
         }
 
-        public override string ToString() => $"Name: {Name ?? "Unknown"}, Bounds: {Bounds}, DisplayModes: {DisplayModes.Length}";
+        public override string ToString() => $"Name: {Name ?? "Unknown"}, Bounds: {Bounds}, DisplayModes: {DisplayModes.Length}, Index: {Index}";
 
         public bool Equals(Display other)
         {

--- a/osu.Framework/Platform/DisplayMode.cs
+++ b/osu.Framework/Platform/DisplayMode.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using System.Drawing;
 
 namespace osu.Framework.Platform
@@ -8,7 +9,7 @@ namespace osu.Framework.Platform
     /// <summary>
     /// Represents a display mode on a given <see cref="Display"/>.
     /// </summary>
-    public readonly struct DisplayMode
+    public readonly struct DisplayMode : IEquatable<DisplayMode>
     {
         /// <summary>
         /// The pixel format of the display mode, if available.
@@ -45,5 +46,19 @@ namespace osu.Framework.Platform
         }
 
         public override string ToString() => $"Size: {Size}, BitsPerPixel: {BitsPerPixel}, RefreshRate: {RefreshRate}, Format: {Format}, DisplayIndex: {DisplayIndex}";
+
+        public bool Equals(DisplayMode other) =>
+            Format == other.Format
+            && Size == other.Size
+            && BitsPerPixel == other.BitsPerPixel
+            && RefreshRate == other.RefreshRate
+            && DisplayIndex == other.DisplayIndex;
+
+        public static bool operator ==(DisplayMode left, DisplayMode right) => left.Equals(right);
+        public static bool operator !=(DisplayMode left, DisplayMode right) => !(left == right);
+
+        public override bool Equals(object obj) => obj is DisplayMode other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(Format, Size, BitsPerPixel, RefreshRate, DisplayIndex);
     }
 }

--- a/osu.Framework/Platform/DisplayMode.cs
+++ b/osu.Framework/Platform/DisplayMode.cs
@@ -31,25 +31,19 @@ namespace osu.Framework.Platform
         public readonly int RefreshRate;
 
         /// <summary>
-        /// The index of the display mode as determined by the windowing backend.
-        /// </summary>
-        public readonly int Index;
-
-        /// <summary>
         /// The index of the display this mode belongs to as determined by the windowing backend.
         /// </summary>
         public readonly int DisplayIndex;
 
-        public DisplayMode(string format, Size size, int bitsPerPixel, int refreshRate, int index, int displayIndex)
+        public DisplayMode(string format, Size size, int bitsPerPixel, int refreshRate, int displayIndex)
         {
             Format = format ?? "Unknown";
             Size = size;
             BitsPerPixel = bitsPerPixel;
             RefreshRate = refreshRate;
-            Index = index;
             DisplayIndex = displayIndex;
         }
 
-        public override string ToString() => $"Size: {Size}, BitsPerPixel: {BitsPerPixel}, RefreshRate: {RefreshRate}, Format: {Format}, Index: {Index}, DisplayIndex: {DisplayIndex}";
+        public override string ToString() => $"Size: {Size}, BitsPerPixel: {BitsPerPixel}, RefreshRate: {RefreshRate}, Format: {Format}, DisplayIndex: {DisplayIndex}";
     }
 }

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -96,7 +96,7 @@ namespace osu.Framework.Platform
             get
             {
                 var display = CurrentDisplayDevice;
-                return new Bindable<DisplayMode>(new DisplayMode(null, new Size(display.Width, display.Height), display.BitsPerPixel, (int)Math.Round(display.RefreshRate), 0, 0));
+                return new Bindable<DisplayMode>(new DisplayMode(null, new Size(display.Width, display.Height), display.BitsPerPixel, (int)Math.Round(display.RefreshRate), 0));
             }
         }
 

--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -1013,10 +1013,10 @@ namespace osu.Framework.Platform.SDL2
             return true;
         }
 
-        public static DisplayMode ToDisplayMode(this SDL.SDL_DisplayMode mode, int displayIndex, int modeIndex)
+        public static DisplayMode ToDisplayMode(this SDL.SDL_DisplayMode mode, int displayIndex)
         {
             SDL.SDL_PixelFormatEnumToMasks(mode.format, out int bpp, out _, out _, out _, out _);
-            return new DisplayMode(SDL.SDL_GetPixelFormatName(mode.format), new Size(mode.w, mode.h), bpp, mode.refresh_rate, modeIndex, displayIndex);
+            return new DisplayMode(SDL.SDL_GetPixelFormatName(mode.format), new Size(mode.w, mode.h), bpp, mode.refresh_rate, displayIndex);
         }
     }
 }

--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
+using System.Drawing;
 using System.Runtime.InteropServices;
 using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Graphics.Primitives;
@@ -1010,6 +1011,12 @@ namespace osu.Framework.Platform.SDL2
 
             str = Marshal.PtrToStringUTF8(ptr) ?? string.Empty;
             return true;
+        }
+
+        public static DisplayMode ToDisplayMode(this SDL.SDL_DisplayMode mode, int displayIndex, int modeIndex)
+        {
+            SDL.SDL_PixelFormatEnumToMasks(mode.format, out int bpp, out _, out _, out _, out _);
+            return new DisplayMode(SDL.SDL_GetPixelFormatName(mode.format), new Size(mode.w, mode.h), bpp, mode.refresh_rate, modeIndex, displayIndex);
         }
     }
 }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1107,13 +1107,11 @@ namespace osu.Framework.Platform
             {
                 case WindowState.Fullscreen:
                     if (!updateDisplayMode(true))
-                        // if we failed to get the fullscreen mode, query the desktop mode so that we always have an up-to-date display mode.
                         updateDisplayMode(false);
                     break;
 
                 default:
                     if (!updateDisplayMode(false))
-                        // if we failed to get the desktop mode, query the fullscreen mode so that we always have an up-to-date display mode.
                         updateDisplayMode(true);
                     break;
             }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1127,7 +1127,7 @@ namespace osu.Framework.Platform
                 int localIndex = SDL.SDL_GetWindowDisplayIndex(SDLWindowHandle);
 
                 if (localIndex != displayIndex)
-                    Logger.Log($"Stored displayIndex ({displayIndex}) doesn't match real index ({localIndex})");
+                    Logger.Log($"Stored display index ({displayIndex}) doesn't match current index ({localIndex})");
 
                 if (queryFullscreenMode)
                 {

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1131,7 +1131,7 @@ namespace osu.Framework.Platform
                     if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
                     {
                         currentDisplayMode.Value = mode.ToDisplayMode(localIndex);
-                        Logger.Log($"Updated display mode to desktop resolution: {mode.w}x{mode.h}@{mode.refresh_rate}, {currentDisplayMode.Value.Format}");
+                        Logger.Log($"Updated display mode to fullscreen resolution: {mode.w}x{mode.h}@{mode.refresh_rate}, {currentDisplayMode.Value.Format}");
                         return true;
                     }
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1131,11 +1131,11 @@ namespace osu.Framework.Platform
                     if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
                     {
                         currentDisplayMode.Value = mode.ToDisplayMode(localIndex);
-                        Logger.Log($"Updated display mode (from fullscreen) to: {currentDisplayMode.Value}");
+                        Logger.Log($"Updated display mode to desktop resolution: {mode.w}x{mode.h}@{mode.refresh_rate}, {currentDisplayMode.Value.Format}");
                         return true;
                     }
 
-                    Logger.Log($"Failed to get display mode (from fullscreen). Display index: {localIndex}. SDL error: {SDL.SDL_GetError()}", level: LogLevel.Error);
+                    Logger.Log($"Failed to get fullscreen display mode. Display index: {localIndex}. SDL error: {SDL.SDL_GetError()}", level: LogLevel.Error);
                     return false;
                 }
                 else
@@ -1143,11 +1143,11 @@ namespace osu.Framework.Platform
                     if (SDL.SDL_GetCurrentDisplayMode(localIndex, out var mode) >= 0)
                     {
                         currentDisplayMode.Value = mode.ToDisplayMode(localIndex);
-                        Logger.Log($"Updated display mode (from desktop) to: {currentDisplayMode.Value}");
+                        Logger.Log($"Updated display mode to desktop resolution: {mode.w}x{mode.h}@{mode.refresh_rate}, {currentDisplayMode.Value.Format}");
                         return true;
                     }
 
-                    Logger.Log($"Failed to get display mode (from desktop). Display index: {localIndex}. SDL error: {SDL.SDL_GetError()}", level: LogLevel.Error);
+                    Logger.Log($"Failed to get desktop display mode. Display index: {localIndex}. SDL error: {SDL.SDL_GetError()}", level: LogLevel.Error);
                     return false;
                 }
             }

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1133,7 +1133,7 @@ namespace osu.Framework.Platform
                 {
                     if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
                     {
-                        currentDisplayMode.Value = mode.ToDisplayMode(localIndex, -1);
+                        currentDisplayMode.Value = mode.ToDisplayMode(localIndex);
                         Logger.Log($"Updated display mode (from fullscreen) to: {currentDisplayMode.Value}");
                         return true;
                     }
@@ -1145,7 +1145,7 @@ namespace osu.Framework.Platform
                 {
                     if (SDL.SDL_GetCurrentDisplayMode(localIndex, out var mode) >= 0)
                     {
-                        currentDisplayMode.Value = mode.ToDisplayMode(localIndex, -1);
+                        currentDisplayMode.Value = mode.ToDisplayMode(localIndex);
                         Logger.Log($"Updated display mode (from desktop) to: {currentDisplayMode.Value}");
                         return true;
                     }
@@ -1423,7 +1423,7 @@ namespace osu.Framework.Platform
                                          .Select(modeIndex =>
                                          {
                                              SDL.SDL_GetDisplayMode(displayIndex, modeIndex, out var mode);
-                                             return mode.ToDisplayMode(displayIndex, modeIndex);
+                                             return mode.ToDisplayMode(displayIndex);
                                          })
                                          .ToArray();
 

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1103,7 +1103,7 @@ namespace osu.Framework.Platform
             updateMaximisedState();
 
             if (SDL.SDL_GetWindowDisplayMode(SDLWindowHandle, out var mode) >= 0)
-                currentDisplayMode.Value = new DisplayMode(mode.format.ToString(), new Size(mode.w, mode.h), 32, mode.refresh_rate, displayIndex, displayIndex);
+                currentDisplayMode.Value = mode.ToDisplayMode(displayIndex, -1);
         }
 
         private void updateMaximisedState()
@@ -1373,18 +1373,12 @@ namespace osu.Framework.Platform
                                          .Select(modeIndex =>
                                          {
                                              SDL.SDL_GetDisplayMode(displayIndex, modeIndex, out var mode);
-                                             return displayModeFromSDL(mode, displayIndex, modeIndex);
+                                             return mode.ToDisplayMode(displayIndex, modeIndex);
                                          })
                                          .ToArray();
 
             SDL.SDL_GetDisplayBounds(displayIndex, out var rect);
             return new Display(displayIndex, SDL.SDL_GetDisplayName(displayIndex), new Rectangle(rect.x, rect.y, rect.w, rect.h), displayModes);
-        }
-
-        private static DisplayMode displayModeFromSDL(SDL.SDL_DisplayMode mode, int displayIndex, int modeIndex)
-        {
-            SDL.SDL_PixelFormatEnumToMasks(mode.format, out int bpp, out _, out _, out _, out _);
-            return new DisplayMode(SDL.SDL_GetPixelFormatName(mode.format), new Size(mode.w, mode.h), bpp, mode.refresh_rate, modeIndex, displayIndex);
         }
 
         #endregion

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -1107,14 +1107,13 @@ namespace osu.Framework.Platform
             {
                 case WindowState.Fullscreen:
                     if (!updateDisplayMode(true))
+                        // if we failed to get the fullscreen mode, query the desktop mode so that we always have an up-to-date display mode.
                         updateDisplayMode(false);
                     break;
 
-                case WindowState.Normal:
-                case WindowState.FullscreenBorderless:
-                case WindowState.Maximised:
-                case WindowState.Minimised:
+                default:
                     if (!updateDisplayMode(false))
+                        // if we failed to get the desktop mode, query the fullscreen mode so that we always have an up-to-date display mode.
                         updateDisplayMode(true);
                     break;
             }


### PR DESCRIPTION
Should fix https://github.com/ppy/osu/issues/17804.

The problem boils down to differences between [`SDL_GetWindowDisplayMode`](https://wiki.libsdl.org/SDL_GetWindowDisplayMode) and [`SDL_GetCurrentDisplayMode`](https://wiki.libsdl.org/SDL_GetCurrentDisplayMode). The former (roughly) gives the display mode that would be used if the window were set to fullscreen (without changing the mode). So in windowed, it could match a resolution lower than the native one (and presumably a high refresh rate display supports only 60 Hz on lower resolutions).

For that reason, we use `SDL_GetCurrentDisplayMode` in windowed modes which will give us the correct (desktop) mode.

As noted by the TODOs, some things are still broken.
- `CurrentDisplayMode` will always have an invalid index (-1) (not really important)
- `CurrentDisplayBindable` is really broken (see 0e7b66600fc20450e63bd092949fe612d82b6c53) (out of scope for this PR)
   - [`Display.Equals()`](https://github.com/ppy/osu-framework/blob/189633892af4b798743fc4365d767120affc11ec/osu.Framework/Platform/Display.cs#L47-L53) only checking the index probably doesn't help.

`CurrentDisplayMode` is only used in

https://github.com/ppy/osu-framework/blob/3f707df24d2efbc1ff44ed80c55d445911df8091/osu.Framework/Platform/GameHost.cs#L1030

so this should be a safe change. (No usages osu!-side.)

---

Tested on:
- [x] Windows
- [x] Linux
- [x] macOS

For testing, you should run the test four times, each time starting the visual tests in a different `WindowMode` and running trough all tests. For fullscreen, test twice, once with `FrameworkSetting.SizeFullscreen` set to default (`9999x9999`) and once with non-native resolution (could also test with resolution set to native).