### PR TITLE
Fix incorrect `Game` exit blocking default

### DIFF
--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -394,7 +394,11 @@ namespace osu.Framework
             Host.Exit();
         }
 
-        protected virtual bool OnExiting() => false;
+        /// <summary>
+        /// Fired when the game host signals that an exit has been requested.
+        /// </summary>
+        /// <returns>Return <c>false</c> to block the exit process.</returns>
+        protected virtual bool OnExiting() => true;
 
         protected override void Dispose(bool isDisposing)
         {


### PR DESCRIPTION
With the recent change to test browser exit logic (https://github.com/ppy/osu-framework/pull/5101), it became obvious that... no game can actually exit without manually overriding `OnExiting`. Like what? Am I missing something? How did people use osu!framework until now?

Can reproduce with `SampleGame` or osu! visual test browser..