### PR TITLE
Standardise `DrawableMenuItem` colour update logic

### DIFF
--- a/osu.Framework/Graphics/UserInterface/Dropdown.cs
+++ b/osu.Framework/Graphics/UserInterface/Dropdown.cs
@@ -477,7 +477,7 @@ namespace osu.Framework.Graphics.UserInterface
                     set
                     {
                         backgroundColourSelected = value;
-                        UpdateBackgroundColour();
+                        Scheduler.AddOnce(UpdateBackgroundColour);
                     }
                 }
 
@@ -489,17 +489,14 @@ namespace osu.Framework.Graphics.UserInterface
                     set
                     {
                         foregroundColourSelected = value;
-                        UpdateForegroundColour();
+                        Scheduler.AddOnce(UpdateForegroundColour);
                     }
                 }
 
                 protected virtual void OnSelectChange()
                 {
-                    if (!IsLoaded)
-                        return;
-
-                    UpdateBackgroundColour();
-                    UpdateForegroundColour();
+                    Scheduler.AddOnce(UpdateBackgroundColour);
+                    Scheduler.AddOnce(UpdateForegroundColour);
                 }
 
                 protected override void UpdateBackgroundColour()
@@ -510,13 +507,6 @@ namespace osu.Framework.Graphics.UserInterface
                 protected override void UpdateForegroundColour()
                 {
                     Foreground.FadeColour(IsPreSelected ? ForegroundColourHover : IsSelected ? ForegroundColourSelected : ForegroundColour);
-                }
-
-                protected override void LoadComplete()
-                {
-                    base.LoadComplete();
-                    Background.Colour = IsSelected ? BackgroundColourSelected : BackgroundColour;
-                    Foreground.Colour = IsSelected ? ForegroundColourSelected : ForegroundColour;
                 }
 
                 protected override bool OnHover(HoverEvent e)

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -739,7 +739,7 @@ namespace osu.Framework.Graphics.UserInterface
                 set
                 {
                     backgroundColour = value;
-                    UpdateBackgroundColour();
+                    Scheduler.AddOnce(UpdateBackgroundColour);
                 }
             }
 
@@ -754,7 +754,7 @@ namespace osu.Framework.Graphics.UserInterface
                 set
                 {
                     foregroundColour = value;
-                    UpdateForegroundColour();
+                    Scheduler.AddOnce(UpdateForegroundColour);
                 }
             }
 
@@ -769,7 +769,7 @@ namespace osu.Framework.Graphics.UserInterface
                 set
                 {
                     backgroundColourHover = value;
-                    UpdateBackgroundColour();
+                    Scheduler.AddOnce(UpdateBackgroundColour);
                 }
             }
 
@@ -784,7 +784,7 @@ namespace osu.Framework.Graphics.UserInterface
                 set
                 {
                     foregroundColourHover = value;
-                    UpdateForegroundColour();
+                    Scheduler.AddOnce(UpdateForegroundColour);
                 }
             }
 
@@ -797,8 +797,8 @@ namespace osu.Framework.Graphics.UserInterface
                 {
                     state = value;
 
-                    UpdateForegroundColour();
-                    UpdateBackgroundColour();
+                    Scheduler.AddOnce(UpdateBackgroundColour);
+                    Scheduler.AddOnce(UpdateForegroundColour);
 
                     StateChanged?.Invoke(state);
                 }
@@ -833,14 +833,15 @@ namespace osu.Framework.Graphics.UserInterface
             protected override void LoadComplete()
             {
                 base.LoadComplete();
-                Background.Colour = BackgroundColour;
-                Foreground.Colour = ForegroundColour;
+
+                Scheduler.AddOnce(UpdateBackgroundColour);
+                Scheduler.AddOnce(UpdateForegroundColour);
             }
 
             protected override bool OnHover(HoverEvent e)
             {
-                UpdateBackgroundColour();
-                UpdateForegroundColour();
+                Scheduler.AddOnce(UpdateBackgroundColour);
+                Scheduler.AddOnce(UpdateForegroundColour);
 
                 Schedule(() =>
                 {
@@ -853,8 +854,8 @@ namespace osu.Framework.Graphics.UserInterface
 
             protected override void OnHoverLost(HoverLostEvent e)
             {
-                UpdateBackgroundColour();
-                UpdateForegroundColour();
+                Scheduler.AddOnce(UpdateBackgroundColour);
+                Scheduler.AddOnce(UpdateForegroundColour);
                 base.OnHoverLost(e);
             }
 


### PR DESCRIPTION
As of https://github.com/ppy/osu-framework/pull/5054, it was feasible that `OnSelected` would be fired by a `DrawableDropdown` on its child items before they were `IsLoaded`. If an implementation relied on `OnSelected` to update the colour state correctly, this would have caused a potential regression in behaviour due to calls to `Update*Colour` not happening when `!IsLoaded`.

https://github.com/ppy/osu-framework/blob/963f15675c07c654cbb8f5627d5999080131f1e9/osu.Framework/Graphics/UserInterface/Dropdown.cs#L496-L503

Note that the framework implementation was saved by the ad-hoc logic in `LoadComplete` (which would not work for osu! due to not having the correct overrides):

https://github.com/ppy/osu-framework/blob/963f15675c07c654cbb8f5627d5999080131f1e9/osu.Framework/Graphics/UserInterface/Dropdown.cs#L515-L520

To fix this, I've standardised all calls to `UpdateBackgroundColour` and `UpdateForegroundColour` to be scheduled and debounced. I've also replaced multiple methods of performing the same colour set in different ways.



The `AddOnce` was a large improvement, as each item was previously having it called unnecessarily 3-5 times before initial display.

I've tested this against osu! manually. It's hard to test framework-side because it was caused by a non-standard osu! side implementation of colour/hover/select handling.

Closes https://github.com/ppy/osu/issues/8912.