### PR TITLE
Fix accidental API breakage of `Game.OnExiting()` return value

### DIFF
--- a/osu.Framework.Tests/Platform/GameExitTest.cs
+++ b/osu.Framework.Tests/Platform/GameExitTest.cs
@@ -40,6 +40,8 @@ namespace osu.Framework.Tests.Platform
             game.BlockExit.Value = true;
             // `RequestExit()` should return true.
             Assert.That(host.RequestExit(), Is.True);
+            // game's last exit result should match.
+            Assert.That(game.LastExitResult, Is.True);
             // exit should be blocked.
             Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Running).After(timeout));
             Assert.That(task.IsCompleted, Is.False);
@@ -48,6 +50,8 @@ namespace osu.Framework.Tests.Platform
             game.BlockExit.Value = false;
             // `RequestExit()` should not be blocked and return false.
             Assert.That(host.RequestExit(), Is.False);
+            // game's last exit result should match.
+            Assert.That(game.LastExitResult, Is.False);
             // finally, the game should exit.
             Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Stopped).After(timeout));
             task.WaitSafely();
@@ -62,9 +66,18 @@ namespace osu.Framework.Tests.Platform
         {
             public readonly ManualResetEventSlim BecameAlive = new ManualResetEventSlim();
 
+            public bool? LastExitResult { get; private set; }
+
             protected override void LoadComplete()
             {
                 BecameAlive.Set();
+            }
+
+            protected override bool OnExiting()
+            {
+                bool result = base.OnExiting();
+                LastExitResult = result;
+                return result;
             }
         }
     }

--- a/osu.Framework.Tests/Platform/GameExitTest.cs
+++ b/osu.Framework.Tests/Platform/GameExitTest.cs
@@ -1,0 +1,71 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
+// See the LICENCE file in the repository root for full licence text.
+
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using osu.Framework.Extensions;
+using osu.Framework.Platform;
+using osu.Framework.Testing;
+
+namespace osu.Framework.Tests.Platform
+{
+    [TestFixture]
+    public class GameExitTest
+    {
+        private TestTestGame game;
+        private ManualExitHeadlessGameHost host;
+
+        private const int timeout = 5000;
+
+        [Test]
+        public void TestExitBlocking()
+        {
+            var gameCreated = new ManualResetEventSlim();
+
+            var task = Task.Factory.StartNew(() =>
+            {
+                using (host = new ManualExitHeadlessGameHost())
+                {
+                    game = new TestTestGame();
+                    gameCreated.Set();
+                    host.Run(game);
+                }
+            }, TaskCreationOptions.LongRunning);
+
+            gameCreated.Wait(timeout);
+            Assert.IsTrue(game.BecameAlive.Wait(timeout));
+
+            // block game from exiting.
+            game.BlockExit.Value = true;
+            // `RequestExit()` should return true.
+            Assert.That(host.RequestExit(), Is.True);
+            // exit should be blocked.
+            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Running).After(timeout));
+            Assert.That(task.IsCompleted, Is.False);
+
+            // unblock game from exiting.
+            game.BlockExit.Value = false;
+            // `RequestExit()` should not be blocked and return false.
+            Assert.That(host.RequestExit(), Is.False);
+            // finally, the game should exit.
+            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Stopped).After(timeout));
+            task.WaitSafely();
+        }
+
+        private class ManualExitHeadlessGameHost : TestRunHeadlessGameHost
+        {
+            public bool RequestExit() => OnExitRequested();
+        }
+
+        private class TestTestGame : TestGame
+        {
+            public readonly ManualResetEventSlim BecameAlive = new ManualResetEventSlim();
+
+            protected override void LoadComplete()
+            {
+                BecameAlive.Set();
+            }
+        }
+    }
+}

--- a/osu.Framework.Tests/TestGame.cs
+++ b/osu.Framework.Tests/TestGame.cs
@@ -18,6 +18,6 @@ namespace osu.Framework.Tests
             Resources.AddStore(new NamespacedResourceStore<byte[]>(new DllResourceStore(typeof(TestGame).Assembly), "Resources"));
         }
 
-        protected override bool OnExiting() => !BlockExit.Value;
+        protected override bool OnExiting() => BlockExit.Value;
     }
 }

--- a/osu.Framework/Game.cs
+++ b/osu.Framework/Game.cs
@@ -397,8 +397,8 @@ namespace osu.Framework
         /// <summary>
         /// Fired when the game host signals that an exit has been requested.
         /// </summary>
-        /// <returns>Return <c>false</c> to block the exit process.</returns>
-        protected virtual bool OnExiting() => true;
+        /// <returns>Return <c>true</c> to block the exit process.</returns>
+        protected virtual bool OnExiting() => false;
 
         protected override void Dispose(bool isDisposing)
         {

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -413,7 +413,7 @@ namespace osu.Framework.Platform
                     Thread.Sleep(1);
             }
 
-            if (response == false)
+            if (response == true)
                 return true;
 
             Exit();

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -85,7 +85,7 @@ namespace osu.Framework.Platform
         public event Action Deactivated;
 
         /// <summary>
-        /// Called when the host is requesting to exit. Return <c>false</c> to block the exit process.
+        /// Called when the host is requesting to exit. Return <c>true</c> to block the exit process.
         /// </summary>
         public event Func<bool> Exiting;
 


### PR DESCRIPTION
As correctly pointed out by @Joehuu, all of the recent troubles with the exit flow breaking originated in #5097, namely the [change to `GameHost` therein](https://github.com/ppy/osu-framework/pull/5097/files#diff-c694d93cea53f76879738dce61918a64bc3110e7df817250864f1f4754607512). This led to *unintentional API breakage in the latest framework release* and as such I think it makes sense to just revert it. The explanation why it is a regression is very simple but also stems from some very confusing code:

| `response` | `response ?? false` | `response == false` |
| :-: | :-: | :-: |
| `true` | `true` | `false` |
| `false` | `false` | `true` |

I'm not including the `null` case, as it was never reachable due to how the surrounding code is structured - [it is guaranteed that `response` is not null](https://github.com/ppy/osu-framework/blob/439aeddd031c79fe96ae6fe428082d0c833d9146/osu.Framework/Platform/GameHost.cs#L407-L414) when the aforementioned guard is reached.

#5101 partially papered over this, by updating xmldoc to the post-regression state and inverting one `OnExiting()` return value. This continued in #5104 wherein a second `OnExiting()` return value was inverted and a second xmldoc using the post-regression state was added. Both changes are reverted here, and xmldoc is updated to match.

This change supersedes / closes https://github.com/ppy/osu/pull/17870.

Test coverage for return value correctness included.