### PR TITLE
Fix `TestExitBlocking` taking 10 seconds to run

### DIFF
--- a/osu.Framework.Tests/Platform/GameExitTest.cs
+++ b/osu.Framework.Tests/Platform/GameExitTest.cs
@@ -4,7 +4,6 @@
 using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using osu.Framework.Extensions;
 using osu.Framework.Platform;
 using osu.Framework.Testing;
 
@@ -42,8 +41,9 @@ namespace osu.Framework.Tests.Platform
             Assert.That(host.RequestExit(), Is.True);
             // game's last exit result should match.
             Assert.That(game.LastExitResult, Is.True);
+
             // exit should be blocked.
-            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Running).After(timeout));
+            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Running));
             Assert.That(task.IsCompleted, Is.False);
 
             // unblock game from exiting.
@@ -52,9 +52,10 @@ namespace osu.Framework.Tests.Platform
             Assert.That(host.RequestExit(), Is.False);
             // game's last exit result should match.
             Assert.That(game.LastExitResult, Is.False);
+
             // finally, the game should exit.
-            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Stopped).After(timeout));
-            task.WaitSafely();
+            task.Wait(timeout);
+            Assert.That(() => host.ExecutionState, Is.EqualTo(ExecutionState.Stopped));
         }
 
         private class ManualExitHeadlessGameHost : TestRunHeadlessGameHost

--- a/osu.Framework/Platform/GameHost.cs
+++ b/osu.Framework/Platform/GameHost.cs
@@ -413,7 +413,7 @@ namespace osu.Framework.Platform
                     Thread.Sleep(1);
             }
 
-            if (response == true)
+            if (response.Value)
                 return true;
 
             Exit();


### PR DESCRIPTION
Initially I was just looking to fix the weird conditional (3b8c1a36e), but noticed the test is quite slow to execute.

I think the original code was a bit too safe. Internally the `host.RequestExit()` call is blocking until the exit has been handled, but I can understand that we may be trying to black box test here to avoid any uncertainty.

If this solution is seen as unsatisfactory then we can count update frames or something. I'd just like to avoid a single test taking 10 seconds to run while spinning.