### PR TITLE
Provide default proxy credentials to `HttpClient`

### DIFF
--- a/osu.Framework/IO/Network/WebRequest.cs
+++ b/osu.Framework/IO/Network/WebRequest.cs
@@ -153,10 +153,16 @@ namespace osu.Framework.IO.Network
             new SocketsHttpHandler
             {
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                // Can be replaced by a static HttpClient.DefaultCredentials after net60 everywhere.
+                Credentials = CredentialCache.DefaultCredentials,
                 ConnectCallback = onConnect,
             }
 #else
-            new HttpClientHandler { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate }
+            new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
+                Credentials = CredentialCache.DefaultCredentials,
+            }
 #endif
         )
         {


### PR DESCRIPTION
Partially solves https://github.com/ppy/osu/discussions/17897.

See https://github.com/dotnet/runtime/issues/30222 for reference.

As a disclaimer, I haven't tested this apart from confirming it doesn't
break a flow with no proxy specified. But should work in theory.