### PR TITLE
Allow layered `ScrollContainer`s to coexist on input handling

### DIFF
--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
@@ -369,7 +369,7 @@ namespace osu.Framework.Tests.Visual.Containers
 
         [TestCase(Direction.Horizontal, Direction.Vertical)]
         [TestCase(Direction.Vertical, Direction.Horizontal)]
-        public void TestInputHandlingRespectsDirection(Direction outer, Direction inner)
+        public void TestNestedScrolling(Direction outer, Direction inner)
         {
             BasicScrollContainer horizontalScroll = null;
             BasicScrollContainer verticalScroll = null;

--- a/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
+++ b/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs
@@ -367,6 +367,90 @@ namespace osu.Framework.Tests.Visual.Containers
             checkScrollbarPosition(64);
         }
 
+        [TestCase(Direction.Horizontal, Direction.Vertical)]
+        [TestCase(Direction.Vertical, Direction.Horizontal)]
+        public void TestInputHandlingRespectsDirection(Direction outer, Direction inner)
+        {
+            BasicScrollContainer horizontalScroll = null;
+            BasicScrollContainer verticalScroll = null;
+
+            AddStep("create scroll containers", () =>
+            {
+                BasicScrollContainer outerScroll;
+                BasicScrollContainer innerScroll;
+
+                Child = outerScroll = new BasicScrollContainer(outer)
+                {
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Size = new Vector2(500),
+                    Children = new Drawable[]
+                    {
+                        new Box
+                        {
+                            Size = new Vector2(500f),
+                            Colour = FrameworkColour.Yellow,
+                        },
+                        innerScroll = new BasicScrollContainer(inner)
+                        {
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Size = new Vector2(250, 250),
+                            Child = new Box
+                            {
+                                Size = new Vector2(250, 250),
+                                Colour = FrameworkColour.Green,
+                            },
+                        }
+                    }
+                };
+
+                horizontalScroll = outer == Direction.Horizontal ? outerScroll : innerScroll;
+                verticalScroll = outer == Direction.Vertical ? outerScroll : innerScroll;
+            });
+
+            AddStep("drag vertically", () =>
+            {
+                InputManager.MoveMouseTo(verticalScroll);
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.MoveMouseTo(verticalScroll, new Vector2(0, -50));
+            });
+            AddAssert("vertical container scrolled only", () => checkScrollCurrent(verticalScroll, horizontalScroll));
+            AddStep("reset vertical scroll", () =>
+            {
+                InputManager.ReleaseButton(MouseButton.Left);
+                verticalScroll.ScrollToStart(false, true);
+            });
+
+            AddStep("drag horizontally", () =>
+            {
+                InputManager.MoveMouseTo(horizontalScroll);
+                InputManager.PressButton(MouseButton.Left);
+                InputManager.MoveMouseTo(horizontalScroll, new Vector2(-50, 0));
+            });
+            AddAssert("horizontal container scrolled only", () => checkScrollCurrent(horizontalScroll, verticalScroll));
+            AddStep("reset horizontal scroll", () =>
+            {
+                InputManager.ReleaseButton(MouseButton.Left);
+                horizontalScroll.ScrollToStart(false, true);
+            });
+
+            // if the inner is a horizontal scroll container, it'll absorb input either way,
+            // as vertical scrolls translate to horizontal in a horizontal scroll container.
+            if (inner != Direction.Horizontal)
+            {
+                AddStep("scroll vertically", () => InputManager.ScrollVerticalBy(-50));
+                AddAssert("vertical container scrolled only", () => checkScrollCurrent(verticalScroll, horizontalScroll));
+                AddStep("reset vertical scroll", () => verticalScroll.ScrollToStart(false));
+            }
+
+            AddStep("scroll horizontally", () => InputManager.ScrollHorizontalBy(-50));
+            AddAssert("horizontal container scrolled only", () => checkScrollCurrent(horizontalScroll, verticalScroll));
+            AddStep("reset horizontal scroll", () => horizontalScroll.ScrollToStart(false));
+
+            static bool checkScrollCurrent(BasicScrollContainer scrolled, BasicScrollContainer notScrolled) => notScrolled.Current == 0 && Precision.DefinitelyBigger(scrolled.Current, 0f);
+        }
+
         private void scrollIntoView(int index, float expectedPosition, float? heightAdjust = null, float? expectedPostAdjustPosition = null)
         {
             if (heightAdjust != null)

--- a/osu.Framework.Tests/Visual/Input/TestSceneClickLenience.cs
+++ b/osu.Framework.Tests/Visual/Input/TestSceneClickLenience.cs
@@ -85,21 +85,6 @@ namespace osu.Framework.Tests.Visual.Input
         [TestCase(TestType.Direct)]
         [TestCase(TestType.Scroll)]
         [TestCase(TestType.NonBlockingScroll)]
-        public void TestDiagonalDragOnButton(TestType type)
-        {
-            AddStep("create button", () => Child = createClickBox(type));
-
-            AddStep("move to TopLeft", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).TopLeft));
-            AddStep("mouse down", () => InputManager.PressButton(MouseButton.Left));
-            AddStep("move to BottomRight", () => InputManager.MoveMouseTo(box.ScreenSpaceDrawQuad.AABBFloat.Shrink(10).BottomRight));
-            AddStep("mouse up", () => InputManager.ReleaseButton(MouseButton.Left));
-
-            checkClicked(type != TestType.Scroll);
-        }
-
-        [TestCase(TestType.Direct)]
-        [TestCase(TestType.Scroll)]
-        [TestCase(TestType.NonBlockingScroll)]
         public void TestHorizontalDragOut(TestType type)
         {
             AddStep("create button", () => Child = createClickBox(type));

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -243,6 +243,9 @@ namespace osu.Framework.Graphics.Containers
             if (IsDragging || e.Button != MouseButton.Left || Content.AliveInternalChildren.Count == 0)
                 return false;
 
+            if (Math.Abs(e.Delta.X) > Math.Abs(e.Delta.Y) != (ScrollDirection == Direction.Horizontal))
+                return false;
+
             lastDragTime = Time.Current;
             averageDragDelta = averageDragTime = 0;
 

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -277,6 +277,9 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
+            if (IsDragging || e.Button != MouseButton.Left)
+                return false;
+
             // Continue from where we currently are scrolled to.
             Target = Current;
             return false;

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -243,7 +243,9 @@ namespace osu.Framework.Graphics.Containers
             if (IsDragging || e.Button != MouseButton.Left || Content.AliveInternalChildren.Count == 0)
                 return false;
 
-            if (Math.Abs(e.Delta.X) > Math.Abs(e.Delta.Y) != (ScrollDirection == Direction.Horizontal))
+            bool dragWasMostlyHorizontal = Math.Abs(e.Delta.X) > Math.Abs(e.Delta.Y);
+
+            if (dragWasMostlyHorizontal != (ScrollDirection == Direction.Horizontal))
                 return false;
 
             lastDragTime = Time.Current;
@@ -366,7 +368,11 @@ namespace osu.Framework.Graphics.Containers
             if (Content.AliveInternalChildren.Count == 0)
                 return false;
 
-            if (Math.Abs(e.ScrollDelta.X) > Math.Abs(e.ScrollDelta.Y) && ScrollDirection == Direction.Vertical)
+            bool scrollWasMostlyHorizontal = Math.Abs(e.ScrollDelta.X) > Math.Abs(e.ScrollDelta.Y);
+
+            // For horizontal scrolling containers, vertical scroll is also used to perform horizontal traversal.
+            // Due to this, we only block horizontal scroll in vertical containers, but not vice-versa.
+            if (scrollWasMostlyHorizontal && ScrollDirection == Direction.Vertical)
                 return false;
 
             bool isPrecise = e.IsPrecise;

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -366,6 +366,9 @@ namespace osu.Framework.Graphics.Containers
             if (Content.AliveInternalChildren.Count == 0)
                 return false;
 
+            if (Math.Abs(e.ScrollDelta.X) > Math.Abs(e.ScrollDelta.Y) && ScrollDirection == Direction.Vertical)
+                return false;
+
             bool isPrecise = e.IsPrecise;
 
             Vector2 scrollDelta = e.ScrollDelta;

--- a/osu.Framework/Graphics/Containers/ScrollContainer.cs
+++ b/osu.Framework/Graphics/Containers/ScrollContainer.cs
@@ -277,12 +277,9 @@ namespace osu.Framework.Graphics.Containers
 
         protected override bool OnMouseDown(MouseDownEvent e)
         {
-            if (IsDragging || e.Button != MouseButton.Left) return false;
-
             // Continue from where we currently are scrolled to.
             Target = Current;
-
-            return true;
+            return false;
         }
 
         // We keep track of this because input events may happen at different intervals than update frames

--- a/osu.Framework/Input/Events/DragStartEvent.cs
+++ b/osu.Framework/Input/Events/DragStartEvent.cs
@@ -12,6 +12,11 @@ namespace osu.Framework.Input.Events
     /// </summary>
     public class DragStartEvent : MouseButtonEvent
     {
+        /// <summary>
+        /// The difference from mouse down position to current position in local space.
+        /// </summary>
+        public Vector2 Delta => MousePosition - MouseDownPosition;
+
         public DragStartEvent(InputState state, MouseButton button, Vector2? screenSpaceMouseDownPosition = null)
             : base(state, button, screenSpaceMouseDownPosition)
         {


### PR DESCRIPTION
- Closes #3576

This changes drag event handling and scroll event handling in `ScrollContainer`s to be based on their `ScrollDirection`, to allow for layered scroll containers to coexist.

This however becomes a nuisance on two parts:
 - https://github.com/ppy/osu-framework/commit/20c1d72502c4f85d5e23def9a28aa02a5725dbb6: In order for scroll containers to coexist, the innermost must not `OnMouseDown` to let the parenting scroll containers enter the mouse-down/drag input queue, for receiving drag events.

   I'm not entirely sure if there's a reason for that in the first place, checking with git blame threw me back to 4 years ago (https://github.com/ppy/osu-framework/pull/316).
 - https://github.com/ppy/osu-framework/commit/7bff9b96bebc982b5dfabf75cd714b41237bf25a: When a scroll container is horizontal, scrolling vertically will also be considered as horizontal, therefore this coexistence change cannot apply when the inner scroll container is horizontal ([as done in test](https://github.com/ppy/osu-framework/blob/e81e2b80acf9c2edfaf532620b36fa8160b17f18/osu.Framework.Tests/Visual/Containers/TestSceneScrollContainer.cs#L438-L445)).

    In addition, it also results in this kinda weird UX (inner = horizontal, outer = vertical):

    https://user-images.githubusercontent.com/22781491/164593522-314825a1-8388-47c6-b9c2-090fe519fd3e.mp4

 