### PR TITLE
Enforce code style analysis shipped with .NET SDK

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -8,12 +8,6 @@
         "dotnet-cake"
       ]
     },
-    "dotnet-format": {
-      "version": "3.1.37601",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "jetbrains.resharper.globaltools": {
       "version": "2022.1.0-eap10",
       "commands": [

--- a/.editorconfig
+++ b/.editorconfig
@@ -43,7 +43,7 @@ dotnet_naming_rule.local_function_camelcase.severity = warning
 dotnet_naming_rule.local_function_camelcase.symbols = local_function
 dotnet_naming_rule.local_function_camelcase.style = camelcase
 
-#all_lower for private and local constants/static readonlys
+#all_lower for private and local constants
 dotnet_naming_style.all_lower.capitalization = all_lower
 dotnet_naming_style.all_lower.word_separator = _
 
@@ -54,20 +54,13 @@ dotnet_naming_rule.private_const_all_lower.severity = warning
 dotnet_naming_rule.private_const_all_lower.symbols = private_constants
 dotnet_naming_rule.private_const_all_lower.style = all_lower
 
-dotnet_naming_symbols.private_static_readonly.applicable_accessibilities = private
-dotnet_naming_symbols.private_static_readonly.required_modifiers = static,readonly
-dotnet_naming_symbols.private_static_readonly.applicable_kinds = field
-dotnet_naming_rule.private_static_readonly_all_lower.severity = warning
-dotnet_naming_rule.private_static_readonly_all_lower.symbols = private_static_readonly
-dotnet_naming_rule.private_static_readonly_all_lower.style = all_lower
-
 dotnet_naming_symbols.local_constants.applicable_kinds = local
 dotnet_naming_symbols.local_constants.required_modifiers = const
 dotnet_naming_rule.local_const_all_lower.severity = warning
 dotnet_naming_rule.local_const_all_lower.symbols = local_constants
 dotnet_naming_rule.local_const_all_lower.style = all_lower
 
-#ALL_UPPER for non private constants/static readonlys
+#ALL_UPPER for non private constants
 dotnet_naming_style.all_upper.capitalization = all_upper
 dotnet_naming_style.all_upper.word_separator = _
 
@@ -77,13 +70,6 @@ dotnet_naming_symbols.public_constants.applicable_kinds = field
 dotnet_naming_rule.public_const_all_upper.severity = warning
 dotnet_naming_rule.public_const_all_upper.symbols = public_constants
 dotnet_naming_rule.public_const_all_upper.style = all_upper
-
-dotnet_naming_symbols.public_static_readonly.applicable_accessibilities = public,internal,protected,protected_internal,private_protected
-dotnet_naming_symbols.public_static_readonly.required_modifiers = static,readonly
-dotnet_naming_symbols.public_static_readonly.applicable_kinds = field
-dotnet_naming_rule.public_static_readonly_all_upper.severity = warning
-dotnet_naming_rule.public_static_readonly_all_upper.symbols = public_static_readonly
-dotnet_naming_rule.public_static_readonly_all_upper.style = all_upper
 
 #Roslyn formating options
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -43,7 +43,7 @@ dotnet_naming_rule.local_function_camelcase.severity = warning
 dotnet_naming_rule.local_function_camelcase.symbols = local_function
 dotnet_naming_rule.local_function_camelcase.style = camelcase
 
-#all_lower for private and local constants
+#all_lower for private and local constants/static readonlys
 dotnet_naming_style.all_lower.capitalization = all_lower
 dotnet_naming_style.all_lower.word_separator = _
 
@@ -54,13 +54,20 @@ dotnet_naming_rule.private_const_all_lower.severity = warning
 dotnet_naming_rule.private_const_all_lower.symbols = private_constants
 dotnet_naming_rule.private_const_all_lower.style = all_lower
 
+dotnet_naming_symbols.private_static_readonly.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_readonly.required_modifiers = static,readonly
+dotnet_naming_symbols.private_static_readonly.applicable_kinds = field
+dotnet_naming_rule.private_static_readonly_all_lower.severity = warning
+dotnet_naming_rule.private_static_readonly_all_lower.symbols = private_static_readonly
+dotnet_naming_rule.private_static_readonly_all_lower.style = all_lower
+
 dotnet_naming_symbols.local_constants.applicable_kinds = local
 dotnet_naming_symbols.local_constants.required_modifiers = const
 dotnet_naming_rule.local_const_all_lower.severity = warning
 dotnet_naming_rule.local_const_all_lower.symbols = local_constants
 dotnet_naming_rule.local_const_all_lower.style = all_lower
 
-#ALL_UPPER for non private constants
+#ALL_UPPER for non private constants/static readonlys
 dotnet_naming_style.all_upper.capitalization = all_upper
 dotnet_naming_style.all_upper.word_separator = _
 
@@ -70,6 +77,13 @@ dotnet_naming_symbols.public_constants.applicable_kinds = field
 dotnet_naming_rule.public_const_all_upper.severity = warning
 dotnet_naming_rule.public_const_all_upper.symbols = public_constants
 dotnet_naming_rule.public_const_all_upper.style = all_upper
+
+dotnet_naming_symbols.public_static_readonly.applicable_accessibilities = public,internal,protected,protected_internal,private_protected
+dotnet_naming_symbols.public_static_readonly.required_modifiers = static,readonly
+dotnet_naming_symbols.public_static_readonly.applicable_kinds = field
+dotnet_naming_rule.public_static_readonly_all_upper.severity = warning
+dotnet_naming_rule.public_static_readonly_all_upper.symbols = public_static_readonly
+dotnet_naming_rule.public_static_readonly_all_upper.style = all_upper
 
 #Roslyn formating options
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -180,19 +180,6 @@ csharp_style_prefer_switch_expression = false:none
 #Supressing roslyn built-in analyzers
 # Suppress: EC112
 
-#Private method is unused
-dotnet_diagnostic.IDE0051.severity = silent
-#Private member is unused
-dotnet_diagnostic.IDE0052.severity = silent
-
-#Rules for disposable
-dotnet_diagnostic.IDE0067.severity = none
-dotnet_diagnostic.IDE0068.severity = none
-dotnet_diagnostic.IDE0069.severity = none
-
-#File header
-dotnet_diagnostic.IDE0073.severity = warning
-
 #Disable operator overloads requiring alternate named methods
 dotnet_diagnostic.CA2225.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -177,15 +177,6 @@ csharp_style_prefer_index_operator = true:warning
 csharp_style_prefer_range_operator = true:warning
 csharp_style_prefer_switch_expression = false:none
 
-#Supressing roslyn built-in analyzers
-# Suppress: EC112
-
-#Disable operator overloads requiring alternate named methods
-dotnet_diagnostic.CA2225.severity = none
-
-# Banned APIs
-dotnet_diagnostic.RS0030.severity = error
-
 [*.{yaml,yml}]
 insert_final_newline = true
 indent_style = space

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,6 @@ jobs:
           done <<< $(dotnet codefilesanity)
           exit $exit_code
 
-      # Temporarily disabled due to test failures, but it won't work anyway until the tool is upgraded.
-      # - name: .NET Format (Dry Run)
-      #   run: dotnet format --dry-run --check
-
       - name: InspectCode
         run: dotnet jb inspectcode $(pwd)/osu-framework.Desktop.slnf --no-build --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN
 

--- a/.globalconfig
+++ b/.globalconfig
@@ -37,7 +37,7 @@ dotnet_diagnostic.IDE0055.severity = warning
 dotnet_diagnostic.IDE0051.severity = silent
 
 # IDE0052: Private member is unused
-dotnet_diagnostic.IDE0052.severity = silent
+dotnet_diagnostic.IDE0052.severity = warning
 
 # IDE0073: File header
 dotnet_diagnostic.IDE0073.severity = warning

--- a/.globalconfig
+++ b/.globalconfig
@@ -1,0 +1,6 @@
+is_global = true
+
+# .NET Code Style
+
+# IDE0055: Fix formatting
+dotnet_diagnostic.IDE0055.severity = warning

--- a/.globalconfig
+++ b/.globalconfig
@@ -47,3 +47,9 @@ dotnet_diagnostic.IDE0130.severity = warning
 
 # IDE1006: Naming style
 dotnet_diagnostic.IDE1006.severity = warning
+
+#Disable operator overloads requiring alternate named methods
+dotnet_diagnostic.CA2225.severity = none
+
+# Banned APIs
+dotnet_diagnostic.RS0030.severity = error

--- a/.globalconfig
+++ b/.globalconfig
@@ -4,3 +4,6 @@ is_global = true
 
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = warning
+
+# IDE1006: Naming style
+dotnet_diagnostic.IDE1006.severity = warning

--- a/.globalconfig
+++ b/.globalconfig
@@ -1,6 +1,22 @@
 is_global = true
 
 # .NET Code Style
+# IDE styles reference: https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/
+
+# IDE0001: Simplify names
+dotnet_diagnostic.IDE0001.severity = warning
+
+# IDE0002: Simplify member access
+dotnet_diagnostic.IDE0002.severity = warning
+
+# IDE0003: Remove qualification
+dotnet_diagnostic.IDE0003.severity = warning
+
+# IDE0004: Remove unnecessary cast
+dotnet_diagnostic.IDE0004.severity = warning
+
+# IDE0005: Remove unnecessary imports
+dotnet_diagnostic.IDE0005.severity = warning
 
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = warning

--- a/.globalconfig
+++ b/.globalconfig
@@ -5,5 +5,13 @@ is_global = true
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = warning
 
+# IDE0051: Private method is unused
+dotnet_diagnostic.IDE0051.severity = silent
+# IDE0052: Private member is unused
+dotnet_diagnostic.IDE0052.severity = silent
+
+# IDE0073: File header
+dotnet_diagnostic.IDE0073.severity = warning
+
 # IDE1006: Naming style
 dotnet_diagnostic.IDE1006.severity = warning

--- a/.globalconfig
+++ b/.globalconfig
@@ -18,16 +18,32 @@ dotnet_diagnostic.IDE0004.severity = warning
 # IDE0005: Remove unnecessary imports
 dotnet_diagnostic.IDE0005.severity = warning
 
+# IDE0034: Simplify default literal
+dotnet_diagnostic.IDE0034.severity = warning
+
+# IDE0036: Sort modifiers
+dotnet_diagnostic.IDE0036.severity = warning
+
+# IDE0040: Add accessibility modifier
+dotnet_diagnostic.IDE0040.severity = warning
+
+# IDE0049: Use keyword for type name
+dotnet_diagnostic.IDE0040.severity = warning
+
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = warning
 
 # IDE0051: Private method is unused
 dotnet_diagnostic.IDE0051.severity = silent
+
 # IDE0052: Private member is unused
 dotnet_diagnostic.IDE0052.severity = silent
 
 # IDE0073: File header
 dotnet_diagnostic.IDE0073.severity = warning
+
+# IDE0130: Namespace mismatch with folder
+dotnet_diagnostic.IDE0130.severity = warning
 
 # IDE1006: Naming style
 dotnet_diagnostic.IDE1006.severity = warning

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,7 @@
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)CodeAnalysis\BannedSymbols.txt" />
   </ItemGroup>
   <PropertyGroup Label="Code Analysis">
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis\osu-framework.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Label="NuGet">

--- a/InspectCode.ps1
+++ b/InspectCode.ps1
@@ -1,9 +1,5 @@
 dotnet tool restore
 
-# Temporarily disabled until the tool is upgraded to 5.0.
-  # The version specified in .config/dotnet-tools.json (3.1.37601) won't run on .NET hosts >=5.0.7.
-  # - cmd: dotnet format --dry-run --check
-
 dotnet CodeFileSanity
 dotnet jb inspectcode "osu-framework.Desktop.slnf" --no-build --output="inspectcodereport.xml" --caches-home="inspectcode" --verbosity=WARN
 dotnet nvika parsereport "inspectcodereport.xml" --treatwarningsaserrors

--- a/build/build.cake
+++ b/build/build.cake
@@ -123,11 +123,6 @@ Task("CodeFileSanity")
         });
     });
 
-// Temporarily disabled until the tool is upgraded to 5.0.
-// The version specified in .config/dotnet-tools.json (3.1.37601) won't run on .NET hosts >=5.0.7.
-// Task("DotnetFormat")
-//    .Does(() => DotNetCoreTool(sln.FullPath, "format", "--dry-run --check"));
-
 Task("PackFramework")
     .Does(() => {
         DotNetCorePack(frameworkProject.FullPath, new DotNetCorePackSettings{
@@ -224,7 +219,6 @@ Task("Build")
     .IsDependentOn("Clean")
     .IsDependentOn("DetermineAppveyorBuildProperties")
     .IsDependentOn("CodeFileSanity")
-    //.IsDependentOn("DotnetFormat") <- To be uncommented after fixing the task.
     .IsDependentOn("InspectCode")
     .IsDependentOn("Test")
     .IsDependentOn("DetermineAppveyorDeployProperties")

--- a/osu-framework.sln
+++ b/osu-framework.sln
@@ -28,6 +28,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D29A2153-C171-457E-A147-720976BA430F}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
+		.globalconfig = .globalconfig
 		Directory.Build.props = Directory.Build.props
 		.config\dotnet-tools.json = .config\dotnet-tools.json
 		CodeAnalysis\osu-framework.ruleset = CodeAnalysis\osu-framework.ruleset

--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -313,6 +313,8 @@ namespace osu.Framework.Tests.Dependencies
 #pragma warning restore 169
         }
 
+#pragma warning disable IDE0052 // Unread private member
+
         private class Provider5
         {
             [Cached]

--- a/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
+++ b/osu.Framework.Tests/Dependencies/CachedAttributeTest.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Testing.Dependencies;
 
+#pragma warning disable IDE0052 // Unread private member
+
 namespace osu.Framework.Tests.Dependencies
 {
     [TestFixture]
@@ -312,8 +314,6 @@ namespace osu.Framework.Tests.Dependencies
             private int fail;
 #pragma warning restore 169
         }
-
-#pragma warning disable IDE0052 // Unread private member
 
         private class Provider5
         {

--- a/osu.Framework.Tests/Polygons/LineIntersections.cs
+++ b/osu.Framework.Tests/Polygons/LineIntersections.cs
@@ -14,7 +14,9 @@ namespace osu.Framework.Tests.Polygons
         private static readonly Vector2 up_1 = new Vector2(0, 1);
         private static readonly Vector2 up_2 = new Vector2(0, 2);
         private static readonly Vector2 down_1 = new Vector2(0, -1);
+
         // private static readonly Vector2 down_2 = new Vector2(0, -2); // unused
+
         private static readonly Vector2 left_1 = new Vector2(-1, 0);
         private static readonly Vector2 left_2 = new Vector2(-2, 0);
         private static readonly Vector2 right_1 = new Vector2(1, 0);

--- a/osu.Framework.Tests/Polygons/LineIntersections.cs
+++ b/osu.Framework.Tests/Polygons/LineIntersections.cs
@@ -14,7 +14,7 @@ namespace osu.Framework.Tests.Polygons
         private static readonly Vector2 up_1 = new Vector2(0, 1);
         private static readonly Vector2 up_2 = new Vector2(0, 2);
         private static readonly Vector2 down_1 = new Vector2(0, -1);
-        private static readonly Vector2 down_2 = new Vector2(0, -2);
+        // private static readonly Vector2 down_2 = new Vector2(0, -2); // unused
         private static readonly Vector2 left_1 = new Vector2(-1, 0);
         private static readonly Vector2 left_2 = new Vector2(-2, 0);
         private static readonly Vector2 right_1 = new Vector2(1, 0);

--- a/osu.Framework.Tests/Polygons/LineIntersections.cs
+++ b/osu.Framework.Tests/Polygons/LineIntersections.cs
@@ -14,9 +14,6 @@ namespace osu.Framework.Tests.Polygons
         private static readonly Vector2 up_1 = new Vector2(0, 1);
         private static readonly Vector2 up_2 = new Vector2(0, 2);
         private static readonly Vector2 down_1 = new Vector2(0, -1);
-
-        // private static readonly Vector2 down_2 = new Vector2(0, -2); // unused
-
         private static readonly Vector2 left_1 = new Vector2(-1, 0);
         private static readonly Vector2 left_2 = new Vector2(-2, 0);
         private static readonly Vector2 right_1 = new Vector2(1, 0);

--- a/osu.Framework.Tests/Text/TextBuilderTest.cs
+++ b/osu.Framework.Tests/Text/TextBuilderTest.cs
@@ -33,6 +33,9 @@ namespace osu.Framework.Tests.Text
         private const float b_height = 13;
         private const float b_kerning = -14;
 
+#pragma warning disable IDE1006 // Naming style
+        // m_ recognized as prefix instead of part of the name
+
         private const float m_x_offset = 15;
         private const float m_y_offset = 16;
         private const float m_x_advance = 17;
@@ -40,6 +43,8 @@ namespace osu.Framework.Tests.Text
         private const float m_baseline = 19;
         private const float m_height = 20;
         private const float m_kerning = -21;
+
+#pragma warning restore IDE1006
 
         private static readonly Vector2 spacing = new Vector2(22, 23);
 

--- a/osu.Framework.Tests/Visual/Bindables/TestSceneBindableAutoUnbinding.cs
+++ b/osu.Framework.Tests/Visual/Bindables/TestSceneBindableAutoUnbinding.cs
@@ -106,7 +106,9 @@ namespace osu.Framework.Tests.Visual.Bindables
         public class BindableExposingFillFlowContainer : FillFlowContainer
         {
             [Cached]
+#pragma warning disable IDE0052 // Unread private member
             private Bindable<int> bindable = new Bindable<int>();
+#pragma warning restore IDE0052 //
         }
 
         public class TestResolvedBindableDrawable : TestExposedBindableDrawable

--- a/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
+++ b/osu.Framework/Allocation/BackgroundDependencyLoaderAttribute.cs
@@ -12,7 +12,7 @@ using osu.Framework.Extensions.TypeExtensions;
 namespace osu.Framework.Allocation
 {
     /// <summary>
-    /// Marks a method as the (potentially asynchronous) initialization method of a <see cref="osu.Framework.Graphics.Drawable"/>, allowing for automatic injection of dependencies via the parameters of the method.
+    /// Marks a method as the (potentially asynchronous) initialization method of a <see cref="Graphics.Drawable"/>, allowing for automatic injection of dependencies via the parameters of the method.
     /// </summary>
     [MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     [AttributeUsage(AttributeTargets.Method)]

--- a/osu.Framework/Allocation/DependencyContainer.cs
+++ b/osu.Framework/Allocation/DependencyContainer.cs
@@ -74,7 +74,7 @@ namespace osu.Framework.Allocation
             => CacheAs(type, info, instance, false);
 
         /// <summary>
-        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="DependencyContainer.Get(Type)"/>.
+        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
         /// <remarks>
         /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
@@ -85,7 +85,7 @@ namespace osu.Framework.Allocation
             => CacheValue(instance, default);
 
         /// <summary>
-        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="DependencyContainer.Get(Type)"/>.
+        /// Caches an instance of a type as its most derived type. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
         /// <remarks>
         /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
@@ -102,7 +102,7 @@ namespace osu.Framework.Allocation
         }
 
         /// <summary>
-        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="DependencyContainer.Get(Type)"/>.
+        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
         /// <remarks>
         /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.
@@ -113,7 +113,7 @@ namespace osu.Framework.Allocation
             => CacheValueAs(instance, default);
 
         /// <summary>
-        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="DependencyContainer.Get(Type)"/>.
+        /// Caches an instance of a type as a type of <typeparamref name="T"/>. This instance will be returned each time you <see cref="Get(Type)"/>.
         /// </summary>
         /// <remarks>
         /// This should only be used when it is guaranteed that the internal state of the type will remain consistent through retrieval.

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -170,8 +170,6 @@ namespace osu.Framework.Audio
             scheduler.Add(() =>
             {
                 // sync audioDevices every 1000ms
-
-#pragma warning disable IDE0055 // VS and Rider formatting conflict
                 new Thread(() =>
                 {
                     while (!token.IsCancellationRequested)
@@ -185,8 +183,10 @@ namespace osu.Framework.Audio
                         {
                         }
                     }
-                }) { IsBackground = true }.Start();
-#pragma warning restore IDE0055
+                })
+                {
+                    IsBackground = true
+                }.Start();
             });
         }
 
@@ -228,7 +228,8 @@ namespace osu.Framework.Audio
         /// Channels removed from this <see cref="AudioMixer"/> fall back to the global <see cref="SampleMixer"/>.
         /// </remarks>
         /// <param name="identifier">An identifier displayed on the audio mixer visualiser.</param>
-        public AudioMixer CreateAudioMixer(string identifier = default) => createAudioMixer(SampleMixer, !string.IsNullOrEmpty(identifier) ? identifier : $"user #{Interlocked.Increment(ref userMixerID)}");
+        public AudioMixer CreateAudioMixer(string identifier = default) =>
+            createAudioMixer(SampleMixer, !string.IsNullOrEmpty(identifier) ? identifier : $"user #{Interlocked.Increment(ref userMixerID)}");
 
         private AudioMixer createAudioMixer(AudioMixer globalMixer, string identifier)
         {

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using ManagedBass;
 using ManagedBass.Fx;
 using ManagedBass.Mix;
@@ -171,20 +170,23 @@ namespace osu.Framework.Audio
             scheduler.Add(() =>
             {
                 // sync audioDevices every 1000ms
-                Task.Run(async () =>
+
+#pragma warning disable IDE0055 // VS and Rider formatting conflict
+                new Thread(() =>
                 {
                     while (!token.IsCancellationRequested)
                     {
                         try
                         {
                             syncAudioDevices();
-                            await Task.Delay(1000).ConfigureAwait(false);
+                            Thread.Sleep(1000);
                         }
                         catch
                         {
                         }
                     }
-                });
+                }) { IsBackground = true }.Start();
+#pragma warning restore IDE0055
             });
         }
 

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using ManagedBass;
 using ManagedBass.Fx;
 using ManagedBass.Mix;
@@ -170,21 +171,20 @@ namespace osu.Framework.Audio
             scheduler.Add(() =>
             {
                 // sync audioDevices every 1000ms
-                new Thread(() =>
+                Task.Run(async () =>
+                {
+                    while (!token.IsCancellationRequested)
                     {
-                        while (!token.IsCancellationRequested)
+                        try
                         {
-                            try
-                            {
-                                syncAudioDevices();
-                                Thread.Sleep(1000);
-                            }
-                            catch
-                            {
-                            }
+                            syncAudioDevices();
+                            await Task.Delay(1000).ConfigureAwait(false);
                         }
-                    })
-                { IsBackground = true }.Start();
+                        catch
+                        {
+                        }
+                    }
+                });
             });
         }
 

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -183,7 +183,8 @@ namespace osu.Framework.Audio
                         {
                         }
                     }
-                }) { IsBackground = true }.Start();
+                })
+                { IsBackground = true }.Start();
             });
         }
 

--- a/osu.Framework/Audio/AudioManager.cs
+++ b/osu.Framework/Audio/AudioManager.cs
@@ -171,19 +171,19 @@ namespace osu.Framework.Audio
             {
                 // sync audioDevices every 1000ms
                 new Thread(() =>
-                {
-                    while (!token.IsCancellationRequested)
                     {
-                        try
+                        while (!token.IsCancellationRequested)
                         {
-                            syncAudioDevices();
-                            Thread.Sleep(1000);
+                            try
+                            {
+                                syncAudioDevices();
+                                Thread.Sleep(1000);
+                            }
+                            catch
+                            {
+                            }
                         }
-                        catch
-                        {
-                        }
-                    }
-                })
+                    })
                 { IsBackground = true }.Start();
             });
         }

--- a/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
+++ b/osu.Framework/Audio/Mixing/Bass/BassAudioMixer.cs
@@ -132,7 +132,7 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// </summary>
         /// <remarks>See: <see cref="ManagedBass.Bass.ChannelIsActive"/>.</remarks>
         /// <param name="channel">The channel to get the state of.</param>
-        /// <returns><see cref="ManagedBass.PlaybackState"/> indicating the state of the channel.</returns>
+        /// <returns><see cref="PlaybackState"/> indicating the state of the channel.</returns>
         public PlaybackState ChannelIsActive(IBassAudioChannel channel)
         {
             // The audio channel's state tells us whether it's stalled or stopped.
@@ -215,7 +215,7 @@ namespace osu.Framework.Audio.Mixing.Bass
         /// <summary>
         /// Sets up a synchroniser on a mixer source channel.
         /// </summary>
-        /// <remarks>See: <see cref="ManagedBass.Mix.BassMix.ChannelSetSync(int, SyncFlags, long, SyncProcedure, IntPtr)"/>.</remarks>
+        /// <remarks>See: <see cref="BassMix.ChannelSetSync(int, SyncFlags, long, SyncProcedure, IntPtr)"/>.</remarks>
         /// <param name="channel">The <see cref="IBassAudioChannel"/> to set up the synchroniser for.</param>
         /// <param name="type">The type of sync.</param>
         /// <param name="parameter">The sync parameters, depending on the sync type.</param>

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -46,7 +46,7 @@ namespace osu.Framework.Graphics.Audio
         private float resolution = 1;
 
         /// <summary>
-        /// Gets or sets the amount of <see cref="Framework.Audio.Track.Waveform.Point"/>'s displayed relative to <see cref="Drawable.DrawWidth">DrawWidth</see>.
+        /// Gets or sets the amount of <see cref="Waveform.Point"/>'s displayed relative to <see cref="Drawable.DrawWidth">DrawWidth</see>.
         /// </summary>
         public float Resolution
         {

--- a/osu.Framework/Graphics/Audio/WaveformGraph.cs
+++ b/osu.Framework/Graphics/Audio/WaveformGraph.cs
@@ -46,7 +46,7 @@ namespace osu.Framework.Graphics.Audio
         private float resolution = 1;
 
         /// <summary>
-        /// Gets or sets the amount of <see cref="Waveform.Point"/>'s displayed relative to <see cref="Drawable.DrawWidth">DrawWidth</see>.
+        /// Gets or sets the amount of <see cref="Framework.Audio.Track.Waveform.Point"/>'s displayed relative to <see cref="Drawable.DrawWidth">DrawWidth</see>.
         /// </summary>
         public float Resolution
         {

--- a/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
+++ b/osu.Framework/Graphics/Containers/CompositeDrawable_DrawNode.cs
@@ -43,7 +43,7 @@ namespace osu.Framework.Graphics.Containers
             private MaskingInfo? maskingInfo;
 
             /// <summary>
-            /// The screen-space version of <see cref="OpenGL.MaskingInfo.MaskingRect"/>.
+            /// The screen-space version of <see cref="MaskingInfo.MaskingRect"/>.
             /// Used as cache of screen-space masking quads computed in previous frames.
             /// Assign null to reset.
             /// </summary>

--- a/osu.Framework/Graphics/Containers/GridContainer.cs
+++ b/osu.Framework/Graphics/Containers/GridContainer.cs
@@ -428,7 +428,7 @@ namespace osu.Framework.Graphics.Containers
     {
         /// <summary>
         /// Any remaining area of the <see cref="GridContainer"/> will be divided amongst this and all
-        /// other elements which use <see cref="GridSizeMode.Distributed"/>.
+        /// other elements which use <see cref="Distributed"/>.
         /// </summary>
         Distributed,
 

--- a/osu.Framework/Graphics/Containers/TextFlowContainer.cs
+++ b/osu.Framework/Graphics/Containers/TextFlowContainer.cs
@@ -222,7 +222,7 @@ namespace osu.Framework.Graphics.Containers
             where TSpriteText : SpriteText, new()
             => AddPart(CreateChunkFor(text, true, () => new TSpriteText(), creationParameters));
 
-        /// <inheritdoc cref="AddText{TSpriteText}(LocalisableString,System.Action{TSpriteText})"/>
+        /// <inheritdoc cref="AddText{TSpriteText}(LocalisableString,Action{TSpriteText})"/>
         public ITextPart AddText(LocalisableString text, Action<SpriteText> creationParameters = null)
             => AddPart(CreateChunkFor(text, true, CreateSpriteText, creationParameters));
 

--- a/osu.Framework/Graphics/Containers/VisibilityContainer.cs
+++ b/osu.Framework/Graphics/Containers/VisibilityContainer.cs
@@ -74,10 +74,10 @@ namespace osu.Framework.Graphics.Containers
         protected abstract void PopOut();
 
         /// <summary>
-        /// Called whenever <see cref="VisibilityContainer.State"/> is changed.
+        /// Called whenever <see cref="State"/> is changed.
         /// Used to update this container's elements according to the new visibility state.
         /// </summary>
-        /// <param name="state">The <see cref="ValueChangedEvent{T}"/> provided by <see cref="VisibilityContainer.State"/></param>
+        /// <param name="state">The <see cref="ValueChangedEvent{T}"/> provided by <see cref="State"/></param>
         protected virtual void UpdateState(ValueChangedEvent<Visibility> state)
         {
             switch (state.NewValue)

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1103,7 +1103,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// The origin of this <see cref="Drawable"/> expressed in relative coordinates from the top-left corner of <see cref="DrawRectangle"/>.
         /// </summary>
-        /// <exception cref="InvalidOperationException">If <see cref="Origin"/> is <see cref="Anchor.Custom"/>.</exception>
+        /// <exception cref="InvalidOperationException">If <see cref="Origin"/> is <see cref="osu.Framework.Graphics.Anchor.Custom"/>.</exception>
         public Vector2 RelativeOriginPosition
         {
             get
@@ -2742,7 +2742,7 @@ namespace osu.Framework.Graphics
         Colour = 1 << 3,
 
         /// <summary>
-        /// <see cref="DrawNode.ApplyState"/> has to be invoked on all old draw nodes.
+        /// <see cref="Graphics.DrawNode.ApplyState"/> has to be invoked on all old draw nodes.
         /// This <see cref="Invalidation"/> flag never propagates to children.
         /// </summary>
         DrawNode = 1 << 4,

--- a/osu.Framework/Graphics/Drawable.cs
+++ b/osu.Framework/Graphics/Drawable.cs
@@ -1082,7 +1082,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// The origin of this <see cref="Drawable"/>.
         /// </summary>
-        /// <exception cref="ArgumentException">If the provided value does not exist in the <see cref="osu.Framework.Graphics.Anchor"/> enumeration.</exception>
+        /// <exception cref="ArgumentException">If the provided value does not exist in the <see cref="Graphics.Anchor"/> enumeration.</exception>
         public virtual Anchor Origin
         {
             get => origin;
@@ -1103,7 +1103,7 @@ namespace osu.Framework.Graphics
         /// <summary>
         /// The origin of this <see cref="Drawable"/> expressed in relative coordinates from the top-left corner of <see cref="DrawRectangle"/>.
         /// </summary>
-        /// <exception cref="InvalidOperationException">If <see cref="Origin"/> is <see cref="osu.Framework.Graphics.Anchor.Custom"/>.</exception>
+        /// <exception cref="InvalidOperationException">If <see cref="Origin"/> is <see cref="Anchor.Custom"/>.</exception>
         public Vector2 RelativeOriginPosition
         {
             get
@@ -2343,7 +2343,7 @@ namespace osu.Framework.Graphics
         public virtual bool HandlePositionalInput => RequestsPositionalInput;
 
         /// <summary>
-        /// Nested class which is used for caching <see cref="Drawable.HandleNonPositionalInput"/>, <see cref="Drawable.HandlePositionalInput"/> values obtained via reflection.
+        /// Nested class which is used for caching <see cref="HandleNonPositionalInput"/>, <see cref="HandlePositionalInput"/> values obtained via reflection.
         /// </summary>
         private static class HandleInputCache
         {
@@ -2742,7 +2742,7 @@ namespace osu.Framework.Graphics
         Colour = 1 << 3,
 
         /// <summary>
-        /// <see cref="Graphics.DrawNode.ApplyState"/> has to be invoked on all old draw nodes.
+        /// <see cref="DrawNode.ApplyState"/> has to be invoked on all old draw nodes.
         /// This <see cref="Invalidation"/> flag never propagates to children.
         /// </summary>
         DrawNode = 1 << 4,

--- a/osu.Framework/Graphics/Primitives/RectangleF.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleF.cs
@@ -17,7 +17,9 @@ namespace osu.Framework.Graphics.Primitives
     {
         /// <summary>Represents an instance of the <see cref="RectangleF"/> class with its members uninitialized.</summary>
         /// <filterpriority>1</filterpriority>
+#pragma warning disable IDE1006 // Naming style
         public static readonly RectangleF Empty;
+#pragma warning restore IDE1006
 
         public float X;
         public float Y;

--- a/osu.Framework/Graphics/Primitives/RectangleF.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleF.cs
@@ -129,7 +129,7 @@ namespace osu.Framework.Graphics.Primitives
 
         /// <summary>Tests whether obj is a <see cref="RectangleF"/> with the same location and size of this <see cref="RectangleF"/>.</summary>
         /// <returns>This method returns true if obj is a <see cref="RectangleF"/> and its X, Y, Width, and Height properties are equal to the corresponding properties of this <see cref="RectangleF"/>; otherwise, false.</returns>
-        /// <param name="obj">The <see cref="System.Object"/> to test.</param>
+        /// <param name="obj">The <see cref="object"/> to test.</param>
         /// <filterpriority>1</filterpriority>
         public override bool Equals(object obj) => obj is RectangleF rec && Equals(rec);
 

--- a/osu.Framework/Graphics/Primitives/RectangleF.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleF.cs
@@ -17,9 +17,7 @@ namespace osu.Framework.Graphics.Primitives
     {
         /// <summary>Represents an instance of the <see cref="RectangleF"/> class with its members uninitialized.</summary>
         /// <filterpriority>1</filterpriority>
-#pragma warning disable IDE1006 // Naming style
-        public static readonly RectangleF Empty;
-#pragma warning restore IDE1006
+        public static RectangleF Empty { get; } = new RectangleF();
 
         public float X;
         public float Y;

--- a/osu.Framework/Graphics/Primitives/RectangleF.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleF.cs
@@ -50,7 +50,7 @@ namespace osu.Framework.Graphics.Primitives
         }
 
         /// <summary>Gets or sets the coordinates of the upper-left corner of this <see cref="RectangleF"/> structure.</summary>
-        /// <returns>A <see cref="osuTK.Vector2"/> that represents the upper-left corner of this <see cref="RectangleF"/> structure.</returns>
+        /// <returns>A <see cref="Vector2"/> that represents the upper-left corner of this <see cref="RectangleF"/> structure.</returns>
         /// <filterpriority>1</filterpriority>
         [Browsable(false)]
         public Vector2 Location
@@ -64,7 +64,7 @@ namespace osu.Framework.Graphics.Primitives
         }
 
         /// <summary>Gets or sets the size of this <see cref="RectangleF"/>.</summary>
-        /// <returns>A <see cref="osuTK.Vector2"/> that represents the width and height of this <see cref="RectangleF"/> structure.</returns>
+        /// <returns>A <see cref="Vector2"/> that represents the width and height of this <see cref="RectangleF"/> structure.</returns>
         /// <filterpriority>1</filterpriority>
         [Browsable(false)]
         public Vector2 Size

--- a/osu.Framework/Graphics/Primitives/RectangleI.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleI.cs
@@ -17,9 +17,7 @@ namespace osu.Framework.Graphics.Primitives
     {
         /// <summary>Represents an instance of the <see cref="RectangleI"/> class with its members uninitialized.</summary>
         /// <filterpriority>1</filterpriority>
-#pragma warning disable IDE1006 // Naming style
-        public static readonly RectangleI Empty;
-#pragma warning restore IDE1006
+        public static RectangleI Empty { get; } = new RectangleI();
 
         public int X;
         public int Y;

--- a/osu.Framework/Graphics/Primitives/RectangleI.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleI.cs
@@ -39,13 +39,13 @@ namespace osu.Framework.Graphics.Primitives
         }
 
         /// <summary>Gets or sets the coordinates of the upper-left corner of this <see cref="RectangleI"/> structure.</summary>
-        /// <returns>A <see cref="osuTK.Vector2"/> that represents the upper-left corner of this <see cref="RectangleI"/> structure.</returns>
+        /// <returns>A <see cref="Vector2"/> that represents the upper-left corner of this <see cref="RectangleI"/> structure.</returns>
         /// <filterpriority>1</filterpriority>
         [Browsable(false)]
         public Vector2I Location => new Vector2I(X, Y);
 
         /// <summary>Gets or sets the size of this <see cref="RectangleI"/>.</summary>
-        /// <returns>A <see cref="osuTK.Vector2"/> that represents the width and height of this <see cref="RectangleI"/> structure.</returns>
+        /// <returns>A <see cref="Vector2"/> that represents the width and height of this <see cref="RectangleI"/> structure.</returns>
         /// <filterpriority>1</filterpriority>
         [Browsable(false)]
         public Vector2I Size => new Vector2I(Width, Height);

--- a/osu.Framework/Graphics/Primitives/RectangleI.cs
+++ b/osu.Framework/Graphics/Primitives/RectangleI.cs
@@ -17,7 +17,9 @@ namespace osu.Framework.Graphics.Primitives
     {
         /// <summary>Represents an instance of the <see cref="RectangleI"/> class with its members uninitialized.</summary>
         /// <filterpriority>1</filterpriority>
+#pragma warning disable IDE1006 // Naming style
         public static readonly RectangleI Empty;
+#pragma warning restore IDE1006
 
         public int X;
         public int Y;

--- a/osu.Framework/Graphics/Primitives/Vector2I.cs
+++ b/osu.Framework/Graphics/Primitives/Vector2I.cs
@@ -25,11 +25,9 @@ namespace osu.Framework.Graphics.Primitives
             Y = y;
         }
 
-#pragma warning disable IDE1006 // Naming style
-        public static readonly Vector2I Zero;
+        public static Vector2I Zero { get; } = new Vector2I();
 
-        public static readonly Vector2I One = new Vector2I(1);
-#pragma warning restore IDE1006
+        public static Vector2I One { get; } = new Vector2I(1);
 
         public static implicit operator Vector2(Vector2I r) => new Vector2(r.X, r.Y);
 

--- a/osu.Framework/Graphics/Primitives/Vector2I.cs
+++ b/osu.Framework/Graphics/Primitives/Vector2I.cs
@@ -25,9 +25,11 @@ namespace osu.Framework.Graphics.Primitives
             Y = y;
         }
 
+#pragma warning disable IDE1006 // Naming style
         public static readonly Vector2I Zero;
 
         public static readonly Vector2I One = new Vector2I(1);
+#pragma warning restore IDE1006
 
         public static implicit operator Vector2(Vector2I r) => new Vector2(r.X, r.Y);
 

--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
@@ -7,6 +7,8 @@ using FFmpeg.AutoGen;
 namespace osu.Framework.Graphics.Video
 {
     // ReSharper disable InconsistentNaming
+#pragma warning disable IDE1006 // Naming style
+
     public unsafe class FFmpegFuncs
     {
         #region Delegates

--- a/osu.Framework/Graphics/Video/FFmpegFuncs.cs
+++ b/osu.Framework/Graphics/Video/FFmpegFuncs.cs
@@ -4,11 +4,11 @@
 using System.Runtime.InteropServices;
 using FFmpeg.AutoGen;
 
-namespace osu.Framework.Graphics.Video
-{
-    // ReSharper disable InconsistentNaming
+// ReSharper disable InconsistentNaming
 #pragma warning disable IDE1006 // Naming style
 
+namespace osu.Framework.Graphics.Video
+{
     public unsafe class FFmpegFuncs
     {
         #region Delegates

--- a/osu.Framework/Layout/LayoutValue.cs
+++ b/osu.Framework/Layout/LayoutValue.cs
@@ -8,7 +8,7 @@ namespace osu.Framework.Layout
 {
     /// <summary>
     /// A member that represents the validation state of the layout of a <see cref="Drawable"/>.
-    /// Can be invalidated according to state changes in a <see cref="Drawable"/> (via <see cref="Graphics.Invalidation"/> flags), and validated on-demand when the layout has been re-computed.
+    /// Can be invalidated according to state changes in a <see cref="Drawable"/> (via <see cref="Invalidation"/> flags), and validated on-demand when the layout has been re-computed.
     /// </summary>
     public class LayoutValue : LayoutMember
     {
@@ -31,7 +31,7 @@ namespace osu.Framework.Layout
 
     /// <summary>
     /// A member that represents the validation state of a value in the layout of a <see cref="Drawable"/>.
-    /// Can be invalidated according to state changes in a <see cref="Drawable"/> (via <see cref="Graphics.Invalidation"/> flags), and validated when an up-to-date value is set.
+    /// Can be invalidated according to state changes in a <see cref="Drawable"/> (via <see cref="Invalidation"/> flags), and validated when an up-to-date value is set.
     /// </summary>
     /// <typeparam name="T">The type of value stored.</typeparam>
     public class LayoutValue<T> : LayoutMember

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -11,10 +11,7 @@ namespace osu.Framework.Localisation
     /// </summary>
     public class LocalisableStringEqualityComparer : IEqualityComparer<LocalisableString>
     {
-        // ReSharper disable once InconsistentNaming (follows EqualityComparer<T>.Default)
-#pragma warning disable IDE1006 // Naming style
-        public static readonly LocalisableStringEqualityComparer Default = new LocalisableStringEqualityComparer();
-#pragma warning restore IDE1006
+        public static LocalisableStringEqualityComparer Default { get; } = new LocalisableStringEqualityComparer();
 
         public bool Equals(LocalisableString x, LocalisableString y)
         {

--- a/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
+++ b/osu.Framework/Localisation/LocalisableStringEqualityComparer.cs
@@ -12,7 +12,9 @@ namespace osu.Framework.Localisation
     public class LocalisableStringEqualityComparer : IEqualityComparer<LocalisableString>
     {
         // ReSharper disable once InconsistentNaming (follows EqualityComparer<T>.Default)
+#pragma warning disable IDE1006 // Naming style
         public static readonly LocalisableStringEqualityComparer Default = new LocalisableStringEqualityComparer();
+#pragma warning restore IDE1006
 
         public bool Equals(LocalisableString x, LocalisableString y)
         {

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -63,11 +63,11 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Controls the state of the OS cursor.
         /// </summary>
-        /// <remarks>If the cursor is <see cref="Platform.CursorState.Confined"/>, <see cref="CursorConfineRect"/> will be used.</remarks>
+        /// <remarks>If the cursor is <see cref="CursorState.Confined"/>, <see cref="CursorConfineRect"/> will be used.</remarks>
         CursorState CursorState { get; set; }
 
         /// <summary>
-        /// Area to which the mouse cursor is confined to when <see cref="CursorState"/> is <see cref="Platform.CursorState.Confined"/>.
+        /// Area to which the mouse cursor is confined to when <see cref="CursorState"/> is <see cref="CursorState.Confined"/>.
         /// </summary>
         /// <remarks>
         /// Will confine to the whole window by default (or when set to <c>null</c>).

--- a/osu.Framework/Platform/IWindow.cs
+++ b/osu.Framework/Platform/IWindow.cs
@@ -63,11 +63,11 @@ namespace osu.Framework.Platform
         /// <summary>
         /// Controls the state of the OS cursor.
         /// </summary>
-        /// <remarks>If the cursor is <see cref="CursorState.Confined"/>, <see cref="CursorConfineRect"/> will be used.</remarks>
+        /// <remarks>If the cursor is <see cref="Platform.CursorState.Confined"/>, <see cref="CursorConfineRect"/> will be used.</remarks>
         CursorState CursorState { get; set; }
 
         /// <summary>
-        /// Area to which the mouse cursor is confined to when <see cref="CursorState"/> is <see cref="CursorState.Confined"/>.
+        /// Area to which the mouse cursor is confined to when <see cref="CursorState"/> is <see cref="Platform.CursorState.Confined"/>.
         /// </summary>
         /// <remarks>
         /// Will confine to the whole window by default (or when set to <c>null</c>).

--- a/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
@@ -9,10 +9,6 @@ namespace osu.Framework.Platform.MacOS.Native
     {
         internal IntPtr Handle { get; }
 
-#pragma warning disable IDE0052 // Unread private member
-        private static IntPtr classPointer = Class.Get("NSDictionary");
-#pragma warning restore IDE0052 //
-
         internal NSDictionary(IntPtr handle)
         {
             Handle = handle;

--- a/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
+++ b/osu.Framework/Platform/MacOS/Native/NSDictionary.cs
@@ -9,7 +9,9 @@ namespace osu.Framework.Platform.MacOS.Native
     {
         internal IntPtr Handle { get; }
 
+#pragma warning disable IDE0052 // Unread private member
         private static IntPtr classPointer = Class.Get("NSDictionary");
+#pragma warning restore IDE0052 //
 
         internal NSDictionary(IntPtr handle)
         {

--- a/osu.Framework/Platform/OsuTKWindow.cs
+++ b/osu.Framework/Platform/OsuTKWindow.cs
@@ -166,7 +166,7 @@ namespace osu.Framework.Platform
 
         /// <summary>
         /// Creates a <see cref="OsuTKWindow"/> with given dimensions.
-        /// <para>Note that this will use the default <see cref="osuTK.GameWindow"/> implementation, which is not compatible with every platform.</para>
+        /// <para>Note that this will use the default <see cref="GameWindow"/> implementation, which is not compatible with every platform.</para>
         /// </summary>
         protected OsuTKWindow(int width, int height)
             : this(new GameWindow(width, height, new GraphicsMode(GraphicsMode.Default.ColorFormat, GraphicsMode.Default.Depth, GraphicsMode.Default.Stencil, GraphicsMode.Default.Samples, GraphicsMode.Default.AccumulatorFormat, 3)))

--- a/osu.Framework/Platform/SDL2/SDL2Structs.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Structs.cs
@@ -12,6 +12,8 @@ using SDL2;
 // ReSharper disable IdentifierTypo
 // (Mimics SDL and SDL2-CS naming)
 
+#pragma warning disable IDE1006 // Naming style
+
 namespace osu.Framework.Platform.SDL2
 {
     internal static class SDL2Structs

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Platform
         private Point position;
 
         /// <summary>
-        /// Returns or sets the window's position in screen space. Only valid when in <see cref="osu.Framework.Configuration.WindowMode.Windowed"/>
+        /// Returns or sets the window's position in screen space. Only valid when in <see cref="WindowMode.Windowed"/>
         /// </summary>
         public Point Position
         {
@@ -98,7 +98,7 @@ namespace osu.Framework.Platform
         private bool resizable = true;
 
         /// <summary>
-        /// Returns or sets whether the window is resizable or not. Only valid when in <see cref="osu.Framework.Platform.WindowState.Normal"/>.
+        /// Returns or sets whether the window is resizable or not. Only valid when in <see cref="WindowState.Normal"/>.
         /// </summary>
         public bool Resizable
         {

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -83,7 +83,7 @@ namespace osu.Framework.Platform
         private Point position;
 
         /// <summary>
-        /// Returns or sets the window's position in screen space. Only valid when in <see cref="WindowMode.Windowed"/>
+        /// Returns or sets the window's position in screen space. Only valid when in <see cref="osu.Framework.Configuration.WindowMode.Windowed"/>
         /// </summary>
         public Point Position
         {
@@ -98,7 +98,7 @@ namespace osu.Framework.Platform
         private bool resizable = true;
 
         /// <summary>
-        /// Returns or sets whether the window is resizable or not. Only valid when in <see cref="WindowState.Normal"/>.
+        /// Returns or sets whether the window is resizable or not. Only valid when in <see cref="osu.Framework.Platform.WindowState.Normal"/>.
         /// </summary>
         public bool Resizable
         {

--- a/osu.Framework/Platform/Windows/Native/Input.cs
+++ b/osu.Framework/Platform/Windows/Native/Input.cs
@@ -201,6 +201,8 @@ namespace osu.Framework.Platform.Windows.Native
         HID = 2
     }
 
+#pragma warning disable IDE1006 // Naming style
+
     /// <summary>
     /// Value type for a raw input header.
     /// </summary>
@@ -235,6 +237,8 @@ namespace osu.Framework.Platform.Windows.Native
         /// <summary>Handle to the target device. If NULL, it follows the keyboard focus.</summary>
         public IntPtr WindowHandle;
     }
+
+#pragma warning restore IDE1006
 
     /// <summary>Enumeration containing flags for a raw input device.</summary>
     public enum RawInputDeviceFlags

--- a/osu.Framework/Platform/Windows/TimePeriod.cs
+++ b/osu.Framework/Platform/Windows/TimePeriod.cs
@@ -82,6 +82,8 @@ namespace osu.Framework.Platform.Windows
 
         #endregion
 
+#pragma warning disable IDE1006 // Naming style
+
         [StructLayout(LayoutKind.Sequential)]
         private readonly struct TimeCaps
         {

--- a/osu.Framework/Statistics/FrameStatistics.cs
+++ b/osu.Framework/Statistics/FrameStatistics.cs
@@ -54,7 +54,7 @@ namespace osu.Framework.Statistics
         PositionalIQ,
 
         /// <summary>
-        /// See <see cref="osu.Framework.Graphics.Containers.CompositeDrawable.CheckChildrenLife"/>.
+        /// See <see cref="Graphics.Containers.CompositeDrawable.CheckChildrenLife"/>.
         /// </summary>
         CCL,
 


### PR DESCRIPTION
The IDExxxx analyzers were only shipped with Visual Studio. `dotnet format` gives some access to them.

From .NET 5, most of them are shipped together with .NET SDK, and can be included with `EnforceCodeStyleInBuild` property. They will now be invoked in any `dotnet build` command, available to other IDE and CI. `dotnet format` can be replaced now.

In this PR, I'm focusing on pure stylish analyzers to simplify reviewing. If you prefer I can also include language feature adoption ones.

#### Performance

This should theoretically add overhead to every build, but I can't see a measurable difference with `Measure-Command { dotnet build /p:EnforceCodeStyleInBuild=true }`. Turning on them during normal build could inform non Visual Studio users.
There are several analyzers not included in the SDK, which are claimed with performance issues. I suppose the already shipped ones are good in performance.

#### CI

This will now be enforced during Build&Test with WarningAsError enabled. A violation would cause a red in test legs. This is the same of CAxxxx analyzers.

Another options is to disable analyzers in Test leg and enforce them in Code Quality leg to improve clarity. What do you think?