### PR TITLE
Add mapping for the windows context menu key (and log unknown SDL keys)

### DIFF
--- a/osu.Framework/Platform/SDL2/SDL2Extensions.cs
+++ b/osu.Framework/Platform/SDL2/SDL2Extensions.cs
@@ -384,6 +384,7 @@ namespace osu.Framework.Platform.SDL2
                     return Key.F24;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_MENU:
+                case SDL.SDL_Scancode.SDL_SCANCODE_APPLICATION:
                     return Key.Menu;
 
                 case SDL.SDL_Scancode.SDL_SCANCODE_STOP:

--- a/osu.Framework/Platform/SDL2DesktopWindow.cs
+++ b/osu.Framework/Platform/SDL2DesktopWindow.cs
@@ -13,6 +13,7 @@ using osu.Framework.Extensions.EnumExtensions;
 using osu.Framework.Extensions.ImageExtensions;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Input;
+using osu.Framework.Logging;
 using osu.Framework.Platform.SDL2;
 using osu.Framework.Platform.Windows.Native;
 using osu.Framework.Threading;
@@ -944,7 +945,10 @@ namespace osu.Framework.Platform
             Key key = evtKey.keysym.ToKey();
 
             if (key == Key.Unknown)
+            {
+                Logger.Log($"Unknown SDL key: {evtKey.keysym.scancode}, {evtKey.keysym.sym}");
                 return;
+            }
 
             switch (evtKey.type)
             {


### PR DESCRIPTION
The log message renders as:
```cs
[runtime] 2022-04-23 16:09:22 [verbose]: Unknown SDL key: SDL_SCANCODE_APPLICATION, SDLK_APPLICATION
```

The log will help if more unknown keys crop up in the future (as there are many scancodes we're not handling).

The menu key is reported by windows/SDL as `SDL_SCANCODE_APPLICATION`, and is listed as such on the [SDL wiki](https://wiki.libsdl.org/SDL_Scancode):
- "Application" (the Application / Compose / Context Menu (Windows) key)

![image](https://user-images.githubusercontent.com/16479013/164914600-40a1f078-4e08-4436-a41d-d3c8b0fa1ca6.png)
