### PR TITLE
Fix `Menu` not handling mouse down events

### DIFF
--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneClosableMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneClosableMenu.cs
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the MIT Licence.
 // See the LICENCE file in the repository root for full licence text.
 
+using System;
 using NUnit.Framework;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.UserInterface;
@@ -70,6 +71,38 @@ namespace osu.Framework.Tests.Visual.UserInterface
             AddStep("reset flag", () => menu.PressBlocked = false);
             AddStep("press escape again", () => InputManager.Key(Key.Escape));
             AddAssert("press not handled", () => !menu.PressBlocked);
+        }
+
+        [Test]
+        public void TestMenuBlocksInputUnderneathIt()
+        {
+            bool actionReceived = false;
+
+            AddStep("add mouse handler", () => Add(new MouseHandlingLayer
+            {
+                Action = () => actionReceived = true,
+                Depth = 1,
+            }));
+
+            AddStep("click item", () => ClickItem(0, 0));
+            AddStep("click item", () => ClickItem(1, 0));
+            AddAssert("mouse handler not activated", () => !actionReceived);
+        }
+
+        private class MouseHandlingLayer : Drawable
+        {
+            public Action Action { get; set; }
+
+            public MouseHandlingLayer()
+            {
+                RelativeSizeAxes = Axes.Both;
+            }
+
+            protected override bool OnMouseDown(MouseDownEvent e)
+            {
+                Action?.Invoke();
+                return base.OnMouseDown(e);
+            }
         }
 
         private class AnimatedMenu : BasicMenu

--- a/osu.Framework.Tests/Visual/UserInterface/TestSceneClosableMenu.cs
+++ b/osu.Framework.Tests/Visual/UserInterface/TestSceneClosableMenu.cs
@@ -76,8 +76,10 @@ namespace osu.Framework.Tests.Visual.UserInterface
         [Test]
         public void TestMenuBlocksInputUnderneathIt()
         {
+            bool itemClicked = false;
             bool actionReceived = false;
 
+            AddStep("set item action", () => Menus.GetSubMenu(0).Items[0].Items[0].Action.Value = () => itemClicked = true);
             AddStep("add mouse handler", () => Add(new MouseHandlingLayer
             {
                 Action = () => actionReceived = true,
@@ -86,6 +88,7 @@ namespace osu.Framework.Tests.Visual.UserInterface
 
             AddStep("click item", () => ClickItem(0, 0));
             AddStep("click item", () => ClickItem(1, 0));
+            AddAssert("menu item activated", () => itemClicked);
             AddAssert("mouse handler not activated", () => !actionReceived);
         }
 

--- a/osu.Framework/Graphics/UserInterface/Menu.cs
+++ b/osu.Framework/Graphics/UserInterface/Menu.cs
@@ -591,6 +591,7 @@ namespace osu.Framework.Graphics.UserInterface
             return base.OnKeyDown(e);
         }
 
+        protected override bool OnMouseDown(MouseDownEvent e) => true;
         protected override bool OnClick(ClickEvent e) => true;
         protected override bool OnHover(HoverEvent e) => true;
 


### PR DESCRIPTION
- Closes ppy/osu#17961

Was previously relying on its `ScrollContainer` layer which used to block mouse down from drawables behind it, until https://github.com/ppy/osu-framework/pull/5118.

